### PR TITLE
[ISSUE #7899]♻️Use typed client callback errors

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -38,7 +38,7 @@ use rocketmq_common::common::FAQUrl;
 use rocketmq_common::utils::util_all;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_error::ClientErr;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
 use rocketmq_remoting::protocol::body::pop_process_queue_info::PopProcessQueueInfo;
@@ -699,11 +699,8 @@ impl DefaultMQPushConsumerImpl {
         let sub = self.consumer_config.subscription();
         if !sub.is_empty() {
             for (topic, sub_expression) in sub.as_ref() {
-                let subscription_data = FilterAPI::build_subscription_data(topic, sub_expression).map_err(|e| {
-                    rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(format!(
-                        "buildSubscriptionData exception, {e}",
-                    )))
-                })?;
+                let subscription_data = FilterAPI::build_subscription_data(topic, sub_expression)
+                    .map_err(|e| RocketMQError::illegal_argument(format!("buildSubscriptionData exception, {e}")))?;
                 self.rebalance_impl
                     .put_subscription_data(topic.clone(), subscription_data);
             }
@@ -721,11 +718,7 @@ impl DefaultMQPushConsumerImpl {
                     retry_topic.as_ref(),
                     &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
                 )
-                .map_err(|e| {
-                    rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(format!(
-                        "buildSubscriptionData exception, {e}",
-                    )))
-                })?;
+                .map_err(|e| RocketMQError::illegal_argument(format!("buildSubscriptionData exception, {e}")))?;
                 self.rebalance_impl
                     .put_subscription_data(retry_topic, subscription_data);
             }

--- a/rocketmq-client/src/consumer/pop_callback.rs
+++ b/rocketmq-client/src/consumer/pop_callback.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
-use rocketmq_error::RocketmqError;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_rust::ArcMut;
@@ -82,6 +83,13 @@ pub type PopCallbackFn = Arc<
         + Send
         + Sync,
 >;
+
+fn broker_response_code(error: &(dyn Error + Send + 'static)) -> Option<ResponseCode> {
+    error.downcast_ref::<RocketMQError>().and_then(|error| match error {
+        RocketMQError::BrokerOperationFailed { code, .. } => Some(ResponseCode::from(*code)),
+        _ => None,
+    })
+}
 
 pub struct DefaultPopCallback {
     pub(crate) push_consumer_impl: ArcMut<DefaultMQPushConsumerImpl>,
@@ -175,47 +183,22 @@ impl PopCallback for DefaultPopCallback {
             return;
         };
         let topic = message_queue_inner.topic_str();
+        let broker_code = broker_response_code(err.as_ref());
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
-            if let Some(er) = err.downcast_ref::<RocketmqError>() {
-                match er {
-                    RocketmqError::MQClientBrokerError(broker_error) => {
-                        if ResponseCode::from(broker_error.response_code()) == ResponseCode::SubscriptionNotLatest {
-                            warn!(
-                                "the subscription is not latest, group={}",
-                                push_consumer_impl.consumer_config.consumer_group,
-                            );
-                        } else {
-                            warn!(
-                                "execute the pop request exception, group={}",
-                                push_consumer_impl.consumer_config.consumer_group
-                            );
-                        }
-                    }
-                    _ => {
-                        warn!(
-                            "execute the pop request exception, group={}",
-                            push_consumer_impl.consumer_config.consumer_group
-                        );
-                    }
-                }
+            if broker_code == Some(ResponseCode::SubscriptionNotLatest) {
+                warn!(
+                    "the subscription is not latest, group={}",
+                    push_consumer_impl.consumer_config.consumer_group,
+                );
             } else {
                 warn!(
-                    "execute the pull request exception, group={}",
+                    "execute the pop request exception, group={}",
                     push_consumer_impl.consumer_config.consumer_group
                 );
             }
         }
-        let time_delay = if let Some(er) = err.downcast_ref::<RocketmqError>() {
-            match er {
-                RocketmqError::MQClientBrokerError(broker_error) => {
-                    if ResponseCode::from(broker_error.response_code()) == ResponseCode::FlowControl {
-                        PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
-                    } else {
-                        push_consumer_impl.pull_time_delay_mills_when_exception
-                    }
-                }
-                _ => push_consumer_impl.pull_time_delay_mills_when_exception,
-            }
+        let time_delay = if broker_code == Some(ResponseCode::FlowControl) {
+            PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
         } else {
             push_consumer_impl.pull_time_delay_mills_when_exception
         };
@@ -263,6 +246,17 @@ mod tests {
             subscription_data: None,
             pop_request: None,
         }
+    }
+
+    #[test]
+    fn broker_response_code_reads_typed_broker_error() {
+        let error = rocketmq_error::RocketMQError::broker_operation_failed(
+            "POP_MESSAGE",
+            ResponseCode::SubscriptionNotLatest.to_i32(),
+            "subscription not latest",
+        );
+
+        assert_eq!(broker_response_code(&error), Some(ResponseCode::SubscriptionNotLatest));
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error;
 use std::sync::Arc;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
-use rocketmq_error::RocketmqError;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_rust::ArcMut;
@@ -31,6 +32,13 @@ use crate::consumer::pull_status::PullStatus;
 
 pub type PullCallbackFn =
     Arc<dyn FnOnce(Option<PullResultExt>, Option<Box<dyn std::error::Error + Send>>) + Send + Sync>;
+
+fn broker_response_code(error: &(dyn Error + Send + 'static)) -> Option<ResponseCode> {
+    error.downcast_ref::<RocketMQError>().and_then(|error| match error {
+        RocketMQError::BrokerOperationFailed { code, .. } => Some(ResponseCode::from(*code)),
+        _ => None,
+    })
+}
 
 #[trait_variant::make(PullCallback: Send)]
 pub trait PullCallbackLocal: Sync {
@@ -198,29 +206,13 @@ impl PullCallback for DefaultPullCallback {
             return;
         };
         let topic = message_queue_inner.topic_str();
+        let broker_code = broker_response_code(err.as_ref());
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
-            if let Some(er) = err.downcast_ref::<RocketmqError>() {
-                match er {
-                    RocketmqError::MQClientBrokerError(broker_error) => {
-                        if ResponseCode::from(broker_error.response_code()) == ResponseCode::SubscriptionNotLatest {
-                            warn!(
-                                "the subscription is not latest, group={}",
-                                self.push_consumer_impl.consumer_config.consumer_group,
-                            );
-                        } else {
-                            warn!(
-                                "execute the pull request exception, group={}",
-                                self.push_consumer_impl.consumer_config.consumer_group
-                            );
-                        }
-                    }
-                    _ => {
-                        warn!(
-                            "execute the pull request exception, group={}",
-                            self.push_consumer_impl.consumer_config.consumer_group
-                        );
-                    }
-                }
+            if broker_code == Some(ResponseCode::SubscriptionNotLatest) {
+                warn!(
+                    "the subscription is not latest, group={}",
+                    self.push_consumer_impl.consumer_config.consumer_group,
+                );
             } else {
                 warn!(
                     "execute the pull request exception, group={}",
@@ -228,17 +220,8 @@ impl PullCallback for DefaultPullCallback {
                 );
             }
         }
-        let time_delay = if let Some(er) = err.downcast_ref::<RocketmqError>() {
-            match er {
-                RocketmqError::MQClientBrokerError(broker_error) => {
-                    if ResponseCode::from(broker_error.response_code()) == ResponseCode::FlowControl {
-                        PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
-                    } else {
-                        self.push_consumer_impl.pull_time_delay_mills_when_exception
-                    }
-                }
-                _ => self.push_consumer_impl.pull_time_delay_mills_when_exception,
-            }
+        let time_delay = if broker_code == Some(ResponseCode::FlowControl) {
+            PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
         } else {
             self.push_consumer_impl.pull_time_delay_mills_when_exception
         };
@@ -272,6 +255,17 @@ mod tests {
             subscription_data: None,
             pull_request: None,
         }
+    }
+
+    #[test]
+    fn broker_response_code_reads_typed_broker_error() {
+        let error = rocketmq_error::RocketMQError::broker_operation_failed(
+            "PULL_MESSAGE",
+            ResponseCode::FlowControl.to_i32(),
+            "flow control",
+        );
+
+        assert_eq!(broker_response_code(&error), Some(ResponseCode::FlowControl));
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -49,8 +49,7 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::RecallMessageHandle;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_error::ClientErr;
-use rocketmq_error::RocketmqError::RemotingTooMuchRequestError;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
@@ -468,6 +467,16 @@ impl DefaultMQProducerImpl {
         } else {
             tracing::error!("Async send failed without callback: {}", error);
         }
+    }
+
+    #[inline]
+    fn async_send_rejected_error(message: impl Into<String>) -> RocketMQError {
+        RocketMQError::illegal_argument(message)
+    }
+
+    #[inline]
+    fn request_cause_from_error(error: &dyn std::error::Error) -> Box<dyn std::error::Error + Send + Sync> {
+        Box::new(RocketMQError::illegal_argument(error.to_string()))
     }
 
     #[inline]
@@ -908,10 +917,7 @@ impl DefaultMQProducerImpl {
         let future = async move {
             let cost_time = begin_start_time.elapsed().as_millis() as u64;
             let Some(remaining_timeout) = Self::remaining_async_timeout(timeout, cost_time) else {
-                Self::notify_callback_exception(
-                    &send_callback_clone,
-                    &RemotingTooMuchRequestError("call timeout".to_string()),
-                );
+                Self::notify_callback_exception(&send_callback_clone, &Self::async_send_rejected_error("call timeout"));
                 return Ok(None);
             };
 
@@ -1051,10 +1057,7 @@ impl DefaultMQProducerImpl {
 
             let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
             let Some(remaining_timeout) = Self::remaining_async_timeout(timeout, cost_time) else {
-                Self::notify_callback_exception(
-                    &send_callback_inner,
-                    &RemotingTooMuchRequestError("call timeout".to_string()),
-                );
+                Self::notify_callback_exception(&send_callback_inner, &Self::async_send_rejected_error("call timeout"));
                 return;
             };
             let result = producer_impl
@@ -1105,7 +1108,7 @@ impl DefaultMQProducerImpl {
             let Some(remaining_timeout) = Self::remaining_async_timeout(timeout, cost_time) else {
                 Self::notify_callback_exception(
                     &send_callback_inner,
-                    &RemotingTooMuchRequestError("asyncSend call timeout".to_string()),
+                    &Self::async_send_rejected_error("asyncSend call timeout"),
                 );
                 return;
             };
@@ -1149,7 +1152,7 @@ impl DefaultMQProducerImpl {
             let Some(remaining_timeout) = timeout.checked_sub(cost_time).filter(|remaining| *remaining > 0) else {
                 Self::notify_callback_exception(
                     &send_callback,
-                    &RemotingTooMuchRequestError("send message tryAcquire semaphoreAsyncNum timeout".to_string()),
+                    &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncNum timeout"),
                 );
                 return Ok(());
             };
@@ -1164,9 +1167,7 @@ impl DefaultMQProducerImpl {
                     Err(_) => {
                         Self::notify_callback_exception(
                             &send_callback,
-                            &RemotingTooMuchRequestError(
-                                "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
-                            ),
+                            &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncNum timeout"),
                         );
                         return Ok(());
                     }
@@ -1174,7 +1175,7 @@ impl DefaultMQProducerImpl {
                 Err(_) => {
                     Self::notify_callback_exception(
                         &send_callback,
-                        &RemotingTooMuchRequestError("send message tryAcquire semaphoreAsyncNum timeout".to_string()),
+                        &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncNum timeout"),
                     );
                     return Ok(());
                 }
@@ -1185,7 +1186,7 @@ impl DefaultMQProducerImpl {
             let Some(remaining_timeout) = timeout.checked_sub(cost_time).filter(|remaining| *remaining > 0) else {
                 Self::notify_callback_exception(
                     &send_callback,
-                    &RemotingTooMuchRequestError("send message tryAcquire semaphoreAsyncSize timeout".to_string()),
+                    &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncSize timeout"),
                 );
                 return Ok(());
             };
@@ -1202,9 +1203,7 @@ impl DefaultMQProducerImpl {
                     Err(_) => {
                         Self::notify_callback_exception(
                             &send_callback,
-                            &RemotingTooMuchRequestError(
-                                "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
-                            ),
+                            &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncSize timeout"),
                         );
                         return Ok(());
                     }
@@ -1212,7 +1211,7 @@ impl DefaultMQProducerImpl {
                 Err(_) => {
                     Self::notify_callback_exception(
                         &send_callback,
-                        &RemotingTooMuchRequestError("send message tryAcquire semaphoreAsyncSize timeout".to_string()),
+                        &Self::async_send_rejected_error("send message tryAcquire semaphoreAsyncSize timeout"),
                     );
                     return Ok(());
                 }
@@ -2165,9 +2164,7 @@ impl DefaultMQProducerImpl {
             if let Some(error) = err {
                 request_response_future_inner.set_send_request_ok(false);
                 request_response_future_inner.put_response_message(None);
-                request_response_future_inner.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(
-                    ClientErr::new(error.to_string()),
-                )) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future_inner.set_cause(Self::request_cause_from_error(error));
             }
         };
         let topic = msg.topic().clone();
@@ -2225,9 +2222,7 @@ impl DefaultMQProducerImpl {
                 return;
             }
             if let Some(error) = err {
-                request_response_future.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(
-                    error.to_string(),
-                ))) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future.set_cause(Self::request_cause_from_error(error));
                 Self::request_fail(correlation_id.as_str());
             }
         };
@@ -2271,9 +2266,7 @@ impl DefaultMQProducerImpl {
             if let Some(error) = err {
                 request_response_future_inner.set_send_request_ok(false);
                 request_response_future_inner.put_response_message(None);
-                request_response_future_inner.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(
-                    ClientErr::new(error.to_string()),
-                )) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future_inner.set_cause(Self::request_cause_from_error(error));
             }
         };
         let topic = msg.topic().clone();
@@ -2328,9 +2321,7 @@ impl DefaultMQProducerImpl {
                 return;
             }
             if let Some(error) = err {
-                request_response_future.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(
-                    error.to_string(),
-                ))) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future.set_cause(Self::request_cause_from_error(error));
                 Self::request_fail(correlation_id.as_str());
             }
         };
@@ -2376,9 +2367,7 @@ impl DefaultMQProducerImpl {
                 return;
             }
             if let Some(error) = err {
-                request_response_future.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(
-                    error.to_string(),
-                ))) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future.set_cause(Self::request_cause_from_error(error));
                 Self::request_fail(correlation_id.as_str());
             }
         };
@@ -2428,9 +2417,7 @@ impl DefaultMQProducerImpl {
             if let Some(error) = err {
                 //request_response_future_inner.set_send_request_ok(false);
                 request_response_future_inner.put_response_message(None);
-                request_response_future_inner.set_cause(Box::new(rocketmq_error::RocketmqError::MQClientErr(
-                    ClientErr::new(error.to_string()),
-                )) as Box<dyn std::error::Error + Send + Sync>);
+                request_response_future_inner.set_cause(Self::request_cause_from_error(error));
             }
         };
         let send_result = self
@@ -3637,6 +3624,17 @@ mod tests {
             .mut_from_ref()
             .set_default_mqproducer_impl_inner(ArcMut::downgrade(&producer));
         producer
+    }
+
+    #[test]
+    fn request_cause_from_error_uses_typed_error() {
+        let cause = DefaultMQProducerImpl::request_cause_from_error(&std::io::Error::other("send failed"));
+        let error = cause
+            .downcast_ref::<rocketmq_error::RocketMQError>()
+            .expect("request cause should use RocketMQError");
+
+        assert!(matches!(error, rocketmq_error::RocketMQError::IllegalArgument(_)));
+        assert_eq!(error.to_string(), "Illegal argument: send failed");
     }
 
     #[test]

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn client_callback_files_do_not_use_legacy_error_enum() {
+    let files = [
+        include_str!("../src/consumer/consumer_impl/default_mq_push_consumer_impl.rs"),
+        include_str!("../src/consumer/pop_callback.rs"),
+        include_str!("../src/consumer/pull_callback.rs"),
+        include_str!("../src/producer/producer_impl/default_mq_producer_impl.rs"),
+    ];
+
+    for source in files {
+        assert!(!source.contains("RocketmqError"));
+        assert!(!source.contains("RemotingTooMuchRequestError"));
+        assert!(!source.contains("MQClientErr(ClientErr"));
+        assert!(!source.contains("downcast_ref::<RocketmqError>"));
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7899

### Brief Description

This refactors client callback error payloads to use typed `RocketMQError` values instead of the legacy `RocketmqError` enum. Producer request-response futures now store typed causes, pull and pop callbacks read broker response codes from `BrokerOperationFailed`, and push consumer subscription setup maps subscription parse failures to typed illegal argument errors.

The PR also adds focused unit tests plus a source-level guard for the migrated client callback files.

### How Did You Test This Change?

- `$env:CARGO_INCREMENTAL='0'; cargo test -p rocketmq-client-rust --test typed_error_client_flow_tests` passed.
- `$env:CARGO_INCREMENTAL='0'; cargo test -p rocketmq-client-rust request_cause_from_error_uses_typed_error` passed.
- `$env:CARGO_INCREMENTAL='0'; cargo test -p rocketmq-client-rust consumer::pull_callback::tests::broker_response_code_reads_typed_broker_error` passed.
- `$env:CARGO_INCREMENTAL='0'; cargo test -p rocketmq-client-rust consumer::pop_callback::tests::broker_response_code_reads_typed_broker_error` passed.
- `cargo fmt --all` passed.
- `$env:CARGO_INCREMENTAL='0'; cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client error handling for send, request, and callback flows so retry behavior and timeout/backpressure cases are reported more consistently.
  * Fixed several consumer callback paths to better distinguish broker responses, improving how retry delays and warnings are handled.

* **Tests**
  * Added coverage to verify the client uses the updated error handling paths and avoids legacy error patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->