### PR TITLE
[ISSUE #7915]♻️Split auth error categories

### DIFF
--- a/rocketmq-auth/src/acl/loader.rs
+++ b/rocketmq-auth/src/acl/loader.rs
@@ -83,7 +83,7 @@ impl FileAclConfigLoader {
         self.blocking
             .spawn_io("auth.acl.discover_files", move || discover_acl_files(&roots))
             .await
-            .map_err(|error| RocketMQError::Internal(format!("acl file discovery task failed: {error}")))?
+            .map_err(|error| RocketMQError::storage_read_failed("auth.acl.discover_files", error.to_string()))?
     }
 }
 

--- a/rocketmq-auth/src/authorization/chain/acl_authorization_handler.rs
+++ b/rocketmq-auth/src/authorization/chain/acl_authorization_handler.rs
@@ -244,10 +244,12 @@ impl<P: AuthorizationMetadataProvider> AclAuthorizationHandler<P> {
         let source_ip_binding = context.source_ip();
         let source_ip = source_ip_binding.unwrap_or("unknown");
 
-        RocketMQError::authentication_failed(format!(
-            "{} has no permission to access {} from {}, {}",
-            subject_key, resource_key, source_ip, detail
-        ))
+        RocketMQError::BrokerPermissionDenied {
+            operation: format!(
+                "{} has no permission to access {} from {}, {}",
+                subject_key, resource_key, source_ip, detail
+            ),
+        }
     }
 }
 
@@ -276,7 +278,7 @@ impl<P: AuthorizationMetadataProvider + 'static> AuthorizationHandler for AclAut
             let subject_binding = context.subject();
             let subject_wrapper = subject_binding
                 .as_ref()
-                .ok_or_else(|| RocketMQError::authentication_failed("Subject not found in authorization context"))?;
+                .ok_or_else(|| RocketMQError::illegal_argument("Subject not found in authorization context"))?;
 
             // Create a User subject for ACL lookup (required by metadata provider trait)
             let subject = SubjectLookup {
@@ -289,7 +291,7 @@ impl<P: AuthorizationMetadataProvider + 'static> AuthorizationHandler for AclAut
                 .metadata_provider
                 .get_acl(&subject)
                 .await
-                .map_err(|e| RocketMQError::Internal(format!("Failed to fetch ACL: {}", e)))?
+                .map_err(RocketMQError::from)?
                 .ok_or_else(|| self.create_error(context, "no matched policies"))?;
 
             // Step 3: Match policy entries

--- a/rocketmq-auth/src/authorization/chain/handler_chain.rs
+++ b/rocketmq-auth/src/authorization/chain/handler_chain.rs
@@ -69,7 +69,8 @@ impl AuthorizationHandlerChain {
     /// - `Err(RocketMQError)` if all handlers deny access
     pub async fn handle(&self, context: &DefaultAuthorizationContext) -> Result<(), RocketMQError> {
         if self.handlers.is_empty() {
-            return Err(RocketMQError::authentication_failed(
+            return Err(RocketMQError::auth_config_invalid(
+                "auth.authorization.handlers",
                 "No authorization handlers configured",
             ));
         }
@@ -87,8 +88,9 @@ impl AuthorizationHandlerChain {
         }
 
         // All handlers failed
-        Err(last_error
-            .unwrap_or_else(|| RocketMQError::authentication_failed("All authorization handlers denied access")))
+        Err(last_error.unwrap_or_else(|| RocketMQError::BrokerPermissionDenied {
+            operation: "All authorization handlers denied access".to_string(),
+        }))
     }
 
     /// Get the number of handlers in the chain.
@@ -149,7 +151,11 @@ mod tests {
             _context: &'a DefaultAuthorizationContext,
         ) -> Pin<Box<dyn Future<Output = Result<(), RocketMQError>> + Send + 'a>> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async move { Err(RocketMQError::authentication_failed("Access denied")) })
+            Box::pin(async move {
+                Err(RocketMQError::BrokerPermissionDenied {
+                    operation: "Access denied".to_string(),
+                })
+            })
         }
     }
 

--- a/rocketmq-auth/src/authorization/chain/user_authorization_handler.rs
+++ b/rocketmq-auth/src/authorization/chain/user_authorization_handler.rs
@@ -57,11 +57,7 @@ impl<P: AuthenticationMetadataProvider> UserAuthorizationHandler<P> {
         }
 
         let username = User::username_from_subject_key(subject.subject_key());
-        let user = self
-            .authentication_metadata_provider
-            .get_user(username)
-            .await
-            .map_err(|error| RocketMQError::authentication_failed(error.to_string()))?;
+        let user = self.authentication_metadata_provider.get_user(username).await?;
 
         if user.user_status() == Some(UserStatus::Disable) {
             return Err(RocketMQError::authentication_failed(format!(

--- a/rocketmq-auth/src/authorization/manager/metadata_manager.rs
+++ b/rocketmq-auth/src/authorization/manager/metadata_manager.rs
@@ -176,8 +176,9 @@ impl AuthorizationMetadataManager {
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
     /// - `AuthorizationError::InvalidContext` if ACL validation fails
-    /// - `AuthorizationError::InternalError` if ACL already exists (and merge fails)
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::InvalidContext` if ACL already exists (and merge fails)
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -237,7 +238,8 @@ impl AuthorizationMetadataManager {
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
     /// - `AuthorizationError::InvalidContext` if ACL validation fails
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -293,7 +295,8 @@ impl AuthorizationMetadataManager {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     pub async fn delete_acl<S: Subject + Send + Sync>(&self, subject: &S) -> ManagerResult<()> {
         self.delete_acl_with_filter(subject, None, None).await
     }
@@ -314,8 +317,9 @@ impl AuthorizationMetadataManager {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::InternalError` if ACL doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::InvalidContext` if ACL doesn't exist
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -344,7 +348,7 @@ impl AuthorizationMetadataManager {
 
         // 3. Get existing ACL
         let mut acl = self.authorization_provider.get_acl(subject).await?.ok_or_else(|| {
-            AuthorizationError::InternalError(format!(
+            AuthorizationError::InvalidContext(format!(
                 "The ACL for subject '{}' does not exist",
                 subject.subject_key()
             ))
@@ -390,7 +394,8 @@ impl AuthorizationMetadataManager {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -421,7 +426,8 @@ impl AuthorizationMetadataManager {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -554,7 +560,10 @@ impl AuthorizationMetadataManager {
             Err(RocketMQError::Authentication(AuthError::UserNotFound(_))) => Err(AuthorizationError::SubjectNotFound(
                 format!("The subject of {subject_key} is not exist."),
             )),
-            Err(error) => Err(AuthorizationError::MetadataServiceError(error.to_string())),
+            Err(error) => Err(AuthorizationError::StorageReadFailed {
+                path: "auth.authentication.users".to_string(),
+                reason: error.to_string(),
+            }),
         }
     }
 }

--- a/rocketmq-auth/src/authorization/manager/metadata_manager_impl.rs
+++ b/rocketmq-auth/src/authorization/manager/metadata_manager_impl.rs
@@ -44,7 +44,8 @@
 //!
 //! - Validation errors return `AuthorizationError::InvalidContext`
 //! - Missing subjects return `AuthorizationError::SubjectNotFound`
-//! - Storage failures return `AuthorizationError::MetadataServiceError`
+//! - Storage failures return `AuthorizationError::StorageReadFailed` or
+//!   `AuthorizationError::StorageWriteFailed`
 //! - All errors are propagated without panic, enabling graceful degradation
 //!
 //! # Thread Safety
@@ -227,7 +228,8 @@ impl AuthorizationMetadataManagerImpl {
     ///
     /// - `AuthorizationError::InvalidContext` if ACL validation fails
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -288,7 +290,8 @@ impl AuthorizationMetadataManagerImpl {
     ///
     /// - `AuthorizationError::InvalidContext` if ACL validation fails
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -345,8 +348,9 @@ impl AuthorizationMetadataManagerImpl {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::InternalError` if ACL doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::InvalidContext` if ACL doesn't exist
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -374,8 +378,9 @@ impl AuthorizationMetadataManagerImpl {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::InternalError` if ACL doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::InvalidContext` if ACL doesn't exist
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -404,7 +409,7 @@ impl AuthorizationMetadataManagerImpl {
 
         // Step 3: Get existing ACL
         let mut acl = self.authorization_provider.get_acl(subject).await?.ok_or_else(|| {
-            AuthorizationError::InternalError(format!(
+            AuthorizationError::InvalidContext(format!(
                 "The ACL for subject '{}' does not exist",
                 subject.subject_key()
             ))
@@ -450,7 +455,8 @@ impl AuthorizationMetadataManagerImpl {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if subject doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -481,7 +487,8 @@ impl AuthorizationMetadataManagerImpl {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -710,7 +717,10 @@ impl AuthorizationMetadataManagerImpl {
             Err(RocketMQError::Authentication(AuthError::UserNotFound(_))) => Err(AuthorizationError::SubjectNotFound(
                 format!("The subject of {subject_key} is not exist."),
             )),
-            Err(error) => Err(AuthorizationError::MetadataServiceError(error.to_string())),
+            Err(error) => Err(AuthorizationError::StorageReadFailed {
+                path: "auth.authentication.users".to_string(),
+                reason: error.to_string(),
+            }),
         }
     }
 

--- a/rocketmq-auth/src/authorization/metadata_provider.rs
+++ b/rocketmq-auth/src/authorization/metadata_provider.rs
@@ -147,8 +147,9 @@ pub trait AuthorizationMetadataProvider: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::InternalError` if ACL already exists
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::InvalidContext` if ACL already exists
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     /// - `AuthorizationError::InvalidContext` if ACL data is malformed
     ///
     /// # Examples
@@ -170,7 +171,8 @@ pub trait AuthorizationMetadataProvider: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -192,7 +194,8 @@ pub trait AuthorizationMetadataProvider: Send + Sync {
     /// # Errors
     ///
     /// - `AuthorizationError::SubjectNotFound` if ACL doesn't exist
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     /// - `AuthorizationError::InvalidContext` if ACL data is malformed
     ///
     /// # Examples
@@ -220,7 +223,8 @@ pub trait AuthorizationMetadataProvider: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///
@@ -251,7 +255,8 @@ pub trait AuthorizationMetadataProvider: Send + Sync {
     ///
     /// # Errors
     ///
-    /// - `AuthorizationError::MetadataServiceError` if storage operation fails
+    /// - `AuthorizationError::StorageReadFailed` or `AuthorizationError::StorageWriteFailed` if
+    ///   storage operation fails
     ///
     /// # Examples
     ///

--- a/rocketmq-auth/src/authorization/metadata_provider/local.rs
+++ b/rocketmq-auth/src/authorization/metadata_provider/local.rs
@@ -194,13 +194,17 @@ impl LocalAuthorizationMetadataProvider {
             return Ok(());
         };
         let path = path.clone();
+        let path_display = path.display().to_string();
         let snapshot = snapshot.clone();
         self.blocking
             .spawn_io("auth.authorization.write_acl_snapshot", move || {
                 write_acl_snapshot(&path, &snapshot)
             })
             .await
-            .map_err(|error| AuthorizationError::MetadataServiceError(format!("ACL snapshot task failed: {error}")))?
+            .map_err(|error| AuthorizationError::StorageWriteFailed {
+                path: path_display,
+                reason: format!("ACL snapshot task failed: {error}"),
+            })?
     }
 
     fn replace_storage(&self, snapshot: HashMap<String, Acl>) -> MetadataResult<()> {
@@ -303,37 +307,37 @@ impl LocalAuthorizationMetadataProvider {
     fn initialized_read(&self) -> MetadataResult<RwLockReadGuard<'_, bool>> {
         self.initialized
             .read()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL initialized lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.initialized".to_string()))
     }
 
     fn initialized_write(&self) -> MetadataResult<RwLockWriteGuard<'_, bool>> {
         self.initialized
             .write()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL initialized lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.initialized".to_string()))
     }
 
     fn storage_read(&self) -> MetadataResult<RwLockReadGuard<'_, HashMap<String, Acl>>> {
         self.storage
             .read()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL storage lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.storage".to_string()))
     }
 
     fn storage_write(&self) -> MetadataResult<RwLockWriteGuard<'_, HashMap<String, Acl>>> {
         self.storage
             .write()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL storage lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.storage".to_string()))
     }
 
     fn cache_write(&self) -> MetadataResult<RwLockWriteGuard<'_, HashMap<String, CachedAcl>>> {
         self.cache
             .write()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL cache lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.cache".to_string()))
     }
 
     fn cache_read(&self) -> MetadataResult<RwLockReadGuard<'_, HashMap<String, CachedAcl>>> {
         self.cache
             .read()
-            .map_err(|_| AuthorizationError::MetadataServiceError("ACL cache lock is poisoned".to_string()))
+            .map_err(|_| AuthorizationError::StorageLockFailed("auth.authorization.cache".to_string()))
     }
 
     /// Filter ACLs by subject and resource patterns.
@@ -421,13 +425,13 @@ fn read_acl_snapshot(path: &Path) -> MetadataResult<HashMap<String, Acl>> {
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
-        Err(error) => return Err(storage_error(path, error)),
+        Err(error) => return Err(storage_read_error(path, error)),
     };
     if bytes.iter().all(u8::is_ascii_whitespace) {
         return Ok(HashMap::new());
     }
     let snapshot: StoredAclSnapshot = serde_json::from_slice(&bytes)
-        .map_err(|error| AuthorizationError::MetadataServiceError(format!("{}: {error}", path.display())))?;
+        .map_err(|error| snapshot_decode_error(format!("{}: {error}", path.display())))?;
     let mut acls = HashMap::new();
     for record in snapshot.acls {
         let acl = acl_from_record(record)?;
@@ -440,23 +444,20 @@ fn write_acl_snapshot(path: &Path, acls: &HashMap<String, Acl>) -> MetadataResul
     let mut records = acls.values().map(acl_to_record).collect::<Vec<_>>();
     records.sort_by(|left, right| left.subject.cmp(&right.subject));
     let snapshot = StoredAclSnapshot { acls: records };
-    let content = serde_json::to_vec_pretty(&snapshot)
-        .map_err(|error| AuthorizationError::MetadataServiceError(error.to_string()))?;
+    let content = serde_json::to_vec_pretty(&snapshot).map_err(|error| snapshot_encode_error(error.to_string()))?;
 
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|error| storage_error(parent, error))?;
+        std::fs::create_dir_all(parent).map_err(|error| storage_write_error(parent, error))?;
     }
 
     let temp_file = temp_snapshot_path(path);
-    std::fs::write(&temp_file, content).map_err(|error| storage_error(&temp_file, error))?;
+    std::fs::write(&temp_file, content).map_err(|error| storage_write_error(&temp_file, error))?;
     match std::fs::rename(&temp_file, path) {
         Ok(()) => Ok(()),
         Err(rename_error) => {
-            std::fs::copy(&temp_file, path).map_err(|error| {
-                AuthorizationError::MetadataServiceError(format!(
-                    "{}: {error}; rename failed first: {rename_error}",
-                    path.display()
-                ))
+            std::fs::copy(&temp_file, path).map_err(|error| AuthorizationError::StorageWriteFailed {
+                path: path.display().to_string(),
+                reason: format!("{error}; rename failed first: {rename_error}"),
             })?;
             let _ = std::fs::remove_file(&temp_file);
             Ok(())
@@ -501,9 +502,8 @@ fn acl_from_record(record: StoredAclRecord) -> MetadataResult<Acl> {
 }
 
 fn policy_from_record(record: StoredPolicyRecord) -> MetadataResult<Policy> {
-    let policy_type = PolicyType::get_by_name(&record.policy_type).ok_or_else(|| {
-        AuthorizationError::MetadataServiceError(format!("Invalid policy type '{}'", record.policy_type))
-    })?;
+    let policy_type = PolicyType::get_by_name(&record.policy_type)
+        .ok_or_else(|| snapshot_decode_error(format!("Invalid policy type '{}'", record.policy_type)))?;
     let entries = record
         .entries
         .into_iter()
@@ -514,17 +514,16 @@ fn policy_from_record(record: StoredPolicyRecord) -> MetadataResult<Policy> {
 
 fn policy_entry_from_record(record: StoredPolicyEntryRecord) -> MetadataResult<PolicyEntry> {
     let resource = Resource::of_str(&record.resource)
-        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid resource '{}'", record.resource)))?;
+        .ok_or_else(|| snapshot_decode_error(format!("Invalid resource '{}'", record.resource)))?;
     let actions = record
         .actions
         .iter()
         .map(|action| {
-            Action::get_by_name(action)
-                .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid action '{action}'")))
+            Action::get_by_name(action).ok_or_else(|| snapshot_decode_error(format!("Invalid action '{action}'")))
         })
         .collect::<MetadataResult<Vec<_>>>()?;
     let decision = Decision::get_by_name(&record.decision)
-        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid decision '{}'", record.decision)))?;
+        .ok_or_else(|| snapshot_decode_error(format!("Invalid decision '{}'", record.decision)))?;
     let environment = Environment::of_list(record.source_ips);
     Ok(PolicyEntry::of(resource, actions, environment, decision))
 }
@@ -534,11 +533,37 @@ fn subject_type_from_key(subject_key: &str) -> MetadataResult<SubjectType> {
         return Ok(SubjectType::User);
     };
     SubjectType::get_by_name(subject_type)
-        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid subject type '{subject_type}'")))
+        .ok_or_else(|| snapshot_decode_error(format!("Invalid subject type '{subject_type}'")))
 }
 
-fn storage_error(path: &Path, error: std::io::Error) -> AuthorizationError {
-    AuthorizationError::MetadataServiceError(format!("{}: {error}", path.display()))
+fn storage_read_error(path: &Path, error: std::io::Error) -> AuthorizationError {
+    AuthorizationError::StorageReadFailed {
+        path: path.display().to_string(),
+        reason: error.to_string(),
+    }
+}
+
+fn storage_write_error(path: &Path, error: std::io::Error) -> AuthorizationError {
+    AuthorizationError::StorageWriteFailed {
+        path: path.display().to_string(),
+        reason: error.to_string(),
+    }
+}
+
+fn snapshot_encode_error(reason: impl Into<String>) -> AuthorizationError {
+    AuthorizationError::SerializationFailed {
+        operation: "encode",
+        format: "JSON",
+        reason: reason.into(),
+    }
+}
+
+fn snapshot_decode_error(reason: impl Into<String>) -> AuthorizationError {
+    AuthorizationError::SerializationFailed {
+        operation: "decode",
+        format: "JSON",
+        reason: reason.into(),
+    }
 }
 
 fn temp_snapshot_path(path: &Path) -> PathBuf {
@@ -623,7 +648,7 @@ impl AuthorizationMetadataProvider for LocalAuthorizationMetadataProvider {
             storage.clone()
         };
         if snapshot.contains_key(&subject_key) {
-            return Err(AuthorizationError::InternalError(format!(
+            return Err(AuthorizationError::InvalidContext(format!(
                 "ACL already exists for subject: {}",
                 subject_key
             )));
@@ -1016,5 +1041,6 @@ mod tests {
         let error = provider.initialize(config, None).unwrap_err();
 
         assert!(error.to_string().contains("acls.json"));
+        assert!(matches!(error, AuthorizationError::SerializationFailed { .. }));
     }
 }

--- a/rocketmq-auth/src/authorization/provider.rs
+++ b/rocketmq-auth/src/authorization/provider.rs
@@ -19,7 +19,9 @@
 
 use std::sync::Arc;
 
+use rocketmq_error::AuthError;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::SerializationError;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 
 use crate::authentication::provider::LocalAuthenticationMetadataProvider;
@@ -80,9 +82,25 @@ pub enum AuthorizationError {
     #[error("Internal authorization error: {0}")]
     InternalError(String),
 
-    /// Metadata service error (e.g., database, cache, remote service failure).
-    #[error("Metadata service error: {0}")]
-    MetadataServiceError(String),
+    /// Authorization metadata read failed.
+    #[error("Authorization metadata read failed for '{path}': {reason}")]
+    StorageReadFailed { path: String, reason: String },
+
+    /// Authorization metadata write failed.
+    #[error("Authorization metadata write failed for '{path}': {reason}")]
+    StorageWriteFailed { path: String, reason: String },
+
+    /// Authorization metadata lock acquisition failed.
+    #[error("Authorization metadata lock failed for '{0}'")]
+    StorageLockFailed(String),
+
+    /// Authorization metadata serialization or deserialization failed.
+    #[error("Authorization metadata {operation} failed for {format}: {reason}")]
+    SerializationFailed {
+        operation: &'static str,
+        format: &'static str,
+        reason: String,
+    },
 
     /// Authorization context is invalid or incomplete.
     #[error("Invalid authorization context: {0}")]
@@ -100,9 +118,25 @@ impl From<AuthorizationError> for RocketMQError {
             AuthorizationError::ConfigurationError(_) | AuthorizationError::NotInitialized(_) => {
                 RocketMQError::auth_config_invalid("auth.authorization", message)
             }
-            AuthorizationError::PolicyEvaluationFailed(_)
-            | AuthorizationError::InternalError(_)
-            | AuthorizationError::MetadataServiceError(_) => RocketMQError::Internal(message),
+            AuthorizationError::PolicyEvaluationFailed(_) => {
+                RocketMQError::Authentication(AuthError::AuthorizationFailed(message))
+            }
+            AuthorizationError::InternalError(_) => RocketMQError::Internal(message),
+            AuthorizationError::StorageReadFailed { path, reason } => RocketMQError::storage_read_failed(path, reason),
+            AuthorizationError::StorageWriteFailed { path, reason } => {
+                RocketMQError::storage_write_failed(path, reason)
+            }
+            AuthorizationError::StorageLockFailed(path) => RocketMQError::StorageLockFailed { path },
+            AuthorizationError::SerializationFailed {
+                operation: "encode",
+                format,
+                reason,
+            } => RocketMQError::Serialization(SerializationError::encode_failed(format, reason)),
+            AuthorizationError::SerializationFailed {
+                operation: _,
+                format,
+                reason,
+            } => RocketMQError::deserialization_failed(format, reason),
         }
     }
 }
@@ -627,7 +661,20 @@ mod tests {
             AuthorizationError::ConfigurationError("missing config".to_string()),
             AuthorizationError::NotInitialized("provider not ready".to_string()),
             AuthorizationError::InternalError("unexpected error".to_string()),
-            AuthorizationError::MetadataServiceError("db connection failed".to_string()),
+            AuthorizationError::StorageReadFailed {
+                path: "acls.json".to_string(),
+                reason: "read failed".to_string(),
+            },
+            AuthorizationError::StorageWriteFailed {
+                path: "acls.json".to_string(),
+                reason: "write failed".to_string(),
+            },
+            AuthorizationError::StorageLockFailed("acl cache".to_string()),
+            AuthorizationError::SerializationFailed {
+                operation: "decode",
+                format: "JSON",
+                reason: "invalid ACL snapshot".to_string(),
+            },
             AuthorizationError::InvalidContext("missing subject".to_string()),
         ];
 
@@ -661,6 +708,27 @@ mod tests {
 
         let internal = RocketMQError::from(AuthorizationError::InternalError("unexpected error".to_string()));
         assert!(matches!(internal, RocketMQError::Internal(_)));
+
+        let storage = RocketMQError::from(AuthorizationError::StorageWriteFailed {
+            path: "acls.json".to_string(),
+            reason: "permission denied".to_string(),
+        });
+        assert!(matches!(storage, RocketMQError::StorageWriteFailed { .. }));
+
+        let serialization = RocketMQError::from(AuthorizationError::SerializationFailed {
+            operation: "decode",
+            format: "JSON",
+            reason: "invalid ACL snapshot".to_string(),
+        });
+        assert!(matches!(serialization, RocketMQError::Serialization(_)));
+
+        let policy = RocketMQError::from(AuthorizationError::PolicyEvaluationFailed(
+            "policy engine rejected".to_string(),
+        ));
+        assert!(matches!(
+            policy,
+            RocketMQError::Authentication(AuthError::AuthorizationFailed(_))
+        ));
     }
 
     #[tokio::test]

--- a/rocketmq-auth/src/authorization/strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy.rs
@@ -40,7 +40,7 @@ pub(super) fn block_on_base_authorization(
 ) -> StrategyResult<()> {
     block_on_sync_bridge(
         || base.do_evaluate(context),
-        |error| AuthorizationError::InternalError(format!("failed to create authorization runtime: {error}")),
+        |error| AuthorizationError::ConfigurationError(format!("failed to create authorization runtime: {error}")),
         || AuthorizationError::InternalError("authorization provider thread panicked".to_string()),
     )
 }

--- a/rocketmq-auth/src/authorization/strategy/stateful_authorization_strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy/stateful_authorization_strategy.rs
@@ -379,12 +379,14 @@ impl AuthorizationStrategy for StatefulAuthorizationStrategy {
                             return if cached_result.granted {
                                 Ok(())
                             } else {
-                                Err(AuthorizationError::InternalError(
-                                    cached_result
+                                Err(AuthorizationError::PermissionDenied {
+                                    subject: context.subject_key().unwrap_or("unknown").to_string(),
+                                    resource: context.resource_key().unwrap_or_else(|| "unknown".to_string()),
+                                    reason: cached_result
                                         .error
                                         .clone()
                                         .unwrap_or_else(|| "Authorization denied (cached)".to_string()),
-                                ))
+                                })
                             };
                         } else {
                             debug!("Cache entry expired for key: {}", cache_key);

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -123,7 +123,9 @@ pub mod bench_support {
     pub async fn run_auth_acl_watcher_lifecycle_probe() -> RocketMQResult<AuthAclWatcherLifecycleProbe> {
         let root = unique_acl_watcher_probe_root();
         let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&root).map_err(|error| rocketmq_error::RocketMQError::Internal(error.to_string()))?;
+        fs::create_dir_all(&root).map_err(|error| {
+            rocketmq_error::RocketMQError::storage_write_failed(root.display().to_string(), error.to_string())
+        })?;
         let acl_file = root.join("plain_acl.yml");
         write_acl_file(&acl_file, "first")?;
 
@@ -302,7 +304,9 @@ accounts:
 "#
             ),
         )
-        .map_err(|error| rocketmq_error::RocketMQError::Internal(error.to_string()))
+        .map_err(|error| {
+            rocketmq_error::RocketMQError::storage_write_failed(path.display().to_string(), error.to_string())
+        })
     }
 
     impl From<crate::runtime_bridge::AuthSyncBridgeSnapshot> for AuthSyncBridgeCounterSnapshot {

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -120,7 +120,9 @@ impl ProviderRegistry {
         let mut guard = self
             .acl_white_list_snapshot
             .write()
-            .map_err(|_| RocketMQError::Internal("ACL white list snapshot lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.white_list_snapshot".to_owned(),
+            })?;
         *guard = snapshot;
         Ok(())
     }
@@ -129,7 +131,9 @@ impl ProviderRegistry {
         let guard = self
             .acl_managed_access_keys
             .read()
-            .map_err(|_| RocketMQError::Internal("ACL managed access key lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.managed_access_keys".to_owned(),
+            })?;
         Ok(guard.clone())
     }
 
@@ -137,7 +141,9 @@ impl ProviderRegistry {
         let mut guard = self
             .acl_managed_access_keys
             .write()
-            .map_err(|_| RocketMQError::Internal("ACL managed access key lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.managed_access_keys".to_owned(),
+            })?;
         *guard = access_keys;
         Ok(())
     }
@@ -167,7 +173,9 @@ impl ProviderRegistry {
         let guard = self
             .acl_fingerprint
             .read()
-            .map_err(|_| RocketMQError::Internal("ACL fingerprint lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.fingerprint".to_owned(),
+            })?;
         Ok(*guard)
     }
 
@@ -175,7 +183,9 @@ impl ProviderRegistry {
         let mut guard = self
             .acl_fingerprint
             .write()
-            .map_err(|_| RocketMQError::Internal("ACL fingerprint lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.fingerprint".to_owned(),
+            })?;
         *guard = fingerprint;
         Ok(())
     }
@@ -188,7 +198,9 @@ impl ProviderRegistry {
         let guard = self
             .acl_white_list_snapshot
             .read()
-            .map_err(|_| RocketMQError::Internal("ACL white list snapshot lock is poisoned".to_owned()))?;
+            .map_err(|_| RocketMQError::StorageLockFailed {
+                path: "auth.acl.white_list_snapshot".to_owned(),
+            })?;
         let matched = guard.matches(access_key, source_ip);
         self.metrics.record_whitelist_check(matched);
         Ok(matched)
@@ -203,7 +215,9 @@ impl ProviderRegistry {
             let guard = self
                 .acl_white_list_snapshot
                 .read()
-                .map_err(|_| RocketMQError::Internal("ACL white list snapshot lock is poisoned".to_owned()))?;
+                .map_err(|_| RocketMQError::StorageLockFailed {
+                    path: "auth.acl.white_list_snapshot".to_owned(),
+                })?;
             guard.with_global_patterns(addresses)
         };
         self.set_acl_white_list_snapshot(updated_snapshot)?;
@@ -1397,6 +1411,7 @@ accounts:
         };
 
         assert!(error.to_string().contains("acls.json"));
+        assert!(matches!(error, RocketMQError::Serialization(_)));
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -630,8 +630,11 @@ mod tests {
             }
         ));
 
-        let internal = map_authz_error(AuthorizationError::MetadataServiceError("storage failed".to_string()));
-        assert!(matches!(internal, RocketMQError::Internal(_)));
+        let storage = map_authz_error(AuthorizationError::StorageReadFailed {
+            path: "auth.authorization.acls".to_string(),
+            reason: "storage failed".to_string(),
+        });
+        assert!(matches!(storage, RocketMQError::StorageReadFailed { .. }));
     }
 
     #[tokio::test]

--- a/rocketmq-error/src/auth_error.rs
+++ b/rocketmq-error/src/auth_error.rs
@@ -47,6 +47,10 @@ pub enum AuthError {
     #[error("Authentication failed: {0}")]
     AuthenticationFailed(String),
 
+    /// Authorization policy denied or failed to evaluate.
+    #[error("Authorization failed: {0}")]
+    AuthorizationFailed(String),
+
     /// User not found
     #[error("User not found: {0}")]
     UserNotFound(String),
@@ -95,6 +99,7 @@ mod tests {
     fn test_auth_error_variants() {
         let errors = vec![
             AuthError::AuthenticationFailed("could not authenticate".to_string()),
+            AuthError::AuthorizationFailed("could not authorize".to_string()),
             AuthError::ContextCreationError("could not create context".to_string()),
             AuthError::InvalidAuthorizationHeader("invalid authorization header".to_string()),
             AuthError::InvalidCredential("invalid credential".to_string()),


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7915

### Brief Description

Split RocketMQ auth error handling into explicit authentication, authorization, configuration, storage, and serialization categories. Authorization metadata failures now map to stable RocketMQError kinds instead of collapsing through generic metadata/internal errors, ACL handlers preserve typed lookup failures, permission-denied paths use BrokerPermissionDenied, and corrupted ACL snapshot tests assert serialization classification at provider and runtime boundaries.

### How Did You Test This Change?

- `cargo test -p rocketmq-error auth_error --lib` passed
- `cargo test -p rocketmq-auth --lib authorization::` passed
- `cargo test -p rocketmq-auth --lib runtime::` passed
- `cargo test -p rocketmq-broker --lib auth::auth_admin_service::tests::map_authz_error_preserves_admin_error_category` passed
- `cargo fmt --all` passed
- `git diff --check` passed
- `rg -n 'MetadataServiceError' rocketmq-auth\src rocketmq-error\src -g '*.rs'` returned no matches
- `rg -n 'RocketMQError::Internal\(format!\("Failed to fetch ACL|auth\.authorization.*Internal|ACL snapshot task failed' rocketmq-auth\src rocketmq-error\src -g '*.rs'` returned no matches
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed
