### PR TITLE
[ISSUE #7851]✨Use static topic filter type text

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1043,7 +1043,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
             read_queue_nums: config.read_queue_nums as i32,
             write_queue_nums: config.write_queue_nums as i32,
             perm: config.perm as i32,
-            topic_filter_type: config.topic_filter_type.to_string().into(),
+            topic_filter_type: CheetahString::from_static_str(config.topic_filter_type.as_str()),
             topic_sys_flag: Some(config.topic_sys_flag as i32),
             order: config.order,
             attributes,

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -203,7 +203,7 @@ impl MQAdminImpl {
                     read_queue_nums: queue_num,
                     write_queue_nums: queue_num,
                     perm: (PermName::PERM_READ | PermName::PERM_WRITE) as i32,
-                    topic_filter_type: CheetahString::from_string(TopicFilterType::SingleTag.to_string()),
+                    topic_filter_type: CheetahString::from_static_str(TopicFilterType::SingleTag.as_str()),
                     topic_sys_flag: Some(topic_sys_flag),
                     order: false,
                     attributes: Self::encode_topic_attributes(attributes.clone()),

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -1679,7 +1679,7 @@ impl MQClientAPIImpl {
             read_queue_nums,
             write_queue_nums,
             perm,
-            topic_filter_type: CheetahString::from_string(topic_config.topic_filter_type.to_string()),
+            topic_filter_type: CheetahString::from_static_str(topic_config.topic_filter_type.as_str()),
             topic_sys_flag: Some(topic_sys_flag),
             order: topic_config.order,
             attributes: None,
@@ -5961,7 +5961,7 @@ fn create_topic_request_header_like_java(
         read_queue_nums: topic_config_u32_to_java_i32("readQueueNums", topic_config.read_queue_nums)?,
         write_queue_nums: topic_config_u32_to_java_i32("writeQueueNums", topic_config.write_queue_nums)?,
         perm: topic_config_u32_to_java_i32("perm", topic_config.perm)?,
-        topic_filter_type: topic_config.topic_filter_type.to_string().into(),
+        topic_filter_type: CheetahString::from_static_str(topic_config.topic_filter_type.as_str()),
         topic_sys_flag: Some(topic_config_u32_to_java_i32(
             "topicSysFlag",
             topic_config.topic_sys_flag,

--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -76,18 +76,21 @@ pub enum TopicFilterType {
 
 impl Display for TopicFilterType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            TopicFilterType::SingleTag => write!(f, "SINGLE_TAG"),
-            TopicFilterType::MultiTag => write!(f, "MULTI_TAG"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
 impl Debug for TopicFilterType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TopicFilterType {
+    pub const fn as_str(&self) -> &'static str {
         match self {
-            TopicFilterType::SingleTag => write!(f, "SINGLE_TAG"),
-            TopicFilterType::MultiTag => write!(f, "MULTI_TAG"),
+            TopicFilterType::SingleTag => "SINGLE_TAG",
+            TopicFilterType::MultiTag => "MULTI_TAG",
         }
     }
 }
@@ -123,11 +126,7 @@ impl Serialize for TopicFilterType {
     where
         S: Serializer,
     {
-        let value = match self {
-            TopicFilterType::SingleTag => "SINGLE_TAG",
-            TopicFilterType::MultiTag => "MULTI_TAG",
-        };
-        serializer.serialize_str(value)
+        serializer.serialize_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7851

### Brief Description

- Add `TopicFilterType::as_str()` for fixed protocol text.
- Reuse static topic filter type text when building create-topic request headers.
- Keep display, debug, serialization, and request values unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-common topic_config`
- `cargo test -p rocketmq-client-rust create_topic_request_header`
- `cargo fmt --all -- --check`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-common --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
