### PR TITLE
[ISSUE #7876]♻️Establish error architecture foundation

### DIFF
--- a/rocketmq-client/src/common/session_credentials.rs
+++ b/rocketmq-client/src/common/session_credentials.rs
@@ -24,6 +24,12 @@ pub const SECRET_KEY: &str = "SecretKey";
 pub const SIGNATURE: &str = "Signature";
 pub const SECURITY_TOKEN: &str = "SecurityToken";
 
+const REDACTED: &str = "<redacted>";
+
+fn redacted_value(value: Option<&CheetahString>) -> Option<&'static str> {
+    value.map(|_| REDACTED)
+}
+
 fn get_key_file_path() -> PathBuf {
     if let Ok(key_file) = std::env::var("rocketmq.client.keyFile") {
         PathBuf::from(key_file)
@@ -162,7 +168,10 @@ impl fmt::Display for SessionCredentials {
         write!(
             f,
             "SessionCredentials [accessKey={:?}, secretKey={:?}, signature={:?}, SecurityToken={:?}]",
-            self.access_key, self.secret_key, self.signature, self.security_token
+            self.access_key,
+            redacted_value(self.secret_key.as_ref()),
+            redacted_value(self.signature.as_ref()),
+            redacted_value(self.security_token.as_ref())
         )
     }
 }
@@ -263,10 +272,16 @@ mod tests {
 
     #[test]
     fn session_credentials_display() {
-        let credentials = SessionCredentials::with_token("ak", "sk", "tk");
+        let mut credentials = SessionCredentials::with_token("ak", "sk", "tk");
+        credentials.set_signature("sig");
+
         let display = format!("{}", credentials);
-        let expected = "SessionCredentials [accessKey=Some(\"ak\"), secretKey=Some(\"sk\"), signature=None, \
-                        SecurityToken=Some(\"tk\")]";
+        let expected = "SessionCredentials [accessKey=Some(\"ak\"), secretKey=Some(\"<redacted>\"), \
+                        signature=Some(\"<redacted>\"), SecurityToken=Some(\"<redacted>\")]";
+
         assert_eq!(display, expected);
+        assert!(!display.contains("\"sk\""));
+        assert!(!display.contains("\"tk\""));
+        assert!(!display.contains("\"sig\""));
     }
 }

--- a/rocketmq-doc/README.md
+++ b/rocketmq-doc/README.md
@@ -50,6 +50,8 @@ rocketmq-doc/
 
 #### Design Documents (07-*)
 - Broker Naming Conventions
+- Error Architecture Redesign ADR
+- Error Architecture Inventory
 - Protocol Design
 - Storage Design
 - Network Architecture
@@ -83,6 +85,8 @@ We welcome contributions to improve our documentation! Please:
 - [Quick Start Guide](en/02-quick-start-guide.md)
 - [Architecture Overview](en/01-architecture.md)
 - [Components](en/02-components.md)
+- [Error Architecture Redesign ADR](en/07-error-architecture-adr.md)
+- [Error Architecture Inventory](en/07-error-inventory.md)
 - [Running with Docker](en/01-run-rocketmq-rust-docker.md)
 - [Running on Kubernetes](en/01-run-rocketmq-rust-k8s.md)
 - [Contributing Guide](en/19-contribute-guide.md)

--- a/rocketmq-doc/en/07-error-architecture-adr.md
+++ b/rocketmq-doc/en/07-error-architecture-adr.md
@@ -1,0 +1,149 @@
+---
+title: "Error Architecture Redesign ADR"
+permalink: /docs/error-architecture-adr/
+excerpt: "Accepted direction for the RocketMQ Rust error architecture redesign."
+last_modified_at: 2026-07-04T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# Error Architecture Redesign ADR
+
+## Status
+
+Accepted.
+
+## Context
+
+RocketMQ Rust already has a central `rocketmq-error` crate and a widely used
+`RocketMQError` type. The current design is still transitional:
+
+- `RocketmqError`, `LegacyRocketMQResult`, `LegacyResult`, and legacy macros are
+  still public.
+- `rocketmq-error::Result<T>` is an alias for `anyhow::Result<T>`.
+- Remoting, proxy gRPC, dashboard HTTP, admin tools, broker processors, and
+  NameServer processors map errors locally.
+- Some domain errors still collapse into string-only variants such as
+  `Internal(String)` or `General(String)`.
+- Client callbacks and request futures still expose dynamic error values.
+- Credential formatting previously printed secret material in
+  `SessionCredentials::Display`.
+
+Compatibility with the legacy error API is not a goal for this redesign. The
+project should converge on the latest error architecture instead of preserving
+old aliases or adapters.
+
+## Decision
+
+Use a single error architecture:
+
+**Typed Error Kernel + ErrorSpec Registry + Boundary Adapter +
+Redaction/Observability Contract**.
+
+The central contract is:
+
+- `rocketmq-error` owns the public error kernel:
+  `RocketMQError`, `RocketMQResult<T>`, `ErrorKind`, `ErrorCode`,
+  `ErrorCategory`, `ErrorScope`, `RetryClass`, `ErrorSeverity`,
+  `ErrorSpec`, `ErrorContext`, and `Sensitive<T>`.
+- Public library APIs return typed errors. Application entry points, tests,
+  and one-shot tools may use `anyhow` only at their outermost boundary.
+- Every cross-boundary error has stable metadata for protocol mapping, retry,
+  severity, redaction, metrics, logs, traces, and runbook routing.
+- External exits use boundary adapters. `rocketmq-error` can define primitive
+  specs, but it must not depend on remoting, proxy, dashboard, or frontend
+  crates.
+- Sensitive fields are redacted by default in `Display`, `Debug`, structured
+  logs, and exported error reports.
+- Legacy error types, legacy result aliases, and legacy macro output are removed
+  after callers are migrated.
+
+## Dependency Direction
+
+`rocketmq-error` stays below all protocol and application crates.
+
+```text
+rocketmq-error
+  -> rocketmq-common
+  -> rocketmq-remoting
+  -> rocketmq-client
+  -> rocketmq-broker / rocketmq-namesrv / rocketmq-controller / rocketmq-store
+  -> rocketmq-proxy / dashboard backends / tools
+```
+
+Boundary crates convert primitive specs into their local protocol types:
+
+| Boundary | Local adapter output |
+| --- | --- |
+| Remoting | `ResponseCode` and response remark |
+| Proxy gRPC | `v2::Code` and `tonic::Code` |
+| Dashboard HTTP | HTTP status, API code, and public message |
+| CLI/tools | exit category and concise user message |
+| Observability | low-cardinality labels and redacted fields |
+
+## Delivery Sequence
+
+Each PR must keep the affected Cargo project buildable. The legacy API is
+deleted only after macro, remoting, client, and public alias callers are moved.
+
+| PR | Scope | Goal |
+| --- | --- | --- |
+| 01 | docs | Accept the no-compatibility error redesign ADR |
+| 02 | docs + scan evidence | Add error inventory and ownership matrix |
+| 03 | `rocketmq-client` | Redact credential formatting |
+| 04 | `rocketmq-error` | Introduce `ErrorKind`, `ErrorCode`, and `ErrorScope` |
+| 05 | `rocketmq-error` | Introduce the `ErrorSpec` registry |
+| 06 | `rocketmq-error` | Add redacted `ErrorContext` and `Sensitive<T>` |
+| 07 | `rocketmq-error` | Add protocol primitive specs |
+| 08 | `rocketmq-error` | Add recovery and observability policies |
+| 09 | broker, controller, namesrv, examples | Replace `rocketmq_error::Result` callers |
+| 10 | `rocketmq-error` | Remove public `anyhow` aliases |
+| 11 | `rocketmq-macros` | Generate typed `RocketMQError` values |
+| 12 | `rocketmq-remoting` | Migrate codec and serialization errors |
+| 13 | `rocketmq-remoting` | Add the remoting boundary adapter |
+| 14 | broker and namesrv | Route processor failures through the adapter |
+| 15 | `rocketmq-client` | Replace callback dynamic error downcasts |
+| 16 | `rocketmq-client` | Centralize retry decisions |
+| 17 | `rocketmq-store` | Replace `StoreError::General` with typed variants |
+| 18 | `rocketmq-controller` | Preserve raft, storage, and serde sources |
+| 19 | `rocketmq-auth` | Split authentication, authorization, config, and storage errors |
+| 20 | common and tools | Remove public `anyhow` and unclassified internals |
+| 21 | `rocketmq-proxy` | Use the gRPC boundary adapter |
+| 22 | dashboard web backend | Use a typed `RocketMQError` wrapper |
+| 23 | standalone projects | Align examples and dashboard apps with typed errors |
+| 24 | `rocketmq-error` | Delete the legacy `RocketmqError` API |
+| 25 | scripts/CI | Add legacy, public-anyhow, mapping, and redaction guards |
+| 26 | docs | Publish contribution guide and runbooks |
+
+## Acceptance Gates
+
+Root workspace Rust changes must finish with:
+
+```powershell
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+Focused tests should also run for the modified crate, for example:
+
+```powershell
+cargo test -p rocketmq-client-rust --lib session_credentials_display
+```
+
+Static checks must eventually reject unapproved occurrences of:
+
+```powershell
+rg -n "RocketmqError|LegacyRocketMQResult|LegacyResult" --glob "*.rs"
+rg -n "type Result<T> = anyhow::Result|pub type Result<T> = anyhow::Result" --glob "*.rs"
+rg -n "Internal\\(String\\)|General\\(String\\)|to_string\\(\\)" --glob "*.rs"
+rg -n "secretKey|SecurityToken|signature" rocketmq-client rocketmq-auth --glob "*.rs"
+```
+
+## Consequences
+
+This is a breaking redesign. The short-term cost is a coordinated migration
+across the error kernel, macros, remoting, client, store, controller, auth,
+proxy, dashboard, tools, and standalone projects.
+
+The long-term result is a single machine-readable error contract for protocol
+mapping, retry behavior, operations, security redaction, and debugging.

--- a/rocketmq-doc/en/07-error-inventory.md
+++ b/rocketmq-doc/en/07-error-inventory.md
@@ -1,0 +1,80 @@
+---
+title: "Error Architecture Inventory"
+permalink: /docs/error-inventory/
+excerpt: "Current RocketMQ Rust error ownership and migration inventory."
+last_modified_at: 2026-07-04T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# Error Architecture Inventory
+
+Snapshot date: 2026-07-04.
+
+This inventory records the current error architecture baseline for the
+no-compatibility redesign. It is not a completion claim; it identifies the
+remaining migration surface and assigns ownership by crate boundary.
+
+## Current Signals
+
+Recent repository scans show these open items:
+
+| Signal | Current evidence |
+| --- | --- |
+| Legacy error API | `RocketmqError`, `LegacyRocketMQResult`, and `LegacyResult` still appear in `rocketmq-error`, `rocketmq-macros`, `rocketmq-remoting`, `rocketmq-client`, and dashboard common code |
+| Public `anyhow` alias | `rocketmq-error/src/unified.rs` exposes `pub type Result<T> = anyhow::Result<T>` |
+| Public alias callers | `rocketmq-broker`, `rocketmq-controller`, `rocketmq-namesrv`, and a controller example import `rocketmq_error::Result` |
+| Dynamic callback errors | client callback and request future paths still use `dyn Error` |
+| Distributed protocol mapping | proxy maps `RocketMQError` to gRPC locally; remoting and proxy remoting paths also map directly to `ResponseCode` |
+| Generic string variants | store, controller, dashboard backend, and unified errors still contain string-only internal or general variants |
+| Credential formatting | `SessionCredentials::Display` now redacts secret key, signature, and security token; broader `Sensitive<T>` infrastructure is still pending |
+
+## Ownership Matrix
+
+| Area | Error owner | Current role | Target role |
+| --- | --- | --- | --- |
+| `rocketmq-error` | Error kernel | Central enum plus legacy API and public `anyhow` alias | Own typed error kernel, spec registry, context, redaction, recovery, and observability metadata |
+| `rocketmq-macros` | Macro output | Generates legacy `RocketmqError` in request header code | Generate typed `RocketMQError` variants only |
+| `rocketmq-remoting` | Protocol boundary | Codec and serialization paths still carry legacy errors and direct response mapping | Convert `ErrorSpec` remoting primitives into `ResponseCode` and remarks |
+| `rocketmq-client` | Client boundary | Uses `RocketMQError`, dynamic callback errors, and local retry decisions | Use typed callback errors, `RetryClass`, and redacted context |
+| `rocketmq-broker` | Broker boundary | Uses typed errors in many areas and direct processor response mapping | Route externally visible processor failures through remoting adapter |
+| `rocketmq-namesrv` | NameServer boundary | Uses typed errors and direct response mapping | Route externally visible failures through remoting adapter |
+| `rocketmq-store` | Storage domain | Uses local `StoreError` and `StoreError::General` | Keep private domain errors but expose typed storage variants and sources |
+| `rocketmq-controller` | Controller domain | Re-exports central controller errors but still has internal string paths and public alias callers | Preserve raft, storage, serde, and network sources in typed variants |
+| `rocketmq-auth` | Auth domain | Uses central errors but mixes authentication, authorization, config, and storage semantics | Split authn, authz, config, and storage categories |
+| `rocketmq-common` | Shared utilities | Contains shared helpers that can spread string conversion patterns | Keep shared helpers typed and avoid public `anyhow` contracts |
+| `rocketmq-tools` | CLI/tools | Uses app-style error handling and string conversion in admin/storage tools | Keep `anyhow` at binary boundary and map typed errors to CLI categories |
+| `rocketmq-proxy` | gRPC and remoting proxy boundary | Owns `ProxyError` and local status mapper | Convert central gRPC primitives to `v2::Code` and `tonic::Code` |
+| dashboard web backend | HTTP boundary | Uses `DashboardError` and string-based RocketMQ wrappers | Wrap typed `RocketMQError` and map through HTTP adapter |
+| standalone projects | App boundaries | Examples and dashboard apps may lag behind root workspace changes | Follow typed public API after root workspace migration |
+
+## Migration Order
+
+The migration must keep deletion after caller movement:
+
+1. Add kernel metadata and redaction primitives.
+2. Add protocol primitive specs and adapter contracts.
+3. Replace public alias callers.
+4. Remove public `anyhow` aliases.
+5. Move macros, remoting codecs, client callbacks, and retry decisions.
+6. Split store, controller, auth, common, and tools string-only errors.
+7. Move proxy, dashboard, and standalone boundaries.
+8. Delete legacy `RocketmqError` and add static guards.
+
+## Done Criteria
+
+The redesign is complete only when all of these are true:
+
+- `rocketmq-error` no longer exposes `RocketmqError`,
+  `LegacyRocketMQResult`, or `LegacyResult`.
+- Library APIs do not expose `anyhow::Result` as the business error contract.
+- Every cross-boundary error has `ErrorKind`, stable code, `ErrorSpec`, retry,
+  severity, redaction, and observability metadata.
+- Remoting, gRPC, HTTP, CLI, and observability exits read from the central
+  metadata instead of interpreting display text.
+- Credentials, tokens, signatures, and authorization values are redacted by
+  default.
+- Source chains are preserved for I/O, serde, storage, raft, transport, and
+  runtime failures.
+- CI rejects unapproved legacy, public `anyhow`, unmapped error metadata, and
+  sensitive formatting regressions.


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7876

### Brief Description

- Accepts the no-compatibility typed error architecture direction in an ADR.
- Adds an error inventory and ownership matrix for the full migration surface.
- Redacts secret key, signature, and security token values in client credential formatting.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust --lib session_credentials_display`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credential values are now hidden in displayed output, reducing the risk of exposing secrets in logs or diagnostics.

* **Documentation**
  * Added new documentation for the error architecture redesign and an error inventory overview.
  * Updated the documentation index with links to the new pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->