### PR TITLE
[ISSUE #7788]✨Add TopicConfig read snapshot

### DIFF
--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -150,3 +150,7 @@ harness = false
 [[bench]]
 name    = "send_message_properties_benchmark"
 harness = false
+
+[[bench]]
+name    = "topic_config_lookup_benchmark"
+harness = false

--- a/rocketmq-broker/benches/topic_config_lookup_benchmark.rs
+++ b/rocketmq-broker/benches/topic_config_lookup_benchmark.rs
@@ -1,0 +1,82 @@
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::path::Path;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use dashmap::DashMap;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_rust::ArcMut;
+
+type TopicConfigMap = DashMap<CheetahString, ArcMut<TopicConfig>>;
+type TopicConfigSnapshot = ArcSwap<HashMap<CheetahString, ArcMut<TopicConfig>>>;
+
+fn topic_name(index: usize) -> CheetahString {
+    CheetahString::from_string(format!("TopicConfigLookup{index}"))
+}
+
+fn build_topic_config_maps(topic_count: usize) -> (TopicConfigMap, TopicConfigSnapshot, Vec<CheetahString>) {
+    let dash_map = DashMap::with_capacity(topic_count);
+    let mut snapshot_map = HashMap::with_capacity(topic_count);
+    let mut topics = Vec::with_capacity(topic_count);
+
+    for index in 0..topic_count {
+        let topic = topic_name(index);
+        let config = ArcMut::new(TopicConfig::with_queues(topic.clone(), 4, 4));
+        dash_map.insert(topic.clone(), config.clone());
+        snapshot_map.insert(topic.clone(), config);
+        topics.push(topic);
+    }
+
+    (dash_map, ArcSwap::from(Arc::new(snapshot_map)), topics)
+}
+
+fn bench_topic_config_lookup(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("topic_config_lookup");
+
+    for topic_count in [1_024usize, 10_000, 100_000] {
+        let (dash_map, snapshot, topics) = build_topic_config_maps(topic_count);
+        let hot_topic = &topics[topic_count / 2];
+        group.throughput(Throughput::Elements(1));
+
+        group.bench_with_input(
+            BenchmarkId::new("dashmap_get_clone", topic_count),
+            hot_topic,
+            |bencher, topic| {
+                bencher.iter(|| {
+                    let config = dash_map.get(black_box(topic)).as_deref().cloned();
+                    black_box(config);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("snapshot_hashmap_get_clone", topic_count),
+            hot_topic,
+            |bencher, topic| {
+                bencher.iter(|| {
+                    let snapshot = snapshot.load();
+                    let config = snapshot.get(black_box(topic)).cloned();
+                    black_box(config);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = topic_config_lookup_benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .output_directory(Path::new("target/criterion-broker-topic-config-lookup"));
+    targets = bench_topic_config_lookup
+}
+criterion_main!(topic_config_lookup_benches);

--- a/rocketmq-broker/src/slave/slave_synchronize.rs
+++ b/rocketmq-broker/src/slave/slave_synchronize.rs
@@ -178,7 +178,9 @@ where
             }
 
             drop(topic_config_table);
-            self.broker_runtime_inner.topic_config_manager().persist();
+            let topic_config_manager = self.broker_runtime_inner.topic_config_manager();
+            topic_config_manager.rebuild_topic_config_snapshot();
+            topic_config_manager.persist();
         }
 
         // Sync topic queue mapping if present and data version differs
@@ -200,6 +202,9 @@ where
                 topic_config_table.insert(key, ArcMut::new(value));
             }
             drop(topic_config_table);
+            self.broker_runtime_inner
+                .topic_config_manager()
+                .rebuild_topic_config_snapshot();
             self.broker_runtime_inner.topic_queue_mapping_manager().persist();
         }
         Ok(())

--- a/rocketmq-broker/src/topic/manager/topic_config_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_manager.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::attribute::attribute_util::AttributeUtil;
@@ -53,6 +54,7 @@ use crate::config::rocksdb_manager::RocksDbBrokerConfigManager;
 
 pub(crate) struct TopicConfigManager<MS: MessageStore> {
     topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
+    topic_config_snapshot: ArcSwap<HashMap<CheetahString, ArcMut<TopicConfig>>>,
     data_version: ArcMut<DataVersion>,
     persist_lock: Arc<parking_lot::Mutex<()>>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
@@ -73,6 +75,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
     pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>, init: bool) -> Self {
         let mut manager = Self {
             topic_config_table: Arc::new(DashMap::with_capacity(1024)),
+            topic_config_snapshot: ArcSwap::from_pointee(HashMap::new()),
             data_version: ArcMut::new(DataVersion::default()),
             persist_lock: Arc::new(parking_lot::Mutex::new(())),
             broker_runtime_inner,
@@ -279,7 +282,16 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
     #[inline]
     pub fn select_topic_config(&self, topic: &CheetahString) -> Option<ArcMut<TopicConfig>> {
-        self.topic_config_table.get(topic).as_deref().cloned()
+        self.topic_config_snapshot.load().get(topic).cloned()
+    }
+
+    pub(crate) fn rebuild_topic_config_snapshot(&self) {
+        let snapshot = self
+            .topic_config_table
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<HashMap<CheetahString, ArcMut<TopicConfig>>>();
+        self.topic_config_snapshot.store(Arc::new(snapshot));
     }
 
     pub fn build_serialize_wrapper(
@@ -320,8 +332,11 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
     }
 
     pub(crate) fn put_topic_config(&self, topic_config: ArcMut<TopicConfig>) -> Option<ArcMut<TopicConfig>> {
-        self.topic_config_table
-            .insert(topic_config.topic_name.as_ref().unwrap().clone(), topic_config)
+        let old = self
+            .topic_config_table
+            .insert(topic_config.topic_name.as_ref().unwrap().clone(), topic_config);
+        self.rebuild_topic_config_snapshot();
+        old
     }
 
     pub async fn create_topic_in_send_message_method(
@@ -400,6 +415,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
         // Persist operation only needs lock to prevent concurrent file writes
         if create_new {
+            self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
             let _lock = self.persist_lock.lock();
@@ -459,6 +475,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
         // Persist operation only needs lock
         if create_new {
+            self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
             let _lock = self.persist_lock.lock();
@@ -501,7 +518,10 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
     pub fn remove_topic_config(&self, topic: &str) -> Option<ArcMut<TopicConfig>> {
         match self.topic_config_table.remove(topic) {
             None => None,
-            Some(value) => Some(value.1),
+            Some(value) => {
+                self.rebuild_topic_config_snapshot();
+                Some(value.1)
+            }
         }
     }
 
@@ -606,6 +626,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
     pub fn set_topic_config_table(&mut self, topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>) {
         self.topic_config_table = topic_config_table;
+        self.rebuild_topic_config_snapshot();
     }
 
     pub async fn create_topic_of_tran_check_max_time(
@@ -643,6 +664,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
         // Persist operation only needs lock
         if create_new {
+            self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
             let _lock = self.persist_lock.lock();
@@ -747,6 +769,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
 
         // Persist operation only needs lock
         if create_new {
+            self.rebuild_topic_config_snapshot();
             let config_for_register = if register { result.clone() } else { None };
 
             let _lock = self.persist_lock.lock();
@@ -909,6 +932,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
                 return false;
             }
         }
+        self.rebuild_topic_config_snapshot();
         true
     }
 
@@ -1106,7 +1130,99 @@ impl<MS: MessageStore> ConfigManager for TopicConfigManager<MS> {
             for (key, value) in map {
                 self.topic_config_table.insert(key, ArcMut::new(value));
             }
+            self.rebuild_topic_config_snapshot();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::config_manager::ConfigManager;
+    use rocketmq_rust::ArcMut;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_store::message_store::GenericMessageStore;
+    use tempfile::TempDir;
+
+    use crate::broker_runtime::BrokerRuntime;
+    use crate::topic::manager::topic_config_manager::TopicConfigManager;
+
+    fn test_topic_config_manager() -> (TempDir, TopicConfigManager<GenericMessageStore>) {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let root = CheetahString::from_string(temp_dir.path().to_string_lossy().to_string());
+        let mut runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig {
+                store_path_root_dir: root.clone(),
+                ..BrokerConfig::default()
+            }),
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: root,
+                ..MessageStoreConfig::default()
+            }),
+        );
+        let manager = TopicConfigManager::new(runtime.inner_for_test().clone(), false);
+        (temp_dir, manager)
+    }
+
+    #[test]
+    fn select_topic_config_reads_snapshot_after_put_and_delete() {
+        let (_temp_dir, manager) = test_topic_config_manager();
+        let topic = CheetahString::from_static_str("SnapshotTopic");
+
+        assert!(manager.select_topic_config(&topic).is_none());
+
+        manager.put_topic_config(ArcMut::new(TopicConfig::with_queues(topic.clone(), 2, 3)));
+        let config = manager
+            .select_topic_config(&topic)
+            .expect("topic should be visible through snapshot");
+        assert_eq!(config.read_queue_nums, 2);
+        assert_eq!(config.write_queue_nums, 3);
+
+        manager.delete_topic_config(&topic);
+        assert!(manager.select_topic_config(&topic).is_none());
+    }
+
+    #[test]
+    fn select_topic_config_reads_snapshot_after_table_replacement() {
+        let (_temp_dir, mut manager) = test_topic_config_manager();
+        let topic = CheetahString::from_static_str("ReplacementTopic");
+        let replacement = Arc::new(DashMap::new());
+        replacement.insert(
+            topic.clone(),
+            ArcMut::new(TopicConfig::with_queues(topic.clone(), 4, 5)),
+        );
+
+        manager.set_topic_config_table(replacement);
+        let config = manager
+            .select_topic_config(&topic)
+            .expect("replacement table should rebuild snapshot");
+        assert_eq!(config.read_queue_nums, 4);
+        assert_eq!(config.write_queue_nums, 5);
+
+        manager.set_topic_config_table(Arc::new(DashMap::new()));
+        assert!(manager.select_topic_config(&topic).is_none());
+    }
+
+    #[test]
+    fn decode_rebuilds_topic_config_snapshot() {
+        let (_temp_dir, manager) = test_topic_config_manager();
+        let topic = CheetahString::from_static_str("LoadedTopic");
+        manager.put_topic_config(ArcMut::new(TopicConfig::with_queues(topic.clone(), 6, 7)));
+        let encoded = manager.encode_pretty(false);
+
+        let (_restart_temp_dir, restarted_manager) = test_topic_config_manager();
+        restarted_manager.decode(&encoded);
+
+        let config = restarted_manager
+            .select_topic_config(&topic)
+            .expect("decoded topic should be visible through snapshot");
+        assert_eq!(config.read_queue_nums, 6);
+        assert_eq!(config.write_queue_nums, 7);
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7788

### Brief Description

Add an ArcSwap-backed read snapshot to `TopicConfigManager` and route `select_topic_config` through it for send-path lookups. Rebuild the snapshot after topic put/create/delete/table replacement/decode/RocksDB load paths and after slave topic-config synchronization mutates the shared DashMap. Add focused snapshot visibility tests and a Criterion benchmark comparing DashMap lookup with snapshot HashMap lookup.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-broker topic_config_snapshot --lib` passed.
- `cargo test -p rocketmq-broker select_topic_config_reads_snapshot_after_put_and_delete --lib` passed.
- `cargo test -p rocketmq-broker select_topic_config_reads_snapshot_after_table_replacement --lib` passed.
- `cargo test -p rocketmq-broker --bench topic_config_lookup_benchmark --no-run` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a benchmark for topic configuration lookup performance.

* **Performance**
  * Improved topic config reads by using a refreshed in-memory snapshot for lookups.
  * Topic config updates now automatically refresh the snapshot after changes, helping keep reads fast and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->