### PR TITLE
[ISSUE #7909]♻️Centralize client retry decisions

### DIFF
--- a/rocketmq-client/src/common.rs
+++ b/rocketmq-client/src/common.rs
@@ -18,5 +18,6 @@ pub mod admin_tool_result;
 pub mod admin_tools_result_code_enum;
 pub mod client_error_code;
 pub mod nameserver_access_config;
+pub(crate) mod retry_decision;
 pub mod session_credentials;
 pub mod thread_local_index;

--- a/rocketmq-client/src/common/retry_decision.rs
+++ b/rocketmq-client/src/common/retry_decision.rs
@@ -1,0 +1,137 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use rocketmq_error::NetworkError;
+use rocketmq_error::RetryClass;
+use rocketmq_error::RocketMQError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientRetryDecision {
+    NoRetry,
+    Immediate,
+    Backoff,
+    RefreshRoute,
+    SwitchBroker,
+    RefreshLeader,
+}
+
+impl ClientRetryDecision {
+    #[inline]
+    pub(crate) fn from_error(error: &RocketMQError) -> Self {
+        match error.kind().spec().recovery.retry {
+            RetryClass::Never => Self::NoRetry,
+            RetryClass::Immediate => Self::Immediate,
+            RetryClass::AfterBackoff => Self::Backoff,
+            RetryClass::RefreshRoute => Self::RefreshRoute,
+            RetryClass::SwitchBroker => Self::SwitchBroker,
+            RetryClass::RefreshLeader => Self::RefreshLeader,
+        }
+    }
+
+    #[inline]
+    pub(crate) const fn should_retry(self) -> bool {
+        !matches!(self, Self::NoRetry)
+    }
+}
+
+#[inline]
+pub(crate) fn should_retry_async_send_error(error: &RocketMQError) -> bool {
+    if is_terminal_send_error(error) {
+        return false;
+    }
+
+    ClientRetryDecision::from_error(error).should_retry()
+}
+
+#[inline]
+pub(crate) fn should_retry_producer_send_error(error: &RocketMQError, retry_response_codes: &HashSet<i32>) -> bool {
+    if is_terminal_send_error(error) {
+        return false;
+    }
+
+    match error {
+        RocketMQError::BrokerOperationFailed { code, .. } => retry_response_codes.contains(code),
+        _ => ClientRetryDecision::from_error(error).should_retry(),
+    }
+}
+
+#[inline]
+fn is_terminal_send_error(error: &RocketMQError) -> bool {
+    matches!(
+        error,
+        RocketMQError::Timeout { .. }
+            | RocketMQError::ClientNotStarted
+            | RocketMQError::ClientShuttingDown
+            | RocketMQError::Network(
+                NetworkError::ConnectionTimeout { .. }
+                    | NetworkError::RequestTimeout { .. }
+                    | NetworkError::TooManyRequests { .. },
+            )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_decision_uses_error_recovery_policy() {
+        let route_error = RocketMQError::route_not_found("TopicA");
+        let network_error = RocketMQError::network_connection_failed("broker-a:10911", "connection failed");
+        let client_state_error = RocketMQError::ClientNotStarted;
+
+        assert_eq!(
+            ClientRetryDecision::from_error(&route_error),
+            ClientRetryDecision::RefreshRoute
+        );
+        assert_eq!(
+            ClientRetryDecision::from_error(&network_error),
+            ClientRetryDecision::Backoff
+        );
+        assert_eq!(
+            ClientRetryDecision::from_error(&client_state_error),
+            ClientRetryDecision::NoRetry
+        );
+    }
+
+    #[test]
+    fn async_send_retry_excludes_terminal_send_errors() {
+        let retryable = RocketMQError::Network(NetworkError::send_failed("broker-a:10911", "write failed"));
+        let request_timeout = RocketMQError::Network(NetworkError::RequestTimeout {
+            addr: "broker-a:10911".to_string(),
+            timeout_ms: 3_000,
+        });
+        let too_many_requests = RocketMQError::Network(NetworkError::TooManyRequests {
+            addr: "broker-a:10911".to_string(),
+            limit: 1,
+        });
+
+        assert!(should_retry_async_send_error(&retryable));
+        assert!(!should_retry_async_send_error(&request_timeout));
+        assert!(!should_retry_async_send_error(&too_many_requests));
+        assert!(!should_retry_async_send_error(&RocketMQError::ClientShuttingDown));
+    }
+
+    #[test]
+    fn producer_send_retry_uses_response_code_allow_list() {
+        let error = RocketMQError::broker_operation_failed("SEND_MESSAGE", 12, "system busy");
+        let retry_codes = HashSet::from([12]);
+        let non_retry_codes = HashSet::from([13]);
+
+        assert!(should_retry_producer_send_error(&error, &retry_codes));
+        assert!(!should_retry_producer_send_error(&error, &non_retry_codes));
+    }
+}

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2782,17 +2782,7 @@ impl MQClientAPIImpl {
     }
 
     fn should_retry_async_send_error(error: &rocketmq_error::RocketMQError) -> bool {
-        !matches!(
-            error,
-            rocketmq_error::RocketMQError::Timeout { .. }
-                | rocketmq_error::RocketMQError::ClientNotStarted
-                | rocketmq_error::RocketMQError::ClientShuttingDown
-                | rocketmq_error::RocketMQError::Network(
-                    rocketmq_error::NetworkError::ConnectionTimeout { .. }
-                        | rocketmq_error::NetworkError::RequestTimeout { .. }
-                        | rocketmq_error::NetworkError::TooManyRequests { .. },
-                )
-        )
+        crate::common::retry_decision::should_retry_async_send_error(error)
     }
 
     async fn select_async_retry_target(

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1423,14 +1423,10 @@ impl DefaultMQProducerImpl {
     /// Check if should retry based on error type
     #[inline]
     fn should_retry_on_error(&self, error: &rocketmq_error::RocketMQError) -> bool {
-        match error {
-            rocketmq_error::RocketMQError::IllegalArgument(_) => true,
-            rocketmq_error::RocketMQError::Network(_) => true,
-            rocketmq_error::RocketMQError::BrokerOperationFailed { code, .. } => {
-                self.producer_config.retry_response_codes().contains(code)
-            }
-            _ => false,
-        }
+        crate::common::retry_decision::should_retry_producer_send_error(
+            error,
+            self.producer_config.retry_response_codes(),
+        )
     }
 
     /// Check if should retry based on send result


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7909

### Brief Description

Centralizes client retry classification in `common::retry_decision`. The new module derives default retry behavior from `RocketMQError.kind().spec().recovery.retry`, while preserving send-path terminal exclusions for timeout, stopped/shutting-down client state, request timeout, connection timeout, and async-send backpressure. Async send and producer send retry checks now delegate to the shared module.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib retry_decision` passed.
- `cargo test -p rocketmq-client-rust --lib async_send_` passed.
- `cargo fmt --all` passed.
- `git diff --check` passed.
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for client send operations and producer requests.
  * Retry decisions now consistently respect error type, recovery policy, and allowed broker response codes.
  * Reduced unnecessary retries for terminal errors such as timeouts, shutdown states, and certain network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->