### PR TITLE
[ISSUE #7772]✨Expose CommitLog put lock profile runtime info

### DIFF
--- a/rocketmq-store/benches/commit_log_performance.rs
+++ b/rocketmq-store/benches/commit_log_performance.rs
@@ -17,11 +17,15 @@
 //! Run with:
 //! `cargo bench -p rocketmq-store --bench commit_log_performance`
 
+use std::fs;
 use std::hint::black_box;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use cheetah_string::CheetahString;
 use criterion::criterion_group;
@@ -37,6 +41,7 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::config::flush_disk_type::FlushDiskType;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -48,6 +53,98 @@ struct BenchStore {
     store: ArcMut<LocalFileMessageStore>,
     _temp_dir: TempDir,
 }
+
+#[derive(Clone, Copy)]
+struct LockProfileScenario {
+    name: &'static str,
+    flush_disk_type: FlushDiskType,
+    queue_count: usize,
+    body_size: usize,
+    messages_per_queue: u64,
+}
+
+const LOCK_PROFILE_ARTIFACT_SCENARIOS: [LockProfileScenario; 8] = [
+    LockProfileScenario {
+        name: "async_1q_256b",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 1,
+        body_size: 256,
+        messages_per_queue: 32,
+    },
+    LockProfileScenario {
+        name: "async_1q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 1,
+        body_size: 1024,
+        messages_per_queue: 32,
+    },
+    LockProfileScenario {
+        name: "async_1q_4kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 1,
+        body_size: 4096,
+        messages_per_queue: 32,
+    },
+    LockProfileScenario {
+        name: "async_4q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 4,
+        body_size: 1024,
+        messages_per_queue: 16,
+    },
+    LockProfileScenario {
+        name: "async_8q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 8,
+        body_size: 1024,
+        messages_per_queue: 16,
+    },
+    LockProfileScenario {
+        name: "async_16q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 16,
+        body_size: 1024,
+        messages_per_queue: 16,
+    },
+    LockProfileScenario {
+        name: "sync_1q_1kb",
+        flush_disk_type: FlushDiskType::SyncFlush,
+        queue_count: 1,
+        body_size: 1024,
+        messages_per_queue: 8,
+    },
+    LockProfileScenario {
+        name: "sync_4q_1kb",
+        flush_disk_type: FlushDiskType::SyncFlush,
+        queue_count: 4,
+        body_size: 1024,
+        messages_per_queue: 4,
+    },
+];
+
+const LOCK_PROFILE_CRITERION_SCENARIOS: [LockProfileScenario; 3] = [
+    LockProfileScenario {
+        name: "async_1q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 1,
+        body_size: 1024,
+        messages_per_queue: 1,
+    },
+    LockProfileScenario {
+        name: "async_16q_1kb",
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        queue_count: 16,
+        body_size: 1024,
+        messages_per_queue: 1,
+    },
+    LockProfileScenario {
+        name: "sync_1q_1kb",
+        flush_disk_type: FlushDiskType::SyncFlush,
+        queue_count: 1,
+        body_size: 1024,
+        messages_per_queue: 1,
+    },
+];
 
 fn new_async_flush_bench_store() -> BenchStore {
     new_bench_store(FlushDiskType::AsyncFlush)
@@ -101,6 +198,128 @@ fn create_test_message(topic: &str, queue_id: i32, body_size: usize, key_seed: u
     };
     inner.message_ext_inner.set_queue_id(queue_id);
     inner
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rocketmq-store should live below workspace root")
+        .to_path_buf()
+}
+
+fn benchmark_artifact_dir() -> PathBuf {
+    workspace_root().join("target/runtime-baseline/prototype")
+}
+
+async fn start_store_if_needed(bench_store: &BenchStore, flush_disk_type: FlushDiskType) {
+    if flush_disk_type != FlushDiskType::SyncFlush {
+        return;
+    }
+
+    bench_store
+        .store
+        .clone()
+        .mut_from_ref()
+        .init()
+        .await
+        .expect("init sync flush benchmark store");
+    assert!(bench_store.store.clone().mut_from_ref().load().await, "load store");
+    bench_store
+        .store
+        .clone()
+        .mut_from_ref()
+        .start()
+        .await
+        .expect("start sync flush benchmark store");
+}
+
+fn run_lock_profile_messages(runtime: &Runtime, bench_store: &BenchStore, scenario: LockProfileScenario) -> u64 {
+    runtime.block_on(async {
+        let mut put_ok_total = 0_u64;
+        for round in 0..scenario.messages_per_queue {
+            if scenario.queue_count == 1 {
+                let msg = create_test_message("BenchLockProfileTopic", 0, scenario.body_size, round);
+                let status = bench_store
+                    .store
+                    .clone()
+                    .mut_from_ref()
+                    .put_message(msg)
+                    .await
+                    .put_message_status();
+                assert_eq!(status, PutMessageStatus::PutOk);
+                put_ok_total += 1;
+                continue;
+            }
+
+            let mut handles = Vec::with_capacity(scenario.queue_count);
+            for queue_id in 0..scenario.queue_count {
+                let store = bench_store.store.clone();
+                let key_seed = round * scenario.queue_count as u64 + queue_id as u64;
+                let msg = create_test_message("BenchLockProfileTopic", queue_id as i32, scenario.body_size, key_seed);
+                handles.push(tokio::spawn(async move {
+                    store.mut_from_ref().put_message(msg).await.put_message_status()
+                }));
+            }
+
+            for handle in handles {
+                let status = handle.await.expect("join lock profile benchmark task");
+                assert_eq!(status, PutMessageStatus::PutOk);
+                put_ok_total += 1;
+            }
+        }
+        put_ok_total
+    })
+}
+
+fn put_message_lock_profile_json(bench_store: &BenchStore) -> serde_json::Value {
+    let runtime_info = bench_store.store.get_runtime_info();
+    serde_json::json!({
+        "acquire_total": runtime_info["putMessageLockAcquireTotal"].parse::<u64>().expect("parse acquire total"),
+        "wait_total_millis": runtime_info["putMessageLockWaitTotalMillis"].parse::<u64>().expect("parse wait total"),
+        "wait_max_millis": runtime_info["putMessageLockWaitMaxMillis"].parse::<u64>().expect("parse wait max"),
+        "hold_total_millis": runtime_info["putMessageLockHoldTotalMillis"].parse::<u64>().expect("parse hold total"),
+        "hold_max_millis": runtime_info["putMessageLockHoldMaxMillis"].parse::<u64>().expect("parse hold max"),
+    })
+}
+
+fn write_commit_log_lock_profile_artifact() {
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_millis();
+    let mut cases = Vec::with_capacity(LOCK_PROFILE_ARTIFACT_SCENARIOS.len());
+
+    for scenario in LOCK_PROFILE_ARTIFACT_SCENARIOS {
+        let runtime = Runtime::new().expect("create runtime");
+        let bench_store = new_bench_store(scenario.flush_disk_type);
+        runtime.block_on(start_store_if_needed(&bench_store, scenario.flush_disk_type));
+        let put_ok_total = run_lock_profile_messages(&runtime, &bench_store, scenario);
+        let profile = put_message_lock_profile_json(&bench_store);
+        assert_eq!(profile["acquire_total"], serde_json::json!(put_ok_total));
+        cases.push(serde_json::json!({
+            "name": scenario.name,
+            "flush_disk_type": scenario.flush_disk_type.get_flush_disk_type(),
+            "queue_count": scenario.queue_count,
+            "body_size": scenario.body_size,
+            "messages_per_queue": scenario.messages_per_queue,
+            "put_ok_total": put_ok_total,
+            "lock_profile": profile,
+        }));
+    }
+
+    let output_dir = benchmark_artifact_dir();
+    fs::create_dir_all(&output_dir).expect("CommitLog benchmark artifact directory should be created");
+    let payload = serde_json::json!({
+        "case": "commit_log_put_message_lock_profile",
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "cases": cases,
+    });
+    let path = output_dir.join("commit-log-lock-profile-report.json");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&payload).expect("CommitLog lock profile report should serialize"),
+    )
+    .expect("CommitLog lock profile report should be written");
 }
 
 fn bench_async_flush_single_message(c: &mut Criterion) {
@@ -171,6 +390,36 @@ fn bench_async_flush_multi_queue(c: &mut Criterion) {
                 });
             },
         );
+    }
+
+    group.finish();
+}
+
+fn bench_commit_log_lock_profile_contention(c: &mut Criterion) {
+    write_commit_log_lock_profile_artifact();
+
+    let mut group = c.benchmark_group("phase5/commit_log_lock_profile_contention");
+    group.sample_size(10);
+
+    for scenario in LOCK_PROFILE_CRITERION_SCENARIOS {
+        group.throughput(Throughput::Elements(
+            scenario.queue_count as u64 * scenario.messages_per_queue,
+        ));
+        group.bench_with_input(BenchmarkId::from_parameter(scenario.name), &scenario, |b, &scenario| {
+            let runtime = Runtime::new().expect("create runtime");
+            let bench_store = new_bench_store(scenario.flush_disk_type);
+            runtime.block_on(start_store_if_needed(&bench_store, scenario.flush_disk_type));
+
+            b.iter_custom(|iters| {
+                let started = Instant::now();
+                for _ in 0..iters {
+                    black_box(run_lock_profile_messages(&runtime, &bench_store, scenario));
+                }
+                let elapsed = started.elapsed();
+                black_box(put_message_lock_profile_json(&bench_store));
+                elapsed
+            });
+        });
     }
 
     group.finish();
@@ -275,6 +524,7 @@ criterion_group!(
     benches,
     bench_async_flush_single_message,
     bench_async_flush_multi_queue,
+    bench_commit_log_lock_profile_contention,
     bench_reput_once_after_batch,
     bench_sync_flush_tail_latency_baseline,
 );

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -280,6 +281,54 @@ pub fn get_message_num(
     message_num
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CommitLogPutMessageLockRuntimeInfo {
+    pub acquire_total: u64,
+    pub wait_total_millis: u64,
+    pub wait_max_millis: u64,
+    pub hold_total_millis: u64,
+    pub hold_max_millis: u64,
+}
+
+#[derive(Debug, Default)]
+struct CommitLogPutMessageLockStats {
+    acquire_total: AtomicU64,
+    wait_total_millis: AtomicU64,
+    wait_max_millis: AtomicU64,
+    hold_total_millis: AtomicU64,
+    hold_max_millis: AtomicU64,
+}
+
+impl CommitLogPutMessageLockStats {
+    fn record(&self, wait_millis: u64, hold_millis: u64) {
+        self.acquire_total.fetch_add(1, Ordering::Relaxed);
+        self.wait_total_millis.fetch_add(wait_millis, Ordering::Relaxed);
+        self.hold_total_millis.fetch_add(hold_millis, Ordering::Relaxed);
+        Self::update_max(&self.wait_max_millis, wait_millis);
+        Self::update_max(&self.hold_max_millis, hold_millis);
+    }
+
+    fn snapshot(&self) -> CommitLogPutMessageLockRuntimeInfo {
+        CommitLogPutMessageLockRuntimeInfo {
+            acquire_total: self.acquire_total.load(Ordering::Relaxed),
+            wait_total_millis: self.wait_total_millis.load(Ordering::Relaxed),
+            wait_max_millis: self.wait_max_millis.load(Ordering::Relaxed),
+            hold_total_millis: self.hold_total_millis.load(Ordering::Relaxed),
+            hold_max_millis: self.hold_max_millis.load(Ordering::Relaxed),
+        }
+    }
+
+    fn update_max(target: &AtomicU64, value: u64) {
+        let mut current = target.load(Ordering::Relaxed);
+        while value > current {
+            match target.compare_exchange_weak(current, value, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
 pub struct CommitLog {
     mapped_file_queue: ArcMut<MappedFileQueue>,
     message_store_config: Arc<MessageStoreConfig>,
@@ -291,6 +340,7 @@ pub struct CommitLog {
     store_checkpoint: Arc<StoreCheckpoint>,
     append_message_callback: Arc<DefaultAppendMessageCallback>,
     put_message_lock: Arc<tokio::sync::Mutex<()>>,
+    put_message_lock_stats: Arc<CommitLogPutMessageLockStats>,
     topic_queue_lock: Arc<TopicQueueLock>,
     topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
     consume_queue_store: ConsumeQueueStore,
@@ -336,6 +386,7 @@ impl CommitLog {
                 topic_config_table.clone(),
             )),
             put_message_lock: Arc::new(Default::default()),
+            put_message_lock_stats: Arc::new(Default::default()),
             topic_queue_lock: Arc::new(TopicQueueLock::with_size(message_store_config.topic_queue_lock_num)),
             topic_config_table,
             consume_queue_store,
@@ -612,6 +663,24 @@ impl CommitLog {
         self.flush_manager.sync_flush_runtime_info()
     }
 
+    pub fn put_message_lock_runtime_info(&self) -> CommitLogPutMessageLockRuntimeInfo {
+        self.put_message_lock_stats.snapshot()
+    }
+
+    fn release_put_message_lock(
+        &self,
+        put_message_lock: tokio::sync::MutexGuard<'_, ()>,
+        lock_wait_millis: u64,
+        lock_hold_start: Instant,
+    ) -> u64 {
+        let elapsed_time_in_lock = lock_hold_start.elapsed().as_millis() as u64;
+        self.put_message_lock_stats
+            .record(lock_wait_millis, elapsed_time_in_lock);
+        drop(put_message_lock);
+        self.begin_time_in_lock.store(0, Ordering::Release);
+        elapsed_time_in_lock
+    }
+
     pub async fn shutdown_gracefully(&mut self) {
         self.flush();
         let mut flush_manager = self.flush_manager.clone();
@@ -804,7 +873,9 @@ impl CommitLog {
         let _topic_queue_guard = self.topic_queue_lock.lock(topic_queue_key.as_str()).await;
         self.assign_offset(&mut msg_batch.message_ext_broker_inner);
 
+        let lock_wait_start = Instant::now();
         let _put_message_lock = self.put_message_lock.lock().await;
+        let lock_wait_millis = lock_wait_start.elapsed().as_millis() as u64;
         self.begin_time_in_lock
             .store(time_utils::current_millis(), std::sync::atomic::Ordering::Release);
         let start_time = Instant::now();
@@ -816,19 +887,18 @@ impl CommitLog {
         }
 
         if mapped_file.is_none() {
-            drop(_put_message_lock);
+            self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
             drop(_topic_queue_guard); // Explicitly release topic_queue_lock on error
             error!(
                 "create mapped file error, topic: {}  clientAddr: {}",
                 msg_batch.message_ext_broker_inner.topic(),
                 msg_batch.message_ext_broker_inner.born_host()
             );
-            self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
             return PutMessageResult::new_default(PutMessageStatus::CreateMappedFileFailed);
         }
 
         if let Err(error) = self.ensure_active_mapped_file_locked(mapped_file.as_ref().unwrap()) {
-            drop(_put_message_lock);
+            self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
             drop(_topic_queue_guard);
             error!(
                 "lock active commitlog mapped file error, topic: {} clientAddr: {} error: {}",
@@ -836,7 +906,6 @@ impl CommitLog {
                 msg_batch.message_ext_broker_inner.born_host(),
                 error
             );
-            self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
             return PutMessageResult::new_default(PutMessageStatus::CreateMappedFileFailed);
         }
 
@@ -856,9 +925,8 @@ impl CommitLog {
                 unlock_mapped_file = mapped_file;
                 mapped_file = self.mapped_file_queue.get_last_mapped_file_mut_start_offset(0, true);
                 if mapped_file.is_none() {
-                    drop(_put_message_lock);
+                    self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                     drop(_topic_queue_guard);
-                    self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                     error!(
                         "create mapped file error, topic: {}  clientAddr: {}",
                         msg_batch.message_ext_broker_inner.topic(),
@@ -867,9 +935,8 @@ impl CommitLog {
                     return PutMessageResult::new_append_result(PutMessageStatus::CreateMappedFileFailed, Some(result));
                 }
                 if let Err(error) = self.ensure_active_mapped_file_locked(mapped_file.as_ref().unwrap()) {
-                    drop(_put_message_lock);
+                    self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                     drop(_topic_queue_guard);
-                    self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                     error!(
                         "lock rolled commitlog mapped file error, topic: {} clientAddr: {} error: {}",
                         msg_batch.message_ext_broker_inner.topic(),
@@ -891,23 +958,19 @@ impl CommitLog {
                 }
             }
             AppendMessageStatus::MessageSizeExceeded | AppendMessageStatus::PropertiesSizeExceeded => {
-                drop(_put_message_lock);
+                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                 drop(_topic_queue_guard);
-                self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                 return PutMessageResult::new_append_result(PutMessageStatus::MessageIllegal, Some(result));
             }
             AppendMessageStatus::UnknownError => {
-                drop(_put_message_lock);
+                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                 drop(_topic_queue_guard);
-                self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                 return PutMessageResult::new_append_result(PutMessageStatus::UnknownError, Some(result));
             }
         };
-        let elapsed_time_in_lock = start_time.elapsed().as_millis() as u64;
+        let elapsed_time_in_lock = self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::store::record_append_latency(elapsed_time_in_lock);
-        drop(_put_message_lock);
-        self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
         if elapsed_time_in_lock > 500 {
             warn!(
                 "[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}",
@@ -1027,7 +1090,9 @@ impl CommitLog {
             None
         };
 
+        let lock_wait_start = Instant::now();
         let _put_message_lock = self.put_message_lock.lock().await;
+        let lock_wait_millis = lock_wait_start.elapsed().as_millis() as u64;
         let begin_lock_timestamp = time_utils::current_millis();
         self.begin_time_in_lock
             .store(begin_lock_timestamp, std::sync::atomic::Ordering::Release);
@@ -1042,19 +1107,18 @@ impl CommitLog {
         }
 
         if mapped_file.is_none() {
-            drop(_put_message_lock);
+            self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
             drop(_topic_queue_guard); // Explicitly release topic_queue_lock on error
             error!(
                 "create mapped file error, topic: {}  clientAddr: {}",
                 msg.topic(),
                 msg.born_host()
             );
-            self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
             return PutMessageResult::new_default(PutMessageStatus::CreateMappedFileFailed);
         }
 
         if let Err(error) = self.ensure_active_mapped_file_locked(mapped_file.as_ref().unwrap()) {
-            drop(_put_message_lock);
+            self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
             drop(_topic_queue_guard);
             error!(
                 "lock active commitlog mapped file error, topic: {} clientAddr: {} error: {}",
@@ -1062,7 +1126,6 @@ impl CommitLog {
                 msg.born_host(),
                 error
             );
-            self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
             return PutMessageResult::new_default(PutMessageStatus::CreateMappedFileFailed);
         }
 
@@ -1081,9 +1144,8 @@ impl CommitLog {
                 unlock_mapped_file = mapped_file;
                 mapped_file = self.mapped_file_queue.get_last_mapped_file_mut_start_offset(0, true);
                 if mapped_file.is_none() {
-                    drop(_put_message_lock);
+                    self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                     drop(_topic_queue_guard); // CRITICAL FIX: Release topic_queue_lock on error
-                    self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                     error!(
                         "create mapped file error, topic: {}  clientAddr: {}",
                         msg.topic(),
@@ -1092,9 +1154,8 @@ impl CommitLog {
                     return PutMessageResult::new_append_result(PutMessageStatus::CreateMappedFileFailed, Some(result));
                 }
                 if let Err(error) = self.ensure_active_mapped_file_locked(mapped_file.as_ref().unwrap()) {
-                    drop(_put_message_lock);
+                    self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                     drop(_topic_queue_guard);
-                    self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                     error!(
                         "lock rolled commitlog mapped file error, topic: {} clientAddr: {} error: {}",
                         msg.topic(),
@@ -1115,23 +1176,19 @@ impl CommitLog {
                 }
             }
             AppendMessageStatus::MessageSizeExceeded | AppendMessageStatus::PropertiesSizeExceeded => {
-                drop(_put_message_lock);
+                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                 drop(_topic_queue_guard);
-                self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                 return PutMessageResult::new_append_result(PutMessageStatus::MessageIllegal, Some(result));
             }
             AppendMessageStatus::UnknownError => {
-                drop(_put_message_lock);
+                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
                 drop(_topic_queue_guard);
-                self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
                 return PutMessageResult::new_append_result(PutMessageStatus::UnknownError, Some(result));
             }
         };
-        let elapsed_time_in_lock = start_time.elapsed().as_millis() as u64;
+        let elapsed_time_in_lock = self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::store::record_append_latency(elapsed_time_in_lock);
-        drop(_put_message_lock);
-        self.begin_time_in_lock.store(0, std::sync::atomic::Ordering::Release);
         if elapsed_time_in_lock > 500 {
             warn!(
                 "[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}",
@@ -2679,6 +2736,21 @@ mod tests {
         assert_eq!(normal_recovery_start_index(5, 1), 4);
         assert_eq!(normal_recovery_start_index(5, 2), 3);
         assert_eq!(normal_recovery_start_index(5, 10), 0);
+    }
+
+    #[test]
+    fn put_message_lock_stats_records_totals_and_maxes() {
+        let stats = CommitLogPutMessageLockStats::default();
+
+        stats.record(3, 7);
+        stats.record(5, 2);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.acquire_total, 2);
+        assert_eq!(snapshot.wait_total_millis, 8);
+        assert_eq!(snapshot.wait_max_millis, 5);
+        assert_eq!(snapshot.hold_total_millis, 9);
+        assert_eq!(snapshot.hold_max_millis, 7);
     }
 
     fn new_test_message_store(

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2722,6 +2722,27 @@ impl MessageStore for LocalFileMessageStore {
             RunningStats::CommitLogMaxOffset.as_str().to_string(),
             self.get_max_phy_offset().to_string(),
         );
+        let put_message_lock_runtime_info = self.commit_log.put_message_lock_runtime_info();
+        result.insert(
+            "putMessageLockAcquireTotal".to_string(),
+            put_message_lock_runtime_info.acquire_total.to_string(),
+        );
+        result.insert(
+            "putMessageLockWaitTotalMillis".to_string(),
+            put_message_lock_runtime_info.wait_total_millis.to_string(),
+        );
+        result.insert(
+            "putMessageLockWaitMaxMillis".to_string(),
+            put_message_lock_runtime_info.wait_max_millis.to_string(),
+        );
+        result.insert(
+            "putMessageLockHoldTotalMillis".to_string(),
+            put_message_lock_runtime_info.hold_total_millis.to_string(),
+        );
+        result.insert(
+            "putMessageLockHoldMaxMillis".to_string(),
+            put_message_lock_runtime_info.hold_max_millis.to_string(),
+        );
         let sync_flush_runtime_info = self.commit_log.sync_flush_runtime_info();
         result.insert(
             "syncFlushQueueDepth".to_string(),
@@ -7877,6 +7898,11 @@ mod tests {
         assert_eq!(runtime_info["timerDequeueTps"], "0.0");
         assert_eq!(runtime_info["timerTopicBacklogDistribution"], "{}");
         assert_eq!(runtime_info["timerBacklogDistribution"], "{}");
+        assert_eq!(runtime_info["putMessageLockAcquireTotal"], "0");
+        assert_eq!(runtime_info["putMessageLockWaitTotalMillis"], "0");
+        assert_eq!(runtime_info["putMessageLockWaitMaxMillis"], "0");
+        assert_eq!(runtime_info["putMessageLockHoldTotalMillis"], "0");
+        assert_eq!(runtime_info["putMessageLockHoldMaxMillis"], "0");
         assert_eq!(runtime_info["syncFlushQueueDepth"], "0");
         assert_eq!(runtime_info["syncFlushEnqueueTotal"], "0");
         assert_eq!(runtime_info["syncFlushCompletedTotal"], "0");


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7772

### Brief Description

Adds CommitLog put-message lock profiling without changing append, flush, or HA ordering.

- records put lock acquisition count, total/max wait millis, and total/max hold millis
- exposes the counters through `LocalFileMessageStore::get_runtime_info`
- covers both `put_message` and `put_messages` release paths, including error returns
- extends `commit_log_performance` with lock-profile contention scenarios and a JSON report artifact for before/after comparison

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store put_message_lock_stats_records_totals_and_maxes --lib`
- `cargo test -p rocketmq-store runtime_info_includes_store_offsets_and_timer_defaults_when_timer_disabled --lib`
- `cargo test -p rocketmq-store --bench commit_log_performance --no-run`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
