### PR TITLE
[ISSUE #7837]✨Reuse admin query request strings without allocations

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -6178,7 +6178,7 @@ impl MQClientAPIImpl {
         request: RemotingCommand,
         timeout_millis: u64,
     ) -> RocketMQResult<RemotingCommand> {
-        let address = CheetahString::from_string(address.to_string());
+        let address = CheetahString::from_slice(address);
         self.remoting_client
             .invoke_request(Some(&address), request, timeout_millis)
             .await
@@ -6200,7 +6200,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request.ensure_ext_fields_initialized();
         request.add_ext_field(
             mix_all::UNIQUE_MSG_QUERY_FLAG,
-            CheetahString::from_string(unique_key_flag.to_string()),
+            CheetahString::from_static_str(if unique_key_flag { "true" } else { "false" }),
         );
 
         let mut response = self.invoke_admin_request(address, request, timeout_millis).await?;


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7837

### Brief Description

- Build admin request broker addresses directly from borrowed address input.
- Write the unique-message query flag from static protocol text for true and false values.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust admin_message_matches_query`
- `cargo test -p rocketmq-client-rust admin_query_filter`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how broker request details are prepared for message lookup and admin calls, helping ensure protocol data is sent in a more reliable format.
  * Standardized request flags for message queries, reducing the chance of inconsistent values being transmitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->