### PR TITLE
[ISSUE #7839]✨Use static transaction prepared flag text

### DIFF
--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2545,7 +2545,7 @@ impl DefaultMQProducerImpl {
         MessageAccessor::put_property(
             &mut msg,
             CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_PREPARED),
-            CheetahString::from_string("true".to_owned()),
+            CheetahString::from_static_str("true"),
         );
         MessageAccessor::put_property(
             &mut msg,


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7839

### Brief Description

- Store the transactional prepared message property using static `CheetahString` text.
- Keep the prepared flag key and value unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust default_mq_producer_impl`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of transactional message state with no expected change in user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->