### PR TITLE
[ISSUE #7803]♻️Consolidate message property codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,6 +4206,7 @@ dependencies = [
  "local-ip-address",
  "lz4_flex",
  "md-5 0.10.6",
+ "memchr",
  "mockall",
  "num_cpus",
  "parking_lot",

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -81,6 +81,7 @@ trait-variant.workspace = true
 
 dashmap   = "6.2.1"
 hostname  = "0.4"
+memchr    = "2.8.0"
 regex     = "1.12.4"
 thiserror = { workspace = true }
 

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -32,6 +32,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahBuilder;
 use cheetah_string::CheetahString;
+use memchr::memchr;
 
 use crate::common::compression::compressor_factory::CompressorFactory;
 use crate::common::message::message_client_ext::MessageClientExt;
@@ -65,6 +66,29 @@ pub const BORN_TIMESTAMP_POSITION: usize = 4 + 4 + 4 + 4 + 4 + 8 + 8 + 4 + 8;
 
 const SMALL_PROPERTIES_PREALLOC_THRESHOLD: usize = 16;
 const SMALL_PROPERTY_PREALLOC_BYTES: usize = 34;
+
+macro_rules! decode_message_properties_into {
+    ($map:ident, $properties:expr) => {{
+        let properties = $properties;
+        let bytes = properties.as_bytes();
+        let mut index = 0;
+        let len = bytes.len();
+        while index < len {
+            let new_index = memchr(PROPERTY_SEPARATOR as u8, &bytes[index..]).map_or(len, |i| index + i);
+            if new_index - index >= 3 {
+                if let Some(kv_sep_index) = memchr(NAME_VALUE_SEPARATOR as u8, &bytes[index..new_index]) {
+                    let kv_sep_index = index + kv_sep_index;
+                    if kv_sep_index > index && kv_sep_index < new_index - 1 {
+                        let k = &properties[index..kv_sep_index];
+                        let v = &properties[kv_sep_index + 1..new_index];
+                        $map.insert(CheetahString::from_slice(k), CheetahString::from_slice(v));
+                    }
+                }
+            }
+            index = new_index + 1;
+        }
+    }};
+}
 
 fn get_i16_checked(buffer: &mut Bytes) -> Option<i16> {
     if buffer.remaining() < 2 {
@@ -134,47 +158,17 @@ fn get_topic_length_checked(version: MessageVersion, buffer: &mut Bytes) -> Opti
 }
 
 pub fn string_to_message_properties(properties: Option<&CheetahString>) -> HashMap<CheetahString, CheetahString> {
-    let mut map = HashMap::new();
     if let Some(properties) = properties {
-        let mut index = 0;
-        let len = properties.len();
-        while index < len {
-            let new_index = properties[index..].find(PROPERTY_SEPARATOR).map_or(len, |i| index + i);
-            if new_index - index >= 3 {
-                if let Some(kv_sep_index) = properties[index..new_index].find(NAME_VALUE_SEPARATOR) {
-                    let kv_sep_index = index + kv_sep_index;
-                    if kv_sep_index > index && kv_sep_index < new_index - 1 {
-                        let k = &properties[index..kv_sep_index];
-                        let v = &properties[kv_sep_index + 1..new_index];
-                        map.insert(CheetahString::from_slice(k), CheetahString::from_slice(v));
-                    }
-                }
-            }
-            index = new_index + 1;
-        }
+        str_to_message_properties(Some(properties.as_str()))
+    } else {
+        HashMap::new()
     }
-    map
 }
 
 pub fn str_to_message_properties(properties: Option<&str>) -> HashMap<CheetahString, CheetahString> {
     let mut map = HashMap::new();
     if let Some(properties) = properties {
-        let mut index = 0;
-        let len = properties.len();
-        while index < len {
-            let new_index = properties[index..].find(PROPERTY_SEPARATOR).map_or(len, |i| index + i);
-            if new_index - index >= 3 {
-                if let Some(kv_sep_index) = properties[index..new_index].find(NAME_VALUE_SEPARATOR) {
-                    let kv_sep_index = index + kv_sep_index;
-                    if kv_sep_index > index && kv_sep_index < new_index - 1 {
-                        let k = &properties[index..kv_sep_index];
-                        let v = &properties[kv_sep_index + 1..new_index];
-                        map.insert(CheetahString::from_slice(k), CheetahString::from_slice(v));
-                    }
-                }
-            }
-            index = new_index + 1;
-        }
+        decode_message_properties_into!(map, properties);
     }
     map
 }
@@ -1027,6 +1021,18 @@ mod tests {
         let decoded = string_to_message_properties(Some(&encoded));
 
         assert_eq!(decoded, properties);
+    }
+
+    #[test]
+    fn string_and_str_property_decoders_share_behavior() {
+        let encoded =
+            CheetahString::from_static_str("valid\u{0001}value\u{0002}empty\u{0001}\u{0002}next\u{0001}two\u{0002}");
+
+        let from_cheetah = string_to_message_properties(Some(&encoded));
+        let from_str = str_to_message_properties(Some(encoded.as_str()));
+
+        assert_eq!(from_cheetah, from_str);
+        assert_eq!(from_cheetah.len(), 2);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -2579,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -4052,6 +4052,7 @@ dependencies = [
  "local-ip-address",
  "lz4_flex",
  "md-5 0.10.6",
+ "memchr",
  "num_cpus",
  "parking_lot",
  "regex",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "local-ip-address",
  "lz4_flex",
  "md-5 0.10.6",
+ "memchr",
  "num_cpus",
  "parking_lot",
  "regex",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -1486,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -2272,6 +2272,7 @@ dependencies = [
  "local-ip-address",
  "lz4_flex",
  "md-5 0.10.6",
+ "memchr",
  "num_cpus",
  "parking_lot",
  "regex",


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7803

### Brief Description

Consolidates message property decoding so the CheetahString entry point delegates to the &str decoder, and both decode paths use one memchr-backed scanner for the RocketMQ property separators. The public API and wire format stay unchanged.

Adds memchr as a direct rocketmq-common dependency because this hot path now depends on byte-level ASCII separator search instead of duplicate string find loops.

Benchmark validation used same-machine Criterion A/B baselines against current main to avoid cross-run CPU noise:

- message_properties_encode/3: 42.658 ns, -11.305% versus codec-main-encode2
- message_properties_encode/32: 202.11 ns, -27.821% versus codec-main-encode2
- message_properties_decode/cheetah_string/3: 182.37 ns, -8.9261% versus codec-main-decode2
- message_properties_decode/str/3: 181.40 ns, -9.5645% versus codec-main-decode2
- message_properties_decode/cheetah_string/32: 2.3200 us, -4.7336% versus codec-main-decode2
- message_properties_decode/str/32: 2.3848 us, -14.009% versus codec-main-decode2

### How Did You Test This Change?

- cargo fmt --all
- cargo test -p rocketmq-common message_decoder
- cargo test -p rocketmq-common --test cheetah_string_2_1_contract
- cargo test -p rocketmq-common --test message_cheetah_allocation_contract
- cargo bench -p rocketmq-common --bench message_cheetah_string message_properties_encode -- --baseline codec-main-encode2
- cargo bench -p rocketmq-common --bench message_cheetah_string message_properties_decode -- --baseline codec-main-decode2
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
- cargo fmt --all, in rocketmq-example
- cargo clippy --all-targets -- -D warnings, in rocketmq-example
- cargo fmt --all, in rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri
- cargo clippy --all-targets --all-features -- -D warnings, in rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri
- cargo fmt --all, in rocketmq-dashboard/rocketmq-dashboard-web/backend
- cargo clippy --all-targets --all-features -- -D warnings, in rocketmq-dashboard/rocketmq-dashboard-web/backend
- cargo build --all-targets --all-features, in rocketmq-dashboard/rocketmq-dashboard-web/backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message property decoding performance, which may make message handling faster in some cases.
  * Unified decoding behavior so different string inputs now produce consistent property results.

* **Bug Fixes**
  * Strengthened parsing of message properties to better handle valid segment boundaries and avoid incorrect key/value extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->