### PR TITLE
[ISSUE #7704]✨Add Linux storage degradation metrics

### DIFF
--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -114,6 +114,7 @@ const STORE_TOPIC_LABELS: &[&str] = &[labels::STORAGE_TYPE, labels::STORAGE_MEDI
 const STORE_MEMORY_LOCK_CATEGORY_LABELS: &[&str] = &[labels::CATEGORY];
 const STORE_MEMORY_LOCK_ERRNO_LABELS: &[&str] = &[labels::CATEGORY, labels::ERRNO];
 const STORE_MEMORY_LOCK_SKIP_LABELS: &[&str] = &[labels::CATEGORY, labels::REASON];
+const STORE_LINUX_STORAGE_DEGRADATION_LABELS: &[&str] = &[labels::OPERATION, labels::REASON, labels::ERRNO];
 const STORE_TRANSFER_ENGINE_LABELS: &[&str] = &[labels::ENGINE];
 const STORE_TRANSFER_FALLBACK_LABELS: &[&str] = &[labels::FROM, labels::TO, labels::REASON];
 const TIMER_BOUND_LABELS: &[&str] = &[
@@ -491,6 +492,13 @@ pub const JAVA_METRICS: &[MetricDescriptor] = &[
         kind: MetricKind::Histogram,
         unit: "ms",
         labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_STORAGE_DEGRADATION_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{operation}",
+        labels: STORE_LINUX_STORAGE_DEGRADATION_LABELS,
         source: MetricSource::Store,
     },
     MetricDescriptor {
@@ -873,6 +881,7 @@ mod tests {
         "rocketmq_store_linux_mlock_success_total",
         "rocketmq_store_linux_munlock_failure_total",
         "rocketmq_store_linux_page_cache_warmup_millis",
+        "rocketmq_store_linux_storage_degradation_total",
         "rocketmq_store_transfer_batch_total",
         "rocketmq_store_transfer_bytes_total",
         "rocketmq_store_transfer_engine_total",
@@ -1079,5 +1088,16 @@ mod tests {
             .expect("linux munlock failure descriptor");
         assert_eq!(munlock_failure.kind, MetricKind::Counter);
         assert_eq!(munlock_failure.labels, &[labels::CATEGORY, labels::ERRNO]);
+
+        let storage_degradation = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_STORAGE_DEGRADATION_TOTAL)
+            .expect("linux storage degradation descriptor");
+        assert_eq!(storage_degradation.kind, MetricKind::Counter);
+        assert_eq!(storage_degradation.unit, "{operation}");
+        assert_eq!(
+            storage_degradation.labels,
+            &[labels::OPERATION, labels::REASON, labels::ERRNO]
+        );
     }
 }

--- a/rocketmq-observability/src/metrics/store.rs
+++ b/rocketmq-observability/src/metrics/store.rs
@@ -33,6 +33,7 @@ pub use crate::semantic::metrics::STORE_LINUX_MLOCK_SUCCESS_TOTAL;
 pub use crate::semantic::metrics::STORE_LINUX_MUNLOCK_FAILURE_TOTAL;
 pub use crate::semantic::metrics::STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS;
 pub use crate::semantic::metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL;
+pub use crate::semantic::metrics::STORE_LINUX_STORAGE_DEGRADATION_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_BATCH_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_BYTES_TOTAL;
 pub use crate::semantic::metrics::STORE_TRANSFER_ENGINE_TOTAL;
@@ -295,6 +296,19 @@ pub fn record_linux_page_cache_warmup_millis(latency_ms: u64) {
     let _ = latency_ms;
 }
 
+pub fn record_linux_storage_degradation(operation: &str, reason: &str, errno: i32, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_storage_degradation_total(
+            count,
+            &linux_storage_degradation_attributes(operation, reason, errno),
+        );
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (operation, reason, errno, count);
+}
+
 pub fn record_commitlog_segment_lease_active(count: u64) {
     #[cfg(feature = "otel-metrics")]
     if let Some(metrics) = STORE_METRICS.get() {
@@ -379,6 +393,9 @@ impl StoreMetrics {
     pub fn record_linux_page_cache_warmup_millis(&self, _latency_ms: u64) {}
 
     #[inline]
+    pub fn record_linux_storage_degradation_total(&self, _count: u64) {}
+
+    #[inline]
     pub fn record_commitlog_segment_lease_active(&self, _count: u64) {}
 }
 
@@ -406,6 +423,7 @@ pub struct StoreMetrics {
     linux_locked_bytes: opentelemetry::metrics::Gauge<u64>,
     linux_munlock_failure_total: opentelemetry::metrics::Counter<u64>,
     linux_page_cache_warmup_millis: opentelemetry::metrics::Histogram<u64>,
+    linux_storage_degradation_total: opentelemetry::metrics::Counter<u64>,
     commitlog_segment_lease_active: opentelemetry::metrics::Gauge<u64>,
 }
 
@@ -538,6 +556,12 @@ impl StoreMetrics {
             .with_unit("ms")
             .build();
 
+        let linux_storage_degradation_total = meter
+            .u64_counter(STORE_LINUX_STORAGE_DEGRADATION_TOTAL)
+            .with_description("Total Linux storage lifecycle degradation events")
+            .with_unit("{operation}")
+            .build();
+
         let commitlog_segment_lease_active = meter
             .u64_gauge(STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE)
             .with_description("Active commitlog segment leases")
@@ -566,6 +590,7 @@ impl StoreMetrics {
             linux_locked_bytes,
             linux_munlock_failure_total,
             linux_page_cache_warmup_millis,
+            linux_storage_degradation_total,
             commitlog_segment_lease_active,
         }
     }
@@ -733,6 +758,11 @@ impl StoreMetrics {
     }
 
     #[inline]
+    pub fn record_linux_storage_degradation_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_storage_degradation_total.add(count, attributes);
+    }
+
+    #[inline]
     pub fn record_commitlog_segment_lease_active(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
         self.commitlog_segment_lease_active.record(count, attributes);
     }
@@ -797,6 +827,15 @@ fn memory_lock_skip_attributes(category: &str, reason: &str) -> [opentelemetry::
     ]
 }
 
+#[cfg(feature = "otel-metrics")]
+fn linux_storage_degradation_attributes(operation: &str, reason: &str, errno: i32) -> [opentelemetry::KeyValue; 3] {
+    [
+        opentelemetry::KeyValue::new(crate::semantic::labels::OPERATION, operation.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::REASON, reason.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::ERRNO, errno as i64),
+    ]
+}
+
 #[cfg(all(test, feature = "otel-metrics"))]
 mod tests {
     use opentelemetry::metrics::MeterProvider;
@@ -836,6 +875,10 @@ mod tests {
         );
         metrics.record_linux_locked_bytes(8192, &memory_lock_category_attributes("transient_store_pool"));
         metrics.record_linux_munlock_failure_total(1, &memory_lock_errno_attributes("transient_store_pool", 22));
+        metrics.record_linux_storage_degradation_total(
+            1,
+            &linux_storage_degradation_attributes("fallocate", "unsupported", 95),
+        );
         record_delay_message_latency(30);
     }
 
@@ -897,5 +940,6 @@ mod helper_tests {
         record_linux_mlock_skipped("commitlog_active_window", "budget_exhausted", 1);
         record_linux_locked_bytes("transient_store_pool", 8192);
         record_linux_munlock_failure("transient_store_pool", 22, 1);
+        record_linux_storage_degradation("fallocate", "unsupported", 95, 1);
     }
 }

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -62,6 +62,7 @@ pub mod metrics {
     pub const STORE_LINUX_LOCKED_BYTES: &str = "rocketmq_store_linux_locked_bytes";
     pub const STORE_LINUX_MUNLOCK_FAILURE_TOTAL: &str = "rocketmq_store_linux_munlock_failure_total";
     pub const STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS: &str = "rocketmq_store_linux_page_cache_warmup_millis";
+    pub const STORE_LINUX_STORAGE_DEGRADATION_TOTAL: &str = "rocketmq_store_linux_storage_degradation_total";
     pub const STORE_TRANSFER_BATCH_TOTAL: &str = "rocketmq_store_transfer_batch_total";
     pub const STORE_TRANSFER_BYTES_TOTAL: &str = "rocketmq_store_transfer_bytes_total";
     pub const STORE_TRANSFER_ENGINE_TOTAL: &str = "rocketmq_store_transfer_engine_total";

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -79,6 +79,66 @@ fn invalid_input_error(message: String) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, message)
 }
 
+const LINUX_STORAGE_DEGRADATION_UNKNOWN_ERRNO: i32 = -1;
+const LINUX_STORAGE_OP_FALLOCATE: &str = "fallocate";
+const LINUX_STORAGE_OP_MADVISE: &str = "madvise";
+const LINUX_STORAGE_OP_PAGE_TOUCH: &str = "page_touch";
+const LINUX_STORAGE_REASON_FAILED: &str = "failed";
+const LINUX_STORAGE_REASON_FLUSH_FAILED: &str = "flush_failed";
+const LINUX_STORAGE_REASON_UNSUPPORTED: &str = "unsupported";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LinuxStorageDegradationEvent {
+    operation: &'static str,
+    reason: &'static str,
+    errno: i32,
+    count: u64,
+}
+
+impl LinuxStorageDegradationEvent {
+    fn new(operation: &'static str, reason: &'static str, errno: i32) -> Self {
+        Self {
+            operation,
+            reason,
+            errno,
+            count: 1,
+        }
+    }
+}
+
+fn errno_from_io_error(error: &io::Error) -> i32 {
+    error.raw_os_error().unwrap_or(LINUX_STORAGE_DEGRADATION_UNKNOWN_ERRNO)
+}
+
+fn file_preallocate_degradation_event(outcome: FilePreallocateOutcome) -> Option<LinuxStorageDegradationEvent> {
+    match outcome {
+        FilePreallocateOutcome::Allocated => None,
+        FilePreallocateOutcome::Unsupported { errno } => Some(LinuxStorageDegradationEvent::new(
+            LINUX_STORAGE_OP_FALLOCATE,
+            LINUX_STORAGE_REASON_UNSUPPORTED,
+            errno,
+        )),
+        FilePreallocateOutcome::Failed { errno } => Some(LinuxStorageDegradationEvent::new(
+            LINUX_STORAGE_OP_FALLOCATE,
+            LINUX_STORAGE_REASON_FAILED,
+            errno,
+        )),
+    }
+}
+
+fn emit_linux_storage_degradation_observability(event: LinuxStorageDegradationEvent) {
+    #[cfg(feature = "observability")]
+    rocketmq_observability::metrics::store::record_linux_storage_degradation(
+        event.operation,
+        event.reason,
+        event.errno,
+        event.count,
+    );
+
+    #[cfg(not(feature = "observability"))]
+    let _ = event;
+}
+
 pub struct DefaultMappedFile {
     reference_resource: ReferenceResourceCounter,
     file: File,
@@ -162,7 +222,11 @@ impl DefaultMappedFile {
             .open(&path_buf)?;
         file.set_len(file_size)?;
         if existing_len < file_size {
-            match preallocate_file(&file, file_size) {
+            let preallocate_outcome = preallocate_file(&file, file_size);
+            if let Some(event) = file_preallocate_degradation_event(preallocate_outcome) {
+                emit_linux_storage_degradation_observability(event);
+            }
+            match preallocate_outcome {
                 FilePreallocateOutcome::Allocated => {}
                 FilePreallocateOutcome::Unsupported { errno } => debug!(
                     "File preallocation is unsupported for mapped file {} and will be skipped, errno={}",
@@ -862,65 +926,14 @@ impl MappedFile for DefaultMappedFile {
 
     #[inline]
     fn warm_mapped_file(&self, flush_disk_type: FlushDiskType, pages: usize) {
-        let page_size = get_page_size().max(1);
-        let file_size = self.file_size as usize;
-        if file_size == 0 {
-            return;
-        }
-
-        let warmup_started = Instant::now();
-        let flush_every_pages = pages.max(1);
-        let mut last_flush_offset = 0usize;
-        {
-            let mapped_file = self.get_mapped_file_mut();
-            let mut touched_pages = 0usize;
-            let mapped_ptr = mapped_file.as_mut_ptr();
-            for offset in (0..file_size).step_by(page_size) {
-                unsafe {
-                    let page_ptr = mapped_ptr.add(offset);
-                    let value = std::ptr::read_volatile(page_ptr);
-                    std::ptr::write_volatile(page_ptr, value);
-                }
-                touched_pages += 1;
-
-                if flush_disk_type == FlushDiskType::SyncFlush && touched_pages % flush_every_pages == 0 {
-                    let end = (offset + 1).min(file_size);
-                    if let Err(error) = mapped_file.flush_range(last_flush_offset, end - last_flush_offset) {
-                        warn!(
-                            "Failed to flush warmed mapped file range {}-{} for {}: {:?}",
-                            last_flush_offset, end, self.file_name, error
-                        );
-                    } else {
-                        self.last_flush_time.store(current_millis(), Ordering::Relaxed);
-                    }
-                    last_flush_offset = end;
-                }
-            }
-
-            if flush_disk_type == FlushDiskType::SyncFlush && last_flush_offset < file_size {
-                if let Err(error) = mapped_file.flush_range(last_flush_offset, file_size - last_flush_offset) {
-                    warn!(
-                        "Failed to flush final warmed mapped file range {}-{} for {}: {:?}",
-                        last_flush_offset, file_size, self.file_name, error
-                    );
-                } else {
-                    self.last_flush_time.store(current_millis(), Ordering::Relaxed);
-                }
-            }
-        }
-
-        if madvise(self.mmapped_file.as_ptr(), file_size, MADV_WILLNEED) != 0 {
-            warn!(
-                "madvise(MADV_WILLNEED) failed while warming mapped file {}",
-                self.file_name
-            );
-        }
-        let warmup_duration = warmup_started.elapsed();
-        let warmup_millis = u64::try_from(warmup_duration.as_millis()).unwrap_or(u64::MAX);
-        rocketmq_observability::metrics::store::record_linux_page_cache_warmup_millis(warmup_millis);
-        if let Some(metrics) = &self.metrics {
-            metrics.record_warm_with_latency(file_size, warmup_duration);
-        }
+        self.warm_mapped_file_with_ops(
+            flush_disk_type,
+            pages,
+            Self::touch_mapped_page,
+            Self::flush_mapped_file_range,
+            Self::advise_mapped_file,
+            emit_linux_storage_degradation_observability,
+        );
     }
 
     #[inline]
@@ -1172,6 +1185,123 @@ impl DefaultMappedFile {
     #[inline]
     pub fn get_mapped_file_arcmut(&self) -> ArcMut<MmapMut> {
         self.mmapped_file.clone()
+    }
+
+    fn touch_mapped_page(mapped_ptr: *mut u8, offset: usize) -> io::Result<()> {
+        unsafe {
+            let page_ptr = mapped_ptr.add(offset);
+            let value = std::ptr::read_volatile(page_ptr);
+            std::ptr::write_volatile(page_ptr, value);
+        }
+        Ok(())
+    }
+
+    fn flush_mapped_file_range(mapped_file: &mut MmapMut, offset: usize, len: usize) -> io::Result<()> {
+        mapped_file.flush_range(offset, len)
+    }
+
+    fn advise_mapped_file(addr: *const u8, len: usize, advice: i32) -> io::Result<()> {
+        if madvise(addr, len, advice) == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn warm_mapped_file_with_ops<T, F, A, R>(
+        &self,
+        flush_disk_type: FlushDiskType,
+        pages: usize,
+        mut touch_page: T,
+        mut flush_range: F,
+        mut advise: A,
+        mut record_degradation: R,
+    ) where
+        T: FnMut(*mut u8, usize) -> io::Result<()>,
+        F: FnMut(&mut MmapMut, usize, usize) -> io::Result<()>,
+        A: FnMut(*const u8, usize, i32) -> io::Result<()>,
+        R: FnMut(LinuxStorageDegradationEvent),
+    {
+        let page_size = get_page_size().max(1);
+        let file_size = self.file_size as usize;
+        if file_size == 0 {
+            return;
+        }
+
+        let warmup_started = Instant::now();
+        let flush_every_pages = pages.max(1);
+        let mut last_flush_offset = 0usize;
+        {
+            let mapped_file = self.get_mapped_file_mut();
+            let mut touched_pages = 0usize;
+            let mapped_ptr = mapped_file.as_mut_ptr();
+            for offset in (0..file_size).step_by(page_size) {
+                if let Err(error) = touch_page(mapped_ptr, offset) {
+                    record_degradation(LinuxStorageDegradationEvent::new(
+                        LINUX_STORAGE_OP_PAGE_TOUCH,
+                        LINUX_STORAGE_REASON_FAILED,
+                        errno_from_io_error(&error),
+                    ));
+                    warn!(
+                        "Failed to touch warmed mapped file page at offset {} for {}: {:?}",
+                        offset, self.file_name, error
+                    );
+                }
+                touched_pages += 1;
+
+                if flush_disk_type == FlushDiskType::SyncFlush && touched_pages % flush_every_pages == 0 {
+                    let end = (offset + 1).min(file_size);
+                    if let Err(error) = flush_range(mapped_file, last_flush_offset, end - last_flush_offset) {
+                        record_degradation(LinuxStorageDegradationEvent::new(
+                            LINUX_STORAGE_OP_PAGE_TOUCH,
+                            LINUX_STORAGE_REASON_FLUSH_FAILED,
+                            errno_from_io_error(&error),
+                        ));
+                        warn!(
+                            "Failed to flush warmed mapped file range {}-{} for {}: {:?}",
+                            last_flush_offset, end, self.file_name, error
+                        );
+                    } else {
+                        self.last_flush_time.store(current_millis(), Ordering::Relaxed);
+                    }
+                    last_flush_offset = end;
+                }
+            }
+
+            if flush_disk_type == FlushDiskType::SyncFlush && last_flush_offset < file_size {
+                if let Err(error) = flush_range(mapped_file, last_flush_offset, file_size - last_flush_offset) {
+                    record_degradation(LinuxStorageDegradationEvent::new(
+                        LINUX_STORAGE_OP_PAGE_TOUCH,
+                        LINUX_STORAGE_REASON_FLUSH_FAILED,
+                        errno_from_io_error(&error),
+                    ));
+                    warn!(
+                        "Failed to flush final warmed mapped file range {}-{} for {}: {:?}",
+                        last_flush_offset, file_size, self.file_name, error
+                    );
+                } else {
+                    self.last_flush_time.store(current_millis(), Ordering::Relaxed);
+                }
+            }
+        }
+
+        if let Err(error) = advise(self.mmapped_file.as_ptr(), file_size, MADV_WILLNEED) {
+            record_degradation(LinuxStorageDegradationEvent::new(
+                LINUX_STORAGE_OP_MADVISE,
+                LINUX_STORAGE_REASON_FAILED,
+                errno_from_io_error(&error),
+            ));
+            warn!(
+                "madvise(MADV_WILLNEED) failed while warming mapped file {}",
+                self.file_name
+            );
+        }
+        let warmup_duration = warmup_started.elapsed();
+        let warmup_millis = u64::try_from(warmup_duration.as_millis()).unwrap_or(u64::MAX);
+        rocketmq_observability::metrics::store::record_linux_page_cache_warmup_millis(warmup_millis);
+        if let Some(metrics) = &self.metrics {
+            metrics.record_warm_with_latency(file_size, warmup_duration);
+        }
     }
 
     pub fn lock_region(
@@ -1869,6 +1999,63 @@ mod tests {
         let metrics = mapped_file.get_metrics().unwrap();
         assert_eq!(metrics.warm_operations(), 2);
         assert_eq!(metrics.warm_bytes(), mapped_file.get_file_size() * 2);
+    }
+
+    #[test]
+    fn preallocate_degradation_events_include_operation_reason_and_errno() {
+        let unsupported = file_preallocate_degradation_event(FilePreallocateOutcome::Unsupported { errno: 95 })
+            .expect("unsupported preallocation should be observable");
+        let failed = file_preallocate_degradation_event(FilePreallocateOutcome::Failed { errno: 28 })
+            .expect("failed preallocation should be observable");
+
+        assert_eq!(
+            unsupported,
+            LinuxStorageDegradationEvent::new(LINUX_STORAGE_OP_FALLOCATE, LINUX_STORAGE_REASON_UNSUPPORTED, 95)
+        );
+        assert_eq!(
+            failed,
+            LinuxStorageDegradationEvent::new(LINUX_STORAGE_OP_FALLOCATE, LINUX_STORAGE_REASON_FAILED, 28)
+        );
+        assert!(file_preallocate_degradation_event(FilePreallocateOutcome::Allocated).is_none());
+    }
+
+    #[test]
+    fn warm_mapped_file_records_warmup_degradation_events_without_position_changes() {
+        let (_temp_dir, mapped_file) = create_test_file();
+        assert!(mapped_file.append_message_bytes(b"warm-degradation"));
+        let wrote_position = mapped_file.get_wrote_position();
+        let committed_position = mapped_file.get_committed_position();
+        let flushed_position = mapped_file.get_flushed_position();
+        let mut events = Vec::new();
+        let mut flush_calls = 0usize;
+
+        mapped_file.warm_mapped_file_with_ops(
+            FlushDiskType::SyncFlush,
+            1,
+            |_, _| Err(io::Error::from_raw_os_error(5)),
+            |_, _, _| {
+                flush_calls += 1;
+                if flush_calls == 1 {
+                    Ok(())
+                } else {
+                    Err(io::Error::from_raw_os_error(28))
+                }
+            },
+            |_, _, _| Err(io::Error::from_raw_os_error(12)),
+            |event| events.push(event),
+        );
+
+        assert_eq!(mapped_file.get_wrote_position(), wrote_position);
+        assert_eq!(mapped_file.get_committed_position(), committed_position);
+        assert_eq!(mapped_file.get_flushed_position(), flushed_position);
+        assert_eq!(
+            events,
+            vec![
+                LinuxStorageDegradationEvent::new(LINUX_STORAGE_OP_PAGE_TOUCH, LINUX_STORAGE_REASON_FAILED, 5),
+                LinuxStorageDegradationEvent::new(LINUX_STORAGE_OP_PAGE_TOUCH, LINUX_STORAGE_REASON_FLUSH_FAILED, 28),
+                LinuxStorageDegradationEvent::new(LINUX_STORAGE_OP_MADVISE, LINUX_STORAGE_REASON_FAILED, 12),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7704

### Brief Description

Adds Linux storage lifecycle degradation observability for mapped file allocation and warmup paths. The new counter records `fallocate`, `madvise`, and page-touch warmup degradation by operation, reason, and errno, while existing `mlock` warn-only/skipped/failed metrics remain the memory-lock degradation signal.

The mapped file warmup path keeps the existing non-fatal fallback behavior: page touch, sync warmup flush, and `madvise` failures are logged, recorded, and the warmup operation continues without changing write, commit, or flush positions.

Performance data: Not applicable. This PR does not change a performance optimization path or claim a throughput/latency improvement; it only adds metrics for existing degradation behavior.

### How Did You Test This Change?

- `cargo test -p rocketmq-store preallocate_degradation_events_include_operation_reason_and_errno` passed.
- `cargo test -p rocketmq-store warm_mapped_file_records_warmup_degradation_events_without_position_changes` passed.
- `cargo test -p rocketmq-store --features observability warm_mapped_file_records_warmup_degradation_events_without_position_changes` passed.
- `cargo test -p rocketmq-observability --features otel-metrics metrics::store` passed.
- `cargo test -p rocketmq-observability metrics::catalog` passed.
- `cargo test -p rocketmq-store --lib` passed: 542 tests.
- `cargo test -p rocketmq-observability --features otel-metrics` passed: 113 unit tests, 2 architecture guard tests, 1 ignored doctest.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability for Linux storage degradation events during file preallocation and warm-up.
  * Exposed a new metric for tracking degradation by operation, reason, and error code.

* **Bug Fixes**
  * Storage warm-up now records degradation events when filesystem operations fail, while preserving existing behavior.
  * Mapped-file creation now logs degradation events for unsupported or failed preallocation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->