### PR TITLE
[ISSUE #7895]♻️Use typed remoting codec errors

### DIFF
--- a/rocketmq-remoting/src/code/broker_request_code.rs
+++ b/rocketmq-remoting/src/code/broker_request_code.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use rocketmq_error::RocketmqError::FromStrErr;
+use rocketmq_error::RocketMQError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BrokerRequestCode {
@@ -33,14 +33,14 @@ impl BrokerRequestCode {
 }
 
 impl FromStr for BrokerRequestCode {
-    type Err = rocketmq_error::RocketmqError;
+    type Err = RocketMQError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_uppercase().as_str() {
             "REGISTERBROKER" => Ok(BrokerRequestCode::RegisterBroker),
             "BROKERHEARTBEAT" => Ok(BrokerRequestCode::BrokerHeartbeat),
             "GETBROKERCLUSTERINFO" => Ok(BrokerRequestCode::GetBrokerClusterInfo),
-            _ => Err(FromStrErr(format!(
+            _ => Err(RocketMQError::illegal_argument(format!(
                 "Parse from string error,Invalid BrokerRequestCode: {s}"
             ))),
         }

--- a/rocketmq-remoting/src/codec/remoting_command_codec.rs
+++ b/rocketmq-remoting/src/codec/remoting_command_codec.rs
@@ -15,11 +15,11 @@
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
-use rocketmq_error::RocketmqError;
 use tokio_util::codec::BytesCodec;
 use tokio_util::codec::Decoder;
 use tokio_util::codec::Encoder;
 
+use crate::error_helpers::encoder_error;
 use crate::protocol::remoting_command::RemotingCommand;
 
 /// Encodes a `RemotingCommand` into a `BytesMut` buffer.
@@ -154,9 +154,9 @@ impl Encoder<Bytes> for CompositeCodec {
     type Error = rocketmq_error::RocketMQError;
 
     fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.bytes_codec.encode(item, dst).map_err(|error| {
-            RocketmqError::RemotingCommandEncoderError(format!("Error encoding bytes: {error}")).into()
-        })
+        self.bytes_codec
+            .encode(item, dst)
+            .map_err(|error| encoder_error(format!("Error encoding bytes: {error}")))
     }
 }
 

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -19,9 +19,8 @@ use rocketmq_common::common::key_builder;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::mix_all;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
-use rocketmq_error::RocketmqError::IllegalArgument;
-use rocketmq_error::RocketmqError::IllegalArgumentError;
 
 pub struct ExtraInfoUtil;
 
@@ -29,6 +28,11 @@ const NORMAL_TOPIC: &str = "0";
 const RETRY_TOPIC: &str = "1";
 const RETRY_TOPIC_V2: &str = "2";
 const QUEUE_OFFSET: &str = "qo";
+
+#[inline]
+fn illegal_argument(message: impl Into<String>) -> RocketMQError {
+    RocketMQError::illegal_argument(message)
+}
 
 impl ExtraInfoUtil {
     /// Split the extra info string using the key separator
@@ -42,67 +46,62 @@ impl ExtraInfoUtil {
     /// Get the checkpoint queue offset from the extra info
     pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> RocketMQResult<i64> {
         if extra_info_strs.is_empty() {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getCkQueueOffset fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[0]
             .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse ck_queue_offset error".to_string()).into())
+            .map_err(|_| illegal_argument("parse ck_queue_offset error"))
     }
 
     /// Get the pop time from the extra info
     pub fn get_pop_time(extra_info_strs: &[String]) -> RocketMQResult<i64> {
         if extra_info_strs.len() < 2 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getPopTime fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[1]
             .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse pop_time error".to_string()).into())
+            .map_err(|_| illegal_argument("parse pop_time error"))
     }
 
     /// Get the invisible time from the extra info
     pub fn get_invisible_time(extra_info_strs: &[String]) -> RocketMQResult<i64> {
         if extra_info_strs.len() < 3 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getInvisibleTime fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[2]
             .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse invisible_time error".to_string()).into())
+            .map_err(|_| illegal_argument("parse invisible_time error"))
     }
 
     /// Get the revive queue ID from the extra info
     pub fn get_revive_qid(extra_info_strs: &[String]) -> RocketMQResult<i32> {
         if extra_info_strs.len() < 4 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getReviveQid fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[3]
             .parse::<i32>()
-            .map_err(|_| IllegalArgument("parse revive_qid error".to_string()).into())
+            .map_err(|_| illegal_argument("parse revive_qid error"))
     }
 
     /// Get the real topic name based on the retry flag
     pub fn get_real_topic(extra_info_strs: &[String], topic: &str, cid: &str) -> RocketMQResult<String> {
         if extra_info_strs.len() < 5 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getRealTopic fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
 
         if RETRY_TOPIC == extra_info_strs[4] {
@@ -123,16 +122,17 @@ impl ExtraInfoUtil {
         } else if retry == RETRY_TOPIC_V2 {
             Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid))
         } else {
-            Err(IllegalArgument("getRetry fail, format is wrong".to_string()).into())
+            Err(illegal_argument("getRetry fail, format is wrong"))
         }
     }
 
     /// Get the retry flag from the extra info
     pub fn get_retry(extra_info_strs: &[String]) -> RocketMQResult<String> {
         if extra_info_strs.len() < 5 {
-            return Err(
-                IllegalArgument(format!("getRetry fail, extraInfoStrs length {}", extra_info_strs.len())).into(),
-            );
+            return Err(illegal_argument(format!(
+                "getRetry fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
         }
         Ok(extra_info_strs[4].clone())
     }
@@ -140,11 +140,10 @@ impl ExtraInfoUtil {
     /// Get the broker name from the extra info
     pub fn get_broker_name(extra_info_strs: &[String]) -> RocketMQResult<String> {
         if extra_info_strs.len() < 6 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getBrokerName fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         Ok(extra_info_strs[5].clone())
     }
@@ -152,29 +151,27 @@ impl ExtraInfoUtil {
     /// Get the queue ID from the extra info
     pub fn get_queue_id(extra_info_strs: &[String]) -> rocketmq_error::RocketMQResult<i32> {
         if extra_info_strs.len() < 7 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getQueueId fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[6]
             .parse::<i32>()
-            .map_err(|_| IllegalArgument("parse queue_id error".to_string()).into())
+            .map_err(|_| illegal_argument("parse queue_id error"))
     }
 
     /// Get the queue offset from the extra info
     pub fn get_queue_offset(extra_info_strs: &[String]) -> rocketmq_error::RocketMQResult<i64> {
         if extra_info_strs.len() < 8 {
-            return Err(IllegalArgument(format!(
+            return Err(illegal_argument(format!(
                 "getQueueOffset fail, extraInfoStrs length {}",
                 extra_info_strs.len()
-            ))
-            .into());
+            )));
         }
         extra_info_strs[7]
             .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse queue_offset error".to_string()).into())
+            .map_err(|_| illegal_argument("parse queue_offset error"))
     }
 
     /// Build extra info string
@@ -306,13 +303,13 @@ impl ExtraInfoUtil {
         for one in array {
             let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
             if split.len() != 3 {
-                return Err(IllegalArgument("parse msgOffsetInfo error".to_string()).into());
+                return Err(illegal_argument("parse msgOffsetInfo error"));
             }
 
             let key = format!("{}@{}", split[0], split[1]);
             let offsets = match msg_offset_map.entry(key) {
                 std::collections::hash_map::Entry::Occupied(_) => {
-                    return Err(IllegalArgument("parse msgOffsetMap error, duplicate".to_string()).into());
+                    return Err(illegal_argument("parse msgOffsetMap error, duplicate"));
                 }
                 std::collections::hash_map::Entry::Vacant(entry) => entry.insert(Vec::with_capacity(8)),
             };
@@ -321,7 +318,7 @@ impl ExtraInfoUtil {
             for msg_offset in msg_offsets {
                 let offset = msg_offset
                     .parse::<i64>()
-                    .map_err(|_| IllegalArgumentError("parse msgOffset error".to_string()))?;
+                    .map_err(|_| illegal_argument("parse msgOffset error"))?;
                 offsets.push(offset);
             }
         }
@@ -344,19 +341,21 @@ impl ExtraInfoUtil {
         for one in array {
             let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
             if split.len() != 3 {
-                return Err(IllegalArgument(format!("parse startOffsetInfo error, {start_offset_info}")).into());
+                return Err(illegal_argument(format!(
+                    "parse startOffsetInfo error, {start_offset_info}"
+                )));
             }
 
             let key = format!("{}@{}", split[0], split[1]);
             if start_offset_map.contains_key(&key) {
-                return Err(IllegalArgumentError("parse startOffsetMap error, duplicate".to_string()).into());
+                return Err(illegal_argument("parse startOffsetMap error, duplicate"));
             }
 
             start_offset_map.insert(
                 key,
                 split[2]
                     .parse::<i64>()
-                    .map_err(|_| IllegalArgumentError("parse startOffset error".to_string()))?,
+                    .map_err(|_| illegal_argument("parse startOffset error"))?,
             );
         }
 
@@ -378,21 +377,23 @@ impl ExtraInfoUtil {
         for one in array {
             let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
             if split.len() != 3 {
-                return Err(IllegalArgument(format!("parse orderCountInfo error {order_count_info}")).into());
+                return Err(illegal_argument(format!(
+                    "parse orderCountInfo error {order_count_info}"
+                )));
             }
 
             let key = format!("{}@{}", split[0], split[1]);
             if order_count_map.contains_key(&key) {
-                return Err(
-                    IllegalArgument(format!("parse orderCountInfo error, duplicate, {order_count_info}")).into(),
-                );
+                return Err(illegal_argument(format!(
+                    "parse orderCountInfo error, duplicate, {order_count_info}"
+                )));
             }
 
             order_count_map.insert(
                 key,
                 split[2]
                     .parse::<i32>()
-                    .map_err(|_| IllegalArgumentError("parse orderCountInfo error".to_string()))?,
+                    .map_err(|_| illegal_argument("parse orderCountInfo error"))?,
             );
         }
 

--- a/rocketmq-remoting/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-remoting/src/protocol/rocketmq_serializable.rs
@@ -20,8 +20,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
-use rocketmq_error::RocketmqError;
 
+use crate::error_helpers::decoding_error;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::protocol::LanguageCode;
 
@@ -56,12 +56,12 @@ impl RocketMQSerializable {
         // Read length prefix
         let len = if use_short_length {
             if buf.remaining() < 2 {
-                return Err(RocketmqError::DecodingError(2, buf.remaining()).into());
+                return Err(decoding_error(2, buf.remaining()));
             }
             buf.get_u16() as usize
         } else {
             if buf.remaining() < 4 {
-                return Err(RocketmqError::DecodingError(4, buf.remaining()).into());
+                return Err(decoding_error(4, buf.remaining()));
             }
             buf.get_u32() as usize
         };
@@ -73,12 +73,12 @@ impl RocketMQSerializable {
 
         // Boundary check
         if len > limit {
-            return Err(RocketmqError::DecodingError(len, limit).into());
+            return Err(decoding_error(len, limit));
         }
 
         // Ensure buffer has enough data
         if buf.remaining() < len {
-            return Err(RocketmqError::DecodingError(len, buf.remaining()).into());
+            return Err(decoding_error(len, buf.remaining()));
         }
 
         // Checked UTF-8 decode with CheetahString storage optimization
@@ -278,7 +278,7 @@ impl RocketMQSerializable {
         const LENGTH_FIELD_LEN: usize = 4;
 
         if header_buffer.remaining() < FIXED_HEADER_LEN {
-            return Err(RocketmqError::DecodingError(FIXED_HEADER_LEN, header_buffer.remaining()).into());
+            return Err(decoding_error(FIXED_HEADER_LEN, header_buffer.remaining()));
         }
 
         let cmd = RemotingCommand::default()
@@ -292,17 +292,17 @@ impl RocketMQSerializable {
 
         // HashMap<String, String> extFields
         if header_buffer.remaining() < LENGTH_FIELD_LEN {
-            return Err(RocketmqError::DecodingError(LENGTH_FIELD_LEN, header_buffer.remaining()).into());
+            return Err(decoding_error(LENGTH_FIELD_LEN, header_buffer.remaining()));
         }
 
         let ext_fields_length = header_buffer.get_i32();
         let ext = if ext_fields_length > 0 {
             let ext_fields_length = ext_fields_length as usize;
             if ext_fields_length > header_len {
-                return Err(RocketmqError::DecodingError(ext_fields_length, header_len).into());
+                return Err(decoding_error(ext_fields_length, header_len));
             }
             if ext_fields_length > header_buffer.remaining() {
-                return Err(RocketmqError::DecodingError(ext_fields_length, header_buffer.remaining()).into());
+                return Err(decoding_error(ext_fields_length, header_buffer.remaining()));
             }
             Self::map_deserialize(header_buffer, ext_fields_length)?
         } else {
@@ -322,7 +322,7 @@ impl RocketMQSerializable {
             return Ok(HashMap::new());
         }
         if len > buffer.remaining() {
-            return Err(RocketmqError::DecodingError(len, buffer.remaining()).into());
+            return Err(decoding_error(len, buffer.remaining()));
         }
 
         // Pre-allocate HashMap with estimated capacity (assume ~50 bytes per entry)
@@ -333,10 +333,10 @@ impl RocketMQSerializable {
 
         while buffer.remaining() > target_remaining {
             // Read key (short length prefix)
-            let key = Self::read_str(buffer, true, len)?.ok_or_else(|| RocketmqError::DecodingError(0, 0))?;
+            let key = Self::read_str(buffer, true, len)?.ok_or_else(|| decoding_error(0, 0))?;
 
             // Read value (long length prefix)
-            let value = Self::read_str(buffer, false, len)?.ok_or_else(|| RocketmqError::DecodingError(0, 0))?;
+            let value = Self::read_str(buffer, false, len)?.ok_or_else(|| decoding_error(0, 0))?;
 
             map.insert(key, value);
         }

--- a/rocketmq-remoting/tests/typed_error_boundary_tests.rs
+++ b/rocketmq-remoting/tests/typed_error_boundary_tests.rs
@@ -1,0 +1,45 @@
+use bytes::BytesMut;
+use rocketmq_error::RocketMQError;
+use rocketmq_remoting::code::BrokerRequestCode;
+use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
+use rocketmq_remoting::rocketmq_serializable::RocketMQSerializable;
+
+#[test]
+fn broker_request_code_parse_returns_typed_error() {
+    let err: RocketMQError = "UNKNOWN".parse::<BrokerRequestCode>().unwrap_err();
+
+    assert!(matches!(err, RocketMQError::IllegalArgument(_)));
+}
+
+#[test]
+fn remoting_decode_boundaries_return_typed_serialization_error() {
+    let mut buf = BytesMut::from(&[0_u8][..]);
+    let err = RocketMQSerializable::read_str(&mut buf, true, 10).unwrap_err();
+
+    assert!(matches!(err, RocketMQError::Serialization(_)));
+}
+
+#[test]
+fn extra_info_boundaries_return_typed_illegal_argument_error() {
+    let err = ExtraInfoUtil::get_ck_queue_offset(&[]).unwrap_err();
+
+    assert!(matches!(err, RocketMQError::IllegalArgument(_)));
+}
+
+#[test]
+fn remoting_boundary_files_do_not_use_legacy_error_enum() {
+    let files = [
+        include_str!("../src/code/broker_request_code.rs"),
+        include_str!("../src/codec/remoting_command_codec.rs"),
+        include_str!("../src/protocol/header/extra_info_util.rs"),
+        include_str!("../src/protocol/rocketmq_serializable.rs"),
+    ];
+
+    for source in files {
+        assert!(!source.contains("RocketmqError"));
+        assert!(!source.contains("DecodingError"));
+        assert!(!source.contains("FromStrErr"));
+        assert!(!source.contains("IllegalArgumentError"));
+        assert!(!source.contains("RemotingCommandEncoderError"));
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7895

### Brief Description

This refactors remoting boundary error handling to return typed `RocketMQError` values directly. Broker request parsing now exposes the unified error type, codec byte encode failures use the remoting encode helper, binary decode failures use the remoting decode helper, and extra-info parser validation uses typed illegal argument errors consistently.

The PR also adds an integration test that verifies these boundary errors map to the unified taxonomy and prevents the migrated files from reintroducing legacy error constructors.

### How Did You Test This Change?

- `cargo test -p rocketmq-remoting --test typed_error_boundary_tests` passed with 4 tests.
- `cargo fmt --all` passed.
- `cargo test -p rocketmq-remoting` passed with 1434 unit tests, all integration tests, and doctests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during protocol parsing and decoding for more consistent, user-facing errors.
  * Boundary cases now return clearer invalid-input or serialization errors instead of legacy error forms.
  * Several parsing paths now behave more reliably when data is missing, truncated, or malformed.

* **Tests**
  * Added regression coverage for parsing and decoding edge cases.
  * Added checks to ensure error handling stays consistent across key components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->