### PR TITLE
[ISSUE #7621]🧪Add NameServer blacklist helper tests

### DIFF
--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -854,6 +854,78 @@ mod tests {
     }
 
     #[test]
+    fn build_effective_config_blacklist_includes_fixed_keys() {
+        let effective =
+            build_effective_config_blacklist(&rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig {
+                config_black_list: "customConfig".to_string(),
+                ..Default::default()
+            });
+
+        for required in ["configBlackList", "configStorePath", "kvConfigPath", "rocketmqHome"] {
+            assert!(
+                effective.iter().any(|entry| entry.as_str() == required),
+                "missing required blacklist entry: {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_effective_config_blacklist_appends_unique_custom_entries() {
+        let effective =
+            build_effective_config_blacklist(&rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig {
+                config_black_list: "customConfig; rocketmqHome ; customConfig ; anotherConfig".to_string(),
+                ..Default::default()
+            });
+        let effective_keys: Vec<&str> = effective.iter().map(|entry| entry.as_str()).collect();
+
+        assert_eq!(
+            effective
+                .iter()
+                .filter(|entry| entry.as_str() == "customConfig")
+                .count(),
+            1
+        );
+        assert_eq!(
+            effective
+                .iter()
+                .filter(|entry| entry.as_str() == "rocketmqHome")
+                .count(),
+            1
+        );
+        assert_eq!(
+            effective_keys,
+            vec![
+                "configBlackList",
+                "configStorePath",
+                "kvConfigPath",
+                "rocketmqHome",
+                "customConfig",
+                "anotherConfig",
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_blacklist_config_exist_distinguishes_blocked_from_allowed_properties() {
+        let blacklist = vec![
+            CheetahString::from_static_str("rocketmqHome"),
+            CheetahString::from_static_str("customConfig"),
+        ];
+
+        let blocked_properties = HashMap::from([(
+            CheetahString::from_static_str("customConfig"),
+            CheetahString::from_static_str("value"),
+        )]);
+        assert!(validate_blacklist_config_exist(&blocked_properties, &blacklist));
+
+        let allowed_properties = HashMap::from([(
+            CheetahString::from_static_str("listenPort"),
+            CheetahString::from_static_str("9876"),
+        )]);
+        assert!(!validate_blacklist_config_exist(&allowed_properties, &blacklist));
+    }
+
+    #[test]
     fn get_namesrv_config_defaults_to_full_response_without_probe_header() {
         let request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
         assert!(!is_probe_only_namesrv_config_request(&request));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7621

### Brief Description

Add focused unit coverage for the NameServer runtime config blacklist helpers used by `UpdateNamesrvConfig`. The new tests verify that the fixed protected keys are always present, custom blacklist entries are appended once in order, and blacklist detection rejects blocked properties while allowing unrelated ones.

### How Did You Test This Change?

- `cargo test -p rocketmq-namesrv default_request_processor`
- `cargo fmt --all`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for nameserver blacklist configuration behavior.
  * Verified required blacklist entries are always included.
  * Confirmed custom entries are added without duplicates and with whitespace handled correctly.
  * Added checks for distinguishing blocked properties from allowed ones not listed in the blacklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->