### PR TITLE
[ISSUE #7835]✨Reuse borrowed client strings for lite pull setup

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -196,7 +196,7 @@ impl MessageQueueListener for LitePullRebalanceListener {
             return;
         };
 
-        let topic = CheetahString::from_string(topic.to_string());
+        let topic = CheetahString::from_slice(topic);
         let mq_all = mq_all.clone();
         let mq_assigned = mq_assigned.clone();
         let user_listener = self.user_listener.clone();

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -1642,7 +1642,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
     async fn update_name_server_address(&self, name_server_address: &str) {
         self.client_config
             .mut_from_ref()
-            .set_namesrv_addr(CheetahString::from_string(name_server_address.to_string()));
+            .set_namesrv_addr(CheetahString::from_slice(name_server_address));
 
         if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
             let addresses: Vec<String> = name_server_address

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -469,7 +469,7 @@ impl TraceDispatcher for AsyncTraceDispatcher {
 
         // Create client config with proper trace settings
         let mut client_config = ClientConfig::default();
-        client_config.set_namesrv_addr(CheetahString::from_string(name_srv_addr.to_string()));
+        client_config.set_namesrv_addr(CheetahString::from_slice(name_srv_addr));
         client_config.set_enable_trace(false); // Prevents recursive trace operations
         client_config.set_vip_channel_enabled(false); // Disable VIP channel (matches Java implementation)
         client_config.set_use_tls(self.use_tls.load(Ordering::Acquire));


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7835

### Brief Description

- Build lite pull rebalance listener topics directly from borrowed topic input.
- Build lite pull and trace dispatcher nameserver `CheetahString` values directly from borrowed address input.
- Keep the owned nameserver address list used for remoting updates unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust lite_pull_rebalance_listener`
- `cargo test -p rocketmq-client-rust update_name_server_address_updates_client_api_like_java`
- `cargo test -p rocketmq-client-rust trace_init_registers_custom_dispatcher_and_starts_with_client_config`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how several address strings are handled internally, reducing unnecessary string allocations.
  * No user-facing behavior or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->