### PR TITLE
[ISSUE #7614]🧪Add config file parsing coverage for rocketmq-namesrv

### DIFF
--- a/rocketmq-namesrv/src/namesrv_config_parse.rs
+++ b/rocketmq-namesrv/src/namesrv_config_parse.rs
@@ -30,3 +30,66 @@ pub fn parse_command_and_config_file(config_file: PathBuf) -> anyhow::Result<Nam
     info!("rocketmq-namesrv config: {:?}", namesrv_config);
     Ok(namesrv_config)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use super::*;
+
+    fn temp_config_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("rocketmq-namesrv-{name}-{}-{nanos}.toml", std::process::id()))
+    }
+
+    #[test]
+    fn namesrv_config_parse_reads_selected_toml_fields() {
+        let path = temp_config_path("selected-fields");
+        fs::write(
+            &path,
+            r#"
+rocketmqHome = "/tmp/rocketmq"
+kvConfigPath = "/tmp/rocketmq/kvConfig.json"
+useRouteInfoManagerV2 = false
+"#,
+        )
+        .expect("test config should be written");
+
+        let config = parse_command_and_config_file(path.clone()).expect("config should parse");
+        fs::remove_file(path).expect("test config should be removed");
+
+        assert_eq!(config.rocketmq_home, "/tmp/rocketmq");
+        assert_eq!(config.kv_config_path, "/tmp/rocketmq/kvConfig.json");
+        assert!(!config.use_route_info_manager_v2);
+    }
+
+    #[test]
+    fn namesrv_config_parse_loads_example_file() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resource/namesrv-example.toml");
+
+        let config = parse_command_and_config_file(path).expect("example config should parse");
+
+        assert_eq!(config.rocketmq_home, "/opt/rocketmq");
+        assert_eq!(config.kv_config_path, "/home/rocketmq/rocketmq-namesrv/kvConfig.json");
+        assert!(config.use_route_info_manager_v2);
+    }
+
+    #[test]
+    fn namesrv_config_parse_falls_back_to_default_for_missing_file() {
+        let config =
+            parse_command_and_config_file(temp_config_path("missing")).expect("missing config should fall back");
+        let default_config = NamesrvConfig::default();
+
+        assert_eq!(config.rocketmq_home, default_config.rocketmq_home);
+        assert_eq!(config.kv_config_path, default_config.kv_config_path);
+        assert_eq!(
+            config.use_route_info_manager_v2,
+            default_config.use_route_info_manager_v2
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7614 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for configuration parsing, including custom TOML input, the bundled example config, and missing-file fallback behavior.
  * Verified key parsed settings, including boolean option handling and default values when no config file is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->