### PR TITLE
[ISSUE #7684]✨Expose mapped file warmup runtime info

### DIFF
--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -55,6 +55,14 @@ pub struct MappedFileQueue {
     commit_lock: Arc<Mutex<()>>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MappedFileWarmupStats {
+    pub operations: u64,
+    pub bytes: u64,
+    pub total_millis: u64,
+    pub last_millis: u64,
+}
+
 impl Default for MappedFileQueue {
     fn default() -> Self {
         Self {
@@ -352,6 +360,25 @@ impl MappedFileQueue {
     #[inline]
     pub fn get_mapped_files_size(&self) -> usize {
         self.mapped_files.load().len()
+    }
+
+    pub fn warmup_stats(&self) -> MappedFileWarmupStats {
+        let mapped_files = self.mapped_files.load();
+        let mut stats = MappedFileWarmupStats::default();
+        for mapped_file in mapped_files.iter() {
+            let Some(metrics) = mapped_file.get_metrics() else {
+                continue;
+            };
+            let operations = metrics.warm_operations();
+            if operations == 0 {
+                continue;
+            }
+            stats.operations = stats.operations.saturating_add(operations);
+            stats.bytes = stats.bytes.saturating_add(metrics.warm_bytes());
+            stats.total_millis = stats.total_millis.saturating_add(metrics.total_warm_millis());
+            stats.last_millis = metrics.last_warm_millis();
+        }
+        stats
     }
 
     #[inline]
@@ -1308,6 +1335,47 @@ mod tests {
         };
         assert!(queue.load());
         assert_eq!(queue.mapped_files.load().len(), 1);
+    }
+
+    #[test]
+    fn warmup_stats_aggregates_mapped_file_metrics() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let first_path = temp_dir.path().join(offset_to_file_name(0));
+        let second_path = temp_dir.path().join(offset_to_file_name(1024));
+        let first_file = Arc::new(
+            DefaultMappedFile::try_new(
+                CheetahString::from_string(first_path.to_string_lossy().to_string()),
+                1024,
+            )
+            .expect("first mapped file"),
+        );
+        let second_file = Arc::new(
+            DefaultMappedFile::try_new(
+                CheetahString::from_string(second_path.to_string_lossy().to_string()),
+                1024,
+            )
+            .expect("second mapped file"),
+        );
+        first_file
+            .get_metrics()
+            .unwrap()
+            .record_warm_with_latency(1024, std::time::Duration::from_millis(4));
+        second_file
+            .get_metrics()
+            .unwrap()
+            .record_warm_with_latency(2048, std::time::Duration::from_millis(5));
+
+        let queue = MappedFileQueue {
+            mapped_file_size: 1024,
+            mapped_files: ArcSwap::from_pointee(vec![first_file, second_file]),
+            ..MappedFileQueue::default()
+        };
+
+        let stats = queue.warmup_stats();
+        assert_eq!(stats.operations, 2);
+        assert_eq!(stats.bytes, 3072);
+        assert_eq!(stats.total_millis, 9);
+        assert_eq!(stats.last_millis, 5);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1666,6 +1666,11 @@ impl CommitLog {
         self.mapped_file_queue.warmup_stats()
     }
 
+    #[cfg(test)]
+    pub(crate) fn last_mapped_file_for_testing(&self) -> Option<Arc<DefaultMappedFile>> {
+        self.mapped_file_queue.get_last_mapped_file()
+    }
+
     #[inline]
     pub fn flush(&self) -> i64 {
         self.mapped_file_queue.flush(0);

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -74,6 +74,7 @@ use crate::base::topic_queue_lock::TopicQueueLock;
 use crate::config::flush_disk_type::FlushDiskType;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
+use crate::consume_queue::mapped_file_queue::MappedFileWarmupStats;
 use crate::ha::ha_service::HAService;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
 // Import the optimized loader module
@@ -1658,6 +1659,11 @@ impl CommitLog {
     #[inline]
     pub fn get_flushed_where(&self) -> i64 {
         self.mapped_file_queue.get_flushed_where()
+    }
+
+    #[inline]
+    pub fn mapped_file_warmup_stats(&self) -> MappedFileWarmupStats {
+        self.mapped_file_queue.warmup_stats()
     }
 
     #[inline]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -5530,7 +5530,22 @@ mod tests {
     #[test]
     fn runtime_info_reports_linux_storage_lifecycle_fields() {
         let temp_dir = tempdir().unwrap();
-        let store = new_configured_test_store(&temp_dir, MessageStoreConfig::default());
+        let store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                mapped_file_size_commit_log: 1024,
+                ..MessageStoreConfig::default()
+            },
+        );
+        assert!(store.get_last_mapped_file(0));
+        let mapped_file = store
+            .commit_log
+            .last_mapped_file_for_testing()
+            .expect("runtime info test should create commitlog mapped file");
+        mapped_file
+            .get_metrics()
+            .expect("mapped file metrics should be enabled")
+            .record_warm_with_latency(4096, Duration::from_millis(12));
 
         let runtime_info = store.get_runtime_info();
 
@@ -5546,10 +5561,10 @@ mod tests {
         assert_eq!(runtime_info["linuxStorageProfile"], "balanced");
         assert_eq!(runtime_info["linuxStorageTransferEngine"], "vectored");
         assert_eq!(runtime_info["linuxStorageMappedFileWarmMode"], "madvise");
-        assert_eq!(runtime_info["linuxStorageMappedFileWarmOperations"], "0");
-        assert_eq!(runtime_info["linuxStorageMappedFileWarmBytes"], "0");
-        assert_eq!(runtime_info["linuxStorageMappedFileWarmTotalMillis"], "0");
-        assert_eq!(runtime_info["linuxStorageMappedFileWarmLastMillis"], "0");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmOperations"], "1");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmBytes"], "4096");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmTotalMillis"], "12");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmLastMillis"], "12");
         assert_eq!(runtime_info["linuxStorageMemoryLockMode"], "off");
         assert_eq!(runtime_info["linuxStorageHaSendfileEnable"], "false");
         assert_eq!(runtime_info["linuxStorageIoUringEnable"], "false");

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2626,6 +2626,23 @@ impl MessageStore for LocalFileMessageStore {
             "linuxStorageMappedFileWarmMode".to_string(),
             linux_profile_settings.mapped_file_warm_mode.as_str().to_string(),
         );
+        let mapped_file_warmup_stats = self.commit_log.mapped_file_warmup_stats();
+        result.insert(
+            "linuxStorageMappedFileWarmOperations".to_string(),
+            mapped_file_warmup_stats.operations.to_string(),
+        );
+        result.insert(
+            "linuxStorageMappedFileWarmBytes".to_string(),
+            mapped_file_warmup_stats.bytes.to_string(),
+        );
+        result.insert(
+            "linuxStorageMappedFileWarmTotalMillis".to_string(),
+            mapped_file_warmup_stats.total_millis.to_string(),
+        );
+        result.insert(
+            "linuxStorageMappedFileWarmLastMillis".to_string(),
+            mapped_file_warmup_stats.last_millis.to_string(),
+        );
         result.insert(
             "linuxStorageMemoryLockMode".to_string(),
             linux_profile_settings.memory_lock_mode.as_str().to_string(),
@@ -5529,6 +5546,10 @@ mod tests {
         assert_eq!(runtime_info["linuxStorageProfile"], "balanced");
         assert_eq!(runtime_info["linuxStorageTransferEngine"], "vectored");
         assert_eq!(runtime_info["linuxStorageMappedFileWarmMode"], "madvise");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmOperations"], "0");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmBytes"], "0");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmTotalMillis"], "0");
+        assert_eq!(runtime_info["linuxStorageMappedFileWarmLastMillis"], "0");
         assert_eq!(runtime_info["linuxStorageMemoryLockMode"], "off");
         assert_eq!(runtime_info["linuxStorageHaSendfileEnable"], "false");
         assert_eq!(runtime_info["linuxStorageIoUringEnable"], "false");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7684

### Brief Description

- Adds `MappedFileWarmupStats` aggregation over CommitLog mapped files.
- Exposes mapped-file warmup operation count, warmed bytes, total warmup milliseconds, and last warmup milliseconds in local file store runtime info.
- Adds tests for non-empty warmup aggregation and the new runtime-info fields.
- This is observability for existing warmup metrics, not a runtime performance optimization. It does not claim throughput, latency, CPU, syscall, or memory improvement, so before/after performance comparison is not applicable.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store message_store::local_file_message_store::tests::runtime_info_reports_linux_storage_lifecycle_fields` failed before implementation because the new runtime-info fields were missing.
- GREEN: `cargo test -p rocketmq-store message_store::local_file_message_store::tests::runtime_info_reports_linux_storage_lifecycle_fields` passed after implementation.
- `cargo test -p rocketmq-store consume_queue::mapped_file_queue::tests::warmup_stats_aggregates_mapped_file_metrics` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo test -p rocketmq-store --lib` passed: 528 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warmup statistics to storage/runtime information, including warmed operations, bytes, total time, and last warmup time.
  * Exposed these metrics through the commit log so they’re available in runtime details.

* **Tests**
  * Updated coverage to verify the new warmup statistics appear with expected default values and are aggregated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->