### PR TITLE
[ISSUE #7680]🧪Cover mapped file warmup position stability

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -1780,6 +1780,25 @@ mod tests {
     }
 
     #[test]
+    fn warm_mapped_file_preserves_write_commit_and_flush_positions() {
+        let (_temp_dir, mapped_file) = create_test_file();
+        assert!(mapped_file.append_message_bytes(b"warm-position"));
+        let wrote_position = mapped_file.get_wrote_position();
+        let committed_position = mapped_file.get_committed_position();
+        let flushed_position = mapped_file.get_flushed_position();
+
+        mapped_file.warm_mapped_file(FlushDiskType::AsyncFlush, 1);
+        mapped_file.warm_mapped_file(FlushDiskType::SyncFlush, 1);
+
+        assert_eq!(mapped_file.get_wrote_position(), wrote_position);
+        assert_eq!(mapped_file.get_committed_position(), committed_position);
+        assert_eq!(mapped_file.get_flushed_position(), flushed_position);
+        let metrics = mapped_file.get_metrics().unwrap();
+        assert_eq!(metrics.warm_operations(), 2);
+        assert_eq!(metrics.warm_bytes(), mapped_file.get_file_size() * 2);
+    }
+
+    #[test]
     fn is_loaded_rejects_invalid_ranges() {
         let (_temp_dir, mapped_file) = create_test_file();
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7680

### Brief Description

- Adds a mapped-file regression test proving `warm_mapped_file` does not advance wrote, committed, or flushed positions.
- Covers both async and sync warmup paths while preserving the existing warm metrics expectations.
- This is test coverage for an existing safety invariant. It does not claim runtime performance improvement, so before/after throughput, latency, CPU, syscall, or memory benchmark comparison is not applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-store log_file::mapped_file::default_mapped_file_impl::tests::warm_mapped_file_preserves_write_commit_and_flush_positions` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo test -p rocketmq-store --lib` passed: 527 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
