### PR TITLE
[ISSUE #7841]✨Use static lite topic type attribute text

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -512,7 +512,7 @@ fn lite_pull_topic_config(
     );
     config.attributes.insert(
         TopicAttributes::topic_message_type_attribute().name().clone(),
-        CheetahString::from_string(TopicMessageType::Lite.to_string()),
+        CheetahString::from_static_str(TopicMessageType::Lite.as_str()),
     );
     Ok(config)
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7841

### Brief Description

- Build the lite topic type attribute value from `TopicMessageType::Lite.as_str()`.
- Keep the stored attribute text as `LITE`.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust lite_pull_topic_config`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reduced unnecessary string allocation when handling lite topic metadata, improving efficiency with no change to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->