### PR TITLE
[ISSUE #7859]✨Reuse borrowed runtime map lookups

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -1825,7 +1825,7 @@ pub fn process_send_response(
         if let Some(region_id) = response
             .get_ext_fields()
             .unwrap()
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_MSG_REGION))
+            .get(MessageConst::PROPERTY_MSG_REGION)
         {
             send_result.set_region_id(region_id.to_string());
         } else {
@@ -1835,7 +1835,7 @@ pub fn process_send_response(
         if let Some(trace_on) = response
             .get_ext_fields()
             .unwrap()
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_SWITCH))
+            .get(MessageConst::PROPERTY_TRACE_SWITCH)
         {
             send_result.set_trace_on(trace_on == "true");
         } else {

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use cheetah_string::CheetahString;
 use rocketmq_auth::authentication::enums::user_type::UserType;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -82,10 +81,7 @@ impl<MS: MessageStore> CreateUserRequestHandler<MS> {
     }
 
     async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
-        let Some(access_key) = request
-            .ext_fields()
-            .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
-        else {
+        let Some(access_key) = request.ext_fields().and_then(|fields| fields.get("AccessKey")) else {
             return Ok(false);
         };
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use cheetah_string::CheetahString;
 use rocketmq_auth::authentication::enums::user_type::UserType;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -78,10 +77,7 @@ impl<MS: MessageStore> DeleteUserRequestHandler<MS> {
     }
 
     async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
-        let Some(access_key) = request
-            .ext_fields()
-            .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
-        else {
+        let Some(access_key) = request.ext_fields().and_then(|fields| fields.get("AccessKey")) else {
             return Ok(false);
         };
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -81,10 +80,7 @@ impl<MS: MessageStore> UpdateGlobalWhiteAddrsConfigRequestHandler<MS> {
     }
 
     async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
-        let Some(access_key) = request
-            .ext_fields()
-            .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
-        else {
+        let Some(access_key) = request.ext_fields().and_then(|fields| fields.get("AccessKey")) else {
             return Ok(false);
         };
 
@@ -111,6 +107,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::SystemTime;
 
+    use cheetah_string::CheetahString;
     use rocketmq_auth::config::AuthConfig;
     use rocketmq_auth::ProviderRegistry;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -1,7 +1,6 @@
 use crate::auth::auth_admin_service::AuthAdminService;
 use crate::auth::user_converter::UserConverter;
 use crate::broker_runtime::BrokerRuntimeInner;
-use cheetah_string::CheetahString;
 use rocketmq_auth::authentication::enums::user_type::UserType;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -101,10 +100,7 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
     }
 
     async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
-        let Some(access_key) = request
-            .ext_fields()
-            .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
-        else {
+        let Some(access_key) = request.ext_fields().and_then(|fields| fields.get("AccessKey")) else {
             return Ok(false);
         };
 

--- a/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
+++ b/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
@@ -122,7 +122,7 @@ impl ConsumeMessageTraceHookImpl {
     fn parse_context_code(&self, context: &ConsumeMessageContext) -> i32 {
         context
             .props
-            .get(&CheetahString::from_static_str(mix_all::CONSUME_CONTEXT_TYPE))
+            .get(mix_all::CONSUME_CONTEXT_TYPE)
             .and_then(|type_str| match type_str.as_str() {
                 "SUCCESS" => Some(ConsumeReturnType::Success),
                 "TIME_OUT" | "TIMEOUT" => Some(ConsumeReturnType::TimeOut),

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
@@ -438,7 +438,7 @@ impl TopicQueueMappingUtils {
                                 ));
                             }
                             if let Some(bname) = &item.bname {
-                                let topic_config = broker_config_map.get(&CheetahString::from(bname));
+                                let topic_config = broker_config_map.get(bname.as_str());
                                 if topic_config.is_none() {
                                     return Err(RocketMQError::Internal(
                                         "The broker of item does not exist".to_string(),


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7859

### Brief Description

Replaces temporary `CheetahString` lookup keys with borrowed string lookups in runtime maps for remoting static-topic validation, consumer trace context parsing, broker send response ext fields, and ACL administration access-key checks. Protocol names, public APIs, and persisted bytes are unchanged.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust consume_trace`
- `cargo test -p rocketmq-broker update_global_white_addrs_config_updates_runtime_snapshot`
- `cargo test -p rocketmq-remoting check_if_leader_requires_last_item_broker_to_match_detail_broker`
- `cargo bench -p rocketmq-remoting --bench remoting_string_fields_bench -- get_by_str/32 --sample-size 10 --measurement-time 1 --warm-up-time 1`
- `cargo clippy -p rocketmq-remoting --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified several internal lookups for message tracing, broker settings, and user access checks.
  * Made key retrieval more direct and consistent across broker and client flows.
* **Bug Fixes**
  * Improved reliability when reading extended fields and mapping queue configuration values, with existing fallback behavior preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->