### PR TITLE
[ISSUE #7887]✨Add recovery and observability policies

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -55,6 +55,7 @@ pub mod unified;
 pub mod boundary;
 pub mod context;
 pub mod kind;
+pub mod policy;
 pub mod spec;
 
 // Auth error module
@@ -94,6 +95,10 @@ pub use filter_error::FilterError;
 pub use kind::ErrorCode;
 pub use kind::ErrorKind;
 pub use kind::ErrorScope;
+pub use policy::ErrorSeverity;
+pub use policy::ObserveSpec;
+pub use policy::RecoverySpec;
+pub use policy::RetryClass;
 pub use spec::error_spec;
 pub use spec::ErrorSpec;
 pub use spec::ALL_ERROR_SPECS;

--- a/rocketmq-error/src/policy.rs
+++ b/rocketmq-error/src/policy.rs
@@ -1,0 +1,118 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ErrorKind;
+
+/// Retry or recovery classification for one error kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RetryClass {
+    Never,
+    Immediate,
+    AfterBackoff,
+    RefreshRoute,
+    SwitchBroker,
+    RefreshLeader,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RecoverySpec {
+    pub retry: RetryClass,
+}
+
+impl RecoverySpec {
+    #[inline]
+    pub const fn new(retry: RetryClass) -> Self {
+        Self { retry }
+    }
+
+    #[inline]
+    pub const fn for_kind(kind: ErrorKind) -> Self {
+        Self::new(match kind {
+            ErrorKind::RouteNotFound
+            | ErrorKind::RouteInconsistent
+            | ErrorKind::RouteRegistrationConflict
+            | ErrorKind::RouteVersionConflict => RetryClass::RefreshRoute,
+            ErrorKind::BrokerOperationFailed
+            | ErrorKind::BrokerNotFound
+            | ErrorKind::BrokerRegistrationFailed
+            | ErrorKind::QueueNotExist
+            | ErrorKind::ProducerNotAvailable
+            | ErrorKind::ConsumerNotAvailable => RetryClass::SwitchBroker,
+            ErrorKind::NotMasterBroker | ErrorKind::ControllerNotLeader => RetryClass::RefreshLeader,
+            ErrorKind::Network
+            | ErrorKind::Rpc
+            | ErrorKind::Timeout
+            | ErrorKind::RetryLimitExceeded
+            | ErrorKind::StorageLockFailed
+            | ErrorKind::Tools => RetryClass::AfterBackoff,
+            ErrorKind::MessageLookupFailed | ErrorKind::SubscriptionGroupNotExist => RetryClass::Immediate,
+            _ => RetryClass::Never,
+        })
+    }
+}
+
+/// Default severity for logs, metrics, traces, and alert routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorSeverity {
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObserveSpec {
+    pub severity: ErrorSeverity,
+    pub metric_label: &'static str,
+}
+
+impl ObserveSpec {
+    #[inline]
+    pub const fn new(severity: ErrorSeverity, metric_label: &'static str) -> Self {
+        Self { severity, metric_label }
+    }
+
+    #[inline]
+    pub const fn for_kind(kind: ErrorKind) -> Self {
+        Self::new(observe_severity(kind), kind.code().as_str())
+    }
+}
+
+#[inline]
+const fn observe_severity(kind: ErrorKind) -> ErrorSeverity {
+    match kind {
+        ErrorKind::IllegalArgument
+        | ErrorKind::InvalidProperty
+        | ErrorKind::RequestBodyInvalid
+        | ErrorKind::RequestHeaderError
+        | ErrorKind::ResponseProcessFailed
+        | ErrorKind::ConfigMissing
+        | ErrorKind::ConfigInvalidValue
+        | ErrorKind::MissingRequiredMessageProperty => ErrorSeverity::Info,
+        ErrorKind::RouteNotFound
+        | ErrorKind::TopicNotExist
+        | ErrorKind::SubscriptionGroupNotExist
+        | ErrorKind::QueueNotExist
+        | ErrorKind::MessageLookupFailed
+        | ErrorKind::Network
+        | ErrorKind::Timeout
+        | ErrorKind::RetryLimitExceeded
+        | ErrorKind::NotMasterBroker
+        | ErrorKind::ControllerNotLeader => ErrorSeverity::Warn,
+        ErrorKind::StorageCorrupted | ErrorKind::StorageOutOfSpace => ErrorSeverity::Critical,
+        ErrorKind::Legacy => ErrorSeverity::Debug,
+        _ => ErrorSeverity::Error,
+    }
+}

--- a/rocketmq-error/src/spec.rs
+++ b/rocketmq-error/src/spec.rs
@@ -19,6 +19,8 @@ use crate::boundary::RemotingSpec;
 use crate::kind::ErrorCode;
 use crate::kind::ErrorKind;
 use crate::kind::ErrorScope;
+use crate::policy::ObserveSpec;
+use crate::policy::RecoverySpec;
 
 /// Static metadata for one [`ErrorKind`].
 ///
@@ -35,6 +37,8 @@ pub struct ErrorSpec {
     pub grpc: GrpcSpec,
     pub http: HttpSpec,
     pub cli: CliSpec,
+    pub recovery: RecoverySpec,
+    pub observe: ObserveSpec,
 }
 
 impl ErrorSpec {
@@ -49,6 +53,8 @@ impl ErrorSpec {
             grpc: GrpcSpec::for_kind(kind),
             http: HttpSpec::for_kind(kind),
             cli: CliSpec::for_kind(kind),
+            recovery: RecoverySpec::for_kind(kind),
+            observe: ObserveSpec::for_kind(kind),
         }
     }
 }

--- a/rocketmq-error/tests/error_policy_specs.rs
+++ b/rocketmq-error/tests/error_policy_specs.rs
@@ -1,0 +1,41 @@
+use rocketmq_error::ErrorKind;
+use rocketmq_error::ErrorSeverity;
+use rocketmq_error::RetryClass;
+use rocketmq_error::ALL_ERROR_SPECS;
+
+#[test]
+fn selected_error_kinds_have_recovery_policy() {
+    assert_eq!(ErrorKind::RouteNotFound.spec().recovery.retry, RetryClass::RefreshRoute);
+    assert_eq!(
+        ErrorKind::BrokerOperationFailed.spec().recovery.retry,
+        RetryClass::SwitchBroker
+    );
+    assert_eq!(
+        ErrorKind::ControllerNotLeader.spec().recovery.retry,
+        RetryClass::RefreshLeader
+    );
+    assert_eq!(ErrorKind::AuthConfigInvalid.spec().recovery.retry, RetryClass::Never);
+}
+
+#[test]
+fn selected_error_kinds_have_observability_policy() {
+    let route = ErrorKind::RouteNotFound.spec();
+    assert_eq!(route.observe.severity, ErrorSeverity::Warn);
+    assert_eq!(route.observe.metric_label, "ROUTE_NOT_FOUND");
+
+    let internal = ErrorKind::Internal.spec();
+    assert_eq!(internal.observe.severity, ErrorSeverity::Error);
+    assert_eq!(internal.observe.metric_label, "INTERNAL");
+
+    let invalid = ErrorKind::RequestHeaderError.spec();
+    assert_eq!(invalid.observe.severity, ErrorSeverity::Info);
+}
+
+#[test]
+fn every_error_spec_has_low_cardinality_observability_labels() {
+    for spec in ALL_ERROR_SPECS {
+        assert_eq!(spec.observe.metric_label, spec.code.as_str());
+        assert!(!spec.observe.metric_label.is_empty());
+        assert!(!spec.observe.metric_label.contains(' '));
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7887

### Brief Description

- Adds RetryClass and RecoverySpec for registry-driven recovery decisions.
- Adds ErrorSeverity and ObserveSpec for low-cardinality operational metadata.
- Extends ErrorSpec with recovery and observability policy fields and tests.

### How Did You Test This Change?

- `cargo test -p rocketmq-error --test error_policy_specs`
- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
