### PR TITLE
[ISSUE #7821]✨Reuse producer request strings without owned round trips

### DIFF
--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2678,8 +2678,8 @@ impl DefaultMQProducerImpl {
             .find_broker_address_in_publish(dest_broker_name.as_ref())
             .ok_or_else(|| mq_client_err!(format!("broker address not found for {}", dest_broker_name)))?;
         let request_header = EndTransactionRequestHeader {
-            topic: CheetahString::from_string(msg.topic().to_string()),
-            producer_group: CheetahString::from_string(self.producer_config.producer_group().to_string()),
+            topic: msg.topic().clone(),
+            producer_group: self.producer_config.producer_group().clone(),
             tran_state_table_offset: Self::u64_to_java_long_field(
                 "endTransaction",
                 "tranStateTableOffset",
@@ -3449,7 +3449,7 @@ impl DefaultMQProducerImpl {
 
         self.try_to_find_topic_publish_info(&topic).await;
 
-        let broker_name_cs = CheetahString::from_string(handle_entity.broker_name().to_string());
+        let broker_name_cs = CheetahString::from_slice(handle_entity.broker_name());
         let client_instance = self
             .client_instance
             .as_ref()


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7821

### Brief Description

Reuses existing cheetah-string-compatible values while building producer request headers. Transaction request construction now clones the message topic and producer group directly, and recall request routing uses `CheetahString::from_slice` for the decoded broker name.

This removes owned `String` round trips without changing request values, APIs, or protocol formats.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-client-rust default_mq_producer_impl` completed successfully: 37 passed.
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.
