### PR TITLE
[ISSUE #7857]✨Reuse borrowed store property keys

### DIFF
--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -236,7 +236,7 @@ fn generate_key(msg: &MessageExtBrokerInner) -> String {
 }
 
 fn parse_property_crc(properties_map: &HashMap<CheetahString, CheetahString>) -> Result<Option<u32>, ()> {
-    let Some(crc_32) = properties_map.get(&CheetahString::from_static_str(MessageConst::PROPERTY_CRC32)) else {
+    let Some(crc_32) = properties_map.get(MessageConst::PROPERTY_CRC32) else {
         return Ok(None);
     };
 
@@ -2520,8 +2520,7 @@ pub fn check_message_and_return_size(
 
         {
             // Timing message processing
-            let delay_time_level =
-                properties_map.get(&CheetahString::from_static_str(MessageConst::PROPERTY_DELAY_TIME_LEVEL));
+            let delay_time_level = properties_map.get(MessageConst::PROPERTY_DELAY_TIME_LEVEL);
             if let (Some(delay_time_level_str), true) =
                 (delay_time_level, TopicValidator::RMQ_SYS_SCHEDULE_TOPIC == topic)
             {

--- a/rocketmq-store/src/rocksdb/index.rs
+++ b/rocketmq-store/src/rocksdb/index.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::Weak;
 
-use cheetah_string::CheetahString;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_error::RocketMQError;
@@ -190,7 +189,7 @@ impl RocksDbIndexBuildService {
         if let Some(tag) = dispatch_request
             .properties_map
             .as_ref()
-            .and_then(|properties| properties.get(&CheetahString::from_static_str(MessageConst::PROPERTY_TAGS)))
+            .and_then(|properties| properties.get(MessageConst::PROPERTY_TAGS))
             .filter(|tag| !tag.is_empty())
         {
             records.push(IndexRocksDbRecord::tag_key(

--- a/rocketmq-store/src/rocksdb/timer.rs
+++ b/rocketmq-store/src/rocksdb/timer.rs
@@ -171,7 +171,7 @@ impl RocksDbTimerBuildService {
             return Ok(None);
         };
         let Some(delay_time) = properties
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))
+            .get(MessageConst::PROPERTY_TIMER_OUT_MS)
             .and_then(|delay_time| delay_time.as_str().parse::<i64>().ok())
             .filter(|delay_time| *delay_time > 0)
         else {
@@ -179,9 +179,7 @@ impl RocksDbTimerBuildService {
         };
 
         let (uniq_key, action) = if let Some(delete_key) = properties
-            .get(&CheetahString::from_static_str(
-                MessageConst::PROPERTY_TIMER_DEL_UNIQKEY,
-            ))
+            .get(MessageConst::PROPERTY_TIMER_DEL_UNIQKEY)
             .filter(|delete_key| !delete_key.is_empty())
         {
             (
@@ -189,7 +187,7 @@ impl RocksDbTimerBuildService {
                 TimerRocksDbAction::Delete,
             )
         } else if properties
-            .get(&CheetahString::from_static_str(PROPERTY_TIMER_ROLL_LABEL))
+            .get(PROPERTY_TIMER_ROLL_LABEL)
             .is_some_and(|roll_label| !roll_label.is_empty())
         {
             let Some(uniq_key) = timer_uniq_key(dispatch_request, properties) else {
@@ -324,9 +322,7 @@ fn timer_uniq_key(
         .map(ToString::to_string)
         .or_else(|| {
             properties
-                .get(&CheetahString::from_static_str(
-                    MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
-                ))
+                .get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
                 .filter(|uniq_key| !uniq_key.is_empty())
                 .map(ToString::to_string)
         })

--- a/rocketmq-store/src/rocksdb/transaction.rs
+++ b/rocketmq-store/src/rocksdb/transaction.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::Weak;
 
-use cheetah_string::CheetahString;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_error::RocketMQError;
 use tracing::warn;
@@ -164,13 +163,13 @@ impl RocksDbTransBuildService {
             return Ok(None);
         };
         let Some(real_topic) = properties
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+            .get(MessageConst::PROPERTY_REAL_TOPIC)
             .filter(|topic| !topic.is_empty())
         else {
             return Ok(None);
         };
         let Some(transaction_id) = properties
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_ID))
+            .get(MessageConst::PROPERTY_TRANSACTION_ID)
             .filter(|transaction_id| !transaction_id.is_empty())
         else {
             return Ok(None);
@@ -189,7 +188,7 @@ impl RocksDbTransBuildService {
         }
 
         let trans_offset = properties
-            .get(&CheetahString::from_static_str(PROPERTY_TRANS_OFFSET))
+            .get(PROPERTY_TRANS_OFFSET)
             .and_then(|offset| offset.as_str().parse::<i64>().ok())
             .filter(|offset| *offset >= 0);
         Ok(trans_offset.map(|offset_py| TransRocksDbRecord {


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7857

### Brief Description

Replaces temporary `CheetahString` construction with borrowed `&str` lookups for store property maps in commit-log CRC/delay handling and RocksDB index, timer, and transaction builders. This keeps persisted bytes and public APIs unchanged while removing avoidable lookup allocations.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store check_message_and_return_size_verifies_property_crc_when_enabled`
- `cargo test -p rocketmq-store --all-features --test rocksdb_foundation_tests dispatch_request`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal message property lookups across store, index, timer, and transaction processing.
  * Reduced overhead by using shared property constants directly, keeping behavior unchanged.
  * No visible API or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->