### PR TITLE
[ISSUE #7753]✨Add Windows recovery prefetch path

### DIFF
--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -83,6 +83,7 @@ use crate::log_file::cold_data_check_service::ColdDataCheckService;
 // Import the optimized loader module
 use crate::log_file::commit_log_loader::CommitLogLoader;
 use crate::log_file::commit_log_loader::LoadStatistics;
+use crate::log_file::commit_log_loader::RecoveryFilePrefetch;
 use crate::log_file::commit_log_loader::RecoveryMmapAdvice;
 use crate::log_file::flush_manager_impl::default_flush_manager::DefaultFlushManager;
 use crate::log_file::group_commit_request::GroupCommitRequest;
@@ -538,11 +539,13 @@ impl CommitLog {
         let enable_parallel = cfg!(feature = "fast-load") || !cfg!(feature = "safe-load");
 
         let recovery_mmap_advice = self.recovery_mmap_advice();
-        let loader = CommitLogLoader::new_with_recovery_mmap_advice(
+        let recovery_file_prefetch = self.recovery_file_prefetch();
+        let loader = CommitLogLoader::new_with_recovery_hints(
             store_path,
             mapped_file_size,
             enable_parallel,
             recovery_mmap_advice,
+            recovery_file_prefetch,
         );
 
         match loader.load_optimized() {
@@ -1976,6 +1979,16 @@ impl CommitLog {
             LinuxRecoveryFadviseMode::Disabled => RecoveryMmapAdvice::Disabled,
             LinuxRecoveryFadviseMode::Sequential => RecoveryMmapAdvice::Sequential,
         }
+    }
+
+    fn recovery_file_prefetch(&self) -> RecoveryFilePrefetch {
+        let platform_capability = crate::platform::current_store_platform_capability();
+        if !self.message_store_config.store_io_hint_enable || !platform_capability.optimization.file_prefetch_supported
+        {
+            return RecoveryFilePrefetch::Disabled;
+        }
+
+        RecoveryFilePrefetch::Sequential
     }
 
     #[cfg(test)]

--- a/rocketmq-store/src/log_file/commit_log_loader.rs
+++ b/rocketmq-store/src/log_file/commit_log_loader.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
+use crate::utils::ffi::prefetch_virtual_memory;
 
 /// Metadata for a single commit log file, collected during parallel scan
 #[derive(Debug, Clone)]
@@ -57,13 +58,20 @@ pub struct LoadStatistics {
     pub mmap_advice_successes: u64,
     pub mmap_advice_failures: u64,
     pub mmap_advice_elapsed_ms: u64,
+    pub recovery_file_prefetch: RecoveryFilePrefetch,
+    pub file_prefetch_attempts: u64,
+    pub file_prefetch_successes: u64,
+    pub file_prefetch_failures: u64,
+    pub file_prefetch_elapsed_ms: u64,
 }
 
 impl LoadStatistics {
     pub fn log_summary(&self) {
         info!(
             "CommitLog load completed: {} files ({:.2} GB), {} removed, parallel: {}ms, total: {}ms, mmapAdvice={}, \
-             mmapAdviceAttempts={}, mmapAdviceSuccesses={}, mmapAdviceFailures={}, mmapAdviceElapsedMs={}",
+             mmapAdviceAttempts={}, mmapAdviceSuccesses={}, mmapAdviceFailures={}, mmapAdviceElapsedMs={}, \
+             filePrefetch={}, filePrefetchAttempts={}, filePrefetchSuccesses={}, filePrefetchFailures={}, \
+             filePrefetchElapsedMs={}",
             self.total_files,
             self.total_size_bytes as f64 / 1024.0 / 1024.0 / 1024.0,
             self.files_removed,
@@ -73,11 +81,16 @@ impl LoadStatistics {
             self.mmap_advice_attempts,
             self.mmap_advice_successes,
             self.mmap_advice_failures,
-            self.mmap_advice_elapsed_ms
+            self.mmap_advice_elapsed_ms,
+            self.recovery_file_prefetch.as_str(),
+            self.file_prefetch_attempts,
+            self.file_prefetch_successes,
+            self.file_prefetch_failures,
+            self.file_prefetch_elapsed_ms
         );
     }
 
-    fn record_mmap_advice(&mut self, result: MmapAdviceResult) {
+    fn record_mmap_advice(&mut self, result: HintResult) {
         if !result.attempted {
             return;
         }
@@ -89,6 +102,21 @@ impl LoadStatistics {
         }
         self.mmap_advice_elapsed_ms = self
             .mmap_advice_elapsed_ms
+            .saturating_add(duration_to_millis(result.elapsed));
+    }
+
+    fn record_file_prefetch(&mut self, result: HintResult) {
+        if !result.attempted {
+            return;
+        }
+        self.file_prefetch_attempts = self.file_prefetch_attempts.saturating_add(1);
+        if result.succeeded {
+            self.file_prefetch_successes = self.file_prefetch_successes.saturating_add(1);
+        } else {
+            self.file_prefetch_failures = self.file_prefetch_failures.saturating_add(1);
+        }
+        self.file_prefetch_elapsed_ms = self
+            .file_prefetch_elapsed_ms
             .saturating_add(duration_to_millis(result.elapsed));
     }
 }
@@ -110,10 +138,26 @@ impl RecoveryMmapAdvice {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-struct MmapAdviceResult {
+struct HintResult {
     attempted: bool,
     succeeded: bool,
     elapsed: Duration,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RecoveryFilePrefetch {
+    #[default]
+    Disabled,
+    Sequential,
+}
+
+impl RecoveryFilePrefetch {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Sequential => "sequential",
+        }
+    }
 }
 
 fn duration_to_millis(duration: Duration) -> u64 {
@@ -126,6 +170,7 @@ pub struct CommitLogLoader {
     mapped_file_size: u64,
     enable_parallel: bool,
     recovery_mmap_advice: RecoveryMmapAdvice,
+    recovery_file_prefetch: RecoveryFilePrefetch,
 }
 
 impl CommitLogLoader {
@@ -145,11 +190,28 @@ impl CommitLogLoader {
         enable_parallel: bool,
         recovery_mmap_advice: RecoveryMmapAdvice,
     ) -> Self {
+        Self::new_with_recovery_hints(
+            store_path,
+            mapped_file_size,
+            enable_parallel,
+            recovery_mmap_advice,
+            RecoveryFilePrefetch::Disabled,
+        )
+    }
+
+    pub fn new_with_recovery_hints(
+        store_path: String,
+        mapped_file_size: u64,
+        enable_parallel: bool,
+        recovery_mmap_advice: RecoveryMmapAdvice,
+        recovery_file_prefetch: RecoveryFilePrefetch,
+    ) -> Self {
         Self {
             store_path,
             mapped_file_size,
             enable_parallel,
             recovery_mmap_advice,
+            recovery_file_prefetch,
         }
     }
 
@@ -166,6 +228,7 @@ impl CommitLogLoader {
         let start = std::time::Instant::now();
         let mut stats = LoadStatistics {
             recovery_mmap_advice: self.recovery_mmap_advice,
+            recovery_file_prefetch: self.recovery_file_prefetch,
             ..LoadStatistics::default()
         };
 
@@ -214,6 +277,10 @@ impl CommitLogLoader {
         stats.mmap_advice_successes = mmap_advice_stats.mmap_advice_successes;
         stats.mmap_advice_failures = mmap_advice_stats.mmap_advice_failures;
         stats.mmap_advice_elapsed_ms = mmap_advice_stats.mmap_advice_elapsed_ms;
+        stats.file_prefetch_attempts = mmap_advice_stats.file_prefetch_attempts;
+        stats.file_prefetch_successes = mmap_advice_stats.file_prefetch_successes;
+        stats.file_prefetch_failures = mmap_advice_stats.file_prefetch_failures;
+        stats.file_prefetch_elapsed_ms = mmap_advice_stats.file_prefetch_elapsed_ms;
 
         stats.total_load_time_ms = start.elapsed().as_millis();
         stats.log_summary();
@@ -337,14 +404,14 @@ impl CommitLogLoader {
                 )?;
 
                 // Apply memory hints for sequential access
-                let mmap_advice_result = self.apply_memory_hints(&mapped_file);
+                let (mmap_advice_result, file_prefetch_result) = self.apply_memory_hints(&mapped_file);
 
                 // Set positions (all full since we're loading existing files)
                 mapped_file.set_wrote_position(self.mapped_file_size as i32);
                 mapped_file.set_flushed_position(self.mapped_file_size as i32);
                 mapped_file.set_committed_position(self.mapped_file_size as i32);
 
-                Ok((Arc::new(mapped_file), mmap_advice_result))
+                Ok((Arc::new(mapped_file), mmap_advice_result, file_prefetch_result))
             })
             .collect();
 
@@ -352,11 +419,13 @@ impl CommitLogLoader {
         let results = results?;
         let mut mmap_advice_stats = LoadStatistics {
             recovery_mmap_advice: self.recovery_mmap_advice,
+            recovery_file_prefetch: self.recovery_file_prefetch,
             ..LoadStatistics::default()
         };
         let mut mapped_files = Vec::with_capacity(results.len());
-        for (mapped_file, mmap_advice_result) in results {
+        for (mapped_file, mmap_advice_result, file_prefetch_result) in results {
             mmap_advice_stats.record_mmap_advice(mmap_advice_result);
+            mmap_advice_stats.record_file_prefetch(file_prefetch_result);
             mapped_files.push(mapped_file);
         }
         Ok((mapped_files, mmap_advice_stats))
@@ -370,6 +439,7 @@ impl CommitLogLoader {
         let mut mapped_files = Vec::with_capacity(metadata.len());
         let mut mmap_advice_stats = LoadStatistics {
             recovery_mmap_advice: self.recovery_mmap_advice,
+            recovery_file_prefetch: self.recovery_file_prefetch,
             ..LoadStatistics::default()
         };
 
@@ -379,8 +449,9 @@ impl CommitLogLoader {
                 self.mapped_file_size,
             )?;
 
-            let mmap_advice_result = self.apply_memory_hints(&mapped_file);
+            let (mmap_advice_result, file_prefetch_result) = self.apply_memory_hints(&mapped_file);
             mmap_advice_stats.record_mmap_advice(mmap_advice_result);
+            mmap_advice_stats.record_file_prefetch(file_prefetch_result);
 
             mapped_file.set_wrote_position(self.mapped_file_size as i32);
             mapped_file.set_flushed_position(self.mapped_file_size as i32);
@@ -401,9 +472,15 @@ impl CommitLogLoader {
     /// # Implementation
     /// Uses `memmap2::Mmap::advise()` to provide sequential access hints to the kernel,
     /// which can improve performance by optimizing readahead and page cache behavior.
-    fn apply_memory_hints(&self, mapped_file: &DefaultMappedFile) -> MmapAdviceResult {
+    fn apply_memory_hints(&self, mapped_file: &DefaultMappedFile) -> (HintResult, HintResult) {
+        let mmap_advice_result = self.apply_mmap_advice(mapped_file);
+        let file_prefetch_result = self.apply_file_prefetch(mapped_file);
+        (mmap_advice_result, file_prefetch_result)
+    }
+
+    fn apply_mmap_advice(&self, mapped_file: &DefaultMappedFile) -> HintResult {
         if self.recovery_mmap_advice == RecoveryMmapAdvice::Disabled {
-            return MmapAdviceResult::default();
+            return HintResult::default();
         }
 
         #[cfg(unix)]
@@ -414,7 +491,7 @@ impl CommitLogLoader {
             let start = std::time::Instant::now();
             let mmap = mapped_file.get_mapped_file();
             match self.recovery_mmap_advice {
-                RecoveryMmapAdvice::Disabled => MmapAdviceResult::default(),
+                RecoveryMmapAdvice::Disabled => HintResult::default(),
                 RecoveryMmapAdvice::Sequential => {
                     if let Err(e) = mmap.advise(Advice::Sequential) {
                         // Non-fatal: madvise failure doesn't affect correctness
@@ -423,7 +500,7 @@ impl CommitLogLoader {
                             mapped_file.get_file_name(),
                             e
                         );
-                        MmapAdviceResult {
+                        HintResult {
                             attempted: true,
                             succeeded: false,
                             elapsed: start.elapsed(),
@@ -431,7 +508,7 @@ impl CommitLogLoader {
                     } else {
                         #[cfg(debug_assertions)]
                         tracing::debug!("Applied MADV_SEQUENTIAL hint to {}", mapped_file.get_file_name());
-                        MmapAdviceResult {
+                        HintResult {
                             attempted: true,
                             succeeded: true,
                             elapsed: start.elapsed(),
@@ -441,22 +518,51 @@ impl CommitLogLoader {
             }
         }
 
-        #[cfg(windows)]
-        {
-            // Windows: PrefetchVirtualMemory requires additional Win32 API bindings
-            // For now, rely on OS defaults which already provide good performance
-            // Future enhancement: Use windows-sys crate to call PrefetchVirtualMemory
-
-            #[cfg(debug_assertions)]
-            tracing::debug!(
-                "Memory hints not implemented for Windows, relying on OS defaults for {}",
-                mapped_file.get_file_name()
-            );
-        }
-
         #[cfg(not(unix))]
         {
-            MmapAdviceResult::default()
+            let _ = mapped_file;
+            HintResult::default()
+        }
+    }
+
+    fn apply_file_prefetch(&self, mapped_file: &DefaultMappedFile) -> HintResult {
+        if self.recovery_file_prefetch == RecoveryFilePrefetch::Disabled {
+            return HintResult::default();
+        }
+
+        #[cfg(windows)]
+        {
+            let start = std::time::Instant::now();
+            let mmap = mapped_file.get_mapped_file();
+            match self.recovery_file_prefetch {
+                RecoveryFilePrefetch::Disabled => HintResult::default(),
+                RecoveryFilePrefetch::Sequential => match prefetch_virtual_memory(mmap.as_ptr(), mmap.len()) {
+                    Ok(true) => HintResult {
+                        attempted: true,
+                        succeeded: true,
+                        elapsed: start.elapsed(),
+                    },
+                    Ok(false) => HintResult::default(),
+                    Err(error) => {
+                        warn!(
+                            "Failed to prefetch recovery mapped file {}: {}",
+                            mapped_file.get_file_name(),
+                            error
+                        );
+                        HintResult {
+                            attempted: true,
+                            succeeded: false,
+                            elapsed: start.elapsed(),
+                        }
+                    }
+                },
+            }
+        }
+
+        #[cfg(not(windows))]
+        {
+            let _ = mapped_file;
+            HintResult::default()
         }
     }
 }
@@ -540,6 +646,55 @@ mod tests {
         assert_eq!(
             stats.mmap_advice_attempts,
             stats.mmap_advice_successes.saturating_add(stats.mmap_advice_failures)
+        );
+    }
+
+    #[test]
+    fn disabled_recovery_file_prefetch_records_no_attempts() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("00000000000000000000");
+        let file_size = 1024 * 1024u64;
+        std::fs::write(&file_path, vec![0u8; file_size as usize]).unwrap();
+
+        let loader = CommitLogLoader::new_with_recovery_hints(
+            temp_dir.path().to_string_lossy().to_string(),
+            file_size,
+            false,
+            RecoveryMmapAdvice::Disabled,
+            RecoveryFilePrefetch::Disabled,
+        );
+
+        let (_, stats) = loader.load_optimized().unwrap();
+        assert_eq!(stats.recovery_file_prefetch, RecoveryFilePrefetch::Disabled);
+        assert_eq!(stats.file_prefetch_attempts, 0);
+        assert_eq!(stats.file_prefetch_successes, 0);
+        assert_eq!(stats.file_prefetch_failures, 0);
+    }
+
+    #[test]
+    fn sequential_recovery_file_prefetch_records_windows_attempts() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("00000000000000000000");
+        let file_size = 1024 * 1024u64;
+        std::fs::write(&file_path, vec![0u8; file_size as usize]).unwrap();
+
+        let loader = CommitLogLoader::new_with_recovery_hints(
+            temp_dir.path().to_string_lossy().to_string(),
+            file_size,
+            false,
+            RecoveryMmapAdvice::Disabled,
+            RecoveryFilePrefetch::Sequential,
+        );
+
+        let (_, stats) = loader.load_optimized().unwrap();
+        let expected_attempts = if cfg!(windows) { 1 } else { 0 };
+        assert_eq!(stats.recovery_file_prefetch, RecoveryFilePrefetch::Sequential);
+        assert_eq!(stats.file_prefetch_attempts, expected_attempts);
+        assert_eq!(
+            stats.file_prefetch_attempts,
+            stats
+                .file_prefetch_successes
+                .saturating_add(stats.file_prefetch_failures)
         );
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2884,6 +2884,26 @@ impl MessageStore for LocalFileMessageStore {
             commit_log_load_stats.mmap_advice_elapsed_ms.to_string(),
         );
         result.insert(
+            "windowsStorageRecoveryFilePrefetch".to_string(),
+            commit_log_load_stats.recovery_file_prefetch.as_str().to_string(),
+        );
+        result.insert(
+            "windowsStorageRecoveryFilePrefetchAttempts".to_string(),
+            commit_log_load_stats.file_prefetch_attempts.to_string(),
+        );
+        result.insert(
+            "windowsStorageRecoveryFilePrefetchSuccesses".to_string(),
+            commit_log_load_stats.file_prefetch_successes.to_string(),
+        );
+        result.insert(
+            "windowsStorageRecoveryFilePrefetchFailures".to_string(),
+            commit_log_load_stats.file_prefetch_failures.to_string(),
+        );
+        result.insert(
+            "windowsStorageRecoveryFilePrefetchElapsedMs".to_string(),
+            commit_log_load_stats.file_prefetch_elapsed_ms.to_string(),
+        );
+        result.insert(
             "linuxStorageHaSendfileEnable".to_string(),
             self.message_store_config
                 .effective_linux_ha_sendfile_enable()
@@ -6414,6 +6434,11 @@ mod tests {
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdviceSuccesses"], "0");
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdviceFailures"], "0");
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdviceElapsedMs"], "0");
+        assert_eq!(runtime_info["windowsStorageRecoveryFilePrefetch"], "disabled");
+        assert_eq!(runtime_info["windowsStorageRecoveryFilePrefetchAttempts"], "0");
+        assert_eq!(runtime_info["windowsStorageRecoveryFilePrefetchSuccesses"], "0");
+        assert_eq!(runtime_info["windowsStorageRecoveryFilePrefetchFailures"], "0");
+        assert_eq!(runtime_info["windowsStorageRecoveryFilePrefetchElapsedMs"], "0");
         assert_eq!(runtime_info["linuxStorageHaSendfileEnable"], "false");
         assert_eq!(runtime_info["linuxStorageIoUringEnable"], "false");
     }

--- a/rocketmq-store/src/utils/ffi.rs
+++ b/rocketmq-store/src/utils/ffi.rs
@@ -91,6 +91,40 @@ pub fn madvise(addr: *const u8, len: usize, advice: i32) -> i32 {
     }
 }
 
+pub fn prefetch_virtual_memory(addr: *const u8, len: usize) -> RocketMQResult<bool> {
+    if len == 0 {
+        return Ok(false);
+    }
+
+    #[cfg(windows)]
+    {
+        use std::ffi::c_void;
+
+        use windows::Win32::System::Memory::PrefetchVirtualMemory;
+        use windows::Win32::System::Memory::WIN32_MEMORY_RANGE_ENTRY;
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        let range = WIN32_MEMORY_RANGE_ENTRY {
+            VirtualAddress: addr as *mut c_void,
+            NumberOfBytes: len,
+        };
+        unsafe { PrefetchVirtualMemory(GetCurrentProcess(), &[range], 0) }.map_err(|error| {
+            RocketMQError::StorageReadFailed {
+                path: "PrefetchVirtualMemory".to_string(),
+                reason: error.to_string(),
+            }
+        })?;
+        Ok(true)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = addr;
+        let _ = len;
+        Ok(false)
+    }
+}
+
 pub fn mincore(addr: *const u8, len: usize, vec: *const u8) -> i32 {
     #[cfg(target_os = "linux")]
     {


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7753

### Brief Description

Adds the P5-T3 Windows recovery prefetch path. Recovery-loaded CommitLog mappings can now use a cfg-protected `PrefetchVirtualMemory` helper when the current platform supports file prefetch, while unsupported platforms remain no-op. Prefetch attempts, successes, failures, and elapsed time are recorded and exposed through store runtime info without affecting recovery correctness.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store recovery_file_prefetch --lib`
- `cargo test -p rocketmq-store runtime_info_reports_linux_storage_lifecycle_fields --lib`
- `cargo test -p rocketmq-store recovery_mmap_advice --lib`
- `git diff --check`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved commit-log recovery with optional file prefetch support on supported platforms.
  * Runtime status now reports additional storage recovery prefetch metrics on Windows.

* **Bug Fixes**
  * Recovery loading now tracks and logs more detailed hint execution results, including success, failure, and elapsed time.
  * Platform-specific behavior was added so unsupported systems safely skip file prefetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->