### PR TITLE
[ISSUE #7823]✨Reuse static topic remapping strings directly

### DIFF
--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
@@ -580,12 +580,9 @@ impl TopicQueueMappingUtils {
         )?;
         TopicQueueMappingUtils::check_if_reuse_physical_queue(&global_id_map.values().cloned().collect())?;
         TopicQueueMappingUtils::check_physical_queue_consistence(broker_config_map)?;
-        let map = broker_config_map
-            .iter()
-            .map(|(k, v)| (CheetahString::from_string(k.to_string()), v.clone()))
-            .collect();
+        let map = broker_config_map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         Ok(TopicRemappingDetailWrapper::new(
-            topic.to_string().into(),
+            CheetahString::from_slice(topic),
             topic_remapping_detail_wrapper::TYPE_CREATE_OR_UPDATE.to_string().into(),
             new_epoch,
             map,
@@ -877,13 +874,10 @@ impl TopicQueueMappingUtils {
             target_brokers,
         )?;
 
-        let map = broker_config_map
-            .iter()
-            .map(|(k, v)| (CheetahString::from_string(k.to_string()), v.clone()))
-            .collect();
+        let map = broker_config_map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
         Ok(TopicRemappingDetailWrapper::new(
-            topic.to_string().into(),
+            CheetahString::from_slice(topic),
             topic_remapping_detail_wrapper::TYPE_REMAPPING.to_string().into(),
             new_epoch as u64,
             map,


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7823

### Brief Description

Reuses existing `CheetahString` values when building static topic remapping wrappers. Broker keys are cloned directly from the source map, and wrapper topic values are built from borrowed topic text with `CheetahString::from_slice`.

This removes owned string round trips without changing remapping behavior, public APIs, or serialized values.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-remoting topic_queue_mapping_utils` completed successfully: 3 passed.
- `cargo clippy -p rocketmq-remoting --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.
