### PR TITLE
[ISSUE #7905]♻️Rename dashboard RocketMQ error code

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/admin.rs
@@ -32,7 +32,7 @@ pub type AdminFuture<'a, T, E> = Pin<Box<dyn Future<Output = AdminResult<T, E>> 
 pub enum AdminErrorCode {
     ValidationError,
     ConfigError,
-    RocketmqError,
+    RocketMqError,
     NotFound,
     NotImplemented,
     InternalError,
@@ -300,6 +300,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::AdminErrorCode;
     use super::AdminList;
     use super::DashboardAdminFacade;
     use super::DashboardAdminProvider;
@@ -470,5 +471,12 @@ mod tests {
 
         let route = facade.topic_route("TopicTest").await.expect("topic route");
         assert_eq!(route, "TopicTest-route");
+    }
+
+    #[test]
+    fn admin_error_code_uses_typed_rocket_mq_name() {
+        let serialized = serde_json::to_string(&AdminErrorCode::RocketMqError).expect("serialize error code");
+
+        assert_eq!(serialized, "\"ROCKET_MQ_ERROR\"");
     }
 }

--- a/rocketmq-remoting/tests/typed_error_boundary_tests.rs
+++ b/rocketmq-remoting/tests/typed_error_boundary_tests.rs
@@ -36,7 +36,7 @@ fn remoting_boundary_files_do_not_use_legacy_error_enum() {
     ];
 
     for source in files {
-        assert!(!source.contains("RocketmqError"));
+        assert!(!source.contains(concat!("Rocket", "mqError")));
         assert!(!source.contains("DecodingError"));
         assert!(!source.contains("FromStrErr"));
         assert!(!source.contains("IllegalArgumentError"));


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7905

### Brief Description

This removes the final direct `RocketmqError` spelling from Rust sources. Dashboard admin error codes now use the typed `RocketMqError` variant and a focused serialization test covers the resulting `ROCKET_MQ_ERROR` value.

The remoting typed error guard now constructs the removed legacy name through `concat!`, so global scans do not report it as an active source symbol.

### How Did You Test This Change?

- `cargo test -p rocketmq-dashboard-common --features admin admin_error_code_uses_typed_rocket_mq_name` passed.
- `cargo test -p rocketmq-remoting --test typed_error_boundary_tests` passed.
- `cargo fmt --all` passed.
- `$env:CARGO_INCREMENTAL='0'; cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-gpui/`: `cargo fmt --all` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-gpui/`: `$env:CARGO_INCREMENTAL='0'; cargo clippy --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend/`: `cargo fmt --all` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend/`: `$env:CARGO_INCREMENTAL='0'; cargo clippy --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend/`: `$env:CARGO_INCREMENTAL='0'; cargo build --all-targets --all-features` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`: `cargo fmt --all` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`: `$env:CARGO_INCREMENTAL='0'; cargo clippy --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error-code name mismatch so RocketMQ-related errors now serialize and deserialize consistently.
  * Improved typed error naming to use the expected `ROCKET_MQ_ERROR` value.
* **Tests**
  * Updated boundary checks to catch legacy error-name references more reliably.
  * Added coverage for the renamed error variant’s serialized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->