### PR TITLE
[ISSUE #7692]✨Apply profile memory lock mode to CommitLog

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -1366,6 +1366,18 @@ impl MessageStoreConfig {
         self.linux_storage_profile.settings()
     }
 
+    pub fn effective_linux_memory_lock_mode(&self) -> LinuxMemoryLockMode {
+        if self.linux_memory_lock_mode != LinuxMemoryLockMode::Off {
+            return self.linux_memory_lock_mode;
+        }
+
+        if self.linux_storage_optimization_enable {
+            return self.effective_linux_storage_profile_settings().memory_lock_mode;
+        }
+
+        LinuxMemoryLockMode::Off
+    }
+
     pub fn effective_linux_memory_lock_budget_bytes(&self, memory_lock_limit_bytes: Option<u64>) -> u64 {
         if self.linux_memory_lock_budget_bytes > 0 {
             return self.linux_memory_lock_budget_bytes as u64;
@@ -2229,6 +2241,44 @@ mod tests {
         assert_eq!(config.effective_linux_memory_lock_budget_bytes(None), 0);
         assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(0)), 0);
         assert_eq!(config.effective_linux_memory_lock_budget_bytes(Some(u64::MAX)), 0);
+    }
+
+    #[test]
+    fn effective_linux_memory_lock_mode_uses_low_latency_profile_when_optimization_is_enabled() {
+        let config = MessageStoreConfig {
+            linux_storage_optimization_enable: true,
+            linux_storage_profile: LinuxStorageProfile::LowLatency,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.effective_linux_memory_lock_mode(),
+            LinuxMemoryLockMode::ActiveWindow
+        );
+    }
+
+    #[test]
+    fn effective_linux_memory_lock_mode_preserves_direct_mode_and_disabled_optimization() {
+        let disabled_profile = MessageStoreConfig {
+            linux_storage_optimization_enable: false,
+            linux_storage_profile: LinuxStorageProfile::LowLatency,
+            ..Default::default()
+        };
+        let explicit_mode = MessageStoreConfig {
+            linux_storage_optimization_enable: true,
+            linux_storage_profile: LinuxStorageProfile::SafeCompat,
+            linux_memory_lock_mode: LinuxMemoryLockMode::ActiveFile,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            disabled_profile.effective_linux_memory_lock_mode(),
+            LinuxMemoryLockMode::Off
+        );
+        assert_eq!(
+            explicit_mode.effective_linux_memory_lock_mode(),
+            LinuxMemoryLockMode::ActiveFile
+        );
     }
 
     #[cfg(not(feature = "tieredstore"))]

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -337,7 +337,7 @@ impl CommitLog {
             return None;
         }
 
-        match message_store_config.linux_memory_lock_mode {
+        match message_store_config.effective_linux_memory_lock_mode() {
             LinuxMemoryLockMode::Off => None,
             LinuxMemoryLockMode::ActiveWindow => {
                 if wrote_position >= file_size {
@@ -2589,6 +2589,7 @@ mod tests {
     use crate::base::memory_lock_manager::MemoryLockCategory;
     use crate::base::message_store::MessageStore;
     use crate::config::message_store_config::LinuxMemoryLockMode;
+    use crate::config::message_store_config::LinuxStorageProfile;
     use crate::config::message_store_config::MessageStoreConfig;
     use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
     use crate::message_store::local_file_message_store::LocalFileMessageStore;
@@ -2834,6 +2835,24 @@ mod tests {
         assert_eq!(target.offset, 64);
         assert_eq!(target.len, 128 * 1024 * 1024);
         assert_ne!(target.len as u64, file_size);
+    }
+
+    #[test]
+    fn active_memory_lock_target_uses_low_latency_profile_effective_mode() {
+        let config = MessageStoreConfig {
+            linux_storage_optimization_enable: true,
+            linux_storage_profile: LinuxStorageProfile::LowLatency,
+            linux_memory_lock_mode: LinuxMemoryLockMode::Off,
+            linux_memory_lock_active_window_bytes: 1024,
+            ..MessageStoreConfig::default()
+        };
+
+        let target = CommitLog::active_memory_lock_target_for_config(&config, 0, 4096)
+            .expect("low latency profile should enable active window locking");
+
+        assert_eq!(target.category, MemoryLockCategory::CommitLogActiveWindow);
+        assert_eq!(target.offset, 0);
+        assert_eq!(target.len, 1024);
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -927,7 +927,7 @@ impl LocalFileMessageStore {
                 enabled_rocksdb_options.join(", ")
             )));
         }
-        if self.message_store_config.linux_memory_lock_mode == LinuxMemoryLockMode::ActiveFile
+        if self.message_store_config.effective_linux_memory_lock_mode() == LinuxMemoryLockMode::ActiveFile
             && self.message_store_config.linux_memory_lock_budget_bytes == 0
             && !self.message_store_config.linux_memory_lock_warn_only
         {
@@ -2645,7 +2645,10 @@ impl MessageStore for LocalFileMessageStore {
         );
         result.insert(
             "linuxStorageMemoryLockMode".to_string(),
-            linux_profile_settings.memory_lock_mode.as_str().to_string(),
+            self.message_store_config
+                .effective_linux_memory_lock_mode()
+                .as_str()
+                .to_string(),
         );
         result.insert(
             "linuxStorageMemoryLockWarnOnly".to_string(),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7692

### Brief Description

Applies an effective Linux memory lock mode so profile-driven settings are used by CommitLog and runtime reporting.

This change preserves explicit `linux_memory_lock_mode` values, applies the selected profile mode when Linux storage optimization is enabled and the direct mode remains `off`, and keeps `off` when optimization is disabled.

No runtime performance improvement is claimed in this PR; no before/after performance comparison is applicable.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store config::message_store_config::tests::effective_linux_memory_lock_mode` failed before implementation because `effective_linux_memory_lock_mode` did not exist.
- RED: `cargo test -p rocketmq-store log_file::commit_log::tests::active_memory_lock_target_uses_low_latency_profile_effective_mode` failed before implementation for the same missing effective mode behavior.
- GREEN: `cargo test -p rocketmq-store config::message_store_config::tests::effective_linux_memory_lock_mode` passed: 2 tests.
- GREEN: `cargo test -p rocketmq-store log_file::commit_log::tests::active_memory_lock_target_uses_low_latency_profile_effective_mode` passed: 1 test.
- `cargo test -p rocketmq-store log_file::commit_log::tests::active_` passed: 4 tests.
- `cargo test -p rocketmq-store message_store::local_file_message_store::tests::runtime_info_reports_linux_storage_lifecycle_fields` passed.
- `cargo test -p rocketmq-store message_store::local_file_message_store::tests::init_rejects_strict_active_file_memory_lock_without_explicit_budget` passed.
- `cargo test -p rocketmq-store --lib` passed: 538 tests.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how Linux memory-lock settings are resolved, so runtime behavior now matches the selected storage optimization profile when no explicit lock mode is set.
  * Updated validation to more accurately reflect the effective memory-lock mode, reducing incorrect configuration errors.
  * Runtime info now reports the effective Linux memory-lock mode more consistently.
  * Added tests covering profile-based mode selection and explicit overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->