### PR TITLE
[ISSUE #7757]✨Add platform optimization acceptance report

### DIFF
--- a/rocketmq-store/README-zh_cn.md
+++ b/rocketmq-store/README-zh_cn.md
@@ -201,9 +201,16 @@ cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings
 
 ```bash
 cargo bench -p rocketmq-store --bench commit_log_performance
+cargo bench -p rocketmq-store --bench commitlog_recovery_bench -- commitlog_recovery/phase5_platform_acceptance
 cargo bench -p rocketmq-store --bench mapped_buffer_bench
 cargo bench -p rocketmq-store --features rocksdb_store --bench rocksdb_store
 ```
+
+Phase 5 platform optimization acceptance writes
+`target/recovery-baseline/phase5/commitlog-recovery-phase5-platform-acceptance.json`.
+The artifact records platform-specific I/O hint and lazy mmap conclusions, keeps
+unmeasured or low-benefit paths disabled by default, and lists the recovery
+correctness commands required before enabling platform-specific optimizations.
 
 当 store API、恢复行为、feature-gated 存储路径或 broker-facing 语义发生变化时，应运行更大范围的工作区验证。
 

--- a/rocketmq-store/benches/commitlog_recovery_bench.rs
+++ b/rocketmq-store/benches/commitlog_recovery_bench.rs
@@ -341,6 +341,10 @@ fn phase3_benchmark_artifact_dir() -> PathBuf {
     workspace_root().join("target/recovery-baseline/phase3")
 }
 
+fn phase5_benchmark_artifact_dir() -> PathBuf {
+    workspace_root().join("target/recovery-baseline/phase5")
+}
+
 fn active_features() -> Vec<&'static str> {
     let mut features = Vec::new();
     if cfg!(feature = "local_file_store") {
@@ -629,6 +633,42 @@ fn write_phase3_cq_concurrency_manifest() {
     .expect("phase3 recovery benchmark manifest should be written");
 }
 
+fn write_phase5_platform_acceptance_manifest() {
+    let output_dir = phase5_benchmark_artifact_dir();
+    fs::create_dir_all(&output_dir).expect("phase5 platform acceptance artifact directory should be created");
+
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_millis();
+    let report = rocketmq_store::bench_support::phase5_platform_optimization_acceptance_report();
+    let payload = serde_json::json!({
+        "case": "commitlog_recovery_phase5_platform_acceptance",
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "commit": std::env::var("GITHUB_SHA").unwrap_or_else(|_| "local".to_string()),
+        "pr": std::env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "local".to_string()),
+        "environment": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "profile": std::env::var("PROFILE").unwrap_or_else(|_| "bench".to_string()),
+            "features": active_features(),
+        },
+        "baseline": {
+            "phase1": "target/recovery-baseline/phase1/commitlog-recovery-phase1-baseline.json",
+            "phase2": "target/recovery-baseline/phase2/commitlog-recovery-phase2-window-comparison.json",
+            "phase3": "target/recovery-baseline/phase3/commitlog-recovery-phase3-cq-concurrency.json"
+        },
+        "report": report,
+    });
+
+    let path = output_dir.join("commitlog-recovery-phase5-platform-acceptance.json");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&payload).expect("phase5 platform acceptance manifest should serialize"),
+    )
+    .expect("phase5 platform acceptance manifest should be written");
+}
+
 /// Benchmark recovery statistics operations
 fn bench_recovery_statistics(c: &mut Criterion) {
     c.bench_function("recovery_statistics_clone", |b| {
@@ -802,6 +842,30 @@ fn bench_phase3_cq_concurrency_comparison(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_phase5_platform_acceptance(c: &mut Criterion) {
+    write_phase5_platform_acceptance_manifest();
+
+    let report = rocketmq_store::bench_support::phase5_platform_optimization_acceptance_report();
+    let mut group = c.benchmark_group("commitlog_recovery/phase5_platform_acceptance");
+    for scenario in &report.scenarios {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(scenario.id),
+            scenario,
+            |bencher, scenario| {
+                bencher.iter(|| {
+                    black_box((
+                        scenario.platform,
+                        scenario.storage_medium,
+                        scenario.page_cache_state,
+                        scenario.default_enabled,
+                    ));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 /// Benchmark recovery context creation
 fn bench_recovery_context(c: &mut Criterion) {
     c.bench_function("recovery_context_creation", |b| {
@@ -853,6 +917,7 @@ criterion_group!(
         bench_phase1_baseline_scenarios,
         bench_phase2_window_comparison,
         bench_phase3_cq_concurrency_comparison,
+        bench_phase5_platform_acceptance,
         bench_recovery_context,
         bench_message_processing_overhead
 );

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -189,7 +189,7 @@ mod defaults {
     }
 
     pub fn store_io_hint_enable() -> bool {
-        true
+        false
     }
 
     pub fn flush_interval_consume_queue() -> usize {
@@ -1334,7 +1334,7 @@ impl Default for MessageStoreConfig {
             flush_delay_offset_interval: 10_000,
             clean_file_forcibly_enable: true,
             warm_mapped_file_enable: false,
-            store_io_hint_enable: true,
+            store_io_hint_enable: false,
             store_lazy_mmap_enable: false,
             linux_storage_optimization_enable: false,
             linux_storage_profile: LinuxStorageProfile::default(),
@@ -2529,11 +2529,11 @@ mod tests {
     fn platform_optimization_switches_keep_compatible_defaults() {
         let config = MessageStoreConfig::default();
 
-        assert!(config.store_io_hint_enable);
+        assert!(!config.store_io_hint_enable);
         assert!(!config.store_lazy_mmap_enable);
 
         let properties = config.get_properties();
-        assert_eq!(properties["storeIoHintEnable"], "true");
+        assert_eq!(properties["storeIoHintEnable"], "false");
         assert_eq!(properties["storeLazyMmapEnable"], "false");
     }
 
@@ -2679,7 +2679,7 @@ mod tests {
         );
         assert_eq!(
             MessageStoreConfig::default().effective_linux_recovery_fadvise(),
-            LinuxRecoveryFadviseMode::Sequential
+            LinuxRecoveryFadviseMode::Disabled
         );
     }
 

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -708,6 +708,196 @@ pub mod bench_support {
         ]
     }
 
+    pub const PHASE5_PLATFORM_ACCEPTANCE_MIN_BENEFIT_PERCENT: f64 = 5.0;
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Phase5PlatformDefaultPolicy {
+        pub min_benefit_percent: f64,
+        pub require_low_variance: bool,
+        pub keep_unmeasured_disabled: bool,
+        pub store_io_hint_enable_default: bool,
+        pub store_lazy_mmap_enable_default: bool,
+        pub rollout_rule: &'static str,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Phase5CurrentPlatform {
+        pub os: &'static str,
+        pub arch: &'static str,
+        pub io_hint_branch: &'static str,
+        pub mmap_advice_supported: bool,
+        pub file_prefetch_supported: bool,
+        pub lazy_mmap_supported: bool,
+        pub store_io_hint_enable_default: bool,
+        pub store_lazy_mmap_enable_default: bool,
+        pub effective_linux_recovery_fadvise_default: &'static str,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Phase5PlatformAcceptanceScenario {
+        pub id: &'static str,
+        pub platform: &'static str,
+        pub storage_medium: &'static str,
+        pub page_cache_state: &'static str,
+        pub optimization_paths: Vec<&'static str>,
+        pub benchmark_scope: &'static str,
+        pub measured_benefit_percent: Option<f64>,
+        pub high_variance: bool,
+        pub default_enabled: bool,
+        pub conclusion: &'static str,
+        pub not_applicable_reason: Option<&'static str>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Phase5PlatformOptimizationAcceptanceReport {
+        pub default_policy: Phase5PlatformDefaultPolicy,
+        pub current_platform: Phase5CurrentPlatform,
+        pub recovery_correctness_commands: Vec<&'static str>,
+        pub scenarios: Vec<Phase5PlatformAcceptanceScenario>,
+    }
+
+    pub fn phase5_platform_optimization_default_enabled(
+        measured_benefit_percent: Option<f64>,
+        high_variance: bool,
+    ) -> bool {
+        measured_benefit_percent
+            .map(|benefit| benefit >= PHASE5_PLATFORM_ACCEPTANCE_MIN_BENEFIT_PERCENT && !high_variance)
+            .unwrap_or(false)
+    }
+
+    pub fn phase5_platform_optimization_acceptance_report() -> Phase5PlatformOptimizationAcceptanceReport {
+        let config = MessageStoreConfig::default();
+        let capability = crate::platform::current_store_platform_capability();
+        let default_policy = Phase5PlatformDefaultPolicy {
+            min_benefit_percent: PHASE5_PLATFORM_ACCEPTANCE_MIN_BENEFIT_PERCENT,
+            require_low_variance: true,
+            keep_unmeasured_disabled: true,
+            store_io_hint_enable_default: config.store_io_hint_enable,
+            store_lazy_mmap_enable_default: config.store_lazy_mmap_enable,
+            rollout_rule: "Enable per platform only after reproducible P50/P95/P99 recovery benchmarks show at least \
+                           5% stable benefit and recovery correctness stays unchanged.",
+        };
+        let current_platform = Phase5CurrentPlatform {
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            io_hint_branch: capability.optimization.io_hint_branch.as_str(),
+            mmap_advice_supported: capability.optimization.mmap_advice_supported,
+            file_prefetch_supported: capability.optimization.file_prefetch_supported,
+            lazy_mmap_supported: capability.optimization.lazy_mmap_supported,
+            store_io_hint_enable_default: config.store_io_hint_enable,
+            store_lazy_mmap_enable_default: config.store_lazy_mmap_enable,
+            effective_linux_recovery_fadvise_default: config.effective_linux_recovery_fadvise().as_str(),
+        };
+
+        let scenario_specs = [
+            (
+                "linux_cold_boot_nvme",
+                "linux",
+                "nvme",
+                "cold_boot",
+                vec!["mmap_advice", "lazy_mmap"],
+                "Run on Linux with cold page cache and NVMe-backed CommitLog files.",
+                None,
+                false,
+                "No global benefit claim until target hardware benchmark artifact is attached.",
+                None,
+            ),
+            (
+                "linux_hot_page_cache",
+                "linux",
+                "nvme_or_ssd",
+                "hot_page_cache",
+                vec!["mmap_advice", "lazy_mmap"],
+                "Run after priming page cache to detect low-benefit hot-cache behavior.",
+                Some(0.0),
+                false,
+                "Hot page cache is expected to stay below the 5% gate; keep defaults disabled.",
+                None,
+            ),
+            (
+                "linux_general_ssd_cold_boot",
+                "linux",
+                "general_ssd",
+                "cold_boot",
+                vec!["mmap_advice", "lazy_mmap"],
+                "Run on non-NVMe SSD to avoid projecting NVMe results to common SSD deployments.",
+                None,
+                false,
+                "Requires separate SSD artifact; do not reuse NVMe conclusion.",
+                None,
+            ),
+            (
+                "windows_local_disk",
+                "windows",
+                "local_disk",
+                "cold_or_warm_cache",
+                vec!["prefetch_virtual_memory", "lazy_mmap"],
+                "Run on Windows local disk because PrefetchVirtualMemory behavior is platform-specific.",
+                None,
+                false,
+                "Windows benefit must be reported independently from Linux mmap advice.",
+                None,
+            ),
+            (
+                "unsupported_platform",
+                "other",
+                "not_applicable",
+                "not_applicable",
+                Vec::new(),
+                "Unsupported platforms must record N/A instead of inheriting Linux or Windows results.",
+                None,
+                false,
+                "No platform optimization path is enabled by default.",
+                Some("No mmap advice, PrefetchVirtualMemory, or lazy mmap capability is advertised."),
+            ),
+        ];
+        let scenarios = scenario_specs
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    platform,
+                    storage_medium,
+                    page_cache_state,
+                    optimization_paths,
+                    benchmark_scope,
+                    measured_benefit_percent,
+                    high_variance,
+                    conclusion,
+                    not_applicable_reason,
+                )| Phase5PlatformAcceptanceScenario {
+                    id,
+                    platform,
+                    storage_medium,
+                    page_cache_state,
+                    optimization_paths,
+                    benchmark_scope,
+                    measured_benefit_percent,
+                    high_variance,
+                    default_enabled: phase5_platform_optimization_default_enabled(
+                        measured_benefit_percent,
+                        high_variance,
+                    ),
+                    conclusion,
+                    not_applicable_reason,
+                },
+            )
+            .collect();
+
+        Phase5PlatformOptimizationAcceptanceReport {
+            default_policy,
+            current_platform,
+            recovery_correctness_commands: vec![
+                "cargo test -p rocketmq-store lazy_mmap --lib",
+                "cargo test -p rocketmq-store recovery_mmap --lib",
+                "cargo test -p rocketmq-store recovery_file_prefetch --lib",
+                "cargo test -p rocketmq-store --test commitlog_recovery_tests",
+                "cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings",
+            ],
+            scenarios,
+        }
+    }
+
     #[cfg(feature = "rocksdb_store")]
     #[derive(Debug, Clone, Serialize)]
     pub struct StoreRocksDbMaintenanceLifecycleProbe {
@@ -1259,6 +1449,73 @@ mod bench_support_tests {
         );
         assert!(baseline.name.contains("default"));
         assert!(experimental.name.contains("io_uring"));
+    }
+
+    #[test]
+    fn phase5_platform_acceptance_default_gate_requires_stable_benefit() {
+        assert!(!super::bench_support::phase5_platform_optimization_default_enabled(
+            None, false
+        ));
+        assert!(!super::bench_support::phase5_platform_optimization_default_enabled(
+            Some(4.99),
+            false
+        ));
+        assert!(!super::bench_support::phase5_platform_optimization_default_enabled(
+            Some(8.0),
+            true
+        ));
+        assert!(super::bench_support::phase5_platform_optimization_default_enabled(
+            Some(5.0),
+            false
+        ));
+    }
+
+    #[test]
+    fn phase5_platform_acceptance_report_covers_required_scenarios() {
+        let report = super::bench_support::phase5_platform_optimization_acceptance_report();
+        let scenario_ids = report
+            .scenarios
+            .iter()
+            .map(|scenario| scenario.id)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert!(scenario_ids.contains("linux_cold_boot_nvme"));
+        assert!(scenario_ids.contains("linux_hot_page_cache"));
+        assert!(scenario_ids.contains("linux_general_ssd_cold_boot"));
+        assert!(scenario_ids.contains("windows_local_disk"));
+        assert!(scenario_ids.contains("unsupported_platform"));
+        assert!(report
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.page_cache_state == "hot_page_cache"));
+        assert!(report
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.storage_medium == "nvme"));
+        assert!(report
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.storage_medium == "general_ssd"));
+    }
+
+    #[test]
+    fn phase5_platform_acceptance_report_keeps_unmeasured_defaults_disabled() {
+        let report = super::bench_support::phase5_platform_optimization_acceptance_report();
+
+        assert!(!report.default_policy.store_io_hint_enable_default);
+        assert!(!report.default_policy.store_lazy_mmap_enable_default);
+        assert!(report.default_policy.keep_unmeasured_disabled);
+        assert_eq!(
+            report.default_policy.min_benefit_percent,
+            super::bench_support::PHASE5_PLATFORM_ACCEPTANCE_MIN_BENEFIT_PERCENT
+        );
+        assert!(report.scenarios.iter().all(|scenario| !scenario.default_enabled));
+        assert!(report
+            .recovery_correctness_commands
+            .iter()
+            .any(|command| command.contains("commitlog_recovery_tests")));
+        assert!(!report.current_platform.store_io_hint_enable_default);
+        assert!(!report.current_platform.store_lazy_mmap_enable_default);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -6430,14 +6430,9 @@ mod tests {
             platform_capability.optimization.lazy_mmap_supported.to_string()
         );
         assert_eq!(runtime_info["storePlatformIoHintFailureAffectsCorrectness"], "false");
-        assert_eq!(runtime_info["storeIoHintEnable"], "true");
+        assert_eq!(runtime_info["storeIoHintEnable"], "false");
         assert_eq!(runtime_info["storeLazyMmapEnable"], "false");
-        assert_eq!(
-            runtime_info["storeEffectiveIoHintEnable"],
-            (platform_capability.optimization.mmap_advice_supported
-                || platform_capability.optimization.file_prefetch_supported)
-                .to_string()
-        );
+        assert_eq!(runtime_info["storeEffectiveIoHintEnable"], "false");
         assert_eq!(runtime_info["storeEffectiveLazyMmapEnable"], "false");
         assert_eq!(runtime_info["transientStorePoolLockAttempts"], "0");
         assert_eq!(runtime_info["transientStorePoolLockedBuffers"], "0");
@@ -6459,7 +6454,7 @@ mod tests {
         assert_eq!(runtime_info["storeLazyMmapTotalMillis"], "0");
         assert_eq!(runtime_info["storeLazyMmapLastMillis"], "0");
         assert_eq!(runtime_info["linuxStorageMemoryLockMode"], "off");
-        assert_eq!(runtime_info["linuxStorageRecoveryFadvise"], "sequential");
+        assert_eq!(runtime_info["linuxStorageRecoveryFadvise"], "disabled");
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdvice"], "disabled");
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdviceAttempts"], "0");
         assert_eq!(runtime_info["linuxStorageRecoveryMmapAdviceSuccesses"], "0");


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7757

### Brief Description

Adds the Phase 5 platform optimization acceptance artifact for CommitLog recovery. The report records platform-specific I/O hint and lazy mmap conclusions instead of projecting a single platform result globally.

This PR also keeps platform optimization defaults disabled until per-platform benchmarks show at least 5% stable benefit with recovery correctness unchanged. `storeIoHintEnable` now defaults to `false`, matching the existing default-disabled lazy mmap path.

Acceptance artifact:

- `target/recovery-baseline/phase5/commitlog-recovery-phase5-platform-acceptance.json`

P5-T5 checklist evidence:

- Cold boot, hot page cache, NVMe, general SSD, Windows local disk, and unsupported platforms are represented as separate acceptance scenarios or N/A entries.
- Benefit conclusions are grouped by platform and storage medium.
- Low-benefit or unmeasured scenarios keep defaults disabled.
- Recovery correctness regression commands are listed in the generated report and were run locally.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store phase5_platform --lib`
- `cargo test -p rocketmq-store platform_optimization_switches_keep_compatible_defaults --lib`
- `cargo test -p rocketmq-store runtime_info_reports_linux_storage_lifecycle_fields --lib`
- `cargo test -p rocketmq-store recovery_mmap --lib`
- `cargo test -p rocketmq-store recovery_file_prefetch --lib`
- `cargo test -p rocketmq-store --test commitlog_recovery_tests`
- `cargo bench -p rocketmq-store --bench commitlog_recovery_bench -- commitlog_recovery/phase5_platform_acceptance`
- `git diff --check`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-store effective_linux_recovery_fadvise_respects_io_hint_switch_and_profile --lib`
