### PR TITLE
[ISSUE #7719]✨Complete recovery plan report model

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -141,7 +141,9 @@ use crate::log_file::commit_log;
 use crate::log_file::commit_log::CommitLog;
 use crate::log_file::mapped_file::MappedFile;
 use crate::log_file::MAX_PULL_MSG_SIZE;
+use crate::message_store::recovery::RecoveryCrcPolicy;
 use crate::message_store::recovery::RecoveryExit;
+use crate::message_store::recovery::RecoveryIndexRepairPolicy;
 use crate::message_store::recovery::RecoveryPhase;
 use crate::message_store::recovery::RecoveryPlan;
 use crate::message_store::recovery::RecoveryReport;
@@ -1204,18 +1206,37 @@ impl LocalFileMessageStore {
     async fn recover(&mut self, last_exit_ok: bool) {
         let previous_state = self.lifecycle_state();
         let recover_concurrently = self.is_recover_concurrently();
-        let mut recovery_report = RecoveryReport::new(RecoveryPlan::new(
+        let mut recovery_plan = RecoveryPlan::new(
             self.message_store_config.recovery_mode,
             RecoveryExit::from_last_exit_ok(last_exit_ok),
             recover_concurrently,
             self.message_store_config.max_recovery_commit_log_files,
-        ));
+        );
+        recovery_plan.crc_policy = RecoveryCrcPolicy::new(
+            self.message_store_config.check_crc_on_recover,
+            self.message_store_config.force_verify_prop_crc,
+        );
+        recovery_plan.index_repair_policy = if self.message_store_config.message_index_enable {
+            RecoveryIndexRepairPolicy::Synchronous
+        } else {
+            RecoveryIndexRepairPolicy::Disabled
+        };
+        recovery_plan.set_commit_log_offsets(
+            self.get_min_phy_offset(),
+            self.get_max_phy_offset(),
+            self.get_confirm_offset(),
+        );
+        let mut recovery_report = RecoveryReport::new(recovery_plan);
         info!(
-            "message store recover mode: {}, recoveryMode: {}, lastExit: {}, maxRecoveryCommitLogFiles: {}",
+            "message store recover mode: {}, recoveryMode: {}, lastExit: {}, maxRecoveryCommitLogFiles: {}, \
+             crcPolicy: message={}, property={}, indexRepairPolicy: {}",
             if recover_concurrently { "concurrent" } else { "normal" },
             self.message_store_config.recovery_mode.as_str(),
             recovery_report.plan.exit.as_str(),
-            recovery_report.plan.max_recovery_commit_log_files
+            recovery_report.plan.max_recovery_commit_log_files,
+            recovery_report.plan.crc_policy.check_message_crc,
+            recovery_report.plan.crc_policy.check_property_crc,
+            recovery_report.plan.index_repair_policy.as_str()
         );
         let recover_consume_queue_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringConsumeQueue);
@@ -1224,6 +1245,9 @@ impl LocalFileMessageStore {
         recovery_report
             .plan
             .set_dispatch_recovery_offset(dispatch_recovery_offset);
+        recovery_report
+            .plan
+            .set_max_consume_queue_physical_offset(dispatch_recovery_offset);
         let recover_consume_queue = Instant::now()
             .saturating_duration_since(recover_consume_queue_start)
             .as_millis();
@@ -1251,16 +1275,25 @@ impl LocalFileMessageStore {
         if self.lifecycle_state() != StoreLifecycleState::Shutdown {
             self.set_lifecycle_state(previous_state);
         }
+        recovery_report.plan.set_commit_log_offsets(
+            self.get_min_phy_offset(),
+            self.get_max_phy_offset(),
+            self.get_confirm_offset(),
+        );
         info!(
             "message store recover total cost: {} ms, recoverConsumeQueue: {} ms, recoverCommitLog: {} ms, \
-             recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}",
+             recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}, commitLogRange: \
+             {:?}-{:?}, confirmOffset: {:?}",
             recovery_report.total_duration_ms,
             recover_consume_queue,
             recover_commit_log,
             recover_topic_queue_table,
             recovery_report.plan.mode.as_str(),
             recovery_report.plan.exit.as_str(),
-            recovery_report.plan.dispatch_recovery_offset
+            recovery_report.plan.dispatch_recovery_offset,
+            recovery_report.plan.offsets.commit_log_min_offset,
+            recovery_report.plan.offsets.commit_log_max_offset,
+            recovery_report.plan.offsets.confirm_offset
         );
         self.last_recovery_report = Some(recovery_report);
     }
@@ -4764,8 +4797,12 @@ mod tests {
     use crate::kv::compaction_service::CompactionService;
     use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
     use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
+    use crate::message_store::recovery::RecoveryCrcPolicy;
     use crate::message_store::recovery::RecoveryExit;
+    use crate::message_store::recovery::RecoveryIndexRepairPolicy;
     use crate::message_store::recovery::RecoveryPhase;
+    use crate::message_store::recovery::RecoveryPhaseStatus;
+    use crate::message_store::recovery::RecoveryReportStats;
     use crate::queue::consume_queue::ConsumeQueueTrait;
     use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
     use crate::store_error::StoreError;
@@ -5894,6 +5931,8 @@ mod tests {
             MessageStoreConfig {
                 max_recovery_commit_log_files: 7,
                 recovery_mode: RecoveryMode::Strict,
+                check_crc_on_recover: true,
+                force_verify_prop_crc: true,
                 ..Default::default()
             },
         );
@@ -5905,11 +5944,34 @@ mod tests {
         assert_eq!(report.plan.exit, RecoveryExit::Abnormal);
         assert!(!report.plan.recover_concurrently);
         assert_eq!(report.plan.max_recovery_commit_log_files, 7);
+        assert_eq!(report.plan.scan_range.file_count_limit, Some(7));
         assert!(report.plan.dispatch_recovery_offset.is_some());
+        assert_eq!(
+            report.plan.offsets.dispatch_recovery_offset,
+            report.plan.dispatch_recovery_offset
+        );
+        assert_eq!(
+            report.plan.scan_range.start_offset,
+            report.plan.dispatch_recovery_offset
+        );
+        assert!(report.plan.offsets.commit_log_min_offset.is_some());
+        assert!(report.plan.offsets.commit_log_max_offset.is_some());
+        assert!(report.plan.offsets.confirm_offset.is_some());
+        assert_eq!(
+            report.plan.scan_range.end_offset,
+            report.plan.offsets.commit_log_max_offset
+        );
+        assert_eq!(report.plan.crc_policy, RecoveryCrcPolicy::new(true, true));
+        assert_eq!(report.plan.index_repair_policy, RecoveryIndexRepairPolicy::Synchronous);
         assert_eq!(report.phases.len(), 3);
         assert!(report.phase_duration_ms(RecoveryPhase::ConsumeQueue).is_some());
         assert!(report.phase_duration_ms(RecoveryPhase::CommitLog).is_some());
         assert!(report.phase_duration_ms(RecoveryPhase::TopicQueueTable).is_some());
+        assert!(report
+            .phases
+            .iter()
+            .all(|phase| phase.status == RecoveryPhaseStatus::Success));
+        assert_eq!(report.stats, RecoveryReportStats::default());
         assert_eq!(
             report.total_duration_ms,
             report.phases.iter().map(|phase| phase.duration_ms).sum()

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -54,6 +54,96 @@ impl RecoveryPhase {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RecoveryIndexRepairPolicy {
+    #[default]
+    Synchronous,
+    Background,
+    Disabled,
+}
+
+impl RecoveryIndexRepairPolicy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Synchronous => "synchronous",
+            Self::Background => "background",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RecoveryFallbackPolicy {
+    #[default]
+    Fail,
+    Strict,
+    DegradedStart,
+    BackgroundContinue,
+}
+
+impl RecoveryFallbackPolicy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fail => "fail",
+            Self::Strict => "strict",
+            Self::DegradedStart => "degraded_start",
+            Self::BackgroundContinue => "background_continue",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecoveryCrcPolicy {
+    pub check_message_crc: bool,
+    pub check_property_crc: bool,
+}
+
+impl RecoveryCrcPolicy {
+    pub const fn new(check_message_crc: bool, check_property_crc: bool) -> Self {
+        Self {
+            check_message_crc,
+            check_property_crc,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecoveryScanRange {
+    pub start_file_index: Option<usize>,
+    pub start_offset: Option<i64>,
+    pub end_offset: Option<i64>,
+    pub file_count_limit: Option<usize>,
+}
+
+impl RecoveryScanRange {
+    pub const fn with_file_count_limit(file_count_limit: usize) -> Self {
+        Self {
+            start_file_index: None,
+            start_offset: None,
+            end_offset: None,
+            file_count_limit: if file_count_limit == 0 {
+                None
+            } else {
+                Some(file_count_limit)
+            },
+        }
+    }
+
+    pub fn set_offsets(&mut self, start_offset: i64, end_offset: i64) {
+        self.start_offset = Some(start_offset);
+        self.end_offset = Some(end_offset);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecoveryOffsets {
+    pub dispatch_recovery_offset: Option<i64>,
+    pub commit_log_min_offset: Option<i64>,
+    pub commit_log_max_offset: Option<i64>,
+    pub confirm_offset: Option<i64>,
+    pub max_consume_queue_physical_offset: Option<i64>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoveryPlan {
     pub mode: RecoveryMode,
@@ -61,10 +151,15 @@ pub struct RecoveryPlan {
     pub recover_concurrently: bool,
     pub max_recovery_commit_log_files: usize,
     pub dispatch_recovery_offset: Option<i64>,
+    pub scan_range: RecoveryScanRange,
+    pub crc_policy: RecoveryCrcPolicy,
+    pub index_repair_policy: RecoveryIndexRepairPolicy,
+    pub fallback_policy: RecoveryFallbackPolicy,
+    pub offsets: RecoveryOffsets,
 }
 
 impl RecoveryPlan {
-    pub const fn new(
+    pub fn new(
         mode: RecoveryMode,
         exit: RecoveryExit,
         recover_concurrently: bool,
@@ -76,11 +171,68 @@ impl RecoveryPlan {
             recover_concurrently,
             max_recovery_commit_log_files,
             dispatch_recovery_offset: None,
+            scan_range: RecoveryScanRange::with_file_count_limit(max_recovery_commit_log_files),
+            crc_policy: RecoveryCrcPolicy::default(),
+            index_repair_policy: RecoveryIndexRepairPolicy::default(),
+            fallback_policy: RecoveryFallbackPolicy::default(),
+            offsets: RecoveryOffsets::default(),
         }
     }
 
     pub fn set_dispatch_recovery_offset(&mut self, dispatch_recovery_offset: i64) {
         self.dispatch_recovery_offset = Some(dispatch_recovery_offset);
+        self.offsets.dispatch_recovery_offset = Some(dispatch_recovery_offset);
+        self.scan_range.start_offset = Some(dispatch_recovery_offset);
+    }
+
+    pub fn set_commit_log_offsets(&mut self, min_offset: i64, max_offset: i64, confirm_offset: i64) {
+        self.offsets.commit_log_min_offset = Some(min_offset);
+        self.offsets.commit_log_max_offset = Some(max_offset);
+        self.offsets.confirm_offset = Some(confirm_offset);
+        self.scan_range.end_offset = Some(max_offset);
+    }
+
+    pub fn set_max_consume_queue_physical_offset(&mut self, max_offset: i64) {
+        self.offsets.max_consume_queue_physical_offset = Some(max_offset);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RecoveryPhaseStatus {
+    #[default]
+    Success,
+    Fallback,
+    Failed,
+}
+
+impl RecoveryPhaseStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Fallback => "fallback",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecoveryReportStats {
+    pub scanned_bytes: u64,
+    pub recovered_messages: u64,
+    pub invalid_messages: u64,
+    pub truncated_files: u64,
+    pub index_files_removed: u64,
+    pub index_files_rebuilt: u64,
+}
+
+impl RecoveryReportStats {
+    pub fn accumulate(&mut self, other: Self) {
+        self.scanned_bytes = self.scanned_bytes.saturating_add(other.scanned_bytes);
+        self.recovered_messages = self.recovered_messages.saturating_add(other.recovered_messages);
+        self.invalid_messages = self.invalid_messages.saturating_add(other.invalid_messages);
+        self.truncated_files = self.truncated_files.saturating_add(other.truncated_files);
+        self.index_files_removed = self.index_files_removed.saturating_add(other.index_files_removed);
+        self.index_files_rebuilt = self.index_files_rebuilt.saturating_add(other.index_files_rebuilt);
     }
 }
 
@@ -88,12 +240,15 @@ impl RecoveryPlan {
 pub struct RecoveryPhaseReport {
     pub phase: RecoveryPhase,
     pub duration_ms: u128,
+    pub status: RecoveryPhaseStatus,
+    pub stats: RecoveryReportStats,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoveryReport {
     pub plan: RecoveryPlan,
     pub phases: Vec<RecoveryPhaseReport>,
+    pub stats: RecoveryReportStats,
     pub total_duration_ms: u128,
     pub fallback_reason: Option<String>,
 }
@@ -103,14 +258,35 @@ impl RecoveryReport {
         Self {
             plan,
             phases: Vec::with_capacity(3),
+            stats: RecoveryReportStats::default(),
             total_duration_ms: 0,
             fallback_reason: None,
         }
     }
 
     pub fn record_phase(&mut self, phase: RecoveryPhase, duration_ms: u128) {
+        self.record_phase_with_stats(phase, duration_ms, RecoveryReportStats::default());
+    }
+
+    pub fn record_phase_with_stats(&mut self, phase: RecoveryPhase, duration_ms: u128, stats: RecoveryReportStats) {
+        self.record_phase_with_status(phase, duration_ms, RecoveryPhaseStatus::Success, stats);
+    }
+
+    pub fn record_phase_with_status(
+        &mut self,
+        phase: RecoveryPhase,
+        duration_ms: u128,
+        status: RecoveryPhaseStatus,
+        stats: RecoveryReportStats,
+    ) {
         self.total_duration_ms = self.total_duration_ms.saturating_add(duration_ms);
-        self.phases.push(RecoveryPhaseReport { phase, duration_ms });
+        self.stats.accumulate(stats);
+        self.phases.push(RecoveryPhaseReport {
+            phase,
+            duration_ms,
+            status,
+            stats,
+        });
     }
 
     pub fn set_fallback_reason(&mut self, fallback_reason: impl Into<String>) {
@@ -151,5 +327,92 @@ mod tests {
         assert_eq!(report.total_duration_ms, 35);
         assert_eq!(report.phase_duration_ms(RecoveryPhase::CommitLog), Some(20));
         assert_eq!(report.phase_duration_ms(RecoveryPhase::TopicQueueTable), Some(5));
+        assert_eq!(report.phases[0].status, RecoveryPhaseStatus::Success);
+        assert_eq!(report.stats, RecoveryReportStats::default());
+    }
+
+    #[test]
+    fn recovery_plan_defaults_preserve_strict_compatible_policy() {
+        let plan = RecoveryPlan::new(RecoveryMode::Strict, RecoveryExit::Normal, false, 7);
+
+        assert_eq!(plan.mode, RecoveryMode::Strict);
+        assert_eq!(plan.exit, RecoveryExit::Normal);
+        assert!(!plan.recover_concurrently);
+        assert_eq!(plan.max_recovery_commit_log_files, 7);
+        assert_eq!(plan.scan_range.file_count_limit, Some(7));
+        assert_eq!(plan.scan_range.start_offset, None);
+        assert_eq!(plan.scan_range.end_offset, None);
+        assert_eq!(plan.crc_policy, RecoveryCrcPolicy::default());
+        assert_eq!(plan.index_repair_policy, RecoveryIndexRepairPolicy::Synchronous);
+        assert_eq!(plan.fallback_policy, RecoveryFallbackPolicy::Fail);
+    }
+
+    #[test]
+    fn recovery_plan_tracks_offsets_and_policies() {
+        let mut plan = RecoveryPlan::new(RecoveryMode::Balanced, RecoveryExit::Abnormal, true, 0);
+        plan.crc_policy = RecoveryCrcPolicy::new(true, true);
+        plan.index_repair_policy = RecoveryIndexRepairPolicy::Background;
+        plan.fallback_policy = RecoveryFallbackPolicy::Strict;
+
+        plan.set_dispatch_recovery_offset(1024);
+        plan.set_commit_log_offsets(512, 4096, 3072);
+        plan.set_max_consume_queue_physical_offset(2048);
+
+        assert_eq!(plan.dispatch_recovery_offset, Some(1024));
+        assert_eq!(plan.offsets.dispatch_recovery_offset, Some(1024));
+        assert_eq!(plan.offsets.commit_log_min_offset, Some(512));
+        assert_eq!(plan.offsets.commit_log_max_offset, Some(4096));
+        assert_eq!(plan.offsets.confirm_offset, Some(3072));
+        assert_eq!(plan.offsets.max_consume_queue_physical_offset, Some(2048));
+        assert_eq!(plan.scan_range.start_offset, Some(1024));
+        assert_eq!(plan.scan_range.end_offset, Some(4096));
+        assert_eq!(plan.scan_range.file_count_limit, None);
+        assert_eq!(plan.crc_policy, RecoveryCrcPolicy::new(true, true));
+        assert_eq!(plan.index_repair_policy.as_str(), "background");
+        assert_eq!(plan.fallback_policy.as_str(), "strict");
+    }
+
+    #[test]
+    fn recovery_report_accumulates_phase_stats() {
+        let plan = RecoveryPlan::new(RecoveryMode::Fast, RecoveryExit::Abnormal, true, 3);
+        let mut report = RecoveryReport::new(plan);
+
+        report.record_phase_with_stats(
+            RecoveryPhase::CommitLog,
+            12,
+            RecoveryReportStats {
+                scanned_bytes: 4096,
+                recovered_messages: 8,
+                invalid_messages: 1,
+                truncated_files: 2,
+                index_files_removed: 0,
+                index_files_rebuilt: 0,
+            },
+        );
+        report.record_phase_with_status(
+            RecoveryPhase::TopicQueueTable,
+            3,
+            RecoveryPhaseStatus::Fallback,
+            RecoveryReportStats {
+                scanned_bytes: 1024,
+                recovered_messages: 2,
+                invalid_messages: 0,
+                truncated_files: 0,
+                index_files_removed: 1,
+                index_files_rebuilt: 4,
+            },
+        );
+        report.set_fallback_reason("index repair deferred");
+
+        assert_eq!(report.total_duration_ms, 15);
+        assert_eq!(report.stats.scanned_bytes, 5120);
+        assert_eq!(report.stats.recovered_messages, 10);
+        assert_eq!(report.stats.invalid_messages, 1);
+        assert_eq!(report.stats.truncated_files, 2);
+        assert_eq!(report.stats.index_files_removed, 1);
+        assert_eq!(report.stats.index_files_rebuilt, 4);
+        assert_eq!(report.phases[1].status, RecoveryPhaseStatus::Fallback);
+        assert_eq!(report.phases[1].status.as_str(), "fallback");
+        assert_eq!(report.fallback_reason.as_deref(), Some("index repair deferred"));
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7719

### Brief Description

Expand the broker startup recovery model without changing the recovery execution path. The change adds first-class recovery plan fields for scan range, CRC policy, Index repair policy, fallback policy, and recovery offsets, plus report statistics for scanned bytes, recovered messages, invalid messages, truncated files, and Index repair counters. Local file recovery now populates the model with the configuration and offsets already available at the recovery boundary.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo test -p rocketmq-store recovery` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved store recovery with clearer tracking of scan ranges, commit-log offsets, and consume-queue offsets.
  * Recovery reports now include richer progress details, status information, and overall timing/statistics.
* **Bug Fixes**
  * Added more robust CRC and index-repair handling during recovery to help detect and recover from corrupted data more reliably.
  * Recovery logging now surfaces more useful details for troubleshooting failed or partial recovery runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->