### PR TITLE
[ISSUE #7721]✨Add recovery executor orchestration

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -142,6 +142,7 @@ use crate::log_file::commit_log::CommitLog;
 use crate::log_file::mapped_file::MappedFile;
 use crate::log_file::MAX_PULL_MSG_SIZE;
 use crate::message_store::recovery::RecoveryCrcPolicy;
+use crate::message_store::recovery::RecoveryExecutor;
 use crate::message_store::recovery::RecoveryExit;
 use crate::message_store::recovery::RecoveryIndexRepairPolicy;
 use crate::message_store::recovery::RecoveryPhase;
@@ -1226,60 +1227,62 @@ impl LocalFileMessageStore {
             self.get_max_phy_offset(),
             self.get_confirm_offset(),
         );
-        let mut recovery_report = RecoveryReport::new(recovery_plan);
+        let mut recovery_executor = RecoveryExecutor::new(recovery_plan);
         info!(
             "message store recover mode: {}, recoveryMode: {}, lastExit: {}, maxRecoveryCommitLogFiles: {}, \
              crcPolicy: message={}, property={}, indexRepairPolicy: {}",
             if recover_concurrently { "concurrent" } else { "normal" },
             self.message_store_config.recovery_mode.as_str(),
-            recovery_report.plan.exit.as_str(),
-            recovery_report.plan.max_recovery_commit_log_files,
-            recovery_report.plan.crc_policy.check_message_crc,
-            recovery_report.plan.crc_policy.check_property_crc,
-            recovery_report.plan.index_repair_policy.as_str()
+            recovery_executor.plan().exit.as_str(),
+            recovery_executor.plan().max_recovery_commit_log_files,
+            recovery_executor.plan().crc_policy.check_message_crc,
+            recovery_executor.plan().crc_policy.check_property_crc,
+            recovery_executor.plan().index_repair_policy.as_str()
         );
-        let recover_consume_queue_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringConsumeQueue);
-        self.recover_consume_queue().await;
+        let recover_consume_queue = recovery_executor
+            .run_phase(RecoveryPhase::ConsumeQueue, self.recover_consume_queue())
+            .await;
         let dispatch_recovery_offset = self.get_dispatch_recovery_offset();
-        recovery_report
-            .plan
+        recovery_executor
+            .plan_mut()
             .set_dispatch_recovery_offset(dispatch_recovery_offset);
-        recovery_report
-            .plan
+        recovery_executor
+            .plan_mut()
             .set_max_consume_queue_physical_offset(dispatch_recovery_offset);
-        let recover_consume_queue = Instant::now()
-            .saturating_duration_since(recover_consume_queue_start)
-            .as_millis();
-        recovery_report.record_phase(RecoveryPhase::ConsumeQueue, recover_consume_queue);
 
-        let recover_commit_log_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringCommitLog);
-        if last_exit_ok {
-            self.recover_normally(dispatch_recovery_offset).await;
+        let recover_commit_log = if last_exit_ok {
+            recovery_executor
+                .run_phase(
+                    RecoveryPhase::CommitLog,
+                    self.recover_normally(dispatch_recovery_offset),
+                )
+                .await
         } else {
-            self.recover_abnormally(dispatch_recovery_offset).await;
-        }
-        let recover_commit_log = Instant::now()
-            .saturating_duration_since(recover_commit_log_start)
-            .as_millis();
-        recovery_report.record_phase(RecoveryPhase::CommitLog, recover_commit_log);
+            recovery_executor
+                .run_phase(
+                    RecoveryPhase::CommitLog,
+                    self.recover_abnormally(dispatch_recovery_offset),
+                )
+                .await
+        };
 
-        let recover_topic_queue_table_start = Instant::now();
         self.set_lifecycle_state(StoreLifecycleState::RecoveringTopicQueueTable);
-        self.recover_topic_queue_table();
-        let recover_topic_queue_table = Instant::now()
-            .saturating_duration_since(recover_topic_queue_table_start)
-            .as_millis();
-        recovery_report.record_phase(RecoveryPhase::TopicQueueTable, recover_topic_queue_table);
+        let recover_topic_queue_table = recovery_executor
+            .run_phase(RecoveryPhase::TopicQueueTable, async {
+                self.recover_topic_queue_table();
+            })
+            .await;
         if self.lifecycle_state() != StoreLifecycleState::Shutdown {
             self.set_lifecycle_state(previous_state);
         }
-        recovery_report.plan.set_commit_log_offsets(
+        recovery_executor.plan_mut().set_commit_log_offsets(
             self.get_min_phy_offset(),
             self.get_max_phy_offset(),
             self.get_confirm_offset(),
         );
+        let recovery_report = recovery_executor.finish();
         info!(
             "message store recover total cost: {} ms, recoverConsumeQueue: {} ms, recoverCommitLog: {} ms, \
              recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}, commitLogRange: \

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+use std::time::Instant;
+
 use crate::config::message_store_config::RecoveryMode;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -301,6 +304,65 @@ impl RecoveryReport {
     }
 }
 
+#[derive(Debug)]
+pub struct RecoveryExecutor {
+    report: RecoveryReport,
+}
+
+impl RecoveryExecutor {
+    pub fn new(plan: RecoveryPlan) -> Self {
+        Self {
+            report: RecoveryReport::new(plan),
+        }
+    }
+
+    pub fn plan(&self) -> &RecoveryPlan {
+        &self.report.plan
+    }
+
+    pub fn plan_mut(&mut self) -> &mut RecoveryPlan {
+        &mut self.report.plan
+    }
+
+    pub fn report(&self) -> &RecoveryReport {
+        &self.report
+    }
+
+    pub async fn run_phase<F>(&mut self, phase: RecoveryPhase, future: F) -> u128
+    where
+        F: Future<Output = ()>,
+    {
+        self.run_phase_with_status(
+            phase,
+            RecoveryPhaseStatus::Success,
+            RecoveryReportStats::default(),
+            future,
+        )
+        .await
+    }
+
+    pub async fn run_phase_with_status<F>(
+        &mut self,
+        phase: RecoveryPhase,
+        status: RecoveryPhaseStatus,
+        stats: RecoveryReportStats,
+        future: F,
+    ) -> u128
+    where
+        F: Future<Output = ()>,
+    {
+        let start = Instant::now();
+        future.await;
+        let duration_ms = Instant::now().saturating_duration_since(start).as_millis();
+        self.report.record_phase_with_status(phase, duration_ms, status, stats);
+        duration_ms
+    }
+
+    pub fn finish(self) -> RecoveryReport {
+        self.report
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,5 +476,59 @@ mod tests {
         assert_eq!(report.phases[1].status, RecoveryPhaseStatus::Fallback);
         assert_eq!(report.phases[1].status.as_str(), "fallback");
         assert_eq!(report.fallback_reason.as_deref(), Some("index repair deferred"));
+    }
+
+    #[tokio::test]
+    async fn recovery_executor_wraps_phase_execution() {
+        let plan = RecoveryPlan::new(RecoveryMode::Strict, RecoveryExit::Normal, false, 3);
+        let mut executor = RecoveryExecutor::new(plan);
+        let mut ran = false;
+
+        let duration_ms = executor
+            .run_phase(RecoveryPhase::ConsumeQueue, async {
+                ran = true;
+            })
+            .await;
+        executor.plan_mut().set_dispatch_recovery_offset(256);
+
+        assert!(ran);
+        assert_eq!(duration_ms, executor.report().phases[0].duration_ms);
+        assert_eq!(
+            executor.report().phase_duration_ms(RecoveryPhase::ConsumeQueue),
+            Some(duration_ms)
+        );
+        assert_eq!(executor.plan().dispatch_recovery_offset, Some(256));
+
+        let report = executor.finish();
+        assert_eq!(report.phases.len(), 1);
+        assert_eq!(report.phases[0].phase, RecoveryPhase::ConsumeQueue);
+        assert_eq!(report.phases[0].status, RecoveryPhaseStatus::Success);
+    }
+
+    #[tokio::test]
+    async fn recovery_executor_records_phase_status_and_stats() {
+        let plan = RecoveryPlan::new(RecoveryMode::Balanced, RecoveryExit::Abnormal, true, 2);
+        let mut executor = RecoveryExecutor::new(plan);
+
+        executor
+            .run_phase_with_status(
+                RecoveryPhase::CommitLog,
+                RecoveryPhaseStatus::Fallback,
+                RecoveryReportStats {
+                    scanned_bytes: 64,
+                    recovered_messages: 1,
+                    invalid_messages: 0,
+                    truncated_files: 0,
+                    index_files_removed: 0,
+                    index_files_rebuilt: 0,
+                },
+                async {},
+            )
+            .await;
+
+        let report = executor.finish();
+        assert_eq!(report.phases[0].status, RecoveryPhaseStatus::Fallback);
+        assert_eq!(report.stats.scanned_bytes, 64);
+        assert_eq!(report.stats.recovered_messages, 1);
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7721

### Brief Description

Add a behavior-compatible `RecoveryExecutor` that owns the recovery report and wraps existing recovery futures as explicit phases. Local file message store recovery now uses the executor for ConsumeQueue recovery, CommitLog recovery, and TopicQueueTable recovery while preserving the existing phase order, lifecycle state transitions, dispatch recovery offset calculation, and report output.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo test -p rocketmq-store recovery` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message store recovery handling for more reliable startup after unexpected shutdowns.
  * Recovery now tracks progress more consistently across different recovery steps, which may reduce recovery-related failures and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->