### PR TITLE
[ISSUE #7696]✨Add HA transfer runtime fallback to bytes engine

### DIFF
--- a/rocketmq-store/src/ha/transfer_engine/vectored.rs
+++ b/rocketmq-store/src/ha/transfer_engine/vectored.rs
@@ -19,10 +19,12 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 
 use crate::ha::transfer_engine::batch_body_chunks;
+use crate::ha::transfer_engine::bytes::BytesTransferEngine;
 use crate::ha::transfer_engine::write_zero_error;
 use crate::ha::transfer_engine::TransferEngineKind;
 use crate::ha::transfer_engine::TransferStats;
 use crate::transfer::batch::TransferBatch;
+use crate::transfer::error::TransferError;
 use crate::transfer::error::TransferResult;
 
 pub struct VectoredTransferEngine<W> {
@@ -55,10 +57,14 @@ where
         while chunk_index < chunks.len() {
             let remaining_before_write = total_len - bytes_written;
             let slices = io_slices(&chunks, chunk_index, chunk_offset);
-            let written = self.writer.write_vectored(&slices).await?;
-            if written == 0 {
-                return Err(write_zero_error());
-            }
+            let written = match self.writer.write_vectored(&slices).await {
+                Ok(0) => return Err(write_zero_error()),
+                Ok(written) => written,
+                Err(_) if bytes_written == 0 && batch.body_bytes().is_some() => {
+                    return self.send_with_bytes_fallback(batch).await;
+                }
+                Err(error) => return Err(TransferError::Io(error)),
+            };
             write_call_count += 1;
             bytes_written += written;
             if written < remaining_before_write {
@@ -80,6 +86,13 @@ where
             fallback_bytes: 0,
             partial_write_count,
         })
+    }
+
+    async fn send_with_bytes_fallback(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        let mut fallback = BytesTransferEngine::new(&mut self.writer);
+        let mut stats = fallback.send_batch(batch).await?;
+        stats.fallback_bytes = stats.body_bytes;
+        Ok(stats)
     }
 }
 

--- a/rocketmq-store/tests/ha_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_transfer_engine.rs
@@ -99,6 +99,48 @@ async fn vectored_transfer_engine_reduces_write_calls_for_complete_frame_writes(
     assert_eq!(bytes_writer.written, vectored_writer.written);
 }
 
+#[tokio::test]
+async fn vectored_transfer_engine_falls_back_to_bytes_when_first_vectored_write_fails() {
+    let header = transfer_header(768, 6);
+    let body = Bytes::from_static(b"rocket");
+    let batch = transfer_batch(header.clone(), body.clone());
+    let mut engine = VectoredTransferEngine::new(FailingVectoredWriter::fail_before_write());
+
+    let stats = engine.send_batch(&batch).await.expect("fallback transfer");
+
+    let writer = engine.into_inner();
+    let mut expected = header.to_vec();
+    expected.extend_from_slice(&body);
+    assert_eq!(writer.written, expected);
+    assert_eq!(stats.engine, TransferEngineKind::Bytes);
+    assert_eq!(stats.bytes_written, expected.len());
+    assert_eq!(stats.body_bytes, body.len());
+    assert_eq!(stats.fallback_bytes, body.len());
+    assert_eq!(writer.vectored_calls, 1);
+    assert_eq!(writer.write_calls, 2);
+}
+
+#[tokio::test]
+async fn vectored_transfer_engine_does_not_fallback_after_partial_write() {
+    let header = transfer_header(1024, 6);
+    let body = Bytes::from_static(b"rocket");
+    let batch = transfer_batch(header.clone(), body.clone());
+    let mut engine = VectoredTransferEngine::new(FailingVectoredWriter::fail_after_partial_write(5));
+
+    let error = engine
+        .send_batch(&batch)
+        .await
+        .expect_err("partial frame write should remain non-retriable");
+
+    let writer = engine.into_inner();
+    let mut expected = header.to_vec();
+    expected.extend_from_slice(&body);
+    assert_eq!(writer.written, expected[..5]);
+    assert_eq!(writer.write_calls, 0);
+    assert_eq!(writer.vectored_calls, 2);
+    assert!(error.to_string().contains("vectored write failed after partial frame"));
+}
+
 #[test]
 fn transfer_engine_selection_falls_back_to_bytes_when_vectored_is_unavailable() {
     let selection = select_transfer_engine(TransferEnginePreference::Vectored, false);
@@ -295,6 +337,97 @@ impl AsyncWrite for ChunkedWriter {
             remaining -= len;
             written += len;
         }
+        Poll::Ready(Ok(written))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct FailingVectoredWriter {
+    written: Vec<u8>,
+    write_calls: usize,
+    vectored_calls: usize,
+    mode: FailingVectoredMode,
+}
+
+enum FailingVectoredMode {
+    BeforeWrite,
+    AfterPartialWrite { first_write_len: usize },
+}
+
+impl FailingVectoredWriter {
+    fn fail_before_write() -> Self {
+        Self {
+            written: Vec::new(),
+            write_calls: 0,
+            vectored_calls: 0,
+            mode: FailingVectoredMode::BeforeWrite,
+        }
+    }
+
+    fn fail_after_partial_write(first_write_len: usize) -> Self {
+        Self {
+            written: Vec::new(),
+            write_calls: 0,
+            vectored_calls: 0,
+            mode: FailingVectoredMode::AfterPartialWrite { first_write_len },
+        }
+    }
+
+    fn write_vectored_slices(&mut self, bufs: &[IoSlice<'_>], limit: usize) -> usize {
+        let mut remaining = limit;
+        let mut written = 0;
+        for buf in bufs {
+            if remaining == 0 {
+                break;
+            }
+            let len = buf.len().min(remaining);
+            self.written.extend_from_slice(&buf[..len]);
+            remaining -= len;
+            written += len;
+        }
+        written
+    }
+}
+
+impl AsyncWrite for FailingVectoredWriter {
+    fn poll_write(mut self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        self.write_calls += 1;
+        self.written.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.vectored_calls += 1;
+        match self.mode {
+            FailingVectoredMode::BeforeWrite if self.vectored_calls == 1 => {
+                return Poll::Ready(Err(io::Error::other("vectored write failed before frame bytes")));
+            }
+            FailingVectoredMode::AfterPartialWrite { first_write_len } if self.vectored_calls == 1 => {
+                let written = self.write_vectored_slices(bufs, first_write_len);
+                return Poll::Ready(Ok(written));
+            }
+            FailingVectoredMode::AfterPartialWrite { .. } if self.vectored_calls == 2 => {
+                return Poll::Ready(Err(io::Error::other("vectored write failed after partial frame")));
+            }
+            _ => {}
+        }
+
+        let written = self.write_vectored_slices(bufs, usize::MAX);
         Poll::Ready(Ok(written))
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7696

### Brief Description

Adds a runtime fallback path for byte-backed HA batches when `VectoredTransferEngine` fails before any frame bytes are written. The retry uses `BytesTransferEngine`, preserving the existing HA frame byte format.

Keeps partial frame write failures non-retriable so the master does not duplicate HA frame data on the slave connection.

No runtime performance improvement is claimed in this PR; no before/after performance comparison is applicable for this reliability fallback slice.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store --test ha_transfer_engine vectored_transfer_engine_falls_back_to_bytes_when_first_vectored_write_fails` - failed before the fix with the original vectored I/O error.
- `cargo test -p rocketmq-store --test ha_transfer_engine` - passed, 12 tests.
- `cargo fmt --all --check` - passed.
- `git diff --check` - passed.
- `cargo test -p rocketmq-store --lib` - passed, 540 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending batched data over vectored writes.
  * Added a safe fallback to an alternate transfer path when no data has been written yet.
  * Zero-byte write results are now treated as errors, and write failures are reported more clearly.
  * Prevents fallback after partial writes, avoiding duplicate or inconsistent sends.

* **Tests**
  * Added coverage for fallback behavior and partial-write failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->