### PR TITLE
[ISSUE #7807]♻️Prefer borrowed message property reads

### DIFF
--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -116,6 +116,10 @@ name    = "storage_metadata_cheetah_str"
 harness = false
 
 [[bench]]
+name    = "message_property_read"
+harness = false
+
+[[bench]]
 name    = "common_executor_lifecycle_bench"
 harness = false
 

--- a/rocketmq-common/benches/message_property_read.rs
+++ b/rocketmq-common/benches/message_property_read.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::message::MessageTrait;
+
+fn sample_message_ext() -> MessageExt {
+    let mut message = MessageExt::default();
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_KEYS),
+        CheetahString::from_string("order-1001 user-42 payment-777 trace-abcdef".to_owned()),
+    );
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_CONTEXT),
+        CheetahString::from_string(format!("trace-{}", "x".repeat(96))),
+    );
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY),
+        CheetahString::from_string(format!("group-{}", "y".repeat(64))),
+    );
+    message
+}
+
+fn bench_message_property_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_property_read");
+    let message = sample_message_ext();
+    let keys = CheetahString::from_static_str(MessageConst::PROPERTY_KEYS);
+    let trace_context = CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_CONTEXT);
+    let sharding_key = CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY);
+
+    group.bench_function("owned_split_keys", |b| {
+        b.iter(|| {
+            message
+                .property(black_box(&keys))
+                .map(|value| value.split(MessageConst::KEY_SEPARATOR).count())
+        })
+    });
+
+    group.bench_function("ref_split_keys", |b| {
+        b.iter(|| {
+            message
+                .property_ref(black_box(&keys))
+                .map(|value| value.split(MessageConst::KEY_SEPARATOR).count())
+        })
+    });
+
+    group.bench_function("owned_to_string", |b| {
+        b.iter(|| {
+            message
+                .property(black_box(&trace_context))
+                .map(|value| value.to_string())
+        })
+    });
+
+    group.bench_function("ref_to_string", |b| {
+        b.iter(|| {
+            message
+                .property_ref(black_box(&trace_context))
+                .map(|value| value.to_string())
+        })
+    });
+
+    group.bench_function("owned_exists", |b| {
+        b.iter(|| message.property(black_box(&sharding_key)).is_some())
+    });
+
+    group.bench_function("ref_exists", |b| {
+        b.iter(|| message.property_ref(black_box(&sharding_key)).is_some())
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_message_property_read);
+criterion_main!(benches);

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -1153,7 +1153,7 @@ fn build_message_system_properties(
     invisible_duration: Option<Duration>,
 ) -> v2::SystemProperties {
     let keys = message_ext
-        .property(&CheetahString::from_static_str(MessageConst::PROPERTY_KEYS))
+        .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_KEYS))
         .map(|value| {
             value
                 .split(MessageConst::KEY_SEPARATOR)
@@ -1176,17 +1176,17 @@ fn build_message_system_properties(
         store_host: message_ext.store_host().ip().to_string(),
         delivery_timestamp: None,
         receipt_handle: message_ext
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
+            .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
             .map(|value| value.to_string()),
         queue_id: Some(message_ext.queue_id()),
         queue_offset: Some(message_ext.queue_offset()),
         invisible_duration: invisible_duration.and_then(duration_to_proto),
         delivery_attempt: Some(message_ext.reconsume_times().saturating_add(1)),
         message_group: message_ext
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY))
+            .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY))
             .map(|value| value.to_string()),
         trace_context: message_ext
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_CONTEXT))
+            .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_CONTEXT))
             .map(|value| value.to_string()),
         orphaned_transaction_recovery_duration: None,
         dead_letter_queue: dead_letter_queue(message_ext),
@@ -1212,8 +1212,8 @@ fn is_reserved_message_property(key: &str) -> bool {
 }
 
 fn dead_letter_queue(message: &MessageExt) -> Option<v2::DeadLetterQueue> {
-    let topic = message.property(&CheetahString::from_static_str(MessageConst::PROPERTY_DLQ_ORIGIN_TOPIC))?;
-    let message_id = message.property(&CheetahString::from_static_str(
+    let topic = message.property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_DLQ_ORIGIN_TOPIC))?;
+    let message_id = message.property_ref(&CheetahString::from_static_str(
         MessageConst::PROPERTY_DLQ_ORIGIN_MESSAGE_ID,
     ))?;
     Some(v2::DeadLetterQueue {
@@ -1224,22 +1224,22 @@ fn dead_letter_queue(message: &MessageExt) -> Option<v2::DeadLetterQueue> {
 
 fn received_message_type(message: &MessageExt) -> v2::MessageType {
     if message
-        .property(&CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY))
+        .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_SHARDING_KEY))
         .is_some()
     {
         return v2::MessageType::Fifo;
     }
     if message
-        .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))
+        .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))
         .is_some()
         || message
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELIVER_MS))
+            .property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELIVER_MS))
             .is_some()
     {
         return v2::MessageType::Delay;
     }
     if message
-        .property(&CheetahString::from_static_str(
+        .property_ref(&CheetahString::from_static_str(
             MessageConst::PROPERTY_TRANSACTION_PREPARED,
         ))
         .is_some()


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7807

### Brief Description

Updates gRPC message response helpers to use borrowed property reads when the value is only split, stringified, or checked for existence. This avoids cloning CheetahString values before immediately borrowing them.

The tag path remains on get_tags() because the focused benchmark did not show a benefit for the small tag value case. The changed paths are limited to PROPERTY_KEYS, POP_CK, SHARDING_KEY, TRACE_CONTEXT, DLQ origin fields, timer fields, and transaction-prepared checks.

Benchmark validation compares owned property reads with borrowed property reads in the new message_property_read benchmark:

- owned_split_keys: 106.14 ns; ref_split_keys: 58.165 ns
- owned_to_string: 71.431 ns; ref_to_string: 57.297 ns
- owned_exists: 47.675 ns; ref_exists: 16.191 ns

### How Did You Test This Change?

- cargo fmt --all
- cargo bench -p rocketmq-common --bench message_property_read
- cargo test -p rocketmq-proxy grpc::adapter
- cargo test -p rocketmq-common --bench message_property_read -- --help
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how message metadata is read in the proxy, helping ensure keys, trace context, sharding info, and related message attributes are handled more reliably.
  * Refined message type detection so messages are classified more consistently when sharding or timer-related properties are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->