### PR TITLE
[ISSUE #7849]✨Build recall trace message ids from slices

### DIFF
--- a/rocketmq-client/src/trace/hook/default_recall_message_trace_hook.rs
+++ b/rocketmq-client/src/trace/hook/default_recall_message_trace_hook.rs
@@ -108,7 +108,7 @@ fn build_recall_trace_context(
 
     let trace_bean = TraceBean {
         topic: CheetahString::from_string(topic),
-        msg_id: CheetahString::from_string(recall_handle.message_id().to_string()),
+        msg_id: CheetahString::from_slice(recall_handle.message_id()),
         ..Default::default()
     };
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7849

### Brief Description

- Build recall trace bean message ids directly from decoded recall handle slices.
- Preserve topic and group namespace handling in recall trace context construction.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust recall_trace_hook`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
