### PR TITLE
[ISSUE #7811]✨Reduce message property deletion allocations

### DIFF
--- a/rocketmq-common/benches/delete_property.rs
+++ b/rocketmq-common/benches/delete_property.rs
@@ -15,12 +15,14 @@
 use std::hint::black_box;
 use std::net::SocketAddr;
 
+use cheetah_string::CheetahString;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use rocketmq_common::MessageUtils::build_message_id;
 use rocketmq_common::MessageUtils::delete_property;
+use rocketmq_common::MessageUtils::delete_property_to_cheetah_string;
 use rocketmq_common::MessageUtils::delete_property_v2;
 
 fn bench_delete_property(c: &mut Criterion) {
@@ -81,6 +83,40 @@ fn bench_delete_property_v2(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_delete_property_to_cheetah_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delete_property_to_cheetah_string");
+
+    let small =
+        CheetahString::from_static_str("key1\u{0001}value1\u{0002}key2\u{0001}value2\u{0002}key3\u{0001}value3");
+    group.bench_function("small_string", |b| {
+        b.iter(|| delete_property_to_cheetah_string(black_box(&small), black_box("key2")))
+    });
+
+    let medium = CheetahString::from_string(
+        (0..10)
+            .map(|i| format!("key{}\u{0001}value{}\u{0002}", i, i))
+            .collect::<String>(),
+    );
+    group.bench_function("medium_string", |b| {
+        b.iter(|| delete_property_to_cheetah_string(black_box(&medium), black_box("key5")))
+    });
+
+    let large = CheetahString::from_string(
+        (0..100)
+            .map(|i| format!("key{}\u{0001}value{}\u{0002}", i, i))
+            .collect::<String>(),
+    );
+    group.bench_function("large_string", |b| {
+        b.iter(|| delete_property_to_cheetah_string(black_box(&large), black_box("key50")))
+    });
+
+    group.bench_function("non_existent_key", |b| {
+        b.iter(|| delete_property_to_cheetah_string(black_box(&small), black_box("nonexistent")))
+    });
+
+    group.finish();
+}
+
 fn bench_delete_property_comparison(c: &mut Criterion) {
     let mut group = c.benchmark_group("delete_property_comparison");
 
@@ -119,6 +155,7 @@ criterion_group!(
     benches,
     bench_delete_property,
     bench_delete_property_v2,
+    bench_delete_property_to_cheetah_string,
     bench_build_message_id,
     bench_delete_property_comparison
 );

--- a/rocketmq-common/src/common/message/broker_message.rs
+++ b/rocketmq-common/src/common/message/broker_message.rs
@@ -205,8 +205,7 @@ impl BrokerMessage {
     pub fn delete_property(&mut self, name: &str) {
         self.envelope.message_mut().clear_property(name);
 
-        self.properties_string =
-            CheetahString::from_string(MessageUtils::delete_property(&self.properties_string, name));
+        self.properties_string = MessageUtils::delete_property_to_cheetah_string(&self.properties_string, name);
     }
 
     /// Gets a property value

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -50,10 +50,8 @@ impl MessageExtBrokerInner {
     pub fn delete_property(&mut self, name: impl Into<CheetahString>) {
         let name = name.into();
         self.message_ext_inner.message.clear_property(name.as_str());
-        self.properties_string = CheetahString::from_string(MessageUtils::delete_property(
-            self.properties_string.as_str(),
-            name.as_str(),
-        ));
+        self.properties_string =
+            MessageUtils::delete_property_to_cheetah_string(&self.properties_string, name.as_str());
     }
 
     #[inline]

--- a/rocketmq-common/src/utils/message_utils.rs
+++ b/rocketmq-common/src/utils/message_utils.rs
@@ -20,6 +20,7 @@ use std::net::SocketAddr;
 
 use bytes::BufMut;
 use cheetah_string::CheetahFinder;
+use cheetah_string::CheetahString;
 
 use crate::common::message::message_ext::MessageExt;
 use crate::common::message::MessageConst;
@@ -113,9 +114,9 @@ pub fn get_sharding_key_indexes(msgs: &[MessageExt], index_size: usize) -> HashS
     index_set
 }
 
-pub fn delete_property(properties_string: &str, name: &str) -> String {
+fn delete_property_if_present(properties_string: &str, name: &str) -> Option<String> {
     if properties_string.is_empty() || name.is_empty() {
-        return properties_string.to_string();
+        return None;
     }
 
     fn find_from(finder: &CheetahFinder<'_>, haystack: &str, start: usize) -> Option<usize> {
@@ -124,42 +125,42 @@ pub fn delete_property(properties_string: &str, name: &str) -> String {
             .and_then(|remaining| finder.find_in(remaining).map(|offset| start + offset))
     }
 
-    let finder = CheetahFinder::new(name);
-    let Some(_) = find_from(&finder, properties_string, 0) else {
-        return properties_string.to_string();
-    };
+    fn find_property_name_from(
+        finder: &CheetahFinder<'_>,
+        haystack: &str,
+        bytes: &[u8],
+        name_len: usize,
+        start: usize,
+    ) -> Option<usize> {
+        let property_separator = PROPERTY_SEPARATOR as u8;
+        let name_value_separator = NAME_VALUE_SEPARATOR as u8;
+        let mut start_idx = start;
 
+        loop {
+            let candidate_idx = find_from(finder, haystack, start_idx)?;
+            start_idx = candidate_idx + name_len;
+
+            let before_ok = candidate_idx == 0 || bytes.get(candidate_idx - 1) == Some(&property_separator);
+            let after_idx = candidate_idx + name_len;
+            let after_ok = bytes.get(after_idx) == Some(&name_value_separator);
+            if before_ok && after_ok {
+                return Some(candidate_idx);
+            }
+        }
+    }
+
+    let finder = CheetahFinder::new(name);
     let bytes = properties_string.as_bytes();
-    let property_separator = PROPERTY_SEPARATOR as u8;
-    let name_value_separator = NAME_VALUE_SEPARATOR as u8;
+    let mut next_property_idx = find_property_name_from(&finder, properties_string, bytes, name.len(), 0)?;
+
     let mut idx0 = 0;
     let mut string_builder = String::with_capacity(properties_string.len());
 
     loop {
-        let mut start_idx = idx0;
-        let idx1 = loop {
-            let Some(candidate_idx) = find_from(&finder, properties_string, start_idx) else {
-                break None;
-            };
-            start_idx = candidate_idx + name.len();
-            let before_ok = candidate_idx == 0 || bytes.get(candidate_idx - 1) == Some(&property_separator);
-            let after_idx = candidate_idx + name.len();
-            let after_ok = bytes.get(after_idx) == Some(&name_value_separator);
-            if before_ok && after_ok {
-                break Some(candidate_idx);
-            }
-        };
-
-        let Some(idx1) = idx1 else {
-            // there are no characters that need to be skipped. Append all remaining characters.
-            string_builder.push_str(&properties_string[idx0..]);
-            break;
-        };
-
         // there are characters that need to be cropped
-        string_builder.push_str(&properties_string[idx0..idx1]);
+        string_builder.push_str(&properties_string[idx0..next_property_idx]);
         // move idx2 to the end of the cropped character
-        let value_start = idx1 + name.len() + 1;
+        let value_start = next_property_idx + name.len() + 1;
         match properties_string
             .get(value_start..)
             .and_then(|rest| rest.find(PROPERTY_SEPARATOR))
@@ -167,6 +168,12 @@ pub fn delete_property(properties_string: &str, name: &str) -> String {
         {
             Some(idx2) => {
                 idx0 = idx2 + 1;
+                let Some(idx1) = find_property_name_from(&finder, properties_string, bytes, name.len(), idx0) else {
+                    // there are no characters that need to be skipped. Append all remaining characters.
+                    string_builder.push_str(&properties_string[idx0..]);
+                    break;
+                };
+                next_property_idx = idx1;
             }
             None => {
                 break;
@@ -174,11 +181,21 @@ pub fn delete_property(properties_string: &str, name: &str) -> String {
         }
     }
 
-    string_builder
+    Some(string_builder)
+}
+
+pub fn delete_property(properties_string: &str, name: &str) -> String {
+    delete_property_if_present(properties_string, name).unwrap_or_else(|| properties_string.to_string())
 }
 
 pub fn delete_property_v2(properties_str: &str, name: &str) -> String {
     delete_property(properties_str, name)
+}
+
+pub fn delete_property_to_cheetah_string(properties_string: &CheetahString, name: &str) -> CheetahString {
+    delete_property_if_present(properties_string.as_str(), name)
+        .map(CheetahString::from_string)
+        .unwrap_or_else(|| properties_string.clone())
 }
 
 pub fn build_message_id(socket_addr: SocketAddr, wrote_offset: i64) -> String {
@@ -551,6 +568,28 @@ mod tests {
         for (properties, name, expected) in cases {
             assert_eq!(delete_property(properties, name), expected);
             assert_eq!(delete_property_v2(properties, name), expected);
+        }
+    }
+
+    #[test]
+    fn delete_property_to_cheetah_string_matches_string_deletion() {
+        let cases = [
+            (
+                "key1\u{0001}value1\u{0002}key2\u{0001}value2\u{0002}key3\u{0001}value3",
+                "key2",
+            ),
+            ("key1\u{0001}value1\u{0002}key2\u{0001}value2", "key3"),
+            ("Order\u{0001}remove\u{0002}OrderId\u{0001}keep", "Order"),
+            ("key\u{0001}value", ""),
+        ];
+
+        for (properties, name) in cases {
+            let properties = CheetahString::from_static_str(properties);
+
+            assert_eq!(
+                delete_property_to_cheetah_string(&properties, name),
+                delete_property(properties.as_str(), name)
+            );
         }
     }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7811

### Brief Description

Adds a `CheetahString`-aware message property deletion helper that preserves the existing `delete_property` API while avoiding an unnecessary owned `String` round trip for broker message call sites that already store serialized properties as `CheetahString`.

Updates `BrokerMessage` and `MessageExtBrokerInner` to use the new helper, preserves the existing Java-compatible delete behavior through tests, and extends the existing `delete_property` Criterion benchmark with the new helper path.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-common delete_property` completed successfully: 13 passed.
- `cargo bench -p rocketmq-common --bench delete_property --no-run` completed successfully.
- `cargo bench -p rocketmq-common --bench delete_property -- delete_property_to_cheetah_string --quiet` completed successfully. Observed medians: small 119.80 ns, medium 107.34 ns, large 164.37 ns, non-existent key 49.328 ns.
- `cargo clippy -p rocketmq-common --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property deletion handling so message properties stay consistent across different string formats.
  * Added support for deleting properties while preserving the original value when nothing changes.
  * Included a case for missing keys to ensure deletion behaves correctly when a property does not exist.

* **Tests**
  * Added benchmark coverage and validation for the updated property-deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->