### PR TITLE
[ISSUE #7796]✨Add sampled SendMessage hot-path metrics

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -228,6 +228,7 @@ fn build_broker_observability_config(broker_config: &BrokerConfig) -> rocketmq_o
     config.metrics.export_interval_millis = broker_config.metrics_export_interval_millis;
     config.metrics.export_timeout_millis = broker_config.otlp_exporter_timeout_millis;
     config.metrics.cardinality_limit = broker_config.metrics_cardinality_limit;
+    config.metrics.sample_ratio = broker_config.metrics_sample_ratio;
     config.metrics.topic_label_enabled = broker_config.metrics_topic_label_enabled;
     config.metrics.consumer_group_label_enabled = broker_config.metrics_consumer_group_label_enabled;
     config.otlp.endpoint = broker_config.otlp_exporter_endpoint.to_string();
@@ -1557,6 +1558,9 @@ impl BrokerRuntime {
                         config.metrics.topic_label_enabled,
                         config.metrics.consumer_group_label_enabled,
                     );
+                    let sampling_config = crate::metrics::broker_metrics_manager::BrokerMetricsSamplingConfig::new(
+                        config.metrics.sample_ratio,
+                    );
                     let attributes_supplier =
                         Arc::new(crate::metrics::broker_metrics_manager::BrokerAttributesSupplier::new(
                             self.inner.broker_config.broker_identity.broker_cluster_name.to_string(),
@@ -1567,10 +1571,11 @@ impl BrokerRuntime {
                     let consumer_group_num_inner = self.inner.clone();
                     let producer_connections_inner = self.inner.clone();
                     let consumer_connections_inner = self.inner.clone();
-                    crate::metrics::broker_metrics_manager::BrokerMetricsManager::init_global_with_observables_and_label_config(
+                    crate::metrics::broker_metrics_manager::BrokerMetricsManager::init_global_with_observables_and_configs(
                         provider,
                         attributes_supplier,
                         label_config,
+                        sampling_config,
                         None::<fn() -> Vec<(String, i64)>>,
                         move || broker_permission,
                         move || {
@@ -4855,6 +4860,7 @@ mod tests {
             otlp_exporter_headers: "authorization:Bearer token,tenant:rocketmq".into(),
             otlp_exporter_timeout_millis: 1_500,
             metrics_cardinality_limit: 64,
+            metrics_sample_ratio: 0.25,
             metrics_topic_label_enabled: false,
             metrics_consumer_group_label_enabled: true,
             trace_record_message_id: true,
@@ -4880,6 +4886,7 @@ mod tests {
         assert_eq!(config.otlp.timeout_millis, 1_500);
         assert_eq!(config.metrics.export_timeout_millis, 1_500);
         assert_eq!(config.metrics.cardinality_limit, 64);
+        assert!((config.metrics.sample_ratio - 0.25).abs() < f64::EPSILON);
         assert!(!config.metrics.topic_label_enabled);
         assert!(config.metrics.consumer_group_label_enabled);
         assert!(config.traces.record_message_id);

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -119,6 +119,10 @@ mod defaults {
         10_000
     }
 
+    pub fn metrics_sample_ratio() -> f64 {
+        1.0
+    }
+
     pub fn metrics_label_enabled() -> bool {
         true
     }
@@ -860,6 +864,9 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::metrics_cardinality_limit")]
     pub metrics_cardinality_limit: usize,
 
+    #[serde(default = "defaults::metrics_sample_ratio")]
+    pub metrics_sample_ratio: f64,
+
     #[serde(default = "defaults::metrics_label_enabled")]
     pub metrics_topic_label_enabled: bool,
 
@@ -1423,6 +1430,7 @@ impl Default for BrokerConfig {
             metrics_exporter_type: MetricsExporterType::Disable,
             metrics_export_interval_millis: defaults::metrics_export_interval_millis(),
             metrics_cardinality_limit: defaults::metrics_cardinality_limit(),
+            metrics_sample_ratio: defaults::metrics_sample_ratio(),
             metrics_topic_label_enabled: true,
             metrics_consumer_group_label_enabled: true,
             otlp_exporter_endpoint: defaults::otlp_exporter_endpoint(),
@@ -1684,6 +1692,10 @@ impl BrokerConfig {
         properties.insert(
             "metricsCardinalityLimit".into(),
             self.metrics_cardinality_limit.to_string().into(),
+        );
+        properties.insert(
+            "metricsSampleRatio".into(),
+            self.metrics_sample_ratio.to_string().into(),
         );
         properties.insert(
             "metricsTopicLabelEnabled".into(),
@@ -2220,6 +2232,7 @@ mod tests {
         assert_eq!(config.metrics_exporter_type, MetricsExporterType::Disable);
         assert_eq!(config.metrics_export_interval_millis, 30_000);
         assert_eq!(config.metrics_cardinality_limit, 10_000);
+        assert!((config.metrics_sample_ratio - 1.0).abs() < f64::EPSILON);
         assert!(config.metrics_topic_label_enabled);
         assert!(config.metrics_consumer_group_label_enabled);
         assert_eq!(config.otlp_exporter_endpoint, "http://127.0.0.1:4317");
@@ -2251,6 +2264,10 @@ mod tests {
         assert_eq!(
             properties.get("metricsCardinalityLimit").map(CheetahString::as_str),
             Some("10000")
+        );
+        assert_eq!(
+            properties.get("metricsSampleRatio").map(CheetahString::as_str),
+            Some("1")
         );
         assert_eq!(
             properties.get("metricsTopicLabelEnabled").map(CheetahString::as_str),
@@ -2572,6 +2589,18 @@ mod tests {
         assert_eq!(config.acl_file_watch_interval_millis, 250);
         assert_eq!(config.signature_algorithm.as_str(), "HmacSHA256");
         assert_eq!(config.request_timestamp_expired_millis, 300_000);
+    }
+
+    #[test]
+    fn serde_accepts_metrics_sample_ratio_camel_case_key() {
+        let config: BrokerConfig = serde_json::from_str(
+            r#"{
+                "metricsSampleRatio": 0.125
+            }"#,
+        )
+        .expect("broker config should deserialize metrics sampling keys");
+
+        assert!((config.metrics_sample_ratio - 0.125).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/rocketmq-observability/benches/observability_hot_path.rs
+++ b/rocketmq-observability/benches/observability_hot_path.rs
@@ -31,6 +31,7 @@ use criterion::Criterion;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_observability::config::TracesConfig;
 use rocketmq_observability::metrics::labels::LabelGuard;
+use rocketmq_observability::sampling::SamplingGate;
 
 fn bench_label_guard(c: &mut Criterion) {
     let mut group = c.benchmark_group("observability_label_guard");
@@ -92,6 +93,21 @@ fn bench_broker_metrics_record(c: &mut Criterion) {
     {
         group.bench_function("otel_metrics_feature_disabled", |b| b.iter(|| black_box(())));
     }
+
+    group.finish();
+}
+
+fn bench_sampling_gate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("observability_sampling_gate");
+
+    let full = SamplingGate::new(1.0);
+    group.bench_function("full", |b| b.iter(|| black_box(full.should_sample())));
+
+    let ten_percent = SamplingGate::new(0.1);
+    group.bench_function("ten_percent", |b| b.iter(|| black_box(ten_percent.should_sample())));
+
+    let disabled = SamplingGate::new(0.0);
+    group.bench_function("disabled", |b| b.iter(|| black_box(disabled.should_sample())));
 
     group.finish();
 }
@@ -188,6 +204,7 @@ criterion_group!(
     benches,
     bench_label_guard,
     bench_broker_metrics_record,
+    bench_sampling_gate,
     bench_trace_property_carrier,
     bench_trace_message_attributes
 );

--- a/rocketmq-observability/src/config.rs
+++ b/rocketmq-observability/src/config.rs
@@ -48,6 +48,7 @@ pub struct MetricsConfig {
     pub export_interval_millis: u64,
     pub export_timeout_millis: u64,
     pub cardinality_limit: usize,
+    pub sample_ratio: f64,
     pub topic_label_enabled: bool,
     pub consumer_group_label_enabled: bool,
 }
@@ -151,6 +152,7 @@ impl Default for MetricsConfig {
             export_interval_millis: 30_000,
             export_timeout_millis: 3_000,
             cardinality_limit: 10_000,
+            sample_ratio: 1.0,
             topic_label_enabled: true,
             consumer_group_label_enabled: true,
         }
@@ -243,6 +245,7 @@ mod tests {
         assert!(!config.enabled);
         assert!(!config.metrics.enabled);
         assert!(!config.traces.enabled);
+        assert!((config.metrics.sample_ratio - 1.0).abs() < f64::EPSILON);
         assert_eq!(config.prometheus.host, "127.0.0.1");
         assert!(!config.traces.record_message_id);
         assert!(!config.traces.record_message_keys);

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -22,6 +22,7 @@ pub mod metrics;
 pub mod noop;
 pub mod propagation;
 pub mod resource;
+pub mod sampling;
 pub mod semantic;
 pub mod trace;
 

--- a/rocketmq-observability/src/metrics/broker_manager.rs
+++ b/rocketmq-observability/src/metrics/broker_manager.rs
@@ -56,6 +56,7 @@ use super::broker_constants::BrokerMetricsConstant;
 use super::labels::LabelGuard;
 use super::noop_instruments::NopLongCounter;
 use super::noop_instruments::NopLongHistogram;
+use crate::sampling::SamplingGate;
 
 // ============================================================================
 // Constants
@@ -289,6 +290,23 @@ impl Default for BrokerMetricsLabelConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrokerMetricsSamplingConfig {
+    pub sample_ratio: f64,
+}
+
+impl BrokerMetricsSamplingConfig {
+    pub fn new(sample_ratio: f64) -> Self {
+        Self { sample_ratio }
+    }
+}
+
+impl Default for BrokerMetricsSamplingConfig {
+    fn default() -> Self {
+        Self::new(1.0)
+    }
+}
+
 /// Broker metrics manager for comprehensive broker-level metrics
 ///
 /// This struct manages all broker-related metrics including:
@@ -326,6 +344,8 @@ pub struct BrokerMetricsManager {
     // Attributes supplier
     attributes_supplier: Arc<dyn AttributesBuilderSupplier>,
 
+    sampled_metric_gate: SamplingGate,
+
     #[cfg(feature = "otel-metrics")]
     label_guard: RwLock<LabelGuard>,
 }
@@ -340,6 +360,20 @@ impl BrokerMetricsManager {
         meter: Meter,
         attributes_supplier: Arc<dyn AttributesBuilderSupplier>,
         label_config: BrokerMetricsLabelConfig,
+    ) -> Self {
+        Self::new_with_label_and_sampling_config(
+            meter,
+            attributes_supplier,
+            label_config,
+            BrokerMetricsSamplingConfig::default(),
+        )
+    }
+
+    pub fn new_with_label_and_sampling_config(
+        meter: Meter,
+        attributes_supplier: Arc<dyn AttributesBuilderSupplier>,
+        label_config: BrokerMetricsLabelConfig,
+        sampling_config: BrokerMetricsSamplingConfig,
     ) -> Self {
         #[cfg(not(feature = "otel-metrics"))]
         let _ = label_config;
@@ -433,6 +467,7 @@ impl BrokerMetricsManager {
             transaction_finish_latency,
             meter,
             attributes_supplier,
+            sampled_metric_gate: SamplingGate::new(sampling_config.sample_ratio),
             #[cfg(feature = "otel-metrics")]
             label_guard: RwLock::new(LabelGuard::new(
                 label_config.cardinality_limit,
@@ -499,8 +534,50 @@ impl BrokerMetricsManager {
         F5: Fn() -> Vec<(ProducerConnectionAttributes, i64)> + Send + Sync + 'static,
         F6: Fn() -> Vec<(ConsumerConnectionAttributes, i64)> + Send + Sync + 'static,
     {
+        Self::init_with_observables_and_configs(
+            meter_provider,
+            attributes_supplier,
+            label_config,
+            BrokerMetricsSamplingConfig::default(),
+            processor_watermark_fn,
+            broker_permission_fn,
+            topic_num_fn,
+            consumer_group_num_fn,
+            producer_connections_fn,
+            consumer_connections_fn,
+        )
+    }
+
+    /// Initialize with observable gauges, label guard configuration, and sampling configuration.
+    pub fn init_with_observables_and_configs<F1, F2, F3, F4, F5, F6>(
+        meter_provider: &SdkMeterProvider,
+        attributes_supplier: Arc<dyn AttributesBuilderSupplier>,
+        label_config: BrokerMetricsLabelConfig,
+        sampling_config: BrokerMetricsSamplingConfig,
+        // Stats callbacks
+        processor_watermark_fn: Option<F1>,
+        broker_permission_fn: F2,
+        topic_num_fn: F3,
+        consumer_group_num_fn: F4,
+        // Connection callbacks
+        producer_connections_fn: F5,
+        consumer_connections_fn: F6,
+    ) -> Self
+    where
+        F1: Fn() -> Vec<(String, i64)> + Send + Sync + 'static, // (processor_name, count)
+        F2: Fn() -> i64 + Send + Sync + 'static,
+        F3: Fn() -> i64 + Send + Sync + 'static,
+        F4: Fn() -> i64 + Send + Sync + 'static,
+        F5: Fn() -> Vec<(ProducerConnectionAttributes, i64)> + Send + Sync + 'static,
+        F6: Fn() -> Vec<(ConsumerConnectionAttributes, i64)> + Send + Sync + 'static,
+    {
         let meter = meter_provider.meter(BrokerMetricsConstant::OPEN_TELEMETRY_METER_NAME);
-        let manager = Self::new_with_label_config(meter.clone(), attributes_supplier.clone(), label_config);
+        let manager = Self::new_with_label_and_sampling_config(
+            meter.clone(),
+            attributes_supplier.clone(),
+            label_config,
+            sampling_config,
+        );
 
         // Register stats observable gauges
         if let Some(processor_watermark_fn) = processor_watermark_fn {
@@ -646,12 +723,46 @@ impl BrokerMetricsManager {
         F5: Fn() -> Vec<(ProducerConnectionAttributes, i64)> + Send + Sync + 'static,
         F6: Fn() -> Vec<(ConsumerConnectionAttributes, i64)> + Send + Sync + 'static,
     {
-        let _ = ATTRIBUTES_BUILDER_SUPPLIER.set(attributes_supplier.clone());
-        let _ = LABEL_MAP.set(RwLock::new(HashMap::new()));
-        let _ = BROKER_METRICS_MANAGER.set(Self::init_with_observables_and_label_config(
+        Self::init_global_with_observables_and_configs(
             meter_provider,
             attributes_supplier,
             label_config,
+            BrokerMetricsSamplingConfig::default(),
+            processor_watermark_fn,
+            broker_permission_fn,
+            topic_num_fn,
+            consumer_group_num_fn,
+            producer_connections_fn,
+            consumer_connections_fn,
+        );
+    }
+
+    pub fn init_global_with_observables_and_configs<F1, F2, F3, F4, F5, F6>(
+        meter_provider: &SdkMeterProvider,
+        attributes_supplier: Arc<dyn AttributesBuilderSupplier>,
+        label_config: BrokerMetricsLabelConfig,
+        sampling_config: BrokerMetricsSamplingConfig,
+        processor_watermark_fn: Option<F1>,
+        broker_permission_fn: F2,
+        topic_num_fn: F3,
+        consumer_group_num_fn: F4,
+        producer_connections_fn: F5,
+        consumer_connections_fn: F6,
+    ) where
+        F1: Fn() -> Vec<(String, i64)> + Send + Sync + 'static,
+        F2: Fn() -> i64 + Send + Sync + 'static,
+        F3: Fn() -> i64 + Send + Sync + 'static,
+        F4: Fn() -> i64 + Send + Sync + 'static,
+        F5: Fn() -> Vec<(ProducerConnectionAttributes, i64)> + Send + Sync + 'static,
+        F6: Fn() -> Vec<(ConsumerConnectionAttributes, i64)> + Send + Sync + 'static,
+    {
+        let _ = ATTRIBUTES_BUILDER_SUPPLIER.set(attributes_supplier.clone());
+        let _ = LABEL_MAP.set(RwLock::new(HashMap::new()));
+        let _ = BROKER_METRICS_MANAGER.set(Self::init_with_observables_and_configs(
+            meter_provider,
+            attributes_supplier,
+            label_config,
+            sampling_config,
             processor_watermark_fn,
             broker_permission_fn,
             topic_num_fn,
@@ -885,6 +996,10 @@ impl BrokerMetricsManager {
 
     /// Record broker send message processing latency.
     pub fn record_send_message_latency(&self, topic: &str, latency_ms: u64) {
+        if !self.sampled_metric_gate.should_sample() {
+            return;
+        }
+
         #[cfg(feature = "otel-metrics")]
         {
             let mut attrs = self.base_attributes();
@@ -1220,6 +1335,27 @@ mod tests {
         assert_eq!(manager.topic_label("topic-a").value.to_string(), "other");
         assert_eq!(manager.consumer_group_label("group-a").value.to_string(), "group-a");
         assert_eq!(manager.dropped_metric_labels(), 1);
+    }
+
+    #[test]
+    fn broker_metrics_sampling_config_defaults_to_full_recording() {
+        let config = BrokerMetricsSamplingConfig::default();
+
+        assert!((config.sample_ratio - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn broker_metrics_manager_applies_sampling_config() {
+        let meter_provider = SdkMeterProvider::builder().build();
+        let meter = meter_provider.meter("broker-sampling-config-test");
+        let manager = BrokerMetricsManager::new_with_label_and_sampling_config(
+            meter,
+            Arc::new(NoopAttributesSupplier),
+            BrokerMetricsLabelConfig::default(),
+            BrokerMetricsSamplingConfig::new(0.0),
+        );
+
+        assert!(!manager.sampled_metric_gate.should_sample());
     }
 
     #[test]

--- a/rocketmq-observability/src/sampling.rs
+++ b/rocketmq-observability/src/sampling.rs
@@ -1,0 +1,97 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+const SAMPLE_SCALE: u64 = 1_000_000;
+
+#[derive(Debug)]
+pub struct SamplingGate {
+    sampled_per_million: u64,
+    accumulator: AtomicU64,
+}
+
+impl SamplingGate {
+    pub fn new(sample_ratio: f64) -> Self {
+        Self {
+            sampled_per_million: sampled_per_million(sample_ratio),
+            accumulator: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    pub fn should_sample(&self) -> bool {
+        match self.sampled_per_million {
+            0 => false,
+            SAMPLE_SCALE => true,
+            sampled_per_million => {
+                let previous = self.accumulator.fetch_add(sampled_per_million, Ordering::Relaxed);
+                previous % SAMPLE_SCALE + sampled_per_million >= SAMPLE_SCALE
+            }
+        }
+    }
+
+    pub fn sampled_per_million(&self) -> u64 {
+        self.sampled_per_million
+    }
+}
+
+impl Default for SamplingGate {
+    fn default() -> Self {
+        Self::new(1.0)
+    }
+}
+
+fn sampled_per_million(sample_ratio: f64) -> u64 {
+    if sample_ratio.is_nan() || sample_ratio <= 0.0 {
+        return 0;
+    }
+    if sample_ratio >= 1.0 {
+        return SAMPLE_SCALE;
+    }
+    (sample_ratio * SAMPLE_SCALE as f64).ceil() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_sample_ratio_always_samples() {
+        let gate = SamplingGate::new(1.0);
+
+        assert_eq!(gate.sampled_per_million(), SAMPLE_SCALE);
+        assert!((0..8).all(|_| gate.should_sample()));
+    }
+
+    #[test]
+    fn non_positive_or_invalid_ratio_never_samples() {
+        for ratio in [0.0, -1.0, f64::NAN, f64::NEG_INFINITY] {
+            let gate = SamplingGate::new(ratio);
+
+            assert_eq!(gate.sampled_per_million(), 0);
+            assert!((0..8).all(|_| !gate.should_sample()));
+        }
+    }
+
+    #[test]
+    fn fractional_ratio_is_evenly_spread() {
+        let one_quarter = SamplingGate::new(0.25);
+        let three_quarters = SamplingGate::new(0.75);
+
+        assert_eq!((0..8).filter(|_| one_quarter.should_sample()).count(), 2);
+        assert_eq!((0..8).filter(|_| three_quarters.should_sample()).count(), 6);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7796

### Brief Description

Adds `metricsSampleRatio` as a Broker observability setting and maps it into `rocketmq_observability::MetricsConfig`.

Introduces a low-overhead `SamplingGate` and wires it into `BrokerMetricsManager` so SendMessage success latency histograms can be sampled while success counters and throughput counters remain exact. Also extends the observability hot-path benchmark with full, sampled, and disabled sampling cases.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common metrics --lib` passed.
- `cargo test -p rocketmq-observability sampling --lib` passed.
- `cargo test -p rocketmq-observability --features otel-metrics sampling_config --lib` passed.
- `cargo test -p rocketmq-broker --features otel-metrics build_broker_observability_config_maps_otlp_settings --lib` passed.
- `cargo test -p rocketmq-observability --features otel-metrics --bench observability_hot_path --no-run` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sampling for broker metrics, with support for full, partial, or disabled metric collection.
  * Introduced a new observability sampling capability to control how often metrics are recorded.
  * Added benchmark coverage for sampling performance.

* **Bug Fixes**
  * Metric sampling settings now carry through broker observability startup so recorded metrics match the configured sampling rate.

* **Tests**
  * Expanded coverage for default values, configuration loading, and sampling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->