### PR TITLE
[ISSUE #7819]✨Reuse MessageQueue strings in remote offset requests

### DIFF
--- a/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
@@ -72,7 +72,7 @@ impl RemoteBrokerOffsetStore {
         if let Some(find_broker_result) = find_broker_result {
             let request_header = QueryConsumerOffsetRequestHeader {
                 consumer_group: self.group_name.clone(),
-                topic: CheetahString::from_string(mq.topic_str().to_string()),
+                topic: mq.topic().clone(),
                 queue_id: mq.queue_id(),
                 set_zero_if_not_found: None,
                 topic_request_header: Some(TopicRequestHeader {
@@ -80,7 +80,7 @@ impl RemoteBrokerOffsetStore {
                     rpc: Some(RpcRequestHeader {
                         namespace: None,
                         namespaced: None,
-                        broker_name: Some(CheetahString::from_string(mq.broker_name().to_string())),
+                        broker_name: Some(mq.broker_name().clone()),
                         oneway: None,
                     }),
                 }),
@@ -287,7 +287,7 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
                     rpc: Some(RpcRequestHeader {
                         namespace: None,
                         namespaced: None,
-                        broker_name: Some(CheetahString::from_string(mq.broker_name().to_string())),
+                        broker_name: Some(mq.broker_name().clone()),
                         oneway: None,
                     }),
                 }),


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7819

### Brief Description

Reuses the existing `CheetahString` topic and broker name values stored in `MessageQueue` when building remote broker offset query and update request headers.

This removes `to_string()` and `CheetahString::from_string` round trips while preserving request header values and public APIs.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-client-rust remote_broker_offset_store` completed successfully and compiled client test targets; no tests matched the filter.
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.
