### PR TITLE
[ISSUE #7864]✨Shard pull scheduling and persist consume baselines

### DIFF
--- a/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
+++ b/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
@@ -14,16 +14,25 @@
 
 use std::hint::black_box;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use cheetah_string::CheetahString;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
+use rocketmq_client_rust::base::client_config::ClientConfig;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::ProcessQueue;
 use rocketmq_client_rust::consumer::consumer_impl::pull_message_service::PullMessageService;
+use rocketmq_client_rust::consumer::consumer_impl::pull_message_service::PullMessageServiceShardSnapshot;
+use rocketmq_client_rust::consumer::consumer_impl::pull_request::PullRequest;
+use rocketmq_client_rust::factory::mq_client_instance::MQClientInstance;
+use rocketmq_common::common::message::message_queue::MessageQueue;
 use serde::Serialize;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
@@ -36,10 +45,35 @@ struct PullSchedulerBenchOutput {
     p99_late_us: u128,
 }
 
+#[derive(Debug, Serialize)]
+struct ShardedPullSchedulerBenchOutput {
+    request_count: usize,
+    shard_count: usize,
+    worker_task_count: usize,
+    submitted_count: u64,
+    processed_count: u64,
+    rejected_count: u64,
+    pending_count: usize,
+    elapsed_us: u128,
+}
+
 fn p99(mut values: Vec<u128>) -> u128 {
     values.sort_unstable();
     let index = values.len().saturating_mul(99).div_ceil(100).saturating_sub(1);
     values[index]
+}
+
+fn create_pull_request(index: usize) -> PullRequest {
+    PullRequest::new(
+        CheetahString::from_static_str("benchmark_group"),
+        MessageQueue::from_parts(
+            format!("benchmark_topic_{}", index % 128),
+            "benchmark_broker",
+            (index % 32) as i32,
+        ),
+        Arc::new(ProcessQueue::new()),
+        index as i64,
+    )
 }
 
 async fn run_one_shot_sleep_tasks(request_count: usize, delay: Duration) -> PullSchedulerBenchOutput {
@@ -115,6 +149,64 @@ async fn run_shared_scheduler_tasks(request_count: usize, delay: Duration) -> Pu
     }
 }
 
+async fn wait_for_sharded_pull_requests(
+    service: &PullMessageService,
+    request_count: usize,
+) -> PullMessageServiceShardSnapshot {
+    let deadline = TokioInstant::now() + Duration::from_secs(5);
+    loop {
+        let snapshot = service.shard_snapshot().await;
+        if snapshot.processed_count + snapshot.rejected_count >= request_count as u64 {
+            return snapshot;
+        }
+        assert!(
+            TokioInstant::now() < deadline,
+            "sharded pull scheduler benchmark timed out: {snapshot:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
+async fn run_sharded_pull_workers(request_count: usize, shard_count: usize) -> ShardedPullSchedulerBenchOutput {
+    let client_config = ClientConfig {
+        namesrv_addr: None,
+        pull_message_service_shards: shard_count,
+        ..Default::default()
+    };
+    let mut instance = MQClientInstance::new_arc(client_config, 0, "client-pull-scheduler-sharded-bench", None);
+    let mut service = PullMessageService::with_capacity_and_shards(request_count.next_power_of_two(), shard_count);
+    service
+        .start(instance.clone())
+        .await
+        .expect("sharded pull scheduler benchmark service should start");
+
+    let started_at = Instant::now();
+    for index in 0..request_count {
+        service
+            .execute_pull_request_immediately(create_pull_request(index))
+            .await;
+    }
+    let snapshot = wait_for_sharded_pull_requests(&service, request_count).await;
+    let elapsed_us = started_at.elapsed().as_micros();
+
+    service
+        .shutdown(1_000)
+        .await
+        .expect("sharded pull scheduler benchmark service should shutdown");
+    instance.shutdown().await;
+
+    ShardedPullSchedulerBenchOutput {
+        request_count,
+        shard_count: snapshot.shard_count,
+        worker_task_count: snapshot.worker_task_count,
+        submitted_count: snapshot.submitted_count,
+        processed_count: snapshot.processed_count,
+        rejected_count: snapshot.rejected_count,
+        pending_count: snapshot.pending_count,
+        elapsed_us,
+    }
+}
+
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -131,6 +223,7 @@ fn write_pull_scheduler_report_artifact(runtime: &Runtime) {
     let delay = Duration::from_millis(20);
     let one_shot = runtime.block_on(run_one_shot_sleep_tasks(request_count, delay));
     let shared_scheduler = runtime.block_on(run_shared_scheduler_tasks(request_count, delay));
+    let sharded_pull_workers = runtime.block_on(run_sharded_pull_workers(request_count, 4));
     let output_dir = benchmark_artifact_dir();
     std::fs::create_dir_all(&output_dir).expect("pull scheduler benchmark artifact directory should be created");
 
@@ -143,6 +236,7 @@ fn write_pull_scheduler_report_artifact(runtime: &Runtime) {
         "generated_at_unix_ms": generated_at_unix_ms,
         "one_shot_sleep_tasks": one_shot,
         "shared_scheduler": shared_scheduler,
+        "sharded_pull_workers": sharded_pull_workers,
     });
     let path = output_dir.join("client-pull-scheduler-report.json");
     std::fs::write(
@@ -179,6 +273,20 @@ fn bench_pull_scheduler(c: &mut Criterion) {
             },
         );
     }
+
+    group.bench_with_input(
+        BenchmarkId::new("ShardedPullWorkers", request_count),
+        &request_count,
+        |bencher, &request_count| {
+            bencher.to_async(&runtime).iter(|| async move {
+                let output = run_sharded_pull_workers(request_count, 4).await;
+                assert_eq!(output.request_count, request_count);
+                assert_eq!(output.processed_count, request_count as u64);
+                black_box(output.worker_task_count);
+                black_box(output.elapsed_us);
+            });
+        },
+    );
 
     group.finish();
 }

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -71,6 +71,9 @@ pub struct ClientConfig {
     /// Default: number of CPU cores (matches Java: Runtime.getRuntime().availableProcessors())
     // java client has this option, but we keep it for compatibility and future will remove it if it's not needed
     pub concurrent_heartbeat_thread_pool_size: usize,
+    /// Pull request worker shard count for PullMessageService.
+    /// Default: min(number of CPU cores, 8).
+    pub pull_message_service_shards: usize,
 }
 
 impl Default for ClientConfig {
@@ -151,6 +154,7 @@ impl ClientConfig {
             trace_msg_batch_num: 10,
             max_page_size_in_get_metadata: 2000,
             concurrent_heartbeat_thread_pool_size: num_cpus::get(),
+            pull_message_service_shards: num_cpus::get().clamp(1, 8),
         }
     }
 }
@@ -639,6 +643,16 @@ impl ClientConfig {
         self.concurrent_heartbeat_thread_pool_size = size;
     }
 
+    #[inline]
+    pub fn get_pull_message_service_shards(&self) -> usize {
+        self.pull_message_service_shards
+    }
+
+    #[inline]
+    pub fn set_pull_message_service_shards(&mut self, shards: usize) {
+        self.pull_message_service_shards = shards;
+    }
+
     // ============ Utility Methods ============
 
     /// Clones the configuration
@@ -683,6 +697,7 @@ impl ClientConfig {
         self.max_page_size_in_get_metadata = other.max_page_size_in_get_metadata;
         self.enable_concurrent_heartbeat = other.enable_concurrent_heartbeat;
         self.concurrent_heartbeat_thread_pool_size = other.concurrent_heartbeat_thread_pool_size;
+        self.pull_message_service_shards = other.pull_message_service_shards;
     }
 
     /// Deprecated: Use with_namespace instead
@@ -729,7 +744,7 @@ impl std::fmt::Display for ClientConfig {
              {:?}, enable_stream_request_type: {}, send_latency_enable: {}, start_detector_enable: {}, \
              enable_heartbeat_channel_event_listener: {}, enable_trace: {}, trace_topic: {:?}, trace_msg_batch_num: \
              {}, max_page_size_in_get_metadata: {}, enable_concurrent_heartbeat: {}, \
-             concurrent_heartbeat_thread_pool_size: {} }}",
+             concurrent_heartbeat_thread_pool_size: {}, pull_message_service_shards: {} }}",
             self.namesrv_addr,
             self.client_ip,
             self.instance_name,
@@ -762,7 +777,8 @@ impl std::fmt::Display for ClientConfig {
             self.trace_msg_batch_num,
             self.max_page_size_in_get_metadata,
             self.enable_concurrent_heartbeat,
-            self.concurrent_heartbeat_thread_pool_size
+            self.concurrent_heartbeat_thread_pool_size,
+            self.pull_message_service_shards
         )
     }
 }
@@ -795,6 +811,7 @@ mod tests {
         source.set_max_page_size_in_get_metadata(4096);
         source.set_enable_concurrent_heartbeat(true);
         source.set_concurrent_heartbeat_thread_pool_size(8);
+        source.set_pull_message_service_shards(4);
 
         let mut target = ClientConfig::default();
         target.set_use_tls(false);
@@ -804,6 +821,7 @@ mod tests {
         target.set_max_page_size_in_get_metadata(2000);
         target.set_enable_concurrent_heartbeat(false);
         target.set_concurrent_heartbeat_thread_pool_size(1);
+        target.set_pull_message_service_shards(1);
 
         target.reset_client_config(&source);
 
@@ -818,6 +836,7 @@ mod tests {
         assert_eq!(target.get_max_page_size_in_get_metadata(), 4096);
         assert!(target.is_enable_concurrent_heartbeat());
         assert_eq!(target.get_concurrent_heartbeat_thread_pool_size(), 8);
+        assert_eq!(target.get_pull_message_service_shards(), 4);
     }
 
     #[test]

--- a/rocketmq-client/src/base/client_config_builder.rs
+++ b/rocketmq-client/src/base/client_config_builder.rs
@@ -102,6 +102,12 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets the PullMessageService pull worker shard count.
+    pub fn pull_message_service_shards(mut self, shards: usize) -> Self {
+        self.config.set_pull_message_service_shards(shards);
+        self
+    }
+
     // ========================================================================
     // Namespace configuration
     // ========================================================================
@@ -372,6 +378,7 @@ impl ClientConfigBuilder {
 
         // Validate thread pool sizes
         ClientConfigValidator::validate_client_callback_executor_threads(self.config.client_callback_executor_threads)?;
+        ClientConfigValidator::validate_pull_message_service_shards(self.config.pull_message_service_shards)?;
 
         // Only validate concurrent heartbeat thread pool size if concurrent heartbeat is enabled
         if self.config.enable_concurrent_heartbeat {
@@ -411,6 +418,7 @@ mod tests {
             .enable_tls(true)
             .enable_concurrent_heartbeat(true)
             .concurrent_heartbeat_thread_pool_size(4)
+            .pull_message_service_shards(4)
             .build()
             .unwrap();
 
@@ -423,6 +431,7 @@ mod tests {
         assert!(config.tls_config.enable);
         assert!(config.enable_concurrent_heartbeat);
         assert_eq!(config.concurrent_heartbeat_thread_pool_size, 4);
+        assert_eq!(config.pull_message_service_shards, 4);
     }
 
     #[test]

--- a/rocketmq-client/src/base/client_config_validation.rs
+++ b/rocketmq-client/src/base/client_config_validation.rs
@@ -68,6 +68,9 @@ impl ClientConfigValidator {
     /// Maximum MQ client API timeout (60 seconds)
     pub const MAX_MQ_CLIENT_API_TIMEOUT: u64 = 60_000;
 
+    /// Maximum PullMessageService shard multiplier.
+    pub const MAX_PULL_MESSAGE_SERVICE_SHARDS_PER_CPU: usize = 8;
+
     // =========================================================================
     // Validation Methods
     // =========================================================================
@@ -238,6 +241,34 @@ impl ClientConfigValidator {
 
         Ok(())
     }
+
+    /// Validate PullMessageService shard count.
+    ///
+    /// Ensures the shard count is greater than 0 and stays within a reasonable
+    /// CPU-scaled upper bound.
+    pub fn validate_pull_message_service_shards(shards: usize) -> RocketMQResult<()> {
+        if shards == 0 {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "pull_message_service_shards",
+                value: shards.to_string(),
+                reason: "must be greater than 0".to_string(),
+            });
+        }
+
+        #[allow(clippy::redundant_closure)]
+        let cpu_count = std::panic::catch_unwind(|| num_cpus::get()).unwrap_or(4);
+        let max_shards = cpu_count * Self::MAX_PULL_MESSAGE_SERVICE_SHARDS_PER_CPU;
+
+        if shards > max_shards {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "pull_message_service_shards",
+                value: shards.to_string(),
+                reason: format!("should not exceed {} (CPU cores * 8)", max_shards),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -287,6 +318,13 @@ mod tests {
     fn test_validate_concurrent_heartbeat_thread_pool_size_valid() {
         assert!(ClientConfigValidator::validate_concurrent_heartbeat_thread_pool_size(1).is_ok());
         assert!(ClientConfigValidator::validate_concurrent_heartbeat_thread_pool_size(4).is_ok());
+    }
+
+    #[test]
+    fn test_validate_pull_message_service_shards() {
+        assert!(ClientConfigValidator::validate_pull_message_service_shards(1).is_ok());
+        assert!(ClientConfigValidator::validate_pull_message_service_shards(4).is_ok());
+        assert!(ClientConfigValidator::validate_pull_message_service_shards(0).is_err());
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::BinaryHeap;
 use std::future::Future;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
@@ -23,6 +26,7 @@ use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use std::time::Instant;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_error::RocketMQError;
 use rocketmq_rust::ArcMut;
@@ -47,6 +51,9 @@ use crate::runtime::ClientTrackedTaskHandle;
 
 /// Default queue capacity for message requests
 const DEFAULT_QUEUE_CAPACITY: usize = 4096;
+
+/// Maximum default shard count for pull request workers.
+const DEFAULT_MAX_PULL_SHARDS: usize = 8;
 
 /// Default shutdown timeout in milliseconds
 const DEFAULT_SHUTDOWN_TIMEOUT_MS: u64 = 1000;
@@ -83,8 +90,20 @@ pub struct PullMessageService {
     /// Queue capacity
     queue_capacity: usize,
 
+    /// Pull request worker shard count.
+    shard_count: usize,
+
+    /// Pull request dispatcher installed after service startup.
+    pull_dispatcher: Arc<StdMutex<Option<PullRequestDispatcher>>>,
+
     /// Main service loop task handle
     main_task_handle: Arc<tokio::sync::Mutex<Option<ClientTrackedTaskHandle>>>,
+
+    /// Pull worker task handles.
+    pull_shard_task_handles: Arc<tokio::sync::Mutex<Vec<ClientTrackedTaskHandle>>>,
+
+    /// Shared pull worker metrics.
+    pull_shard_metrics: Arc<Vec<Arc<PullRequestShardMetrics>>>,
 
     /// Tracks the shared delayed scheduler and immediate generic tasks.
     scheduled_task_tracker: TaskTracker,
@@ -106,6 +125,7 @@ pub struct PullMessageServiceLifecycleProbe {
     pub task_count_after_shutdown: usize,
     pub shutdown_elapsed_us: u128,
     pub delayed_scheduler: PullMessageServiceDelayedSchedulerSnapshot,
+    pub shards: PullMessageServiceShardSnapshot,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize)]
@@ -115,6 +135,97 @@ pub struct PullMessageServiceDelayedSchedulerSnapshot {
     pub expired_count: u64,
     pub cancelled_count: u64,
     pub scheduler_task_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullMessageServiceShardSnapshot {
+    pub shard_count: usize,
+    pub pending_count: usize,
+    pub submitted_count: u64,
+    pub processed_count: u64,
+    pub rejected_count: u64,
+    pub worker_task_count: usize,
+    pub shards: Vec<PullMessageServiceShardMetricSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct PullMessageServiceShardMetricSnapshot {
+    pub index: usize,
+    pub pending_count: usize,
+    pub submitted_count: u64,
+    pub processed_count: u64,
+    pub rejected_count: u64,
+}
+
+#[derive(Default)]
+struct PullRequestShardMetrics {
+    pending_count: AtomicUsize,
+    submitted_count: AtomicU64,
+    processed_count: AtomicU64,
+    rejected_count: AtomicU64,
+}
+
+impl PullRequestShardMetrics {
+    fn record_submitted(&self) {
+        self.submitted_count.fetch_add(1, Ordering::Relaxed);
+        self.pending_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_processed(&self) {
+        self.processed_count.fetch_add(1, Ordering::Relaxed);
+        self.decrement_pending();
+    }
+
+    fn record_rejected(&self) {
+        self.rejected_count.fetch_add(1, Ordering::Relaxed);
+        self.decrement_pending();
+    }
+
+    fn decrement_pending(&self) {
+        let _ = self
+            .pending_count
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(1))
+            });
+    }
+
+    fn snapshot(&self, index: usize) -> PullMessageServiceShardMetricSnapshot {
+        PullMessageServiceShardMetricSnapshot {
+            index,
+            pending_count: self.pending_count.load(Ordering::Relaxed),
+            submitted_count: self.submitted_count.load(Ordering::Relaxed),
+            processed_count: self.processed_count.load(Ordering::Relaxed),
+            rejected_count: self.rejected_count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PullRequestDispatcher {
+    client_id: CheetahString,
+    shards: Arc<Vec<PullRequestShard>>,
+}
+
+impl PullRequestDispatcher {
+    async fn dispatch(&self, request: PullRequest) {
+        let shard_index = pull_request_shard_index(self.client_id.as_str(), &request, self.shards.len());
+        let shard = &self.shards[shard_index];
+        shard.metrics.record_submitted();
+        if let Err(error) = shard.tx.send(request).await {
+            shard.metrics.record_rejected();
+            warn!(
+                shard_index = shard.index,
+                "Failed to send sharded pull request: {:?}", error
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PullRequestShard {
+    index: usize,
+    tx: mpsc::Sender<PullRequest>,
+    metrics: Arc<PullRequestShardMetrics>,
 }
 
 #[derive(Default)]
@@ -172,7 +283,7 @@ struct DelayedScheduleCommand {
 enum DelayedSchedulePayload {
     Pull {
         request: PullRequest,
-        tx: Option<MessageRequestSender>,
+        dispatcher: Option<PullRequestDispatcher>,
     },
     Pop {
         request: PopRequest,
@@ -188,11 +299,11 @@ impl DelayedSchedulePayload {
         }
 
         match self {
-            Self::Pull { request, tx } => {
-                if let Some(tx) = tx {
-                    if let Err(error) = tx.send(Box::new(request)).await {
-                        warn!("Failed to send pull request: {:?}", error);
-                    }
+            Self::Pull { request, dispatcher } => {
+                if let Some(dispatcher) = dispatcher {
+                    dispatcher.dispatch(request).await;
+                } else {
+                    warn!("PullMessageService not started");
                 }
             }
             Self::Pop { request, tx } => {
@@ -352,20 +463,83 @@ fn cancel_delayed_queue(
     metrics.record_cancelled(cancelled);
 }
 
+fn default_pull_shard_count() -> usize {
+    num_cpus::get().clamp(1, DEFAULT_MAX_PULL_SHARDS)
+}
+
+fn normalize_pull_shard_count(shard_count: usize) -> usize {
+    shard_count.max(1)
+}
+
+fn pull_request_shard_index(client_id: &str, request: &PullRequest, shard_count: usize) -> usize {
+    let shard_count = normalize_pull_shard_count(shard_count);
+    let mut hasher = DefaultHasher::new();
+    client_id.hash(&mut hasher);
+    request.consumer_group.hash(&mut hasher);
+    request.message_queue.hash(&mut hasher);
+    (hasher.finish() as usize) % shard_count
+}
+
+async fn run_pull_request_shard_worker(
+    index: usize,
+    mut rx: mpsc::Receiver<PullRequest>,
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    mut instance: ArcMut<MQClientInstance>,
+    metrics: Arc<PullRequestShardMetrics>,
+) {
+    info!(shard_index = index, "PullMessageService shard worker started");
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                break;
+            }
+            Some(request) = rx.recv() => {
+                PullMessageService::pull_message(request, &mut instance).await;
+                metrics.record_processed();
+            }
+            else => {
+                break;
+            }
+        }
+    }
+
+    info!(shard_index = index, "PullMessageService shard worker end");
+}
+
 impl PullMessageService {
     /// Creates a new PullMessageService instance
     pub fn new() -> Self {
-        Self::with_capacity(DEFAULT_QUEUE_CAPACITY)
+        Self::with_capacity_and_shards(DEFAULT_QUEUE_CAPACITY, default_pull_shard_count())
     }
 
     /// Creates a new PullMessageService instance with custom queue capacity
     pub fn with_capacity(queue_capacity: usize) -> Self {
+        Self::with_capacity_and_shards(queue_capacity, default_pull_shard_count())
+    }
+
+    /// Creates a new PullMessageService instance with custom shard count.
+    pub fn with_shards(shard_count: usize) -> Self {
+        Self::with_capacity_and_shards(DEFAULT_QUEUE_CAPACITY, shard_count)
+    }
+
+    /// Creates a new PullMessageService instance with custom queue capacity and shard count.
+    pub fn with_capacity_and_shards(queue_capacity: usize, shard_count: usize) -> Self {
+        let shard_count = normalize_pull_shard_count(shard_count);
+        let pull_shard_metrics = (0..shard_count)
+            .map(|_| Arc::new(PullRequestShardMetrics::default()))
+            .collect();
+
         PullMessageService {
             tx: None,
             tx_shutdown: None,
             stopped: Arc::new(AtomicBool::new(false)),
             queue_capacity,
+            shard_count,
+            pull_dispatcher: Arc::new(StdMutex::new(None)),
             main_task_handle: Arc::new(tokio::sync::Mutex::new(None)),
+            pull_shard_task_handles: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            pull_shard_metrics: Arc::new(pull_shard_metrics),
             scheduled_task_tracker: TaskTracker::new(),
             scheduled_task_shutdown: CancellationToken::new(),
             delayed_scheduler_tx: Arc::new(StdMutex::new(None)),
@@ -385,6 +559,18 @@ impl PullMessageService {
         "PullMessageService"
     }
 
+    /// Returns configured pull request shard count.
+    #[inline]
+    pub fn shard_count(&self) -> usize {
+        self.shard_count
+    }
+
+    /// Returns the shard index for a pull request and client id.
+    #[doc(hidden)]
+    pub fn shard_index_for_pull_request(&self, client_id: &str, pull_request: &PullRequest) -> usize {
+        pull_request_shard_index(client_id, pull_request, self.shard_count)
+    }
+
     /// Starts the pull message service
     ///
     /// # Arguments
@@ -392,7 +578,7 @@ impl PullMessageService {
     ///
     /// # Errors
     /// Returns error if service is already started
-    pub async fn start(&mut self, mut instance: ArcMut<MQClientInstance>) -> Result<(), RocketMQError> {
+    pub async fn start(&mut self, instance: ArcMut<MQClientInstance>) -> Result<(), RocketMQError> {
         if self.tx.is_some() {
             warn!("{} already started", self.get_service_name());
             return Ok(());
@@ -400,6 +586,7 @@ impl PullMessageService {
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Box<dyn MessageRequest + Send + 'static>>(self.queue_capacity);
         let (mut shutdown, tx_shutdown) = Shutdown::new(1);
+        let mut pop_instance = instance.clone();
 
         let handle = spawn_client_tracked_task("rocketmq-client-pull-message-service", async move {
             info!("{} service started", "PullMessageService");
@@ -412,7 +599,7 @@ impl PullMessageService {
                     }
                     Some(request) = rx.recv() => {
                         // Process request with exception handling
-                        if let Err(e) = Self::process_request(request, &mut instance).await {
+                        if let Err(e) = Self::process_request(request, &mut pop_instance).await {
                             error!("{} failed to process request: {:?}", "PullMessageService", e);
                         }
                     }
@@ -423,25 +610,102 @@ impl PullMessageService {
         })
         .map_err(|error| RocketMQError::Internal(format!("failed to spawn PullMessageService main loop: {error}")))?;
 
+        let mut pull_shards = Vec::with_capacity(self.shard_count);
+        let mut pull_handles = Vec::with_capacity(self.shard_count);
+        for index in 0..self.shard_count {
+            let (shard_tx, shard_rx) = mpsc::channel::<PullRequest>(self.queue_capacity);
+            let metrics = self.pull_shard_metrics[index].clone();
+            let worker_instance = instance.clone();
+            let shutdown_rx = tx_shutdown.subscribe();
+            let handle = spawn_client_tracked_task(
+                "rocketmq-client-pull-message-service-shard",
+                run_pull_request_shard_worker(index, shard_rx, shutdown_rx, worker_instance, metrics.clone()),
+            )
+            .map_err(|error| {
+                RocketMQError::Internal(format!("failed to spawn PullMessageService shard worker: {error}"))
+            })?;
+
+            pull_shards.push(PullRequestShard {
+                index,
+                tx: shard_tx,
+                metrics,
+            });
+            pull_handles.push(handle);
+        }
+
+        {
+            let mut dispatcher = self
+                .pull_dispatcher
+                .lock()
+                .expect("pull dispatcher lock should not be poisoned");
+            *dispatcher = Some(PullRequestDispatcher {
+                client_id: instance.client_id.clone(),
+                shards: Arc::new(pull_shards),
+            });
+        }
+
         self.tx = Some(tx);
         self.tx_shutdown = Some(tx_shutdown);
         self.stopped.store(false, Ordering::Release);
         *self.main_task_handle.lock().await = Some(handle);
+        *self.pull_shard_task_handles.lock().await = pull_handles;
 
         Ok(())
     }
 
     async fn main_task_count(&self) -> usize {
-        self.main_task_handle
+        let main_count = self
+            .main_task_handle
             .lock()
             .await
             .as_ref()
             .map(ClientTrackedTaskHandle::task_count)
-            .unwrap_or_default()
+            .unwrap_or_default();
+        let shard_count = self
+            .pull_shard_task_handles
+            .lock()
+            .await
+            .iter()
+            .map(ClientTrackedTaskHandle::task_count)
+            .sum::<usize>();
+        main_count + shard_count
     }
 
     pub fn delayed_scheduler_snapshot(&self) -> PullMessageServiceDelayedSchedulerSnapshot {
         self.delayed_scheduler_metrics.snapshot()
+    }
+
+    pub async fn shard_snapshot(&self) -> PullMessageServiceShardSnapshot {
+        let shards = self
+            .pull_shard_metrics
+            .iter()
+            .enumerate()
+            .map(|(index, metrics)| metrics.snapshot(index))
+            .collect::<Vec<_>>();
+        let worker_task_count = self
+            .pull_shard_task_handles
+            .lock()
+            .await
+            .iter()
+            .map(ClientTrackedTaskHandle::task_count)
+            .sum();
+
+        PullMessageServiceShardSnapshot {
+            shard_count: self.shard_count,
+            pending_count: shards.iter().map(|snapshot| snapshot.pending_count).sum(),
+            submitted_count: shards.iter().map(|snapshot| snapshot.submitted_count).sum(),
+            processed_count: shards.iter().map(|snapshot| snapshot.processed_count).sum(),
+            rejected_count: shards.iter().map(|snapshot| snapshot.rejected_count).sum(),
+            worker_task_count,
+            shards,
+        }
+    }
+
+    fn pull_dispatcher(&self) -> Option<PullRequestDispatcher> {
+        self.pull_dispatcher
+            .lock()
+            .expect("pull dispatcher lock should not be poisoned")
+            .clone()
     }
 
     fn submit_delayed(&self, payload: DelayedSchedulePayload, time_delay: u64) {
@@ -564,7 +828,7 @@ impl PullMessageService {
         self.submit_delayed(
             DelayedSchedulePayload::Pull {
                 request: pull_request,
-                tx: self.tx.clone(),
+                dispatcher: self.pull_dispatcher(),
             },
             time_delay,
         );
@@ -583,10 +847,8 @@ impl PullMessageService {
             return;
         }
 
-        if let Some(tx) = &self.tx {
-            if let Err(e) = tx.send(Box::new(pull_request)).await {
-                error!("executePullRequestImmediately messageRequestQueue.put error: {:?}", e);
-            }
+        if let Some(dispatcher) = self.pull_dispatcher() {
+            dispatcher.dispatch(pull_request).await;
         } else {
             warn!("PullMessageService not started");
         }
@@ -689,6 +951,10 @@ impl PullMessageService {
             .lock()
             .expect("delayed scheduler sender lock should not be poisoned")
             .take();
+        self.pull_dispatcher
+            .lock()
+            .expect("pull dispatcher lock should not be poisoned")
+            .take();
 
         // 2. Send shutdown signal
         if let Some(tx_shutdown) = &self.tx_shutdown {
@@ -706,6 +972,18 @@ impl PullMessageService {
                 warn!(
                     report = %report.to_json(),
                     "{} main loop shutdown report is unhealthy",
+                    self.get_service_name()
+                );
+            }
+        }
+
+        let shard_tasks = std::mem::take(&mut *self.pull_shard_task_handles.lock().await);
+        for handle in shard_tasks {
+            let report = handle.shutdown(timeout).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "{} shard worker shutdown report is unhealthy",
                     self.get_service_name()
                 );
             }
@@ -746,24 +1024,27 @@ pub async fn run_pull_message_service_lifecycle_probe() -> PullMessageServiceLif
 
     let start_result = service.start(instance.clone()).await;
     let task_count_before_shutdown = service.main_task_count().await;
+    let expected_task_count_before_shutdown = service.shard_count() + 1;
 
     let shutdown_started = Instant::now();
     let shutdown_result = service.shutdown(1_000).await;
     let shutdown_elapsed_us = shutdown_started.elapsed().as_micros();
     let task_count_after_shutdown = service.main_task_count().await;
     let delayed_scheduler = service.delayed_scheduler_snapshot();
+    let shards = service.shard_snapshot().await;
 
     instance.shutdown().await;
 
     PullMessageServiceLifecycleProbe {
         healthy: start_result.is_ok()
             && shutdown_result.is_ok()
-            && task_count_before_shutdown == 1
+            && task_count_before_shutdown == expected_task_count_before_shutdown
             && task_count_after_shutdown == 0,
         task_count_before_shutdown,
         task_count_after_shutdown,
         shutdown_elapsed_us,
         delayed_scheduler,
+        shards,
     }
 }
 
@@ -860,7 +1141,7 @@ mod tests {
         let probe = run_pull_message_service_lifecycle_probe().await;
 
         assert!(probe.healthy, "{probe:?}");
-        assert_eq!(probe.task_count_before_shutdown, 1);
+        assert_eq!(probe.task_count_before_shutdown, probe.shards.shard_count + 1);
         assert_eq!(probe.task_count_after_shutdown, 0);
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -339,7 +339,9 @@ impl MQClientInstance {
             lock_namesrv: Arc::default(),
             lock_heartbeat: Arc::default(),
             service_state: ServiceState::CreateJust,
-            pull_message_service: ArcMut::new(PullMessageService::new()),
+            pull_message_service: ArcMut::new(PullMessageService::with_shards(
+                client_config.pull_message_service_shards,
+            )),
             rebalance_service: RebalanceService::new(),
             default_producer,
             broker_addr_table,

--- a/rocketmq-client/tests/pull_message_service_test.rs
+++ b/rocketmq-client/tests/pull_message_service_test.rs
@@ -67,6 +67,26 @@ async fn test_service_creation_with_custom_capacity() {
     assert!(!service.is_stopped());
 }
 
+#[test]
+fn test_service_creation_with_custom_shards_normalizes_zero() {
+    let service = PullMessageService::with_capacity_and_shards(1024, 0);
+
+    assert_eq!(service.shard_count(), 1);
+}
+
+#[test]
+fn test_same_queue_maps_to_same_pull_shard() {
+    let service = PullMessageService::with_capacity_and_shards(1024, 4);
+    let first = create_test_pull_request("test_group", "test_topic");
+    let mut second = create_test_pull_request("test_group", "test_topic");
+    second.set_next_offset(1024);
+
+    assert_eq!(
+        service.shard_index_for_pull_request("test_client", &first),
+        service.shard_index_for_pull_request("test_client", &second)
+    );
+}
+
 #[tokio::test]
 async fn test_service_start_and_shutdown() {
     let mut service = PullMessageService::new();
@@ -81,6 +101,29 @@ async fn test_service_start_and_shutdown() {
     let result = service.shutdown(1000).await;
     assert!(result.is_ok());
     assert!(service.is_stopped());
+}
+
+#[tokio::test]
+async fn test_start_spawns_configured_pull_workers() {
+    let mut service = PullMessageService::with_capacity_and_shards(1024, 4);
+    let instance = create_mock_client_instance();
+
+    service.start(instance).await.unwrap();
+
+    let mut snapshot = service.shard_snapshot().await;
+    for _ in 0..100 {
+        if snapshot.worker_task_count == 4 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        snapshot = service.shard_snapshot().await;
+    }
+
+    assert_eq!(snapshot.shard_count, 4);
+    assert_eq!(snapshot.worker_task_count, 4);
+    assert_eq!(snapshot.shards.len(), 4);
+
+    service.shutdown(1000).await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7864

### Brief Description

- Adds configurable PullMessageService pull worker sharding through ClientConfig and routes Pull requests by client id, consumer group, topic, broker, and queue id.
- Keeps delayed scheduling shared while sending delayed Pull requests through the same deterministic sharded path; Pop and generic delayed closures keep the existing queue path.
- Adds shard metrics snapshots and extends the pull scheduler benchmark report with sharded Pull worker data.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --test pull_message_service_test` passed: 28 passed, 0 failed.
- `cargo test -p rocketmq-client-rust --test client_lifecycle_probes_test client_service_lifecycle_probes_report_clean_shutdown` passed: 1 passed, 0 failed.
- `cargo test -p rocketmq-client-rust pull_message_service_shards` passed: 1 passed, 0 failed.
- `cargo test -p rocketmq-client-rust test_builder_with_all_options` passed: 1 passed, 0 failed.
- `cargo test -p rocketmq-client-rust reset_client_config_copies_modern_java_fields` passed: 1 passed, 0 failed.
- `cargo fmt --all` passed.
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo bench -p rocketmq-client-rust --bench client_pull_scheduler_benchmark -- --noplot` passed.

Benchmark summary from `client_pull_scheduler_benchmark`:

| Case | Mean interval | Extra artifact data |
| --- | ---: | --- |
| OneShotSleepTasks/1000 | 30.704 ms to 31.098 ms | p99 late 8285 us, submitted 1000 |
| SharedScheduler/1000 | 30.713 ms to 31.326 ms | p99 late 10729 us, submitted 1 |
| ShardedPullWorkers/1000 | 10.279 ms to 13.126 ms | elapsed 8007 us, processed 1000, rejected 0, workers 4 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sharding for pull-message processing.
  * Pull service metrics now report per-shard activity and lifecycle snapshots.
  * Benchmark output now includes sharded pull-worker results.

* **Bug Fixes**
  * Improved pull-request dispatching so requests are consistently routed to the same shard.
  * Added safer validation to reject invalid shard counts and normalize zero-shard setups.

* **Tests**
  * Expanded coverage for shard configuration, routing, and service startup/shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->