### PR TITLE
[ISSUE #7770]✨Add detached send request executor mode

### DIFF
--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -431,6 +431,10 @@ impl BrokerFastFailure {
         self.inner.broker_config.broker_fast_failure_enable
     }
 
+    pub(crate) fn send_request_executor_detached_enabled(&self) -> bool {
+        self.inner.broker_config.send_request_executor_detached_enable
+    }
+
     pub(crate) fn is_running(&self) -> bool {
         self.inner.running.load(Ordering::Acquire)
     }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -396,6 +396,46 @@ where
         let queued_request = request.clone();
         let (task, response_rx) = broker_fast_failure.enqueue(queue_kind, opaque);
         let broker_fast_failure = broker_fast_failure.clone();
+        let detach_response = should_detach_fast_failure_response(
+            queue_kind,
+            broker_fast_failure.send_request_executor_detached_enabled(),
+            self.request_task_group.is_some(),
+        );
+
+        if detach_response {
+            let Some(task_group) = &self.request_task_group else {
+                return Ok(Some(system_error_response(
+                    opaque,
+                    "detached send request executor has no task group",
+                )));
+            };
+            let detached_task = Self::run_detached_fast_failure_request(
+                queue_kind,
+                broker_fast_failure.clone(),
+                task.clone(),
+                processor,
+                channel,
+                ctx,
+                queued_request,
+                opaque,
+                response_rx,
+            );
+            if let Err(error) =
+                task_group.spawn("broker.request.fast-failure.detached", TaskKind::Worker, detached_task)
+            {
+                warn!(?error, "failed to spawn detached fast failure request task");
+                broker_fast_failure.cancel(
+                    queue_kind,
+                    &task,
+                    system_error_response(opaque, "detached fast failure request task spawn failed"),
+                );
+                return Ok(Some(system_error_response(
+                    opaque,
+                    "detached fast failure request task spawn failed",
+                )));
+            }
+            return Ok(None);
+        }
 
         let request_task = Self::run_fast_failure_request(
             queue_kind,
@@ -426,6 +466,55 @@ where
                 opaque,
                 "fast failure response channel closed before request completed",
             ))),
+        }
+    }
+
+    async fn run_detached_fast_failure_request(
+        queue_kind: FastFailureQueueKind,
+        broker_fast_failure: BrokerFastFailure,
+        task: Arc<FastFailureTask>,
+        processor: BrokerProcessorType<MS, TS>,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        queued_request: RemotingCommand,
+        opaque: i32,
+        response_rx: tokio::sync::oneshot::Receiver<Option<RemotingCommand>>,
+    ) {
+        let request_task = Self::run_fast_failure_request(
+            queue_kind,
+            broker_fast_failure,
+            task,
+            processor,
+            channel,
+            ctx.clone(),
+            queued_request,
+            opaque,
+        );
+        tokio::pin!(request_task);
+        tokio::pin!(response_rx);
+
+        let response_result = tokio::select! {
+            _ = &mut request_task => (&mut response_rx).await,
+            response_result = &mut response_rx => response_result,
+        };
+        Self::write_detached_fast_failure_response(response_result, ctx, opaque).await;
+    }
+
+    async fn write_detached_fast_failure_response(
+        response_result: Result<Option<RemotingCommand>, tokio::sync::oneshot::error::RecvError>,
+        mut ctx: ConnectionHandlerContext,
+        opaque: i32,
+    ) {
+        match response_result {
+            Ok(Some(response)) => ctx.write_response(response.set_opaque(opaque)).await,
+            Ok(None) => {}
+            Err(_error) => {
+                ctx.write_response(system_error_response(
+                    opaque,
+                    "fast failure response channel closed before detached request completed",
+                ))
+                .await;
+            }
         }
     }
 
@@ -464,6 +553,14 @@ where
         };
         broker_fast_failure.complete(queue_kind, &task, response);
     }
+}
+
+fn should_detach_fast_failure_response(
+    queue_kind: FastFailureQueueKind,
+    send_request_executor_detached_enabled: bool,
+    has_request_task_group: bool,
+) -> bool {
+    queue_kind == FastFailureQueueKind::Send && send_request_executor_detached_enabled && has_request_task_group
 }
 
 fn fast_failure_queue_kind(request_code: i32, default_processor: bool) -> Option<FastFailureQueueKind> {
@@ -557,6 +654,30 @@ mod tests {
             fast_failure_queue_kind(RequestCode::UpdateBrokerConfig as i32, false),
             None
         );
+    }
+
+    #[test]
+    fn detach_fast_failure_response_only_applies_to_send_with_task_group() {
+        assert!(should_detach_fast_failure_response(
+            FastFailureQueueKind::Send,
+            true,
+            true
+        ));
+        assert!(!should_detach_fast_failure_response(
+            FastFailureQueueKind::Send,
+            false,
+            true
+        ));
+        assert!(!should_detach_fast_failure_response(
+            FastFailureQueueKind::Send,
+            true,
+            false
+        ));
+        assert!(!should_detach_fast_failure_response(
+            FastFailureQueueKind::Pull,
+            true,
+            true
+        ));
     }
 
     #[tokio::test]

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -635,6 +635,10 @@ mod defaults {
         true
     }
 
+    pub const fn send_request_executor_detached_enable() -> bool {
+        false
+    }
+
     pub const fn wait_time_mills_in_send_queue() -> u64 {
         200
     }
@@ -960,6 +964,9 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::broker_fast_failure_enable")]
     pub broker_fast_failure_enable: bool,
+
+    #[serde(default = "defaults::send_request_executor_detached_enable")]
+    pub send_request_executor_detached_enable: bool,
 
     #[serde(default = "defaults::wait_time_mills_in_send_queue")]
     pub wait_time_mills_in_send_queue: u64,
@@ -1422,6 +1429,7 @@ impl Default for BrokerConfig {
             register_name_server_period: 1000 * 30,
             send_heartbeat_timeout_millis: 1000,
             broker_fast_failure_enable: defaults::broker_fast_failure_enable(),
+            send_request_executor_detached_enable: defaults::send_request_executor_detached_enable(),
             wait_time_mills_in_send_queue: defaults::wait_time_mills_in_send_queue(),
             sync_flush_backlog_reject_depth: defaults::sync_flush_backlog_reject_depth(),
             sync_flush_backlog_reject_wait_millis: defaults::sync_flush_backlog_reject_wait_millis(),
@@ -1785,6 +1793,10 @@ impl BrokerConfig {
         properties.insert(
             "brokerFastFailureEnable".into(),
             self.broker_fast_failure_enable.to_string().into(),
+        );
+        properties.insert(
+            "sendRequestExecutorDetachedEnable".into(),
+            self.send_request_executor_detached_enable.to_string().into(),
         );
         properties.insert(
             "waitTimeMillsInSendQueue".into(),
@@ -2251,6 +2263,7 @@ mod tests {
         let config = BrokerConfig::default();
 
         assert!(config.broker_fast_failure_enable);
+        assert!(!config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 200);
         assert_eq!(config.sync_flush_backlog_reject_depth, 0);
         assert_eq!(config.sync_flush_backlog_reject_wait_millis, 0);
@@ -2397,6 +2410,12 @@ mod tests {
             Some("true")
         );
         assert_eq!(
+            properties
+                .get("sendRequestExecutorDetachedEnable")
+                .map(|value| value.as_str()),
+            Some("false")
+        );
+        assert_eq!(
             properties.get("waitTimeMillsInSendQueue").map(|value| value.as_str()),
             Some("200")
         );
@@ -2482,6 +2501,7 @@ mod tests {
         let config: BrokerConfig = serde_json::from_str(
             r#"{
                 "brokerFastFailureEnable": false,
+                "sendRequestExecutorDetachedEnable": true,
                 "waitTimeMillsInSendQueue": 201,
                 "syncFlushBacklogRejectDepth": 32,
                 "syncFlushBacklogRejectWaitMillis": 150,
@@ -2496,6 +2516,7 @@ mod tests {
         .expect("broker config should deserialize Java fast failure keys");
 
         assert!(!config.broker_fast_failure_enable);
+        assert!(config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 201);
         assert_eq!(config.sync_flush_backlog_reject_depth, 32);
         assert_eq!(config.sync_flush_backlog_reject_wait_millis, 150);


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7770

### Brief Description

Adds an opt-in detached send request executor mode for the broker fast-failure path. `sendRequestExecutorDetachedEnable` defaults to `false`, preserving existing behavior. When enabled and a request task group is available, send-family requests use a detached supervisor task that drives the existing fast-failure request future, listens for cleanup/completion responses, writes responses through `ConnectionHandlerContext`, and lets the remoting request loop return `None` immediately.

Non-send queues and disabled configurations keep the old response-waiting path.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common default_broker_config_uses_java_fast_failure_defaults --lib` passed.
- `cargo test -p rocketmq-common get_properties_contains_java_fast_failure_keys --lib` passed.
- `cargo test -p rocketmq-common serde_accepts_java_fast_failure_camel_case_keys --lib` passed.
- `cargo test -p rocketmq-broker detach_fast_failure_response_only_applies_to_send_with_task_group --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new broker setting to enable detached handling for send request fast-failure responses.
  * When enabled, eligible send requests can complete response work asynchronously for improved handling under load.

* **Bug Fixes**
  * Fast-failure response flow now falls back to a clear system error if asynchronous dispatch or response delivery cannot proceed.

* **Tests**
  * Expanded coverage for the new configuration and the conditions under which detached handling applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->