### PR TITLE
[ISSUE #7747]✨Add background Index gray acceptance controls

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -1438,6 +1438,31 @@ impl Default for MessageStoreConfig {
 }
 
 impl MessageStoreConfig {
+    pub fn effective_background_index_rebuild_enable(&self) -> bool {
+        self.enable_background_index_rebuild
+            && self.message_index_enable
+            && matches!(self.recovery_mode, RecoveryMode::Balanced | RecoveryMode::Fast)
+    }
+
+    pub fn background_index_rebuild_gray_mode(&self) -> &'static str {
+        if !self.message_index_enable {
+            return "index_disabled";
+        }
+        if !self.enable_background_index_rebuild {
+            return "disabled";
+        }
+
+        match self.recovery_mode {
+            RecoveryMode::Strict => "strict_blocked",
+            RecoveryMode::Balanced => "balanced_gray",
+            RecoveryMode::Fast => "fast_gray",
+        }
+    }
+
+    pub const fn background_index_rebuild_rollback_hint() -> &'static str {
+        "set enableBackgroundIndexRebuild=false or recoveryMode=strict and restart broker"
+    }
+
     pub fn effective_local_file_consume_queue_recovery_parallelism(&self) -> usize {
         let available_parallelism = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
@@ -2114,6 +2139,14 @@ impl MessageStoreConfig {
             self.enable_background_index_rebuild.to_string(),
         );
         properties.insert(
+            "effectiveBackgroundIndexRebuildEnable".to_string(),
+            self.effective_background_index_rebuild_enable().to_string(),
+        );
+        properties.insert(
+            "backgroundIndexRebuildGrayMode".to_string(),
+            self.background_index_rebuild_gray_mode().to_string(),
+        );
+        properties.insert(
             "backgroundIndexRebuildBatchSize".to_string(),
             self.background_index_rebuild_batch_size.to_string(),
         );
@@ -2249,13 +2282,39 @@ mod tests {
         assert_eq!(config.background_index_rebuild_bytes_per_second, 32 * 1024 * 1024);
         assert_eq!(config.background_index_rebuild_max_retries, 3);
         assert_eq!(config.get_properties()["enableBackgroundIndexRebuild"], "false");
+        assert_eq!(
+            config.get_properties()["effectiveBackgroundIndexRebuildEnable"],
+            "false"
+        );
+        assert_eq!(config.get_properties()["backgroundIndexRebuildGrayMode"], "disabled");
         assert_eq!(config.get_properties()["backgroundIndexRebuildBatchSize"], "64");
+    }
+
+    #[test]
+    fn strict_mode_blocks_background_index_rebuild_gray_enablement() {
+        let config = MessageStoreConfig {
+            enable_background_index_rebuild: true,
+            recovery_mode: RecoveryMode::Strict,
+            ..MessageStoreConfig::default()
+        };
+
+        assert!(!config.effective_background_index_rebuild_enable());
+        assert_eq!(config.background_index_rebuild_gray_mode(), "strict_blocked");
+        assert_eq!(
+            config.get_properties()["effectiveBackgroundIndexRebuildEnable"],
+            "false"
+        );
+        assert_eq!(
+            config.get_properties()["backgroundIndexRebuildGrayMode"],
+            "strict_blocked"
+        );
     }
 
     #[test]
     fn serde_loads_background_index_rebuild_config() -> Result<(), serde_json::Error> {
         let config: MessageStoreConfig = serde_json::from_str(
             r#"{
+                "recoveryMode": "balanced",
                 "enableBackgroundIndexRebuild": true,
                 "backgroundIndexRebuildBatchSize": 16,
                 "backgroundIndexRebuildBytesPerSecond": 1048576,
@@ -2264,6 +2323,8 @@ mod tests {
         )?;
 
         assert!(config.enable_background_index_rebuild);
+        assert!(config.effective_background_index_rebuild_enable());
+        assert_eq!(config.background_index_rebuild_gray_mode(), "balanced_gray");
         assert_eq!(config.background_index_rebuild_batch_size, 16);
         assert_eq!(config.background_index_rebuild_bytes_per_second, 1_048_576);
         assert_eq!(config.background_index_rebuild_max_retries, 5);

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -334,6 +334,7 @@ pub struct LocalFileMessageStore {
     lifecycle_state: Arc<AtomicU8>,
     controller_epoch_start_offset: Arc<AtomicI64>,
     shutdown: Arc<AtomicBool>,
+    background_index_query_degradation_total: Arc<AtomicU64>,
     store_lock_guard: Option<StoreLockGuard>,
     running_flags: Arc<RunningFlags>,
     reput_message_service: ReputMessageService,
@@ -552,6 +553,7 @@ impl LocalFileMessageStore {
             lifecycle_state: Arc::new(AtomicU8::new(StoreLifecycleState::Created.as_u8())),
             controller_epoch_start_offset: Arc::new(AtomicI64::new(-1)),
             shutdown: Arc::new(AtomicBool::new(false)),
+            background_index_query_degradation_total: Arc::new(AtomicU64::new(0)),
             store_lock_guard: None,
             running_flags: running_flags.clone(),
             reput_message_service: ReputMessageService {
@@ -2865,6 +2867,28 @@ impl MessageStore for LocalFileMessageStore {
             background_index_rebuild.state.as_str().to_string(),
         );
         result.insert(
+            "backgroundIndexRebuildEffectiveEnable".to_string(),
+            self.message_store_config
+                .effective_background_index_rebuild_enable()
+                .to_string(),
+        );
+        result.insert(
+            "backgroundIndexRebuildGrayMode".to_string(),
+            self.message_store_config
+                .background_index_rebuild_gray_mode()
+                .to_string(),
+        );
+        result.insert(
+            "backgroundIndexRebuildRollbackHint".to_string(),
+            MessageStoreConfig::background_index_rebuild_rollback_hint().to_string(),
+        );
+        result.insert(
+            "backgroundIndexRebuildQueryDegradationTotal".to_string(),
+            self.background_index_query_degradation_total
+                .load(Ordering::Relaxed)
+                .to_string(),
+        );
+        result.insert(
             "backgroundIndexRebuildCurrentSafeOffset".to_string(),
             background_index_rebuild.current_safe_offset.to_string(),
         );
@@ -3130,6 +3154,11 @@ impl MessageStore for LocalFileMessageStore {
             {
                 return Some(tiered_result);
             }
+        }
+
+        if query_message_result.buffer_total_size == 0 && !query_message_result.index_query_safe {
+            self.background_index_query_degradation_total
+                .fetch_add(1, Ordering::Relaxed);
         }
 
         Some(query_message_result)
@@ -3982,7 +4011,7 @@ impl BackgroundIndexRebuildService {
         delay_level_table: BTreeMap<i32, i64>,
         max_delay_level: i32,
     ) {
-        if self.task_group.is_some() || !message_store_config.enable_background_index_rebuild {
+        if self.task_group.is_some() || !message_store_config.effective_background_index_rebuild_enable() {
             return;
         }
         if !message_store_config.message_index_enable {
@@ -6681,6 +6710,49 @@ mod tests {
 
         let runtime_info = store.get_runtime_info();
         assert_eq!(runtime_info["backgroundIndexRebuildState"], "idle");
+        assert_eq!(runtime_info["backgroundIndexRebuildEffectiveEnable"], "false");
+        assert_eq!(runtime_info["backgroundIndexRebuildGrayMode"], "disabled");
+        assert_eq!(
+            runtime_info["backgroundIndexRebuildRollbackHint"],
+            MessageStoreConfig::background_index_rebuild_rollback_hint()
+        );
+        assert_eq!(runtime_info["backgroundIndexRebuildQueryDegradationTotal"], "0");
+        assert_eq!(runtime_info["backgroundIndexRebuildBacklogBytes"], "0");
+    }
+
+    #[test]
+    fn background_index_rebuild_strict_mode_blocks_gray_start() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                enable_background_index_rebuild: true,
+                recovery_mode: RecoveryMode::Strict,
+                ..MessageStoreConfig::default()
+            },
+        );
+        store.set_confirm_offset(128);
+
+        let commit_log = store.commit_log.clone();
+        let message_store_config = store.message_store_config.clone();
+        let index_service = store.index_service.clone();
+        let delay_level_table = store.delay_level_table_ref().clone();
+        let max_delay_level = store.max_delay_level;
+        store.background_index_rebuild_service.start(
+            commit_log,
+            message_store_config,
+            index_service,
+            delay_level_table,
+            max_delay_level,
+        );
+
+        let snapshot = store.background_index_rebuild_snapshot();
+        assert_eq!(snapshot.state, BackgroundIndexRebuildState::Idle);
+        assert!(!store.background_index_rebuild_service.has_task_group());
+
+        let runtime_info = store.get_runtime_info();
+        assert_eq!(runtime_info["backgroundIndexRebuildEffectiveEnable"], "false");
+        assert_eq!(runtime_info["backgroundIndexRebuildGrayMode"], "strict_blocked");
         assert_eq!(runtime_info["backgroundIndexRebuildBacklogBytes"], "0");
     }
 
@@ -6692,6 +6764,7 @@ mod tests {
             MessageStoreConfig {
                 flush_disk_type: FlushDiskType::AsyncFlush,
                 enable_background_index_rebuild: true,
+                recovery_mode: RecoveryMode::Balanced,
                 background_index_rebuild_batch_size: 1,
                 background_index_rebuild_bytes_per_second: 0,
                 background_index_rebuild_max_retries: 1,
@@ -6724,6 +6797,10 @@ mod tests {
         assert!(!before_rebuild.index_query_safe);
         assert_eq!(before_rebuild.index_safe_phyoffset, 0);
         assert_eq!(before_rebuild.index_confirm_phyoffset, target_offset);
+        assert_eq!(
+            store.get_runtime_info()["backgroundIndexRebuildQueryDegradationTotal"],
+            "1"
+        );
 
         let commit_log = store.commit_log.clone();
         let message_store_config = store.message_store_config.clone();
@@ -6777,12 +6854,15 @@ mod tests {
 
         let runtime_info = store.get_runtime_info();
         assert_eq!(runtime_info["backgroundIndexRebuildState"], "completed");
+        assert_eq!(runtime_info["backgroundIndexRebuildEffectiveEnable"], "true");
+        assert_eq!(runtime_info["backgroundIndexRebuildGrayMode"], "balanced_gray");
         assert_eq!(
             runtime_info["backgroundIndexRebuildCurrentSafeOffset"],
             snapshot.current_safe_offset.to_string()
         );
         assert_eq!(runtime_info["backgroundIndexRebuildBacklogBytes"], "0");
         assert_eq!(runtime_info["backgroundIndexRebuildFailureCount"], "0");
+        assert_eq!(runtime_info["backgroundIndexRebuildQueryDegradationTotal"], "1");
 
         store.background_index_rebuild_service.shutdown().await;
     }
@@ -6818,6 +6898,10 @@ mod tests {
         assert!(!result.index_query_safe);
         assert_eq!(result.index_safe_phyoffset, 0);
         assert_eq!(result.index_confirm_phyoffset, i64::from(msg_size));
+        assert_eq!(
+            store.get_runtime_info()["backgroundIndexRebuildQueryDegradationTotal"],
+            "1"
+        );
     }
 
     #[tokio::test]
@@ -6827,6 +6911,7 @@ mod tests {
             &temp_dir,
             MessageStoreConfig {
                 enable_background_index_rebuild: true,
+                recovery_mode: RecoveryMode::Balanced,
                 background_index_rebuild_bytes_per_second: 0,
                 background_index_rebuild_max_retries: 1,
                 ..MessageStoreConfig::default()
@@ -6879,6 +6964,8 @@ mod tests {
 
         let runtime_info = store.get_runtime_info();
         assert_eq!(runtime_info["backgroundIndexRebuildState"], "failed");
+        assert_eq!(runtime_info["backgroundIndexRebuildEffectiveEnable"], "true");
+        assert_eq!(runtime_info["backgroundIndexRebuildGrayMode"], "balanced_gray");
         assert_eq!(
             runtime_info["backgroundIndexRebuildFailureCount"],
             snapshot.failure_count.to_string()


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7747

### Brief Description

Adds explicit gray-release controls for background Index rebuild: Strict recovery mode blocks effective enablement, Balanced/Fast require the explicit rebuild flag, and runtime info now reports the effective mode, rollback hint, and unsafe Index query degradation count.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store background_index_rebuild --lib`
- `cargo test -p rocketmq-store query_message_marks_empty_result_unsafe_when_index_safe_offset_lags_confirm --lib`
- `git diff --check`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new runtime/configuration details for background index rebuild, including effective enablement, gray mode, rollback hint, and query degradation totals.
* **Bug Fixes**
  * Background index rebuild now starts only when all required conditions are met, preventing it from running in unsupported recovery modes.
  * Empty index queries are now tracked as degradation events when the index is not safe to use.
* **Tests**
  * Expanded coverage for default, strict, and balanced recovery-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->