### PR TITLE
[ISSUE #7891]♻️Remove public anyhow result aliases

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -130,16 +130,12 @@ use std::io;
 
 use thiserror::Error;
 
-// Legacy type aliases (deprecated - use RocketMQResult and Result from unified module)
+// Legacy type alias (deprecated - use RocketMQResult from unified module)
 // Kept for backward compatibility with existing code
 #[deprecated(since = "0.7.0", note = "Use unified::RocketMQResult instead")]
 pub type LegacyRocketMQResult<T> = std::result::Result<T, RocketmqError>;
 
-#[deprecated(since = "0.7.0", note = "Use unified::Result instead")]
-pub type LegacyResult<T> = anyhow::Result<T>;
-
 // Re-export unified result types as the primary API
-pub use unified::Result;
 pub use unified::RocketMQResult;
 // Import ServiceError for use in legacy RocketmqError enum
 use unified::ServiceError;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -860,12 +860,6 @@ pub enum ServiceError {
 /// ```
 pub type RocketMQResult<T> = std::result::Result<T, RocketMQError>;
 
-/// Alias for anyhow::Result for internal use
-///
-/// Use this for internal error handling where you don't need
-/// to expose specific error types to the public API.
-pub type Result<T> = anyhow::Result<T>;
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7891

### Brief Description

- Removes unified::Result and LegacyResult public anyhow aliases from rocketmq-error.
- Keeps RocketMQResult as the typed public result alias.
- Verifies static scans show no remaining public anyhow alias definitions or callers.

### How Did You Test This Change?

- `rg -n "rocketmq_error::Result|use rocketmq_error::\{[^}]*Result|LegacyResult|pub type Result<T> = anyhow::Result|type Result<T> = anyhow::Result|pub use unified::Result" --glob "*.rs"`
- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
