### PR TITLE
[ISSUE #7853]✨Build broker query index types from slices

### DIFF
--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -133,8 +133,7 @@ where
         let is_unique_key = ext_fields
             .get(UNIQUE_MSG_QUERY_FLAG)
             .is_some_and(|value| value == "true");
-        let query_index_type = query_index_type(&request_header, is_unique_key)
-            .map(|idx_type| CheetahString::from_string(idx_type.to_string()));
+        let query_index_type = query_index_type(&request_header, is_unique_key).map(CheetahString::from_slice);
         if is_unique_key
             || query_index_type
                 .as_deref()


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7853

### Brief Description

- Build optional broker query index type values directly from borrowed resolver output.
- Preserve unique/tag index query behavior and max-num adjustment logic.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker query_message_processor`
- `cargo fmt --all`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved message query handling by reducing unnecessary string allocation, which may slightly improve performance and memory usage during queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->