### PR TITLE
[ISSUE #7897]♻️Use typed RPC response exceptions

### DIFF
--- a/rocketmq-remoting/src/rpc/rpc_response.rs
+++ b/rocketmq-remoting/src/rpc/rpc_response.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use rocketmq_error::RocketmqError;
+use rocketmq_error::RocketMQError;
 use rocketmq_rust::ArcMut;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
@@ -24,7 +24,7 @@ pub struct RpcResponse {
     pub code: i32,
     pub header: Option<ArcMut<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
     pub body: Option<Box<dyn Any>>,
-    pub exception: Option<RocketmqError>,
+    pub exception: Option<RocketMQError>,
 }
 
 impl RpcResponse {
@@ -58,10 +58,10 @@ impl RpcResponse {
         }
     }
 
-    pub fn new_exception(exception: Option<RocketmqError>) -> Self {
+    pub fn new_exception(exception: Option<RocketMQError>) -> Self {
         Self {
             code: exception.as_ref().map_or(0, |e| match e {
-                RocketmqError::RpcError(code, _) => *code,
+                RocketMQError::BrokerOperationFailed { code, .. } => *code,
                 _ => 0,
             }),
             header: None,
@@ -90,5 +90,35 @@ impl RpcResponse {
             body,
             exception: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::RocketMQError;
+
+    use super::*;
+
+    #[test]
+    fn new_exception_accepts_typed_broker_operation_error() {
+        let response = RpcResponse::new_exception(Some(RocketMQError::broker_operation_failed(
+            "RPC",
+            206,
+            "broker rejected",
+        )));
+
+        assert_eq!(response.code, 206);
+        assert!(matches!(
+            response.exception,
+            Some(RocketMQError::BrokerOperationFailed { code: 206, .. })
+        ));
+    }
+
+    #[test]
+    fn new_exception_uses_zero_code_for_non_broker_error() {
+        let response = RpcResponse::new_exception(Some(RocketMQError::Internal("local failure".to_string())));
+
+        assert_eq!(response.code, 0);
+        assert!(matches!(response.exception, Some(RocketMQError::Internal(_))));
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7897

### Brief Description

This updates `RpcResponse` so its `exception` field stores the unified `RocketMQError` type instead of the legacy `RocketmqError` enum. `new_exception` now derives the response code from `BrokerOperationFailed`, which matches the current typed broker error representation.

The PR also adds focused tests for typed broker operation errors and non-broker errors in `RpcResponse::new_exception`.

### How Did You Test This Change?

- `cargo test -p rocketmq-remoting rpc_response` passed with 2 matching tests.
- `cargo fmt --all` passed.
- `cargo test -p rocketmq-remoting` passed with 1436 unit tests, all integration tests, and doctests.
- `cargo test -p rocketmq-broker --lib` passed with 501 tests and 1 ignored.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so only broker operation failures carry through their specific error code.
  * Other error types now consistently return a generic code of `0`, avoiding incorrect codes in responses.

* **Tests**
  * Added coverage to verify broker errors preserve their code and non-broker errors use `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->