### PR TITLE
[ISSUE #7745]✨Add Index query safe range protection

### DIFF
--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -26,6 +26,7 @@ use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerCon
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::base::query_message_result::QueryMessageResult;
 use tracing::info;
 use tracing::warn;
 
@@ -46,6 +47,16 @@ fn query_index_type(request_header: &QueryMessageRequestHeader, is_unique_key: b
             )
         })
         .or_else(|| is_unique_key.then_some(MessageConst::INDEX_UNIQUE_TYPE))
+}
+
+fn unsafe_index_query_remark(query_message_result: &QueryMessageResult) -> Option<String> {
+    (!query_message_result.index_query_safe).then(|| {
+        format!(
+            "index query is unsafe because index safe offset {} is behind confirm offset {}; background Index rebuild \
+             may still be in progress",
+            query_message_result.index_safe_phyoffset, query_message_result.index_confirm_phyoffset
+        )
+    })
 }
 
 impl<MS> RequestProcessor for QueryMessageProcessor<MS>
@@ -174,6 +185,9 @@ where
             }
             return Ok(Some(response));
         }
+        if let Some(remark) = unsafe_index_query_remark(&query_message_result) {
+            return Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(remark)));
+        }
         Ok(Some(
             response
                 .set_code(ResponseCode::QueryNotFound)
@@ -219,6 +233,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_store::base::query_message_result::QueryMessageResult;
 
     fn header(index_type: Option<&'static str>) -> QueryMessageRequestHeader {
         QueryMessageRequestHeader {
@@ -259,5 +274,24 @@ mod tests {
             query_index_type(&header(Some(MessageConst::INDEX_KEY_TYPE)), false),
             None
         );
+    }
+
+    #[test]
+    fn unsafe_index_query_remark_is_absent_for_safe_result() {
+        let result = QueryMessageResult::default();
+
+        assert!(unsafe_index_query_remark(&result).is_none());
+    }
+
+    #[test]
+    fn unsafe_index_query_remark_includes_safe_and_confirm_offsets() {
+        let mut result = QueryMessageResult::default();
+        result.set_index_query_safety(false, 128, 256);
+
+        let remark = unsafe_index_query_remark(&result).expect("unsafe remark");
+
+        assert!(remark.contains("index safe offset 128"));
+        assert!(remark.contains("confirm offset 256"));
+        assert!(remark.contains("background Index rebuild"));
     }
 }

--- a/rocketmq-store/src/base/query_message_result.rs
+++ b/rocketmq-store/src/base/query_message_result.rs
@@ -17,15 +17,37 @@ use bytes::BytesMut;
 
 use crate::base::select_result::SelectMappedBufferResult;
 
-#[derive(Default)]
 pub struct QueryMessageResult {
     pub message_maped_list: Vec<SelectMappedBufferResult>,
     pub index_last_update_timestamp: i64,
     pub index_last_update_phyoffset: i64,
     pub buffer_total_size: i32,
+    pub index_query_safe: bool,
+    pub index_safe_phyoffset: i64,
+    pub index_confirm_phyoffset: i64,
+}
+
+impl Default for QueryMessageResult {
+    fn default() -> Self {
+        Self {
+            message_maped_list: Vec::new(),
+            index_last_update_timestamp: 0,
+            index_last_update_phyoffset: 0,
+            buffer_total_size: 0,
+            index_query_safe: true,
+            index_safe_phyoffset: 0,
+            index_confirm_phyoffset: 0,
+        }
+    }
 }
 
 impl QueryMessageResult {
+    pub fn set_index_query_safety(&mut self, safe: bool, safe_phyoffset: i64, confirm_phyoffset: i64) {
+        self.index_query_safe = safe;
+        self.index_safe_phyoffset = safe_phyoffset.max(0);
+        self.index_confirm_phyoffset = confirm_phyoffset.max(0);
+    }
+
     pub fn get_message_data(&self) -> Option<Bytes> {
         if self.buffer_total_size <= 0 || self.message_maped_list.is_empty() {
             return None;
@@ -48,5 +70,30 @@ impl QueryMessageResult {
     pub fn add_message(&mut self, result: SelectMappedBufferResult) {
         self.buffer_total_size += result.size;
         self.message_maped_list.push(result);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryMessageResult;
+
+    #[test]
+    fn query_message_result_is_safe_by_default() {
+        let result = QueryMessageResult::default();
+
+        assert!(result.index_query_safe);
+        assert_eq!(result.index_safe_phyoffset, 0);
+        assert_eq!(result.index_confirm_phyoffset, 0);
+    }
+
+    #[test]
+    fn set_index_query_safety_records_offsets() {
+        let mut result = QueryMessageResult::default();
+
+        result.set_index_query_safety(false, 128, 256);
+
+        assert!(!result.index_query_safe);
+        assert_eq!(result.index_safe_phyoffset, 128);
+        assert_eq!(result.index_confirm_phyoffset, 256);
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3080,6 +3080,13 @@ impl MessageStore for LocalFileMessageStore {
         end_timestamp: i64,
     ) -> Option<QueryMessageResult> {
         let mut query_message_result = QueryMessageResult::default();
+        let index_safe_phyoffset = self.current_index_safe_offset();
+        let index_confirm_phyoffset = self.get_confirm_offset().max(0);
+        query_message_result.set_index_query_safety(
+            !self.message_store_config.message_index_enable || index_safe_phyoffset >= index_confirm_phyoffset,
+            index_safe_phyoffset,
+            index_confirm_phyoffset,
+        );
         let mut last_query_msg_time = end_timestamp;
         for i in 1..3 {
             let mut query_offset_result =
@@ -6714,6 +6721,9 @@ mod tests {
             before_rebuild.message_maped_list.is_empty(),
             "raw commitlog append should not populate the index before background rebuild"
         );
+        assert!(!before_rebuild.index_query_safe);
+        assert_eq!(before_rebuild.index_safe_phyoffset, 0);
+        assert_eq!(before_rebuild.index_confirm_phyoffset, target_offset);
 
         let commit_log = store.commit_log.clone();
         let message_store_config = store.message_store_config.clone();
@@ -6761,6 +6771,9 @@ mod tests {
             .await
             .expect("query result after background rebuild");
         assert_eq!(query_result.message_maped_list.len(), 1);
+        assert!(query_result.index_query_safe);
+        assert_eq!(query_result.index_safe_phyoffset, target_offset);
+        assert_eq!(query_result.index_confirm_phyoffset, target_offset);
 
         let runtime_info = store.get_runtime_info();
         assert_eq!(runtime_info["backgroundIndexRebuildState"], "completed");
@@ -6772,6 +6785,39 @@ mod tests {
         assert_eq!(runtime_info["backgroundIndexRebuildFailureCount"], "0");
 
         store.background_index_rebuild_service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn query_message_marks_empty_result_unsafe_when_index_safe_offset_lags_confirm() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                ..MessageStoreConfig::default()
+            },
+        );
+        let topic = CheetahString::from_static_str("index-query-safe-range-topic");
+        let key = CheetahString::from_static_str("index-query-safe-range-key");
+        let msg_size = append_encoded_test_message_with_key(
+            &mut store,
+            &topic,
+            0,
+            1_000,
+            Bytes::from_static(b"index-query-safe-range-body"),
+            Some(key.clone()),
+        )
+        .await;
+
+        let result = store
+            .query_message(&topic, &key, 10, 0, i64::MAX)
+            .await
+            .expect("query result");
+
+        assert!(result.message_maped_list.is_empty());
+        assert!(!result.index_query_safe);
+        assert_eq!(result.index_safe_phyoffset, 0);
+        assert_eq!(result.index_confirm_phyoffset, i64::from(msg_size));
     }
 
     #[tokio::test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7745

### Brief Description

- Adds Index query safety metadata to `QueryMessageResult`, including safe offset, confirm offset, and whether the Index range is safe.
- Marks LocalFile query results unsafe when `message_index_enable` is active and `index_safe_offset` is behind `confirm_offset`.
- Rejects empty broker query responses with an explicit unsafe Index remark instead of silently returning a normal not-found result while background Index rebuild may still be catching up.
- Extends focused tests for unsafe empty query behavior, background rebuild catch-up, and broker unsafe-range remarks.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store index_query --lib` passed: 1 passed.
- `cargo test -p rocketmq-store background_index_rebuild --lib` passed: 6 passed.
- `cargo test -p rocketmq-broker unsafe_index_query_remark --lib` passed: 2 passed.
- `cargo test -p rocketmq-store query_message_marks_empty_result_unsafe_when_index_safe_offset_lags_confirm --lib` passed: 1 passed.
- `cargo test -p rocketmq-store query_message_result --lib` passed: 2 passed.
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings` passed.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message query behavior when the index is still catching up, returning a clearer error instead of a generic “not found” response.
  * Query results now include safety status, helping distinguish between truly missing messages and temporarily unsafe index lookups.
  * Background index rebuild progress is now reflected in query responses, with safer handling of partial index state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->