### PR TITLE
[ISSUE #7827]✨Avoid trace switch string allocation in broker send properties

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor/message_builder.rs
+++ b/rocketmq-broker/src/processor/send_message_processor/message_builder.rs
@@ -77,7 +77,7 @@ pub(super) fn enrich_send_message_request_properties(
     );
     properties.insert(
         CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_SWITCH),
-        CheetahString::from_string(trace_on.to_string()),
+        CheetahString::from_static_str(if trace_on { "true" } else { "false" }),
     );
     request_header.properties = Some(message_properties_to_string(&properties));
     properties
@@ -101,7 +101,7 @@ mod tests {
         message
             .message_ext_inner
             .message
-            .set_topic(CheetahString::from_string(topic.to_string()));
+            .set_topic(CheetahString::from_slice(topic));
         message
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7827

### Brief Description

- Replace the broker send message trace switch conversion with static `CheetahString` bool text.
- Update the nearby topic test helper to build `CheetahString` directly from the borrowed slice.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-broker enrich_send_message_request_properties`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
