### PR TITLE
[ISSUE #7921]♻️Use typed dashboard RocketMQ error

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2391,7 +2391,6 @@ dependencies = [
 name = "rocketmq-common"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "base64",
  "byteorder",
  "bytes",
@@ -2453,6 +2452,7 @@ dependencies = [
  "rocketmq-client-rust",
  "rocketmq-common",
  "rocketmq-dashboard-common",
+ "rocketmq-error",
  "rocketmq-remoting",
  "rusqlite",
  "serde",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
@@ -27,6 +27,7 @@ rocketmq-dashboard-common = { path = "../../rocketmq-dashboard-common", features
 rocketmq-admin-core = { path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core" }
 rocketmq-client-rust = { path = "../../../rocketmq-client" }
 rocketmq-common = { path = "../../../rocketmq-common" }
+rocketmq-error = { path = "../../../rocketmq-error" }
 rocketmq-remoting = { path = "../../../rocketmq-remoting" }
 
 [dev-dependencies]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -64,6 +64,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -1743,14 +1744,18 @@ fn master_targets_by_cluster_name(
     cluster_info: &ClusterInfo,
     cluster_name: &str,
 ) -> Result<Vec<(String, CheetahString)>, DashboardError> {
-    let cluster_addr_table = cluster_info
-        .cluster_addr_table
-        .as_ref()
-        .ok_or_else(|| DashboardError::RocketMq("NameServer did not return cluster address data".to_string()))?;
-    let broker_addr_table = cluster_info
-        .broker_addr_table
-        .as_ref()
-        .ok_or_else(|| DashboardError::RocketMq("NameServer did not return broker address data".to_string()))?;
+    let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
+        DashboardError::RocketMq(RocketMQError::response_process_failed(
+            "examine_broker_cluster_info",
+            "NameServer did not return cluster address data",
+        ))
+    })?;
+    let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
+        DashboardError::RocketMq(RocketMQError::response_process_failed(
+            "examine_broker_cluster_info",
+            "NameServer did not return broker address data",
+        ))
+    })?;
     let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
         DashboardError::Validation(format!(
             "Cluster `{cluster_name}` was not found in the current NameServer view"
@@ -2322,8 +2327,8 @@ fn unique_admin_group() -> String {
     format!("dashboard-web-admin-{}-{millis}", std::process::id())
 }
 
-fn map_rocketmq_error(error: impl ToString) -> DashboardError {
-    DashboardError::RocketMq(error.to_string())
+fn map_rocketmq_error(error: RocketMQError) -> DashboardError {
+    DashboardError::RocketMq(error)
 }
 
 fn validate_name(value: &str, label: &str) -> Result<(), DashboardError> {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -15,6 +15,7 @@ use crate::model::ApiResponse;
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use rocketmq_error::RocketMQError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -23,8 +24,8 @@ pub enum DashboardError {
     Validation(String),
     #[error("{0}")]
     Config(String),
-    #[error("{0}")]
-    RocketMq(String),
+    #[error(transparent)]
+    RocketMq(#[from] RocketMQError),
     #[error("{0}")]
     NotFound(String),
     #[error("{0}")]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7921

### Brief Description

- Changes dashboard web backend `DashboardError::RocketMq` from a string payload to a typed `RocketMQError` wrapper.
- Adds the explicit backend dependency on `rocketmq-error` and preserves admin/client errors without stringification.
- Converts local malformed NameServer response cases to typed `RocketMQError::response_process_failed` values.
- Keeps the existing dashboard API response code `ROCKETMQ_ERROR` and HTTP `502 Bad Gateway` behavior.

### How Did You Test This Change?

- `cargo check --all-targets --all-features` passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo fmt --all` passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo clippy --all-targets --all-features -- -D warnings` passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo build --all-targets --all-features` passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo test --all-targets --all-features` passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard error handling for RocketMQ-related failures.
  * Missing cluster or broker information now returns more consistent, structured error messages.
  * Users should see more reliable failure responses instead of generic error text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->