### PR TITLE
[ISSUE #7717]✨Add recovery mode report scaffolding

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -170,6 +170,10 @@ mod defaults {
         200
     }
 
+    pub fn recovery_mode() -> RecoveryMode {
+        RecoveryMode::default()
+    }
+
     pub fn disk_space_warning_level_ratio() -> usize {
         90
     }
@@ -413,6 +417,25 @@ impl LinuxStorageProfile {
                 ha_sendfile_enable: false,
                 io_uring_enable: false,
             },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryMode {
+    #[default]
+    Strict,
+    Balanced,
+    Fast,
+}
+
+impl RecoveryMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::Balanced => "balanced",
+            Self::Fast => "fast",
         }
     }
 }
@@ -676,6 +699,9 @@ pub struct MessageStoreConfig {
 
     #[serde(default)]
     pub max_recovery_commit_log_files: usize,
+
+    #[serde(default = "defaults::recovery_mode")]
+    pub recovery_mode: RecoveryMode,
 
     #[serde(default = "defaults::disk_space_warning_level_ratio")]
     pub disk_space_warning_level_ratio: usize,
@@ -1205,6 +1231,7 @@ impl Default for MessageStoreConfig {
             flush_interval_commit_log: 500,
             commit_interval_commit_log: 200,
             max_recovery_commit_log_files: 0,
+            recovery_mode: RecoveryMode::default(),
             disk_space_warning_level_ratio: 90,
             disk_space_clean_forcibly_ratio: 85,
             use_reentrant_lock_when_put_message: false,
@@ -1632,6 +1659,7 @@ impl MessageStoreConfig {
             "maxRecoveryCommitLogFiles".to_string(),
             self.max_recovery_commit_log_files.to_string(),
         );
+        properties.insert("recoveryMode".to_string(), self.recovery_mode.as_str().to_string());
         properties.insert(
             "diskSpaceWarningLevelRatio".to_string(),
             self.disk_space_warning_level_ratio.to_string(),
@@ -2064,6 +2092,7 @@ mod tests {
     use super::LinuxStorageProfile;
     use super::LinuxTransferEngine;
     use super::MessageStoreConfig;
+    use super::RecoveryMode;
 
     #[test]
     fn default_max_checksum_range_matches_java_default() {
@@ -2083,6 +2112,26 @@ mod tests {
     fn serde_defaults_keep_file_reserved_time_java_default() -> Result<(), serde_json::Error> {
         let config: MessageStoreConfig = serde_json::from_str("{}")?;
         assert_eq!(config.file_reserved_time, 72);
+        Ok(())
+    }
+
+    #[test]
+    fn default_recovery_mode_is_strict_for_behavior_compatibility() {
+        let config = MessageStoreConfig::default();
+
+        assert_eq!(config.recovery_mode, RecoveryMode::Strict);
+        assert_eq!(config.get_properties()["recoveryMode"], "strict");
+    }
+
+    #[test]
+    fn serde_loads_snake_case_recovery_mode() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str(
+            r#"{
+                "recoveryMode": "balanced"
+            }"#,
+        )?;
+
+        assert_eq!(config.recovery_mode, RecoveryMode::Balanced);
         Ok(())
     }
 

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod local_file_message_store;
+pub mod recovery;
 
 #[cfg(feature = "rocksdb_store")]
 pub mod rocksdb_message_store;

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -141,6 +141,10 @@ use crate::log_file::commit_log;
 use crate::log_file::commit_log::CommitLog;
 use crate::log_file::mapped_file::MappedFile;
 use crate::log_file::MAX_PULL_MSG_SIZE;
+use crate::message_store::recovery::RecoveryExit;
+use crate::message_store::recovery::RecoveryPhase;
+use crate::message_store::recovery::RecoveryPlan;
+use crate::message_store::recovery::RecoveryReport;
 use crate::queue::build_consume_queue::CommitLogDispatcherBuildConsumeQueue;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
@@ -352,6 +356,7 @@ pub struct LocalFileMessageStore {
     ha_update_master_group: Arc<StdMutex<Option<rocketmq_runtime::TaskGroup>>>,
     delay_level_table: ArcMut<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,
+    last_recovery_report: Option<RecoveryReport>,
 }
 
 fn notify_message_arrive_for_multi_dispatch(
@@ -589,6 +594,7 @@ impl LocalFileMessageStore {
             ha_update_master_group: Arc::new(StdMutex::new(None)),
             delay_level_table: ArcMut::new(delay_level_table),
             max_delay_level,
+            last_recovery_report: None,
         })
     }
 
@@ -1198,17 +1204,30 @@ impl LocalFileMessageStore {
     async fn recover(&mut self, last_exit_ok: bool) {
         let previous_state = self.lifecycle_state();
         let recover_concurrently = self.is_recover_concurrently();
+        let mut recovery_report = RecoveryReport::new(RecoveryPlan::new(
+            self.message_store_config.recovery_mode,
+            RecoveryExit::from_last_exit_ok(last_exit_ok),
+            recover_concurrently,
+            self.message_store_config.max_recovery_commit_log_files,
+        ));
         info!(
-            "message store recover mode: {}",
+            "message store recover mode: {}, recoveryMode: {}, lastExit: {}, maxRecoveryCommitLogFiles: {}",
             if recover_concurrently { "concurrent" } else { "normal" },
+            self.message_store_config.recovery_mode.as_str(),
+            recovery_report.plan.exit.as_str(),
+            recovery_report.plan.max_recovery_commit_log_files
         );
         let recover_consume_queue_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringConsumeQueue);
         self.recover_consume_queue().await;
         let dispatch_recovery_offset = self.get_dispatch_recovery_offset();
+        recovery_report
+            .plan
+            .set_dispatch_recovery_offset(dispatch_recovery_offset);
         let recover_consume_queue = Instant::now()
             .saturating_duration_since(recover_consume_queue_start)
             .as_millis();
+        recovery_report.record_phase(RecoveryPhase::ConsumeQueue, recover_consume_queue);
 
         let recover_commit_log_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringCommitLog);
@@ -1220,6 +1239,7 @@ impl LocalFileMessageStore {
         let recover_commit_log = Instant::now()
             .saturating_duration_since(recover_commit_log_start)
             .as_millis();
+        recovery_report.record_phase(RecoveryPhase::CommitLog, recover_commit_log);
 
         let recover_topic_queue_table_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringTopicQueueTable);
@@ -1227,17 +1247,22 @@ impl LocalFileMessageStore {
         let recover_topic_queue_table = Instant::now()
             .saturating_duration_since(recover_topic_queue_table_start)
             .as_millis();
+        recovery_report.record_phase(RecoveryPhase::TopicQueueTable, recover_topic_queue_table);
         if self.lifecycle_state() != StoreLifecycleState::Shutdown {
             self.set_lifecycle_state(previous_state);
         }
         info!(
             "message store recover total cost: {} ms, recoverConsumeQueue: {} ms, recoverCommitLog: {} ms, \
-             recoverOffsetTable: {} ms",
-            recover_consume_queue + recover_commit_log + recover_topic_queue_table,
+             recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}",
+            recovery_report.total_duration_ms,
             recover_consume_queue,
             recover_commit_log,
-            recover_topic_queue_table
+            recover_topic_queue_table,
+            recovery_report.plan.mode.as_str(),
+            recovery_report.plan.exit.as_str(),
+            recovery_report.plan.dispatch_recovery_offset
         );
+        self.last_recovery_report = Some(recovery_report);
     }
 
     pub async fn recover_normally(&mut self, max_phy_offset_of_consume_queue: i64) {
@@ -1613,6 +1638,10 @@ impl LocalFileMessageStore {
 
     pub fn get_message_store_config(&self) -> Arc<MessageStoreConfig> {
         self.message_store_config.clone()
+    }
+
+    pub fn last_recovery_report(&self) -> Option<&RecoveryReport> {
+        self.last_recovery_report.as_ref()
     }
 
     pub async fn reput_once(&mut self) {
@@ -4728,12 +4757,15 @@ mod tests {
     use crate::config::flush_disk_type::FlushDiskType;
     use crate::config::message_store_config::LinuxMemoryLockMode;
     use crate::config::message_store_config::MessageStoreConfig;
+    use crate::config::message_store_config::RecoveryMode;
     use crate::filter::MessageFilter;
     use crate::hook::put_message_hook::PutMessageHook;
     use crate::hook::send_message_back_hook::SendMessageBackHook;
     use crate::kv::compaction_service::CompactionService;
     use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
     use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
+    use crate::message_store::recovery::RecoveryExit;
+    use crate::message_store::recovery::RecoveryPhase;
     use crate::queue::consume_queue::ConsumeQueueTrait;
     use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
     use crate::store_error::StoreError;
@@ -5852,6 +5884,36 @@ mod tests {
         store.init().await.expect("init store");
         store.recover(false).await;
         assert_eq!(store.lifecycle_state(), StoreLifecycleState::Initialized);
+    }
+
+    #[tokio::test]
+    async fn recover_records_structured_recovery_report() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                max_recovery_commit_log_files: 7,
+                recovery_mode: RecoveryMode::Strict,
+                ..Default::default()
+            },
+        );
+
+        store.recover(false).await;
+
+        let report = store.last_recovery_report().expect("recovery report");
+        assert_eq!(report.plan.mode, RecoveryMode::Strict);
+        assert_eq!(report.plan.exit, RecoveryExit::Abnormal);
+        assert!(!report.plan.recover_concurrently);
+        assert_eq!(report.plan.max_recovery_commit_log_files, 7);
+        assert!(report.plan.dispatch_recovery_offset.is_some());
+        assert_eq!(report.phases.len(), 3);
+        assert!(report.phase_duration_ms(RecoveryPhase::ConsumeQueue).is_some());
+        assert!(report.phase_duration_ms(RecoveryPhase::CommitLog).is_some());
+        assert!(report.phase_duration_ms(RecoveryPhase::TopicQueueTable).is_some());
+        assert_eq!(
+            report.total_duration_ms,
+            report.phases.iter().map(|phase| phase.duration_ms).sum()
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::message_store_config::RecoveryMode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryExit {
+    Normal,
+    Abnormal,
+}
+
+impl RecoveryExit {
+    pub const fn from_last_exit_ok(last_exit_ok: bool) -> Self {
+        if last_exit_ok {
+            Self::Normal
+        } else {
+            Self::Abnormal
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Abnormal => "abnormal",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryPhase {
+    ConsumeQueue,
+    CommitLog,
+    TopicQueueTable,
+}
+
+impl RecoveryPhase {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConsumeQueue => "consume_queue",
+            Self::CommitLog => "commit_log",
+            Self::TopicQueueTable => "topic_queue_table",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryPlan {
+    pub mode: RecoveryMode,
+    pub exit: RecoveryExit,
+    pub recover_concurrently: bool,
+    pub max_recovery_commit_log_files: usize,
+    pub dispatch_recovery_offset: Option<i64>,
+}
+
+impl RecoveryPlan {
+    pub const fn new(
+        mode: RecoveryMode,
+        exit: RecoveryExit,
+        recover_concurrently: bool,
+        max_recovery_commit_log_files: usize,
+    ) -> Self {
+        Self {
+            mode,
+            exit,
+            recover_concurrently,
+            max_recovery_commit_log_files,
+            dispatch_recovery_offset: None,
+        }
+    }
+
+    pub fn set_dispatch_recovery_offset(&mut self, dispatch_recovery_offset: i64) {
+        self.dispatch_recovery_offset = Some(dispatch_recovery_offset);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryPhaseReport {
+    pub phase: RecoveryPhase,
+    pub duration_ms: u128,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryReport {
+    pub plan: RecoveryPlan,
+    pub phases: Vec<RecoveryPhaseReport>,
+    pub total_duration_ms: u128,
+    pub fallback_reason: Option<String>,
+}
+
+impl RecoveryReport {
+    pub fn new(plan: RecoveryPlan) -> Self {
+        Self {
+            plan,
+            phases: Vec::with_capacity(3),
+            total_duration_ms: 0,
+            fallback_reason: None,
+        }
+    }
+
+    pub fn record_phase(&mut self, phase: RecoveryPhase, duration_ms: u128) {
+        self.total_duration_ms = self.total_duration_ms.saturating_add(duration_ms);
+        self.phases.push(RecoveryPhaseReport { phase, duration_ms });
+    }
+
+    pub fn set_fallback_reason(&mut self, fallback_reason: impl Into<String>) {
+        self.fallback_reason = Some(fallback_reason.into());
+    }
+
+    pub fn phase_duration_ms(&self, phase: RecoveryPhase) -> Option<u128> {
+        self.phases
+            .iter()
+            .find(|report| report.phase == phase)
+            .map(|report| report.duration_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_exit_reflects_abort_marker_result() {
+        assert_eq!(RecoveryExit::from_last_exit_ok(true), RecoveryExit::Normal);
+        assert_eq!(RecoveryExit::from_last_exit_ok(false), RecoveryExit::Abnormal);
+        assert_eq!(RecoveryExit::Normal.as_str(), "normal");
+        assert_eq!(RecoveryExit::Abnormal.as_str(), "abnormal");
+    }
+
+    #[test]
+    fn recovery_report_accumulates_phase_durations() {
+        let mut plan = RecoveryPlan::new(RecoveryMode::Strict, RecoveryExit::Abnormal, false, 0);
+        plan.set_dispatch_recovery_offset(1024);
+        let mut report = RecoveryReport::new(plan);
+
+        report.record_phase(RecoveryPhase::ConsumeQueue, 10);
+        report.record_phase(RecoveryPhase::CommitLog, 20);
+        report.record_phase(RecoveryPhase::TopicQueueTable, 5);
+
+        assert_eq!(report.plan.dispatch_recovery_offset, Some(1024));
+        assert_eq!(report.total_duration_ms, 35);
+        assert_eq!(report.phase_duration_ms(RecoveryPhase::CommitLog), Some(20));
+        assert_eq!(report.phase_duration_ms(RecoveryPhase::TopicQueueTable), Some(5));
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7717

### Brief Description

Add recovery-mode configuration and structured recovery-report scaffolding for broker startup recovery without changing the existing recovery execution path. The report captures the selected mode, exit classification, configured recovery file bound, dispatch recovery offset, per-phase durations, and total recovery duration.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo test -p rocketmq-store recovery` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable recovery modes for message store startup and surfaced the chosen mode in configuration output.
  * Introduced recovery reporting so the store can track phase-by-phase recovery progress and timing.
  * Exposed the latest recovery report through the store for visibility into recent recovery behavior.

* **Bug Fixes**
  * Improved recovery handling to preserve and report detailed state across multiple recovery phases.
  * Added coverage for default configuration and recovery report behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->