### PR TITLE
[ISSUE #7776]✨Use fast decode for SendMessage request headers

### DIFF
--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -551,7 +551,7 @@ fn parse_request_header(request: &RemotingCommand) -> rocketmq_error::RocketMQRe
     let mut request_header_v2 = None;
     if RequestCode::SendReplyMessageV2 == request_code || RequestCode::SendReplyMessage == request_code {
         request_header_v2 = request
-            .decode_command_custom_header::<SendMessageRequestHeaderV2>()
+            .decode_command_custom_header_fast::<SendMessageRequestHeaderV2>()
             .ok();
     }
 
@@ -559,7 +559,7 @@ fn parse_request_header(request: &RemotingCommand) -> rocketmq_error::RocketMQRe
         Some(header) => Ok(SendMessageRequestHeaderV2::create_send_message_request_header_v1(
             &header,
         )),
-        None => request.decode_command_custom_header::<SendMessageRequestHeader>(),
+        None => request.decode_command_custom_header_fast::<SendMessageRequestHeader>(),
     }
 }
 

--- a/rocketmq-remoting/benches/encode_decode_bench.rs
+++ b/rocketmq-remoting/benches/encode_decode_bench.rs
@@ -24,7 +24,12 @@ use criterion::criterion_main;
 use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::Throughput;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::protocol::command_custom_header::CommandCustomHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::parse_request_header;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::LanguageCode;
 use rocketmq_remoting::protocol::SerializeType;
@@ -80,6 +85,36 @@ fn create_very_complex_command() -> RemotingCommand {
         .set_ext_fields(ext_fields)
         .set_body(Bytes::from(body))
         .set_command_custom_header(GetRouteInfoRequestHeader::new("TestTopic_Complex", Some(true)))
+}
+
+fn create_send_message_header() -> SendMessageRequestHeader {
+    SendMessageRequestHeader {
+        producer_group: CheetahString::from_static_str("bench_producer_group"),
+        topic: CheetahString::from_static_str("bench_topic"),
+        default_topic: CheetahString::from_static_str("TBW102"),
+        default_topic_queue_nums: 8,
+        queue_id: 1,
+        sys_flag: 0,
+        born_timestamp: 1_700_000_000_000,
+        flag: 0,
+        properties: Some(CheetahString::from_static_str("KEYS=bench-key;TAGS=TagA")),
+        reconsume_times: Some(0),
+        unit_mode: Some(false),
+        batch: Some(false),
+        max_reconsume_times: Some(16),
+        topic_request_header: None,
+    }
+}
+
+fn create_send_message_v1_command() -> RemotingCommand {
+    let header = create_send_message_header();
+    RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_ext_fields(header.to_map().unwrap())
+}
+
+fn create_send_message_v2_command() -> RemotingCommand {
+    let header = create_send_message_header();
+    let header_v2 = SendMessageRequestHeaderV2::create_send_message_request_header_v2(&header);
+    RemotingCommand::create_remoting_command(RequestCode::SendMessageV2).set_ext_fields(header_v2.to_map().unwrap())
 }
 
 /// Benchmark: Encode simple command (JSON)
@@ -268,6 +303,43 @@ fn bench_decode_rocketmq_very_complex(c: &mut Criterion) {
     });
 }
 
+fn bench_decode_send_message_header(c: &mut Criterion) {
+    let mut group = c.benchmark_group("send_message_header_decode");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("v1_normal", |b| {
+        b.iter_batched(
+            create_send_message_v1_command,
+            |cmd| {
+                cmd.decode_command_custom_header::<SendMessageRequestHeader>()
+                    .expect("decode V1 SendMessage header")
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("v1_fast", |b| {
+        b.iter_batched(
+            create_send_message_v1_command,
+            |cmd| {
+                cmd.decode_command_custom_header_fast::<SendMessageRequestHeader>()
+                    .expect("fast decode V1 SendMessage header")
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("v2_fast_to_v1", |b| {
+        b.iter_batched(
+            create_send_message_v2_command,
+            |cmd| parse_request_header(&cmd, RequestCode::SendMessageV2).expect("parse V2 SendMessage header"),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
 /// Benchmark: Full roundtrip (encode + decode) JSON
 fn bench_roundtrip_json(c: &mut Criterion) {
     c.bench_function("roundtrip_json_complex", |b| {
@@ -375,7 +447,8 @@ criterion_group!(
     bench_decode_json_very_complex,
     bench_decode_rocketmq_simple,
     bench_decode_rocketmq_complex,
-    bench_decode_rocketmq_very_complex
+    bench_decode_rocketmq_very_complex,
+    bench_decode_send_message_header
 );
 
 criterion_group!(roundtrip_benches, bench_roundtrip_json, bench_roundtrip_rocketmq);

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -190,7 +190,7 @@ pub fn parse_request_header(
     if RequestCode::SendMessageV2 == request_code || RequestCode::SendBatchMessage == request_code {
         // Attempt to decode the command custom header as SendMessageRequestHeaderV2
         request_header_v2 = request
-            .decode_command_custom_header::<SendMessageRequestHeaderV2>()
+            .decode_command_custom_header_fast::<SendMessageRequestHeaderV2>()
             .ok();
     }
     // Match on the result of the V2 header decoding
@@ -198,7 +198,7 @@ pub fn parse_request_header(
         Some(header) => Ok(SendMessageRequestHeaderV2::create_send_message_request_header_v1(
             &header,
         )),
-        None => request.decode_command_custom_header::<SendMessageRequestHeader>(),
+        None => request.decode_command_custom_header_fast::<SendMessageRequestHeader>(),
     }
 }
 
@@ -231,6 +231,74 @@ mod tests {
             max_reconsume_times: None,
             topic_request_header: None,
         }
+    }
+
+    fn assert_same_send_message_header(left: &SendMessageRequestHeader, right: &SendMessageRequestHeader) {
+        assert_eq!(left.producer_group, right.producer_group);
+        assert_eq!(left.topic, right.topic);
+        assert_eq!(left.default_topic, right.default_topic);
+        assert_eq!(left.default_topic_queue_nums, right.default_topic_queue_nums);
+        assert_eq!(left.queue_id, right.queue_id);
+        assert_eq!(left.sys_flag, right.sys_flag);
+        assert_eq!(left.born_timestamp, right.born_timestamp);
+        assert_eq!(left.flag, right.flag);
+        assert_eq!(left.properties, right.properties);
+        assert_eq!(left.reconsume_times, right.reconsume_times);
+        assert_eq!(left.unit_mode, right.unit_mode);
+        assert_eq!(left.batch, right.batch);
+        assert_eq!(left.max_reconsume_times, right.max_reconsume_times);
+    }
+
+    #[test]
+    fn send_message_request_header_fast_decode_matches_normal_decode() {
+        let mut header = minimal_header();
+        header.properties = Some(CheetahString::from_static_str("KEYS=abc"));
+        header.reconsume_times = Some(2);
+        header.unit_mode = Some(true);
+        header.batch = Some(false);
+        header.max_reconsume_times = Some(16);
+        let request =
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_ext_fields(header.to_map().unwrap());
+
+        let normal = request
+            .decode_command_custom_header::<SendMessageRequestHeader>()
+            .expect("normal decode should succeed");
+        let fast = request
+            .decode_command_custom_header_fast::<SendMessageRequestHeader>()
+            .expect("fast decode should succeed");
+        let parsed = parse_request_header(&request, RequestCode::SendMessage).expect("parse should use fast decode");
+
+        assert_same_send_message_header(&normal, &fast);
+        assert_same_send_message_header(&normal, &parsed);
+    }
+
+    #[test]
+    fn send_message_v2_fast_decode_matches_normal_v1_conversion() {
+        let mut header = minimal_header();
+        header.properties = Some(CheetahString::from_static_str("TAGS=TagA"));
+        header.reconsume_times = Some(1);
+        header.unit_mode = Some(false);
+        header.batch = Some(true);
+        header.max_reconsume_times = Some(8);
+        header.set_broker_name(CheetahString::from_static_str("broker-a"));
+        let v2 = SendMessageRequestHeaderV2::create_send_message_request_header_v2(&header);
+        let request =
+            RemotingCommand::create_remoting_command(RequestCode::SendMessageV2).set_ext_fields(v2.to_map().unwrap());
+
+        let normal_v2 = request
+            .decode_command_custom_header::<SendMessageRequestHeaderV2>()
+            .expect("normal V2 decode should succeed");
+        let fast_v2 = request
+            .decode_command_custom_header_fast::<SendMessageRequestHeaderV2>()
+            .expect("fast V2 decode should succeed");
+        let normal_v1 = SendMessageRequestHeaderV2::create_send_message_request_header_v1(&normal_v2);
+        let fast_v1 = SendMessageRequestHeaderV2::create_send_message_request_header_v1(&fast_v2);
+        let parsed =
+            parse_request_header(&request, RequestCode::SendMessageV2).expect("parse should use V2 fast decode");
+
+        assert_same_send_message_header(&normal_v1, &fast_v1);
+        assert_same_send_message_header(&normal_v1, &parsed);
+        assert_eq!(parsed.broker_name().map(CheetahString::as_str), Some("broker-a"));
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -63,7 +63,7 @@ const KEY_L: CheetahString = CheetahString::from_static_str(FIELD_L);
 const KEY_M: CheetahString = CheetahString::from_static_str(FIELD_M);
 const KEY_N: CheetahString = CheetahString::from_static_str(FIELD_N);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageRequestHeaderV2 {
     pub a: CheetahString,         // producerGroup


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7776

### Brief Description

Routes SendMessage request header parsing through the existing fast custom-header decode path.

- enables fast decode for `SendMessageRequestHeaderV2` by adding `Default`
- uses `decode_command_custom_header_fast` in SendMessage and reply-message header parsing
- keeps V1/V2 conversion behavior compatible with the normal decode path
- adds header compatibility tests and `encode_decode_bench` SendMessage header-only decode cases

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-remoting send_message_request_header_fast_decode_matches_normal_decode --lib`
- `cargo test -p rocketmq-remoting send_message_v2_fast_decode_matches_normal_v1_conversion --lib`
- `cargo test -p rocketmq-remoting --bench encode_decode_bench --no-run`
- `cargo test -p rocketmq-broker reply_message --lib`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message-header decoding for send-message requests, including both standard and V2 formats.
* **Performance**
  * Switched to a faster decoding path for reply/send-message header parsing, which should reduce overhead.
  * Added a new benchmark to compare standard and fast decoding paths.
* **Tests**
  * Expanded coverage to verify fast decoding matches existing decoding behavior.
  * Added checks for both V1 and V2 header parsing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->