### PR TITLE
[ISSUE #7674]✨Apply Linux memory lock budget

### DIFF
--- a/rocketmq-store/src/base/transient_store_pool.rs
+++ b/rocketmq-store/src/base/transient_store_pool.rs
@@ -34,6 +34,10 @@ pub struct TransientStorePool {
 
 impl TransientStorePool {
     pub fn new(pool_size: usize, file_size: usize) -> Self {
+        Self::new_with_memory_lock_budget(pool_size, file_size, 0)
+    }
+
+    pub fn new_with_memory_lock_budget(pool_size: usize, file_size: usize, memory_lock_budget_bytes: u64) -> Self {
         let available_buffers = Arc::new(Mutex::new(VecDeque::with_capacity(pool_size)));
         let is_real_commit = Arc::new(Mutex::new(true));
         TransientStorePool {
@@ -41,7 +45,7 @@ impl TransientStorePool {
             file_size,
             available_buffers,
             is_real_commit,
-            memory_lock_manager: Arc::new(MemoryLockManager::warn_only()),
+            memory_lock_manager: Arc::new(MemoryLockManager::warn_only_with_budget(memory_lock_budget_bytes)),
         }
     }
 
@@ -160,5 +164,19 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(pool.lock_attempt_count(), 1);
         let _ = pool.destroy();
+    }
+
+    #[test]
+    fn init_applies_configured_memory_lock_budget() {
+        let pool = TransientStorePool::new_with_memory_lock_budget(2, 4096, 4096);
+
+        let result = pool.init_with_locker(|_, _| Ok(()));
+
+        assert!(result.is_ok());
+        assert_eq!(pool.lock_attempt_count(), 2);
+        assert_eq!(pool.locked_buffer_count(), 1);
+        assert_eq!(pool.lock_skipped_buffer_count(), 1);
+        assert_eq!(pool.locked_bytes(), 4096);
+        assert_eq!(pool.lock_skipped_bytes(), 4096);
     }
 }

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -1366,6 +1366,17 @@ impl MessageStoreConfig {
         self.linux_storage_profile.settings()
     }
 
+    pub fn effective_linux_memory_lock_budget_bytes(&self, memory_lock_limit_bytes: Option<u64>) -> u64 {
+        if self.linux_memory_lock_budget_bytes > 0 {
+            return self.linux_memory_lock_budget_bytes as u64;
+        }
+
+        match memory_lock_limit_bytes {
+            Some(limit) if limit > 0 && limit != u64::MAX => limit.saturating_sub(limit / 5),
+            _ => 0,
+        }
+    }
+
     pub fn get_store_path_commit_log(&self) -> String {
         if self.store_path_commit_log.is_none() {
             return PathBuf::from(self.store_path_root_dir.to_string())
@@ -2192,6 +2203,32 @@ mod tests {
         assert_eq!(settings.transfer_engine, LinuxTransferEngine::Sendfile);
         assert!(settings.ha_sendfile_enable);
         Ok(())
+    }
+
+    #[test]
+    fn explicit_linux_memory_lock_budget_wins_over_platform_limit() {
+        let config = MessageStoreConfig {
+            linux_memory_lock_budget_bytes: 4096,
+            ..Default::default()
+        };
+
+        assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(8192)), 4096);
+    }
+
+    #[test]
+    fn zero_linux_memory_lock_budget_derives_conservative_finite_platform_limit() {
+        let config = MessageStoreConfig::default();
+
+        assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(10_000)), 8_000);
+    }
+
+    #[test]
+    fn zero_linux_memory_lock_budget_keeps_unbounded_when_limit_is_unknown_zero_or_unlimited() {
+        let config = MessageStoreConfig::default();
+
+        assert_eq!(config.effective_linux_memory_lock_budget_bytes(None), 0);
+        assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(0)), 0);
+        assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(u64::MAX)), 0);
     }
 
     #[cfg(not(feature = "tieredstore"))]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -470,9 +470,13 @@ impl LocalFileMessageStore {
             dispatcher_vec: vec![build_consume_queue, build_index],
         });
 
-        let transient_store_pool = TransientStorePool::new(
+        let memory_lock_budget_bytes = message_store_config.effective_linux_memory_lock_budget_bytes(
+            crate::platform::current_store_platform_capability().memory_lock_limit_bytes,
+        );
+        let transient_store_pool = TransientStorePool::new_with_memory_lock_budget(
             message_store_config.transient_store_pool_size,
             message_store_config.mapped_file_size_commit_log,
+            memory_lock_budget_bytes,
         );
         let transient_store_pool_enable = message_store_config.transient_store_pool_enable
             && (broker_config.enable_controller_mode || message_store_config.broker_role != BrokerRole::Slave);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7674

### Brief Description

- Adds `MessageStoreConfig::effective_linux_memory_lock_budget_bytes` so explicit `linux_memory_lock_budget_bytes` wins and a zero config can derive a conservative budget from finite `RLIMIT_MEMLOCK`.
- Adds `TransientStorePool::new_with_memory_lock_budget` and wires `LocalFileMessageStore` construction to pass the effective budget into `MemoryLockManager`.
- Keeps unknown, zero, or unlimited platform memory-lock limits as budget `0`, preserving the existing unbounded warn-only behavior when no safe finite limit is available.
- This is configuration and accounting semantics only. It does not claim runtime performance improvement, so no before/after performance comparison is applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-store linux_memory_lock_budget` -> passed
- `cargo test -p rocketmq-store base::transient_store_pool::tests::init_applies_configured_memory_lock_budget` -> passed
- `cargo test -p rocketmq-store --lib` -> passed, 524 tests
- `cargo fmt --all --check` -> passed
- `git diff --check` -> passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of memory-lock limits during store startup, using configured and platform-reported limits to choose a safer effective budget.
  * Added support for budget-aware memory locking behavior when initializing the store pool.

* **Bug Fixes**
  * Store initialization now better respects Linux memory-lock constraints, reducing the chance of over-allocating lockable memory.
  * Added coverage to verify expected locking behavior across configured, limited, and unknown budget scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->