### PR TITLE
[ISSUE #7881]✨Add error spec registry

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -53,6 +53,7 @@ pub mod unified;
 
 // Stable error taxonomy
 pub mod kind;
+pub mod spec;
 
 // Auth error module
 pub mod auth_error;
@@ -77,6 +78,9 @@ pub use filter_error::FilterError;
 pub use kind::ErrorCode;
 pub use kind::ErrorKind;
 pub use kind::ErrorScope;
+pub use spec::error_spec;
+pub use spec::ErrorSpec;
+pub use spec::ALL_ERROR_SPECS;
 pub use unified::AuthError;
 pub use unified::NetworkError;
 pub use unified::ProtocolError;

--- a/rocketmq-error/src/spec.rs
+++ b/rocketmq-error/src/spec.rs
@@ -1,0 +1,131 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::kind::ErrorCode;
+use crate::kind::ErrorKind;
+use crate::kind::ErrorScope;
+
+/// Static metadata for one [`ErrorKind`].
+///
+/// The registry is the single source for machine-readable error identity. Later
+/// changes extend this struct with protocol, retry, redaction, and observability
+/// fields without changing the lookup contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErrorSpec {
+    pub kind: ErrorKind,
+    pub code: ErrorCode,
+    pub scope: ErrorScope,
+    pub public_message: &'static str,
+}
+
+impl ErrorSpec {
+    #[inline]
+    pub const fn new(kind: ErrorKind, public_message: &'static str) -> Self {
+        Self {
+            kind,
+            code: kind.code(),
+            scope: kind.scope(),
+            public_message,
+        }
+    }
+}
+
+macro_rules! spec {
+    ($kind:ident, $message:literal) => {
+        ErrorSpec::new(ErrorKind::$kind, $message)
+    };
+}
+
+/// Static registry for all current error kinds.
+pub const ALL_ERROR_SPECS: &[ErrorSpec] = &[
+    spec!(Network, "Network operation failed"),
+    spec!(Serialization, "Serialization failed"),
+    spec!(Protocol, "Protocol error"),
+    spec!(Rpc, "RPC operation failed"),
+    spec!(Authentication, "Authentication failed"),
+    spec!(Controller, "Controller operation failed"),
+    spec!(InvalidProperty, "Message property is invalid"),
+    spec!(BrokerNotFound, "Broker was not found"),
+    spec!(BrokerRegistrationFailed, "Broker registration failed"),
+    spec!(BrokerOperationFailed, "Broker operation failed"),
+    spec!(TopicNotExist, "Topic does not exist"),
+    spec!(QueueNotExist, "Queue does not exist"),
+    spec!(SubscriptionGroupNotExist, "Subscription group does not exist"),
+    spec!(QueueIdOutOfRange, "Queue id is out of range"),
+    spec!(MessageTooLarge, "Message body is too large"),
+    spec!(MessageValidationFailed, "Message validation failed"),
+    spec!(RetryLimitExceeded, "Retry limit was exceeded"),
+    spec!(TransactionRejected, "Transaction message was rejected"),
+    spec!(BrokerPermissionDenied, "Broker permission was denied"),
+    spec!(NotMasterBroker, "Broker is not the master"),
+    spec!(MessageLookupFailed, "Message lookup failed"),
+    spec!(TopicSendingForbidden, "Topic sending is forbidden"),
+    spec!(BrokerAsyncTaskFailed, "Broker asynchronous operation failed"),
+    spec!(RequestBodyInvalid, "Request body is invalid"),
+    spec!(RequestHeaderError, "Request header is invalid"),
+    spec!(ResponseProcessFailed, "Response processing failed"),
+    spec!(RouteNotFound, "Route information was not found"),
+    spec!(RouteInconsistent, "Route data is inconsistent"),
+    spec!(RouteRegistrationConflict, "Route registration conflict"),
+    spec!(RouteVersionConflict, "Route version conflict"),
+    spec!(ClusterNotFound, "Cluster was not found"),
+    spec!(ClientNotStarted, "Client is not started"),
+    spec!(ClientAlreadyStarted, "Client is already started"),
+    spec!(ClientShuttingDown, "Client is shutting down"),
+    spec!(ClientInvalidState, "Client state is invalid"),
+    spec!(ProducerNotAvailable, "Producer is not available"),
+    spec!(ConsumerNotAvailable, "Consumer is not available"),
+    spec!(Tools, "Tools operation failed"),
+    spec!(Filter, "Filter operation failed"),
+    spec!(StorageReadFailed, "Storage read failed"),
+    spec!(StorageWriteFailed, "Storage write failed"),
+    spec!(StorageCorrupted, "Storage data is corrupted"),
+    spec!(StorageOutOfSpace, "Storage is out of space"),
+    spec!(StorageLockFailed, "Storage lock failed"),
+    spec!(ConfigParseFailed, "Configuration parsing failed"),
+    spec!(ConfigMissing, "Required configuration is missing"),
+    spec!(ConfigInvalidValue, "Configuration value is invalid"),
+    spec!(AuthConfigInvalid, "Authentication configuration is invalid"),
+    spec!(AuthHotReloadFailed, "Authentication hot reload failed"),
+    spec!(ControllerNotLeader, "Controller is not the leader"),
+    spec!(ControllerRaftError, "Controller raft operation failed"),
+    spec!(ControllerConsensusTimeout, "Controller consensus operation timed out"),
+    spec!(ControllerSnapshotFailed, "Controller snapshot operation failed"),
+    spec!(Io, "I/O operation failed"),
+    spec!(IllegalArgument, "Argument is illegal"),
+    spec!(Timeout, "Operation timed out"),
+    spec!(Internal, "Internal error"),
+    spec!(Service, "Service lifecycle operation failed"),
+    spec!(InvalidVersionOrdinal, "Version ordinal is invalid"),
+    spec!(Legacy, "Legacy error"),
+    spec!(NotInitialized, "Component is not initialized"),
+    spec!(MissingRequiredMessageProperty, "Message is missing a required property"),
+];
+
+/// Return the static metadata for an error kind.
+#[inline]
+pub fn error_spec(kind: ErrorKind) -> &'static ErrorSpec {
+    ALL_ERROR_SPECS
+        .iter()
+        .find(|spec| spec.kind == kind)
+        .expect("all ErrorKind variants must have an ErrorSpec")
+}
+
+impl ErrorKind {
+    /// Return the static metadata for this error kind.
+    #[inline]
+    pub fn spec(self) -> &'static ErrorSpec {
+        error_spec(self)
+    }
+}

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -30,6 +30,7 @@ use std::io;
 pub use crate::filter_error::FilterError;
 
 use crate::kind::ErrorKind;
+use crate::spec::ErrorSpec;
 pub use network::NetworkError;
 pub use protocol::ProtocolError;
 pub use rpc::RpcClientError;
@@ -477,6 +478,12 @@ impl RocketMQError {
             Self::NotInitialized(_) => ErrorKind::NotInitialized,
             Self::MissingRequiredMessageProperty { .. } => ErrorKind::MissingRequiredMessageProperty,
         }
+    }
+
+    /// Return the static metadata for this error.
+    #[inline]
+    pub fn spec(&self) -> &'static ErrorSpec {
+        self.kind().spec()
     }
 
     /// Create a network connection failed error

--- a/rocketmq-error/tests/error_spec_registry.rs
+++ b/rocketmq-error/tests/error_spec_registry.rs
@@ -1,0 +1,42 @@
+use std::collections::HashSet;
+
+use rocketmq_error::error_spec;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::ErrorSpec;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::ALL_ERROR_SPECS;
+
+#[test]
+fn every_error_kind_has_one_spec() {
+    assert_eq!(ALL_ERROR_SPECS.len(), ErrorKind::ALL.len());
+
+    let mut kinds = HashSet::new();
+    for spec in ALL_ERROR_SPECS {
+        assert!(kinds.insert(spec.kind), "duplicate spec for {:?}", spec.kind);
+        assert_eq!(spec.code, spec.kind.code());
+        assert_eq!(spec.scope, spec.kind.scope());
+        assert!(!spec.public_message.is_empty());
+    }
+
+    for kind in ErrorKind::ALL {
+        assert!(kinds.contains(kind), "missing spec for {kind:?}");
+    }
+}
+
+#[test]
+fn error_spec_lookup_returns_static_spec() {
+    let spec = error_spec(ErrorKind::RouteNotFound);
+
+    assert_eq!(spec.kind, ErrorKind::RouteNotFound);
+    assert_eq!(spec.code.as_str(), "ROUTE_NOT_FOUND");
+    assert_eq!(spec.public_message, "Route information was not found");
+}
+
+#[test]
+fn rocketmq_error_reports_spec() {
+    let error = RocketMQError::route_not_found("TopicA");
+    let spec: &'static ErrorSpec = error.spec();
+
+    assert_eq!(spec.kind, ErrorKind::RouteNotFound);
+    assert_eq!(spec.code.as_str(), "ROUTE_NOT_FOUND");
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7881

### Brief Description

- Adds ErrorSpec as static metadata for each ErrorKind.
- Adds ALL_ERROR_SPECS and error_spec lookup.
- Adds RocketMQError::spec() and registry completeness tests.

### How Did You Test This Change?

- `cargo test -p rocketmq-error --test error_spec_registry`
- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public error-spec registry for accessing standardized error details.
  * Exposed error metadata directly from error kinds and unified errors, including code, scope, and public message.
  * Added a complete list of supported error specs for consistent lookup across the crate.

* **Bug Fixes**
  * Improved coverage to ensure every error kind has a matching spec entry and no duplicates.
  * Added validation for error metadata consistency and lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->