### PR TITLE
[ISSUE #7907]♻️Redact session credential debug formatting

### DIFF
--- a/rocketmq-client/src/common/session_credentials.rs
+++ b/rocketmq-client/src/common/session_credentials.rs
@@ -40,7 +40,7 @@ fn get_key_file_path() -> PathBuf {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SessionCredentials {
     access_key: Option<CheetahString>,
     secret_key: Option<CheetahString>,
@@ -154,6 +154,17 @@ impl PartialEq for SessionCredentials {
 }
 
 impl Eq for SessionCredentials {}
+
+impl fmt::Debug for SessionCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionCredentials")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &redacted_value(self.secret_key.as_ref()))
+            .field("signature", &redacted_value(self.signature.as_ref()))
+            .field("security_token", &redacted_value(self.security_token.as_ref()))
+            .finish()
+    }
+}
 
 impl std::hash::Hash for SessionCredentials {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -283,5 +294,21 @@ mod tests {
         assert!(!display.contains("\"sk\""));
         assert!(!display.contains("\"tk\""));
         assert!(!display.contains("\"sig\""));
+    }
+
+    #[test]
+    fn session_credentials_debug_redacts_sensitive_fields() {
+        let mut credentials = SessionCredentials::with_token("ak", "sk", "tk");
+        credentials.set_signature("sig");
+
+        let debug = format!("{credentials:?}");
+
+        assert!(debug.contains("access_key: Some(\"ak\")"));
+        assert!(debug.contains("secret_key: Some(\"<redacted>\")"));
+        assert!(debug.contains("signature: Some(\"<redacted>\")"));
+        assert!(debug.contains("security_token: Some(\"<redacted>\")"));
+        assert!(!debug.contains("\"sk\""));
+        assert!(!debug.contains("\"tk\""));
+        assert!(!debug.contains("\"sig\""));
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7907

### Brief Description

Redacts `SessionCredentials` debug formatting so credential secrets do not leak through `{:?}` output. The manual Debug implementation keeps the access key visible for diagnostics and redacts the secret key, signature, and security token consistently with the existing Display formatting.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib session_credentials` passed.
- `cargo fmt --all` passed.
- `git diff --check` passed.
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug output for session credentials so sensitive values are hidden when logs or diagnostics are generated.
  * Added coverage to ensure redacted fields stay concealed and only non-sensitive information is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->