### PR TITLE
[ISSUE #7799]🧪Add message CheetahString benchmark baseline

### DIFF
--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -107,6 +107,10 @@ name    = "json_utils_comparison"
 harness = false
 
 [[bench]]
+name    = "message_cheetah_string"
+harness = false
+
+[[bench]]
 name    = "common_executor_lifecycle_bench"
 harness = false
 

--- a/rocketmq-common/benches/message_cheetah_string.rs
+++ b/rocketmq-common/benches/message_cheetah_string.rs
@@ -1,0 +1,244 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use bytes::Bytes;
+use cheetah_string::CheetahBuilder;
+use cheetah_string::CheetahStr;
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rocketmq_common::common::message::broker_message::BrokerMessage;
+use rocketmq_common::common::message::message_envelope::MessageEnvelope;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::MessageDecoder;
+
+fn sample_properties(count: usize) -> HashMap<CheetahString, CheetahString> {
+    let mut properties = HashMap::with_capacity(count);
+    properties.insert(
+        CheetahString::from_static_str("KEYS"),
+        CheetahString::from_static_str("order-1001"),
+    );
+    properties.insert(
+        CheetahString::from_static_str("TAGS"),
+        CheetahString::from_static_str("paid"),
+    );
+    properties.insert(
+        CheetahString::from_static_str("UNIQ_KEY"),
+        CheetahString::from_static_str("AC14000100002A9F0000000000010001"),
+    );
+
+    for i in 3..count {
+        properties.insert(
+            CheetahString::from_string(format!("K{i}")),
+            CheetahString::from_string(format!("value-{i}-{}", "x".repeat(i % 31))),
+        );
+    }
+
+    properties
+}
+
+fn sample_message(count: usize) -> Message {
+    let mut message = Message::default();
+    message.set_topic(CheetahString::from_static_str("BenchmarkTopic"));
+    message.set_body(Some(Bytes::from_static(b"benchmark-message-body")));
+
+    for (key, value) in sample_properties(count) {
+        message.put_property(key, value);
+    }
+
+    message
+}
+
+fn sample_message_ext(count: usize) -> MessageExt {
+    let mut message_ext = MessageExt::default();
+    message_ext.set_topic(CheetahString::from_static_str("BenchmarkTopic"));
+    message_ext.set_body(Bytes::from_static(b"benchmark-message-body"));
+    message_ext.set_queue_id(3);
+    message_ext.set_queue_offset(1024);
+    message_ext.set_commit_log_offset(4096);
+    message_ext.set_born_timestamp(1_720_000_000_000);
+    message_ext.set_store_timestamp(1_720_000_000_123);
+
+    for (key, value) in sample_properties(count) {
+        message_ext.put_property(key, value);
+    }
+
+    message_ext
+}
+
+fn broker_message_with_properties() -> BrokerMessage {
+    let mut envelope = MessageEnvelope::default();
+    envelope.set_topic(CheetahString::from_static_str("BenchmarkTopic"));
+
+    for (key, value) in sample_properties(32) {
+        envelope.put_property(key, value);
+    }
+
+    BrokerMessage::from_envelope(envelope)
+}
+
+fn bench_message_properties_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_properties_encode");
+
+    for count in [3usize, 32] {
+        let properties = sample_properties(count);
+        group.bench_with_input(BenchmarkId::from_parameter(count), &properties, |b, properties| {
+            b.iter(|| MessageDecoder::message_properties_to_string(black_box(properties)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_message_properties_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_properties_decode");
+
+    for count in [3usize, 32] {
+        let encoded = MessageDecoder::message_properties_to_string(&sample_properties(count));
+
+        group.bench_with_input(BenchmarkId::new("cheetah_string", count), &encoded, |b, encoded| {
+            b.iter(|| MessageDecoder::string_to_message_properties(Some(black_box(encoded))))
+        });
+
+        group.bench_with_input(BenchmarkId::new("str", count), encoded.as_str(), |b, encoded| {
+            b.iter(|| MessageDecoder::str_to_message_properties(Some(black_box(encoded))))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_broker_message_property_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("broker_message_property_lookup");
+    let broker_message = broker_message_with_properties();
+
+    group.bench_function("existing_key", |b| {
+        b.iter(|| broker_message.property(black_box("KEYS")))
+    });
+
+    group.bench_function("missing_key", |b| {
+        b.iter(|| broker_message.property(black_box("NOT_EXISTS")))
+    });
+
+    group.finish();
+}
+
+fn bench_message_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_decode");
+
+    for count in [3usize, 32] {
+        let inner_message_bytes = MessageDecoder::encode_message(&sample_message(count));
+        group.bench_with_input(
+            BenchmarkId::new("inner_message", count),
+            &inner_message_bytes,
+            |b, encoded| {
+                b.iter(|| {
+                    let mut bytes = encoded.clone();
+                    MessageDecoder::decode_message(black_box(&mut bytes))
+                })
+            },
+        );
+
+        let commitlog_bytes =
+            MessageDecoder::encode(&sample_message_ext(count), false).expect("sample message should encode");
+        group.bench_with_input(
+            BenchmarkId::new("commitlog_message", count),
+            &commitlog_bytes,
+            |b, encoded| {
+                b.iter(|| {
+                    let mut bytes = encoded.clone();
+                    MessageDecoder::decode(black_box(&mut bytes), true, false, false, false, false)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_metadata_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("metadata_clone");
+    let broker_name = CheetahString::from_static_str("broker-a");
+    let topic = CheetahString::from_static_str("BenchmarkTopic");
+    let msg_id = CheetahString::from_static_str("AC14000100002A9F0000000000010001");
+
+    group.bench_function("cheetah_string_clone", |b| {
+        b.iter(|| {
+            black_box((
+                broker_name.clone(),
+                topic.clone(),
+                msg_id.clone(),
+                msg_id.clone(),
+                topic.clone(),
+            ))
+        })
+    });
+
+    let broker_name = CheetahStr::from_static_str("broker-a");
+    let topic = CheetahStr::from_static_str("BenchmarkTopic");
+    let msg_id = CheetahStr::from_static_str("AC14000100002A9F0000000000010001");
+
+    group.bench_function("cheetah_str_clone_candidate", |b| {
+        b.iter(|| {
+            black_box((
+                broker_name.clone(),
+                topic.clone(),
+                msg_id.clone(),
+                msg_id.clone(),
+                topic.clone(),
+            ))
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_message_builder_join(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_builder_join");
+    let keys = ["order-1001", "user-42", "payment-777", "trace-abc"];
+
+    group.bench_function("keys_join", |b| {
+        b.iter(|| {
+            let capacity = keys.iter().map(|key| key.len()).sum::<usize>() + keys.len().saturating_sub(1);
+            let mut builder = CheetahBuilder::with_capacity(capacity);
+            for (index, key) in keys.iter().enumerate() {
+                if index > 0 {
+                    builder.push(' ');
+                }
+                builder.push_str(black_box(key));
+            }
+            builder.finish_string()
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_message_properties_encode,
+    bench_message_properties_decode,
+    bench_broker_message_property_lookup,
+    bench_message_decode,
+    bench_metadata_clone,
+    bench_message_builder_join
+);
+criterion_main!(benches);

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -1030,6 +1030,47 @@ mod tests {
     }
 
     #[test]
+    fn str_to_message_properties_ignores_empty_and_malformed_segments() {
+        let encoded = concat!(
+            "valid\u{0001}value\u{0002}",
+            "\u{0002}",
+            "empty_value\u{0001}\u{0002}",
+            "missing_separator\u{0002}",
+            "second\u{0001}two\u{0002}"
+        );
+
+        let decoded = str_to_message_properties(Some(encoded));
+
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded.get("valid").map(CheetahString::as_str), Some("value"));
+        assert_eq!(decoded.get("second").map(CheetahString::as_str), Some("two"));
+    }
+
+    #[test]
+    fn decode_messages_rejects_invalid_utf8_properties() {
+        let mut bytes = BytesMut::new();
+        let store_size = 4 // TOTALSIZE
+            + 4 // MAGICCODE
+            + 4 // BODYCRC
+            + 4 // FLAG
+            + 4 // BODY LENGTH
+            + 2 // PROPERTIES LENGTH
+            + 1; // INVALID PROPERTY BYTE
+
+        bytes.put_i32(store_size);
+        bytes.put_i32(0);
+        bytes.put_i32(0);
+        bytes.put_i32(0);
+        bytes.put_i32(0);
+        bytes.put_i16(1);
+        bytes.put_u8(0xff);
+
+        let mut bytes = bytes.freeze();
+
+        assert!(decode_messages(&mut bytes).is_empty());
+    }
+
+    #[test]
     fn cheetah_from_utf8_lossy_borrows_valid_utf8() {
         let encoded = b"key\x01value\x02";
 

--- a/rocketmq-common/tests/message_cheetah_allocation_contract.rs
+++ b/rocketmq-common/tests/message_cheetah_allocation_contract.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 The RocketMQ Rust Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::alloc::GlobalAlloc;
+use std::alloc::Layout;
+use std::alloc::System;
+use std::hint::black_box;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::message::broker_message::BrokerMessage;
+use rocketmq_common::common::message::message_envelope::MessageEnvelope;
+use rocketmq_common::common::message::MessageTrait;
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: The allocator delegates all memory operations to the standard
+// allocator and only records allocation counts for this integration test crate.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: The call is delegated unchanged to the standard allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: The pointer and layout were provided by the global allocation API.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn allocations_for<R>(operation: impl FnOnce() -> R) -> usize {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    let result = operation();
+    black_box(&result);
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+fn broker_message_with_properties() -> BrokerMessage {
+    let mut envelope = MessageEnvelope::default();
+    envelope.put_property(
+        CheetahString::from_static_str("KEYS"),
+        CheetahString::from_static_str("order-1001"),
+    );
+    envelope.put_property(
+        CheetahString::from_static_str("TAGS"),
+        CheetahString::from_static_str("paid"),
+    );
+
+    BrokerMessage::from_envelope(envelope)
+}
+
+#[test]
+fn broker_message_property_lookup_allocation_baseline_is_bounded() {
+    let broker_message = broker_message_with_properties();
+
+    let existing_key_allocations = allocations_for(|| broker_message.property(black_box("KEYS")));
+    let missing_key_allocations = allocations_for(|| broker_message.property(black_box("NOT_EXISTS")));
+
+    assert!(
+        existing_key_allocations <= 1,
+        "existing key lookup allocated {existing_key_allocations} times"
+    );
+    assert!(
+        missing_key_allocations <= 1,
+        "missing key lookup allocated {missing_key_allocations} times"
+    );
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7799

### Brief Description

Adds a `rocketmq-common` Criterion benchmark target for the message-module `CheetahString` 2.1 migration baseline. The benchmark covers property encode/decode, broker property lookup by `&str`, inner and commitlog message decode fixtures, clone-heavy metadata candidates, and builder-based key joining.

Also adds message decoder behavior guards for malformed property segments and strict invalid UTF-8 inner-message properties, plus a test-only allocation contract for `BrokerMessage::property(&str)` lookup.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common --test cheetah_string_2_1_contract` passed: 8 tests.
- `cargo test -p rocketmq-common message_decoder` passed: 32 message decoder tests.
- `cargo test -p rocketmq-common --test message_cheetah_allocation_contract` passed: 1 test.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo bench -p rocketmq-common --bench message_cheetah_string -- --save-baseline cheetah21-message-before` passed and saved the baseline.

Benchmark baseline medians from the final run:

| Benchmark | Median |
| --- | ---: |
| `message_properties_encode/3` | 41.476 ns |
| `message_properties_encode/32` | 201.35 ns |
| `message_properties_decode/cheetah_string/3` | 146.18 ns |
| `message_properties_decode/str/3` | 151.77 ns |
| `message_properties_decode/cheetah_string/32` | 2.2818 us |
| `message_properties_decode/str/32` | 2.2667 us |
| `broker_message_property_lookup/existing_key` | 38.950 ns |
| `broker_message_property_lookup/missing_key` | 35.709 ns |
| `message_decode/inner_message/3` | 190.39 ns |
| `message_decode/commitlog_message/3` | 365.10 ns |
| `message_decode/inner_message/32` | 2.2248 us |
| `message_decode/commitlog_message/32` | 2.6003 us |
| `metadata_clone/cheetah_string_clone` | 14.316 ns |
| `metadata_clone/cheetah_str_clone_candidate` | 12.027 ns |
| `message_builder_join/keys_join` | 35.590 ns |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark suite for message property handling and string operations.
* **Tests**
  * Added coverage for parsing message properties with empty or malformed segments.
  * Added coverage for invalid property payloads returning no decoded messages.
  * Added an allocation check to help ensure message property lookups stay lightweight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->