### PR TITLE
[ISSUE #7672]✨Wire memory lock observability recorders

### DIFF
--- a/rocketmq-store/src/base/memory_lock_manager.rs
+++ b/rocketmq-store/src/base/memory_lock_manager.rs
@@ -21,6 +21,13 @@ use tracing::warn;
 
 use crate::utils::ffi::mlock;
 
+#[cfg(any(test, feature = "observability"))]
+const TRANSIENT_STORE_POOL_CATEGORY: &str = "transient_store_pool";
+#[cfg(any(test, feature = "observability"))]
+const MEMORY_LOCK_BUDGET_EXHAUSTED_REASON: &str = "budget_exhausted";
+#[cfg(any(test, feature = "observability"))]
+const MEMORY_LOCK_UNKNOWN_ERRNO: i32 = 0;
+
 #[derive(Debug)]
 pub struct MemoryLockManager {
     warn_only: bool,
@@ -62,10 +69,13 @@ impl MemoryLockManager {
         F: FnMut(*const u8, usize) -> RocketMQResult<()>,
     {
         self.lock_attempts.fetch_add(1, Ordering::Relaxed);
+        emit_memory_lock_attempt_observability();
+
         let len_bytes = len as u64;
         if !self.reserve_lock_budget(len_bytes) {
             self.lock_skipped_buffers.fetch_add(1, Ordering::Relaxed);
             self.lock_skipped_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+            emit_memory_lock_skip_observability(self.locked_bytes.load(Ordering::Relaxed));
             if self.warn_only {
                 warn!(
                     "Skipped memory lock of {} bytes because lock budget {} bytes is exhausted",
@@ -89,12 +99,14 @@ impl MemoryLockManager {
                 if self.budget_bytes.load(Ordering::Relaxed) == 0 {
                     self.locked_bytes.fetch_add(len_bytes, Ordering::Relaxed);
                 }
+                emit_memory_lock_success_observability(self.locked_bytes.load(Ordering::Relaxed));
                 Ok(())
             }
             Err(error) => {
                 self.release_reserved_budget(len_bytes);
                 self.lock_failed_buffers.fetch_add(1, Ordering::Relaxed);
                 self.lock_failed_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+                emit_memory_lock_failure_observability(self.locked_bytes.load(Ordering::Relaxed));
                 if self.warn_only {
                     warn!(
                         "Failed to lock memory buffer of {} bytes, continuing without mlock: {}",
@@ -166,6 +178,120 @@ impl MemoryLockManager {
     }
 }
 
+#[cfg(any(test, feature = "observability"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryLockAttemptObservabilityEvent {
+    category: &'static str,
+    count: u64,
+}
+
+#[cfg(any(test, feature = "observability"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryLockSuccessObservabilityEvent {
+    category: &'static str,
+    count: u64,
+    locked_bytes: u64,
+}
+
+#[cfg(any(test, feature = "observability"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryLockSkipObservabilityEvent {
+    category: &'static str,
+    reason: &'static str,
+    count: u64,
+    locked_bytes: u64,
+}
+
+#[cfg(any(test, feature = "observability"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryLockFailureObservabilityEvent {
+    category: &'static str,
+    errno: i32,
+    count: u64,
+    locked_bytes: u64,
+}
+
+#[cfg(any(test, feature = "observability"))]
+fn memory_lock_attempt_observability_event() -> MemoryLockAttemptObservabilityEvent {
+    MemoryLockAttemptObservabilityEvent {
+        category: TRANSIENT_STORE_POOL_CATEGORY,
+        count: 1,
+    }
+}
+
+#[cfg(any(test, feature = "observability"))]
+fn memory_lock_success_observability_event(locked_bytes: u64) -> MemoryLockSuccessObservabilityEvent {
+    MemoryLockSuccessObservabilityEvent {
+        category: TRANSIENT_STORE_POOL_CATEGORY,
+        count: 1,
+        locked_bytes,
+    }
+}
+
+#[cfg(any(test, feature = "observability"))]
+fn memory_lock_skip_observability_event(locked_bytes: u64) -> MemoryLockSkipObservabilityEvent {
+    MemoryLockSkipObservabilityEvent {
+        category: TRANSIENT_STORE_POOL_CATEGORY,
+        reason: MEMORY_LOCK_BUDGET_EXHAUSTED_REASON,
+        count: 1,
+        locked_bytes,
+    }
+}
+
+#[cfg(any(test, feature = "observability"))]
+fn memory_lock_failure_observability_event(locked_bytes: u64) -> MemoryLockFailureObservabilityEvent {
+    MemoryLockFailureObservabilityEvent {
+        category: TRANSIENT_STORE_POOL_CATEGORY,
+        errno: MEMORY_LOCK_UNKNOWN_ERRNO,
+        count: 1,
+        locked_bytes,
+    }
+}
+
+fn emit_memory_lock_attempt_observability() {
+    #[cfg(feature = "observability")]
+    {
+        let event = memory_lock_attempt_observability_event();
+        rocketmq_observability::metrics::store::record_linux_mlock_attempt(event.category, event.count);
+    }
+}
+
+fn emit_memory_lock_success_observability(locked_bytes: u64) {
+    #[cfg(feature = "observability")]
+    {
+        let event = memory_lock_success_observability_event(locked_bytes);
+        rocketmq_observability::metrics::store::record_linux_mlock_success(event.category, event.count);
+        rocketmq_observability::metrics::store::record_linux_locked_bytes(event.category, event.locked_bytes);
+    }
+
+    #[cfg(not(feature = "observability"))]
+    let _ = locked_bytes;
+}
+
+fn emit_memory_lock_skip_observability(locked_bytes: u64) {
+    #[cfg(feature = "observability")]
+    {
+        let event = memory_lock_skip_observability_event(locked_bytes);
+        rocketmq_observability::metrics::store::record_linux_mlock_skipped(event.category, event.reason, event.count);
+        rocketmq_observability::metrics::store::record_linux_locked_bytes(event.category, event.locked_bytes);
+    }
+
+    #[cfg(not(feature = "observability"))]
+    let _ = locked_bytes;
+}
+
+fn emit_memory_lock_failure_observability(locked_bytes: u64) {
+    #[cfg(feature = "observability")]
+    {
+        let event = memory_lock_failure_observability_event(locked_bytes);
+        rocketmq_observability::metrics::store::record_linux_mlock_failure(event.category, event.errno, event.count);
+        rocketmq_observability::metrics::store::record_linux_locked_bytes(event.category, event.locked_bytes);
+    }
+
+    #[cfg(not(feature = "observability"))]
+    let _ = locked_bytes;
+}
+
 impl Default for MemoryLockManager {
     fn default() -> Self {
         Self::warn_only()
@@ -210,5 +336,34 @@ mod tests {
         assert_eq!(manager.lock_skipped_buffer_count(), 1);
         assert_eq!(manager.lock_skipped_bytes(), 8192);
         assert_eq!(manager.locked_bytes(), 0);
+    }
+
+    #[test]
+    fn memory_lock_success_observability_event_uses_transient_pool_category() {
+        let event = memory_lock_success_observability_event(4096);
+
+        assert_eq!(event.category, TRANSIENT_STORE_POOL_CATEGORY);
+        assert_eq!(event.count, 1);
+        assert_eq!(event.locked_bytes, 4096);
+    }
+
+    #[test]
+    fn memory_lock_skip_observability_event_uses_budget_reason() {
+        let event = memory_lock_skip_observability_event(2048);
+
+        assert_eq!(event.category, TRANSIENT_STORE_POOL_CATEGORY);
+        assert_eq!(event.reason, MEMORY_LOCK_BUDGET_EXHAUSTED_REASON);
+        assert_eq!(event.count, 1);
+        assert_eq!(event.locked_bytes, 2048);
+    }
+
+    #[test]
+    fn memory_lock_failure_observability_event_uses_unknown_errno_until_syscall_exposes_it() {
+        let event = memory_lock_failure_observability_event(1024);
+
+        assert_eq!(event.category, TRANSIENT_STORE_POOL_CATEGORY);
+        assert_eq!(event.errno, MEMORY_LOCK_UNKNOWN_ERRNO);
+        assert_eq!(event.count, 1);
+        assert_eq!(event.locked_bytes, 1024);
     }
 }

--- a/rocketmq-store/src/base/transient_store_pool.rs
+++ b/rocketmq-store/src/base/transient_store_pool.rs
@@ -20,6 +20,7 @@ use rocketmq_error::RocketMQResult;
 use tracing::warn;
 
 use crate::base::memory_lock_manager::MemoryLockManager;
+use crate::utils::ffi::mlock;
 use crate::utils::ffi::munlock;
 
 #[derive(Clone)]
@@ -45,8 +46,7 @@ impl TransientStorePool {
     }
 
     pub fn init(&self) -> RocketMQResult<()> {
-        let memory_lock_manager = self.memory_lock_manager.clone();
-        self.init_with_locker(|addr, len| memory_lock_manager.lock_buffer(addr, len))
+        self.init_with_locker(mlock)
     }
 
     pub(crate) fn init_with_locker<F>(&self, mut locker: F) -> RocketMQResult<()>
@@ -149,5 +149,16 @@ mod tests {
         assert_eq!(pool.available_buffer_nums(), 2);
         assert_eq!(pool.locked_buffer_count(), 0);
         assert_eq!(pool.lock_failed_buffer_count(), 2);
+    }
+
+    #[test]
+    fn init_records_one_lock_attempt_per_buffer() {
+        let pool = TransientStorePool::new(1, 1);
+
+        let result = pool.init();
+
+        assert!(result.is_ok());
+        assert_eq!(pool.lock_attempt_count(), 1);
+        let _ = pool.destroy();
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7672

### Brief Description

- Wires `MemoryLockManager` lock outcomes to the store observability recorders for transient store pool mlock attempts, successes, failures, skips, and current locked bytes.
- Keeps the recorder calls gated by the `observability` feature, so default builds keep the existing no-op behavior.
- Fixes `TransientStorePool::init` so each buffer goes through `MemoryLockManager` once instead of nesting manager calls and double-counting lock attempts.
- Failed mlock errno is reported as `0` until the storage FFI error type exposes structured errno.
- This is observability and accounting wiring only. It does not claim runtime performance improvement, so no before/after performance comparison is applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-store base::memory_lock_manager` -> passed
- `cargo test -p rocketmq-store --features observability base::memory_lock_manager` -> passed
- `cargo test -p rocketmq-store base::transient_store_pool` -> passed
- `cargo test -p rocketmq-store --lib` -> passed, 520 tests
- `cargo test -p rocketmq-store --features observability --lib` -> passed, 520 tests
- `cargo fmt --all --check` -> passed
- `git diff --check` -> passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer locking behavior during store initialization and lock attempts.
  * Added clearer handling for lock skips and failures, including better internal tracking when memory locking cannot be completed.

* **Tests**
  * Expanded test coverage for lock attempts and observability-related event reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->