### PR TITLE
[ISSUE #7741]✨Add Index safe offset recovery semantics

### DIFF
--- a/rocketmq-store/src/base/store_checkpoint.rs
+++ b/rocketmq-store/src/base/store_checkpoint.rs
@@ -33,6 +33,7 @@ pub struct StoreCheckpoint {
     index_msg_timestamp: AtomicU64,
     master_flushed_offset: AtomicU64,
     confirm_phy_offset: AtomicU64,
+    index_safe_phy_offset: AtomicU64,
 }
 
 impl StoreCheckpoint {
@@ -61,6 +62,7 @@ impl StoreCheckpoint {
             let index_msg_timestamp = read_checkpoint_u64(&mmap, 16, "indexMsgTimestamp")?;
             let master_flushed_offset = read_checkpoint_u64(&mmap, 24, "masterFlushedOffset")?;
             let confirm_phy_offset = read_checkpoint_u64(&mmap, 32, "confirmPhyOffset")?;
+            let index_safe_phy_offset = read_checkpoint_u64(&mmap, 40, "indexSafePhyOffset")?;
 
             info!("store checkpoint file exists, {}", checkpoint_path.display());
             info!("physicMsgTimestamp: {}", physic_msg_timestamp);
@@ -68,6 +70,7 @@ impl StoreCheckpoint {
             info!("indexMsgTimestamp: {}", index_msg_timestamp);
             info!("masterFlushedOffset: {}", master_flushed_offset);
             info!("confirmPhyOffset: {}", confirm_phy_offset);
+            info!("indexSafePhyOffset: {}", index_safe_phy_offset);
 
             Ok(Self {
                 file,
@@ -77,6 +80,7 @@ impl StoreCheckpoint {
                 index_msg_timestamp: AtomicU64::new(index_msg_timestamp),
                 master_flushed_offset: AtomicU64::new(master_flushed_offset),
                 confirm_phy_offset: AtomicU64::new(confirm_phy_offset),
+                index_safe_phy_offset: AtomicU64::new(index_safe_phy_offset),
             })
         } else {
             //info!("store checkpoint file not exists, {}", path.as_ref());
@@ -88,6 +92,7 @@ impl StoreCheckpoint {
                 index_msg_timestamp: AtomicU64::new(0),
                 master_flushed_offset: AtomicU64::new(0),
                 confirm_phy_offset: AtomicU64::new(0),
+                index_safe_phy_offset: AtomicU64::new(0),
             })
         }
     }
@@ -100,6 +105,7 @@ impl StoreCheckpoint {
         mmap[16..24].copy_from_slice(&self.index_msg_timestamp.load(Ordering::Relaxed).to_be_bytes());
         mmap[24..32].copy_from_slice(&self.master_flushed_offset.load(Ordering::Relaxed).to_be_bytes());
         mmap[32..40].copy_from_slice(&self.confirm_phy_offset.load(Ordering::Relaxed).to_be_bytes());
+        mmap[40..48].copy_from_slice(&self.index_safe_phy_offset.load(Ordering::Relaxed).to_be_bytes());
         mmap.flush()?;
         Ok(())
     }
@@ -136,6 +142,28 @@ impl StoreCheckpoint {
     }
 
     #[inline]
+    pub fn set_index_safe_phy_offset(&self, index_safe_phy_offset: u64) {
+        self.index_safe_phy_offset
+            .store(index_safe_phy_offset, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn advance_index_safe_phy_offset(&self, index_safe_phy_offset: u64) {
+        let mut current = self.index_safe_phy_offset.load(Ordering::Relaxed);
+        while index_safe_phy_offset > current {
+            match self.index_safe_phy_offset.compare_exchange_weak(
+                current,
+                index_safe_phy_offset,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    #[inline]
     pub fn physic_msg_timestamp(&self) -> u64 {
         self.physic_msg_timestamp.load(Ordering::Relaxed)
     }
@@ -158,6 +186,11 @@ impl StoreCheckpoint {
     #[inline]
     pub fn confirm_phy_offset(&self) -> u64 {
         self.confirm_phy_offset.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn index_safe_phy_offset(&self) -> u64 {
+        self.index_safe_phy_offset.load(Ordering::Relaxed)
     }
 
     #[inline]
@@ -190,4 +223,26 @@ fn read_checkpoint_u64(mmap: &[u8], offset: usize, field_name: &str) -> io::Resu
 
 fn invalid_checkpoint_error(message: String) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn store_checkpoint_persists_index_safe_phy_offset() {
+        let temp_dir = tempdir().unwrap();
+        let checkpoint_path = temp_dir.path().join("checkpoint");
+        let checkpoint = StoreCheckpoint::new(&checkpoint_path).unwrap();
+
+        checkpoint.set_index_safe_phy_offset(1024);
+        checkpoint.advance_index_safe_phy_offset(2048);
+        checkpoint.advance_index_safe_phy_offset(1536);
+        checkpoint.flush().unwrap();
+
+        let reloaded = StoreCheckpoint::new(&checkpoint_path).unwrap();
+        assert_eq!(reloaded.index_safe_phy_offset(), 2048);
+    }
 }

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -93,6 +93,7 @@ impl IndexService {
         let checkpoint_timestamp = self.store_checkpoint.index_msg_timestamp() as i64;
         let mut write_list = self.index_file_list.write();
 
+        let mut removed_unsafe_index_file = false;
         for file in files {
             let Some(file_path) = file.to_str() else {
                 warn!("Invalid file path: {:?}", file);
@@ -111,12 +112,35 @@ impl IndexService {
 
             if !last_exit_ok && index_file.get_end_timestamp() > checkpoint_timestamp {
                 index_file.destroy(0);
+                removed_unsafe_index_file = true;
                 continue;
             }
 
             info!("load index file OK, {}", file_path);
             write_list.push(Arc::new(index_file));
         }
+
+        let loaded_index_safe_offset = write_list
+            .iter()
+            .rev()
+            .find(|index_file| index_file.has_entries())
+            .map(|index_file| index_file.get_end_phy_offset().max(0) as u64)
+            .unwrap_or(0);
+        let restored_index_safe_offset = self.store_checkpoint.index_safe_phy_offset();
+        let effective_index_safe_offset = if removed_unsafe_index_file || loaded_index_safe_offset == 0 {
+            loaded_index_safe_offset
+        } else {
+            restored_index_safe_offset.max(loaded_index_safe_offset)
+        };
+        self.store_checkpoint
+            .set_index_safe_phy_offset(effective_index_safe_offset);
+        info!(
+            "index safe offset restored, persisted: {}, loaded: {}, effective: {}, removedUnsafeIndexFile: {}",
+            restored_index_safe_offset,
+            loaded_index_safe_offset,
+            effective_index_safe_offset,
+            removed_unsafe_index_file
+        );
 
         true
     }
@@ -137,6 +161,11 @@ impl IndexService {
             .rev()
             .find(|index_file| index_file.has_entries())
             .map(|index_file| index_file.get_end_phy_offset())
+    }
+
+    #[inline]
+    pub fn index_safe_phy_offset(&self) -> u64 {
+        self.store_checkpoint.index_safe_phy_offset()
     }
 
     pub fn delete_expired_file(&self, offset: u64) {
@@ -277,7 +306,10 @@ impl IndexService {
             MessageSysFlag::TRANSACTION_NOT_TYPE
             | MessageSysFlag::TRANSACTION_PREPARED_TYPE
             | MessageSysFlag::TRANSACTION_COMMIT_TYPE => {}
-            MessageSysFlag::TRANSACTION_ROLLBACK_TYPE => return,
+            MessageSysFlag::TRANSACTION_ROLLBACK_TYPE => {
+                self.advance_index_safe_phy_offset(dispatch_request);
+                return;
+            }
             _ => {}
         }
 
@@ -291,6 +323,7 @@ impl IndexService {
 
         let has_normal_key = keys.split(MessageConst::KEY_SEPARATOR).any(|key| !key.is_empty());
         if dispatch_request.uniq_key.is_none() && !has_normal_key && tags.is_none() {
+            self.advance_index_safe_phy_offset(dispatch_request);
             return;
         }
 
@@ -395,11 +428,23 @@ impl IndexService {
                         );
                     }
                 }
+                self.advance_index_safe_phy_offset(dispatch_request);
             }
             None => {
                 error!("build index error, stop building index");
             }
         }
+    }
+
+    fn advance_index_safe_phy_offset(&self, dispatch_request: &DispatchRequest) {
+        if dispatch_request.commit_log_offset < 0 || dispatch_request.msg_size <= 0 {
+            return;
+        }
+        let safe_offset = dispatch_request
+            .commit_log_offset
+            .saturating_add(i64::from(dispatch_request.msg_size));
+        self.store_checkpoint
+            .advance_index_safe_phy_offset(safe_offset.max(0) as u64);
     }
 
     #[inline]
@@ -711,11 +756,13 @@ mod tests {
         index_service.build_index(&DispatchRequest {
             topic: CheetahString::from_slice("TestTopic"),
             commit_log_offset: 1000,
+            msg_size: 100,
             store_timestamp: 1000000000000,
             ..DispatchRequest::default()
         });
 
         assert_eq!(index_service.get_total_size(), 0);
+        assert_eq!(index_service.index_safe_phy_offset(), 1100);
     }
 
     #[test]
@@ -726,6 +773,7 @@ mod tests {
         index_service.build_index(&DispatchRequest {
             topic: CheetahString::from_slice("TestTopic"),
             commit_log_offset: 1000,
+            msg_size: 100,
             store_timestamp: 1000000000000,
             keys: CheetahString::from_slice("key1"),
             uniq_key: Some(CheetahString::from_slice("uniq123")),
@@ -734,6 +782,75 @@ mod tests {
         });
 
         assert_eq!(index_service.get_total_size(), 0);
+        assert_eq!(index_service.index_safe_phy_offset(), 1100);
+    }
+
+    #[test]
+    fn build_index_advances_index_safe_offset_after_indexed_message() {
+        let temp_dir = tempdir().unwrap();
+        let index_service = new_index_service_for_test(&temp_dir, "store_checkpoint_test_index_safe_advance");
+
+        index_service.build_index(&DispatchRequest {
+            topic: CheetahString::from_slice("TestTopic"),
+            commit_log_offset: 1000,
+            msg_size: 100,
+            store_timestamp: 1000000000000,
+            keys: CheetahString::from_slice("key1"),
+            ..DispatchRequest::default()
+        });
+
+        assert_eq!(index_service.index_safe_phy_offset(), 1100);
+    }
+
+    #[test]
+    fn load_restores_index_safe_offset_from_loaded_index_files_for_legacy_checkpoint() {
+        let temp_dir = tempdir().unwrap();
+        let checkpoint_name = "store_checkpoint_test_index_safe_legacy_load";
+        let index_service = new_index_service_for_test(&temp_dir, checkpoint_name);
+
+        index_service.build_index(&DispatchRequest {
+            topic: CheetahString::from_slice("TestTopic"),
+            commit_log_offset: 1000,
+            msg_size: 100,
+            store_timestamp: 1000000000000,
+            keys: CheetahString::from_slice("key1"),
+            ..DispatchRequest::default()
+        });
+        let index_file = index_service.index_file_list.read().last().cloned();
+        index_service.flush(index_file);
+        index_service.store_checkpoint.set_index_safe_phy_offset(0);
+        index_service.store_checkpoint.flush().unwrap();
+
+        let mut reloaded = new_index_service_for_test(&temp_dir, checkpoint_name);
+        assert!(reloaded.load(true));
+
+        assert_eq!(reloaded.index_safe_phy_offset(), 1000);
+    }
+
+    #[test]
+    fn load_clamps_index_safe_offset_when_unsafe_index_file_removed() {
+        let temp_dir = tempdir().unwrap();
+        let checkpoint_name = "store_checkpoint_test_index_safe_clamp_removed";
+        let index_service = new_index_service_for_test(&temp_dir, checkpoint_name);
+
+        index_service.build_index(&DispatchRequest {
+            topic: CheetahString::from_slice("TestTopic"),
+            commit_log_offset: 1000,
+            msg_size: 100,
+            store_timestamp: 1000000000000,
+            keys: CheetahString::from_slice("key1"),
+            ..DispatchRequest::default()
+        });
+        let index_file = index_service.index_file_list.read().last().cloned();
+        index_service.flush(index_file);
+        index_service.store_checkpoint.set_index_safe_phy_offset(1100);
+        index_service.store_checkpoint.set_index_msg_timestamp(0);
+        index_service.store_checkpoint.flush().unwrap();
+
+        let mut reloaded = new_index_service_for_test(&temp_dir, checkpoint_name);
+        assert!(reloaded.load(false));
+
+        assert_eq!(reloaded.index_safe_phy_offset(), 0);
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1228,6 +1228,7 @@ impl LocalFileMessageStore {
             self.get_max_phy_offset(),
             self.get_confirm_offset(),
         );
+        recovery_plan.set_index_safe_offset(self.current_index_safe_offset());
         recovery_plan.set_consume_queue_recovery_concurrency(ConsumeQueueRecoveryConcurrency::new(
             self.message_store_config
                 .enable_local_file_consume_queue_recovery_concurrently,
@@ -1298,11 +1299,14 @@ impl LocalFileMessageStore {
             self.get_max_phy_offset(),
             self.get_confirm_offset(),
         );
+        recovery_executor
+            .plan_mut()
+            .set_index_safe_offset(self.current_index_safe_offset());
         let recovery_report = recovery_executor.finish();
         info!(
             "message store recover total cost: {} ms, recoverConsumeQueue: {} ms, recoverCommitLog: {} ms, \
              recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}, commitLogRange: \
-             {:?}-{:?}, confirmOffset: {:?}",
+             {:?}-{:?}, confirmOffset: {:?}, indexSafeOffset: {:?}",
             recovery_report.total_duration_ms,
             recover_consume_queue,
             recover_commit_log,
@@ -1312,9 +1316,19 @@ impl LocalFileMessageStore {
             recovery_report.plan.dispatch_recovery_offset,
             recovery_report.plan.offsets.commit_log_min_offset,
             recovery_report.plan.offsets.commit_log_max_offset,
-            recovery_report.plan.offsets.confirm_offset
+            recovery_report.plan.offsets.confirm_offset,
+            recovery_report.plan.offsets.index_safe_offset
         );
         self.last_recovery_report = Some(recovery_report);
+    }
+
+    fn current_index_safe_offset(&self) -> i64 {
+        let Some(store_checkpoint) = self.store_checkpoint.as_ref() else {
+            return 0;
+        };
+        let checkpoint_safe_offset = store_checkpoint.index_safe_phy_offset();
+        let confirm_offset = self.get_confirm_offset().max(0) as u64;
+        checkpoint_safe_offset.min(confirm_offset) as i64
     }
 
     pub async fn recover_normally(&mut self, max_phy_offset_of_consume_queue: i64) {
@@ -6015,6 +6029,7 @@ mod tests {
         assert!(report.plan.offsets.commit_log_min_offset.is_some());
         assert!(report.plan.offsets.commit_log_max_offset.is_some());
         assert!(report.plan.offsets.confirm_offset.is_some());
+        assert_eq!(report.plan.offsets.index_safe_offset, Some(0));
         assert_eq!(
             report.plan.scan_range.end_offset,
             report.plan.offsets.commit_log_max_offset
@@ -6036,6 +6051,25 @@ mod tests {
             report.total_duration_ms,
             report.phases.iter().map(|phase| phase.duration_ms).sum()
         );
+    }
+
+    #[test]
+    fn current_index_safe_offset_is_bounded_by_confirm_offset() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store_with_broker(
+            &temp_dir,
+            MessageStoreConfig::default(),
+            BrokerConfig {
+                duplication_enable: true,
+                ..BrokerConfig::default()
+            },
+        );
+        let checkpoint = store.store_checkpoint.as_ref().expect("checkpoint");
+
+        checkpoint.set_index_safe_phy_offset(512);
+        store.set_confirm_offset(128);
+
+        assert_eq!(store.current_index_safe_offset(), 128);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -145,6 +145,7 @@ pub struct RecoveryOffsets {
     pub commit_log_max_offset: Option<i64>,
     pub confirm_offset: Option<i64>,
     pub max_consume_queue_physical_offset: Option<i64>,
+    pub index_safe_offset: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -214,6 +215,10 @@ impl RecoveryPlan {
 
     pub fn set_max_consume_queue_physical_offset(&mut self, max_offset: i64) {
         self.offsets.max_consume_queue_physical_offset = Some(max_offset);
+    }
+
+    pub fn set_index_safe_offset(&mut self, index_safe_offset: i64) {
+        self.offsets.index_safe_offset = Some(index_safe_offset);
     }
 
     pub fn set_consume_queue_recovery_concurrency(&mut self, concurrency: ConsumeQueueRecoveryConcurrency) {
@@ -444,6 +449,7 @@ mod tests {
         plan.set_dispatch_recovery_offset(1024);
         plan.set_commit_log_offsets(512, 4096, 3072);
         plan.set_max_consume_queue_physical_offset(2048);
+        plan.set_index_safe_offset(1536);
 
         assert_eq!(plan.dispatch_recovery_offset, Some(1024));
         assert_eq!(plan.offsets.dispatch_recovery_offset, Some(1024));
@@ -451,6 +457,7 @@ mod tests {
         assert_eq!(plan.offsets.commit_log_max_offset, Some(4096));
         assert_eq!(plan.offsets.confirm_offset, Some(3072));
         assert_eq!(plan.offsets.max_consume_queue_physical_offset, Some(2048));
+        assert_eq!(plan.offsets.index_safe_offset, Some(1536));
         assert_eq!(plan.scan_range.start_offset, Some(1024));
         assert_eq!(plan.scan_range.end_offset, Some(4096));
         assert_eq!(plan.scan_range.file_count_limit, None);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7741

### Brief Description

Adds the Phase 4 P4-T1 `index_safe_offset` recovery contract.

This change:

- Persists `index_safe_phy_offset` in `StoreCheckpoint`.
- Restores the safe offset during `IndexService::load` from persisted checkpoint data and loaded Index files.
- Advances the safe offset when synchronous Index dispatch processes indexed, non-indexed, or rollback messages.
- Exposes `index_safe_offset` through `RecoveryPlan` / `RecoveryReport` and recovery logs.
- Keeps background Index rebuild and query fallback out of scope for later Phase 4 tasks.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store index_safe --lib` passed.
- `cargo test -p rocketmq-store recover_records_structured_recovery_report --lib` passed.
- `cargo test -p rocketmq-store index::index_service --lib` passed.
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved store recovery now preserves a safer index position across restarts.
  * Recovery reports now include the index-safe offset for better visibility.
* **Bug Fixes**
  * Fixed index rebuilding so skipped or rollback messages still advance the safe recovery position.
  * Reloading after shutdown now better handles older checkpoints and removes unsafe index files more reliably.
  * The stored safe offset is now kept within valid bounds during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->