### PR TITLE
[ISSUE #7913]♻️Preserve controller raft storage serde sources

### DIFF
--- a/rocketmq-controller/src/manager/replicas_info_manager.rs
+++ b/rocketmq-controller/src/manager/replicas_info_manager.rs
@@ -983,13 +983,13 @@ impl ReplicasInfoManager {
                 .collect(),
         };
 
-        serde_json::to_vec(&state).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&state).map_err(|e| ControllerError::serialization_source("serialize sync state data", e))
     }
 
     /// Deserialize the state machine from bytes
     pub fn deserialize_from(&self, data: &[u8]) -> Result<()> {
-        let state: SerializedState =
-            serde_json::from_slice(data).map_err(|e| ControllerError::SerializationError(e.to_string()))?;
+        let state: SerializedState = serde_json::from_slice(data)
+            .map_err(|e| ControllerError::serialization_source("deserialize sync state data", e))?;
 
         self.replica_info_table.clear();
         self.sync_state_set_info_table.clear();
@@ -1039,7 +1039,7 @@ impl ReplicasInfoManager {
             .split(';')
             .map(|s| {
                 s.parse::<u64>()
-                    .map_err(|e| ControllerError::InvalidRequest(e.to_string()))
+                    .map_err(|e| ControllerError::invalid_request_source("deserialize broker replica info", e))
             })
             .collect()
     }

--- a/rocketmq-controller/src/openraft/node.rs
+++ b/rocketmq-controller/src/openraft/node.rs
@@ -83,7 +83,7 @@ impl RaftNodeManager {
         let raft_config = Arc::new(
             raft_config
                 .validate()
-                .map_err(|e| ControllerError::Internal(format!("Invalid Raft config: {}", e)))?,
+                .map_err(|e| ControllerError::raft_source("validate Raft config", e))?,
         );
 
         // Create Raft instance
@@ -95,7 +95,7 @@ impl RaftNodeManager {
             store.state_machine.clone(),
         )
         .await
-        .map_err(|e| ControllerError::Internal(format!("Failed to create Raft: {}", e)))?;
+        .map_err(|e| ControllerError::raft_source("create Raft node", e))?;
 
         info!("Created OpenRaft node with ID: {}", node_id);
 
@@ -113,7 +113,7 @@ impl RaftNodeManager {
         self.raft
             .initialize(nodes)
             .await
-            .map_err(|e| ControllerError::Internal(format!("Failed to initialize cluster: {}", e)))?;
+            .map_err(|e| ControllerError::raft_source("initialize Raft cluster", e))?;
 
         info!("Raft cluster initialized successfully");
         Ok(())
@@ -126,7 +126,7 @@ impl RaftNodeManager {
         self.raft
             .add_learner(node_id, node, blocking)
             .await
-            .map_err(|e| ControllerError::Internal(format!("Failed to add learner: {}", e)))?;
+            .map_err(|e| ControllerError::raft_source(format!("add Raft learner {node_id}"), e))?;
 
         info!("Learner node {} added successfully", node_id);
         Ok(())
@@ -139,7 +139,7 @@ impl RaftNodeManager {
         self.raft
             .change_membership(members, retain)
             .await
-            .map_err(|e| ControllerError::Internal(format!("Failed to change membership: {}", e)))?;
+            .map_err(|e| ControllerError::raft_source("change Raft membership", e))?;
 
         info!("Cluster membership changed successfully");
         Ok(())
@@ -152,17 +152,9 @@ impl RaftNodeManager {
             .trigger()
             .allow_next_revert(&node_id, allow)
             .await
+            .map_err(|e| ControllerError::raft_source(format!("send allow-next-revert request for node {node_id}"), e))?
             .map_err(|e| {
-                ControllerError::Internal(format!(
-                    "Failed to send allow-next-revert request for node {}: {}",
-                    node_id, e
-                ))
-            })?
-            .map_err(|e| {
-                ControllerError::Internal(format!(
-                    "Failed to apply allow-next-revert request for node {}: {}",
-                    node_id, e
-                ))
+                ControllerError::raft_source(format!("apply allow-next-revert request for node {node_id}"), e)
             })?;
         Ok(())
     }
@@ -196,7 +188,7 @@ impl RaftNodeManager {
         self.raft
             .client_write(request)
             .await
-            .map_err(|e| ControllerError::Internal(format!("Client write failed: {}", e)))
+            .map_err(|e| ControllerError::raft_source("client write", e))
     }
 
     /// Get the Raft instance
@@ -216,7 +208,7 @@ impl RaftNodeManager {
         self.raft
             .shutdown()
             .await
-            .map_err(|e| ControllerError::Internal(format!("Shutdown failed: {}", e)))?;
+            .map_err(|e| ControllerError::raft_source("shutdown Raft node", e))?;
 
         info!("Raft node {} shut down successfully", self.node_id);
         Ok(())

--- a/rocketmq-controller/src/processor/broker_processor.rs
+++ b/rocketmq-controller/src/processor/broker_processor.rs
@@ -103,14 +103,15 @@ impl RegisterBrokerProcessor {
 impl RequestProcessor for RegisterBrokerProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
         // Deserialize request
-        let req: RegisterBrokerRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: RegisterBrokerRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode register broker request", e))?;
 
         // Process request
         let response = self.process_request(req).await?;
 
         // Serialize response
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode register broker response", e))
     }
 }
 
@@ -164,12 +165,13 @@ impl UnregisterBrokerProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for UnregisterBrokerProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: UnregisterBrokerRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: UnregisterBrokerRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode unregister broker request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode unregister broker response", e))
     }
 }
 
@@ -212,12 +214,13 @@ impl BrokerHeartbeatProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for BrokerHeartbeatProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: BrokerHeartbeatRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: BrokerHeartbeatRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode broker heartbeat request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode broker heartbeat response", e))
     }
 }
 
@@ -295,11 +298,12 @@ impl ElectMasterProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for ElectMasterProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: ElectMasterRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: ElectMasterRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode elect master request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode elect master response", e))
     }
 }

--- a/rocketmq-controller/src/processor/metadata_processor.rs
+++ b/rocketmq-controller/src/processor/metadata_processor.rs
@@ -76,12 +76,13 @@ impl GetMetadataProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for GetMetadataProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: GetMetadataRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: GetMetadataRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode get metadata request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode get metadata response", e))
     }
 }
 

--- a/rocketmq-controller/src/processor/topic_processor.rs
+++ b/rocketmq-controller/src/processor/topic_processor.rs
@@ -103,12 +103,13 @@ impl CreateTopicProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for CreateTopicProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: CreateTopicRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: CreateTopicRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode create topic request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode create topic response", e))
     }
 }
 
@@ -174,12 +175,13 @@ impl UpdateTopicProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for UpdateTopicProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: UpdateTopicRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: UpdateTopicRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode update topic request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode update topic response", e))
     }
 }
 
@@ -233,11 +235,12 @@ impl DeleteTopicProcessor {
 #[async_trait::async_trait]
 impl RequestProcessor for DeleteTopicProcessor {
     async fn process(&self, request: &[u8]) -> Result<Vec<u8>> {
-        let req: DeleteTopicRequest =
-            serde_json::from_slice(request).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let req: DeleteTopicRequest = serde_json::from_slice(request)
+            .map_err(|e| ControllerError::invalid_request_source("decode delete topic request", e))?;
 
         let response = self.process_request(req).await?;
 
-        serde_json::to_vec(&response).map_err(|e| ControllerError::SerializationError(e.to_string()))
+        serde_json::to_vec(&response)
+            .map_err(|e| ControllerError::serialization_source("encode delete topic response", e))
     }
 }

--- a/rocketmq-controller/src/rpc/codec.rs
+++ b/rocketmq-controller/src/rpc/codec.rs
@@ -126,8 +126,8 @@ impl Decoder for RpcCodec {
         let data = src.split_to(length);
 
         // Deserialize the request
-        let request: RpcRequest =
-            serde_json::from_slice(&data).map_err(|e| ControllerError::InvalidRequest(e.to_string()))?;
+        let request: RpcRequest = serde_json::from_slice(&data)
+            .map_err(|e| ControllerError::invalid_request_source("decode RPC request frame", e))?;
 
         debug!(
             "Decoded RPC request: id={}, type={:?}",
@@ -148,7 +148,8 @@ impl Encoder<RpcResponse> for RpcCodec {
         );
 
         // Serialize the response
-        let data = serde_json::to_vec(&item).map_err(|e| ControllerError::SerializationError(e.to_string()))?;
+        let data = serde_json::to_vec(&item)
+            .map_err(|e| ControllerError::serialization_source("encode RPC response frame", e))?;
 
         // Check size
         if data.len() > Self::MAX_FRAME_SIZE {

--- a/rocketmq-controller/src/storage/file_backend.rs
+++ b/rocketmq-controller/src/storage/file_backend.rs
@@ -60,12 +60,12 @@ impl FileBackend {
         // Create directories
         fs::create_dir_all(&path)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to create directory: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("create storage directory", e))?;
 
         let data_dir = path.join("data");
         fs::create_dir_all(&data_dir)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to create data directory: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("create storage data directory", e))?;
 
         let backend = Self {
             path,
@@ -96,10 +96,10 @@ impl FileBackend {
 
         let content = fs::read(&metadata_path)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to read metadata: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("read storage metadata", e))?;
 
         let loaded_index: HashMap<String, PathBuf> = serde_json::from_slice(&content)
-            .map_err(|e| ControllerError::SerializationError(format!("Failed to parse metadata: {}", e)))?;
+            .map_err(|e| ControllerError::serialization_source("parse storage metadata", e))?;
 
         *self.index.write() = loaded_index;
 
@@ -114,11 +114,11 @@ impl FileBackend {
 
         let index = self.index.read().clone();
         let content = serde_json::to_vec_pretty(&index)
-            .map_err(|e| ControllerError::SerializationError(format!("Failed to serialize metadata: {}", e)))?;
+            .map_err(|e| ControllerError::serialization_source("serialize storage metadata", e))?;
 
         fs::write(&metadata_path, content)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to write metadata: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("write storage metadata", e))?;
 
         Ok(())
     }
@@ -161,15 +161,15 @@ impl StorageBackend for FileBackend {
         // Write data to file
         let mut file = fs::File::create(&file_path)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to create file: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("create storage data file", e))?;
 
         file.write_all(value)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to write file: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("write storage data file", e))?;
 
         file.sync_all()
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to sync file: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("sync storage data file", e))?;
 
         // Update index
         self.index.write().insert(key.to_string(), file_path);
@@ -200,12 +200,12 @@ impl StorageBackend for FileBackend {
         // Read file
         let mut file = fs::File::open(&file_path)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to open file: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("open storage data file", e))?;
 
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)
             .await
-            .map_err(|e| ControllerError::StorageError(format!("Failed to read file: {}", e)))?;
+            .map_err(|e| ControllerError::storage_source("read storage data file", e))?;
 
         Ok(Some(buffer))
     }
@@ -222,7 +222,7 @@ impl StorageBackend for FileBackend {
         if file_path.exists() {
             fs::remove_file(&file_path)
                 .await
-                .map_err(|e| ControllerError::StorageError(format!("Failed to delete file: {}", e)))?;
+                .map_err(|e| ControllerError::storage_source("delete storage data file", e))?;
         }
 
         // Save index
@@ -281,11 +281,11 @@ impl StorageBackend for FileBackend {
         if data_dir.exists() {
             fs::remove_dir_all(&data_dir)
                 .await
-                .map_err(|e| ControllerError::StorageError(format!("Failed to clear data: {}", e)))?;
+                .map_err(|e| ControllerError::storage_source("clear storage data directory", e))?;
 
             fs::create_dir_all(&data_dir)
                 .await
-                .map_err(|e| ControllerError::StorageError(format!("Failed to recreate data directory: {}", e)))?;
+                .map_err(|e| ControllerError::storage_source("recreate storage data directory", e))?;
         }
 
         // Clear index

--- a/rocketmq-controller/src/storage/mod.rs
+++ b/rocketmq-controller/src/storage/mod.rs
@@ -110,8 +110,8 @@ pub struct StorageStats {
 pub trait StorageBackendExt: StorageBackend {
     /// Put a serializable value
     async fn put_json<T: Serialize + Send + Sync>(&self, key: &str, value: &T) -> Result<()> {
-        let data =
-            serde_json::to_vec(value).map_err(|e| crate::error::ControllerError::SerializationError(e.to_string()))?;
+        let data = serde_json::to_vec(value)
+            .map_err(|e| crate::error::ControllerError::serialization_source("serialize storage value", e))?;
         self.put(key, &data).await
     }
 
@@ -120,7 +120,7 @@ pub trait StorageBackendExt: StorageBackend {
         match self.get(key).await? {
             Some(data) => {
                 let value = serde_json::from_slice(&data)
-                    .map_err(|e| crate::error::ControllerError::SerializationError(e.to_string()))?;
+                    .map_err(|e| crate::error::ControllerError::serialization_source("deserialize storage value", e))?;
                 Ok(Some(value))
             }
             None => Ok(None),
@@ -134,8 +134,9 @@ pub trait StorageBackendExt: StorageBackend {
 
         for key in keys {
             if let Some(data) = self.get(&key).await? {
-                let value: T = serde_json::from_slice(&data)
-                    .map_err(|e| crate::error::ControllerError::SerializationError(e.to_string()))?;
+                let value: T = serde_json::from_slice(&data).map_err(|e| {
+                    crate::error::ControllerError::serialization_source("deserialize listed storage value", e)
+                })?;
                 values.push(value);
             }
         }

--- a/rocketmq-controller/src/storage/rocksdb_backend.rs
+++ b/rocketmq-controller/src/storage/rocksdb_backend.rs
@@ -64,7 +64,7 @@ impl RocksDBBackend {
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
-                .map_err(|e| ControllerError::StorageError(format!("Failed to create directory: {}", e)))?;
+                .map_err(|e| ControllerError::storage_source("create RocksDB parent directory", e))?;
         }
 
         // Configure RocksDB options
@@ -90,10 +90,7 @@ impl RocksDBBackend {
         let db = blocking
             .spawn_io("controller.rocksdb.open", {
                 let path = path.clone();
-                move || {
-                    DB::open(&opts, &path)
-                        .map_err(|e| ControllerError::StorageError(format!("Failed to open RocksDB: {}", e)))
-                }
+                move || DB::open(&opts, &path).map_err(|e| ControllerError::storage_source("open RocksDB", e))
             })
             .await
             .map_err(map_blocking_error)??;
@@ -145,7 +142,7 @@ impl RocksDBBackend {
 }
 
 fn map_blocking_error(error: rocketmq_runtime::RuntimeError) -> ControllerError {
-    ControllerError::StorageError(format!("RocksDB blocking task failed: {error}"))
+    ControllerError::storage_source("RocksDB blocking task failed", error)
 }
 
 #[async_trait]
@@ -159,7 +156,7 @@ impl StorageBackend for RocksDBBackend {
 
         self.spawn_io("controller.rocksdb.put", move || {
             db.put(key.as_bytes(), value)
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB put failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB put failed", e))
         })
         .await?;
 
@@ -174,7 +171,7 @@ impl StorageBackend for RocksDBBackend {
 
         self.spawn_io("controller.rocksdb.get", move || {
             db.get(key.as_bytes())
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB get failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB get failed", e))
         })
         .await
     }
@@ -187,7 +184,7 @@ impl StorageBackend for RocksDBBackend {
 
         self.spawn_io("controller.rocksdb.delete", move || {
             db.delete(key.as_bytes())
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB delete failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB delete failed", e))
         })
         .await?;
 
@@ -214,10 +211,7 @@ impl StorageBackend for RocksDBBackend {
                         }
                     }
                     Err(e) => {
-                        return Err(ControllerError::StorageError(format!(
-                            "RocksDB iteration failed: {}",
-                            e
-                        )));
+                        return Err(ControllerError::storage_source("RocksDB iteration failed", e));
                     }
                 }
             }
@@ -240,7 +234,7 @@ impl StorageBackend for RocksDBBackend {
             }
 
             db.write(batch)
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB batch write failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB batch write failed", e))
         })
         .await?;
 
@@ -260,7 +254,7 @@ impl StorageBackend for RocksDBBackend {
             }
 
             db.write(batch)
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB batch delete failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB batch delete failed", e))
         })
         .await?;
 
@@ -276,7 +270,7 @@ impl StorageBackend for RocksDBBackend {
         self.spawn_io("controller.rocksdb.exists", move || {
             db.get(key.as_bytes())
                 .map(|opt| opt.is_some())
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB exists check failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB exists check failed", e))
         })
         .await
     }
@@ -296,16 +290,13 @@ impl StorageBackend for RocksDBBackend {
                         batch.delete(&key);
                     }
                     Err(e) => {
-                        return Err(ControllerError::StorageError(format!(
-                            "RocksDB iteration failed: {}",
-                            e
-                        )));
+                        return Err(ControllerError::storage_source("RocksDB iteration failed", e));
                     }
                 }
             }
 
             db.write(batch)
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB clear failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB clear failed", e))
         })
         .await?;
 
@@ -319,7 +310,7 @@ impl StorageBackend for RocksDBBackend {
 
         self.spawn_io("controller.rocksdb.sync", move || {
             db.flush()
-                .map_err(|e| ControllerError::StorageError(format!("RocksDB sync failed: {}", e)))
+                .map_err(|e| ControllerError::storage_source("RocksDB sync failed", e))
         })
         .await?;
 
@@ -343,10 +334,7 @@ impl StorageBackend for RocksDBBackend {
                         total_size += (key.len() + value.len()) as u64;
                     }
                     Err(e) => {
-                        return Err(ControllerError::StorageError(format!(
-                            "RocksDB iteration failed: {}",
-                            e
-                        )));
+                        return Err(ControllerError::storage_source("RocksDB iteration failed", e));
                     }
                 }
             }

--- a/rocketmq-error/src/controller_error.rs
+++ b/rocketmq-error/src/controller_error.rs
@@ -17,6 +17,7 @@
 //! This module provides error types specific to the RocketMQ controller subsystem,
 //! which manages broker lifecycles, master elections, and cluster coordination.
 
+use std::error::Error as StdError;
 use std::io;
 
 use thiserror::Error;
@@ -38,6 +39,14 @@ pub enum ControllerError {
     #[error("Raft error: {0}")]
     Raft(String),
 
+    /// Raft consensus errors with preserved source.
+    #[error("Raft error: {message}")]
+    RaftSource {
+        message: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
     /// Not the leader error
     #[error("Not leader, current leader is: {}", leader_id.map(|id| id.to_string()).unwrap_or_else(|| "unknown".to_string()))]
     NotLeader { leader_id: Option<u64> },
@@ -49,6 +58,14 @@ pub enum ControllerError {
     /// Invalid request
     #[error("Invalid request: {0}")]
     InvalidRequest(String),
+
+    /// Invalid request with preserved decode or validation source.
+    #[error("Invalid request: {message}")]
+    InvalidRequestSource {
+        message: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
 
     /// Broker registration error
     #[error("Broker registration failed: {0}")]
@@ -70,9 +87,25 @@ pub enum ControllerError {
     #[error("Serialization error: {0}")]
     SerializationError(String),
 
+    /// Serialization error with preserved source.
+    #[error("Serialization error: {message}")]
+    SerializationSource {
+        message: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
     /// Storage error
     #[error("Storage error: {0}")]
     StorageError(String),
+
+    /// Storage error with preserved source.
+    #[error("Storage error: {message}")]
+    StorageSource {
+        message: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
 
     /// Network error
     #[error("Network error: {0}")]
@@ -91,6 +124,40 @@ pub enum ControllerError {
     Shutdown,
 }
 
+impl ControllerError {
+    #[inline]
+    pub fn raft_source(message: impl Into<String>, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self::RaftSource {
+            message: message.into(),
+            source: Box::new(source),
+        }
+    }
+
+    #[inline]
+    pub fn invalid_request_source(message: impl Into<String>, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self::InvalidRequestSource {
+            message: message.into(),
+            source: Box::new(source),
+        }
+    }
+
+    #[inline]
+    pub fn serialization_source(message: impl Into<String>, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self::SerializationSource {
+            message: message.into(),
+            source: Box::new(source),
+        }
+    }
+
+    #[inline]
+    pub fn storage_source(message: impl Into<String>, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self::StorageSource {
+            message: message.into(),
+            source: Box::new(source),
+        }
+    }
+}
+
 /// Result type alias for Controller operations
 pub type ControllerResult<T> = std::result::Result<T, ControllerError>;
 
@@ -106,6 +173,10 @@ mod tests {
         let err = ControllerError::Raft("raft error".to_string());
         assert_eq!(err.to_string(), "Raft error: raft error");
 
+        let err = ControllerError::raft_source("raft append failed", io::Error::other("transport closed"));
+        assert_eq!(err.to_string(), "Raft error: raft append failed");
+        assert!(err.source().is_some());
+
         let err = ControllerError::NotLeader { leader_id: Some(1) };
         assert_eq!(err.to_string(), "Not leader, current leader is: 1");
 
@@ -119,6 +190,10 @@ mod tests {
 
         let err = ControllerError::InvalidRequest("bad request".to_string());
         assert_eq!(err.to_string(), "Invalid request: bad request");
+
+        let err = ControllerError::invalid_request_source("decode request", io::Error::other("bad bytes"));
+        assert_eq!(err.to_string(), "Invalid request: decode request");
+        assert!(err.source().is_some());
 
         let err = ControllerError::BrokerRegistrationFailed("failed".to_string());
         assert_eq!(err.to_string(), "Broker registration failed: failed");
@@ -135,8 +210,16 @@ mod tests {
         let err = ControllerError::SerializationError("serde error".to_string());
         assert_eq!(err.to_string(), "Serialization error: serde error");
 
+        let err = ControllerError::serialization_source("encode response", io::Error::other("serde failure"));
+        assert_eq!(err.to_string(), "Serialization error: encode response");
+        assert!(err.source().is_some());
+
         let err = ControllerError::StorageError("disk full".to_string());
         assert_eq!(err.to_string(), "Storage error: disk full");
+
+        let err = ControllerError::storage_source("write metadata", io::Error::other("disk full"));
+        assert_eq!(err.to_string(), "Storage error: write metadata");
+        assert!(err.source().is_some());
 
         let err = ControllerError::NetworkError("disconnected".to_string());
         assert_eq!(err.to_string(), "Network error: disconnected");


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7913

### Brief Description

Adds source-preserving controller error variants for Raft, invalid request decoding, serialization, and storage failures. Controller JSON boundaries, file/RocksDB storage backend failures, and OpenRaft node operation failures now keep the original error as `#[source]` instead of immediately flattening it into a string.

### How Did You Test This Change?

- `cargo test -p rocketmq-error controller_error --lib` passed.
- `cargo test -p rocketmq-controller --lib storage::tests::test_json_operations` passed.
- `cargo test -p rocketmq-controller --lib processor::metadata_processor::tests::test_get_metadata_processor` passed.
- `cargo test -p rocketmq-controller --lib processor::` passed.
- `cargo test -p rocketmq-controller --lib rpc::` passed.
- `cargo test -p rocketmq-controller --lib storage::` passed.
- Targeted source-preservation scans for old serde, storage, and Raft string-flattening patterns produced no matches.
- `cargo fmt --all` passed.
- `git diff --check` passed.
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across controller operations so failures now return clearer, more specific messages.
  * Storage, request parsing, RPC, and Raft-related issues now preserve the original error details for easier troubleshooting.
  * JSON encoding and decoding errors are reported more consistently during topic, broker, and metadata operations.
  * File-backed and RocksDB-backed storage paths now surface more accurate failure context when reads, writes, or syncs fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->