### PR TITLE
[ISSUE #7666]✨Add store runtime observability metrics

### DIFF
--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -407,9 +407,44 @@ pub const JAVA_METRICS: &[MetricDescriptor] = &[
         source: MetricSource::Store,
     },
     MetricDescriptor {
+        name: metrics::STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE,
+        kind: MetricKind::ObservableGauge,
+        unit: "{lease}",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_HA_ACK_LATENCY_MILLIS,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_HA_REPLICATION_LAG_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
         name: metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL,
         kind: MetricKind::Counter,
         unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MLOCK_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS,
+        kind: MetricKind::Histogram,
+        unit: "ms",
         labels: &[],
         source: MetricSource::Store,
     },
@@ -781,7 +816,12 @@ mod tests {
         "rocketmq_storage_flush_behind_bytes",
         "rocketmq_storage_message_reserve_time",
         "rocketmq_storage_size",
+        "rocketmq_store_commitlog_segment_lease_active",
+        "rocketmq_store_ha_ack_latency_millis",
+        "rocketmq_store_ha_replication_lag_bytes",
         "rocketmq_store_linux_sendfile_bytes_total",
+        "rocketmq_store_linux_mlock_bytes",
+        "rocketmq_store_linux_page_cache_warmup_millis",
         "rocketmq_store_transfer_batch_total",
         "rocketmq_store_transfer_bytes_total",
         "rocketmq_store_transfer_engine_total",
@@ -898,5 +938,50 @@ mod tests {
         assert_eq!(linux_sendfile_bytes.kind, MetricKind::Counter);
         assert_eq!(linux_sendfile_bytes.unit, "By");
         assert_eq!(linux_sendfile_bytes.source, MetricSource::Store);
+
+        let ha_replication_lag = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_HA_REPLICATION_LAG_BYTES)
+            .expect("ha replication lag descriptor");
+        assert_eq!(ha_replication_lag.kind, MetricKind::ObservableGauge);
+        assert_eq!(ha_replication_lag.unit, "By");
+        assert_eq!(ha_replication_lag.source, MetricSource::Store);
+        assert!(ha_replication_lag.labels.is_empty());
+
+        let ha_ack_latency = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_HA_ACK_LATENCY_MILLIS)
+            .expect("ha ack latency descriptor");
+        assert_eq!(ha_ack_latency.kind, MetricKind::Histogram);
+        assert_eq!(ha_ack_latency.unit, "ms");
+        assert_eq!(ha_ack_latency.source, MetricSource::Store);
+        assert!(ha_ack_latency.labels.is_empty());
+
+        let linux_mlock_bytes = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MLOCK_BYTES)
+            .expect("linux mlock bytes descriptor");
+        assert_eq!(linux_mlock_bytes.kind, MetricKind::ObservableGauge);
+        assert_eq!(linux_mlock_bytes.unit, "By");
+        assert_eq!(linux_mlock_bytes.source, MetricSource::Store);
+        assert!(linux_mlock_bytes.labels.is_empty());
+
+        let warmup_latency = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS)
+            .expect("linux page-cache warmup descriptor");
+        assert_eq!(warmup_latency.kind, MetricKind::Histogram);
+        assert_eq!(warmup_latency.unit, "ms");
+        assert_eq!(warmup_latency.source, MetricSource::Store);
+        assert!(warmup_latency.labels.is_empty());
+
+        let lease_active = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE)
+            .expect("commitlog segment lease descriptor");
+        assert_eq!(lease_active.kind, MetricKind::ObservableGauge);
+        assert_eq!(lease_active.unit, "{lease}");
+        assert_eq!(lease_active.source, MetricSource::Store);
+        assert!(lease_active.labels.is_empty());
     }
 }

--- a/rocketmq-observability/src/metrics/store.rs
+++ b/rocketmq-observability/src/metrics/store.rs
@@ -18,9 +18,14 @@ pub use crate::semantic::metrics::STORAGE_FLUSH_BEHIND_BYTES;
 pub use crate::semantic::metrics::STORAGE_MESSAGE_RESERVE_TIME;
 pub use crate::semantic::metrics::STORAGE_SIZE;
 pub use crate::semantic::metrics::STORE_APPEND_LATENCY;
+pub use crate::semantic::metrics::STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE;
 pub use crate::semantic::metrics::STORE_DISK_USAGE;
 pub use crate::semantic::metrics::STORE_DISPATCH_LATENCY;
 pub use crate::semantic::metrics::STORE_FLUSH_LATENCY;
+pub use crate::semantic::metrics::STORE_HA_ACK_LATENCY_MILLIS;
+pub use crate::semantic::metrics::STORE_HA_REPLICATION_LAG_BYTES;
+pub use crate::semantic::metrics::STORE_LINUX_MLOCK_BYTES;
+pub use crate::semantic::metrics::STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS;
 pub use crate::semantic::metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_BATCH_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_BYTES_TOTAL;
@@ -184,6 +189,56 @@ pub fn record_linux_sendfile_bytes(bytes: u64) {
     let _ = bytes;
 }
 
+pub fn record_ha_replication_lag_bytes(bytes: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_ha_replication_lag_bytes(bytes, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = bytes;
+}
+
+pub fn record_ha_ack_latency_millis(latency_ms: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_ha_ack_latency_millis(latency_ms, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = latency_ms;
+}
+
+pub fn record_linux_mlock_bytes(bytes: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_mlock_bytes(bytes, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = bytes;
+}
+
+pub fn record_linux_page_cache_warmup_millis(latency_ms: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_page_cache_warmup_millis(latency_ms, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = latency_ms;
+}
+
+pub fn record_commitlog_segment_lease_active(count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_commitlog_segment_lease_active(count, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = count;
+}
+
 #[cfg(not(feature = "otel-metrics"))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StoreMetrics;
@@ -226,6 +281,21 @@ impl StoreMetrics {
 
     #[inline]
     pub fn record_linux_sendfile_bytes_total(&self, _bytes: u64) {}
+
+    #[inline]
+    pub fn record_ha_replication_lag_bytes(&self, _bytes: u64) {}
+
+    #[inline]
+    pub fn record_ha_ack_latency_millis(&self, _latency_ms: u64) {}
+
+    #[inline]
+    pub fn record_linux_mlock_bytes(&self, _bytes: u64) {}
+
+    #[inline]
+    pub fn record_linux_page_cache_warmup_millis(&self, _latency_ms: u64) {}
+
+    #[inline]
+    pub fn record_commitlog_segment_lease_active(&self, _count: u64) {}
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -242,6 +312,11 @@ pub struct StoreMetrics {
     transfer_fallback_total: opentelemetry::metrics::Counter<u64>,
     transfer_partial_write_total: opentelemetry::metrics::Counter<u64>,
     linux_sendfile_bytes_total: opentelemetry::metrics::Counter<u64>,
+    ha_replication_lag_bytes: opentelemetry::metrics::Gauge<u64>,
+    ha_ack_latency_millis: opentelemetry::metrics::Histogram<u64>,
+    linux_mlock_bytes: opentelemetry::metrics::Gauge<u64>,
+    linux_page_cache_warmup_millis: opentelemetry::metrics::Histogram<u64>,
+    commitlog_segment_lease_active: opentelemetry::metrics::Gauge<u64>,
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -313,6 +388,36 @@ impl StoreMetrics {
             .with_unit("By")
             .build();
 
+        let ha_replication_lag_bytes = meter
+            .u64_gauge(STORE_HA_REPLICATION_LAG_BYTES)
+            .with_description("HA replication lag in bytes")
+            .with_unit("By")
+            .build();
+
+        let ha_ack_latency_millis = meter
+            .u64_histogram(STORE_HA_ACK_LATENCY_MILLIS)
+            .with_description("HA replication ack latency")
+            .with_unit("ms")
+            .build();
+
+        let linux_mlock_bytes = meter
+            .u64_gauge(STORE_LINUX_MLOCK_BYTES)
+            .with_description("Current Linux mlock bytes tracked by store")
+            .with_unit("By")
+            .build();
+
+        let linux_page_cache_warmup_millis = meter
+            .u64_histogram(STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS)
+            .with_description("Linux page cache warmup latency")
+            .with_unit("ms")
+            .build();
+
+        let commitlog_segment_lease_active = meter
+            .u64_gauge(STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE)
+            .with_description("Active commitlog segment leases")
+            .with_unit("{lease}")
+            .build();
+
         Self {
             append_latency,
             flush_latency,
@@ -325,6 +430,11 @@ impl StoreMetrics {
             transfer_fallback_total,
             transfer_partial_write_total,
             linux_sendfile_bytes_total,
+            ha_replication_lag_bytes,
+            ha_ack_latency_millis,
+            linux_mlock_bytes,
+            linux_page_cache_warmup_millis,
+            commitlog_segment_lease_active,
         }
     }
 
@@ -439,6 +549,31 @@ impl StoreMetrics {
     pub fn record_linux_sendfile_bytes_total(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
         self.linux_sendfile_bytes_total.add(bytes, attributes);
     }
+
+    #[inline]
+    pub fn record_ha_replication_lag_bytes(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.ha_replication_lag_bytes.record(bytes, attributes);
+    }
+
+    #[inline]
+    pub fn record_ha_ack_latency_millis(&self, latency_ms: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.ha_ack_latency_millis.record(latency_ms, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_mlock_bytes(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_mlock_bytes.record(bytes, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_page_cache_warmup_millis(&self, latency_ms: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_page_cache_warmup_millis.record(latency_ms, attributes);
+    }
+
+    #[inline]
+    pub fn record_commitlog_segment_lease_active(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.commitlog_segment_lease_active.record(count, attributes);
+    }
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -501,6 +636,11 @@ mod tests {
         metrics.record_transfer_fallback_total(1, &transfer_fallback_attributes("io_uring", "vectored", "unsupported"));
         metrics.record_transfer_partial_write_total(2, &[]);
         metrics.record_linux_sendfile_bytes_total(512, &[]);
+        metrics.record_ha_replication_lag_bytes(4096, &[]);
+        metrics.record_ha_ack_latency_millis(12, &[]);
+        metrics.record_linux_mlock_bytes(8192, &[]);
+        metrics.record_linux_page_cache_warmup_millis(20, &[]);
+        metrics.record_commitlog_segment_lease_active(3, &[]);
         record_delay_message_latency(30);
     }
 
@@ -551,5 +691,10 @@ mod helper_tests {
         record_transfer_fallback("io_uring", "vectored", "unsupported", 1);
         record_transfer_partial_write(2);
         record_linux_sendfile_bytes(512);
+        record_ha_replication_lag_bytes(4096);
+        record_ha_ack_latency_millis(12);
+        record_linux_mlock_bytes(8192);
+        record_linux_page_cache_warmup_millis(20);
+        record_commitlog_segment_lease_active(3);
     }
 }

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -50,7 +50,12 @@ pub mod metrics {
     pub const STORE_FLUSH_LATENCY: &str = "rocketmq_store_flush_latency";
     pub const STORE_DISPATCH_LATENCY: &str = "rocketmq_store_dispatch_latency";
     pub const STORE_DISK_USAGE: &str = "rocketmq_store_disk_usage";
+    pub const STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE: &str = "rocketmq_store_commitlog_segment_lease_active";
+    pub const STORE_HA_ACK_LATENCY_MILLIS: &str = "rocketmq_store_ha_ack_latency_millis";
+    pub const STORE_HA_REPLICATION_LAG_BYTES: &str = "rocketmq_store_ha_replication_lag_bytes";
     pub const STORE_LINUX_SENDFILE_BYTES_TOTAL: &str = "rocketmq_store_linux_sendfile_bytes_total";
+    pub const STORE_LINUX_MLOCK_BYTES: &str = "rocketmq_store_linux_mlock_bytes";
+    pub const STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS: &str = "rocketmq_store_linux_page_cache_warmup_millis";
     pub const STORE_TRANSFER_BATCH_TOTAL: &str = "rocketmq_store_transfer_batch_total";
     pub const STORE_TRANSFER_BYTES_TOTAL: &str = "rocketmq_store_transfer_bytes_total";
     pub const STORE_TRANSFER_ENGINE_TOTAL: &str = "rocketmq_store_transfer_engine_total";


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7666

### Brief Description

Add the remaining store runtime observability metric contract in `rocketmq-observability`:

- Define semantic metric names for HA replication lag, HA ack latency, Linux mlock bytes, Linux page-cache warmup latency, and active commitlog segment leases.
- Register the metrics in the catalog with store source and expected gauge or histogram kinds.
- Add store recorder helpers and OpenTelemetry instruments while keeping no-OTEL builds as safe no-ops.

This change only adds observability contract and recorder plumbing. It does not claim throughput, latency, CPU, syscall, PageCache, memory, or zero-copy optimization, so no before/after performance comparison is applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability metrics::catalog::tests::java_metric_catalog_has_required_label_sets` passed.
- `cargo test -p rocketmq-observability metrics::store::helper_tests::ha_transfer_recorders_are_safe_without_explicit_meter` passed.
- `cargo test -p rocketmq-observability --features otel-metrics metrics::store::tests::store_metrics_constructs_and_records` passed.
- `cargo test -p rocketmq-observability` passed.
- `cargo test -p rocketmq-observability --features otel-metrics` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new store metrics for HA replication lag, HA acknowledgment latency, Linux memory lock usage, page-cache warmup time, and commitlog segment lease activity.
  * Exposed recording helpers so these metrics can be tracked when observability is enabled.

* **Tests**
  * Expanded metric coverage to include the new store metrics and validate their expected names, kinds, units, and source labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->