### PR TITLE
[ISSUE #7780]✨Expose Reput batch dispatch stats

### DIFF
--- a/rocketmq-store/benches/commit_log_performance.rs
+++ b/rocketmq-store/benches/commit_log_performance.rs
@@ -429,7 +429,7 @@ fn bench_reput_once_after_batch(c: &mut Criterion) {
     let mut group = c.benchmark_group("phase5/reput_once_after_batch");
     group.sample_size(10);
 
-    for batch_size in [32_usize, 64, 128] {
+    for batch_size in [32_usize, 64, 128, 256] {
         group.throughput(Throughput::Elements(batch_size as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("{batch_size}_messages")),

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -102,6 +102,12 @@ pub struct StoreStatsService {
     put_message_entire_time_max: AtomicU64,
     get_message_entire_time_max: AtomicU64,
     dispatch_max_buffer: AtomicU64,
+    reput_dispatch_behind_bytes: AtomicU64,
+    reput_dispatch_batches_total: AtomicU64,
+    reput_dispatch_requests_total: AtomicU64,
+    reput_dispatch_batch_size_max: AtomicU64,
+    reput_dispatch_duration_total_millis: AtomicU64,
+    reput_dispatch_duration_max_millis: AtomicU64,
     sampling_lock: Mutex<()>,
     last_print_timestamp: AtomicU64,
     stopped: AtomicBool,
@@ -134,6 +140,12 @@ impl StoreStatsService {
             put_message_entire_time_max: AtomicU64::new(0),
             get_message_entire_time_max: AtomicU64::new(0),
             dispatch_max_buffer: AtomicU64::new(0),
+            reput_dispatch_behind_bytes: AtomicU64::new(0),
+            reput_dispatch_batches_total: AtomicU64::new(0),
+            reput_dispatch_requests_total: AtomicU64::new(0),
+            reput_dispatch_batch_size_max: AtomicU64::new(0),
+            reput_dispatch_duration_total_millis: AtomicU64::new(0),
+            reput_dispatch_duration_max_millis: AtomicU64::new(0),
             sampling_lock: Mutex::new(()),
             last_print_timestamp: AtomicU64::new(current_millis()),
             stopped: AtomicBool::new(true),
@@ -284,6 +296,27 @@ impl StoreStatsService {
     }
 
     #[inline]
+    pub fn set_reput_dispatch_behind_bytes(&self, value: u64) {
+        self.reput_dispatch_behind_bytes.store(value, Ordering::Relaxed);
+        self.set_dispatch_max_buffer(value);
+    }
+
+    #[inline]
+    pub fn record_reput_dispatch_batch(&self, batch_size: usize, elapsed: Duration) {
+        let batch_size = u64::try_from(batch_size).unwrap_or(u64::MAX);
+        let elapsed_millis = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+        self.reput_dispatch_batches_total.fetch_add(1, Ordering::Relaxed);
+        self.reput_dispatch_requests_total
+            .fetch_add(batch_size, Ordering::Relaxed);
+        self.reput_dispatch_batch_size_max
+            .fetch_max(batch_size, Ordering::Relaxed);
+        self.reput_dispatch_duration_total_millis
+            .fetch_add(elapsed_millis, Ordering::Relaxed);
+        self.reput_dispatch_duration_max_millis
+            .fetch_max(elapsed_millis, Ordering::Relaxed);
+    }
+
+    #[inline]
     pub fn add_single_put_message_topic_times_total(&self, topic: &str, delta: usize) {
         self.add_topic_value(&self.put_message_topic_times_total, topic, delta as u64);
     }
@@ -326,6 +359,34 @@ impl StoreStatsService {
         result.insert(
             "dispatchMaxBuffer".to_string(),
             self.dispatch_max_buffer.load(Ordering::Relaxed).to_string(),
+        );
+        result.insert(
+            "reputDispatchBehindBytes".to_string(),
+            self.reput_dispatch_behind_bytes.load(Ordering::Relaxed).to_string(),
+        );
+        result.insert(
+            "reputDispatchBatchCountTotal".to_string(),
+            self.reput_dispatch_batches_total.load(Ordering::Relaxed).to_string(),
+        );
+        result.insert(
+            "reputDispatchRequestTotal".to_string(),
+            self.reput_dispatch_requests_total.load(Ordering::Relaxed).to_string(),
+        );
+        result.insert(
+            "reputDispatchBatchSizeMax".to_string(),
+            self.reput_dispatch_batch_size_max.load(Ordering::Relaxed).to_string(),
+        );
+        result.insert(
+            "reputDispatchDurationTotalMillis".to_string(),
+            self.reput_dispatch_duration_total_millis
+                .load(Ordering::Relaxed)
+                .to_string(),
+        );
+        result.insert(
+            "reputDispatchDurationMaxMillis".to_string(),
+            self.reput_dispatch_duration_max_millis
+                .load(Ordering::Relaxed)
+                .to_string(),
         );
         result.insert(
             "getMessageEntireTimeMax".to_string(),

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -4626,25 +4626,22 @@ impl ReputMessageService {
             loop {
                 tokio::select! {
                     Some(mut batch) = dispatch_rx.recv() => {
-                        // Dispatch the batch
-                        dispatcher.dispatch_batch(&mut batch);
-
-                        // Notify message arrival if needed
-                        if !notify_message_arrive_in_batch {
-                            for req in batch.iter_mut() {
-                                message_store.notify_message_arrive_if_necessary(req);
-                            }
-                        }
+                        dispatch_reput_batch(
+                            &dispatcher,
+                            &message_store,
+                            notify_message_arrive_in_batch,
+                            &mut batch,
+                        );
                     }
                     _ = shutdown_dispatcher.cancelled() => {
                         // Process remaining messages in channel before shutdown
                         while let Ok(mut batch) = dispatch_rx.try_recv() {
-                            dispatcher.dispatch_batch(&mut batch);
-                            if !notify_message_arrive_in_batch {
-                                for req in batch.iter_mut() {
-                                    message_store.notify_message_arrive_if_necessary(req);
-                                }
-                            }
+                            dispatch_reput_batch(
+                                &dispatcher,
+                                &message_store,
+                                notify_message_arrive_in_batch,
+                                &mut batch,
+                            );
                         }
                         break;
                     }
@@ -4764,6 +4761,26 @@ struct ReputMessageServiceInner {
     message_store: ArcMut<LocalFileMessageStore>,
 }
 
+fn dispatch_reput_batch(
+    dispatcher: &ArcMut<CommitLogDispatcherDefault>,
+    message_store: &ArcMut<LocalFileMessageStore>,
+    notify_message_arrive_in_batch: bool,
+    dispatch_batch: &mut [DispatchRequest],
+) {
+    let batch_size = dispatch_batch.len();
+    let started = Instant::now();
+    dispatcher.dispatch_batch(dispatch_batch);
+    message_store
+        .store_stats_service
+        .record_reput_dispatch_batch(batch_size, started.elapsed());
+
+    if !notify_message_arrive_in_batch {
+        for req in dispatch_batch.iter_mut() {
+            message_store.notify_message_arrive_if_necessary(req);
+        }
+    }
+}
+
 impl ReputMessageServiceInner {
     fn notify_message_arrive4multi_queue(&self, dispatch_request: &mut DispatchRequest) {
         if let Some(message_arriving_listener) = self.message_store.message_arriving_listener.as_ref() {
@@ -4849,12 +4866,12 @@ impl ReputMessageServiceInner {
 
                             // Dispatch batch when reaching threshold or at end
                             if dispatch_batch.len() >= 32 {
-                                self.dispatcher.dispatch_batch(&mut dispatch_batch);
-                                if !self.notify_message_arrive_in_batch {
-                                    for req in dispatch_batch.iter_mut() {
-                                        self.message_store.notify_message_arrive_if_necessary(req);
-                                    }
-                                }
+                                dispatch_reput_batch(
+                                    &self.dispatcher,
+                                    &self.message_store,
+                                    self.notify_message_arrive_in_batch,
+                                    &mut dispatch_batch,
+                                );
                                 dispatch_batch.clear();
                             }
 
@@ -4888,12 +4905,12 @@ impl ReputMessageServiceInner {
 
         // Dispatch remaining messages in batch
         if !dispatch_batch.is_empty() {
-            self.dispatcher.dispatch_batch(&mut dispatch_batch);
-            if !self.notify_message_arrive_in_batch {
-                for req in dispatch_batch.iter_mut() {
-                    self.message_store.notify_message_arrive_if_necessary(req);
-                }
-            }
+            dispatch_reput_batch(
+                &self.dispatcher,
+                &self.message_store,
+                self.notify_message_arrive_in_batch,
+                &mut dispatch_batch,
+            );
         }
         self.record_dispatch_behind_bytes();
     }
@@ -4921,7 +4938,7 @@ impl ReputMessageServiceInner {
             .saturating_sub(self.reput_from_offset.load(Ordering::Relaxed));
         self.message_store
             .store_stats_service
-            .set_dispatch_max_buffer(behind.max(0) as u64);
+            .set_reput_dispatch_behind_bytes(behind.max(0) as u64);
     }
 
     pub fn reput_from_offset(&self) -> i64 {
@@ -7910,6 +7927,12 @@ mod tests {
         assert_eq!(runtime_info["syncFlushOldestWaitMillis"], "0");
         assert_eq!(runtime_info["syncFlushMaxWaitMillis"], "0");
         assert_eq!(runtime_info["syncFlushWaitTotalMillis"], "0");
+        assert_eq!(runtime_info["reputDispatchBehindBytes"], "0");
+        assert_eq!(runtime_info["reputDispatchBatchCountTotal"], "0");
+        assert_eq!(runtime_info["reputDispatchRequestTotal"], "0");
+        assert_eq!(runtime_info["reputDispatchBatchSizeMax"], "0");
+        assert_eq!(runtime_info["reputDispatchDurationTotalMillis"], "0");
+        assert_eq!(runtime_info["reputDispatchDurationMaxMillis"], "0");
     }
 
     #[tokio::test]
@@ -7965,6 +7988,29 @@ mod tests {
         assert!(result.buffer_total_size > 0);
         assert!(result.index_last_update_timestamp > 0);
         assert!(result.get_message_data().is_some());
+    }
+
+    #[tokio::test]
+    async fn reput_once_records_dispatch_batch_runtime_info() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_async_flush_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("reput-dispatch-runtime-topic");
+
+        for index in 0..33 {
+            let body = Bytes::from(format!("reput-dispatch-body-{index}"));
+            let put_result = store.put_message(build_test_message(&topic, body)).await;
+            assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+        }
+
+        store.reput_once().await;
+
+        let runtime_info = store.get_runtime_info();
+        assert_eq!(runtime_info["reputDispatchBehindBytes"], "0");
+        assert_eq!(runtime_info["reputDispatchBatchCountTotal"], "2");
+        assert_eq!(runtime_info["reputDispatchRequestTotal"], "33");
+        assert_eq!(runtime_info["reputDispatchBatchSizeMax"], "32");
+        assert!(runtime_info.contains_key("reputDispatchDurationTotalMillis"));
+        assert!(runtime_info.contains_key("reputDispatchDurationMaxMillis"));
     }
 
     #[test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7780

### Brief Description

Expose Reput batch dispatch runtime info without changing dispatch behavior. Store runtime info now includes current Reput behind bytes, dispatch batch count, request count, max batch size, total dispatch duration, and max dispatch duration. Both direct `reput_once` and async Reput dispatcher paths record through the same helper.

The CommitLog performance benchmark now covers a 256-message Reput-after-batch case while preserving the existing benchmark group name for baseline continuity.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store reput_once_records_dispatch_batch_runtime_info --lib` passed.
- `cargo test -p rocketmq-store runtime_info_includes_store_offsets_and_timer_defaults_when_timer_disabled --lib` passed.
- `cargo test -p rocketmq-store --bench commit_log_performance --no-run` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new runtime statistics for dispatch activity, including queue lag, batch counts, request counts, batch size peaks, and dispatch timing metrics.
  * Expanded runtime info output with new `reputDispatch*` fields.

* **Bug Fixes**
  * Improved batch dispatch handling so remaining messages are processed consistently during normal operation and shutdown.

* **Tests**
  * Updated coverage to verify the new runtime statistics are reported and initialized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->