### PR TITLE
[ISSUE #7694]✨Wire HA transfer engine selection to Linux profile

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -420,9 +420,9 @@ impl LinuxStorageProfile {
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum LinuxTransferEngine {
+    #[default]
     Auto,
     Bytes,
-    #[default]
     Vectored,
     Sendfile,
     IoUring,
@@ -1366,6 +1366,32 @@ impl MessageStoreConfig {
         self.linux_storage_profile.settings()
     }
 
+    pub fn effective_linux_transfer_engine(&self) -> LinuxTransferEngine {
+        if self.linux_transfer_engine != LinuxTransferEngine::Auto {
+            return self.linux_transfer_engine;
+        }
+
+        if self.linux_storage_optimization_enable {
+            return self.effective_linux_storage_profile_settings().transfer_engine;
+        }
+
+        LinuxTransferEngine::Vectored
+    }
+
+    pub fn effective_linux_ha_sendfile_enable(&self) -> bool {
+        if self.linux_ha_sendfile_enable {
+            return true;
+        }
+
+        if self.linux_transfer_engine == LinuxTransferEngine::Sendfile {
+            return true;
+        }
+
+        self.effective_linux_transfer_engine() == LinuxTransferEngine::Sendfile
+            && self.linux_storage_optimization_enable
+            && self.effective_linux_storage_profile_settings().ha_sendfile_enable
+    }
+
     pub fn effective_linux_memory_lock_mode(&self) -> LinuxMemoryLockMode {
         if self.linux_memory_lock_mode != LinuxMemoryLockMode::Off {
             return self.linux_memory_lock_mode;
@@ -2215,6 +2241,45 @@ mod tests {
         assert_eq!(settings.transfer_engine, LinuxTransferEngine::Sendfile);
         assert!(settings.ha_sendfile_enable);
         Ok(())
+    }
+
+    #[test]
+    fn effective_linux_transfer_engine_uses_high_throughput_profile_when_optimization_is_enabled() {
+        let config = MessageStoreConfig {
+            linux_storage_optimization_enable: true,
+            linux_storage_profile: LinuxStorageProfile::HighThroughputReplication,
+            ..Default::default()
+        };
+
+        assert_eq!(config.effective_linux_transfer_engine(), LinuxTransferEngine::Sendfile);
+        assert!(config.effective_linux_ha_sendfile_enable());
+    }
+
+    #[test]
+    fn effective_linux_transfer_engine_preserves_direct_engine_and_disabled_optimization() {
+        let explicit_engine = MessageStoreConfig {
+            linux_storage_optimization_enable: true,
+            linux_storage_profile: LinuxStorageProfile::HighThroughputReplication,
+            linux_transfer_engine: LinuxTransferEngine::Bytes,
+            linux_ha_sendfile_enable: false,
+            ..Default::default()
+        };
+        let disabled_profile = MessageStoreConfig {
+            linux_storage_optimization_enable: false,
+            linux_storage_profile: LinuxStorageProfile::HighThroughputReplication,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            explicit_engine.effective_linux_transfer_engine(),
+            LinuxTransferEngine::Bytes
+        );
+        assert!(!explicit_engine.effective_linux_ha_sendfile_enable());
+        assert_eq!(
+            disabled_profile.effective_linux_transfer_engine(),
+            LinuxTransferEngine::Vectored
+        );
+        assert!(!disabled_profile.effective_linux_ha_sendfile_enable());
     }
 
     #[test]

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -45,6 +45,7 @@ use tracing::info;
 use tracing::warn;
 
 use crate::base::message_store::MessageStore;
+use crate::config::message_store_config::LinuxTransferEngine;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::ha::default_ha_client::CONTROLLER_REPORT_HEADER_SIZE;
 use crate::ha::default_ha_service::DefaultHAService;
@@ -54,8 +55,9 @@ use crate::ha::ha_connection::HAConnection;
 use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::ha_service::HAService;
-use crate::ha::transfer_engine::select_transfer_engine;
+use crate::ha::transfer_engine::select_transfer_engine_with_availability;
 use crate::ha::transfer_engine::HaTransferEngine;
+use crate::ha::transfer_engine::TransferEngineAvailability;
 use crate::ha::transfer_engine::TransferEngineKind;
 use crate::ha::transfer_engine::TransferEnginePreference;
 use crate::ha::HAConnectionError;
@@ -649,16 +651,28 @@ impl WriteSocketService {
         next_transfer_from_where: Arc<AtomicI64>,
     ) -> Result<Self, HAConnectionError> {
         let enable_controller_mode = message_store_config.enable_controller_mode;
-        let preference = TransferEnginePreference::Vectored;
-        let selection = select_transfer_engine(preference, writer.is_write_vectored());
+        let preference = transfer_engine_preference(&message_store_config);
+        let selection = select_transfer_engine_with_availability(
+            preference,
+            TransferEngineAvailability {
+                vectored_write_available: writer.is_write_vectored(),
+                sendfile_available: message_store_config.effective_linux_ha_sendfile_enable()
+                    && cfg!(target_os = "linux"),
+                io_uring_available: message_store_config.linux_io_uring_enable
+                    && crate::log_file::mapped_file::io_uring_impl::probe_io_uring_runtime_capability()
+                        .basic_path_available(),
+            },
+        );
         if let Some(reason) = selection.fallback_reason {
             info!(
                 "HA transfer engine fallback to {:?} for slave[{}]: {}",
                 selection.engine, client_address, reason
             );
-            ha_service
-                .ha_transfer_metrics()
-                .record_fallback(TransferEngineKind::Vectored, selection.engine, reason);
+            ha_service.ha_transfer_metrics().record_fallback(
+                transfer_engine_kind(preference),
+                selection.engine,
+                reason,
+            );
         } else {
             info!(
                 "HA transfer engine selected {:?} for slave[{}]",
@@ -929,6 +943,26 @@ impl WriteSocketService {
 
     fn get_service_name(&self) -> String {
         format!("WriteSocketService[{}]", self.client_address)
+    }
+}
+
+fn transfer_engine_preference(message_store_config: &MessageStoreConfig) -> TransferEnginePreference {
+    match message_store_config.effective_linux_transfer_engine() {
+        LinuxTransferEngine::Auto => TransferEnginePreference::Auto,
+        LinuxTransferEngine::Bytes => TransferEnginePreference::Bytes,
+        LinuxTransferEngine::Vectored => TransferEnginePreference::Vectored,
+        LinuxTransferEngine::Sendfile => TransferEnginePreference::Sendfile,
+        LinuxTransferEngine::IoUring => TransferEnginePreference::IoUring,
+    }
+}
+
+fn transfer_engine_kind(preference: TransferEnginePreference) -> TransferEngineKind {
+    match preference {
+        TransferEnginePreference::Auto => TransferEngineKind::Vectored,
+        TransferEnginePreference::Bytes => TransferEngineKind::Bytes,
+        TransferEnginePreference::Vectored => TransferEngineKind::Vectored,
+        TransferEnginePreference::Sendfile => TransferEngineKind::Sendfile,
+        TransferEnginePreference::IoUring => TransferEngineKind::IoUring,
     }
 }
 

--- a/rocketmq-store/src/ha/transfer_engine.rs
+++ b/rocketmq-store/src/ha/transfer_engine.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(unix)]
+use crate::ha::transfer_engine::sendfile::SendfileWriteTarget;
 use ::bytes::Bytes;
 use tokio::io::AsyncWrite;
 
 use crate::ha::transfer_engine::bytes::BytesTransferEngine;
+#[cfg(unix)]
+use crate::ha::transfer_engine::sendfile::SendfileTransferEngine;
 use crate::ha::transfer_engine::vectored::VectoredTransferEngine;
 use crate::transfer::batch::TransferBatch;
 use crate::transfer::error::TransferError;
@@ -35,14 +39,17 @@ pub enum TransferEngineKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransferEnginePreference {
+    Auto,
     Bytes,
     Vectored,
+    Sendfile,
     IoUring,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransferEngineAvailability {
     pub vectored_write_available: bool,
+    pub sendfile_available: bool,
     pub io_uring_available: bool,
 }
 
@@ -73,6 +80,7 @@ pub fn select_transfer_engine(
         preference,
         TransferEngineAvailability {
             vectored_write_available,
+            sendfile_available: false,
             io_uring_available: false,
         },
     )
@@ -83,11 +91,28 @@ pub fn select_transfer_engine_with_availability(
     availability: TransferEngineAvailability,
 ) -> TransferEngineSelection {
     match preference {
+        TransferEnginePreference::Auto if availability.sendfile_available => TransferEngineSelection {
+            engine: TransferEngineKind::Sendfile,
+            fallback_reason: None,
+        },
+        TransferEnginePreference::Auto => select_vectored_transfer_engine(availability.vectored_write_available),
         TransferEnginePreference::Bytes => TransferEngineSelection {
             engine: TransferEngineKind::Bytes,
             fallback_reason: None,
         },
         TransferEnginePreference::Vectored => select_vectored_transfer_engine(availability.vectored_write_available),
+        TransferEnginePreference::Sendfile if availability.sendfile_available => TransferEngineSelection {
+            engine: TransferEngineKind::Sendfile,
+            fallback_reason: None,
+        },
+        TransferEnginePreference::Sendfile if availability.vectored_write_available => TransferEngineSelection {
+            engine: TransferEngineKind::Vectored,
+            fallback_reason: Some("sendfile unavailable"),
+        },
+        TransferEnginePreference::Sendfile => TransferEngineSelection {
+            engine: TransferEngineKind::Bytes,
+            fallback_reason: Some("sendfile and vectored write unavailable"),
+        },
         TransferEnginePreference::IoUring if availability.io_uring_available => TransferEngineSelection {
             engine: TransferEngineKind::IoUring,
             fallback_reason: None,
@@ -120,15 +145,21 @@ fn select_vectored_transfer_engine(vectored_write_available: bool) -> TransferEn
 pub enum HaTransferEngine<W> {
     Bytes(BytesTransferEngine<W>),
     Vectored(VectoredTransferEngine<W>),
+    #[cfg(unix)]
+    Sendfile(SendfileTransferEngine<W>),
 }
 
 impl<W> HaTransferEngine<W> {
     pub fn from_selection(writer: W, engine: TransferEngineKind) -> Self {
         match engine {
             TransferEngineKind::Bytes => Self::Bytes(BytesTransferEngine::new(writer)),
-            TransferEngineKind::Vectored | TransferEngineKind::Sendfile | TransferEngineKind::IoUring => {
+            TransferEngineKind::Vectored | TransferEngineKind::IoUring => {
                 Self::Vectored(VectoredTransferEngine::new(writer))
             }
+            #[cfg(unix)]
+            TransferEngineKind::Sendfile => Self::Sendfile(SendfileTransferEngine::new(writer)),
+            #[cfg(not(unix))]
+            TransferEngineKind::Sendfile => Self::Vectored(VectoredTransferEngine::new(writer)),
         }
     }
 
@@ -136,6 +167,11 @@ impl<W> HaTransferEngine<W> {
         match self {
             Self::Bytes(engine) => engine.into_inner(),
             Self::Vectored(engine) => engine.into_inner(),
+            #[cfg(unix)]
+            Self::Sendfile(engine) => {
+                let (writer, _) = engine.into_parts();
+                writer
+            }
         }
     }
 
@@ -143,10 +179,27 @@ impl<W> HaTransferEngine<W> {
         match self {
             Self::Bytes(_) => TransferEngineKind::Bytes,
             Self::Vectored(_) => TransferEngineKind::Vectored,
+            #[cfg(unix)]
+            Self::Sendfile(_) => TransferEngineKind::Sendfile,
         }
     }
 }
 
+#[cfg(unix)]
+impl<W> HaTransferEngine<W>
+where
+    W: AsyncWrite + SendfileWriteTarget + Unpin,
+{
+    pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        match self {
+            Self::Bytes(engine) => engine.send_batch(batch).await,
+            Self::Vectored(engine) => engine.send_batch(batch).await,
+            Self::Sendfile(engine) => engine.send_batch(batch).await,
+        }
+    }
+}
+
+#[cfg(not(unix))]
 impl<W> HaTransferEngine<W>
 where
     W: AsyncWrite + Unpin,

--- a/rocketmq-store/src/ha/transfer_engine/sendfile.rs
+++ b/rocketmq-store/src/ha/transfer_engine/sendfile.rs
@@ -23,6 +23,8 @@ use std::os::fd::RawFd;
 use tokio::io::AsyncWrite;
 #[cfg(unix)]
 use tokio::io::AsyncWriteExt;
+#[cfg(unix)]
+use tokio::net::tcp::OwnedWriteHalf;
 
 #[cfg(unix)]
 use crate::ha::transfer_engine::bytes::write_all_counted;
@@ -46,6 +48,28 @@ use crate::transfer::segment::FileRange;
 #[cfg(unix)]
 pub trait SendfileOperation {
     fn sendfile(&mut self, out_fd: RawFd, in_fd: RawFd, offset: u64, len: usize) -> io::Result<usize>;
+}
+
+#[cfg(unix)]
+pub trait SendfileWriteTarget {
+    fn sendfile_out_fd(&self) -> RawFd;
+}
+
+#[cfg(unix)]
+impl SendfileWriteTarget for OwnedWriteHalf {
+    fn sendfile_out_fd(&self) -> RawFd {
+        self.as_ref().as_raw_fd()
+    }
+}
+
+#[cfg(unix)]
+impl<T> SendfileWriteTarget for &mut T
+where
+    T: SendfileWriteTarget,
+{
+    fn sendfile_out_fd(&self) -> RawFd {
+        (**self).sendfile_out_fd()
+    }
 }
 
 #[cfg(unix)]
@@ -110,7 +134,7 @@ impl<W, O> SendfileTransferEngine<W, O> {
 #[cfg(unix)]
 impl<W, O> SendfileTransferEngine<W, O>
 where
-    W: AsyncWrite + AsRawFd + Unpin,
+    W: AsyncWrite + SendfileWriteTarget + Unpin,
     O: SendfileOperation,
 {
     pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
@@ -127,7 +151,7 @@ where
         let mut sendfile_bytes = 0;
         let mut sendfile_call_count = 0;
         let mut partial_write_count = header_calls.saturating_sub(expected_header_calls);
-        let out_fd = self.writer.as_raw_fd();
+        let out_fd = self.writer.sendfile_out_fd();
 
         for range in file_ranges {
             let in_fd = range.file.as_raw_fd();

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2620,7 +2620,10 @@ impl MessageStore for LocalFileMessageStore {
         );
         result.insert(
             "linuxStorageTransferEngine".to_string(),
-            linux_profile_settings.transfer_engine.as_str().to_string(),
+            self.message_store_config
+                .effective_linux_transfer_engine()
+                .as_str()
+                .to_string(),
         );
         result.insert(
             "linuxStorageMappedFileWarmMode".to_string(),
@@ -2660,7 +2663,9 @@ impl MessageStore for LocalFileMessageStore {
         );
         result.insert(
             "linuxStorageHaSendfileEnable".to_string(),
-            linux_profile_settings.ha_sendfile_enable.to_string(),
+            self.message_store_config
+                .effective_linux_ha_sendfile_enable()
+                .to_string(),
         );
         result.insert(
             "linuxStorageIoUringEnable".to_string(),

--- a/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
@@ -30,7 +30,9 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use rocketmq_store::ha::transfer_engine::sendfile::SendfileOperation;
 use rocketmq_store::ha::transfer_engine::sendfile::SendfileTransferEngine;
+use rocketmq_store::ha::transfer_engine::sendfile::SendfileWriteTarget;
 use rocketmq_store::ha::transfer_engine::vectored::VectoredTransferEngine;
+use rocketmq_store::ha::transfer_engine::HaTransferEngine;
 use rocketmq_store::ha::transfer_engine::TransferEngineKind;
 use rocketmq_store::transfer::batch::TransferBatch;
 use rocketmq_store::transfer::batch::TransferKind;
@@ -50,6 +52,13 @@ fn segment_lease_from_file_range_exposes_file_position_and_len() {
     assert_eq!(range.position, 5);
     assert_eq!(range.len, 7);
     assert_eq!(lease.len(), 7);
+}
+
+#[test]
+fn ha_transfer_engine_from_sendfile_selection_keeps_sendfile_kind() {
+    let engine = HaTransferEngine::from_selection(RecordingWriter::default(), TransferEngineKind::Sendfile);
+
+    assert_eq!(engine.kind(), TransferEngineKind::Sendfile);
 }
 
 #[tokio::test]
@@ -200,6 +209,12 @@ struct RecordingWriter {
 impl AsRawFd for RecordingWriter {
     fn as_raw_fd(&self) -> RawFd {
         77
+    }
+}
+
+impl SendfileWriteTarget for RecordingWriter {
+    fn sendfile_out_fd(&self) -> RawFd {
+        self.as_raw_fd()
     }
 }
 

--- a/rocketmq-store/tests/ha_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_transfer_engine.rs
@@ -108,11 +108,90 @@ fn transfer_engine_selection_falls_back_to_bytes_when_vectored_is_unavailable() 
 }
 
 #[test]
+fn sendfile_transfer_selection_uses_sendfile_when_available() {
+    let selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Sendfile,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            sendfile_available: true,
+            io_uring_available: false,
+        },
+    );
+
+    assert_eq!(selection.engine, TransferEngineKind::Sendfile);
+    assert_eq!(selection.fallback_reason, None);
+}
+
+#[test]
+fn sendfile_transfer_selection_falls_back_to_vectored_then_bytes() {
+    let vectored_selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Sendfile,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            sendfile_available: false,
+            io_uring_available: false,
+        },
+    );
+    let bytes_selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Sendfile,
+        TransferEngineAvailability {
+            vectored_write_available: false,
+            sendfile_available: false,
+            io_uring_available: false,
+        },
+    );
+
+    assert_eq!(vectored_selection.engine, TransferEngineKind::Vectored);
+    assert_eq!(vectored_selection.fallback_reason, Some("sendfile unavailable"));
+    assert_eq!(bytes_selection.engine, TransferEngineKind::Bytes);
+    assert_eq!(
+        bytes_selection.fallback_reason,
+        Some("sendfile and vectored write unavailable")
+    );
+}
+
+#[test]
+fn auto_transfer_selection_prefers_sendfile_then_vectored_then_bytes() {
+    let sendfile_selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Auto,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            sendfile_available: true,
+            io_uring_available: false,
+        },
+    );
+    let vectored_selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Auto,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            sendfile_available: false,
+            io_uring_available: false,
+        },
+    );
+    let bytes_selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::Auto,
+        TransferEngineAvailability {
+            vectored_write_available: false,
+            sendfile_available: false,
+            io_uring_available: false,
+        },
+    );
+
+    assert_eq!(sendfile_selection.engine, TransferEngineKind::Sendfile);
+    assert_eq!(sendfile_selection.fallback_reason, None);
+    assert_eq!(vectored_selection.engine, TransferEngineKind::Vectored);
+    assert_eq!(vectored_selection.fallback_reason, None);
+    assert_eq!(bytes_selection.engine, TransferEngineKind::Bytes);
+    assert_eq!(bytes_selection.fallback_reason, Some("vectored write unavailable"));
+}
+
+#[test]
 fn io_uring_transfer_selection_uses_io_uring_when_available() {
     let selection = select_transfer_engine_with_availability(
         TransferEnginePreference::IoUring,
         TransferEngineAvailability {
             vectored_write_available: true,
+            sendfile_available: true,
             io_uring_available: true,
         },
     );
@@ -127,6 +206,7 @@ fn io_uring_transfer_selection_falls_back_to_vectored_when_unavailable() {
         TransferEnginePreference::IoUring,
         TransferEngineAvailability {
             vectored_write_available: true,
+            sendfile_available: true,
             io_uring_available: false,
         },
     );
@@ -141,6 +221,7 @@ fn io_uring_transfer_selection_falls_back_to_bytes_when_vectored_is_unavailable(
         TransferEnginePreference::IoUring,
         TransferEngineAvailability {
             vectored_write_available: false,
+            sendfile_available: false,
             io_uring_available: false,
         },
     );


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7694

### Brief Description

Connects the effective Linux storage profile to HA transfer engine selection so `auto` can select `sendfile` for high-throughput replication and fall back to vectored or bytes when capabilities are unavailable.

Updates HA runtime wiring to instantiate the sendfile transfer engine on Linux, records fallback metrics from the requested engine, and reports the effective transfer engine/sendfile setting in runtime info.

No runtime performance improvement is claimed in this PR; no before/after performance comparison is applicable for this configuration and fallback wiring slice.

### How Did You Test This Change?

- `cargo test -p rocketmq-store config::message_store_config::tests::effective_linux_transfer_engine` - passed, 2 tests.
- `cargo test -p rocketmq-store --test ha_transfer_engine` - passed, 10 tests.
- `cargo test -p rocketmq-store --test ha_sendfile_transfer_engine` - passed, 5 tests.
- `cargo test -p rocketmq-store message_store::local_file_message_store::tests::runtime_info_reports_linux_storage_lifecycle_fields` - passed, 1 test.
- `cargo test -p rocketmq-store --test ha_transfer_metrics` - passed, 2 tests.
- `cargo test -p rocketmq-store --lib` - passed, 540 tests.
- `cargo fmt --all --check` - passed.
- `git diff --check` - passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter Linux transfer-engine handling that automatically picks the best available option at runtime.
  * Exposed updated runtime information for Linux storage settings, including the active transfer engine and HA sendfile status.

* **Bug Fixes**
  * Improved fallback behavior when a preferred transfer method isn’t available, with better automatic selection across Linux I/O options.
  * Corrected the default Linux transfer setting to use automatic selection instead of a fixed mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->