### PR TITLE
[ISSUE #7829]✨Reuse broker hook strings without owned round trips

### DIFF
--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -320,7 +320,7 @@ impl HookUtils {
         }
 
         // Backup real topic, queueId
-        let topic_value = CheetahString::from_string(msg.topic().to_string());
+        let topic_value = CheetahString::from_slice(msg.topic());
         msg.message_ext_inner.message.properties_mut().as_map_mut().insert(
             CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC), // real topic: %RETRY% + consumerGroup
             topic_value,
@@ -346,7 +346,7 @@ impl HookUtils {
         for msg in msg_list.iter_mut() {
             msg.message.properties_mut().as_map_mut().insert(
                 CheetahString::from_static_str(MessageConst::PROPERTY_WAIT_STORE_MSG_OK),
-                CheetahString::from_string(false.to_string()),
+                CheetahString::from_static_str("false"),
             );
         }
         msg_list.clear();


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7829

### Brief Description

- Build the delayed-message real topic backup directly from the borrowed topic slice.
- Write the send-back wait-store flag as static `CheetahString` text instead of formatting `false` through an owned `String`.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker hook_utils`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
