### PR TITLE
[ISSUE #7801]♻️Remove message CheetahString lookup allocation

### DIFF
--- a/rocketmq-common/src/common/message/broker_message.rs
+++ b/rocketmq-common/src/common/message/broker_message.rs
@@ -211,10 +211,7 @@ impl BrokerMessage {
 
     /// Gets a property value
     pub fn property(&self, name: &str) -> Option<CheetahString> {
-        self.envelope
-            .properties()
-            .get(&CheetahString::from_string(name.to_string()))
-            .cloned()
+        self.envelope.properties().get(name).cloned()
     }
 }
 

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -425,7 +425,7 @@ impl From<crate::common::message::message_envelope::MessageEnvelope> for Message
     fn from(envelope: crate::common::message::message_envelope::MessageEnvelope) -> Self {
         Self {
             message: envelope.message().clone(),
-            broker_name: CheetahString::from_string(envelope.broker_name().to_string()),
+            broker_name: CheetahString::from_slice(envelope.broker_name()),
             queue_id: envelope.queue_id(),
             store_size: envelope.store_size(),
             queue_offset: envelope.queue_offset(),

--- a/rocketmq-common/tests/message_cheetah_allocation_contract.rs
+++ b/rocketmq-common/tests/message_cheetah_allocation_contract.rs
@@ -76,12 +76,12 @@ fn broker_message_property_lookup_allocation_baseline_is_bounded() {
     let existing_key_allocations = allocations_for(|| broker_message.property(black_box("KEYS")));
     let missing_key_allocations = allocations_for(|| broker_message.property(black_box("NOT_EXISTS")));
 
-    assert!(
-        existing_key_allocations <= 1,
+    assert_eq!(
+        existing_key_allocations, 0,
         "existing key lookup allocated {existing_key_allocations} times"
     );
-    assert!(
-        missing_key_allocations <= 1,
+    assert_eq!(
+        missing_key_allocations, 0,
         "missing key lookup allocated {missing_key_allocations} times"
     );
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7801

### Brief Description

Removes an unnecessary lookup-only `CheetahString` construction in `BrokerMessage::property(&str)` by using the existing borrowed `&str` HashMap lookup support. Also replaces the `MessageEnvelope` to `MessageExt` broker name conversion with direct `CheetahString::from_slice` construction and tightens the allocation contract so broker property lookup must allocate zero times.

Public APIs and message wire format are unchanged.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common --test cheetah_string_2_1_contract` passed: 8 tests.
- `cargo test -p rocketmq-common message_decoder` passed: 32 message decoder tests.
- `cargo test -p rocketmq-common --test message_cheetah_allocation_contract` passed: 1 test, verifying existing and missing key lookup allocate 0 times.
- `cargo bench -p rocketmq-common --bench message_cheetah_string -- --baseline cheetah21-message-before` passed.
- `cargo bench -p rocketmq-common --bench message_cheetah_string broker_message_property_lookup -- --baseline cheetah21-message-before` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

Target benchmark comparison against `cheetah21-message-before`:

| Benchmark | Candidate median | Change |
| --- | ---: | ---: |
| `broker_message_property_lookup/existing_key` | 12.188 ns | -68.325% |
| `broker_message_property_lookup/missing_key` | 11.801 ns | -67.708% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary allocations during message property lookups.
  * Improved message conversion efficiency by avoiding extra string copying.

* **Tests**
  * Tightened allocation checks to ensure key message operations perform with zero allocations for both existing and missing properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->