### PR TITLE
[ISSUE #7889]♻️Replace public result alias callers

### DIFF
--- a/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
+++ b/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use anyhow::Error;
-use rocketmq_error::Result;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use tokio::sync::mpsc;
 use tokio::time;
 
@@ -44,23 +44,28 @@ impl MessageQueueOpContext {
         self.last_write_timestamp.store(timestamp, Ordering::Release);
     }
 
-    pub async fn push(&self, msg: String) -> Result<()> {
+    pub async fn push(&self, msg: String) -> RocketMQResult<()> {
         if self.context_receiver.len() > self.queue_capacity {
-            return Err(anyhow::Error::msg("queue is full".to_string()));
+            return Err(RocketMQError::Internal("queue is full".to_string()));
         }
-        self.context_queue.send(msg).map_err(anyhow::Error::new)
+        self.context_queue
+            .send(msg)
+            .map_err(|error| RocketMQError::Internal(format!("queue send failed: {error}")))
     }
-    pub async fn offer(&self, item: String, timeout: std::time::Duration) -> Result<()> {
+    pub async fn offer(&self, item: String, timeout: std::time::Duration) -> RocketMQResult<()> {
         if let Ok(res) = time::timeout(timeout, self.push(item)).await {
             return res;
         }
-        Err(Error::msg("offer time out"))
+        Err(RocketMQError::Timeout {
+            operation: "message_queue_offer",
+            timeout_ms: timeout.as_millis() as u64,
+        })
     }
-    pub async fn pull(&mut self) -> Result<String> {
+    pub async fn pull(&mut self) -> RocketMQResult<String> {
         if let Some(item) = self.context_receiver.recv().await {
             return Ok(item);
         }
-        Err(Error::msg("pull failed, channel closed".to_string()))
+        Err(RocketMQError::Internal("pull failed, channel closed".to_string()))
     }
     pub async fn is_empty(&self) -> bool {
         self.context_receiver.len() == 0

--- a/rocketmq-controller/examples/cli_usage.rs
+++ b/rocketmq-controller/examples/cli_usage.rs
@@ -30,9 +30,9 @@
 //! cargo run --example cli_usage -- --help
 //! ```
 
+use anyhow::Result;
 use rocketmq_controller::parse_command_line;
 use rocketmq_controller::ControllerCli;
-use rocketmq_error::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -15,13 +15,13 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use anyhow::Result;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_controller::parse_command_line;
 use rocketmq_controller::typ::Node;
 use rocketmq_controller::ControllerManager;
 use rocketmq_error::ControllerError;
-use rocketmq_error::Result;
 use rocketmq_remoting::protocol::remoting_command;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -20,6 +20,7 @@ use std::process;
 
 use anyhow::bail;
 use anyhow::Context;
+use anyhow::Result;
 use clap::Parser;
 use config::Config;
 use rocketmq_common::common::controller::controller_config::RaftPeer;
@@ -32,7 +33,6 @@ use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::ParseConfigFile;
 use rocketmq_controller::ControllerCli;
 use rocketmq_controller::ControllerConfig;
-use rocketmq_error::Result;
 use rocketmq_namesrv::bootstrap::Builder;
 use rocketmq_remoting::protocol::remoting_command;
 use rocketmq_runtime::RuntimeConfig;


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7889

### Brief Description

- Replaces binary and example imports of rocketmq_error::Result with anyhow::Result.
- Changes broker MessageQueueOpContext to return RocketMQResult with typed RocketMQError values.
- Verifies no remaining caller imports rocketmq_error::Result outside rocketmq-error itself.

### How Did You Test This Change?

- `rg -n "rocketmq_error::Result|use rocketmq_error::\{[^}]*Result" --glob "*.rs"`
- `cargo fmt --all`
- `cargo test -p rocketmq-broker --lib`
- `cargo test -p rocketmq-controller --bin rocketmq-controller-rust --example cli_usage`
- `cargo test -p rocketmq-namesrv --bins`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
