### PR TITLE
[ISSUE #7711]🐛Add recursion limit to grpc ingress test

### DIFF
--- a/rocketmq-proxy/tests/grpc_ingress.rs
+++ b/rocketmq-proxy/tests/grpc_ingress.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::collections::HashMap;
 use std::fs;
 use std::net::SocketAddr;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7711

### Brief Description

Add `#![recursion_limit = "256"]` to `rocketmq-proxy/tests/grpc_ingress.rs` so the integration test crate compiles successfully when the remoting async stack drives rustc query expansion past the default depth limit. This mirrors the existing crate-level setting already used by `rocketmq-proxy/tests/remoting_ingress.rs` and restores the workspace test path that was failing during compilation.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy --test grpc_ingress --all-features`
- `cargo fmt --all`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to allow deeper recursion during gRPC ingress test compilation, helping the test suite handle more complex cases reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->