### PR TITLE
[ISSUE #7805]♻️Use CheetahStr for storage metadata broker name

### DIFF
--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -112,6 +112,10 @@ name    = "message_cheetah_string"
 harness = false
 
 [[bench]]
+name    = "storage_metadata_cheetah_str"
+harness = false
+
+[[bench]]
 name    = "common_executor_lifecycle_bench"
 harness = false
 

--- a/rocketmq-common/benches/storage_metadata_cheetah_str.rs
+++ b/rocketmq-common/benches/storage_metadata_cheetah_str.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::net::SocketAddr;
+
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rocketmq_common::common::message::storage_metadata::StorageMetadata;
+
+fn sample_storage_metadata() -> StorageMetadata {
+    let addr: SocketAddr = "192.168.1.100:10911".parse().expect("sample address should parse");
+    StorageMetadata::new(
+        CheetahString::from_string(format!("benchmark-broker-{}", "x".repeat(96))),
+        3,
+        1024,
+        4096,
+        1_720_000_000_123,
+        addr,
+        256,
+    )
+}
+
+fn bench_storage_metadata_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("storage_metadata");
+    let metadata = sample_storage_metadata();
+
+    group.bench_function("clone", |b| b.iter(|| black_box(metadata.clone())));
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_storage_metadata_clone);
+criterion_main!(benches);

--- a/rocketmq-common/src/common/message/storage_metadata.rs
+++ b/rocketmq-common/src/common/message/storage_metadata.rs
@@ -17,6 +17,7 @@ use std::net::SocketAddr;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
+use cheetah_string::CheetahStr;
 use cheetah_string::CheetahString;
 
 use crate::common::sys_flag::message_sys_flag::MessageSysFlag;
@@ -26,7 +27,7 @@ use crate::common::sys_flag::message_sys_flag::MessageSysFlag;
 /// Contains indexing and location information for messages in the Broker storage engine.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StorageMetadata {
-    broker_name: CheetahString,
+    broker_name: CheetahStr,
     queue_id: i32,
     queue_offset: i64,
     commit_log_offset: i64,
@@ -48,7 +49,7 @@ impl StorageMetadata {
         store_size: i32,
     ) -> Self {
         Self {
-            broker_name,
+            broker_name: broker_name.into(),
             queue_id,
             queue_offset,
             commit_log_offset,
@@ -61,7 +62,7 @@ impl StorageMetadata {
     /// Gets the broker name
     #[inline]
     pub fn broker_name(&self) -> &str {
-        &self.broker_name
+        self.broker_name.as_str()
     }
 
     /// Gets the queue ID
@@ -131,7 +132,7 @@ impl StorageMetadata {
     /// Sets the broker name (internal use)
     #[inline]
     pub(crate) fn set_broker_name(&mut self, broker_name: CheetahString) {
-        self.broker_name = broker_name;
+        self.broker_name = broker_name.into();
     }
 
     /// Sets the queue offset (internal use)
@@ -174,7 +175,7 @@ impl StorageMetadata {
 impl Default for StorageMetadata {
     fn default() -> Self {
         Self {
-            broker_name: CheetahString::new(),
+            broker_name: CheetahStr::new(),
             queue_id: 0,
             queue_offset: 0,
             commit_log_offset: 0,
@@ -256,5 +257,24 @@ mod tests {
         assert_eq!(metadata.commit_log_offset(), 5000);
         assert_eq!(metadata.store_timestamp(), 999999);
         assert_eq!(metadata.store_size(), 2048);
+    }
+
+    #[test]
+    fn test_clone_and_eq_keep_broker_name_contract() {
+        let addr: SocketAddr = "192.168.1.100:10911".parse().unwrap();
+        let metadata = StorageMetadata::new(
+            CheetahString::from_string(format!("broker-{}", "x".repeat(64))),
+            1,
+            100,
+            5000,
+            999999,
+            addr,
+            2048,
+        );
+
+        let cloned = metadata.clone();
+
+        assert_eq!(cloned, metadata);
+        assert_eq!(cloned.broker_name(), metadata.broker_name());
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7805

### Brief Description

Changes the private StorageMetadata broker_name field from CheetahString to CheetahStr while keeping the public constructor, setter, and broker_name() contract compatible.

This keeps the external API stable and moves immutable storage metadata toward the cheetah-string 2.1.0 clone-cheap representation. The change also adds a focused Criterion benchmark for the actual StorageMetadata clone path.

Benchmark validation used a clean main worktree with only the new benchmark file added as the before baseline, then rebuilt this branch against the same benchmark:

- storage_metadata/clone: 33.210 ns -> 11.666 ns, -65.001%, improved

A broader message_decode exploratory comparison was not used as the stage gate because it does not exercise StorageMetadata and was unstable on the local Windows benchmark run after repeated full recompiles. The targeted benchmark above is the path affected by this refactor.

### How Did You Test This Change?

- cargo fmt --all
- cargo test -p rocketmq-common storage_metadata
- cargo test -p rocketmq-common --test cheetah_string_2_1_contract
- cargo test -p rocketmq-common --test message_cheetah_allocation_contract
- cargo test -p rocketmq-common message_decoder
- cargo bench -p rocketmq-common --bench storage_metadata_cheetah_str -- --baseline phase3-storage-main
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
- cargo fmt --all, in rocketmq-example
- cargo clippy --all-targets -- -D warnings, in rocketmq-example
- cargo fmt --all, in rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri
- cargo clippy --all-targets --all-features -- -D warnings, in rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri
- cargo fmt --all, in rocketmq-dashboard/rocketmq-dashboard-web/backend
- cargo clippy --all-targets --all-features -- -D warnings, in rocketmq-dashboard/rocketmq-dashboard-web/backend
- cargo build --all-targets --all-features, in rocketmq-dashboard/rocketmq-dashboard-web/backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new benchmark to measure storage metadata cloning performance.
  * Updated storage metadata handling to use a more efficient string representation internally.
* **Tests**
  * Expanded coverage to verify cloning preserves metadata values and equality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->