### PR TITLE
[ISSUE #7831]✨Build session credential strings from trimmed slices

### DIFF
--- a/rocketmq-client/src/common/session_credentials.rs
+++ b/rocketmq-client/src/common/session_credentials.rs
@@ -98,13 +98,13 @@ impl SessionCredentials {
 
     pub fn update_content(&mut self, properties: &HashMap<String, String>) {
         if let Some(value) = properties.get(ACCESS_KEY) {
-            self.access_key = Some(CheetahString::from_string(value.trim().to_string()));
+            self.access_key = Some(CheetahString::from_slice(value.trim()));
         }
         if let Some(value) = properties.get(SECRET_KEY) {
-            self.secret_key = Some(CheetahString::from_string(value.trim().to_string()));
+            self.secret_key = Some(CheetahString::from_slice(value.trim()));
         }
         if let Some(value) = properties.get(SECURITY_TOKEN) {
-            self.security_token = Some(CheetahString::from_string(value.trim().to_string()));
+            self.security_token = Some(CheetahString::from_slice(value.trim()));
         }
     }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7831

### Brief Description

- Build session credential `CheetahString` values directly from trimmed property slices.
- Preserve existing trimming behavior for access key, secret key, and security token updates.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust session_credentials`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
