### PR TITLE
[ISSUE #7825]✨Reuse broker names in NameServer route management

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -915,7 +915,7 @@ impl RouteInfoManager {
             }
             for (broker_id, ip) in broker_data.broker_addrs().iter() {
                 if &broker_addr_info.broker_addr == ip {
-                    un_register_request.broker_name = CheetahString::from_string(broker_data.broker_name().to_string());
+                    un_register_request.broker_name = broker_data.broker_name().clone();
                     un_register_request.broker_id = *broker_id;
                     return true;
                 }

--- a/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
@@ -333,7 +333,7 @@ impl RouteInfoManagerWrapper {
         use cheetah_string::CheetahString;
         match self {
             RouteInfoManagerWrapper::V1(manager) => {
-                manager.wipe_write_perm_of_broker_by_lock(&CheetahString::from_string(broker_name.to_string()))
+                manager.wipe_write_perm_of_broker_by_lock(&CheetahString::from_slice(broker_name))
             }
             RouteInfoManagerWrapper::V2(manager) => manager
                 .wipe_write_perm_of_broker_by_lock(broker_name.to_string())
@@ -346,7 +346,7 @@ impl RouteInfoManagerWrapper {
         use cheetah_string::CheetahString;
         match self {
             RouteInfoManagerWrapper::V1(manager) => {
-                manager.add_write_perm_of_broker_by_lock(&CheetahString::from_string(broker_name.to_string()))
+                manager.add_write_perm_of_broker_by_lock(&CheetahString::from_slice(broker_name))
             }
             RouteInfoManagerWrapper::V2(manager) => manager
                 .add_write_perm_of_broker_by_lock(broker_name.to_string())


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7825

### Brief Description

Reuses broker name strings in NameServer route management instead of rebuilding them through owned `String` conversion. The V1 wrapper now creates temporary `CheetahString` values from borrowed broker names with `from_slice`, and unregister request population clones the existing broker name from route data.

This keeps route behavior and APIs unchanged while removing redundant conversion work.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-namesrv route_info_manager` completed successfully: 5 passed.
- `cargo clippy -p rocketmq-namesrv --all-targets --all-features -- -D warnings` completed successfully.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` completed successfully.
