### PR TITLE
[ISSUE #7833]✨Build lite lag topics from borrowed slices

### DIFF
--- a/rocketmq-broker/src/lite/lite_consumer_lag_calculator.rs
+++ b/rocketmq-broker/src/lite/lite_consumer_lag_calculator.rs
@@ -130,7 +130,7 @@ impl LiteConsumerLagCalculator {
             let Some(consumer_offset) = queue_offsets.get(&0).copied() else {
                 continue;
             };
-            offsets.push((CheetahString::from_string(topic.to_string()), consumer_offset));
+            offsets.push((CheetahString::from_slice(topic), consumer_offset));
         }
 
         offsets


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7833

### Brief Description

- Build lite lag collected topic names directly from the borrowed split topic slice.
- Preserve offset filtering and result construction behavior.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker lite_consumer_lag_calculator`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
