### PR TITLE
[ISSUE #7843]✨Use static wait-store message flag text

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -170,7 +170,7 @@ pub trait MessageTrait: Any + Display + Debug {
     fn set_wait_store_msg_ok(&mut self, wait_store_msg_ok: bool) {
         self.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_WAIT_STORE_MSG_OK),
-            CheetahString::from_string(wait_store_msg_ok.to_string()),
+            CheetahString::from_static_str(if wait_store_msg_ok { "true" } else { "false" }),
         );
     }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7843

### Brief Description

- Store the default wait-store message flag using static `CheetahString` text.
- Preserve Java-compatible true and false property values.

### How Did You Test This Change?

- `cargo test -p rocketmq-common wait_store_msg_ok`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-common --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
