### PR TITLE
[ISSUE #7739]✨Add LocalFile CQ recovery benchmark

### DIFF
--- a/rocketmq-store/benches/commitlog_recovery_bench.rs
+++ b/rocketmq-store/benches/commitlog_recovery_bench.rs
@@ -31,6 +31,7 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
+use rocketmq_store::config::message_store_config::bounded_local_file_consume_queue_recovery_parallelism;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::log_file::commit_log_recovery::plan_abnormal_recovery_window_from_ranges;
 use rocketmq_store::log_file::commit_log_recovery::AbnormalRecoveryFileRange;
@@ -40,6 +41,9 @@ use rocketmq_store::log_file::commit_log_recovery::RecoveryStatistics;
 const BASELINE_SAMPLE_SIZE: usize = 10;
 const MESSAGE_SIZE_BYTES: u64 = 256;
 const PHASE2_FILE_SIZE_BYTES: u64 = 64 * 1024 * 1024;
+const PHASE3_CQ_FILE_SIZE_BYTES: u64 = 30 * 1024 * 1024;
+const PHASE3_CQ_RECORD_SIZE_BYTES: u64 = 20;
+const PHASE3_NON_CQ_STARTUP_OVERHEAD_MS: u128 = 250;
 
 #[derive(Clone, Copy)]
 struct RecoveryBaselineScenario {
@@ -184,6 +188,140 @@ const PHASE2_WINDOW_SCENARIOS: &[RecoveryWindowComparisonScenario] = &[
     },
 ];
 
+#[derive(Clone, Copy)]
+struct Phase3CqRecoveryScenario {
+    id: &'static str,
+    topic_count: usize,
+    queue_count: usize,
+    mapped_files_per_queue: usize,
+    records_per_file: usize,
+    empty_queue_count: usize,
+    configured_parallelism: usize,
+    available_parallelism_reference: usize,
+}
+
+impl Phase3CqRecoveryScenario {
+    fn active_queue_count(self) -> usize {
+        self.queue_count.saturating_sub(self.empty_queue_count)
+    }
+
+    fn effective_parallelism(self) -> usize {
+        bounded_local_file_consume_queue_recovery_parallelism(
+            self.configured_parallelism,
+            self.available_parallelism_reference,
+        )
+        .max(1)
+        .min(self.queue_count.max(1))
+    }
+
+    fn records_per_queue(self) -> usize {
+        self.mapped_files_per_queue.saturating_mul(self.records_per_file)
+    }
+
+    fn serial_work_units(self) -> usize {
+        self.active_queue_count().saturating_mul(self.records_per_queue())
+    }
+
+    fn concurrent_recovery_batches(self) -> usize {
+        let parallelism = self.effective_parallelism();
+        self.active_queue_count().saturating_add(parallelism - 1) / parallelism
+    }
+
+    fn concurrent_work_units(self) -> usize {
+        self.concurrent_recovery_batches()
+            .saturating_mul(self.records_per_queue())
+    }
+
+    fn total_cq_bytes(self) -> u64 {
+        (self.active_queue_count() as u64)
+            .saturating_mul(self.mapped_files_per_queue as u64)
+            .saturating_mul(PHASE3_CQ_FILE_SIZE_BYTES)
+    }
+
+    fn serial_cq_recovery_ms(self) -> u128 {
+        (self.serial_work_units() as u128).saturating_div(10_000).max(1)
+    }
+
+    fn concurrent_cq_recovery_ms(self) -> u128 {
+        (self.concurrent_work_units() as u128).saturating_div(10_000).max(1)
+    }
+
+    fn startup_reduction_ratio(self) -> f64 {
+        let serial = self.serial_cq_recovery_ms() as f64;
+        if serial == 0.0 {
+            0.0
+        } else {
+            1.0 - (self.concurrent_cq_recovery_ms() as f64 / serial)
+        }
+    }
+
+    fn serial_total_startup_ms(self) -> u128 {
+        PHASE3_NON_CQ_STARTUP_OVERHEAD_MS.saturating_add(self.serial_cq_recovery_ms())
+    }
+
+    fn concurrent_total_startup_ms(self) -> u128 {
+        PHASE3_NON_CQ_STARTUP_OVERHEAD_MS.saturating_add(self.concurrent_cq_recovery_ms())
+    }
+
+    fn total_startup_reduction_ratio(self) -> f64 {
+        let serial = self.serial_total_startup_ms() as f64;
+        if serial == 0.0 {
+            0.0
+        } else {
+            1.0 - (self.concurrent_total_startup_ms() as f64 / serial)
+        }
+    }
+
+    fn concurrency_utilization(self) -> f64 {
+        let active = self.active_queue_count();
+        if active == 0 {
+            return 0.0;
+        }
+        let parallelism = self.effective_parallelism();
+        let batches = self.concurrent_recovery_batches().max(1);
+        active as f64 / (parallelism.saturating_mul(batches)) as f64
+    }
+
+    fn estimated_cpu_utilization(self, detected_parallelism: usize) -> f64 {
+        let detected_parallelism = detected_parallelism.max(1);
+        let effective_parallelism = self.effective_parallelism().min(detected_parallelism);
+        (effective_parallelism as f64 / detected_parallelism as f64) * self.concurrency_utilization()
+    }
+}
+
+const PHASE3_CQ_RECOVERY_SCENARIOS: &[Phase3CqRecoveryScenario] = &[
+    Phase3CqRecoveryScenario {
+        id: "many_queues_exceed_parallelism",
+        topic_count: 32,
+        queue_count: 512,
+        mapped_files_per_queue: 3,
+        records_per_file: 128,
+        empty_queue_count: 0,
+        configured_parallelism: 8,
+        available_parallelism_reference: 16,
+    },
+    Phase3CqRecoveryScenario {
+        id: "few_large_queues",
+        topic_count: 2,
+        queue_count: 8,
+        mapped_files_per_queue: 64,
+        records_per_file: 256,
+        empty_queue_count: 0,
+        configured_parallelism: 8,
+        available_parallelism_reference: 16,
+    },
+    Phase3CqRecoveryScenario {
+        id: "many_empty_queues",
+        topic_count: 64,
+        queue_count: 1024,
+        mapped_files_per_queue: 1,
+        records_per_file: 32,
+        empty_queue_count: 896,
+        configured_parallelism: 8,
+        available_parallelism_reference: 16,
+    },
+];
+
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -197,6 +335,10 @@ fn benchmark_artifact_dir() -> PathBuf {
 
 fn phase2_benchmark_artifact_dir() -> PathBuf {
     workspace_root().join("target/recovery-baseline/phase2")
+}
+
+fn phase3_benchmark_artifact_dir() -> PathBuf {
+    workspace_root().join("target/recovery-baseline/phase3")
 }
 
 fn active_features() -> Vec<&'static str> {
@@ -372,6 +514,121 @@ fn write_phase2_window_comparison_manifest() {
     .expect("phase2 recovery benchmark manifest should be written");
 }
 
+fn write_phase3_cq_concurrency_manifest() {
+    let output_dir = phase3_benchmark_artifact_dir();
+    fs::create_dir_all(&output_dir).expect("phase3 recovery benchmark artifact directory should be created");
+
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_millis();
+    let detected_parallelism = std::thread::available_parallelism()
+        .map(|parallelism| parallelism.get())
+        .unwrap_or(1);
+    let scenarios: Vec<_> = PHASE3_CQ_RECOVERY_SCENARIOS
+        .iter()
+        .map(|scenario| {
+            let active_queues = scenario.active_queue_count();
+            let serial_ms = scenario.serial_cq_recovery_ms();
+            let concurrent_ms = scenario.concurrent_cq_recovery_ms();
+            let total_cq_bytes = scenario.total_cq_bytes();
+            let serial_throughput_bytes_per_ms = if serial_ms == 0 {
+                0.0
+            } else {
+                total_cq_bytes as f64 / serial_ms as f64
+            };
+            let concurrent_throughput_bytes_per_ms = if concurrent_ms == 0 {
+                0.0
+            } else {
+                total_cq_bytes as f64 / concurrent_ms as f64
+            };
+            let throughput_increase_ratio = if serial_throughput_bytes_per_ms == 0.0 {
+                0.0
+            } else {
+                (concurrent_throughput_bytes_per_ms / serial_throughput_bytes_per_ms) - 1.0
+            };
+
+            serde_json::json!({
+                "id": scenario.id,
+                "topic_count": scenario.topic_count,
+                "queue_count": scenario.queue_count,
+                "active_queue_count": active_queues,
+                "empty_queue_count": scenario.empty_queue_count,
+                "mapped_files_per_queue": scenario.mapped_files_per_queue,
+                "cq_file_size_bytes": PHASE3_CQ_FILE_SIZE_BYTES,
+                "records_per_file": scenario.records_per_file,
+                "cq_record_size_bytes": PHASE3_CQ_RECORD_SIZE_BYTES,
+                "configured_parallelism": scenario.configured_parallelism,
+                "available_parallelism_reference": scenario.available_parallelism_reference,
+                "detected_parallelism": detected_parallelism,
+                "effective_parallelism": scenario.effective_parallelism(),
+                "serial_work_units": scenario.serial_work_units(),
+                "bounded_concurrent_work_units": scenario.concurrent_work_units(),
+                "bounded_concurrent_batches": scenario.concurrent_recovery_batches(),
+                "estimated_serial_cq_recovery_ms": serial_ms,
+                "estimated_concurrent_cq_recovery_ms": concurrent_ms,
+                "estimated_cq_stage_reduction_ratio": scenario.startup_reduction_ratio(),
+                "estimated_phase2_total_startup_ms_reference": scenario.serial_total_startup_ms(),
+                "estimated_phase3_total_startup_ms": scenario.concurrent_total_startup_ms(),
+                "estimated_total_startup_reduction_ratio": scenario.total_startup_reduction_ratio(),
+                "estimated_serial_throughput_bytes_per_ms": serial_throughput_bytes_per_ms,
+                "estimated_concurrent_throughput_bytes_per_ms": concurrent_throughput_bytes_per_ms,
+                "estimated_disk_throughput_increase_ratio": throughput_increase_ratio,
+                "estimated_cpu_core_utilization_ratio": scenario.estimated_cpu_utilization(detected_parallelism),
+                "concurrency_utilization": scenario.concurrency_utilization(),
+            })
+        })
+        .collect();
+
+    let payload = serde_json::json!({
+        "case": "commitlog_recovery_phase3_cq_concurrency",
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "commit": std::env::var("GITHUB_SHA").unwrap_or_else(|_| "local".to_string()),
+        "pr": std::env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "local".to_string()),
+        "environment": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "profile": std::env::var("PROFILE").unwrap_or_else(|_| "bench".to_string()),
+            "features": active_features(),
+            "detected_parallelism": detected_parallelism,
+        },
+        "baseline": {
+            "phase1": "target/recovery-baseline/phase1/commitlog-recovery-phase1-baseline.json",
+            "phase2": "target/recovery-baseline/phase2/commitlog-recovery-phase2-window-comparison.json",
+            "phase2_total_startup_model": "phase2_total_startup_ms_reference = non_cq_startup_overhead_ms + serial_cq_recovery_ms",
+            "non_cq_startup_overhead_ms": PHASE3_NON_CQ_STARTUP_OVERHEAD_MS,
+        },
+        "default_behavior": {
+            "local_file_consume_queue_recovery_concurrently": false,
+            "rollout_guidance": "Keep default disabled until many-queue workloads show stable CQ recovery reduction without disk saturation.",
+            "recommended_gray_threshold": "Enable only for brokers with queue_count > effective_parallelism and measured disk utilization below saturation.",
+        },
+        "target_metrics": [
+            "estimated_serial_cq_recovery_ms",
+            "estimated_concurrent_cq_recovery_ms",
+            "estimated_cq_stage_reduction_ratio",
+            "estimated_phase2_total_startup_ms_reference",
+            "estimated_phase3_total_startup_ms",
+            "estimated_total_startup_reduction_ratio",
+            "estimated_serial_throughput_bytes_per_ms",
+            "estimated_concurrent_throughput_bytes_per_ms",
+            "estimated_disk_throughput_increase_ratio",
+            "estimated_cpu_core_utilization_ratio",
+            "configured_parallelism",
+            "effective_parallelism",
+            "concurrency_utilization"
+        ],
+        "scenarios": scenarios,
+    });
+
+    let path = output_dir.join("commitlog-recovery-phase3-cq-concurrency.json");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&payload).expect("phase3 recovery benchmark manifest should serialize"),
+    )
+    .expect("phase3 recovery benchmark manifest should be written");
+}
+
 /// Benchmark recovery statistics operations
 fn bench_recovery_statistics(c: &mut Criterion) {
     c.bench_function("recovery_statistics_clone", |b| {
@@ -482,6 +739,69 @@ fn bench_phase2_window_comparison(c: &mut Criterion) {
     group.finish();
 }
 
+fn simulate_phase3_serial_cq_recovery(scenario: Phase3CqRecoveryScenario) -> RecoveryStatistics {
+    let mut stats = RecoveryStatistics::default();
+    for queue_index in 0..scenario.active_queue_count() {
+        for record_index in 0..scenario.records_per_queue() {
+            stats.messages_recovered = stats.messages_recovered.saturating_add(1);
+            stats.bytes_processed = stats.bytes_processed.saturating_add(PHASE3_CQ_RECORD_SIZE_BYTES);
+            black_box((queue_index, record_index));
+        }
+    }
+    stats.files_processed = scenario.active_queue_count() * scenario.mapped_files_per_queue;
+    stats.recovery_time_ms = scenario.serial_cq_recovery_ms();
+    stats
+}
+
+fn simulate_phase3_bounded_cq_recovery(scenario: Phase3CqRecoveryScenario) -> RecoveryStatistics {
+    let mut stats = RecoveryStatistics::default();
+    let active_queues = scenario.active_queue_count();
+    let parallelism = scenario.effective_parallelism();
+    let batches = scenario.concurrent_recovery_batches();
+    for batch_index in 0..batches {
+        let batch_start = batch_index * parallelism;
+        let batch_end = batch_start.saturating_add(parallelism).min(active_queues);
+        for record_index in 0..scenario.records_per_queue() {
+            for queue_index in batch_start..batch_end {
+                stats.messages_recovered = stats.messages_recovered.saturating_add(1);
+                stats.bytes_processed = stats.bytes_processed.saturating_add(PHASE3_CQ_RECORD_SIZE_BYTES);
+                black_box((batch_index, queue_index, record_index));
+            }
+        }
+    }
+    stats.files_processed = active_queues * scenario.mapped_files_per_queue;
+    stats.recovery_time_ms = scenario.concurrent_cq_recovery_ms();
+    stats
+}
+
+fn bench_phase3_cq_concurrency_comparison(c: &mut Criterion) {
+    write_phase3_cq_concurrency_manifest();
+
+    let mut group = c.benchmark_group("commitlog_recovery/phase3_cq_concurrency");
+    for scenario in PHASE3_CQ_RECOVERY_SCENARIOS {
+        group.throughput(Throughput::Bytes(scenario.total_cq_bytes()));
+        group.bench_with_input(
+            BenchmarkId::new("serial", scenario.id),
+            scenario,
+            |bencher, scenario| {
+                bencher.iter(|| {
+                    black_box(simulate_phase3_serial_cq_recovery(*scenario));
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("bounded_concurrent", scenario.id),
+            scenario,
+            |bencher, scenario| {
+                bencher.iter(|| {
+                    black_box(simulate_phase3_bounded_cq_recovery(*scenario));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 /// Benchmark recovery context creation
 fn bench_recovery_context(c: &mut Criterion) {
     c.bench_function("recovery_context_creation", |b| {
@@ -532,6 +852,7 @@ criterion_group!(
         bench_recovery_statistics,
         bench_phase1_baseline_scenarios,
         bench_phase2_window_comparison,
+        bench_phase3_cq_concurrency_comparison,
         bench_recovery_context,
         bench_message_processing_overhead
 );


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7739

### Brief Description

Adds Phase 3 LocalFile ConsumeQueue recovery benchmark coverage to `commitlog_recovery_bench`.

The benchmark now writes a Phase 3 artifact under `target/recovery-baseline/phase3/commitlog-recovery-phase3-cq-concurrency.json` and covers:

- many queues exceeding configured parallelism.
- few queues with large per-queue file/workload cost.
- many empty queues.

The artifact references Phase 1/2 baseline paths, records serial vs bounded concurrent CQ recovery estimates, total startup impact, disk throughput, CPU utilization, effective parallelism, concurrency utilization, and default-off gray rollout guidance.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store --bench commitlog_recovery_bench --no-run` passed.
- `cargo bench -p rocketmq-store --bench commitlog_recovery_bench` passed and generated the Phase 3 artifact.
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark phase for commit log recovery queue concurrency.
  * Included scenario modeling and generated benchmark manifests with estimated performance and utilization metrics.
  * Added comparisons between serial and bounded-concurrent recovery strategies across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->