### PR TITLE
[ISSUE #7782]✨Wake HA waits on every slave ack

### DIFF
--- a/rocketmq-remoting/src/protocol/body/ha_runtime_info.rs
+++ b/rocketmq-remoting/src/protocol/body/ha_runtime_info.rs
@@ -24,6 +24,12 @@ pub struct HARuntimeInfo {
     pub master: bool,
     pub master_commit_log_max_offset: u64,
     pub in_sync_slave_nums: i32,
+    #[serde(default)]
+    pub pending_group_transfer_request_count: u64,
+    #[serde(default)]
+    pub pending_group_transfer_oldest_wait_millis: u64,
+    #[serde(default)]
+    pub group_transfer_ack_notify_count: u64,
     pub ha_connection_info: Vec<HAConnectionRuntimeInfo>,
     pub ha_client_runtime_info: HAClientRuntimeInfo,
 }
@@ -38,6 +44,9 @@ mod tests {
             master: true,
             master_commit_log_max_offset: 1000,
             in_sync_slave_nums: 3,
+            pending_group_transfer_request_count: 0,
+            pending_group_transfer_oldest_wait_millis: 0,
+            group_transfer_ack_notify_count: 0,
             ha_connection_info: vec![HAConnectionRuntimeInfo {
                 addr: "127.0.0.1:10912".to_string(),
                 slave_ack_offset: 500,
@@ -59,6 +68,9 @@ mod tests {
         assert!(info.master);
         assert_eq!(info.master_commit_log_max_offset, 1000);
         assert_eq!(info.in_sync_slave_nums, 3);
+        assert_eq!(info.pending_group_transfer_request_count, 0);
+        assert_eq!(info.pending_group_transfer_oldest_wait_millis, 0);
+        assert_eq!(info.group_transfer_ack_notify_count, 0);
         assert_eq!(info.ha_connection_info.len(), 1);
         assert_eq!(info.ha_connection_info[0].addr, "127.0.0.1:10912");
         assert_eq!(info.ha_client_runtime_info.master_addr, "127.0.0.1:10911");
@@ -70,6 +82,9 @@ mod tests {
         assert!(!info.master);
         assert_eq!(info.master_commit_log_max_offset, 0);
         assert_eq!(info.in_sync_slave_nums, 0);
+        assert_eq!(info.pending_group_transfer_request_count, 0);
+        assert_eq!(info.pending_group_transfer_oldest_wait_millis, 0);
+        assert_eq!(info.group_transfer_ack_notify_count, 0);
         assert!(info.ha_connection_info.is_empty());
         assert_eq!(info.ha_client_runtime_info.master_addr, "");
     }
@@ -80,6 +95,9 @@ mod tests {
             master: true,
             master_commit_log_max_offset: 1000,
             in_sync_slave_nums: 3,
+            pending_group_transfer_request_count: 2,
+            pending_group_transfer_oldest_wait_millis: 10,
+            group_transfer_ack_notify_count: 4,
             ha_connection_info: vec![HAConnectionRuntimeInfo {
                 addr: "127.0.0.1:10912".to_string(),
                 slave_ack_offset: 500,
@@ -103,6 +121,8 @@ mod tests {
         assert!(display.contains("master: true"));
         assert!(display.contains("master_commit_log_max_offset: 1000"));
         assert!(display.contains("in_sync_slave_nums: 3"));
+        assert!(display.contains("pending_group_transfer_request_count: 2"));
+        assert!(display.contains("group_transfer_ack_notify_count: 4"));
         assert!(display.contains("ha_connection_info"));
         assert!(display.contains("ha_client_runtime_info"));
     }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -611,6 +611,9 @@ mod tests {
             master: true,
             master_commit_log_max_offset: 0,
             in_sync_slave_nums,
+            pending_group_transfer_request_count: 0,
+            pending_group_transfer_oldest_wait_millis: 0,
+            group_transfer_ack_notify_count: 0,
             ha_connection_info: connections
                 .iter()
                 .enumerate()

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -140,6 +140,10 @@ impl DefaultHAService {
     }
 
     pub async fn notify_transfer_some(&self, offset: i64) {
+        if offset < 0 {
+            return;
+        }
+
         let mut value = self.push2_slave_max_offset.load(Ordering::Relaxed);
 
         while (offset as u64) > value {
@@ -150,10 +154,6 @@ impl DefaultHAService {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    // Successfully updated the value
-                    if let Some(service) = &self.group_transfer_service {
-                        service.notify_transfer_some();
-                    }
                     break;
                 }
                 Err(current_value) => {
@@ -161,6 +161,10 @@ impl DefaultHAService {
                     value = current_value;
                 }
             }
+        }
+
+        if let Some(service) = &self.group_transfer_service {
+            service.notify_transfer_some();
         }
     }
 
@@ -449,6 +453,9 @@ impl HAService for DefaultHAService {
             master: self.default_message_store.message_store_config_ref().broker_role != BrokerRole::Slave,
             master_commit_log_max_offset: master_put_where.max(0) as u64,
             in_sync_slave_nums: (self.in_sync_replicas_nums(master_put_where) - 1).max(0),
+            pending_group_transfer_request_count: 0,
+            pending_group_transfer_oldest_wait_millis: 0,
+            group_transfer_ack_notify_count: 0,
             ha_connection_info: Vec::new(),
             ha_client_runtime_info: HAClientRuntimeInfo::default(),
         };
@@ -476,6 +483,14 @@ impl HAService for DefaultHAService {
                 master_flush_offset: self.default_message_store.get_master_flushed_offset().max(0) as u64,
                 is_activated: ha_client.get_current_state().is_active(),
             };
+        }
+
+        if let Some(group_transfer_service) = &self.group_transfer_service {
+            let group_transfer_runtime_info = group_transfer_service.runtime_info();
+            runtime_info.pending_group_transfer_request_count = group_transfer_runtime_info.pending_request_count;
+            runtime_info.pending_group_transfer_oldest_wait_millis =
+                group_transfer_runtime_info.pending_request_oldest_wait_millis;
+            runtime_info.group_transfer_ack_notify_count = group_transfer_runtime_info.ack_notify_count;
         }
 
         runtime_info
@@ -715,6 +730,24 @@ mod tests {
         );
 
         assert_eq!(service.ha_transfer_metrics().snapshot().fallback_total, 1);
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn notify_transfer_some_counts_repeated_same_offset_acks() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-default-ha-repeated-ack-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, false);
+        let mut service = ArcMut::new(DefaultHAService::new(store));
+        let general_service = GeneralHAService::new_with_default_ha_service(service.clone());
+        DefaultHAService::init(&mut service, general_service).expect("init default ha service");
+
+        service.notify_transfer_some(128).await;
+        service.notify_transfer_some(128).await;
+
+        let runtime_info = service.get_runtime_info(128);
+        assert_eq!(service.get_push_to_slave_max_offset(), 128);
+        assert_eq!(runtime_info.group_transfer_ack_notify_count, 2);
         let _ = std::fs::remove_dir_all(temp_root);
     }
 

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -14,6 +14,7 @@
 
 use std::collections::LinkedList;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -42,6 +43,13 @@ pub struct GroupTransferService {
     service_manager: ServiceManager<GroupTransferServiceInner>,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct GroupTransferRuntimeInfo {
+    pub pending_request_count: u64,
+    pub pending_request_oldest_wait_millis: u64,
+    pub ack_notify_count: u64,
+}
+
 impl GroupTransferService {
     pub fn new(ha_service: GeneralHAService) -> Self {
         let inner = Arc::new(GroupTransferServiceInner::new(ha_service));
@@ -68,6 +76,7 @@ impl GroupTransferService {
     }
 
     pub fn notify_transfer_some(&self) {
+        self.inner.record_ack_notify();
         if self
             .inner
             .notified
@@ -83,11 +92,16 @@ impl GroupTransferService {
             self.inner.notified.0.notify_one();
         }
     }
+
+    pub(crate) fn runtime_info(&self) -> GroupTransferRuntimeInfo {
+        self.inner.runtime_info()
+    }
 }
 
 struct GroupTransferServiceInner {
     ha_service: GeneralHAService,
     notified: (Arc<Notify>, AtomicBool),
+    ack_notify_count: AtomicU64,
     requests_write: Arc<Mutex<LinkedList<GroupCommitRequest>>>,
     requests_read: Arc<Mutex<LinkedList<GroupCommitRequest>>>,
 }
@@ -97,8 +111,26 @@ impl GroupTransferServiceInner {
         GroupTransferServiceInner {
             ha_service,
             notified: (Arc::new(Notify::new()), AtomicBool::new(false)),
+            ack_notify_count: AtomicU64::new(0),
             requests_write: Arc::new(Mutex::new(LinkedList::new())),
             requests_read: Arc::new(Mutex::new(LinkedList::new())),
+        }
+    }
+
+    #[inline]
+    fn record_ack_notify(&self) {
+        self.ack_notify_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn runtime_info(&self) -> GroupTransferRuntimeInfo {
+        let now = Instant::now();
+        let (write_count, write_oldest_wait_millis) = pending_request_snapshot(&self.requests_write, now);
+        let (read_count, read_oldest_wait_millis) = pending_request_snapshot(&self.requests_read, now);
+
+        GroupTransferRuntimeInfo {
+            pending_request_count: write_count.saturating_add(read_count),
+            pending_request_oldest_wait_millis: write_oldest_wait_millis.max(read_oldest_wait_millis),
+            ack_notify_count: self.ack_notify_count.load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 
@@ -201,6 +233,20 @@ impl GroupTransferServiceInner {
     }
 }
 
+fn pending_request_snapshot(requests: &Arc<Mutex<LinkedList<GroupCommitRequest>>>, now: Instant) -> (u64, u64) {
+    let Ok(requests) = requests.try_lock() else {
+        return (0, 0);
+    };
+    let count = requests.len() as u64;
+    let oldest_wait_millis = requests
+        .iter()
+        .map(|request| now.saturating_duration_since(request.created_at()).as_millis())
+        .max()
+        .and_then(|millis| u64::try_from(millis).ok())
+        .unwrap_or(0);
+    (count, oldest_wait_millis)
+}
+
 impl ServiceTask for GroupTransferServiceInner {
     fn get_service_name(&self) -> String {
         "GroupTransferService".to_string()
@@ -266,8 +312,35 @@ fn has_required_acks(required_acks: i32, acked_replicas: &[HAAckedReplicaSnapsho
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_rust::ArcMut;
 
     use super::*;
+    use crate::config::message_store_config::MessageStoreConfig;
+    use crate::ha::default_ha_service::DefaultHAService;
+    use crate::message_store::local_file_message_store::LocalFileMessageStore;
+
+    fn new_test_ha_service() -> GeneralHAService {
+        let temp_root = tempfile::tempdir().expect("create temp root dir");
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: temp_root.path().to_string_lossy().into_owned().into(),
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(BrokerConfig::default()),
+            Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        GeneralHAService::new_with_default_ha_service(ArcMut::new(DefaultHAService::new(store)))
+    }
 
     #[test]
     fn sync_state_set_ack_requires_all_members() {
@@ -308,6 +381,21 @@ mod tests {
         acked_replicas[1].slave_ack_offset = 128;
 
         assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
+    }
+
+    #[tokio::test]
+    async fn runtime_info_reports_pending_requests_and_ack_notifications() {
+        let service = GroupTransferService::new(new_test_ha_service());
+        let (request, _response) = GroupCommitRequest::with_ack_nums(128, 5_000, 2);
+
+        service.put_request(request).await;
+        service.notify_transfer_some();
+        service.notify_transfer_some();
+
+        let runtime_info = service.runtime_info();
+        assert_eq!(runtime_info.pending_request_count, 1);
+        assert!(runtime_info.pending_request_oldest_wait_millis < 5_000);
+        assert_eq!(runtime_info.ack_notify_count, 2);
     }
 
     #[test]

--- a/rocketmq-store/src/log_file/group_commit_request.rs
+++ b/rocketmq-store/src/log_file/group_commit_request.rs
@@ -74,6 +74,7 @@ pub struct GroupCommitRequest {
     next_offset: i64,
     flush_ok_sender: Option<oneshot::Sender<PutMessageStatus>>,
     ack_nums: i32,
+    created_at: Instant,
     deadline: Instant,
 }
 
@@ -101,12 +102,14 @@ impl GroupCommitRequest {
     #[inline]
     fn create_request(next_offset: i64, timeout_millis: u64, ack_nums: i32) -> (Self, GroupCommitResponse) {
         let (sender, receiver) = oneshot::channel();
-        let instant = Instant::now() + Duration::from_millis(timeout_millis);
+        let created_at = Instant::now();
+        let instant = created_at + Duration::from_millis(timeout_millis);
         (
             Self {
                 next_offset,
                 flush_ok_sender: Some(sender),
                 ack_nums,
+                created_at,
                 deadline: instant,
             },
             GroupCommitResponse {
@@ -126,6 +129,11 @@ impl GroupCommitRequest {
         self.ack_nums
     }
 
+    /// Get when this request was created.
+    pub fn created_at(&self) -> Instant {
+        self.created_at
+    }
+
     /// Wake up the customer/caller with the result
     pub fn wakeup_customer(&mut self, status: PutMessageStatus) {
         if let Some(sender) = self.flush_ok_sender.take() {
@@ -143,6 +151,7 @@ impl std::fmt::Debug for GroupCommitRequest {
         f.debug_struct("GroupCommitRequest")
             .field("next_offset", &self.next_offset)
             .field("ack_nums", &self.ack_nums)
+            .field("created_at", &self.created_at)
             .field("has_sender", &self.flush_ok_sender.is_some())
             .finish()
     }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7782

### Brief Description

Wake HA group transfer waiters on every valid slave ack report instead of only when the global max slave ack offset advances. This preserves `push2SlaveMaxOffset` max-offset semantics while allowing all-ack and multi-replica waiters to react to same-offset ack progress without waiting for the periodic check.

HA runtime info now includes pending group-transfer request count, oldest pending wait age, and ack notify count. Group commit requests track creation time so the oldest wait can be reported.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store runtime_info_reports_pending_requests_and_ack_notifications --lib` passed.
- `cargo test -p rocketmq-store notify_transfer_some_counts_repeated_same_offset_acks --lib` passed.
- `cargo test -p rocketmq-remoting ha_runtime_info --lib` passed.
- `cargo test -p rocketmq-store --bench ha_transfer_benchmark --no-run` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new high-availability runtime metrics, including pending transfer requests, oldest wait time, and acknowledgment notifications.
  * Runtime status now reports these transfer metrics when available.

* **Bug Fixes**
  * Transfer notifications are now sent more consistently, even when the target offset does not change.
  * Negative transfer offsets are ignored immediately.

* **Tests**
  * Updated and expanded test coverage for default values, formatting, runtime metric reporting, and repeated transfer notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->