### PR TITLE
[ISSUE #7786]✨Add unified store health backpressure

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -72,6 +72,7 @@ use rocketmq_store::base::flush_manager::SyncFlushRuntimeInfo;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::base::message_store::StoreHealthSnapshot;
 use rocketmq_store::stats::broker_stats_manager::BrokerStatsManager;
 use rocketmq_store::stats::stats_type::StatsType;
 use tracing::debug;
@@ -161,18 +162,9 @@ where
             );
         }
         let message_store = self.inner.broker_runtime_inner.message_store_unchecked();
-        if message_store.is_os_page_cache_busy() || message_store.is_transient_store_pool_deficient() {
-            return (
-                true,
-                Some(RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::SystemBusy,
-                    "The broker message store is busy, please try again later",
-                )),
-            );
-        }
-        if let Some(remark) = sync_flush_backlog_reject_remark(
+        if let Some(remark) = store_health_reject_remark(
             self.inner.broker_runtime_inner.broker_config(),
-            message_store.sync_flush_runtime_info(),
+            message_store.health_snapshot(),
         ) {
             return (
                 true,
@@ -1152,6 +1144,46 @@ fn sync_flush_backlog_reject_remark(
     })
 }
 
+fn store_health_reject_remark(broker_config: &BrokerConfig, snapshot: StoreHealthSnapshot) -> Option<String> {
+    if snapshot.shutdown {
+        return Some("store_backpressure reason=store_shutdown".to_string());
+    }
+    if snapshot.os_page_cache_busy {
+        return Some("store_backpressure reason=page_cache_busy".to_string());
+    }
+    if snapshot.transient_store_pool_deficient {
+        return Some("store_backpressure reason=transient_store_pool_deficient".to_string());
+    }
+    if let Some(remark) = sync_flush_backlog_reject_remark(broker_config, snapshot.sync_flush) {
+        return Some(format!("store_backpressure reason=sync_flush_backlog, {remark}"));
+    }
+
+    let ha_count_threshold = broker_config.ha_pending_reject_count;
+    let ha_wait_threshold = broker_config.ha_pending_reject_wait_millis;
+    let ha_count_exceeded = ha_count_threshold > 0 && snapshot.ha_pending_request_count >= ha_count_threshold;
+    let ha_wait_exceeded = ha_wait_threshold > 0 && snapshot.ha_pending_oldest_wait_millis >= ha_wait_threshold;
+    if ha_count_exceeded || ha_wait_exceeded {
+        return Some(format!(
+            "store_backpressure reason=ha_pending, pendingCount={}, oldestWaitMillis={}, rejectCount={}, \
+             rejectWaitMillis={}",
+            snapshot.ha_pending_request_count,
+            snapshot.ha_pending_oldest_wait_millis,
+            ha_count_threshold,
+            ha_wait_threshold
+        ));
+    }
+
+    let reput_lag_threshold = broker_config.reput_lag_reject_bytes;
+    if reput_lag_threshold > 0 && snapshot.dispatch_behind_bytes >= reput_lag_threshold {
+        return Some(format!(
+            "store_backpressure reason=reput_lag, dispatchBehindBytes={}, rejectBytes={}",
+            snapshot.dispatch_behind_bytes, reput_lag_threshold
+        ));
+    }
+
+    None
+}
+
 pub(crate) struct Inner<MS, TS>
 where
     MS: MessageStore,
@@ -1742,5 +1774,109 @@ mod tests {
         let remark = sync_flush_backlog_reject_remark(&broker_config, runtime_info).expect("wait should reject");
         assert!(remark.contains("oldestWaitMillis=250"));
         assert!(remark.contains("rejectWaitMillis=250"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_does_not_reject_optional_reasons_by_default() {
+        let snapshot = StoreHealthSnapshot {
+            sync_flush: SyncFlushRuntimeInfo {
+                queue_depth: 64,
+                oldest_wait_millis: 10_000,
+                ..SyncFlushRuntimeInfo::default()
+            },
+            dispatch_behind_bytes: 1024 * 1024,
+            ha_pending_request_count: 64,
+            ha_pending_oldest_wait_millis: 10_000,
+            ..StoreHealthSnapshot::default()
+        };
+
+        assert!(store_health_reject_remark(&BrokerConfig::default(), snapshot).is_none());
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_page_cache_busy() {
+        let snapshot = StoreHealthSnapshot {
+            os_page_cache_busy: true,
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark = store_health_reject_remark(&BrokerConfig::default(), snapshot).expect("page cache should reject");
+        assert!(remark.contains("reason=page_cache_busy"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_transient_pool_deficient() {
+        let snapshot = StoreHealthSnapshot {
+            transient_store_pool_deficient: true,
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark =
+            store_health_reject_remark(&BrokerConfig::default(), snapshot).expect("transient pool should reject");
+        assert!(remark.contains("reason=transient_store_pool_deficient"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_sync_flush_backlog() {
+        let broker_config = BrokerConfig {
+            sync_flush_backlog_reject_depth: 8,
+            ..BrokerConfig::default()
+        };
+        let snapshot = StoreHealthSnapshot {
+            sync_flush: SyncFlushRuntimeInfo {
+                queue_depth: 8,
+                ..SyncFlushRuntimeInfo::default()
+            },
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark = store_health_reject_remark(&broker_config, snapshot).expect("sync flush should reject");
+        assert!(remark.contains("reason=sync_flush_backlog"));
+        assert!(remark.contains("queueDepth=8"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_ha_pending() {
+        let broker_config = BrokerConfig {
+            ha_pending_reject_count: 4,
+            ..BrokerConfig::default()
+        };
+        let snapshot = StoreHealthSnapshot {
+            ha_pending_request_count: 4,
+            ha_pending_oldest_wait_millis: 250,
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark = store_health_reject_remark(&broker_config, snapshot).expect("HA pending should reject");
+        assert!(remark.contains("reason=ha_pending"));
+        assert!(remark.contains("pendingCount=4"));
+        assert!(remark.contains("oldestWaitMillis=250"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_reput_lag() {
+        let broker_config = BrokerConfig {
+            reput_lag_reject_bytes: 1024,
+            ..BrokerConfig::default()
+        };
+        let snapshot = StoreHealthSnapshot {
+            dispatch_behind_bytes: 1024,
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark = store_health_reject_remark(&broker_config, snapshot).expect("Reput lag should reject");
+        assert!(remark.contains("reason=reput_lag"));
+        assert!(remark.contains("dispatchBehindBytes=1024"));
+    }
+
+    #[test]
+    fn store_health_reject_remark_reports_store_shutdown() {
+        let snapshot = StoreHealthSnapshot {
+            shutdown: true,
+            ..StoreHealthSnapshot::default()
+        };
+
+        let remark = store_health_reject_remark(&BrokerConfig::default(), snapshot).expect("shutdown should reject");
+        assert!(remark.contains("reason=store_shutdown"));
     }
 }

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -651,6 +651,18 @@ mod defaults {
         0
     }
 
+    pub const fn ha_pending_reject_count() -> u64 {
+        0
+    }
+
+    pub const fn ha_pending_reject_wait_millis() -> u64 {
+        0
+    }
+
+    pub const fn reput_lag_reject_bytes() -> i64 {
+        0
+    }
+
     pub const fn wait_time_mills_in_pull_queue() -> u64 {
         5_000
     }
@@ -976,6 +988,15 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::sync_flush_backlog_reject_wait_millis")]
     pub sync_flush_backlog_reject_wait_millis: u64,
+
+    #[serde(default = "defaults::ha_pending_reject_count")]
+    pub ha_pending_reject_count: u64,
+
+    #[serde(default = "defaults::ha_pending_reject_wait_millis")]
+    pub ha_pending_reject_wait_millis: u64,
+
+    #[serde(default = "defaults::reput_lag_reject_bytes")]
+    pub reput_lag_reject_bytes: i64,
 
     #[serde(default = "defaults::wait_time_mills_in_pull_queue")]
     pub wait_time_mills_in_pull_queue: u64,
@@ -1433,6 +1454,9 @@ impl Default for BrokerConfig {
             wait_time_mills_in_send_queue: defaults::wait_time_mills_in_send_queue(),
             sync_flush_backlog_reject_depth: defaults::sync_flush_backlog_reject_depth(),
             sync_flush_backlog_reject_wait_millis: defaults::sync_flush_backlog_reject_wait_millis(),
+            ha_pending_reject_count: defaults::ha_pending_reject_count(),
+            ha_pending_reject_wait_millis: defaults::ha_pending_reject_wait_millis(),
+            reput_lag_reject_bytes: defaults::reput_lag_reject_bytes(),
             wait_time_mills_in_pull_queue: defaults::wait_time_mills_in_pull_queue(),
             wait_time_mills_in_lite_pull_queue: defaults::wait_time_mills_in_lite_pull_queue(),
             wait_time_mills_in_heartbeat_queue: defaults::wait_time_mills_in_heartbeat_queue(),
@@ -1809,6 +1833,18 @@ impl BrokerConfig {
         properties.insert(
             "syncFlushBacklogRejectWaitMillis".into(),
             self.sync_flush_backlog_reject_wait_millis.to_string().into(),
+        );
+        properties.insert(
+            "haPendingRejectCount".into(),
+            self.ha_pending_reject_count.to_string().into(),
+        );
+        properties.insert(
+            "haPendingRejectWaitMillis".into(),
+            self.ha_pending_reject_wait_millis.to_string().into(),
+        );
+        properties.insert(
+            "reputLagRejectBytes".into(),
+            self.reput_lag_reject_bytes.to_string().into(),
         );
         properties.insert(
             "waitTimeMillsInPullQueue".into(),
@@ -2267,6 +2303,9 @@ mod tests {
         assert_eq!(config.wait_time_mills_in_send_queue, 200);
         assert_eq!(config.sync_flush_backlog_reject_depth, 0);
         assert_eq!(config.sync_flush_backlog_reject_wait_millis, 0);
+        assert_eq!(config.ha_pending_reject_count, 0);
+        assert_eq!(config.ha_pending_reject_wait_millis, 0);
+        assert_eq!(config.reput_lag_reject_bytes, 0);
         assert_eq!(config.wait_time_mills_in_pull_queue, 5_000);
         assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_000);
         assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_000);
@@ -2505,6 +2544,9 @@ mod tests {
                 "waitTimeMillsInSendQueue": 201,
                 "syncFlushBacklogRejectDepth": 32,
                 "syncFlushBacklogRejectWaitMillis": 150,
+                "haPendingRejectCount": 16,
+                "haPendingRejectWaitMillis": 250,
+                "reputLagRejectBytes": 1048576,
                 "waitTimeMillsInPullQueue": 5001,
                 "waitTimeMillsInLitePullQueue": 5002,
                 "waitTimeMillsInHeartbeatQueue": 31001,
@@ -2520,6 +2562,9 @@ mod tests {
         assert_eq!(config.wait_time_mills_in_send_queue, 201);
         assert_eq!(config.sync_flush_backlog_reject_depth, 32);
         assert_eq!(config.sync_flush_backlog_reject_wait_millis, 150);
+        assert_eq!(config.ha_pending_reject_count, 16);
+        assert_eq!(config.ha_pending_reject_wait_millis, 250);
+        assert_eq!(config.reput_lag_reject_bytes, 1_048_576);
         assert_eq!(config.wait_time_mills_in_pull_queue, 5_001);
         assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_002);
         assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_001);

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -60,6 +60,17 @@ use crate::timer::timer_message_store::TimerMessageStore;
 
 type AsyncResult<T> = Pin<Box<dyn Future<Output = Result<T, StoreError>> + Send>>;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StoreHealthSnapshot {
+    pub os_page_cache_busy: bool,
+    pub transient_store_pool_deficient: bool,
+    pub sync_flush: SyncFlushRuntimeInfo,
+    pub dispatch_behind_bytes: i64,
+    pub shutdown: bool,
+    pub ha_pending_request_count: u64,
+    pub ha_pending_oldest_wait_millis: u64,
+}
+
 #[trait_variant::make(MessageStore: Send)]
 pub trait MessageStoreInner: Sync + 'static {
     /// Load previously stored messages.
@@ -374,6 +385,24 @@ pub trait MessageStoreInner: Sync + 'static {
 
     /// Get current sync flush backlog runtime info without building the full runtime-info map.
     fn sync_flush_runtime_info(&self) -> SyncFlushRuntimeInfo;
+
+    /// Get a compact send-path health snapshot for broker backpressure decisions.
+    fn health_snapshot(&self) -> StoreHealthSnapshot {
+        let ha_runtime_info = self.get_ha_runtime_info();
+        StoreHealthSnapshot {
+            os_page_cache_busy: self.is_os_page_cache_busy(),
+            transient_store_pool_deficient: self.is_transient_store_pool_deficient(),
+            sync_flush: self.sync_flush_runtime_info(),
+            dispatch_behind_bytes: self.dispatch_behind_bytes(),
+            shutdown: self.is_shutdown(),
+            ha_pending_request_count: ha_runtime_info
+                .as_ref()
+                .map_or(0, |info| info.pending_group_transfer_request_count),
+            ha_pending_oldest_wait_millis: ha_runtime_info
+                .as_ref()
+                .map_or(0, |info| info.pending_group_transfer_oldest_wait_millis),
+        }
+    }
 
     /// Get lock time in milliseconds of the store.
     fn lock_time_millis(&self) -> i64;

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -35,6 +35,7 @@ use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::general_ha_service::GeneralHAService;
 use crate::ha::general_ha_service::HAAckedReplicaSnapshot;
+use crate::ha::group_transfer_service::GroupTransferRuntimeInfo;
 use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection::HAConnection;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
@@ -76,6 +77,10 @@ impl AutoSwitchHAService {
 
     pub(crate) fn try_snapshot_acked_replicas(&self) -> Option<Vec<HAAckedReplicaSnapshot>> {
         self.delegate.try_snapshot_acked_replicas()
+    }
+
+    pub(crate) fn group_transfer_runtime_info(&self) -> GroupTransferRuntimeInfo {
+        self.delegate.group_transfer_runtime_info()
     }
 
     pub(crate) fn init(this: &mut ArcMut<Self>, general_ha_service: GeneralHAService) -> HAResult<()> {

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -48,6 +48,7 @@ use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::general_ha_service::GeneralHAService;
 use crate::ha::general_ha_service::HAAckedReplicaSnapshot;
+use crate::ha::group_transfer_service::GroupTransferRuntimeInfo;
 use crate::ha::group_transfer_service::GroupTransferService;
 use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection::HAConnection;
@@ -108,6 +109,12 @@ impl DefaultHAService {
 
     pub fn ha_transfer_metrics(&self) -> Arc<HaTransferMetrics> {
         self.ha_transfer_metrics.clone()
+    }
+
+    pub(crate) fn group_transfer_runtime_info(&self) -> GroupTransferRuntimeInfo {
+        self.group_transfer_service
+            .as_ref()
+            .map_or_else(GroupTransferRuntimeInfo::default, GroupTransferService::runtime_info)
     }
 
     pub(crate) fn ensure_ha_client(&mut self) -> HAResult<bool> {

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -23,6 +23,7 @@ use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
 use crate::ha::default_ha_service::DefaultHAService;
 use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_connection::GeneralHAConnection;
+use crate::ha::group_transfer_service::GroupTransferRuntimeInfo;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use crate::ha::ha_service::HAService;
 use crate::log_file::group_commit_request::GroupCommitRequest;
@@ -97,6 +98,13 @@ impl GeneralHAService {
         match self {
             GeneralHAService::DefaultHAService(service) => service.try_snapshot_acked_replicas(),
             GeneralHAService::AutoSwitchHAService(service) => service.try_snapshot_acked_replicas(),
+        }
+    }
+
+    pub(crate) fn group_transfer_runtime_info(&self) -> GroupTransferRuntimeInfo {
+        match self {
+            GeneralHAService::DefaultHAService(service) => service.group_transfer_runtime_info(),
+            GeneralHAService::AutoSwitchHAService(service) => service.group_transfer_runtime_info(),
         }
     }
 }

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -43,6 +43,7 @@ use crate::base::message_arriving_listener::MessageArrivingListener;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_store::MessageStore;
+use crate::base::message_store::StoreHealthSnapshot;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -468,6 +469,10 @@ impl MessageStore for GenericMessageStore {
 
     fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
         delegate_store!(self, sync_flush_runtime_info())
+    }
+
+    fn health_snapshot(&self) -> StoreHealthSnapshot {
+        delegate_store!(self, health_snapshot())
     }
 
     fn lock_time_millis(&self) -> i64 {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -112,6 +112,7 @@ use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::message_store::MessageStore;
+use crate::base::message_store::StoreHealthSnapshot;
 use crate::base::query_message_result::QueryMessageResult;
 #[cfg(feature = "tieredstore")]
 use crate::base::select_result::SelectMappedBufferCacheState;
@@ -3481,6 +3482,22 @@ impl MessageStore for LocalFileMessageStore {
 
     fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
         self.commit_log.sync_flush_runtime_info()
+    }
+
+    fn health_snapshot(&self) -> StoreHealthSnapshot {
+        let ha_runtime_info = self
+            .ha_service
+            .as_ref()
+            .map_or_else(Default::default, GeneralHAService::group_transfer_runtime_info);
+        StoreHealthSnapshot {
+            os_page_cache_busy: self.is_os_page_cache_busy(),
+            transient_store_pool_deficient: self.is_transient_store_pool_deficient(),
+            sync_flush: self.sync_flush_runtime_info(),
+            dispatch_behind_bytes: self.dispatch_behind_bytes(),
+            shutdown: self.is_shutdown(),
+            ha_pending_request_count: ha_runtime_info.pending_request_count,
+            ha_pending_oldest_wait_millis: ha_runtime_info.pending_request_oldest_wait_millis,
+        }
     }
 
     fn lock_time_millis(&self) -> i64 {

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -46,6 +46,7 @@ use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::message_store::MessageStore;
+use crate::base::message_store::StoreHealthSnapshot;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -971,6 +972,10 @@ impl MessageStore for RocksDBMessageStore {
 
     fn sync_flush_runtime_info(&self) -> crate::base::flush_manager::SyncFlushRuntimeInfo {
         self.local_file_store.sync_flush_runtime_info()
+    }
+
+    fn health_snapshot(&self) -> StoreHealthSnapshot {
+        self.local_file_store.health_snapshot()
     }
 
     fn lock_time_millis(&self) -> i64 {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7786

### Brief Description

Add a compact store health snapshot for SendMessage backpressure decisions and route `SendMessageProcessor::reject_request` through a single reason-based helper. The snapshot carries page-cache busy, transient pool deficiency, sync flush backlog, HA pending, Reput lag, and shutdown signals. Existing page-cache/transient-pool rejection stays active, sync flush backlog rejection stays gated by existing thresholds, and new HA/Reput thresholds default to observe-only behavior.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-broker store_health_reject_remark --lib` passed.
- `cargo test -p rocketmq-common default_broker_config_uses_java_fast_failure_defaults --lib` passed.
- `cargo test -p rocketmq-common serde_accepts_java_fast_failure_camel_case_keys --lib` passed.
- `cargo test -p rocketmq-store runtime_info_reports_pending_requests_and_ack_notifications --lib` passed.
- `cargo test -p rocketmq-store notify_transfer_some_counts_repeated_same_offset_acks --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader broker backpressure checks before accepting messages, including store shutdown, page cache pressure, sync flush backlog, HA pending requests, and dispatch lag.
  * Added new broker configuration options for HA pending rejection thresholds and dispatch lag limits.
  * Added health snapshots across message store implementations to surface current store conditions more consistently.

* **Bug Fixes**
  * Improved rejection responses to include clearer reason codes when the broker is under load or unhealthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->