### PR TITLE
[ISSUE #7794]✨Reduce SendMessage response header allocation

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -894,6 +894,7 @@ where
         let auth_type = ext_fields.get(BrokerStatsManager::ACCOUNT_AUTH_TYPE).cloned();
         let owner_parent = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_PARENT).cloned();
         let owner_self = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_SELF).cloned();
+        let has_send_message_hook = self.has_send_message_hook();
 
         if send_ok {
             self.update_broker_stats_on_success(
@@ -921,29 +922,25 @@ where
                 if rewrite_result.is_some() {
                     return (rewrite_result, false);
                 }
+
+                if has_send_message_hook {
+                    self.update_send_context_on_success(
+                        send_message_context,
+                        response_header,
+                        &put_message_result,
+                        owner,
+                        auth_type,
+                        owner_parent,
+                        owner_self,
+                    );
+                }
             }
 
             response.set_opaque_mut(request.opaque());
             ctx.write_response_ref(response).await;
-
-            if self.has_send_message_hook() {
-                let response_header = response
-                    .read_custom_header_mut::<SendMessageResponseHeader>()
-                    .expect("SendMessageResponseHeader must exist");
-
-                self.update_send_context_on_success(
-                    send_message_context,
-                    response_header,
-                    &put_message_result,
-                    owner,
-                    auth_type,
-                    owner_parent,
-                    owner_self,
-                );
-            }
             (None, true)
         } else {
-            if self.has_send_message_hook() {
+            if has_send_message_hook {
                 let request_body_len = request.body().as_ref().map_or(0, |body| body.len() as i32);
                 self.update_send_context_on_failure(
                     send_message_context,

--- a/rocketmq-remoting/benches/encode_decode_bench.rs
+++ b/rocketmq-remoting/benches/encode_decode_bench.rs
@@ -30,6 +30,7 @@ use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequ
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::parse_request_header;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::LanguageCode;
 use rocketmq_remoting::protocol::SerializeType;
@@ -115,6 +116,52 @@ fn create_send_message_v2_command() -> RemotingCommand {
     let header = create_send_message_header();
     let header_v2 = SendMessageRequestHeaderV2::create_send_message_request_header_v2(&header);
     RemotingCommand::create_remoting_command(RequestCode::SendMessageV2).set_ext_fields(header_v2.to_map().unwrap())
+}
+
+fn create_send_message_response_header() -> SendMessageResponseHeader {
+    SendMessageResponseHeader::new(
+        CheetahString::from_static_str("C0A8010100002A9F000000000001"),
+        3,
+        1_024_768,
+        Some(CheetahString::from_static_str("TX-123456789")),
+        None,
+        Some(CheetahString::from_static_str("handle-v1-topic-broker-1700000000000")),
+    )
+}
+
+fn create_send_message_response_command_fast() -> RemotingCommand {
+    RemotingCommand::create_response_command_with_header(create_send_message_response_header())
+        .set_opaque(12345)
+        .set_serialize_type(SerializeType::ROCKETMQ)
+}
+
+fn create_send_message_response_command_ext_fields() -> RemotingCommand {
+    let mut ext_fields = HashMap::new();
+    ext_fields.insert(
+        CheetahString::from_static_str("msgId"),
+        CheetahString::from_static_str("C0A8010100002A9F000000000001"),
+    );
+    ext_fields.insert(
+        CheetahString::from_static_str("queueId"),
+        CheetahString::from_static_str("3"),
+    );
+    ext_fields.insert(
+        CheetahString::from_static_str("queueOffset"),
+        CheetahString::from_static_str("1024768"),
+    );
+    ext_fields.insert(
+        CheetahString::from_static_str("transactionId"),
+        CheetahString::from_static_str("TX-123456789"),
+    );
+    ext_fields.insert(
+        CheetahString::from_static_str("recallHandle"),
+        CheetahString::from_static_str("handle-v1-topic-broker-1700000000000"),
+    );
+
+    RemotingCommand::create_response_command()
+        .set_opaque(12345)
+        .set_serialize_type(SerializeType::ROCKETMQ)
+        .set_ext_fields(ext_fields)
 }
 
 /// Benchmark: Encode simple command (JSON)
@@ -340,6 +387,37 @@ fn bench_decode_send_message_header(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_encode_send_message_response(c: &mut Criterion) {
+    let mut group = c.benchmark_group("send_message_response_encode");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("typed_fast_header", |b| {
+        b.iter_batched(
+            create_send_message_response_command_fast,
+            |mut cmd| {
+                let mut dst = BytesMut::new();
+                cmd.fast_header_encode(&mut dst);
+                dst
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("ext_fields_map", |b| {
+        b.iter_batched(
+            create_send_message_response_command_ext_fields,
+            |mut cmd| {
+                let mut dst = BytesMut::new();
+                cmd.fast_header_encode(&mut dst);
+                dst
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
 /// Benchmark: Full roundtrip (encode + decode) JSON
 fn bench_roundtrip_json(c: &mut Criterion) {
     c.bench_function("roundtrip_json_complex", |b| {
@@ -437,7 +515,8 @@ criterion_group!(
     bench_encode_json_very_complex,
     bench_encode_rocketmq_simple,
     bench_encode_rocketmq_complex,
-    bench_encode_rocketmq_very_complex
+    bench_encode_rocketmq_very_complex,
+    bench_encode_send_message_response
 );
 
 criterion_group!(

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -99,13 +99,36 @@ impl SendMessageResponseHeader {
     pub fn set_recall_handle(&mut self, recall_handle: Option<CheetahString>) {
         self.recall_handle = recall_handle;
     }
+
+    fn write_i64(out: &mut bytes::BytesMut, key: &str, value: i64) {
+        let mut buffer = [0_u8; 20];
+        let mut cursor = buffer.len();
+        let mut number = value.unsigned_abs();
+
+        loop {
+            cursor -= 1;
+            buffer[cursor] = b'0' + (number % 10) as u8;
+            number /= 10;
+            if number == 0 {
+                break;
+            }
+        }
+
+        if value.is_negative() {
+            cursor -= 1;
+            buffer[cursor] = b'-';
+        }
+
+        let value = std::str::from_utf8(&buffer[cursor..]).expect("decimal integer bytes are valid UTF-8");
+        Self::write_if_not_null(out, key, value);
+    }
 }
 
 impl FastCodesHeader for SendMessageResponseHeader {
     fn encode_fast(&mut self, out: &mut bytes::BytesMut) {
         Self::write_if_not_null(out, "msgId", self.msg_id.as_str());
-        Self::write_if_not_null(out, "queueId", self.queue_id.to_string().as_str());
-        Self::write_if_not_null(out, "queueOffset", self.queue_offset.to_string().as_str());
+        Self::write_i64(out, "queueId", i64::from(self.queue_id));
+        Self::write_i64(out, "queueOffset", self.queue_offset);
         if let Some(ref transaction_id) = self.transaction_id {
             Self::write_if_not_null(out, "transactionId", transaction_id.as_str());
         }
@@ -255,5 +278,19 @@ mod tests {
         assert_eq!(header.transaction_id(), Some("tx456"));
         assert_eq!(header.batch_uniq_id(), Some("batch789"));
         assert_eq!(header.recall_handle(), Some("recall-handle"));
+    }
+
+    #[test]
+    fn send_message_response_header_fast_encode_writes_signed_numeric_fields() {
+        let mut header = SendMessageResponseHeader::new(CheetahString::from("msg123"), -1, -42, None, None, None);
+        let mut out = bytes::BytesMut::new();
+
+        header.encode_fast(&mut out);
+
+        let encoded = String::from_utf8(out.to_vec()).unwrap();
+        assert!(encoded.contains("queueId"));
+        assert!(encoded.contains("-1"));
+        assert!(encoded.contains("queueOffset"));
+        assert!(encoded.contains("-42"));
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7794

### Brief Description

Reduce SendMessage response header hot-path allocation by writing numeric `SendMessageResponseHeader` fields through a stack decimal buffer instead of temporary `String`s. Reuse the already-mutated response header when updating send hook context before writeback, and add a dedicated remoting benchmark comparing typed fast response header encoding with an `ext_fields` map path.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-remoting send_message_response_header_fast_encode_writes_signed_numeric_fields --lib`
- `cargo test -p rocketmq-remoting --bench encode_decode_bench --no-run`
- `cargo test -p rocketmq-broker send_message_hook --lib`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message response encoding so signed queue IDs and offsets are preserved correctly.
  * Streamlined message send handling to avoid repeated hook checks and ensure context updates happen only when needed.

* **Tests**
  * Added coverage for signed-value encoding behavior.

* **Chores**
  * Added benchmark coverage for message response encoding performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->