### PR TITLE
[ISSUE #7731]✨Add LocalFile CQ recovery planning

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -26,6 +26,8 @@ use crate::queue::single_consume_queue::CQ_STORE_UNIT_SIZE;
 
 static USER_HOME: LazyLock<PathBuf> = LazyLock::new(|| dirs::home_dir().unwrap());
 
+pub const LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP: usize = 8;
+
 /// Default value functions for Serde deserialization
 mod defaults {
     use super::*;
@@ -530,6 +532,20 @@ pub struct LinuxStorageProfileSettings {
     pub recovery_fadvise: LinuxRecoveryFadviseMode,
     pub ha_sendfile_enable: bool,
     pub io_uring_enable: bool,
+}
+
+pub fn bounded_local_file_consume_queue_recovery_parallelism(
+    configured_parallelism: usize,
+    available_parallelism: usize,
+) -> usize {
+    let available_parallelism = available_parallelism.max(1);
+    let upper_bound = available_parallelism.min(LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP);
+    let requested_parallelism = if configured_parallelism == 0 {
+        upper_bound
+    } else {
+        configured_parallelism
+    };
+    requested_parallelism.clamp(1, upper_bound)
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -1112,6 +1128,12 @@ pub struct MessageStoreConfig {
     pub enable_build_consume_queue_concurrently: bool,
 
     #[serde(default)]
+    pub enable_local_file_consume_queue_recovery_concurrently: bool,
+
+    #[serde(default)]
+    pub local_file_consume_queue_recovery_parallelism: usize,
+
+    #[serde(default)]
     pub batch_dispatch_request_thread_pool_nums: usize,
 
     #[serde(default)]
@@ -1366,6 +1388,8 @@ impl Default for MessageStoreConfig {
             sample_steps: 0,
             access_message_in_memory_hot_ratio: 0,
             enable_build_consume_queue_concurrently: false,
+            enable_local_file_consume_queue_recovery_concurrently: false,
+            local_file_consume_queue_recovery_parallelism: 0,
             batch_dispatch_request_thread_pool_nums: 0,
             clean_rocksdb_dirty_cq_interval_min: 0,
             stat_rocksdb_cq_interval_sec: 0,
@@ -1389,6 +1413,16 @@ impl Default for MessageStoreConfig {
 }
 
 impl MessageStoreConfig {
+    pub fn effective_local_file_consume_queue_recovery_parallelism(&self) -> usize {
+        let available_parallelism = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1);
+        bounded_local_file_consume_queue_recovery_parallelism(
+            self.local_file_consume_queue_recovery_parallelism,
+            available_parallelism,
+        )
+    }
+
     pub fn effective_linux_storage_profile_settings(&self) -> LinuxStorageProfileSettings {
         self.linux_storage_profile.settings()
     }
@@ -2038,6 +2072,19 @@ impl MessageStoreConfig {
             self.enable_build_consume_queue_concurrently.to_string(),
         );
         properties.insert(
+            "enableLocalFileConsumeQueueRecoveryConcurrently".to_string(),
+            self.enable_local_file_consume_queue_recovery_concurrently.to_string(),
+        );
+        properties.insert(
+            "localFileConsumeQueueRecoveryParallelism".to_string(),
+            self.local_file_consume_queue_recovery_parallelism.to_string(),
+        );
+        properties.insert(
+            "effectiveLocalFileConsumeQueueRecoveryParallelism".to_string(),
+            self.effective_local_file_consume_queue_recovery_parallelism()
+                .to_string(),
+        );
+        properties.insert(
             "batchDispatchRequestThreadPoolNums".to_string(),
             self.batch_dispatch_request_thread_pool_nums.to_string(),
         );
@@ -2087,12 +2134,14 @@ impl MessageStoreConfig {
 
 #[cfg(test)]
 mod tests {
+    use super::bounded_local_file_consume_queue_recovery_parallelism;
     use super::LinuxMappedFileWarmMode;
     use super::LinuxMemoryLockMode;
     use super::LinuxStorageProfile;
     use super::LinuxTransferEngine;
     use super::MessageStoreConfig;
     use super::RecoveryMode;
+    use super::LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP;
 
     #[test]
     fn default_max_checksum_range_matches_java_default() {
@@ -2121,6 +2170,53 @@ mod tests {
 
         assert_eq!(config.recovery_mode, RecoveryMode::Strict);
         assert_eq!(config.get_properties()["recoveryMode"], "strict");
+    }
+
+    #[test]
+    fn local_file_consume_queue_recovery_concurrency_is_disabled_by_default() {
+        let config = MessageStoreConfig::default();
+
+        assert!(!config.enable_local_file_consume_queue_recovery_concurrently);
+        assert_eq!(config.local_file_consume_queue_recovery_parallelism, 0);
+        assert_eq!(
+            config.get_properties()["enableLocalFileConsumeQueueRecoveryConcurrently"],
+            "false"
+        );
+        assert_eq!(config.get_properties()["localFileConsumeQueueRecoveryParallelism"], "0");
+    }
+
+    #[test]
+    fn serde_loads_local_file_consume_queue_recovery_concurrency() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str(
+            r#"{
+                "enableLocalFileConsumeQueueRecoveryConcurrently": true,
+                "localFileConsumeQueueRecoveryParallelism": 4
+            }"#,
+        )?;
+
+        assert!(config.enable_local_file_consume_queue_recovery_concurrently);
+        assert_eq!(config.local_file_consume_queue_recovery_parallelism, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn local_file_consume_queue_recovery_parallelism_defaults_to_bounded_cpu_count() {
+        assert_eq!(bounded_local_file_consume_queue_recovery_parallelism(0, 1), 1);
+        assert_eq!(bounded_local_file_consume_queue_recovery_parallelism(0, 4), 4);
+        assert_eq!(
+            bounded_local_file_consume_queue_recovery_parallelism(0, 64),
+            LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP
+        );
+    }
+
+    #[test]
+    fn local_file_consume_queue_recovery_parallelism_clamps_explicit_values() {
+        assert_eq!(bounded_local_file_consume_queue_recovery_parallelism(1, 4), 1);
+        assert_eq!(bounded_local_file_consume_queue_recovery_parallelism(6, 4), 4);
+        assert_eq!(
+            bounded_local_file_consume_queue_recovery_parallelism(64, 64),
+            LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP
+        );
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -141,6 +141,7 @@ use crate::log_file::commit_log;
 use crate::log_file::commit_log::CommitLog;
 use crate::log_file::mapped_file::MappedFile;
 use crate::log_file::MAX_PULL_MSG_SIZE;
+use crate::message_store::recovery::ConsumeQueueRecoveryConcurrency;
 use crate::message_store::recovery::RecoveryCrcPolicy;
 use crate::message_store::recovery::RecoveryExecutor;
 use crate::message_store::recovery::RecoveryExit;
@@ -1227,17 +1228,32 @@ impl LocalFileMessageStore {
             self.get_max_phy_offset(),
             self.get_confirm_offset(),
         );
+        recovery_plan.set_consume_queue_recovery_concurrency(ConsumeQueueRecoveryConcurrency::new(
+            self.message_store_config
+                .enable_local_file_consume_queue_recovery_concurrently,
+            self.message_store_config
+                .effective_local_file_consume_queue_recovery_parallelism(),
+        ));
         let mut recovery_executor = RecoveryExecutor::new(recovery_plan);
         info!(
             "message store recover mode: {}, recoveryMode: {}, lastExit: {}, maxRecoveryCommitLogFiles: {}, \
-             crcPolicy: message={}, property={}, indexRepairPolicy: {}",
+             crcPolicy: message={}, property={}, indexRepairPolicy: {}, localFileCqRecoveryConcurrent: {}, \
+             localFileCqRecoveryParallelism: {}",
             if recover_concurrently { "concurrent" } else { "normal" },
             self.message_store_config.recovery_mode.as_str(),
             recovery_executor.plan().exit.as_str(),
             recovery_executor.plan().max_recovery_commit_log_files,
             recovery_executor.plan().crc_policy.check_message_crc,
             recovery_executor.plan().crc_policy.check_property_crc,
-            recovery_executor.plan().index_repair_policy.as_str()
+            recovery_executor.plan().index_repair_policy.as_str(),
+            recovery_executor
+                .plan()
+                .consume_queue_recovery_concurrency
+                .local_file_enabled,
+            recovery_executor
+                .plan()
+                .consume_queue_recovery_concurrency
+                .local_file_parallelism
         );
         self.set_lifecycle_state(StoreLifecycleState::RecoveringConsumeQueue);
         let recover_consume_queue = recovery_executor
@@ -5936,6 +5952,8 @@ mod tests {
                 recovery_mode: RecoveryMode::Strict,
                 check_crc_on_recover: true,
                 force_verify_prop_crc: true,
+                enable_local_file_consume_queue_recovery_concurrently: true,
+                local_file_consume_queue_recovery_parallelism: 4,
                 ..Default::default()
             },
         );
@@ -5966,6 +5984,8 @@ mod tests {
         );
         assert_eq!(report.plan.crc_policy, RecoveryCrcPolicy::new(true, true));
         assert_eq!(report.plan.index_repair_policy, RecoveryIndexRepairPolicy::Synchronous);
+        assert!(report.plan.consume_queue_recovery_concurrency.local_file_enabled);
+        assert!(report.plan.consume_queue_recovery_concurrency.local_file_parallelism >= 1);
         assert_eq!(report.phases.len(), 3);
         assert!(report.phase_duration_ms(RecoveryPhase::ConsumeQueue).is_some());
         assert!(report.phase_duration_ms(RecoveryPhase::CommitLog).is_some());

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -5985,7 +5985,7 @@ mod tests {
         assert_eq!(report.plan.crc_policy, RecoveryCrcPolicy::new(true, true));
         assert_eq!(report.plan.index_repair_policy, RecoveryIndexRepairPolicy::Synchronous);
         assert!(report.plan.consume_queue_recovery_concurrency.local_file_enabled);
-        assert!(report.plan.consume_queue_recovery_concurrency.local_file_parallelism >= 1);
+        assert_eq!(report.plan.consume_queue_recovery_concurrency.local_file_parallelism, 4);
         assert_eq!(report.phases.len(), 3);
         assert!(report.phase_duration_ms(RecoveryPhase::ConsumeQueue).is_some());
         assert!(report.phase_duration_ms(RecoveryPhase::CommitLog).is_some());

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -147,6 +147,21 @@ pub struct RecoveryOffsets {
     pub max_consume_queue_physical_offset: Option<i64>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConsumeQueueRecoveryConcurrency {
+    pub local_file_enabled: bool,
+    pub local_file_parallelism: usize,
+}
+
+impl ConsumeQueueRecoveryConcurrency {
+    pub const fn new(local_file_enabled: bool, local_file_parallelism: usize) -> Self {
+        Self {
+            local_file_enabled,
+            local_file_parallelism,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoveryPlan {
     pub mode: RecoveryMode,
@@ -159,6 +174,7 @@ pub struct RecoveryPlan {
     pub index_repair_policy: RecoveryIndexRepairPolicy,
     pub fallback_policy: RecoveryFallbackPolicy,
     pub offsets: RecoveryOffsets,
+    pub consume_queue_recovery_concurrency: ConsumeQueueRecoveryConcurrency,
 }
 
 impl RecoveryPlan {
@@ -179,6 +195,7 @@ impl RecoveryPlan {
             index_repair_policy: RecoveryIndexRepairPolicy::default(),
             fallback_policy: RecoveryFallbackPolicy::default(),
             offsets: RecoveryOffsets::default(),
+            consume_queue_recovery_concurrency: ConsumeQueueRecoveryConcurrency::default(),
         }
     }
 
@@ -197,6 +214,10 @@ impl RecoveryPlan {
 
     pub fn set_max_consume_queue_physical_offset(&mut self, max_offset: i64) {
         self.offsets.max_consume_queue_physical_offset = Some(max_offset);
+    }
+
+    pub fn set_consume_queue_recovery_concurrency(&mut self, concurrency: ConsumeQueueRecoveryConcurrency) {
+        self.consume_queue_recovery_concurrency = concurrency;
     }
 }
 
@@ -407,6 +428,10 @@ mod tests {
         assert_eq!(plan.crc_policy, RecoveryCrcPolicy::default());
         assert_eq!(plan.index_repair_policy, RecoveryIndexRepairPolicy::Synchronous);
         assert_eq!(plan.fallback_policy, RecoveryFallbackPolicy::Fail);
+        assert_eq!(
+            plan.consume_queue_recovery_concurrency,
+            ConsumeQueueRecoveryConcurrency::default()
+        );
     }
 
     #[test]
@@ -432,6 +457,18 @@ mod tests {
         assert_eq!(plan.crc_policy, RecoveryCrcPolicy::new(true, true));
         assert_eq!(plan.index_repair_policy.as_str(), "background");
         assert_eq!(plan.fallback_policy.as_str(), "strict");
+    }
+
+    #[test]
+    fn recovery_plan_tracks_consume_queue_recovery_concurrency() {
+        let mut plan = RecoveryPlan::new(RecoveryMode::Balanced, RecoveryExit::Abnormal, false, 0);
+
+        plan.set_consume_queue_recovery_concurrency(ConsumeQueueRecoveryConcurrency::new(true, 4));
+
+        assert_eq!(
+            plan.consume_queue_recovery_concurrency,
+            ConsumeQueueRecoveryConcurrency::new(true, 4)
+        );
     }
 
     #[test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7731

### Brief Description

Adds the Phase 3 P3-T1 planning layer for LocalFile ConsumeQueue recovery concurrency.

This PR adds a disabled-by-default LocalFile CQ recovery concurrency switch, a configurable parallelism value, and a bounded effective parallelism helper capped by available CPU parallelism and a safety limit. The recovery plan now records the LocalFile CQ concurrency plan, and startup recovery logs expose the selected switch and effective parallelism.

The actual LocalFile topic/queue concurrent recovery execution remains unchanged in this PR. That keeps the current default recovery behavior intact and leaves the execution wiring for the next P3 task.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store recovery` passed.
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrency controls for local-file consume queue recovery, including a computed effective parallelism value.
  * Recovery details now include the selected concurrency settings in structured logs and recovery reports.

* **Bug Fixes**
  * Parallelism is now automatically bounded by available CPU capacity and a safety cap to avoid excessive settings.

* **Tests**
  * Added coverage for default values, configuration loading, and parallelism bounding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->