### PR TITLE
[ISSUE #7749]✨Add store platform capability detection

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -188,6 +188,10 @@ mod defaults {
         true
     }
 
+    pub fn store_io_hint_enable() -> bool {
+        true
+    }
+
     pub fn flush_interval_consume_queue() -> usize {
         1000
     }
@@ -875,6 +879,12 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub warm_mapped_file_enable: bool,
 
+    #[serde(default = "defaults::store_io_hint_enable", alias = "store_io_hint_enable")]
+    pub store_io_hint_enable: bool,
+
+    #[serde(default, alias = "store_lazy_mmap_enable")]
+    pub store_lazy_mmap_enable: bool,
+
     #[serde(default, alias = "linux_storage_optimization_enable")]
     pub linux_storage_optimization_enable: bool,
 
@@ -1324,6 +1334,8 @@ impl Default for MessageStoreConfig {
             flush_delay_offset_interval: 10_000,
             clean_file_forcibly_enable: true,
             warm_mapped_file_enable: false,
+            store_io_hint_enable: true,
+            store_lazy_mmap_enable: false,
             linux_storage_optimization_enable: false,
             linux_storage_profile: LinuxStorageProfile::default(),
             linux_transfer_engine: LinuxTransferEngine::default(),
@@ -1888,6 +1900,11 @@ impl MessageStoreConfig {
         properties.insert(
             "warmMappedFileEnable".to_string(),
             self.warm_mapped_file_enable.to_string(),
+        );
+        properties.insert("storeIoHintEnable".to_string(), self.store_io_hint_enable.to_string());
+        properties.insert(
+            "storeLazyMmapEnable".to_string(),
+            self.store_lazy_mmap_enable.to_string(),
         );
         properties.insert("offsetCheckInSlave".to_string(), self.offset_check_in_slave.to_string());
         properties.insert("debugLockEnable".to_string(), self.debug_lock_enable.to_string());
@@ -2493,6 +2510,32 @@ mod tests {
         assert_eq!(safe_compat.transfer_engine, LinuxTransferEngine::Bytes);
         assert!(!safe_compat.file_preallocate_enable);
         assert_eq!(safe_compat.mapped_file_warm_mode, LinuxMappedFileWarmMode::Disabled);
+    }
+
+    #[test]
+    fn platform_optimization_switches_keep_compatible_defaults() {
+        let config = MessageStoreConfig::default();
+
+        assert!(config.store_io_hint_enable);
+        assert!(!config.store_lazy_mmap_enable);
+
+        let properties = config.get_properties();
+        assert_eq!(properties["storeIoHintEnable"], "true");
+        assert_eq!(properties["storeLazyMmapEnable"], "false");
+    }
+
+    #[test]
+    fn serde_loads_platform_optimization_switches() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str(
+            r#"{
+                "storeIoHintEnable": false,
+                "storeLazyMmapEnable": true
+            }"#,
+        )?;
+
+        assert!(!config.store_io_hint_enable);
+        assert!(config.store_lazy_mmap_enable);
+        Ok(())
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2039,8 +2039,10 @@ impl MessageStore for LocalFileMessageStore {
 
         let storage_capability = crate::platform::current_store_platform_capability();
         info!(
-            "Linux storage capability snapshot: os={} page_size={} memory_lock_limit_bytes={} \
-             effective_memory_lock_budget_bytes={} file_preallocate_supported={}",
+            "Store platform capability snapshot: os={} page_size={} memory_lock_limit_bytes={} \
+             effective_memory_lock_budget_bytes={} file_preallocate_supported={} io_hint_branch={} \
+             mmap_advice_supported={} file_prefetch_supported={} lazy_mmap_supported={} \
+             hint_failure_affects_correctness={}",
             storage_capability.os_name,
             storage_capability.page_size,
             storage_capability
@@ -2048,7 +2050,12 @@ impl MessageStore for LocalFileMessageStore {
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "unknown".to_string()),
             Self::effective_linux_memory_lock_budget_bytes(self.message_store_config.as_ref()),
-            storage_capability.file_preallocate_supported
+            storage_capability.file_preallocate_supported,
+            storage_capability.optimization.io_hint_branch.as_str(),
+            storage_capability.optimization.mmap_advice_supported,
+            storage_capability.optimization.file_prefetch_supported,
+            storage_capability.optimization.lazy_mmap_supported,
+            storage_capability.optimization.hint_failure_affects_correctness
         );
 
         if self.is_transient_store_pool_enable() {
@@ -2739,7 +2746,46 @@ impl MessageStore for LocalFileMessageStore {
                 .to_string(),
         );
         let storage_capability = crate::platform::current_store_platform_capability();
+        let platform_optimization = storage_capability.optimization;
         result.insert("linuxStorageOs".to_string(), storage_capability.os_name.to_string());
+        result.insert(
+            "storePlatformIoHintBranch".to_string(),
+            platform_optimization.io_hint_branch.as_str().to_string(),
+        );
+        result.insert(
+            "storePlatformMmapAdviceSupported".to_string(),
+            platform_optimization.mmap_advice_supported.to_string(),
+        );
+        result.insert(
+            "storePlatformFilePrefetchSupported".to_string(),
+            platform_optimization.file_prefetch_supported.to_string(),
+        );
+        result.insert(
+            "storePlatformLazyMmapSupported".to_string(),
+            platform_optimization.lazy_mmap_supported.to_string(),
+        );
+        result.insert(
+            "storePlatformIoHintFailureAffectsCorrectness".to_string(),
+            platform_optimization.hint_failure_affects_correctness.to_string(),
+        );
+        result.insert(
+            "storeIoHintEnable".to_string(),
+            self.message_store_config.store_io_hint_enable.to_string(),
+        );
+        result.insert(
+            "storeLazyMmapEnable".to_string(),
+            self.message_store_config.store_lazy_mmap_enable.to_string(),
+        );
+        result.insert(
+            "storeEffectiveIoHintEnable".to_string(),
+            (self.message_store_config.store_io_hint_enable
+                && (platform_optimization.mmap_advice_supported || platform_optimization.file_prefetch_supported))
+                .to_string(),
+        );
+        result.insert(
+            "storeEffectiveLazyMmapEnable".to_string(),
+            (self.message_store_config.store_lazy_mmap_enable && platform_optimization.lazy_mmap_supported).to_string(),
+        );
         result.insert(
             "linuxStoragePageSize".to_string(),
             storage_capability.page_size.to_string(),
@@ -6297,6 +6343,33 @@ mod tests {
         assert!(runtime_info.contains_key("linuxStorageOs"));
         assert!(runtime_info.contains_key("linuxStoragePageSize"));
         assert!(runtime_info.contains_key("linuxStorageMemoryLockLimitBytes"));
+        let platform_capability = crate::platform::current_store_platform_capability();
+        assert_eq!(
+            runtime_info["storePlatformIoHintBranch"],
+            platform_capability.optimization.io_hint_branch.as_str()
+        );
+        assert_eq!(
+            runtime_info["storePlatformMmapAdviceSupported"],
+            platform_capability.optimization.mmap_advice_supported.to_string()
+        );
+        assert_eq!(
+            runtime_info["storePlatformFilePrefetchSupported"],
+            platform_capability.optimization.file_prefetch_supported.to_string()
+        );
+        assert_eq!(
+            runtime_info["storePlatformLazyMmapSupported"],
+            platform_capability.optimization.lazy_mmap_supported.to_string()
+        );
+        assert_eq!(runtime_info["storePlatformIoHintFailureAffectsCorrectness"], "false");
+        assert_eq!(runtime_info["storeIoHintEnable"], "true");
+        assert_eq!(runtime_info["storeLazyMmapEnable"], "false");
+        assert_eq!(
+            runtime_info["storeEffectiveIoHintEnable"],
+            (platform_capability.optimization.mmap_advice_supported
+                || platform_capability.optimization.file_prefetch_supported)
+                .to_string()
+        );
+        assert_eq!(runtime_info["storeEffectiveLazyMmapEnable"], "false");
         assert_eq!(runtime_info["transientStorePoolLockAttempts"], "0");
         assert_eq!(runtime_info["transientStorePoolLockedBuffers"], "0");
         assert_eq!(runtime_info["transientStorePoolLockFailedBuffers"], "0");

--- a/rocketmq-store/src/platform.rs
+++ b/rocketmq-store/src/platform.rs
@@ -24,6 +24,61 @@ pub struct StorePlatformCapability {
     pub page_size: usize,
     pub memory_lock_limit_bytes: Option<u64>,
     pub file_preallocate_supported: bool,
+    pub optimization: StorePlatformOptimizationCapability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorePlatformIoHintBranch {
+    LinuxMmapAdvice,
+    WindowsPrefetch,
+    Unsupported,
+}
+
+impl StorePlatformIoHintBranch {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LinuxMmapAdvice => "linux_mmap_advice",
+            Self::WindowsPrefetch => "windows_prefetch",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorePlatformOptimizationCapability {
+    pub io_hint_branch: StorePlatformIoHintBranch,
+    pub mmap_advice_supported: bool,
+    pub file_prefetch_supported: bool,
+    pub lazy_mmap_supported: bool,
+    pub hint_failure_affects_correctness: bool,
+}
+
+impl StorePlatformOptimizationCapability {
+    pub fn for_os_name(os_name: &str) -> Self {
+        match os_name {
+            "linux" => Self {
+                io_hint_branch: StorePlatformIoHintBranch::LinuxMmapAdvice,
+                mmap_advice_supported: true,
+                file_prefetch_supported: false,
+                lazy_mmap_supported: true,
+                hint_failure_affects_correctness: false,
+            },
+            "windows" => Self {
+                io_hint_branch: StorePlatformIoHintBranch::WindowsPrefetch,
+                mmap_advice_supported: false,
+                file_prefetch_supported: true,
+                lazy_mmap_supported: true,
+                hint_failure_affects_correctness: false,
+            },
+            _ => Self {
+                io_hint_branch: StorePlatformIoHintBranch::Unsupported,
+                mmap_advice_supported: false,
+                file_prefetch_supported: false,
+                lazy_mmap_supported: false,
+                hint_failure_affects_correctness: false,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,6 +100,7 @@ pub fn current_store_platform_capability() -> StorePlatformCapability {
         page_size: get_page_size().max(1),
         memory_lock_limit_bytes: memory_lock_limit_bytes(),
         file_preallocate_supported: cfg!(target_os = "linux"),
+        optimization: StorePlatformOptimizationCapability::for_os_name(std::env::consts::OS),
     }
 }
 
@@ -115,4 +171,46 @@ fn memory_lock_limit_bytes() -> Option<u64> {
 #[cfg(not(unix))]
 fn memory_lock_limit_bytes() -> Option<u64> {
     Some(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorePlatformIoHintBranch;
+    use super::StorePlatformOptimizationCapability;
+
+    #[test]
+    fn classifies_linux_platform_optimization_capability() {
+        let capability = StorePlatformOptimizationCapability::for_os_name("linux");
+
+        assert_eq!(capability.io_hint_branch, StorePlatformIoHintBranch::LinuxMmapAdvice);
+        assert_eq!(capability.io_hint_branch.as_str(), "linux_mmap_advice");
+        assert!(capability.mmap_advice_supported);
+        assert!(!capability.file_prefetch_supported);
+        assert!(capability.lazy_mmap_supported);
+        assert!(!capability.hint_failure_affects_correctness);
+    }
+
+    #[test]
+    fn classifies_windows_platform_optimization_capability() {
+        let capability = StorePlatformOptimizationCapability::for_os_name("windows");
+
+        assert_eq!(capability.io_hint_branch, StorePlatformIoHintBranch::WindowsPrefetch);
+        assert_eq!(capability.io_hint_branch.as_str(), "windows_prefetch");
+        assert!(!capability.mmap_advice_supported);
+        assert!(capability.file_prefetch_supported);
+        assert!(capability.lazy_mmap_supported);
+        assert!(!capability.hint_failure_affects_correctness);
+    }
+
+    #[test]
+    fn classifies_unsupported_platform_optimization_capability() {
+        let capability = StorePlatformOptimizationCapability::for_os_name("freebsd");
+
+        assert_eq!(capability.io_hint_branch, StorePlatformIoHintBranch::Unsupported);
+        assert_eq!(capability.io_hint_branch.as_str(), "unsupported");
+        assert!(!capability.mmap_advice_supported);
+        assert!(!capability.file_prefetch_supported);
+        assert!(!capability.lazy_mmap_supported);
+        assert!(!capability.hint_failure_affects_correctness);
+    }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7749

### Brief Description

Adds the P5-T1 platform capability detection foundation for store optimizations. The store now classifies Linux mmap advice, Windows prefetch, and unsupported branches, exposes non-fatal hint behavior through runtime info, and adds conservative I/O hint and lazy mmap switches for later Phase 5 work.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store platform_optimization --lib`
- `cargo test -p rocketmq-store runtime_info_reports_linux_storage_lifecycle_fields --lib`
- `cargo test -p rocketmq-store store_platform --lib` (0 matched; retained as a filter check)
- `git diff --check`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
