### PR TITLE
[ISSUE #7874]✨Add consumer runtime tuning profiles

### DIFF
--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -50,6 +50,7 @@ pub use allocate_message_queue_strategy::AbstractAllocateMessageQueueStrategy;
 pub use allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 pub use default_lite_pull_consumer::DefaultLitePullConsumer;
 pub use default_lite_pull_consumer_builder::DefaultLitePullConsumerBuilder;
+pub use default_mq_push_consumer::ConsumerTuningProfile;
 pub use default_mq_push_consumer::DefaultMQPushConsumer;
 pub use default_mq_push_consumer_builder::DefaultMQPushConsumerBuilder;
 pub use listener::ConsumeConcurrentlyContext;

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -49,6 +49,14 @@ use crate::trace::hook::consume_message_trace_hook_impl::ConsumeMessageTraceHook
 use crate::trace::trace_dispatcher::ArcTraceDispatcher;
 use crate::trace::trace_dispatcher::Type;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsumerTuningProfile {
+    LowLatency,
+    Throughput,
+    LargeMessage,
+    SlowListener,
+}
+
 #[derive(Clone)]
 pub struct ConsumerConfig {
     pub(crate) consumer_group: CheetahString,
@@ -220,6 +228,43 @@ impl ConsumerConfig {
 
     pub fn rpc_hook(&self) -> &Option<Arc<dyn RPCHook>> {
         &self.rpc_hook
+    }
+
+    pub fn apply_tuning_profile(&mut self, profile: ConsumerTuningProfile) {
+        match profile {
+            ConsumerTuningProfile::LowLatency => {
+                self.consume_message_batch_max_size = 1;
+                self.pull_batch_size = 16;
+                self.pull_batch_size_in_bytes = 256 * 1024;
+                self.pull_threshold_for_queue = 256;
+                self.pull_threshold_size_for_queue = 32;
+                self.pull_interval = 0;
+            }
+            ConsumerTuningProfile::Throughput => {
+                self.consume_message_batch_max_size = 16;
+                self.pull_batch_size = 128;
+                self.pull_batch_size_in_bytes = 1024 * 1024;
+                self.pull_threshold_for_queue = 4096;
+                self.pull_threshold_size_for_queue = 256;
+                self.pull_interval = 0;
+            }
+            ConsumerTuningProfile::LargeMessage => {
+                self.consume_message_batch_max_size = 1;
+                self.pull_batch_size = 8;
+                self.pull_batch_size_in_bytes = 512 * 1024;
+                self.pull_threshold_for_queue = 128;
+                self.pull_threshold_size_for_queue = 64;
+                self.pull_interval = 0;
+            }
+            ConsumerTuningProfile::SlowListener => {
+                self.consume_message_batch_max_size = 1;
+                self.pull_batch_size = 16;
+                self.pull_batch_size_in_bytes = 256 * 1024;
+                self.pull_threshold_for_queue = 100;
+                self.pull_threshold_size_for_queue = 16;
+                self.pull_interval = 50;
+            }
+        }
     }
 
     pub fn set_consumer_group(&mut self, consumer_group: CheetahString) {
@@ -1297,6 +1342,10 @@ impl DefaultMQPushConsumer {
         self.consumer_config.set_message_queue_listener(message_queue_listener);
     }
 
+    pub fn apply_tuning_profile(&mut self, profile: ConsumerTuningProfile) {
+        self.consumer_config.mut_from_ref().apply_tuning_profile(profile);
+    }
+
     pub fn new(client_config: ClientConfig, consumer_config: ConsumerConfig) -> DefaultMQPushConsumer {
         let consumer_config = ArcMut::new(consumer_config);
         let mut default_mqpush_consumer_impl = ArcMut::new(DefaultMQPushConsumerImpl::new(
@@ -1826,6 +1875,80 @@ mod tests {
 
         consumer.clear_consume_timestamp();
         assert!(consumer.consume_timestamp().is_none());
+    }
+
+    #[test]
+    fn consumer_tuning_profile_keeps_defaults_until_applied() {
+        let config = ConsumerConfig::default();
+
+        assert_eq!(config.consume_message_batch_max_size(), 1);
+        assert_eq!(config.pull_batch_size(), 32);
+        assert_eq!(config.pull_batch_size_in_bytes(), 256 * 1024);
+        assert_eq!(config.pull_threshold_for_queue(), 1000);
+        assert_eq!(config.pull_threshold_size_for_queue(), 100);
+        assert_eq!(config.pull_interval(), 0);
+    }
+
+    #[test]
+    fn consumer_tuning_profiles_apply_expected_values() {
+        let mut config = ConsumerConfig::default();
+
+        config.apply_tuning_profile(ConsumerTuningProfile::Throughput);
+        assert_eq!(config.consume_message_batch_max_size(), 16);
+        assert_eq!(config.pull_batch_size(), 128);
+        assert_eq!(config.pull_batch_size_in_bytes(), 1024 * 1024);
+        assert_eq!(config.pull_threshold_for_queue(), 4096);
+        assert_eq!(config.pull_threshold_size_for_queue(), 256);
+        assert_eq!(config.pull_interval(), 0);
+
+        config.apply_tuning_profile(ConsumerTuningProfile::LargeMessage);
+        assert_eq!(config.consume_message_batch_max_size(), 1);
+        assert_eq!(config.pull_batch_size(), 8);
+        assert_eq!(config.pull_batch_size_in_bytes(), 512 * 1024);
+        assert_eq!(config.pull_threshold_for_queue(), 128);
+        assert_eq!(config.pull_threshold_size_for_queue(), 64);
+
+        config.apply_tuning_profile(ConsumerTuningProfile::SlowListener);
+        assert_eq!(config.consume_message_batch_max_size(), 1);
+        assert_eq!(config.pull_batch_size(), 16);
+        assert_eq!(config.pull_threshold_for_queue(), 100);
+        assert_eq!(config.pull_threshold_size_for_queue(), 16);
+        assert_eq!(config.pull_interval(), 50);
+
+        config.apply_tuning_profile(ConsumerTuningProfile::LowLatency);
+        assert_eq!(config.consume_message_batch_max_size(), 1);
+        assert_eq!(config.pull_batch_size(), 16);
+        assert_eq!(config.pull_batch_size_in_bytes(), 256 * 1024);
+        assert_eq!(config.pull_threshold_for_queue(), 256);
+        assert_eq!(config.pull_threshold_size_for_queue(), 32);
+        assert_eq!(config.pull_interval(), 0);
+    }
+
+    #[test]
+    fn push_consumer_apply_tuning_profile_updates_shared_impl_config() {
+        let mut consumer = DefaultMQPushConsumer::builder()
+            .consumer_group("push_profile_runtime_group")
+            .build();
+
+        consumer.apply_tuning_profile(ConsumerTuningProfile::Throughput);
+
+        assert_eq!(consumer.consume_message_batch_max_size(), 16);
+        assert_eq!(consumer.pull_batch_size(), 128);
+        assert_eq!(consumer.pull_batch_size_in_bytes(), 1024 * 1024);
+        assert_eq!(consumer.pull_threshold_for_queue(), 4096);
+        assert_eq!(consumer.pull_threshold_size_for_queue(), 256);
+
+        let impl_config = &consumer
+            .default_mqpush_consumer_impl
+            .as_ref()
+            .expect("push consumer impl should exist")
+            .consumer_config;
+
+        assert_eq!(impl_config.consume_message_batch_max_size, 16);
+        assert_eq!(impl_config.pull_batch_size, 128);
+        assert_eq!(impl_config.pull_batch_size_in_bytes, 1024 * 1024);
+        assert_eq!(impl_config.pull_threshold_for_queue, 4096);
+        assert_eq!(impl_config.pull_threshold_size_for_queue, 256);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
@@ -24,6 +24,7 @@ use rocketmq_rust::ArcMut;
 use crate::base::client_config::ClientConfig;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+use crate::consumer::default_mq_push_consumer::ConsumerTuningProfile;
 use crate::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 use crate::consumer::message_queue_listener::ArcMessageQueueListener;
 use crate::trace::trace_dispatcher::ArcTraceDispatcher;
@@ -64,6 +65,7 @@ pub struct DefaultMQPushConsumerBuilder {
     trace_dispatcher: Option<ArcTraceDispatcher>,
     client_rebalance: Option<bool>,
     rpc_hook: Option<Arc<dyn RPCHook>>,
+    tuning_profile: Option<ConsumerTuningProfile>,
 }
 
 impl DefaultMQPushConsumerBuilder {
@@ -270,9 +272,18 @@ impl DefaultMQPushConsumerBuilder {
         self
     }
 
+    #[inline]
+    pub fn tuning_profile(mut self, tuning_profile: ConsumerTuningProfile) -> Self {
+        self.tuning_profile = Some(tuning_profile);
+        self
+    }
+
     // Build method to create a DefaultMQPushConsumer instance
     pub fn build(mut self) -> DefaultMQPushConsumer {
         let mut consumer_config = ConsumerConfig::default();
+        if let Some(profile) = self.tuning_profile {
+            consumer_config.apply_tuning_profile(profile);
+        }
 
         // Set optional fields with consistent pattern
         if let Some(value) = self.consumer_group {
@@ -374,5 +385,27 @@ impl DefaultMQPushConsumerBuilder {
         consumer_config.rpc_hook = self.rpc_hook.clone();
 
         DefaultMQPushConsumer::new(self.client_config, consumer_config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::default_mq_push_consumer::ConsumerTuningProfile;
+
+    #[test]
+    fn tuning_profile_applies_before_explicit_builder_overrides() {
+        let consumer = DefaultMQPushConsumerBuilder::new()
+            .consumer_group("push_profile_builder_group")
+            .tuning_profile(ConsumerTuningProfile::Throughput)
+            .pull_batch_size(64)
+            .pull_batch_size_in_bytes(768 * 1024)
+            .build();
+
+        assert_eq!(consumer.consume_message_batch_max_size(), 16);
+        assert_eq!(consumer.pull_batch_size(), 64);
+        assert_eq!(consumer.pull_batch_size_in_bytes(), 768 * 1024);
+        assert_eq!(consumer.pull_threshold_for_queue(), 4096);
+        assert_eq!(consumer.pull_threshold_size_for_queue(), 256);
     }
 }

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -155,6 +155,7 @@ pub use crate::consumer::ConsumeConcurrentlyContext;
 pub use crate::consumer::ConsumeConcurrentlyStatus;
 pub use crate::consumer::ConsumeOrderlyContext;
 pub use crate::consumer::ConsumeOrderlyStatus;
+pub use crate::consumer::ConsumerTuningProfile;
 pub use crate::consumer::ControllableOffset;
 pub use crate::consumer::DefaultLitePullConsumer;
 pub use crate::consumer::DefaultLitePullConsumerBuilder;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #7874

### Brief Description
- Adds `ConsumerTuningProfile` for low-latency, throughput, large-message, and slow-listener push consumer tuning without changing default configuration.
- Allows applying a profile directly to `ConsumerConfig` or `DefaultMQPushConsumer`, and through `DefaultMQPushConsumerBuilder`.
- Applies builder profiles before explicit builder setters so caller-provided values remain authoritative.

### How Did You Test This Change?
- [x] `cargo test -p rocketmq-client-rust consumer_tuning_profile`
- [x] `cargo test -p rocketmq-client-rust push_consumer_apply_tuning_profile_updates_shared_impl_config`
- [x] `cargo test -p rocketmq-client-rust tuning_profile_applies_before_explicit_builder_overrides`
- [x] `cargo test -p rocketmq-client-rust consumer::default_mq_push_consumer::tests`
- [x] `cargo test -p rocketmq-client-rust consumer::default_mq_push_consumer_builder::tests`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`