### PR TITLE
[ISSUE #7845]✨Reuse ACL and send-back header strings

### DIFF
--- a/rocketmq-broker/src/auth/acl_converter.rs
+++ b/rocketmq-broker/src/auth/acl_converter.rs
@@ -45,7 +45,7 @@ impl AclConverter {
 
     pub fn convert_acl(acl: &Acl) -> AclInfo {
         AclInfo {
-            subject: Some(CheetahString::from_string(acl.subject_key().to_string())),
+            subject: Some(CheetahString::from_slice(acl.subject_key())),
             policies: Some(acl.policies().iter().map(Self::convert_policy).collect()),
         }
     }

--- a/rocketmq-remoting/src/protocol/header/consumer_send_msg_back_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/consumer_send_msg_back_request_header.rs
@@ -213,7 +213,7 @@ impl CommandCustomHeader for ConsumerSendMsgBackRequestHeader {
         }
         map.insert(
             CheetahString::from_static_str(Self::UNIT_MODE),
-            CheetahString::from_string(self.unit_mode.to_string()),
+            CheetahString::from_static_str(if self.unit_mode { "true" } else { "false" }),
         );
         if let Some(value) = self.max_reconsume_times {
             map.insert(


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7845

### Brief Description

- Build ACL subject strings directly from borrowed subject keys.
- Serialize consumer send-back unit mode using static boolean protocol text.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker acl_converter`
- `cargo test -p rocketmq-remoting consumer_send_msg_back_request_header`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-remoting --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
