### PR TITLE
[ISSUE #7682]✨Record mapped file warmup latency

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -863,6 +864,7 @@ impl MappedFile for DefaultMappedFile {
             return;
         }
 
+        let warmup_started = Instant::now();
         let flush_every_pages = pages.max(1);
         let mut last_flush_offset = 0usize;
         {
@@ -909,8 +911,11 @@ impl MappedFile for DefaultMappedFile {
                 self.file_name
             );
         }
+        let warmup_duration = warmup_started.elapsed();
+        let warmup_millis = u64::try_from(warmup_duration.as_millis()).unwrap_or(u64::MAX);
+        rocketmq_observability::metrics::store::record_linux_page_cache_warmup_millis(warmup_millis);
         if let Some(metrics) = &self.metrics {
-            metrics.record_warm(file_size);
+            metrics.record_warm_with_latency(file_size, warmup_duration);
         }
     }
 

--- a/rocketmq-store/src/log_file/mapped_file/metrics.rs
+++ b/rocketmq-store/src/log_file/mapped_file/metrics.rs
@@ -80,6 +80,12 @@ pub struct MappedFileMetrics {
     /// Total bytes touched by warm-up operations.
     warm_bytes: AtomicU64,
 
+    /// Cumulative mapped file warm-up time in milliseconds.
+    total_warm_time_ms: AtomicU64,
+
+    /// Duration of the most recent mapped file warm-up in milliseconds.
+    last_warm_time_ms: AtomicU64,
+
     /// Number of mapped file swap decisions.
     swap_operations: AtomicU64,
 
@@ -117,6 +123,8 @@ impl MappedFileMetrics {
             cache_misses: AtomicU64::new(0),
             warm_operations: AtomicU64::new(0),
             warm_bytes: AtomicU64::new(0),
+            total_warm_time_ms: AtomicU64::new(0),
+            last_warm_time_ms: AtomicU64::new(0),
             swap_operations: AtomicU64::new(0),
             clean_swap_operations: AtomicU64::new(0),
             start_time: Instant::now(),
@@ -185,6 +193,19 @@ impl MappedFileMetrics {
         self.warm_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
     }
 
+    /// Records a mapped file warm-up operation with elapsed duration.
+    #[inline]
+    pub fn record_warm_with_latency(&self, bytes: usize, duration: Duration) {
+        self.record_warm(bytes);
+        let millis = duration_to_millis(duration);
+        let _ = self
+            .total_warm_time_ms
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_add(millis))
+            });
+        self.last_warm_time_ms.store(millis, Ordering::Relaxed);
+    }
+
     /// Records a mapped file swap decision.
     #[inline]
     pub fn record_swap(&self) {
@@ -249,6 +270,18 @@ impl MappedFileMetrics {
     #[inline]
     pub fn warm_bytes(&self) -> u64 {
         self.warm_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Returns total time spent in warm-up operations, in milliseconds.
+    #[inline]
+    pub fn total_warm_millis(&self) -> u64 {
+        self.total_warm_time_ms.load(Ordering::Relaxed)
+    }
+
+    /// Returns the most recent warm-up duration, in milliseconds.
+    #[inline]
+    pub fn last_warm_millis(&self) -> u64 {
+        self.last_warm_time_ms.load(Ordering::Relaxed)
     }
 
     /// Returns total swap decisions.
@@ -376,6 +409,8 @@ impl MappedFileMetrics {
         self.cache_misses.store(0, Ordering::Relaxed);
         self.warm_operations.store(0, Ordering::Relaxed);
         self.warm_bytes.store(0, Ordering::Relaxed);
+        self.total_warm_time_ms.store(0, Ordering::Relaxed);
+        self.last_warm_time_ms.store(0, Ordering::Relaxed);
         self.swap_operations.store(0, Ordering::Relaxed);
         self.clean_swap_operations.store(0, Ordering::Relaxed);
         self.start_time = Instant::now();
@@ -389,8 +424,8 @@ impl MappedFileMetrics {
     pub fn summary(&self) -> String {
         format!(
             "MappedFile Metrics:\nWrites: {} ({:.2} writes/sec, {:.2} MB/s)\nReads: {} ({:.1}% zero-copy)\nFlushes: \
-             {} (avg: {:?})\nCache Hit Rate: {:.1}%\nAvg Write Size: {:.1} bytes\nWarm: {} ops, {} bytes\nSwap: {} \
-             ops, clean: {} ops",
+             {} (avg: {:?})\nCache Hit Rate: {:.1}%\nAvg Write Size: {:.1} bytes\nWarm: {} ops, {} bytes, total {} \
+             ms, last {} ms\nSwap: {} ops, clean: {} ops",
             self.total_writes(),
             self.writes_per_sec(),
             self.write_throughput_mb_per_sec(),
@@ -402,10 +437,16 @@ impl MappedFileMetrics {
             self.avg_write_size(),
             self.warm_operations(),
             self.warm_bytes(),
+            self.total_warm_millis(),
+            self.last_warm_millis(),
             self.swap_operations(),
             self.clean_swap_operations()
         )
     }
+}
+
+fn duration_to_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -462,15 +503,19 @@ mod tests {
     fn test_warm_and_swap_metrics() {
         let metrics = MappedFileMetrics::new();
 
-        metrics.record_warm(4096);
+        metrics.record_warm_with_latency(4096, Duration::from_millis(7));
         metrics.record_swap();
         metrics.record_clean_swap();
 
         assert_eq!(metrics.warm_operations(), 1);
         assert_eq!(metrics.warm_bytes(), 4096);
+        assert_eq!(metrics.total_warm_millis(), 7);
+        assert_eq!(metrics.last_warm_millis(), 7);
         assert_eq!(metrics.swap_operations(), 1);
         assert_eq!(metrics.clean_swap_operations(), 1);
-        assert!(metrics.summary().contains("Warm: 1 ops, 4096 bytes"));
+        assert!(metrics
+            .summary()
+            .contains("Warm: 1 ops, 4096 bytes, total 7 ms, last 7 ms"));
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7682

### Brief Description

- Measures elapsed time in `DefaultMappedFile::warm_mapped_file` and records it through the existing Linux page-cache warmup histogram.
- Extends mapped-file local metrics with total and last warmup milliseconds.
- Updates warmup metrics tests to assert latency accounting in addition to operation count and bytes.
- This is observability for an existing operation, not a runtime performance optimization. It does not claim throughput, latency, CPU, syscall, or memory improvement, so before/after performance comparison is not applicable.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store log_file::mapped_file::metrics::tests::test_warm_and_swap_metrics` failed before implementation because warmup latency APIs did not exist.
- GREEN: `cargo test -p rocketmq-store log_file::mapped_file::metrics::tests::test_warm_and_swap_metrics` passed after implementation.
- `cargo test -p rocketmq-store log_file::mapped_file::default_mapped_file_impl::tests::warm_mapped_file_preserves_write_commit_and_flush_positions` passed.
- `cargo test -p rocketmq-store log_file::mapped_file::default_mapped_file_impl::tests::warm_and_clean_swap_are_reflected_in_metrics` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo test -p rocketmq-store --lib` passed: 527 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
