### PR TITLE
[ISSUE #7761]✨Gate CommitLog prefetch import for Linux clippy

### DIFF
--- a/rocketmq-store/src/log_file/commit_log_loader.rs
+++ b/rocketmq-store/src/log_file/commit_log_loader.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
+#[cfg(windows)]
 use crate::utils::ffi::prefetch_virtual_memory;
 
 /// Metadata for a single commit log file, collected during parallel scan


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7761

### Brief Description

Gates the CommitLog recovery `prefetch_virtual_memory` import with `#[cfg(windows)]` so Linux `--all-features` clippy no longer treats the Windows-only helper as an unused import.

This preserves the Windows `PrefetchVirtualMemory` path and unblocks the Linux `Check (fmt + clippy)` failure observed on dependency update PR #7760.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo clippy -p rocketmq-store --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo clippy -p rocketmq-store --target x86_64-unknown-linux-gnu --no-deps --all-targets --all-features -- -D warnings` was attempted but blocked before crate checking because this Windows machine does not have the `x86_64-linux-gnu-gcc` cross compiler required by native build dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility by limiting a memory prefetch dependency to Windows builds only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->