### PR TITLE
[ISSUE #7768]✨Add sync flush backlog send rejection

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -20,6 +20,7 @@ use cheetah_string::CheetahString;
 use rand::RngExt;
 use rocketmq_common::common::attribute::cleanup_policy::CleanupPolicy;
 use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::key_builder::KeyBuilder;
@@ -67,6 +68,7 @@ use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerCon
 use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_rust::ArcMut;
+use rocketmq_store::base::flush_manager::SyncFlushRuntimeInfo;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
@@ -160,6 +162,18 @@ where
                 Some(RemotingCommand::create_response_command_with_code_remark(
                     ResponseCode::SystemBusy,
                     "The broker message store is busy, please try again later",
+                )),
+            );
+        }
+        if let Some(remark) = sync_flush_backlog_reject_remark(
+            self.inner.broker_runtime_inner.broker_config(),
+            message_store.sync_flush_runtime_info(),
+        ) {
+            return (
+                true,
+                Some(RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemBusy,
+                    remark,
                 )),
             );
         }
@@ -1122,6 +1136,24 @@ fn has_registered_send_message_hooks(hooks: &[Box<dyn SendMessageHook>]) -> bool
     !hooks.is_empty()
 }
 
+fn sync_flush_backlog_reject_remark(
+    broker_config: &BrokerConfig,
+    runtime_info: SyncFlushRuntimeInfo,
+) -> Option<String> {
+    let reject_depth = broker_config.sync_flush_backlog_reject_depth;
+    let reject_wait_millis = broker_config.sync_flush_backlog_reject_wait_millis;
+    let depth_exceeded = reject_depth > 0 && runtime_info.queue_depth >= reject_depth;
+    let wait_exceeded = reject_wait_millis > 0 && runtime_info.oldest_wait_millis >= reject_wait_millis;
+
+    (depth_exceeded || wait_exceeded).then(|| {
+        format!(
+            "The broker sync flush backlog is busy, queueDepth={}, oldestWaitMillis={}, rejectDepth={}, \
+             rejectWaitMillis={}",
+            runtime_info.queue_depth, runtime_info.oldest_wait_millis, reject_depth, reject_wait_millis
+        )
+    })
+}
+
 pub(crate) struct Inner<MS, TS>
 where
     MS: MessageStore,
@@ -1741,6 +1773,49 @@ mod tests {
 
         let hooks: Vec<Box<dyn SendMessageHook>> = vec![Box::new(NoopSendMessageHook)];
         assert!(has_registered_send_message_hooks(&hooks));
+    }
+
+    #[test]
+    fn sync_flush_backlog_reject_remark_is_disabled_by_default() {
+        let runtime_info = SyncFlushRuntimeInfo {
+            queue_depth: 64,
+            oldest_wait_millis: 10_000,
+            ..SyncFlushRuntimeInfo::default()
+        };
+
+        assert!(sync_flush_backlog_reject_remark(&BrokerConfig::default(), runtime_info).is_none());
+    }
+
+    #[test]
+    fn sync_flush_backlog_reject_remark_matches_depth_threshold() {
+        let broker_config = BrokerConfig {
+            sync_flush_backlog_reject_depth: 8,
+            ..BrokerConfig::default()
+        };
+        let runtime_info = SyncFlushRuntimeInfo {
+            queue_depth: 8,
+            ..SyncFlushRuntimeInfo::default()
+        };
+
+        let remark = sync_flush_backlog_reject_remark(&broker_config, runtime_info).expect("depth should reject");
+        assert!(remark.contains("queueDepth=8"));
+        assert!(remark.contains("rejectDepth=8"));
+    }
+
+    #[test]
+    fn sync_flush_backlog_reject_remark_matches_oldest_wait_threshold() {
+        let broker_config = BrokerConfig {
+            sync_flush_backlog_reject_wait_millis: 250,
+            ..BrokerConfig::default()
+        };
+        let runtime_info = SyncFlushRuntimeInfo {
+            oldest_wait_millis: 250,
+            ..SyncFlushRuntimeInfo::default()
+        };
+
+        let remark = sync_flush_backlog_reject_remark(&broker_config, runtime_info).expect("wait should reject");
+        assert!(remark.contains("oldestWaitMillis=250"));
+        assert!(remark.contains("rejectWaitMillis=250"));
     }
 
     #[test]

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -639,6 +639,14 @@ mod defaults {
         200
     }
 
+    pub const fn sync_flush_backlog_reject_depth() -> u64 {
+        0
+    }
+
+    pub const fn sync_flush_backlog_reject_wait_millis() -> u64 {
+        0
+    }
+
     pub const fn wait_time_mills_in_pull_queue() -> u64 {
         5_000
     }
@@ -955,6 +963,12 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::wait_time_mills_in_send_queue")]
     pub wait_time_mills_in_send_queue: u64,
+
+    #[serde(default = "defaults::sync_flush_backlog_reject_depth")]
+    pub sync_flush_backlog_reject_depth: u64,
+
+    #[serde(default = "defaults::sync_flush_backlog_reject_wait_millis")]
+    pub sync_flush_backlog_reject_wait_millis: u64,
 
     #[serde(default = "defaults::wait_time_mills_in_pull_queue")]
     pub wait_time_mills_in_pull_queue: u64,
@@ -1409,6 +1423,8 @@ impl Default for BrokerConfig {
             send_heartbeat_timeout_millis: 1000,
             broker_fast_failure_enable: defaults::broker_fast_failure_enable(),
             wait_time_mills_in_send_queue: defaults::wait_time_mills_in_send_queue(),
+            sync_flush_backlog_reject_depth: defaults::sync_flush_backlog_reject_depth(),
+            sync_flush_backlog_reject_wait_millis: defaults::sync_flush_backlog_reject_wait_millis(),
             wait_time_mills_in_pull_queue: defaults::wait_time_mills_in_pull_queue(),
             wait_time_mills_in_lite_pull_queue: defaults::wait_time_mills_in_lite_pull_queue(),
             wait_time_mills_in_heartbeat_queue: defaults::wait_time_mills_in_heartbeat_queue(),
@@ -1773,6 +1789,14 @@ impl BrokerConfig {
         properties.insert(
             "waitTimeMillsInSendQueue".into(),
             self.wait_time_mills_in_send_queue.to_string().into(),
+        );
+        properties.insert(
+            "syncFlushBacklogRejectDepth".into(),
+            self.sync_flush_backlog_reject_depth.to_string().into(),
+        );
+        properties.insert(
+            "syncFlushBacklogRejectWaitMillis".into(),
+            self.sync_flush_backlog_reject_wait_millis.to_string().into(),
         );
         properties.insert(
             "waitTimeMillsInPullQueue".into(),
@@ -2228,6 +2252,8 @@ mod tests {
 
         assert!(config.broker_fast_failure_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 200);
+        assert_eq!(config.sync_flush_backlog_reject_depth, 0);
+        assert_eq!(config.sync_flush_backlog_reject_wait_millis, 0);
         assert_eq!(config.wait_time_mills_in_pull_queue, 5_000);
         assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_000);
         assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_000);
@@ -2375,6 +2401,18 @@ mod tests {
             Some("200")
         );
         assert_eq!(
+            properties
+                .get("syncFlushBacklogRejectDepth")
+                .map(|value| value.as_str()),
+            Some("0")
+        );
+        assert_eq!(
+            properties
+                .get("syncFlushBacklogRejectWaitMillis")
+                .map(|value| value.as_str()),
+            Some("0")
+        );
+        assert_eq!(
             properties.get("waitTimeMillsInPullQueue").map(|value| value.as_str()),
             Some("5000")
         );
@@ -2445,6 +2483,8 @@ mod tests {
             r#"{
                 "brokerFastFailureEnable": false,
                 "waitTimeMillsInSendQueue": 201,
+                "syncFlushBacklogRejectDepth": 32,
+                "syncFlushBacklogRejectWaitMillis": 150,
                 "waitTimeMillsInPullQueue": 5001,
                 "waitTimeMillsInLitePullQueue": 5002,
                 "waitTimeMillsInHeartbeatQueue": 31001,
@@ -2457,6 +2497,8 @@ mod tests {
 
         assert!(!config.broker_fast_failure_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 201);
+        assert_eq!(config.sync_flush_backlog_reject_depth, 32);
+        assert_eq!(config.sync_flush_backlog_reject_wait_millis, 150);
         assert_eq!(config.wait_time_mills_in_pull_queue, 5_001);
         assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_002);
         assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_001);

--- a/rocketmq-store/src/base/flush_manager.rs
+++ b/rocketmq-store/src/base/flush_manager.rs
@@ -17,6 +17,17 @@ use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBroker
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_status_enum::PutMessageStatus;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SyncFlushRuntimeInfo {
+    pub queue_depth: u64,
+    pub enqueue_total: u64,
+    pub completed_total: u64,
+    pub timeout_total: u64,
+    pub oldest_wait_millis: u64,
+    pub max_wait_millis: u64,
+    pub wait_total_millis: u64,
+}
+
 /// The `RocketMQFlushManager` trait defines the operations for managing the flushing of messages to
 /// disk in RocketMQ.
 #[trait_variant::make(FlushManager: Send)]

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -34,6 +34,7 @@ use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
+use crate::base::flush_manager::SyncFlushRuntimeInfo;
 use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
@@ -370,6 +371,9 @@ pub trait MessageStoreInner: Sync + 'static {
 
     /// Check if the operating system page cache is busy.
     fn is_os_page_cache_busy(&self) -> bool;
+
+    /// Get current sync flush backlog runtime info without building the full runtime-info map.
+    fn sync_flush_runtime_info(&self) -> SyncFlushRuntimeInfo;
 
     /// Get lock time in milliseconds of the store.
     fn lock_time_millis(&self) -> i64;

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -81,12 +81,12 @@ use crate::consume_queue::mapped_file_queue::MappedFileWarmupStats;
 use crate::ha::ha_service::HAService;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
 // Import the optimized loader module
+use crate::base::flush_manager::SyncFlushRuntimeInfo;
 use crate::log_file::commit_log_loader::CommitLogLoader;
 use crate::log_file::commit_log_loader::LoadStatistics;
 use crate::log_file::commit_log_loader::RecoveryFilePrefetch;
 use crate::log_file::commit_log_loader::RecoveryMmapAdvice;
 use crate::log_file::flush_manager_impl::default_flush_manager::DefaultFlushManager;
-use crate::log_file::flush_manager_impl::default_flush_manager::SyncFlushRuntimeInfo;
 use crate::log_file::group_commit_request::GroupCommitRequest;
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::default_mapped_file_impl::LazyMmapStats;

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -31,6 +31,7 @@ use tracing::debug;
 use tracing::warn;
 
 use crate::base::flush_manager::FlushManager;
+use crate::base::flush_manager::SyncFlushRuntimeInfo;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -38,17 +39,6 @@ use crate::config::flush_disk_type::FlushDiskType;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
 use crate::log_file::flush_manager_impl::group_commit_request::GroupCommitRequest;
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct SyncFlushRuntimeInfo {
-    pub queue_depth: u64,
-    pub enqueue_total: u64,
-    pub completed_total: u64,
-    pub timeout_total: u64,
-    pub oldest_wait_millis: u64,
-    pub max_wait_millis: u64,
-    pub wait_total_millis: u64,
-}
 
 #[derive(Clone, Default)]
 struct SyncFlushStats {

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -466,6 +466,10 @@ impl MessageStore for GenericMessageStore {
         delegate_store!(self, is_os_page_cache_busy())
     }
 
+    fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
+        delegate_store!(self, sync_flush_runtime_info())
+    }
+
     fn lock_time_millis(&self) -> i64 {
         delegate_store!(self, lock_time_millis())
     }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3458,6 +3458,10 @@ impl MessageStore for LocalFileMessageStore {
         diff < 10000000 && diff > self.message_store_config.os_page_cache_busy_timeout_mills
     }
 
+    fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
+        self.commit_log.sync_flush_runtime_info()
+    }
+
     fn lock_time_millis(&self) -> i64 {
         self.commit_log.lock_time_mills()
     }

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -969,6 +969,10 @@ impl MessageStore for RocksDBMessageStore {
         self.local_file_store.is_os_page_cache_busy()
     }
 
+    fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
+        self.local_file_store.sync_flush_runtime_info()
+    }
+
     fn lock_time_millis(&self) -> i64 {
         self.local_file_store.lock_time_millis()
     }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7768

### Brief Description

Adds optional broker-side send rejection thresholds for sync flush backlog pressure. The store exposes `SyncFlushRuntimeInfo` through the `MessageStore` trait so the send hot path can read sync flush depth and oldest wait without building the full runtime-info map.

`BrokerConfig` now supports `syncFlushBacklogRejectDepth` and `syncFlushBacklogRejectWaitMillis`, both defaulting to `0` so existing behavior remains unchanged. When configured and exceeded, `SendMessageProcessor::reject_request` returns `SystemBusy` with a diagnostic remark containing the observed backlog values and configured thresholds.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common default_broker_config_uses_java_fast_failure_defaults --lib` passed.
- `cargo test -p rocketmq-common get_properties_contains_java_fast_failure_keys --lib` passed.
- `cargo test -p rocketmq-common serde_accepts_java_fast_failure_camel_case_keys --lib` passed.
- `cargo test -p rocketmq-broker sync_flush_backlog_reject_remark --lib` passed.
- `cargo test -p rocketmq-store runtime_info_includes_store_offsets_and_timer_defaults_when_timer_disabled --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sync-flush runtime metrics for message storage, including queue depth and wait-time information.
  * Exposed new broker settings to control when send requests are rejected under sync-flush backlog pressure.

* **Bug Fixes**
  * Send requests can now be automatically rejected with a busy response when sync-flush backlog limits are exceeded.
  * Broader support was added so all storage paths return the new runtime metrics consistently.

* **Tests**
  * Added coverage for backlog-threshold handling and default configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->