### PR TITLE
[ISSUE #7868]✨Reduce broker pull wakeups and offset contention

### DIFF
--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -36,13 +37,17 @@ use crate::long_polling::pull_request::PullRequest;
 use crate::processor::pull_message_processor::PullMessageProcessor;
 
 const TOPIC_QUEUE_ID_SEPARATOR: &str = "@";
+const NO_PENDING_DEADLINE: u64 = u64::MAX;
+const LONG_POLLING_FALLBACK_SCAN_MILLIS: u64 = 5_000;
 
 pub struct PullRequestHoldService<MS: MessageStore> {
     pull_request_table: Arc<parking_lot::RwLock<HashMap<String, ManyPullRequest>>>,
     pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
     shutdown: Arc<Notify>,
+    schedule_signal: Arc<Notify>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     running: AtomicBool,
+    next_deadline_millis: AtomicU64,
     task_group: Mutex<Option<TaskGroup>>,
 }
 
@@ -58,8 +63,10 @@ where
             pull_request_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             pull_message_processor,
             shutdown: Arc::new(Default::default()),
+            schedule_signal: Arc::new(Default::default()),
             broker_runtime_inner,
             running: AtomicBool::new(false),
+            next_deadline_millis: AtomicU64::new(NO_PENDING_DEADLINE),
             task_group: Mutex::new(None),
         }
     }
@@ -90,13 +97,10 @@ where
 
         if let Err(error) = task_group.spawn_service("broker.long-polling.pull-request-hold.scan", async move {
             loop {
-                let handle_future = if this.broker_config().long_polling_enable {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5))
-                } else {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(
-                        this.broker_config().short_polling_time_mills,
-                    ))
-                };
+                let service = this.pull_request_hold_service().unwrap();
+                let shutdown = Arc::clone(&service.shutdown);
+                let schedule_signal = Arc::clone(&service.schedule_signal);
+                let handle_future = tokio::time::sleep(service.next_scan_delay());
                 tokio::select! {
                     _ = cancellation_token.cancelled() => {
                         if let Some(service) = this.pull_request_hold_service() {
@@ -106,12 +110,15 @@ where
                         break;
                     }
                     _ = handle_future => {}
-                    _ = this.pull_request_hold_service().as_ref().unwrap().shutdown.notified() => {
+                    _ = shutdown.notified() => {
                         if let Some(service) = this.pull_request_hold_service() {
                             service.running.store(false, Ordering::Release);
                         }
                         info!("PullRequestHoldService: shutdown..........");
                         break;
+                    }
+                    _ = schedule_signal.notified() => {
+                        continue;
                     }
                 }
                 let instant = Instant::now();
@@ -154,7 +161,47 @@ where
         let mut table = self.pull_request_table.write();
         let mpr = table.entry(key).or_insert_with(ManyPullRequest::new);
         pull_request.request_command_mut().set_suspended_ref(true);
+        self.note_request_deadline(pull_request.deadline_millis());
         mpr.add_pull_request(pull_request);
+    }
+
+    fn note_request_deadline(&self, deadline_millis: u64) {
+        let mut current = self.next_deadline_millis.load(Ordering::Acquire);
+        while deadline_millis < current {
+            match self.next_deadline_millis.compare_exchange(
+                current,
+                deadline_millis,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.schedule_signal.notify_one();
+                    break;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    fn rebuild_next_deadline(&self) {
+        let next_deadline = self
+            .pull_request_table
+            .read()
+            .values()
+            .filter_map(ManyPullRequest::min_deadline_millis)
+            .min()
+            .unwrap_or(NO_PENDING_DEADLINE);
+        self.next_deadline_millis.store(next_deadline, Ordering::Release);
+    }
+
+    fn next_scan_delay(&self) -> Duration {
+        let delay_millis = next_hold_scan_delay_millis(
+            self.next_deadline_millis.load(Ordering::Acquire),
+            current_millis(),
+            self.broker_runtime_inner.broker_config().long_polling_enable,
+            self.broker_runtime_inner.broker_config().short_polling_time_mills,
+        );
+        Duration::from_millis(delay_millis)
     }
 
     fn check_hold_request(&self) {
@@ -175,6 +222,7 @@ where
                 .get_max_offset_in_queue(&topic, queue_id);
             self.notify_message_arriving(&topic, queue_id, max_offset);
         }
+        self.rebuild_next_deadline();
     }
 
     pub fn notify_message_arriving(&self, topic: &CheetahString, queue_id: i32, max_offset: i64) {
@@ -193,6 +241,7 @@ where
     ) {
         let key = build_key(topic, queue_id);
         let mut table = self.pull_request_table.write();
+        let mut deadline_changed = false;
         if let Some(mpr) = table.get_mut(&key) {
             if let Some(request_list) = mpr.clone_list_and_clear() {
                 if request_list.is_empty() {
@@ -252,11 +301,18 @@ where
                 }
 
                 if !replay_list.is_empty() {
+                    if let Some(deadline) = replay_list.iter().map(PullRequest::deadline_millis).min() {
+                        self.note_request_deadline(deadline);
+                    }
                     let mut table = self.pull_request_table.write();
                     let mpr = table.entry(key).or_insert_with(ManyPullRequest::new);
                     mpr.add_pull_requests(replay_list);
                 }
+                deadline_changed = true;
             }
+        }
+        if deadline_changed {
+            self.rebuild_next_deadline();
         }
     }
 
@@ -279,11 +335,27 @@ where
                 }
             }
         }
+        self.rebuild_next_deadline();
     }
 }
 
 fn build_key(topic: &str, queue_id: i32) -> String {
     format!("{topic}{TOPIC_QUEUE_ID_SEPARATOR}{queue_id}")
+}
+
+fn next_hold_scan_delay_millis(
+    next_deadline_millis: u64,
+    now_millis: u64,
+    long_polling_enable: bool,
+    short_polling_time_mills: u64,
+) -> u64 {
+    if !long_polling_enable {
+        return short_polling_time_mills;
+    }
+    if next_deadline_millis == NO_PENDING_DEADLINE {
+        return LONG_POLLING_FALLBACK_SCAN_MILLIS;
+    }
+    next_deadline_millis.saturating_sub(now_millis)
 }
 
 #[cfg(test)]
@@ -316,5 +388,16 @@ mod tests {
 
         service.shutdown().await;
         assert!(!service.is_running());
+    }
+
+    #[test]
+    fn next_hold_scan_delay_uses_deadline_when_long_polling_is_enabled() {
+        assert_eq!(
+            next_hold_scan_delay_millis(NO_PENDING_DEADLINE, 1_000, true, 123),
+            5_000
+        );
+        assert_eq!(next_hold_scan_delay_millis(1_250, 1_000, true, 123), 250);
+        assert_eq!(next_hold_scan_delay_millis(900, 1_000, true, 123), 0);
+        assert_eq!(next_hold_scan_delay_millis(1_250, 1_000, false, 123), 123);
     }
 }

--- a/rocketmq-broker/src/long_polling/many_pull_request.rs
+++ b/rocketmq-broker/src/long_polling/many_pull_request.rs
@@ -50,6 +50,11 @@ impl ManyPullRequest {
         }
     }
 
+    pub fn min_deadline_millis(&self) -> Option<u64> {
+        let list = self.pull_request_list.lock();
+        list.iter().map(PullRequest::deadline_millis).min()
+    }
+
     pub fn is_empty(&self) -> bool {
         let list = self.pull_request_list.lock();
         list.is_empty()

--- a/rocketmq-broker/src/long_polling/pull_request.rs
+++ b/rocketmq-broker/src/long_polling/pull_request.rs
@@ -80,6 +80,11 @@ impl PullRequest {
     pub fn timeout_millis(&self) -> u64 {
         self.timeout_millis
     }
+
+    pub fn deadline_millis(&self) -> u64 {
+        self.suspend_timestamp.saturating_add(self.timeout_millis)
+    }
+
     pub fn suspend_timestamp(&self) -> u64 {
         self.suspend_timestamp
     }

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -245,18 +245,25 @@ where
     ) {
         let key = build_topic_group_key(topic, group);
 
-        let mut write_guard = self.consumer_offset_wrapper.offset_table.write();
-        let map = write_guard.entry(key.clone()).or_default();
-        let store_offset = map.insert(queue_id, offset);
-        if let Some(store_offset) = store_offset {
-            if offset < store_offset {
-                warn!(
-                    "[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, \
-                     requestOffset={}, storeOffset={}",
-                    client_host, key, queue_id, offset, store_offset
-                );
+        {
+            let mut write_guard = self.consumer_offset_wrapper.offset_table.write();
+            let map = write_guard.entry(key.clone()).or_default();
+            if let Some(&store_offset) = map.get(&queue_id) {
+                if offset < store_offset {
+                    warn!(
+                        "[NOTIFYME]update consumer offset less than store. clientHost={}, key={}, queueId={}, \
+                         requestOffset={}, storeOffset={}",
+                        client_host, key, queue_id, offset, store_offset
+                    );
+                    return;
+                }
+                if offset == store_offset {
+                    return;
+                }
             }
+            map.insert(queue_id, offset);
         }
+
         let _ = self
             .consumer_offset_wrapper
             .version_change_counter
@@ -804,6 +811,7 @@ impl<'de> Deserialize<'de> for ConsumerOffsetWrapper {
 mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
+    use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
     use cheetah_string::CheetahString;
@@ -964,6 +972,42 @@ mod tests {
         manager.clone_offset(&src_group, &dest_group, &topic);
 
         assert_eq!(manager.query_offset(&dest_group, &topic, 0), 32);
+    }
+
+    #[test]
+    fn commit_offset_skips_duplicate_and_backward_updates() {
+        let manager = new_manager();
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 32);
+        let after_first = manager
+            .consumer_offset_wrapper
+            .version_change_counter
+            .load(Ordering::Acquire);
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 32);
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 31);
+
+        assert_eq!(manager.query_offset(&group, &topic, 0), 32);
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            after_first
+        );
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 33);
+
+        assert_eq!(manager.query_offset(&group, &topic, 0), 33);
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            after_first + 1
+        );
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -66,6 +70,27 @@ use crate::filter::expression_message_filter::ExpressionMessageFilter;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
 
+const WAKEUP_WRITE_LOCK_SHARDS: usize = 64;
+
+fn new_wakeup_write_locks() -> Arc<Vec<Arc<Mutex<()>>>> {
+    Arc::new(
+        (0..WAKEUP_WRITE_LOCK_SHARDS)
+            .map(|_| Arc::new(Mutex::new(())))
+            .collect(),
+    )
+}
+
+fn wakeup_write_lock_index(remote_address: SocketAddr, shard_count: usize) -> usize {
+    let mut hasher = DefaultHasher::new();
+    remote_address.hash(&mut hasher);
+    (hasher.finish() as usize) % shard_count
+}
+
+fn wakeup_write_lock_for_channel(locks: &[Arc<Mutex<()>>], channel: &Channel) -> Arc<Mutex<()>> {
+    let index = wakeup_write_lock_index(channel.remote_address(), locks.len());
+    locks[index].clone()
+}
+
 /// Handles pull message requests from consumers.
 ///
 /// This processor handles both `PullMessage` and `LitePullMessage` request codes,
@@ -87,11 +112,9 @@ use crate::processor::pull_message_result_handler::PullMessageResultHandler;
 /// - PULL consumers are either suspended or limited to 1 message
 pub struct PullMessageProcessor<MS: MessageStore> {
     pull_message_result_handler: ArcMut<DefaultPullMessageResultHandler<MS>>,
-    /// Lock to serialize writes to channels when waking up suspended requests.
-    ///
-    /// This is a global lock which may become a bottleneck under high concurrency.
-    /// Future optimization: consider per-channel locks for better parallelism.
-    write_message_lock: Arc<Mutex<()>>,
+    /// Sharded write guards used only for suspended-pull wakeup responses.
+    /// Same-channel responses map to the same guard; unrelated channels can write in parallel.
+    wakeup_write_locks: Arc<Vec<Arc<Mutex<()>>>>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     wakeup_task_group: Option<TaskGroup>,
 }
@@ -155,7 +178,7 @@ where
     ) -> Self {
         Self {
             pull_message_result_handler,
-            write_message_lock: Arc::new(Default::default()),
+            wakeup_write_locks: new_wakeup_write_locks(),
             broker_runtime_inner,
             wakeup_task_group: None,
         }
@@ -994,11 +1017,12 @@ where
         mut ctx: ConnectionHandlerContext,
         mut request: RemotingCommand,
     ) {
-        let lock = Arc::clone(&self.write_message_lock);
+        let locks = Arc::clone(&self.wakeup_write_locks);
         let task = async move {
             let broker_allow_flow_ctr_suspend =
                 !(request.ext_fields().is_some() && request.ext_fields().unwrap().contains_key(NO_SUSPEND_KEY));
             let opaque = request.opaque();
+            let write_lock = wakeup_write_lock_for_channel(&locks, &channel);
             let response = pull_message_processor
                 .process_request_inner(
                     RequestCode::from(request.code()),
@@ -1013,7 +1037,7 @@ where
             if let Ok(Some(response)) = response {
                 let command = response.set_opaque(opaque).mark_response_type();
 
-                let guard = lock.lock().await;
+                let guard = write_lock.lock().await;
                 ctx.write_response(command).await;
                 drop(guard);
             }
@@ -1297,6 +1321,18 @@ mod tests {
         let (consume_type, message_model) = consumer_compensation_for_request_source(RequestSource::Unknown);
         assert_eq!(consume_type, ConsumeType::ConsumePassively);
         assert_eq!(message_model, MessageModel::Clustering);
+    }
+
+    #[test]
+    fn wakeup_write_lock_index_spreads_remote_addresses() {
+        let first = wakeup_write_lock_index(SocketAddr::from(([127, 0, 0, 1], 10_000)), WAKEUP_WRITE_LOCK_SHARDS);
+        let same = wakeup_write_lock_index(SocketAddr::from(([127, 0, 0, 1], 10_000)), WAKEUP_WRITE_LOCK_SHARDS);
+        let indexes = (10_000..10_100)
+            .map(|port| wakeup_write_lock_index(SocketAddr::from(([127, 0, 0, 1], port)), WAKEUP_WRITE_LOCK_SHARDS))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(first, same);
+        assert!(indexes.len() > 1);
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
@@ -38,6 +38,7 @@ pub struct RemoteBrokerOffsetStore {
     client_instance: ArcMut<MQClientInstance>,
     group_name: CheetahString,
     offset_table: Arc<Mutex<HashMap<MessageQueue, ControllableOffset>>>,
+    persisted_offset_table: Arc<Mutex<HashMap<MessageQueue, i64>>>,
 }
 
 impl RemoteBrokerOffsetStore {
@@ -46,7 +47,21 @@ impl RemoteBrokerOffsetStore {
             client_instance,
             group_name,
             offset_table: Arc::new(Mutex::new(HashMap::with_capacity(64))),
+            persisted_offset_table: Arc::new(Mutex::new(HashMap::with_capacity(64))),
         }
+    }
+
+    async fn offset_needs_persist(&self, mq: &MessageQueue, offset: i64) -> bool {
+        let persisted_offset_table = self.persisted_offset_table.lock().await;
+        match persisted_offset_table.get(mq) {
+            Some(&persisted_offset) => persisted_offset != offset,
+            None => true,
+        }
+    }
+
+    async fn mark_offset_persisted(&self, mq: &MessageQueue, offset: i64) {
+        let mut persisted_offset_table = self.persisted_offset_table.lock().await;
+        persisted_offset_table.insert(mq.clone(), offset);
     }
 
     async fn fetch_consume_offset_from_broker(&self, mq: &MessageQueue) -> rocketmq_error::RocketMQResult<i64> {
@@ -193,15 +208,25 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
                 unused_mq.insert(mq.clone());
             }
         }
-        for mq in unused_mq {
-            offset_table.remove(&mq);
+        for mq in &unused_mq {
+            offset_table.remove(mq);
             info!("remove unused mq, {}, {}", mq, self.group_name);
         }
         drop(offset_table);
+        if !unused_mq.is_empty() {
+            let mut persisted_offset_table = self.persisted_offset_table.lock().await;
+            for mq in &unused_mq {
+                persisted_offset_table.remove(mq);
+            }
+        }
 
         for (mq, offset) in used_mq {
+            if !self.offset_needs_persist(&mq, offset).await {
+                continue;
+            }
             match self.update_consume_offset_to_broker(&mq, offset, true).await {
                 Ok(_) => {
+                    self.mark_offset_persisted(&mq, offset).await;
                     info!(
                         "[persistAll] Group: {} ClientId: {} updateConsumeOffsetToBroker {} {}",
                         self.group_name, self.client_instance.client_id, mq, offset
@@ -220,8 +245,12 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
             return;
         };
         drop(offset_table);
+        if !self.offset_needs_persist(mq, offset).await {
+            return;
+        }
         match self.update_consume_offset_to_broker(mq, offset, true).await {
             Ok(_) => {
+                self.mark_offset_persisted(mq, offset).await;
                 info!(
                     "[persist] Group: {} ClientId: {} updateConsumeOffsetToBroker {} {}",
                     self.group_name, self.client_instance.client_id, mq, offset
@@ -234,13 +263,16 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
     }
 
     async fn remove_offset(&self, mq: &MessageQueue) {
-        let mut offset_table = self.offset_table.lock().await;
-        offset_table.remove(mq);
+        let offset_table_size = {
+            let mut offset_table = self.offset_table.lock().await;
+            offset_table.remove(mq);
+            offset_table.len()
+        };
+        let mut persisted_offset_table = self.persisted_offset_table.lock().await;
+        persisted_offset_table.remove(mq);
         info!(
             "remove unnecessary messageQueue offset. group={}, mq={}, offsetTableSize={}",
-            mq,
-            self.group_name,
-            offset_table.len()
+            mq, self.group_name, offset_table_size
         );
     }
 
@@ -308,5 +340,48 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
         } else {
             Err(mq_client_err!(format!("broker not found, {}", mq.broker_name())))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::client_config::ClientConfig;
+
+    fn new_store() -> RemoteBrokerOffsetStore {
+        let client_instance =
+            MQClientInstance::new_arc(ClientConfig::default(), 0, "remote-offset-coalescing-test", None);
+        RemoteBrokerOffsetStore::new(client_instance, CheetahString::from_static_str("group-a"))
+    }
+
+    fn message_queue() -> MessageQueue {
+        MessageQueue::from_parts("topic-a", "broker-a", 0)
+    }
+
+    #[tokio::test]
+    async fn persisted_offset_coalescing_skips_only_identical_offsets() {
+        let store = new_store();
+        let mq = message_queue();
+
+        assert!(store.offset_needs_persist(&mq, 10).await);
+
+        store.mark_offset_persisted(&mq, 10).await;
+
+        assert!(!store.offset_needs_persist(&mq, 10).await);
+        assert!(store.offset_needs_persist(&mq, 9).await);
+        assert!(store.offset_needs_persist(&mq, 11).await);
+    }
+
+    #[tokio::test]
+    async fn remove_offset_clears_persisted_coalescing_state() {
+        let store = new_store();
+        let mq = message_queue();
+
+        store.mark_offset_persisted(&mq, 10).await;
+        assert!(!store.offset_needs_persist(&mq, 10).await);
+
+        store.remove_offset(&mq).await;
+
+        assert!(store.offset_needs_persist(&mq, 10).await);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #7868

### Brief Description
- Shards suspended-pull wakeup response write guards by remote channel so unrelated consumers are not serialized behind one broker-wide mutex.
- Schedules long-polling scans from the earliest pending request deadline, with notify-based rescheduling and a bounded fallback scan when no requests are pending.
- Keeps broker committed offsets monotonic by ignoring duplicate and backward commits while preserving existing explicit reset paths.
- Coalesces duplicate remote broker offset persists only after a successful update, so failed one-way updates are retried later and lower explicit corrections still send.

### How Did You Test This Change?
- [x] `cargo test -p rocketmq-broker wakeup_write_lock_index_spreads_remote_addresses`
- [x] `cargo test -p rocketmq-broker next_hold_scan_delay_uses_deadline_when_long_polling_is_enabled`
- [x] `cargo test -p rocketmq-broker commit_offset_skips_duplicate_and_backward_updates`
- [x] `cargo test -p rocketmq-client-rust persisted_offset_coalescing`
- [x] `cargo test -p rocketmq-client-rust remove_offset_clears_persisted_coalescing_state`
- [x] `cargo test -p rocketmq-broker long_polling::long_polling_service::pull_request_hold_service::tests`
- [x] `cargo test -p rocketmq-broker offset::manager::consumer_offset_manager::tests`
- [x] `cargo test -p rocketmq-client-rust consumer::store::remote_broker_offset_store::tests`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved long-polling responsiveness by waking request scanning sooner when earlier timeouts appear.
  * Reduced unnecessary offset updates by remembering the last successfully saved offset.

* **Bug Fixes**
  * Prevented older or duplicate consumer offsets from overwriting newer saved values.
  * Improved request wakeup handling to reduce write contention during concurrent responses.
  * Added overflow-safe deadline handling for pending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->