### PR TITLE
[ISSUE #7790]✨Add async topic create persistence

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -573,6 +573,17 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 .dispatch_behind_bytes()
                 .to_string(),
         );
+        let topic_config_manager = self.broker_runtime_inner.topic_config_manager();
+        runtime_info.insert(
+            "asyncTopicCreatePersistPendingCount".to_string(),
+            topic_config_manager.async_topic_create_pending_count().to_string(),
+        );
+        runtime_info.insert(
+            "asyncTopicCreatePersistSpawnFailureCount".to_string(),
+            topic_config_manager
+                .async_topic_create_spawn_failure_count()
+                .to_string(),
+        );
         runtime_info.insert(
             "pageCacheLockTimeMills".to_string(),
             self.broker_runtime_inner

--- a/rocketmq-broker/src/topic/manager/topic_config_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_manager.rs
@@ -16,6 +16,8 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 #[cfg(feature = "rocksdb_store")]
 use std::path::Path;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -40,6 +42,7 @@ use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQu
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::timer::timer_message_store;
@@ -57,6 +60,8 @@ pub(crate) struct TopicConfigManager<MS: MessageStore> {
     topic_config_snapshot: ArcSwap<HashMap<CheetahString, ArcMut<TopicConfig>>>,
     data_version: ArcMut<DataVersion>,
     persist_lock: Arc<parking_lot::Mutex<()>>,
+    async_topic_create_pending_count: Arc<AtomicU64>,
+    async_topic_create_spawn_failure_count: Arc<AtomicU64>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     #[cfg(feature = "rocksdb_store")]
     rocksdb_config_manager: Option<Arc<RocksDbBrokerConfigManager>>,
@@ -78,6 +83,8 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             topic_config_snapshot: ArcSwap::from_pointee(HashMap::new()),
             data_version: ArcMut::new(DataVersion::default()),
             persist_lock: Arc::new(parking_lot::Mutex::new(())),
+            async_topic_create_pending_count: Arc::new(AtomicU64::new(0)),
+            async_topic_create_spawn_failure_count: Arc::new(AtomicU64::new(0)),
             broker_runtime_inner,
             #[cfg(feature = "rocksdb_store")]
             rocksdb_config_manager: None,
@@ -294,6 +301,14 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
         self.topic_config_snapshot.store(Arc::new(snapshot));
     }
 
+    pub(crate) fn async_topic_create_pending_count(&self) -> u64 {
+        self.async_topic_create_pending_count.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn async_topic_create_spawn_failure_count(&self) -> u64 {
+        self.async_topic_create_spawn_failure_count.load(Ordering::Acquire)
+    }
+
     pub fn build_serialize_wrapper(
         &self,
         topic_config_table: HashMap<CheetahString, TopicConfig>,
@@ -418,17 +433,8 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
-            let _lock = self.persist_lock.lock();
-            self.data_version.mut_from_ref().next_version_with(
-                self.broker_runtime_inner
-                    .message_store()
-                    .unwrap()
-                    .get_state_machine_version(),
-            );
-            self.persist();
-            drop(_lock);
-
-            self.register_broker_data(config_for_register).await;
+            self.next_topic_config_data_version();
+            self.persist_and_register_created_topic(config_for_register, true).await;
             Self::record_topic_create_latency(start_time);
         }
         topic_config
@@ -478,17 +484,8 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
-            let _lock = self.persist_lock.lock();
-            self.data_version.mut_from_ref().next_version_with(
-                self.broker_runtime_inner
-                    .message_store()
-                    .unwrap()
-                    .get_state_machine_version(),
-            );
-            self.persist();
-            drop(_lock);
-
-            self.register_broker_data(config_for_register).await;
+            self.next_topic_config_data_version();
+            self.persist_and_register_created_topic(config_for_register, true).await;
             Self::record_topic_create_latency(start_time);
         }
         topic_config
@@ -504,6 +501,98 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
         } else {
             BrokerRuntimeInner::register_increment_broker_data(broker_runtime_inner, vec![topic_config], data_version)
                 .await;
+        }
+    }
+
+    fn next_topic_config_data_version(&mut self) {
+        let state_machine_version = self
+            .broker_runtime_inner
+            .message_store()
+            .map(|message_store| message_store.get_state_machine_version())
+            .unwrap_or_default();
+        self.data_version
+            .mut_from_ref()
+            .next_version_with(state_machine_version);
+    }
+
+    async fn persist_and_register_created_topic(&mut self, topic_config: ArcMut<TopicConfig>, register: bool) {
+        if self
+            .broker_runtime_inner
+            .broker_config()
+            .async_topic_create_persist_enable
+            && self.enqueue_async_topic_create_persist(topic_config.clone(), register)
+        {
+            return;
+        }
+
+        self.persist_created_topic_sync(topic_config, register).await;
+    }
+
+    async fn persist_created_topic_sync(&mut self, topic_config: ArcMut<TopicConfig>, register: bool) {
+        let _lock = self.persist_lock.lock();
+        self.persist();
+        drop(_lock);
+
+        if register {
+            self.register_broker_data(topic_config).await;
+        }
+    }
+
+    fn enqueue_async_topic_create_persist(&self, topic_config: ArcMut<TopicConfig>, register: bool) -> bool {
+        self.async_topic_create_pending_count.fetch_add(1, Ordering::AcqRel);
+
+        let pending_count_for_task = self.async_topic_create_pending_count.clone();
+        let pending_count_for_spawn_failure = self.async_topic_create_pending_count.clone();
+        let spawn_failure_count = self.async_topic_create_spawn_failure_count.clone();
+        let broker_runtime_inner = self.broker_runtime_inner.clone();
+        let task = async move {
+            let topic_name = topic_config
+                .topic_name
+                .as_ref()
+                .map_or_else(|| "<unknown>".to_string(), ToString::to_string);
+            {
+                let topic_config_manager = broker_runtime_inner.topic_config_manager();
+                let _lock = topic_config_manager.persist_lock.lock();
+                topic_config_manager.persist();
+            }
+
+            if register {
+                let broker_config = broker_runtime_inner.broker_config().clone();
+                if broker_config.enable_single_topic_register {
+                    broker_runtime_inner.register_single_topic_all(topic_config).await;
+                } else {
+                    let data_version = broker_runtime_inner.topic_config_manager().data_version_ref().clone();
+                    BrokerRuntimeInner::register_increment_broker_data(
+                        broker_runtime_inner.clone(),
+                        vec![topic_config],
+                        data_version,
+                    )
+                    .await;
+                }
+            }
+
+            pending_count_for_task.fetch_sub(1, Ordering::AcqRel);
+            info!("async topic create persist/register completed, topic={}", topic_name);
+        };
+
+        if let Some(task_group) = self.broker_runtime_inner.broker_task_group_or_current(
+            "broker.topic-config.async-create",
+            "async topic create persist requested without an active broker runtime; falling back to synchronous \
+             persist",
+        ) {
+            match task_group.spawn("broker.topic-config.async-create.persist", TaskKind::Worker, task) {
+                Ok(_) => true,
+                Err(error) => {
+                    pending_count_for_spawn_failure.fetch_sub(1, Ordering::AcqRel);
+                    spawn_failure_count.fetch_add(1, Ordering::AcqRel);
+                    warn!(?error, "failed to spawn async topic create persist task");
+                    false
+                }
+            }
+        } else {
+            pending_count_for_spawn_failure.fetch_sub(1, Ordering::AcqRel);
+            spawn_failure_count.fetch_add(1, Ordering::AcqRel);
+            false
         }
     }
 
@@ -667,17 +756,8 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.rebuild_topic_config_snapshot();
             let config_for_register = topic_config.clone().unwrap();
 
-            let _lock = self.persist_lock.lock();
-            self.data_version.mut_from_ref().next_version_with(
-                self.broker_runtime_inner
-                    .message_store()
-                    .unwrap()
-                    .get_state_machine_version(),
-            );
-            self.persist();
-            drop(_lock);
-
-            self.register_broker_data(config_for_register).await;
+            self.next_topic_config_data_version();
+            self.persist_and_register_created_topic(config_for_register, true).await;
         }
         topic_config
     }
@@ -772,18 +852,11 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.rebuild_topic_config_snapshot();
             let config_for_register = if register { result.clone() } else { None };
 
-            let _lock = self.persist_lock.lock();
-            self.data_version.mut_from_ref().next_version_with(
-                self.broker_runtime_inner
-                    .message_store()
-                    .unwrap()
-                    .get_state_machine_version(),
-            );
-            self.persist();
-            drop(_lock);
-
+            self.next_topic_config_data_version();
             if let Some(config) = config_for_register {
-                self.register_broker_data(config).await;
+                self.persist_and_register_created_topic(config, true).await;
+            } else if let Some(config) = result.clone() {
+                self.persist_and_register_created_topic(config, false).await;
             }
             Self::record_topic_create_latency(start_time);
         }
@@ -1223,6 +1296,14 @@ mod tests {
             .expect("decoded topic should be visible through snapshot");
         assert_eq!(config.read_queue_nums, 6);
         assert_eq!(config.write_queue_nums, 7);
+    }
+
+    #[test]
+    fn async_topic_create_runtime_counters_start_empty() {
+        let (_temp_dir, manager) = test_topic_config_manager();
+
+        assert_eq!(manager.async_topic_create_pending_count(), 0);
+        assert_eq!(manager.async_topic_create_spawn_failure_count(), 0);
     }
 }
 

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -188,6 +188,10 @@ mod defaults {
         true
     }
 
+    pub fn async_topic_create_persist_enable() -> bool {
+        false
+    }
+
     pub fn enable_single_topic_register() -> bool {
         true
     }
@@ -936,6 +940,9 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::auto_create_topic_enable")]
     pub auto_create_topic_enable: bool,
 
+    #[serde(default = "defaults::async_topic_create_persist_enable")]
+    pub async_topic_create_persist_enable: bool,
+
     #[serde(default = "defaults::enable_single_topic_register")]
     pub enable_single_topic_register: bool,
 
@@ -1437,6 +1444,7 @@ impl Default for BrokerConfig {
             duplication_enable: false,
             start_accept_send_request_time_stamp: 0,
             auto_create_topic_enable: true,
+            async_topic_create_persist_enable: defaults::async_topic_create_persist_enable(),
             enable_single_topic_register: true,
             broker_topic_enable: true,
             cluster_topic_enable: true,
@@ -1781,6 +1789,10 @@ impl BrokerConfig {
         properties.insert(
             "autoCreateTopicEnable".into(),
             self.auto_create_topic_enable.to_string().into(),
+        );
+        properties.insert(
+            "asyncTopicCreatePersistEnable".into(),
+            self.async_topic_create_persist_enable.to_string().into(),
         );
         properties.insert(
             "enableSingleTopicRegister".into(),
@@ -2299,6 +2311,7 @@ mod tests {
         let config = BrokerConfig::default();
 
         assert!(config.broker_fast_failure_enable);
+        assert!(!config.async_topic_create_persist_enable);
         assert!(!config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 200);
         assert_eq!(config.sync_flush_backlog_reject_depth, 0);
@@ -2540,6 +2553,7 @@ mod tests {
         let config: BrokerConfig = serde_json::from_str(
             r#"{
                 "brokerFastFailureEnable": false,
+                "asyncTopicCreatePersistEnable": true,
                 "sendRequestExecutorDetachedEnable": true,
                 "waitTimeMillsInSendQueue": 201,
                 "syncFlushBacklogRejectDepth": 32,
@@ -2558,6 +2572,7 @@ mod tests {
         .expect("broker config should deserialize Java fast failure keys");
 
         assert!(!config.broker_fast_failure_enable);
+        assert!(config.async_topic_create_persist_enable);
         assert!(config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 201);
         assert_eq!(config.sync_flush_backlog_reject_depth, 32);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7790

### Brief Description

Add default-off `asyncTopicCreatePersistEnable` support for auto-created topics. Topic memory insertion, snapshot rebuild, and data-version update still happen on the request path; when the new switch is enabled, config persist/register work is submitted to the broker task group, with spawn failure falling back to the existing synchronous path. Expose pending and spawn-failure counters through broker runtime info.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common default_broker_config_uses_java_fast_failure_defaults --lib` passed.
- `cargo test -p rocketmq-common serde_accepts_java_fast_failure_camel_case_keys --lib` passed.
- `cargo test -p rocketmq-broker async_topic_create_runtime_counters_start_empty --lib` passed.
- `cargo test -p rocketmq-broker select_topic_config_reads_snapshot_after_put_and_delete --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.