### PR TITLE
[ISSUE #7817]✨Avoid redundant CheetahString conversions in common messages

### DIFF
--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -303,7 +303,7 @@ mod tests {
 
     fn create_test_message(topic: &str) -> Message {
         let mut msg = Message::default();
-        msg.set_topic(CheetahString::from_string(topic.to_string()));
+        msg.set_topic(CheetahString::from_slice(topic));
         msg.set_body(Some(Bytes::from_static(b"test body")));
         msg
     }

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -375,7 +375,7 @@ impl From<crate::common::message::broker_message::BrokerMessage> for MessageExtB
 
         Self {
             message_ext_inner,
-            properties_string: CheetahString::from_string(broker_msg.properties_string().to_string()),
+            properties_string: CheetahString::from_slice(broker_msg.properties_string()),
             tags_code: broker_msg.tags_code(),
             encoded_buff: broker_msg.encoded_buff().cloned(),
             encode_completed: broker_msg.is_encode_completed(),


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7817

### Brief Description

Replaces two redundant `CheetahString::from_string(...to_string())` patterns in `rocketmq-common` with `CheetahString::from_slice` where the source is already available as `&str`.

The production change is in the `BrokerMessage` to `MessageExtBrokerInner` conversion. The test helper cleanup keeps message batch tests on the same lower-allocation construction path. Public APIs and serialized formats are unchanged.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-common message_ext_broker_inner` completed successfully: 4 passed.
- `cargo test -p rocketmq-common message_batch` completed successfully: 32 passed.
- `cargo clippy -p rocketmq-common --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified message handling by constructing string values directly, reducing intermediate allocations.
  * Updated internal message conversion and test setup to use a more direct string conversion path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->