### PR TITLE
[ISSUE #7879]✨Add stable error kind taxonomy

### DIFF
--- a/rocketmq-error/src/kind.rs
+++ b/rocketmq-error/src/kind.rs
@@ -1,0 +1,342 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+/// Stable machine-readable error code.
+///
+/// `ErrorCode` values are intentionally separate from display messages. Protocol
+/// mapping, retry policy, and observability should use the code, not formatted
+/// error text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ErrorCode(&'static str);
+
+impl ErrorCode {
+    /// Create a stable error code.
+    #[inline]
+    pub const fn new(value: &'static str) -> Self {
+        Self(value)
+    }
+
+    /// Return the stable code string.
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+/// Architectural boundary where an error belongs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorScope {
+    Network,
+    Serialization,
+    Protocol,
+    Rpc,
+    Authentication,
+    Controller,
+    Broker,
+    Request,
+    Route,
+    Client,
+    Tools,
+    Filter,
+    Storage,
+    Configuration,
+    System,
+    Version,
+    Legacy,
+}
+
+/// Stable logical error kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(deprecated)]
+pub enum ErrorKind {
+    Network,
+    Serialization,
+    Protocol,
+    Rpc,
+    Authentication,
+    Controller,
+    InvalidProperty,
+    BrokerNotFound,
+    BrokerRegistrationFailed,
+    BrokerOperationFailed,
+    TopicNotExist,
+    QueueNotExist,
+    SubscriptionGroupNotExist,
+    QueueIdOutOfRange,
+    MessageTooLarge,
+    MessageValidationFailed,
+    RetryLimitExceeded,
+    TransactionRejected,
+    BrokerPermissionDenied,
+    NotMasterBroker,
+    MessageLookupFailed,
+    TopicSendingForbidden,
+    BrokerAsyncTaskFailed,
+    RequestBodyInvalid,
+    RequestHeaderError,
+    ResponseProcessFailed,
+    RouteNotFound,
+    RouteInconsistent,
+    RouteRegistrationConflict,
+    RouteVersionConflict,
+    ClusterNotFound,
+    ClientNotStarted,
+    ClientAlreadyStarted,
+    ClientShuttingDown,
+    ClientInvalidState,
+    ProducerNotAvailable,
+    ConsumerNotAvailable,
+    Tools,
+    Filter,
+    StorageReadFailed,
+    StorageWriteFailed,
+    StorageCorrupted,
+    StorageOutOfSpace,
+    StorageLockFailed,
+    ConfigParseFailed,
+    ConfigMissing,
+    ConfigInvalidValue,
+    AuthConfigInvalid,
+    AuthHotReloadFailed,
+    ControllerNotLeader,
+    ControllerRaftError,
+    ControllerConsensusTimeout,
+    ControllerSnapshotFailed,
+    Io,
+    IllegalArgument,
+    Timeout,
+    Internal,
+    Service,
+    InvalidVersionOrdinal,
+    Legacy,
+    NotInitialized,
+    MissingRequiredMessageProperty,
+}
+
+impl ErrorKind {
+    /// Every public error kind currently known to the error kernel.
+    pub const ALL: &'static [Self] = &[
+        Self::Network,
+        Self::Serialization,
+        Self::Protocol,
+        Self::Rpc,
+        Self::Authentication,
+        Self::Controller,
+        Self::InvalidProperty,
+        Self::BrokerNotFound,
+        Self::BrokerRegistrationFailed,
+        Self::BrokerOperationFailed,
+        Self::TopicNotExist,
+        Self::QueueNotExist,
+        Self::SubscriptionGroupNotExist,
+        Self::QueueIdOutOfRange,
+        Self::MessageTooLarge,
+        Self::MessageValidationFailed,
+        Self::RetryLimitExceeded,
+        Self::TransactionRejected,
+        Self::BrokerPermissionDenied,
+        Self::NotMasterBroker,
+        Self::MessageLookupFailed,
+        Self::TopicSendingForbidden,
+        Self::BrokerAsyncTaskFailed,
+        Self::RequestBodyInvalid,
+        Self::RequestHeaderError,
+        Self::ResponseProcessFailed,
+        Self::RouteNotFound,
+        Self::RouteInconsistent,
+        Self::RouteRegistrationConflict,
+        Self::RouteVersionConflict,
+        Self::ClusterNotFound,
+        Self::ClientNotStarted,
+        Self::ClientAlreadyStarted,
+        Self::ClientShuttingDown,
+        Self::ClientInvalidState,
+        Self::ProducerNotAvailable,
+        Self::ConsumerNotAvailable,
+        Self::Tools,
+        Self::Filter,
+        Self::StorageReadFailed,
+        Self::StorageWriteFailed,
+        Self::StorageCorrupted,
+        Self::StorageOutOfSpace,
+        Self::StorageLockFailed,
+        Self::ConfigParseFailed,
+        Self::ConfigMissing,
+        Self::ConfigInvalidValue,
+        Self::AuthConfigInvalid,
+        Self::AuthHotReloadFailed,
+        Self::ControllerNotLeader,
+        Self::ControllerRaftError,
+        Self::ControllerConsensusTimeout,
+        Self::ControllerSnapshotFailed,
+        Self::Io,
+        Self::IllegalArgument,
+        Self::Timeout,
+        Self::Internal,
+        Self::Service,
+        Self::InvalidVersionOrdinal,
+        Self::Legacy,
+        Self::NotInitialized,
+        Self::MissingRequiredMessageProperty,
+    ];
+
+    /// Stable machine-readable code for this kind.
+    #[inline]
+    pub const fn code(self) -> ErrorCode {
+        ErrorCode::new(match self {
+            Self::Network => "NETWORK_CONNECTION_FAILED",
+            Self::Serialization => "SERIALIZATION_FAILED",
+            Self::Protocol => "PROTOCOL_ERROR",
+            Self::Rpc => "RPC_ERROR",
+            Self::Authentication => "AUTHENTICATION_FAILED",
+            Self::Controller => "CONTROLLER_ERROR",
+            Self::InvalidProperty => "INVALID_PROPERTY",
+            Self::BrokerNotFound => "BROKER_NOT_FOUND",
+            Self::BrokerRegistrationFailed => "BROKER_REGISTRATION_FAILED",
+            Self::BrokerOperationFailed => "BROKER_OPERATION_FAILED",
+            Self::TopicNotExist => "TOPIC_NOT_EXIST",
+            Self::QueueNotExist => "QUEUE_NOT_EXIST",
+            Self::SubscriptionGroupNotExist => "SUBSCRIPTION_GROUP_NOT_EXIST",
+            Self::QueueIdOutOfRange => "QUEUE_ID_OUT_OF_RANGE",
+            Self::MessageTooLarge => "MESSAGE_TOO_LARGE",
+            Self::MessageValidationFailed => "MESSAGE_VALIDATION_FAILED",
+            Self::RetryLimitExceeded => "RETRY_LIMIT_EXCEEDED",
+            Self::TransactionRejected => "TRANSACTION_REJECTED",
+            Self::BrokerPermissionDenied => "BROKER_PERMISSION_DENIED",
+            Self::NotMasterBroker => "NOT_MASTER_BROKER",
+            Self::MessageLookupFailed => "MESSAGE_LOOKUP_FAILED",
+            Self::TopicSendingForbidden => "TOPIC_SENDING_FORBIDDEN",
+            Self::BrokerAsyncTaskFailed => "BROKER_ASYNC_TASK_FAILED",
+            Self::RequestBodyInvalid => "REQUEST_BODY_INVALID",
+            Self::RequestHeaderError => "REQUEST_HEADER_ERROR",
+            Self::ResponseProcessFailed => "RESPONSE_PROCESS_FAILED",
+            Self::RouteNotFound => "ROUTE_NOT_FOUND",
+            Self::RouteInconsistent => "ROUTE_INCONSISTENT",
+            Self::RouteRegistrationConflict => "ROUTE_REGISTRATION_CONFLICT",
+            Self::RouteVersionConflict => "ROUTE_VERSION_CONFLICT",
+            Self::ClusterNotFound => "CLUSTER_NOT_FOUND",
+            Self::ClientNotStarted => "CLIENT_NOT_STARTED",
+            Self::ClientAlreadyStarted => "CLIENT_ALREADY_STARTED",
+            Self::ClientShuttingDown => "CLIENT_SHUTTING_DOWN",
+            Self::ClientInvalidState => "CLIENT_INVALID_STATE",
+            Self::ProducerNotAvailable => "PRODUCER_NOT_AVAILABLE",
+            Self::ConsumerNotAvailable => "CONSUMER_NOT_AVAILABLE",
+            Self::Tools => "TOOLS_ERROR",
+            Self::Filter => "FILTER_ERROR",
+            Self::StorageReadFailed => "STORAGE_READ_FAILED",
+            Self::StorageWriteFailed => "STORAGE_WRITE_FAILED",
+            Self::StorageCorrupted => "STORAGE_CORRUPTED",
+            Self::StorageOutOfSpace => "STORAGE_OUT_OF_SPACE",
+            Self::StorageLockFailed => "STORAGE_LOCK_FAILED",
+            Self::ConfigParseFailed => "CONFIG_PARSE_FAILED",
+            Self::ConfigMissing => "CONFIG_MISSING",
+            Self::ConfigInvalidValue => "CONFIG_INVALID_VALUE",
+            Self::AuthConfigInvalid => "AUTH_CONFIG_INVALID",
+            Self::AuthHotReloadFailed => "AUTH_HOT_RELOAD_FAILED",
+            Self::ControllerNotLeader => "CONTROLLER_NOT_LEADER",
+            Self::ControllerRaftError => "CONTROLLER_RAFT_ERROR",
+            Self::ControllerConsensusTimeout => "CONTROLLER_CONSENSUS_TIMEOUT",
+            Self::ControllerSnapshotFailed => "CONTROLLER_SNAPSHOT_FAILED",
+            Self::Io => "IO_ERROR",
+            Self::IllegalArgument => "ILLEGAL_ARGUMENT",
+            Self::Timeout => "TIMEOUT",
+            Self::Internal => "INTERNAL",
+            Self::Service => "SERVICE_ERROR",
+            Self::InvalidVersionOrdinal => "INVALID_VERSION_ORDINAL",
+            Self::Legacy => "LEGACY",
+            Self::NotInitialized => "NOT_INITIALIZED",
+            Self::MissingRequiredMessageProperty => "MISSING_REQUIRED_MESSAGE_PROPERTY",
+        })
+    }
+
+    /// Architectural boundary for this kind.
+    #[inline]
+    pub const fn scope(self) -> ErrorScope {
+        match self {
+            Self::Network => ErrorScope::Network,
+            Self::Serialization => ErrorScope::Serialization,
+            Self::Protocol => ErrorScope::Protocol,
+            Self::Rpc => ErrorScope::Rpc,
+            Self::Authentication => ErrorScope::Authentication,
+            Self::Controller
+            | Self::ControllerNotLeader
+            | Self::ControllerRaftError
+            | Self::ControllerConsensusTimeout
+            | Self::ControllerSnapshotFailed => ErrorScope::Controller,
+            Self::InvalidProperty
+            | Self::BrokerNotFound
+            | Self::BrokerRegistrationFailed
+            | Self::BrokerOperationFailed
+            | Self::TopicNotExist
+            | Self::QueueNotExist
+            | Self::SubscriptionGroupNotExist
+            | Self::QueueIdOutOfRange
+            | Self::MessageTooLarge
+            | Self::MessageValidationFailed
+            | Self::RetryLimitExceeded
+            | Self::TransactionRejected
+            | Self::BrokerPermissionDenied
+            | Self::NotMasterBroker
+            | Self::MessageLookupFailed
+            | Self::TopicSendingForbidden
+            | Self::BrokerAsyncTaskFailed => ErrorScope::Broker,
+            Self::RequestBodyInvalid | Self::RequestHeaderError | Self::ResponseProcessFailed => ErrorScope::Request,
+            Self::RouteNotFound
+            | Self::RouteInconsistent
+            | Self::RouteRegistrationConflict
+            | Self::RouteVersionConflict
+            | Self::ClusterNotFound => ErrorScope::Route,
+            Self::ClientNotStarted
+            | Self::ClientAlreadyStarted
+            | Self::ClientShuttingDown
+            | Self::ClientInvalidState
+            | Self::ProducerNotAvailable
+            | Self::ConsumerNotAvailable => ErrorScope::Client,
+            Self::Tools => ErrorScope::Tools,
+            Self::Filter => ErrorScope::Filter,
+            Self::StorageReadFailed
+            | Self::StorageWriteFailed
+            | Self::StorageCorrupted
+            | Self::StorageOutOfSpace
+            | Self::StorageLockFailed => ErrorScope::Storage,
+            Self::ConfigParseFailed | Self::ConfigMissing | Self::ConfigInvalidValue | Self::AuthConfigInvalid => {
+                ErrorScope::Configuration
+            }
+            Self::AuthHotReloadFailed => ErrorScope::Authentication,
+            Self::Io
+            | Self::IllegalArgument
+            | Self::Timeout
+            | Self::Internal
+            | Self::Service
+            | Self::NotInitialized => ErrorScope::System,
+            Self::InvalidVersionOrdinal => ErrorScope::Version,
+            Self::Legacy => ErrorScope::Legacy,
+            Self::MissingRequiredMessageProperty => ErrorScope::Protocol,
+        }
+    }
+
+    /// Resolve an error kind from a stable code.
+    #[inline]
+    pub fn from_code(code: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|kind| kind.code().as_str() == code)
+    }
+}

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -51,6 +51,9 @@
 // New unified error system
 pub mod unified;
 
+// Stable error taxonomy
+pub mod kind;
+
 // Auth error module
 pub mod auth_error;
 
@@ -71,6 +74,9 @@ pub use controller_error::ControllerError;
 pub use controller_error::ControllerResult;
 // Re-export filter error types
 pub use filter_error::FilterError;
+pub use kind::ErrorCode;
+pub use kind::ErrorKind;
+pub use kind::ErrorScope;
 pub use unified::AuthError;
 pub use unified::NetworkError;
 pub use unified::ProtocolError;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -29,6 +29,7 @@ use std::io;
 // Re-export filter error
 pub use crate::filter_error::FilterError;
 
+use crate::kind::ErrorKind;
 pub use network::NetworkError;
 pub use protocol::ProtocolError;
 pub use rpc::RpcClientError;
@@ -408,6 +409,76 @@ pub enum RocketMQError {
 // ============================================================================
 
 impl RocketMQError {
+    /// Return the stable logical error kind.
+    #[inline]
+    #[allow(deprecated)]
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Network(_) => ErrorKind::Network,
+            Self::Serialization(_) => ErrorKind::Serialization,
+            Self::Protocol(_) => ErrorKind::Protocol,
+            Self::Rpc(_) => ErrorKind::Rpc,
+            Self::Authentication(_) => ErrorKind::Authentication,
+            Self::Controller(_) => ErrorKind::Controller,
+            Self::InvalidProperty(_) => ErrorKind::InvalidProperty,
+            Self::BrokerNotFound { .. } => ErrorKind::BrokerNotFound,
+            Self::BrokerRegistrationFailed { .. } => ErrorKind::BrokerRegistrationFailed,
+            Self::BrokerOperationFailed { .. } => ErrorKind::BrokerOperationFailed,
+            Self::TopicNotExist { .. } => ErrorKind::TopicNotExist,
+            Self::QueueNotExist { .. } => ErrorKind::QueueNotExist,
+            Self::SubscriptionGroupNotExist { .. } => ErrorKind::SubscriptionGroupNotExist,
+            Self::QueueIdOutOfRange { .. } => ErrorKind::QueueIdOutOfRange,
+            Self::MessageTooLarge { .. } => ErrorKind::MessageTooLarge,
+            Self::MessageValidationFailed { .. } => ErrorKind::MessageValidationFailed,
+            Self::RetryLimitExceeded { .. } => ErrorKind::RetryLimitExceeded,
+            Self::TransactionRejected => ErrorKind::TransactionRejected,
+            Self::BrokerPermissionDenied { .. } => ErrorKind::BrokerPermissionDenied,
+            Self::NotMasterBroker { .. } => ErrorKind::NotMasterBroker,
+            Self::MessageLookupFailed { .. } => ErrorKind::MessageLookupFailed,
+            Self::TopicSendingForbidden { .. } => ErrorKind::TopicSendingForbidden,
+            Self::BrokerAsyncTaskFailed { .. } => ErrorKind::BrokerAsyncTaskFailed,
+            Self::RequestBodyInvalid { .. } => ErrorKind::RequestBodyInvalid,
+            Self::RequestHeaderError(_) => ErrorKind::RequestHeaderError,
+            Self::ResponseProcessFailed { .. } => ErrorKind::ResponseProcessFailed,
+            Self::RouteNotFound { .. } => ErrorKind::RouteNotFound,
+            Self::RouteInconsistent { .. } => ErrorKind::RouteInconsistent,
+            Self::RouteRegistrationConflict { .. } => ErrorKind::RouteRegistrationConflict,
+            Self::RouteVersionConflict { .. } => ErrorKind::RouteVersionConflict,
+            Self::ClusterNotFound { .. } => ErrorKind::ClusterNotFound,
+            Self::ClientNotStarted => ErrorKind::ClientNotStarted,
+            Self::ClientAlreadyStarted => ErrorKind::ClientAlreadyStarted,
+            Self::ClientShuttingDown => ErrorKind::ClientShuttingDown,
+            Self::ClientInvalidState { .. } => ErrorKind::ClientInvalidState,
+            Self::ProducerNotAvailable => ErrorKind::ProducerNotAvailable,
+            Self::ConsumerNotAvailable => ErrorKind::ConsumerNotAvailable,
+            Self::Tools(_) => ErrorKind::Tools,
+            Self::Filter(_) => ErrorKind::Filter,
+            Self::StorageReadFailed { .. } => ErrorKind::StorageReadFailed,
+            Self::StorageWriteFailed { .. } => ErrorKind::StorageWriteFailed,
+            Self::StorageCorrupted { .. } => ErrorKind::StorageCorrupted,
+            Self::StorageOutOfSpace { .. } => ErrorKind::StorageOutOfSpace,
+            Self::StorageLockFailed { .. } => ErrorKind::StorageLockFailed,
+            Self::ConfigParseFailed { .. } => ErrorKind::ConfigParseFailed,
+            Self::ConfigMissing { .. } => ErrorKind::ConfigMissing,
+            Self::ConfigInvalidValue { .. } => ErrorKind::ConfigInvalidValue,
+            Self::AuthConfigInvalid { .. } => ErrorKind::AuthConfigInvalid,
+            Self::AuthHotReloadFailed { .. } => ErrorKind::AuthHotReloadFailed,
+            Self::ControllerNotLeader { .. } => ErrorKind::ControllerNotLeader,
+            Self::ControllerRaftError { .. } => ErrorKind::ControllerRaftError,
+            Self::ControllerConsensusTimeout { .. } => ErrorKind::ControllerConsensusTimeout,
+            Self::ControllerSnapshotFailed { .. } => ErrorKind::ControllerSnapshotFailed,
+            Self::IO(_) => ErrorKind::Io,
+            Self::IllegalArgument(_) => ErrorKind::IllegalArgument,
+            Self::Timeout { .. } => ErrorKind::Timeout,
+            Self::Internal(_) => ErrorKind::Internal,
+            Self::Service(_) => ErrorKind::Service,
+            Self::InvalidVersionOrdinal(_) => ErrorKind::InvalidVersionOrdinal,
+            Self::Legacy(_) => ErrorKind::Legacy,
+            Self::NotInitialized(_) => ErrorKind::NotInitialized,
+            Self::MissingRequiredMessageProperty { .. } => ErrorKind::MissingRequiredMessageProperty,
+        }
+    }
+
     /// Create a network connection failed error
     #[inline]
     pub fn network_connection_failed(addr: impl Into<String>, reason: impl Into<String>) -> Self {

--- a/rocketmq-error/tests/error_kind_contract.rs
+++ b/rocketmq-error/tests/error_kind_contract.rs
@@ -1,0 +1,72 @@
+use std::collections::HashSet;
+
+use rocketmq_error::ErrorCode;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::ErrorScope;
+use rocketmq_error::RocketMQError;
+
+#[test]
+fn error_code_is_a_stable_machine_code() {
+    let code = ErrorCode::new("NETWORK_CONNECTION_FAILED");
+
+    assert_eq!(code.as_str(), "NETWORK_CONNECTION_FAILED");
+    assert_eq!(code.to_string(), "NETWORK_CONNECTION_FAILED");
+    assert_eq!(code, ErrorKind::Network.code());
+}
+
+#[test]
+fn error_kind_exposes_code_and_scope() {
+    let cases = [
+        (
+            ErrorKind::BrokerOperationFailed,
+            ErrorScope::Broker,
+            "BROKER_OPERATION_FAILED",
+        ),
+        (ErrorKind::RouteNotFound, ErrorScope::Route, "ROUTE_NOT_FOUND"),
+        (
+            ErrorKind::StorageWriteFailed,
+            ErrorScope::Storage,
+            "STORAGE_WRITE_FAILED",
+        ),
+        (
+            ErrorKind::AuthConfigInvalid,
+            ErrorScope::Configuration,
+            "AUTH_CONFIG_INVALID",
+        ),
+        (ErrorKind::Internal, ErrorScope::System, "INTERNAL"),
+    ];
+
+    for (kind, scope, code) in cases {
+        assert_eq!(kind.scope(), scope);
+        assert_eq!(kind.code().as_str(), code);
+    }
+}
+
+#[test]
+fn all_error_kinds_have_unique_codes() {
+    let mut codes = HashSet::new();
+
+    for kind in ErrorKind::ALL {
+        assert!(
+            codes.insert(kind.code()),
+            "duplicate error code for {:?}: {}",
+            kind,
+            kind.code()
+        );
+    }
+
+    assert!(ErrorKind::ALL.contains(&ErrorKind::Network));
+    assert!(ErrorKind::ALL.contains(&ErrorKind::Legacy));
+}
+
+#[test]
+fn rocketmq_error_reports_kind() {
+    let route = RocketMQError::route_not_found("TopicA");
+    assert_eq!(route.kind(), ErrorKind::RouteNotFound);
+
+    let storage = RocketMQError::storage_write_failed("commitlog", "disk full");
+    assert_eq!(storage.kind(), ErrorKind::StorageWriteFailed);
+
+    let auth = RocketMQError::auth_config_invalid("auth.authorization", "missing provider");
+    assert_eq!(auth.kind(), ErrorKind::AuthConfigInvalid);
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7879

### Brief Description

- Adds ErrorCode, ErrorScope, and ErrorKind as stable error taxonomy primitives.
- Exposes the taxonomy from rocketmq-error and adds RocketMQError::kind().
- Adds contract tests for stable codes, unique codes, scopes, and selected RocketMQError mappings.

### How Did You Test This Change?

- `cargo test -p rocketmq-error --test error_kind_contract`
- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable error codes and error kinds for RocketMQ errors, making error handling and identification more consistent.
  * Errors can now be categorized by scope and converted back from their stable code values.
  * Unified errors now expose a single kind value for easier inspection and reporting.

* **Tests**
  * Added coverage to verify error codes, categories, and mappings remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->