### PR TITLE
[ISSUE #7883]✨Add redacted error context primitives

### DIFF
--- a/rocketmq-error/src/context.rs
+++ b/rocketmq-error/src/context.rs
@@ -1,0 +1,148 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+pub const REDACTED: &str = "<redacted>";
+
+/// Wrapper for values that must never be formatted directly.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Sensitive<T> {
+    inner: T,
+}
+
+impl<T> Sensitive<T> {
+    #[inline]
+    pub const fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    #[inline]
+    pub const fn expose_secret(&self) -> &T {
+        &self.inner
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> From<T> for Sensitive<T> {
+    #[inline]
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> fmt::Display for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl<T> fmt::Debug for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Sensitive(<redacted>)")
+    }
+}
+
+/// Redaction policy for one context field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RedactionKind {
+    Public,
+    Sensitive,
+}
+
+/// One structured error context field.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ErrorContextField {
+    pub key: &'static str,
+    pub value: String,
+    pub redaction: RedactionKind,
+}
+
+/// Redaction-aware structured context for errors.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ErrorContext {
+    fields: Vec<ErrorContextField>,
+}
+
+impl ErrorContext {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    #[inline]
+    pub fn with_field(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.push_field(key, value);
+        self
+    }
+
+    #[inline]
+    pub fn with_sensitive<T>(mut self, key: &'static str, _value: Sensitive<T>) -> Self {
+        self.fields.push(ErrorContextField {
+            key,
+            value: REDACTED.to_string(),
+            redaction: RedactionKind::Sensitive,
+        });
+        self
+    }
+
+    #[inline]
+    pub fn push_field(&mut self, key: &'static str, value: impl Into<String>) {
+        self.fields.push(ErrorContextField {
+            key,
+            value: value.into(),
+            redaction: RedactionKind::Public,
+        });
+    }
+
+    #[inline]
+    pub fn push_sensitive<T>(&mut self, key: &'static str, value: Sensitive<T>) {
+        self.fields.push(ErrorContextField {
+            key,
+            value: value.to_string(),
+            redaction: RedactionKind::Sensitive,
+        });
+    }
+
+    #[inline]
+    pub fn fields(&self) -> &[ErrorContextField] {
+        &self.fields
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+}
+
+impl fmt::Display for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, field) in self.fields.iter().enumerate() {
+            if index > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{}={}", field.key, field.value)?;
+        }
+        Ok(())
+    }
+}

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -52,6 +52,7 @@
 pub mod unified;
 
 // Stable error taxonomy
+pub mod context;
 pub mod kind;
 pub mod spec;
 
@@ -71,6 +72,11 @@ pub mod client_error;
 // Re-export auth error types from unified module
 // Re-export controller error types
 pub use client_error::ClientError;
+pub use context::ErrorContext;
+pub use context::ErrorContextField;
+pub use context::RedactionKind;
+pub use context::Sensitive;
+pub use context::REDACTED;
 pub use controller_error::ControllerError;
 pub use controller_error::ControllerResult;
 // Re-export filter error types

--- a/rocketmq-error/tests/error_context_redaction.rs
+++ b/rocketmq-error/tests/error_context_redaction.rs
@@ -1,0 +1,39 @@
+use rocketmq_error::ErrorContext;
+use rocketmq_error::RedactionKind;
+use rocketmq_error::Sensitive;
+
+#[test]
+fn sensitive_display_and_debug_are_redacted() {
+    let secret = Sensitive::new("secret-value");
+
+    assert_eq!(secret.expose_secret(), &"secret-value");
+    assert_eq!(secret.to_string(), "<redacted>");
+
+    let debug = format!("{secret:?}");
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("secret-value"));
+}
+
+#[test]
+fn error_context_redacts_sensitive_fields() {
+    let context = ErrorContext::new()
+        .with_field("topic", "TopicA")
+        .with_sensitive("secret_key", Sensitive::new("sk-123"))
+        .with_sensitive("token", Sensitive::new("token-456"));
+
+    assert_eq!(context.len(), 3);
+    assert_eq!(context.fields()[0].redaction, RedactionKind::Public);
+    assert_eq!(context.fields()[1].redaction, RedactionKind::Sensitive);
+    assert_eq!(context.fields()[1].value, "<redacted>");
+
+    let display = context.to_string();
+    assert!(display.contains("topic=TopicA"));
+    assert!(display.contains("secret_key=<redacted>"));
+    assert!(display.contains("token=<redacted>"));
+    assert!(!display.contains("sk-123"));
+    assert!(!display.contains("token-456"));
+
+    let debug = format!("{context:?}");
+    assert!(!debug.contains("sk-123"));
+    assert!(!debug.contains("token-456"));
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7883

### Brief Description

- Adds Sensitive<T> with redacted Display and Debug output.
- Adds ErrorContext, ErrorContextField, and RedactionKind for structured context.
- Adds tests proving sensitive context values are redacted and not shown in Display or Debug.

### How Did You Test This Change?

- `cargo test -p rocketmq-error --test error_context_redaction`
- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured error context support with public and sensitive fields.
  * Sensitive values are automatically redacted in display and debug output.
  * Error messages can now include readable key/value context while protecting secrets.

* **Tests**
  * Added coverage to verify sensitive data stays redacted and public fields remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->