### PR TITLE
[ISSUE #7670]✨Add Linux memory lock observability metrics

### DIFF
--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -111,6 +111,9 @@ const REMOTING_RPC_LABELS: &[&str] = &[
 ];
 const STORE_STORAGE_LABELS: &[&str] = &[labels::STORAGE_TYPE, labels::STORAGE_MEDIUM];
 const STORE_TOPIC_LABELS: &[&str] = &[labels::STORAGE_TYPE, labels::STORAGE_MEDIUM, labels::TOPIC];
+const STORE_MEMORY_LOCK_CATEGORY_LABELS: &[&str] = &[labels::CATEGORY];
+const STORE_MEMORY_LOCK_ERRNO_LABELS: &[&str] = &[labels::CATEGORY, labels::ERRNO];
+const STORE_MEMORY_LOCK_SKIP_LABELS: &[&str] = &[labels::CATEGORY, labels::REASON];
 const STORE_TRANSFER_ENGINE_LABELS: &[&str] = &[labels::ENGINE];
 const STORE_TRANSFER_FALLBACK_LABELS: &[&str] = &[labels::FROM, labels::TO, labels::REASON];
 const TIMER_BOUND_LABELS: &[&str] = &[
@@ -439,6 +442,48 @@ pub const JAVA_METRICS: &[MetricDescriptor] = &[
         kind: MetricKind::ObservableGauge,
         unit: "By",
         labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MLOCK_ATTEMPT_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_MEMORY_LOCK_CATEGORY_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MLOCK_SUCCESS_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_MEMORY_LOCK_CATEGORY_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MLOCK_FAILURE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_MEMORY_LOCK_ERRNO_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MLOCK_SKIPPED_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_MEMORY_LOCK_SKIP_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_LOCKED_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: STORE_MEMORY_LOCK_CATEGORY_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_MUNLOCK_FAILURE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_MEMORY_LOCK_ERRNO_LABELS,
         source: MetricSource::Store,
     },
     MetricDescriptor {
@@ -820,7 +865,13 @@ mod tests {
         "rocketmq_store_ha_ack_latency_millis",
         "rocketmq_store_ha_replication_lag_bytes",
         "rocketmq_store_linux_sendfile_bytes_total",
+        "rocketmq_store_linux_locked_bytes",
+        "rocketmq_store_linux_mlock_attempt_total",
         "rocketmq_store_linux_mlock_bytes",
+        "rocketmq_store_linux_mlock_failure_total",
+        "rocketmq_store_linux_mlock_skipped_total",
+        "rocketmq_store_linux_mlock_success_total",
+        "rocketmq_store_linux_munlock_failure_total",
         "rocketmq_store_linux_page_cache_warmup_millis",
         "rocketmq_store_transfer_batch_total",
         "rocketmq_store_transfer_bytes_total",
@@ -983,5 +1034,50 @@ mod tests {
         assert_eq!(lease_active.unit, "{lease}");
         assert_eq!(lease_active.source, MetricSource::Store);
         assert!(lease_active.labels.is_empty());
+
+        let mlock_attempt = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MLOCK_ATTEMPT_TOTAL)
+            .expect("linux mlock attempt descriptor");
+        assert_eq!(mlock_attempt.kind, MetricKind::Counter);
+        assert_eq!(mlock_attempt.unit, "{operation}");
+        assert_eq!(mlock_attempt.labels, &[labels::CATEGORY]);
+        assert_eq!(mlock_attempt.source, MetricSource::Store);
+
+        let mlock_success = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MLOCK_SUCCESS_TOTAL)
+            .expect("linux mlock success descriptor");
+        assert_eq!(mlock_success.kind, MetricKind::Counter);
+        assert_eq!(mlock_success.labels, &[labels::CATEGORY]);
+
+        let mlock_failure = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MLOCK_FAILURE_TOTAL)
+            .expect("linux mlock failure descriptor");
+        assert_eq!(mlock_failure.kind, MetricKind::Counter);
+        assert_eq!(mlock_failure.labels, &[labels::CATEGORY, labels::ERRNO]);
+
+        let mlock_skipped = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MLOCK_SKIPPED_TOTAL)
+            .expect("linux mlock skipped descriptor");
+        assert_eq!(mlock_skipped.kind, MetricKind::Counter);
+        assert_eq!(mlock_skipped.labels, &[labels::CATEGORY, labels::REASON]);
+
+        let locked_bytes = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_LOCKED_BYTES)
+            .expect("linux locked bytes descriptor");
+        assert_eq!(locked_bytes.kind, MetricKind::ObservableGauge);
+        assert_eq!(locked_bytes.unit, "By");
+        assert_eq!(locked_bytes.labels, &[labels::CATEGORY]);
+
+        let munlock_failure = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_MUNLOCK_FAILURE_TOTAL)
+            .expect("linux munlock failure descriptor");
+        assert_eq!(munlock_failure.kind, MetricKind::Counter);
+        assert_eq!(munlock_failure.labels, &[labels::CATEGORY, labels::ERRNO]);
     }
 }

--- a/rocketmq-observability/src/metrics/store.rs
+++ b/rocketmq-observability/src/metrics/store.rs
@@ -24,7 +24,13 @@ pub use crate::semantic::metrics::STORE_DISPATCH_LATENCY;
 pub use crate::semantic::metrics::STORE_FLUSH_LATENCY;
 pub use crate::semantic::metrics::STORE_HA_ACK_LATENCY_MILLIS;
 pub use crate::semantic::metrics::STORE_HA_REPLICATION_LAG_BYTES;
+pub use crate::semantic::metrics::STORE_LINUX_LOCKED_BYTES;
+pub use crate::semantic::metrics::STORE_LINUX_MLOCK_ATTEMPT_TOTAL;
 pub use crate::semantic::metrics::STORE_LINUX_MLOCK_BYTES;
+pub use crate::semantic::metrics::STORE_LINUX_MLOCK_FAILURE_TOTAL;
+pub use crate::semantic::metrics::STORE_LINUX_MLOCK_SKIPPED_TOTAL;
+pub use crate::semantic::metrics::STORE_LINUX_MLOCK_SUCCESS_TOTAL;
+pub use crate::semantic::metrics::STORE_LINUX_MUNLOCK_FAILURE_TOTAL;
 pub use crate::semantic::metrics::STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS;
 pub use crate::semantic::metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_BATCH_TOTAL;
@@ -219,6 +225,66 @@ pub fn record_linux_mlock_bytes(bytes: u64) {
     let _ = bytes;
 }
 
+pub fn record_linux_mlock_attempt(category: &str, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_mlock_attempt_total(count, &memory_lock_category_attributes(category));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, count);
+}
+
+pub fn record_linux_mlock_success(category: &str, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_mlock_success_total(count, &memory_lock_category_attributes(category));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, count);
+}
+
+pub fn record_linux_mlock_failure(category: &str, errno: i32, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_mlock_failure_total(count, &memory_lock_errno_attributes(category, errno));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, errno, count);
+}
+
+pub fn record_linux_mlock_skipped(category: &str, reason: &str, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_mlock_skipped_total(count, &memory_lock_skip_attributes(category, reason));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, reason, count);
+}
+
+pub fn record_linux_locked_bytes(category: &str, bytes: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_locked_bytes(bytes, &memory_lock_category_attributes(category));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, bytes);
+}
+
+pub fn record_linux_munlock_failure(category: &str, errno: i32, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_munlock_failure_total(count, &memory_lock_errno_attributes(category, errno));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (category, errno, count);
+}
+
 pub fn record_linux_page_cache_warmup_millis(latency_ms: u64) {
     #[cfg(feature = "otel-metrics")]
     if let Some(metrics) = STORE_METRICS.get() {
@@ -292,6 +358,24 @@ impl StoreMetrics {
     pub fn record_linux_mlock_bytes(&self, _bytes: u64) {}
 
     #[inline]
+    pub fn record_linux_mlock_attempt_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_linux_mlock_success_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_linux_mlock_failure_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_linux_mlock_skipped_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_linux_locked_bytes(&self, _bytes: u64) {}
+
+    #[inline]
+    pub fn record_linux_munlock_failure_total(&self, _count: u64) {}
+
+    #[inline]
     pub fn record_linux_page_cache_warmup_millis(&self, _latency_ms: u64) {}
 
     #[inline]
@@ -315,6 +399,12 @@ pub struct StoreMetrics {
     ha_replication_lag_bytes: opentelemetry::metrics::Gauge<u64>,
     ha_ack_latency_millis: opentelemetry::metrics::Histogram<u64>,
     linux_mlock_bytes: opentelemetry::metrics::Gauge<u64>,
+    linux_mlock_attempt_total: opentelemetry::metrics::Counter<u64>,
+    linux_mlock_success_total: opentelemetry::metrics::Counter<u64>,
+    linux_mlock_failure_total: opentelemetry::metrics::Counter<u64>,
+    linux_mlock_skipped_total: opentelemetry::metrics::Counter<u64>,
+    linux_locked_bytes: opentelemetry::metrics::Gauge<u64>,
+    linux_munlock_failure_total: opentelemetry::metrics::Counter<u64>,
     linux_page_cache_warmup_millis: opentelemetry::metrics::Histogram<u64>,
     commitlog_segment_lease_active: opentelemetry::metrics::Gauge<u64>,
 }
@@ -406,6 +496,42 @@ impl StoreMetrics {
             .with_unit("By")
             .build();
 
+        let linux_mlock_attempt_total = meter
+            .u64_counter(STORE_LINUX_MLOCK_ATTEMPT_TOTAL)
+            .with_description("Total Linux mlock attempts by store category")
+            .with_unit("{operation}")
+            .build();
+
+        let linux_mlock_success_total = meter
+            .u64_counter(STORE_LINUX_MLOCK_SUCCESS_TOTAL)
+            .with_description("Total successful Linux mlock operations by store category")
+            .with_unit("{operation}")
+            .build();
+
+        let linux_mlock_failure_total = meter
+            .u64_counter(STORE_LINUX_MLOCK_FAILURE_TOTAL)
+            .with_description("Total failed Linux mlock operations by store category and errno")
+            .with_unit("{operation}")
+            .build();
+
+        let linux_mlock_skipped_total = meter
+            .u64_counter(STORE_LINUX_MLOCK_SKIPPED_TOTAL)
+            .with_description("Total skipped Linux mlock operations by store category and reason")
+            .with_unit("{operation}")
+            .build();
+
+        let linux_locked_bytes = meter
+            .u64_gauge(STORE_LINUX_LOCKED_BYTES)
+            .with_description("Current Linux locked bytes by store category")
+            .with_unit("By")
+            .build();
+
+        let linux_munlock_failure_total = meter
+            .u64_counter(STORE_LINUX_MUNLOCK_FAILURE_TOTAL)
+            .with_description("Total failed Linux munlock operations by store category and errno")
+            .with_unit("{operation}")
+            .build();
+
         let linux_page_cache_warmup_millis = meter
             .u64_histogram(STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS)
             .with_description("Linux page cache warmup latency")
@@ -433,6 +559,12 @@ impl StoreMetrics {
             ha_replication_lag_bytes,
             ha_ack_latency_millis,
             linux_mlock_bytes,
+            linux_mlock_attempt_total,
+            linux_mlock_success_total,
+            linux_mlock_failure_total,
+            linux_mlock_skipped_total,
+            linux_locked_bytes,
+            linux_munlock_failure_total,
             linux_page_cache_warmup_millis,
             commitlog_segment_lease_active,
         }
@@ -566,6 +698,36 @@ impl StoreMetrics {
     }
 
     #[inline]
+    pub fn record_linux_mlock_attempt_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_mlock_attempt_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_mlock_success_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_mlock_success_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_mlock_failure_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_mlock_failure_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_mlock_skipped_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_mlock_skipped_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_locked_bytes(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_locked_bytes.record(bytes, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_munlock_failure_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_munlock_failure_total.add(count, attributes);
+    }
+
+    #[inline]
     pub fn record_linux_page_cache_warmup_millis(&self, latency_ms: u64, attributes: &[opentelemetry::KeyValue]) {
         self.linux_page_cache_warmup_millis.record(latency_ms, attributes);
     }
@@ -611,6 +773,30 @@ fn transfer_fallback_attributes(from: &str, to: &str, reason: &str) -> [opentele
     ]
 }
 
+#[cfg(feature = "otel-metrics")]
+fn memory_lock_category_attributes(category: &str) -> [opentelemetry::KeyValue; 1] {
+    [opentelemetry::KeyValue::new(
+        crate::semantic::labels::CATEGORY,
+        category.to_owned(),
+    )]
+}
+
+#[cfg(feature = "otel-metrics")]
+fn memory_lock_errno_attributes(category: &str, errno: i32) -> [opentelemetry::KeyValue; 2] {
+    [
+        opentelemetry::KeyValue::new(crate::semantic::labels::CATEGORY, category.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::ERRNO, errno as i64),
+    ]
+}
+
+#[cfg(feature = "otel-metrics")]
+fn memory_lock_skip_attributes(category: &str, reason: &str) -> [opentelemetry::KeyValue; 2] {
+    [
+        opentelemetry::KeyValue::new(crate::semantic::labels::CATEGORY, category.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::REASON, reason.to_owned()),
+    ]
+}
+
 #[cfg(all(test, feature = "otel-metrics"))]
 mod tests {
     use opentelemetry::metrics::MeterProvider;
@@ -641,6 +827,15 @@ mod tests {
         metrics.record_linux_mlock_bytes(8192, &[]);
         metrics.record_linux_page_cache_warmup_millis(20, &[]);
         metrics.record_commitlog_segment_lease_active(3, &[]);
+        metrics.record_linux_mlock_attempt_total(1, &memory_lock_category_attributes("transient_store_pool"));
+        metrics.record_linux_mlock_success_total(1, &memory_lock_category_attributes("transient_store_pool"));
+        metrics.record_linux_mlock_failure_total(1, &memory_lock_errno_attributes("commitlog_active_file", 12));
+        metrics.record_linux_mlock_skipped_total(
+            1,
+            &memory_lock_skip_attributes("commitlog_active_window", "budget_exhausted"),
+        );
+        metrics.record_linux_locked_bytes(8192, &memory_lock_category_attributes("transient_store_pool"));
+        metrics.record_linux_munlock_failure_total(1, &memory_lock_errno_attributes("transient_store_pool", 22));
         record_delay_message_latency(30);
     }
 
@@ -696,5 +891,11 @@ mod helper_tests {
         record_linux_mlock_bytes(8192);
         record_linux_page_cache_warmup_millis(20);
         record_commitlog_segment_lease_active(3);
+        record_linux_mlock_attempt("transient_store_pool", 1);
+        record_linux_mlock_success("transient_store_pool", 1);
+        record_linux_mlock_failure("commitlog_active_file", 12, 1);
+        record_linux_mlock_skipped("commitlog_active_window", "budget_exhausted", 1);
+        record_linux_locked_bytes("transient_store_pool", 8192);
+        record_linux_munlock_failure("transient_store_pool", 22, 1);
     }
 }

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -55,6 +55,12 @@ pub mod metrics {
     pub const STORE_HA_REPLICATION_LAG_BYTES: &str = "rocketmq_store_ha_replication_lag_bytes";
     pub const STORE_LINUX_SENDFILE_BYTES_TOTAL: &str = "rocketmq_store_linux_sendfile_bytes_total";
     pub const STORE_LINUX_MLOCK_BYTES: &str = "rocketmq_store_linux_mlock_bytes";
+    pub const STORE_LINUX_MLOCK_ATTEMPT_TOTAL: &str = "rocketmq_store_linux_mlock_attempt_total";
+    pub const STORE_LINUX_MLOCK_SUCCESS_TOTAL: &str = "rocketmq_store_linux_mlock_success_total";
+    pub const STORE_LINUX_MLOCK_FAILURE_TOTAL: &str = "rocketmq_store_linux_mlock_failure_total";
+    pub const STORE_LINUX_MLOCK_SKIPPED_TOTAL: &str = "rocketmq_store_linux_mlock_skipped_total";
+    pub const STORE_LINUX_LOCKED_BYTES: &str = "rocketmq_store_linux_locked_bytes";
+    pub const STORE_LINUX_MUNLOCK_FAILURE_TOTAL: &str = "rocketmq_store_linux_munlock_failure_total";
     pub const STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS: &str = "rocketmq_store_linux_page_cache_warmup_millis";
     pub const STORE_TRANSFER_BATCH_TOTAL: &str = "rocketmq_store_transfer_batch_total";
     pub const STORE_TRANSFER_BYTES_TOTAL: &str = "rocketmq_store_transfer_bytes_total";
@@ -155,6 +161,8 @@ pub mod labels {
     pub const STORAGE_TYPE: &str = "storage_type";
     pub const STORAGE_MEDIUM: &str = "storage_medium";
     pub const TYPE: &str = "type";
+    pub const CATEGORY: &str = "category";
+    pub const ERRNO: &str = "errno";
     pub const ENGINE: &str = "engine";
     pub const FROM: &str = "from";
     pub const TO: &str = "to";


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7670

### Brief Description

- Adds Linux memory-lock metric constants, Java-compatible catalog descriptors, and store recorders for mlock attempts, successes, failures, skips, locked bytes, and munlock failures.
- Keeps the existing coarse `rocketmq_store_linux_mlock_bytes` metric and adds the category-labeled `rocketmq_store_linux_locked_bytes` view required by the design.
- This is an observability contract change only. It does not claim runtime performance improvement, so no before/after performance comparison is applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability metrics::catalog::tests::java_metric_catalog_has_required_label_sets` -> passed
- `cargo test -p rocketmq-observability metrics::store::helper_tests::ha_transfer_recorders_are_safe_without_explicit_meter` -> passed
- `cargo test -p rocketmq-observability --features otel-metrics metrics::store::tests::store_metrics_constructs_and_records` -> passed
- `cargo test -p rocketmq-observability` -> passed, 60 unit tests, 2 architecture guard tests
- `cargo test -p rocketmq-observability --features otel-metrics` -> passed, 113 unit tests, 2 architecture guard tests, 1 ignored doc test
- `cargo fmt --all --check` -> passed
- `git diff --check` -> passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new store metrics for Linux memory lock and unlock activity, including attempts, successes, failures, skipped operations, and locked bytes.
  * Added support for recording these metrics with category, reason, and error-code labels.

* **Bug Fixes**
  * Expanded metric coverage so Linux memory-lock related activity is now visible in observability data.

* **Tests**
  * Updated metric validation and recording tests to cover the new store metrics and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->