### PR TITLE
[ISSUE #7792]✨Make authorization cache positive-only by default

### DIFF
--- a/rocketmq-auth/benches/auth_hot_path_bench.rs
+++ b/rocketmq-auth/benches/auth_hot_path_bench.rs
@@ -253,6 +253,55 @@ fn bench_stateful_authorization_cache(c: &mut Criterion) {
     });
 }
 
+fn bench_stateful_authorization_negative_cache(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime should build");
+    let _guard = runtime.enter();
+    let mut disabled_config = AuthConfig {
+        config_name: CheetahString::from_static_str("negative-cache-disabled"),
+        authorization_enabled: true,
+        stateful_authorization_cache_max_num: 1024,
+        stateful_authorization_cache_expired_second: 60,
+        stateful_authorization_cache_negative_enable: false,
+        ..AuthConfig::default()
+    };
+    let disabled_strategy = StatefulAuthorizationStrategy::new_with_acl_generation(
+        disabled_config.clone(),
+        None,
+        Arc::new(AtomicU64::new(0)),
+    )
+    .expect("benchmark authorization strategy should build");
+    disabled_config.stateful_authorization_cache_negative_enable = true;
+    disabled_config.config_name = CheetahString::from_static_str("negative-cache-enabled");
+    let enabled_strategy =
+        StatefulAuthorizationStrategy::new_with_acl_generation(disabled_config, None, Arc::new(AtomicU64::new(0)))
+            .expect("benchmark authorization strategy should build");
+    let mut context = DefaultAuthorizationContext::of(
+        "alice",
+        rocketmq_auth::authentication::enums::subject_type::SubjectType::User,
+        Resource::of_topic("TopicDenied"),
+        Action::Pub,
+        "127.0.0.1",
+    );
+    context.set_channel_id("channel-denied".to_owned());
+
+    assert!(disabled_strategy.evaluate(&context).is_err());
+    assert_eq!(disabled_strategy.cache_size(), 0);
+    assert!(enabled_strategy.evaluate(&context).is_err());
+    assert_eq!(enabled_strategy.cache_size(), 1);
+
+    let mut group = c.benchmark_group("auth_stateful_authorization_negative_cache");
+    group.bench_function("deny_no_cache", |b| {
+        b.iter(|| black_box(disabled_strategy.evaluate(black_box(&context)).is_err()))
+    });
+    group.bench_function("deny_negative_cache_enabled", |b| {
+        b.iter(|| black_box(enabled_strategy.evaluate(black_box(&context)).is_err()))
+    });
+    group.finish();
+}
+
 struct AllowAuthenticationProvider;
 
 impl AuthenticationProvider for AllowAuthenticationProvider {
@@ -290,5 +339,6 @@ criterion_group!(
     bench_acl_authorization,
     bench_stateful_authentication_cache,
     bench_stateful_authorization_cache,
+    bench_stateful_authorization_negative_cache,
 );
 criterion_main!(benches);

--- a/rocketmq-auth/src/authorization/strategy/abstract_authorization_strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy/abstract_authorization_strategy.rs
@@ -287,6 +287,7 @@ mod tests {
             stateful_authentication_cache_expired_second: 300,
             stateful_authorization_cache_max_num: 1000,
             stateful_authorization_cache_expired_second: 300,
+            stateful_authorization_cache_negative_enable: false,
         }
     }
 

--- a/rocketmq-auth/src/authorization/strategy/stateful_authorization_strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy/stateful_authorization_strategy.rs
@@ -154,6 +154,7 @@ pub struct StatefulAuthorizationStrategy {
 
     /// Last generation observed by this strategy, used to drop old entries promptly.
     last_seen_acl_generation: AtomicU64,
+    cache_negative_result: bool,
     metrics: AuthMetrics,
 }
 
@@ -196,6 +197,7 @@ impl StatefulAuthorizationStrategy {
     ) -> StrategyResult<Self> {
         let cache_ttl = Duration::from_secs(auth_config.stateful_authorization_cache_expired_second as u64);
         let cache_max_size = auth_config.stateful_authorization_cache_max_num as usize;
+        let cache_negative_result = auth_config.stateful_authorization_cache_negative_enable;
 
         let base = AbstractAuthorizationStrategy::new(auth_config, metadata_service)?;
         let initial_generation = acl_generation.load(Ordering::Acquire);
@@ -213,6 +215,7 @@ impl StatefulAuthorizationStrategy {
             request_counter: AtomicUsize::new(0),
             acl_generation,
             last_seen_acl_generation: AtomicU64::new(initial_generation),
+            cache_negative_result,
             metrics,
         })
     }
@@ -402,8 +405,9 @@ impl AuthorizationStrategy for StatefulAuthorizationStrategy {
 
         let result = block_on_base_authorization(&self.base, context);
 
-        // Cache the result
-        {
+        // Cache granted results by default. Denied results are cached only when
+        // explicitly enabled because ACL updates must take effect conservatively.
+        if result.is_ok() || self.cache_negative_result {
             self.evict_if_full();
 
             let mut cache = self.write_cache_recovering();
@@ -428,8 +432,11 @@ impl AuthorizationStrategy for StatefulAuthorizationStrategy {
 #[cfg(test)]
 mod tests {
     use cheetah_string::CheetahString;
+    use rocketmq_common::common::action::Action;
 
     use super::*;
+    use crate::authentication::enums::subject_type::SubjectType;
+    use crate::authorization::model::resource::Resource;
 
     fn create_test_config() -> AuthConfig {
         AuthConfig {
@@ -464,6 +471,7 @@ mod tests {
             stateful_authentication_cache_expired_second: 300,
             stateful_authorization_cache_max_num: 100,
             stateful_authorization_cache_expired_second: 60,
+            stateful_authorization_cache_negative_enable: false,
         }
     }
 
@@ -596,6 +604,47 @@ mod tests {
             assert!(strategy.evaluate(&context).is_ok());
         });
 
+        assert_eq!(strategy.cache_size(), 1);
+    }
+
+    #[test]
+    fn denied_authorization_is_not_cached_by_default() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let config = create_test_config();
+        let strategy = StatefulAuthorizationStrategy::new(config, None).unwrap();
+        let mut context = DefaultAuthorizationContext::of(
+            "alice",
+            SubjectType::User,
+            Resource::of_topic("TopicA"),
+            Action::Pub,
+            "127.0.0.1",
+        );
+        context.set_channel_id("ch-denied-default".to_string());
+
+        assert!(strategy.evaluate(&context).is_err());
+        assert_eq!(strategy.cache_size(), 0);
+    }
+
+    #[test]
+    fn denied_authorization_can_be_cached_when_enabled() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let mut config = create_test_config();
+        config.stateful_authorization_cache_negative_enable = true;
+        let strategy = StatefulAuthorizationStrategy::new(config, None).unwrap();
+        let mut context = DefaultAuthorizationContext::of(
+            "alice",
+            SubjectType::User,
+            Resource::of_topic("TopicA"),
+            Action::Pub,
+            "127.0.0.1",
+        );
+        context.set_channel_id("ch-denied-cached".to_string());
+
+        assert!(strategy.evaluate(&context).is_err());
         assert_eq!(strategy.cache_size(), 1);
     }
 }

--- a/rocketmq-auth/src/authorization/strategy/stateless_authorization_strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy/stateless_authorization_strategy.rs
@@ -178,6 +178,7 @@ mod tests {
             stateful_authentication_cache_expired_second: 300,
             stateful_authorization_cache_max_num: 1000,
             stateful_authorization_cache_expired_second: 300,
+            stateful_authorization_cache_negative_enable: false,
         }
     }
 

--- a/rocketmq-auth/src/config.rs
+++ b/rocketmq-auth/src/config.rs
@@ -63,6 +63,7 @@ pub struct AuthConfig {
     pub stateful_authentication_cache_expired_second: u32,
     pub stateful_authorization_cache_max_num: u32,
     pub stateful_authorization_cache_expired_second: u32,
+    pub stateful_authorization_cache_negative_enable: bool,
 }
 
 impl fmt::Debug for AuthConfig {
@@ -123,6 +124,10 @@ impl fmt::Debug for AuthConfig {
                 "stateful_authorization_cache_expired_second",
                 &self.stateful_authorization_cache_expired_second,
             )
+            .field(
+                "stateful_authorization_cache_negative_enable",
+                &self.stateful_authorization_cache_negative_enable,
+            )
             .finish()
     }
 }
@@ -175,6 +180,7 @@ impl Default for AuthConfig {
             stateful_authentication_cache_expired_second: 60,
             stateful_authorization_cache_max_num: 10000,
             stateful_authorization_cache_expired_second: 60,
+            stateful_authorization_cache_negative_enable: false,
         }
     }
 }
@@ -227,6 +233,7 @@ mod tests {
         assert_eq!(config.stateful_authentication_cache_expired_second, 60);
         assert_eq!(config.stateful_authorization_cache_max_num, 10000);
         assert_eq!(config.stateful_authorization_cache_expired_second, 60);
+        assert!(!config.stateful_authorization_cache_negative_enable);
     }
 
     #[test]
@@ -238,6 +245,7 @@ aclFileWatchEnabled: true
 aclFileWatchIntervalMillis: 250
 signatureAlgorithm: HmacSHA256
 requestTimestampExpiredMillis: 300000
+statefulAuthorizationCacheNegativeEnable: true
 "#,
         )
         .unwrap();
@@ -247,6 +255,7 @@ requestTimestampExpiredMillis: 300000
         assert_eq!(config.acl_file_watch_interval_millis, 250);
         assert_eq!(config.signature_algorithm, SignatureAlgorithm::HmacSha256);
         assert_eq!(config.request_timestamp_expired_millis, 300_000);
+        assert!(config.stateful_authorization_cache_negative_enable);
     }
 
     #[test]

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -201,6 +201,7 @@ fn build_auth_config(broker_config: &BrokerConfig) -> AuthConfig {
         stateful_authentication_cache_expired_second: broker_config.stateful_authentication_cache_expired_second,
         stateful_authorization_cache_max_num: broker_config.stateful_authorization_cache_max_num,
         stateful_authorization_cache_expired_second: broker_config.stateful_authorization_cache_expired_second,
+        stateful_authorization_cache_negative_enable: broker_config.stateful_authorization_cache_negative_enable,
     }
 }
 
@@ -4937,6 +4938,7 @@ mod tests {
             stateful_authentication_cache_expired_second: 32,
             stateful_authorization_cache_max_num: 41,
             stateful_authorization_cache_expired_second: 42,
+            stateful_authorization_cache_negative_enable: true,
             ..BrokerConfig::default()
         };
 
@@ -4971,6 +4973,7 @@ mod tests {
         assert_eq!(auth_config.stateful_authentication_cache_expired_second, 32);
         assert_eq!(auth_config.stateful_authorization_cache_max_num, 41);
         assert_eq!(auth_config.stateful_authorization_cache_expired_second, 42);
+        assert!(auth_config.stateful_authorization_cache_negative_enable);
     }
 
     #[tokio::test]

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -606,6 +606,10 @@ mod defaults {
         60
     }
 
+    pub fn stateful_authorization_cache_negative_enable() -> bool {
+        false
+    }
+
     pub fn transaction_check_interval() -> u64 {
         30_000
     }
@@ -1384,6 +1388,9 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::stateful_authorization_cache_expired_second")]
     pub stateful_authorization_cache_expired_second: u32,
+
+    #[serde(default = "defaults::stateful_authorization_cache_negative_enable")]
+    pub stateful_authorization_cache_negative_enable: bool,
 }
 
 impl Default for BrokerConfig {
@@ -1590,6 +1597,7 @@ impl Default for BrokerConfig {
             stateful_authentication_cache_expired_second: defaults::stateful_authentication_cache_expired_second(),
             stateful_authorization_cache_max_num: defaults::stateful_authorization_cache_max_num(),
             stateful_authorization_cache_expired_second: defaults::stateful_authorization_cache_expired_second(),
+            stateful_authorization_cache_negative_enable: defaults::stateful_authorization_cache_negative_enable(),
         }
     }
 }
@@ -2125,6 +2133,10 @@ impl BrokerConfig {
             "statefulAuthorizationCacheExpiredSecond".into(),
             self.stateful_authorization_cache_expired_second.to_string().into(),
         );
+        properties.insert(
+            "statefulAuthorizationCacheNegativeEnable".into(),
+            self.stateful_authorization_cache_negative_enable.to_string().into(),
+        );
         for (key, value) in self.broker_server_config.tls_config.java_property_entries() {
             properties.insert(key.into(), value.into());
         }
@@ -2185,6 +2197,20 @@ mod tests {
         assert!(!config.lite_lag_latency_metrics_enable);
         assert!(!config.lite_lag_count_metrics_enable);
         assert_eq!(config.lite_lag_latency_top_k, 50);
+    }
+
+    #[test]
+    fn default_broker_config_disables_authorization_negative_cache() {
+        let config = BrokerConfig::default();
+
+        assert!(!config.stateful_authorization_cache_negative_enable);
+        assert_eq!(
+            config
+                .get_properties()
+                .get("statefulAuthorizationCacheNegativeEnable")
+                .map(CheetahString::as_str),
+            Some("false")
+        );
     }
 
     #[test]

--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -262,6 +262,7 @@ pub struct ProxyAuthConfig {
     pub stateful_authentication_cache_expired_second: u32,
     pub stateful_authorization_cache_max_num: u32,
     pub stateful_authorization_cache_expired_second: u32,
+    pub stateful_authorization_cache_negative_enable: bool,
 }
 
 impl fmt::Debug for ProxyAuthConfig {
@@ -322,6 +323,10 @@ impl fmt::Debug for ProxyAuthConfig {
                 "stateful_authorization_cache_expired_second",
                 &self.stateful_authorization_cache_expired_second,
             )
+            .field(
+                "stateful_authorization_cache_negative_enable",
+                &self.stateful_authorization_cache_negative_enable,
+            )
             .finish()
     }
 }
@@ -368,6 +373,7 @@ impl Default for ProxyAuthConfig {
             stateful_authentication_cache_expired_second: 60,
             stateful_authorization_cache_max_num: 10000,
             stateful_authorization_cache_expired_second: 60,
+            stateful_authorization_cache_negative_enable: false,
         }
     }
 }
@@ -412,6 +418,7 @@ impl ProxyAuthConfig {
             stateful_authentication_cache_expired_second: self.stateful_authentication_cache_expired_second,
             stateful_authorization_cache_max_num: self.stateful_authorization_cache_max_num,
             stateful_authorization_cache_expired_second: self.stateful_authorization_cache_expired_second,
+            stateful_authorization_cache_negative_enable: self.stateful_authorization_cache_negative_enable,
         }
     }
 }
@@ -485,6 +492,7 @@ mod tests {
             stateful_authentication_cache_expired_second: 32,
             stateful_authorization_cache_max_num: 41,
             stateful_authorization_cache_expired_second: 42,
+            stateful_authorization_cache_negative_enable: true,
             ..ProxyAuthConfig::default()
         };
 
@@ -530,6 +538,7 @@ mod tests {
         assert_eq!(auth_config.stateful_authentication_cache_expired_second, 32);
         assert_eq!(auth_config.stateful_authorization_cache_max_num, 41);
         assert_eq!(auth_config.stateful_authorization_cache_expired_second, 42);
+        assert!(auth_config.stateful_authorization_cache_negative_enable);
     }
 
     #[test]
@@ -553,6 +562,7 @@ statefulAuthenticationCacheMaxNum: 31
 statefulAuthenticationCacheExpiredSecond: 32
 statefulAuthorizationCacheMaxNum: 41
 statefulAuthorizationCacheExpiredSecond: 42
+statefulAuthorizationCacheNegativeEnable: true
 "#,
                 config::FileFormat::Yaml,
             ))
@@ -577,6 +587,7 @@ statefulAuthorizationCacheExpiredSecond: 42
         assert_eq!(config.stateful_authentication_cache_expired_second, 32);
         assert_eq!(config.stateful_authorization_cache_max_num, 41);
         assert_eq!(config.stateful_authorization_cache_expired_second, 42);
+        assert!(config.stateful_authorization_cache_negative_enable);
     }
 
     #[test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7792

### Brief Description

Make stateful authorization cache denied results only when `statefulAuthorizationCacheNegativeEnable` is explicitly enabled. Keep granted-result caching, TTL/max-size bounds, and ACL generation invalidation unchanged, and propagate the new default-off setting through broker and proxy auth configuration.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-common default_broker_config_disables_authorization_negative_cache --lib`
- `cargo test -p rocketmq-broker build_auth_config_maps_java_auth_integration_fields --lib`
- `cargo test -p rocketmq-auth --lib`
- `cargo test -p rocketmq-auth --tests --no-run`
- `cargo test -p rocketmq-auth --bench auth_hot_path_bench --no-run`
- `cargo test -p rocketmq-proxy proxy_auth_config_maps_acl_file_fields_to_auth_config --lib`
- `cargo test -p rocketmq-proxy proxy_auth_config_deserializes_acl_file_camel_case_keys --lib`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control whether denied authorization results are cached.
  * The setting is available across broker and proxy configuration and is reflected in runtime auth behavior.

* **Bug Fixes**
  * Denied requests now behave consistently with the chosen cache setting, avoiding unwanted cache growth when negative caching is disabled.
  * Default behavior remains unchanged unless the new option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->