### PR TITLE
[ISSUE #7923]♻️Align standalone RocketMQ errors

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -4033,7 +4033,6 @@ dependencies = [
 name = "rocketmq-common"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "byteorder",
  "bytes",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/admin.rs
@@ -46,10 +46,7 @@ impl ManagedClusterAdmin {
             .client_config_mut()
             .set_vip_channel_enabled(snapshot.use_vip_channel);
         admin.client_config_mut().set_use_tls(snapshot.use_tls);
-        admin
-            .start()
-            .await
-            .map_err(|error| ClusterError::RocketMQ(error.to_string()))?;
+        admin.start().await.map_err(ClusterError::RocketMQ)?;
 
         Ok(Self {
             admin,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/service.rs
@@ -206,7 +206,7 @@ impl ClusterManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ClusterError::RocketMQ(error.to_string()))?;
+            .map_err(ClusterError::RocketMQ)?;
         let items = build_cluster_items(admin, &cluster_info).await;
         let mut clusters: Vec<String> = cluster_info
             .cluster_addr_table
@@ -248,7 +248,7 @@ impl ClusterManager {
         let properties = admin
             .get_broker_config(CheetahString::from(broker_addr))
             .await
-            .map_err(|error| ClusterError::RocketMQ(error.to_string()))?;
+            .map_err(ClusterError::RocketMQ)?;
 
         Ok(ClusterBrokerConfigView {
             broker_addr: broker_addr.to_string(),
@@ -272,7 +272,7 @@ impl ClusterManager {
         let kv_table = admin
             .fetch_broker_runtime_stats(CheetahString::from(broker_addr))
             .await
-            .map_err(|error| ClusterError::RocketMQ(error.to_string()))?;
+            .map_err(ClusterError::RocketMQ)?;
 
         Ok(ClusterBrokerStatusView {
             broker_addr: broker_addr.to_string(),

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::RocketMQError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -23,7 +24,7 @@ pub(crate) type ClusterResult<T> = Result<T, ClusterError>;
 pub(crate) enum ClusterError {
     Configuration(String),
     Validation(String),
-    RocketMQ(String),
+    RocketMQ(RocketMQError),
 }
 
 impl fmt::Display for ClusterError {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/admin.rs
@@ -48,10 +48,7 @@ impl ManagedConsumerAdmin {
             .client_config_mut()
             .set_vip_channel_enabled(snapshot.use_vip_channel);
         admin.client_config_mut().set_use_tls(snapshot.use_tls);
-        admin
-            .start()
-            .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+        admin.start().await.map_err(ConsumerError::RocketMQ)?;
 
         Ok(Self {
             admin,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -43,6 +43,8 @@ use rocketmq_dashboard_common::ConsumerGroupListRequest;
 use rocketmq_dashboard_common::ConsumerGroupRefreshRequest;
 use rocketmq_dashboard_common::ConsumerTopicDetailQueryRequest;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -370,7 +372,7 @@ impl ConsumerManager {
 
     fn should_reset_session<T>(result: &ConsumerResult<T>) -> bool {
         match result {
-            Err(ConsumerError::RocketMQ(message)) => is_reconnect_worthy_error(message),
+            Err(ConsumerError::RocketMQ(error)) => is_reconnect_worthy_error(error),
             _ => false,
         }
     }
@@ -384,7 +386,7 @@ impl ConsumerManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
         let group_map = collect_consumer_group_meta(admin, &cluster_info).await?;
         let address = normalize_address(request.address.as_deref());
 
@@ -415,7 +417,7 @@ impl ConsumerManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
         let group_map = collect_consumer_group_meta(admin, &cluster_info).await?;
         let raw_group_name = strip_system_prefix(&request.consumer_group);
         let meta = group_map.get(raw_group_name.as_str()).ok_or_else(|| {
@@ -444,7 +446,7 @@ impl ConsumerManager {
         let connection = admin
             .examine_consumer_connection_info(raw_group_name.into(), first_address(request.address.as_deref()))
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
 
         Ok(build_consumer_connection_view(raw_group_name, connection))
     }
@@ -460,14 +462,14 @@ impl ConsumerManager {
             admin
                 .examine_consume_stats(raw_group_name.into(), None, None, None, None)
                 .await
-                .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?
+                .map_err(ConsumerError::RocketMQ)?
         } else {
             let mut merged_stats = ConsumeStats::new();
             for broker_addr in broker_addresses {
                 let stats = admin
                     .examine_consume_stats(raw_group_name.into(), None, None, Some(broker_addr), Some(3_000))
                     .await
-                    .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+                    .map_err(ConsumerError::RocketMQ)?;
                 merged_stats.consume_tps += stats.get_consume_tps();
                 merged_stats
                     .get_offset_table_mut()
@@ -494,7 +496,7 @@ impl ConsumerManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
 
         let broker_address = match normalize_address(request.address.as_deref()) {
             Some(address) => address,
@@ -518,7 +520,7 @@ impl ConsumerManager {
         let config = admin
             .examine_subscription_group_config(broker_address.clone(), raw_group_name.into())
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
 
         let broker_name = resolve_broker_name_by_address(&cluster_info, broker_address.as_str()).unwrap_or_default();
 
@@ -539,7 +541,7 @@ impl ConsumerManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
         let broker_names =
             resolve_consumer_target_broker_names(&cluster_info, &request.cluster_name_list, &request.broker_name_list)?;
 
@@ -567,7 +569,7 @@ impl ConsumerManager {
             admin
                 .create_and_update_subscription_group_config(broker_addr, config.clone())
                 .await
-                .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+                .map_err(ConsumerError::RocketMQ)?;
         }
 
         Ok(ConsumerMutationResult {
@@ -586,7 +588,7 @@ impl ConsumerManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+            .map_err(ConsumerError::RocketMQ)?;
         let group_map = collect_consumer_group_meta(admin, &cluster_info).await?;
         let meta = group_map.get(raw_group_name).ok_or_else(|| {
             ConsumerError::Validation(format!(
@@ -621,14 +623,14 @@ impl ConsumerManager {
             admin
                 .delete_subscription_group(broker_addr.clone(), raw_group_name.into(), Some(true))
                 .await
-                .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+                .map_err(ConsumerError::RocketMQ)?;
 
             for topic in consumer_internal_topics(raw_group_name) {
                 let broker_targets = HashSet::from([broker_addr.clone()]);
                 admin
                     .delete_topic_in_broker(broker_targets, topic.clone().into())
                     .await
-                    .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+                    .map_err(ConsumerError::RocketMQ)?;
 
                 if delete_in_namesrv {
                     let namesrv_targets: HashSet<CheetahString> =
@@ -636,7 +638,7 @@ impl ConsumerManager {
                     admin
                         .delete_topic_in_name_server(namesrv_targets, None, topic.into())
                         .await
-                        .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+                        .map_err(ConsumerError::RocketMQ)?;
                 }
             }
         }
@@ -663,13 +665,12 @@ async fn collect_consumer_group_meta(
                 wrapper
             }
             Err(error) => {
-                let message = error.to_string();
                 log::warn!(
                     "Failed to fetch subscription groups from broker `{}` while collecting consumer groups: {}",
                     broker_addr,
-                    message
+                    error
                 );
-                last_error = Some(message);
+                last_error = Some(error);
                 continue;
             }
         };
@@ -685,7 +686,10 @@ async fn collect_consumer_group_meta(
 
     if successful_brokers == 0 {
         return Err(ConsumerError::RocketMQ(last_error.unwrap_or_else(|| {
-            "No broker subscription metadata could be loaded.".to_string()
+            RocketMQError::response_process_failed(
+                "get_all_subscription_group",
+                "No broker subscription metadata could be loaded.",
+            )
         })));
     }
 
@@ -966,7 +970,11 @@ fn now_timestamp_millis() -> i64 {
         .unwrap_or_default()
 }
 
-fn is_reconnect_worthy_error(message: &str) -> bool {
+fn is_reconnect_worthy_error(error: &RocketMQError) -> bool {
+    matches!(error.kind(), ErrorKind::Network | ErrorKind::Timeout) || is_reconnect_worthy_message(&error.to_string())
+}
+
+fn is_reconnect_worthy_message(message: &str) -> bool {
     let normalized = message.to_ascii_lowercase();
     [
         "connect",
@@ -1246,7 +1254,7 @@ mod tests {
     use super::build_consumer_topic_detail_view;
     use super::build_summary;
     use super::classify_consumer_group;
-    use super::is_reconnect_worthy_error;
+    use super::is_reconnect_worthy_message;
     use super::is_system_consumer_group;
     use super::resolve_broker_name_by_address;
     use super::resolve_first_consumer_broker_address;
@@ -1403,10 +1411,10 @@ mod tests {
 
     #[test]
     fn reconnect_error_detection_only_matches_transport_failures() {
-        assert!(is_reconnect_worthy_error("connection refused by broker"));
-        assert!(is_reconnect_worthy_error("request timeout while talking to namesrv"));
-        assert!(!is_reconnect_worthy_error("consumer group not found"));
-        assert!(!is_reconnect_worthy_error("subscription group metadata is empty"));
+        assert!(is_reconnect_worthy_message("connection refused by broker"));
+        assert!(is_reconnect_worthy_message("request timeout while talking to namesrv"));
+        assert!(!is_reconnect_worthy_message("consumer group not found"));
+        assert!(!is_reconnect_worthy_message("subscription group metadata is empty"));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::RocketMQError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
@@ -22,7 +23,7 @@ pub(crate) type ConsumerResult<T> = Result<T, ConsumerError>;
 pub(crate) enum ConsumerError {
     Configuration(String),
     Validation(String),
-    RocketMQ(String),
+    RocketMQ(RocketMQError),
 }
 
 impl fmt::Display for ConsumerError {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/admin.rs
@@ -46,10 +46,7 @@ impl ManagedMessageAdmin {
             .client_config_mut()
             .set_vip_channel_enabled(snapshot.use_vip_channel);
         admin.client_config_mut().set_use_tls(snapshot.use_tls);
-        admin
-            .start()
-            .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+        admin.start().await.map_err(MessageError::RocketMQ)?;
 
         Ok(Self {
             admin,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -61,6 +61,8 @@ use rocketmq_dashboard_common::MessageKeyQueryRequest;
 use rocketmq_dashboard_common::MessagePageQueryRequest;
 use rocketmq_dashboard_common::MessageTraceQueryRequest;
 use rocketmq_dashboard_common::ViewMessageRequest;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::body::cm_result::CMResult;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -508,7 +510,7 @@ impl MessageManager {
 
     fn should_reset_session<T>(result: &MessageResult<T>) -> bool {
         match result {
-            Err(MessageError::RocketMQ(message)) => is_reconnect_worthy_error(message),
+            Err(MessageError::RocketMQ(error)) => is_reconnect_worthy_error(error),
             _ => false,
         }
     }
@@ -688,7 +690,7 @@ impl MessageManager {
         let route = admin
             .examine_topic_route_info(CheetahString::from(query.topic.clone()))
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?
+            .map_err(MessageError::RocketMQ)?
             .unwrap_or_default();
 
         let mut broker_addr_map = HashMap::new();
@@ -717,7 +719,7 @@ impl MessageManager {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| MessageError::RocketMQ(error.to_string()))? as i64;
+                    .map_err(MessageError::RocketMQ)? as i64;
                 let end = admin
                     .search_offset(
                         CheetahString::from(broker_addr.clone()),
@@ -727,7 +729,7 @@ impl MessageManager {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| MessageError::RocketMQ(error.to_string()))? as i64;
+                    .map_err(MessageError::RocketMQ)? as i64;
 
                 queue_states.push(QueueScanState::new(
                     idx,
@@ -775,7 +777,7 @@ impl MessageManager {
                     PULL_TIMEOUT_MILLIS,
                 )
                 .await
-                .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+                .map_err(MessageError::RocketMQ)?;
 
             match result.pull_status() {
                 PullStatus::Found => {
@@ -855,7 +857,7 @@ impl MessageManager {
                     PULL_TIMEOUT_MILLIS,
                 )
                 .await
-                .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+                .map_err(MessageError::RocketMQ)?;
 
             match result.pull_status() {
                 PullStatus::Found => {
@@ -913,7 +915,7 @@ impl MessageManager {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+                    .map_err(MessageError::RocketMQ)?;
 
                 match result.pull_status() {
                     PullStatus::Found => {
@@ -973,7 +975,7 @@ impl MessageManager {
                 None,
             )
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+            .map_err(MessageError::RocketMQ)?;
 
         let mut items: Vec<MessageSummaryView> =
             result.message_list().iter().cloned().map(map_message_summary).collect();
@@ -1101,7 +1103,7 @@ impl MessageManager {
                 CheetahString::from(request.message_id.clone()),
             )
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+            .map_err(MessageError::RocketMQ)?;
 
         Ok(build_message_resend_result(
             request.consumer_group,
@@ -1160,7 +1162,7 @@ impl MessageManager {
                 CheetahString::from(message_id),
             )
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))
+            .map_err(MessageError::RocketMQ)
     }
 
     async fn query_message_trace_by_id_with_admin(
@@ -1206,7 +1208,7 @@ impl MessageManager {
                 None,
             )
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+            .map_err(MessageError::RocketMQ)?;
 
         let mut seeds = Vec::new();
 
@@ -1345,7 +1347,11 @@ fn sort_message_summaries_desc(items: &mut [MessageSummaryView]) {
     });
 }
 
-fn is_reconnect_worthy_error(message: &str) -> bool {
+fn is_reconnect_worthy_error(error: &RocketMQError) -> bool {
+    matches!(error.kind(), ErrorKind::Network | ErrorKind::Timeout) || is_reconnect_worthy_message(&error.to_string())
+}
+
+fn is_reconnect_worthy_message(message: &str) -> bool {
     let normalized = message.to_ascii_lowercase();
     normalized.contains("connection refused")
         || normalized.contains("connection reset")
@@ -1471,10 +1477,7 @@ fn normalize_direct_consume_request(
 }
 
 async fn dlq_topic_exists_with_admin(admin: &mut DefaultMQAdminExt, topic: &str) -> MessageResult<bool> {
-    let topic_list = admin
-        .fetch_all_topic_list()
-        .await
-        .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+    let topic_list = admin.fetch_all_topic_list().await.map_err(MessageError::RocketMQ)?;
 
     Ok(topic_list.topic_list.iter().any(|item| item.as_str() == topic))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::RocketMQError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -23,7 +24,7 @@ pub(crate) type MessageResult<T> = Result<T, MessageError>;
 pub(crate) enum MessageError {
     Configuration(String),
     Validation(String),
-    RocketMQ(String),
+    RocketMQ(RocketMQError),
 }
 
 impl fmt::Display for MessageError {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/admin.rs
@@ -48,10 +48,7 @@ impl ManagedProducerAdmin {
             .client_config_mut()
             .set_vip_channel_enabled(snapshot.use_vip_channel);
         admin.client_config_mut().set_use_tls(snapshot.use_tls);
-        admin
-            .start()
-            .await
-            .map_err(|error| ProducerError::RocketMQ(error.to_string()))?;
+        admin.start().await.map_err(ProducerError::RocketMQ)?;
 
         Ok(Self {
             admin,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
@@ -174,7 +174,7 @@ impl ProducerManager {
         let connection = admin
             .examine_producer_connection_info(request.producer_group.clone().into(), request.topic.clone().into())
             .await
-            .map_err(|error| ProducerError::RocketMQ(error.to_string()))?;
+            .map_err(ProducerError::RocketMQ)?;
 
         Ok(build_connection_view(request, connection))
     }
@@ -184,10 +184,7 @@ impl ProducerManager {
         admin: &mut DefaultMQAdminExt,
         snapshot: &NameServerConfigSnapshot,
     ) -> ProducerResult<ProducerTopicOptionsView> {
-        let topic_list = admin
-            .fetch_all_topic_list()
-            .await
-            .map_err(|error| ProducerError::RocketMQ(error.to_string()))?;
+        let topic_list = admin.fetch_all_topic_list().await.map_err(ProducerError::RocketMQ)?;
         let mut topics: Vec<String> = topic_list.topic_list.iter().map(|topic| topic.to_string()).collect();
         topics.sort();
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::RocketMQError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
@@ -22,7 +23,7 @@ pub(crate) type ProducerResult<T> = Result<T, ProducerError>;
 pub(crate) enum ProducerError {
     Configuration(String),
     Validation(String),
-    RocketMQ(String),
+    RocketMQ(RocketMQError),
 }
 
 impl fmt::Display for ProducerError {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
@@ -46,10 +46,7 @@ impl ManagedTopicAdmin {
             .client_config_mut()
             .set_vip_channel_enabled(snapshot.use_vip_channel);
         admin.client_config_mut().set_use_tls(snapshot.use_tls);
-        admin
-            .start()
-            .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        admin.start().await.map_err(TopicError::RocketMQ)?;
 
         Ok(Self {
             admin,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -61,6 +61,7 @@ use rocketmq_dashboard_common::TopicConfigQueryRequest;
 use rocketmq_dashboard_common::TopicConfigRequest;
 use rocketmq_dashboard_common::TopicListRequest;
 use rocketmq_dashboard_common::TopicQueryRequest;
+use rocketmq_error::ErrorKind;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
@@ -499,7 +500,7 @@ impl TopicManager {
 
     fn should_reset_session<T>(result: &TopicResult<T>) -> bool {
         match result {
-            Err(TopicError::RocketMQ(message)) => is_reconnect_worthy_error(message),
+            Err(TopicError::RocketMQ(error)) => is_reconnect_worthy_error(error),
             _ => false,
         }
     }
@@ -510,14 +511,11 @@ impl TopicManager {
         snapshot: &NameServerConfigSnapshot,
         request: TopicListRequest,
     ) -> TopicResult<TopicListResponse> {
-        let topic_list = admin
-            .fetch_all_topic_list()
-            .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let topic_list = admin.fetch_all_topic_list().await.map_err(TopicError::RocketMQ)?;
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         let targets = cluster_targets_from_cluster_info(&cluster_info);
         let topic_configs = collect_topic_configs(admin, &cluster_info).await?;
 
@@ -538,7 +536,7 @@ impl TopicManager {
             let route = admin
                 .examine_topic_route_info(topic.clone().into())
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+                .map_err(TopicError::RocketMQ)?
                 .unwrap_or_default();
             let (clusters, brokers, read_queue_count, write_queue_count, perm) = summarize_route(&route);
 
@@ -586,7 +584,7 @@ impl TopicManager {
         let request = StatsAllQueryRequest::new(false, None::<String>);
         let stats_result = StatsService::query_stats_all_with_admin(admin, &request)
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
 
         Ok(TopicCurrentStatsResponse {
             items: build_topic_current_stats_items(stats_result.rows),
@@ -633,7 +631,7 @@ impl TopicManager {
                             master_addr,
                             error_message
                         );
-                        last_error = Some(error_message);
+                        last_error = Some(error);
                     }
                 }
             }
@@ -641,7 +639,10 @@ impl TopicManager {
 
         if successful_brokers == 0 {
             return Err(TopicError::RocketMQ(last_error.unwrap_or_else(|| {
-                format!("Topic `{}` has no reachable master broker.", request.topic)
+                RocketMQError::response_process_failed(
+                    "examine_topic_stats",
+                    format!("Topic `{}` has no reachable master broker.", request.topic),
+                )
             })));
         }
 
@@ -663,7 +664,7 @@ impl TopicManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         let route = require_topic_route(admin, &request.topic).await?;
         let broker_configs = collect_route_topic_configs(admin, &route, &request.topic).await?;
         let selected_config = match request.broker_name.as_deref() {
@@ -701,7 +702,7 @@ impl TopicManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         let mut target_addrs = HashSet::new();
         let mut target_broker_names = HashSet::new();
         for cluster_name in &request.cluster_name_list {
@@ -768,7 +769,7 @@ impl TopicManager {
             admin
                 .create_and_update_topic_config(broker_addr.clone(), topic_config.clone())
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                .map_err(TopicError::RocketMQ)?;
         }
 
         if request.order {
@@ -776,7 +777,7 @@ impl TopicManager {
             admin
                 .create_or_update_order_conf(request.topic_name.clone().into(), order_conf.into(), true)
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                .map_err(TopicError::RocketMQ)?;
         }
 
         Ok(TopicMutationResult {
@@ -822,7 +823,7 @@ impl TopicManager {
             admin
                 .delete_topic(topic.clone().into(), cluster_name.clone().into())
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                .map_err(TopicError::RocketMQ)?;
         }
 
         Ok(TopicMutationResult {
@@ -851,7 +852,7 @@ impl TopicManager {
         let cluster_info = admin
             .examine_broker_cluster_info()
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         let broker_addr = find_master_addr_by_broker_name(&cluster_info, &broker_name).ok_or_else(|| {
             TopicError::Validation(format!(
                 "Broker `{broker_name}` was not found in the current cluster view."
@@ -867,7 +868,7 @@ impl TopicManager {
         admin
             .delete_topic_in_broker(HashSet::from([broker_addr]), topic.clone().into())
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
 
         Ok(TopicMutationResult {
             success: true,
@@ -885,7 +886,7 @@ impl TopicManager {
         let groups = admin
             .query_topic_consume_by_who(request.topic.clone().into())
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         let mut consumer_groups: Vec<String> = groups.group_list.into_iter().map(|group| group.to_string()).collect();
         consumer_groups.sort();
         Ok(TopicConsumerGroupListResponse {
@@ -918,7 +919,7 @@ impl TopicManager {
                     None,
                 )
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                .map_err(TopicError::RocketMQ)?;
             items.push(TopicConsumerInfoView {
                 consumer_group,
                 total_diff: stats.compute_total_diff(),
@@ -981,10 +982,10 @@ impl TopicManager {
                                 request.force,
                             )
                             .await
-                            .map_err(|fallback_error| TopicError::RocketMQ(fallback_error.to_string()))?;
+                            .map_err(TopicError::RocketMQ)?;
                         affected_queues += rollback_stats.len();
                     }
-                    Err(error) => return Err(TopicError::RocketMQ(error.to_string())),
+                    Err(error) => return Err(TopicError::RocketMQ(error)),
                 }
             }
 
@@ -1059,19 +1060,20 @@ impl TopicManager {
             .client_config(client_config)
             .build();
 
-        producer
-            .start()
-            .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        producer.start().await.map_err(TopicError::RocketMQ)?;
 
         let message = build_send_message(&request, &normalized_message_body);
         let send_result = producer
             .send_with_timeout(message, 5_000)
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()));
+            .map_err(TopicError::RocketMQ);
         producer.shutdown().await;
-        let send_result = send_result?
-            .ok_or_else(|| TopicError::RocketMQ("Broker acknowledged send without returning a result.".into()))?;
+        let send_result = send_result?.ok_or_else(|| {
+            TopicError::RocketMQ(RocketMQError::response_process_failed(
+                "send_message",
+                "Broker acknowledged send without returning a result.",
+            ))
+        })?;
 
         Ok(map_send_result(request.topic, send_result))
     }
@@ -1132,7 +1134,10 @@ async fn send_transaction_message_with_runtime(
             move || -> TopicResult<TopicSendMessageResult> {
                 let runtime = transaction_message_runtime()?;
                 let runtime = runtime.lock().map_err(|error| {
-                    TopicError::RocketMQ(format!("transaction message runtime lock poisoned: {error}"))
+                    TopicError::RocketMQ(RocketMQError::response_process_failed(
+                        "transaction_message_runtime",
+                        format!("transaction message runtime lock poisoned: {error}"),
+                    ))
                 })?;
 
                 runtime.block_on(async move {
@@ -1153,16 +1158,13 @@ async fn send_transaction_message_with_runtime(
                         .transaction_listener(DashboardTransactionListener)
                         .build();
 
-                    producer
-                        .start()
-                        .await
-                        .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                    producer.start().await.map_err(TopicError::RocketMQ)?;
 
                     let message = build_send_message(&request, &normalized_message_body);
                     let tx_result = producer
                         .send_message_in_transaction::<(), _>(message, None)
                         .await
-                        .map_err(|error| TopicError::RocketMQ(error.to_string()));
+                        .map_err(TopicError::RocketMQ);
                     producer.shutdown().await;
                     let tx_result = tx_result?;
 
@@ -1171,14 +1173,22 @@ async fn send_transaction_message_with_runtime(
             },
         )
         .await
-        .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+        .map_err(|error| {
+            TopicError::RocketMQ(RocketMQError::response_process_failed(
+                "dashboard-topic-transaction-send",
+                error.to_string(),
+            ))
+        })?
 }
 
 fn transaction_message_blocking_executor() -> TopicResult<BlockingExecutor> {
     let runtime = transaction_message_runtime()?;
-    let runtime = runtime
-        .lock()
-        .map_err(|error| TopicError::RocketMQ(format!("transaction message runtime lock poisoned: {error}")))?;
+    let runtime = runtime.lock().map_err(|error| {
+        TopicError::RocketMQ(RocketMQError::response_process_failed(
+            "transaction_message_runtime",
+            format!("transaction message runtime lock poisoned: {error}"),
+        ))
+    })?;
     Ok(runtime.context().blocking().clone())
 }
 
@@ -1200,7 +1210,12 @@ fn transaction_message_runtime() -> TopicResult<&'static StdMutex<RuntimeOwner>>
         },
         ..RuntimeConfig::default()
     })
-    .map_err(|error| TopicError::RocketMQ(format!("failed to start transaction message runtime: {error}")))?;
+    .map_err(|error| {
+        TopicError::RocketMQ(RocketMQError::response_process_failed(
+            "transaction_message_runtime",
+            format!("failed to start transaction message runtime: {error}"),
+        ))
+    })?;
 
     let _ = TRANSACTION_MESSAGE_RUNTIME.set(StdMutex::new(runtime));
     Ok(TRANSACTION_MESSAGE_RUNTIME
@@ -1247,7 +1262,10 @@ fn map_transaction_send_result(
     transaction_result: rocketmq_client_rust::producer::transaction_send_result::TransactionSendResult,
 ) -> TopicResult<TopicSendMessageResult> {
     let send_result = transaction_result.send_result.ok_or_else(|| {
-        TopicError::RocketMQ("Transaction producer completed without returning a send result.".into())
+        TopicError::RocketMQ(RocketMQError::response_process_failed(
+            "send_message_in_transaction",
+            "Transaction producer completed without returning a send result.",
+        ))
     })?;
     let mut result = map_send_result(topic, send_result);
     result.local_transaction_state = transaction_result
@@ -1290,7 +1308,7 @@ async fn require_topic_route(admin: &mut DefaultMQAdminExt, topic: &str) -> Topi
     admin
         .examine_topic_route_info(topic.to_string().into())
         .await
-        .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+        .map_err(TopicError::RocketMQ)?
         .ok_or_else(|| TopicError::Validation(format!("Topic `{topic}` was not found.")))
 }
 
@@ -1350,7 +1368,7 @@ async fn collect_topic_configs(
         let wrapper: TopicConfigSerializeWrapper = admin
             .get_all_topic_config(broker_addr, 5_000)
             .await
-            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            .map_err(TopicError::RocketMQ)?;
         if let Some(config_table) = wrapper.topic_config_table() {
             for (topic, config) in config_table {
                 topic_configs
@@ -1420,14 +1438,18 @@ fn master_targets_by_cluster_name(
     cluster_info: &ClusterInfo,
     cluster_name: &str,
 ) -> TopicResult<Vec<(String, CheetahString)>> {
-    let cluster_addr_table = cluster_info
-        .cluster_addr_table
-        .as_ref()
-        .ok_or_else(|| TopicError::RocketMQ("NameServer did not return cluster address data.".into()))?;
-    let broker_addr_table = cluster_info
-        .broker_addr_table
-        .as_ref()
-        .ok_or_else(|| TopicError::RocketMQ("NameServer did not return broker address data.".into()))?;
+    let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
+        TopicError::RocketMQ(RocketMQError::response_process_failed(
+            "examine_broker_cluster_info",
+            "NameServer did not return cluster address data.",
+        ))
+    })?;
+    let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
+        TopicError::RocketMQ(RocketMQError::response_process_failed(
+            "examine_broker_cluster_info",
+            "NameServer did not return broker address data.",
+        ))
+    })?;
     let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
         TopicError::Validation(format!(
             "Cluster `{cluster_name}` was not found in the current NameServer view."
@@ -1457,7 +1479,7 @@ async fn collect_route_topic_configs(
             let config = admin
                 .examine_topic_config(master_addr.clone(), topic.to_string().into())
                 .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                .map_err(TopicError::RocketMQ)?;
             snapshots.push(TopicBrokerConfigSnapshot {
                 broker_name: broker.broker_name().to_string(),
                 cluster_name: Some(broker.cluster().to_string()),
@@ -1732,7 +1754,11 @@ fn map_status_view(topic: &str, stats: &TopicStatsTable) -> TopicStatusView {
     }
 }
 
-fn is_reconnect_worthy_error(message: &str) -> bool {
+fn is_reconnect_worthy_error(error: &RocketMQError) -> bool {
+    matches!(error.kind(), ErrorKind::Network | ErrorKind::Timeout) || is_reconnect_worthy_message(&error.to_string())
+}
+
+fn is_reconnect_worthy_message(message: &str) -> bool {
     let normalized = message.to_ascii_lowercase();
     [
         "connect",
@@ -1875,7 +1901,7 @@ mod tests {
     use super::classify_topic;
     use super::cluster_targets_from_cluster_info;
     use super::find_master_addr_by_broker_name;
-    use super::is_reconnect_worthy_error;
+    use super::is_reconnect_worthy_message;
     use super::map_send_result;
     use super::map_transaction_send_result;
     use super::master_targets_by_cluster_name;
@@ -2106,10 +2132,10 @@ mod tests {
 
     #[test]
     fn reconnect_error_detection_only_matches_transport_failures() {
-        assert!(is_reconnect_worthy_error("connection refused by broker"));
-        assert!(is_reconnect_worthy_error("request timeout while talking to namesrv"));
-        assert!(!is_reconnect_worthy_error("topic stats info not found"));
-        assert!(!is_reconnect_worthy_error("topic returned no queue offset data"));
+        assert!(is_reconnect_worthy_message("connection refused by broker"));
+        assert!(is_reconnect_worthy_message("request timeout while talking to namesrv"));
+        assert!(!is_reconnect_worthy_message("topic stats info not found"));
+        assert!(!is_reconnect_worthy_message("topic returned no queue offset data"));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::RocketMQError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -23,7 +24,7 @@ pub(crate) type TopicResult<T> = Result<T, TopicError>;
 pub(crate) enum TopicError {
     Configuration(String),
     Validation(String),
-    RocketMQ(String),
+    RocketMQ(RocketMQError),
 }
 
 impl fmt::Display for TopicError {

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2253,7 +2253,6 @@ dependencies = [
 name = "rocketmq-common"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "base64",
  "byteorder",
  "bytes",

--- a/rocketmq-example/examples/interop/request_code_smoke.rs
+++ b/rocketmq-example/examples/interop/request_code_smoke.rs
@@ -91,10 +91,7 @@ async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {
         .name_server_addr(config.namesrv_addr.as_str())
         .build();
 
-    producer
-        .start()
-        .await
-        .map_err(|err| RocketMQError::Internal(format!("producer start failed: {err}")))?;
+    producer.start().await?;
 
     let mut expected_bodies = Vec::with_capacity(config.message_count);
     for index in 0..config.message_count {
@@ -106,14 +103,12 @@ async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {
             .body_slice(body.as_bytes())
             .build()?;
 
-        let result = producer
-            .send_with_timeout(message, config.send_timeout_ms)
-            .await
-            .map_err(|err| RocketMQError::Internal(format!("producer send failed: {err}")))?;
+        let result = producer.send_with_timeout(message, config.send_timeout_ms).await?;
         if result.is_none() {
             producer.shutdown().await;
-            return Err(RocketMQError::Internal(
-                "producer returned no send result for request-code smoke".to_string(),
+            return Err(RocketMQError::response_process_failed(
+                "request_code_smoke_send",
+                "producer returned no send result for request-code smoke",
             ));
         }
         expected_bodies.push(body);
@@ -136,20 +131,19 @@ async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {
         .pull_batch_size(config.message_count as u32)
         .build();
 
-    consumer
-        .subscribe(config.topic.as_str(), "*")
-        .await
-        .map_err(|err| RocketMQError::Internal(format!("consumer subscribe failed: {err}")))?;
+    consumer.subscribe(config.topic.as_str(), "*").await?;
     consumer.register_message_listener_concurrently(listener);
-    consumer
-        .start()
-        .await
-        .map_err(|err| RocketMQError::Internal(format!("consumer start failed: {err}")))?;
+    consumer.start().await?;
 
     for _ in 0..config.poll_attempts {
         let received_count = received_bodies
             .lock()
-            .map_err(|err| RocketMQError::Internal(format!("received body lock poisoned: {err}")))?
+            .map_err(|err| {
+                RocketMQError::response_process_failed(
+                    "request_code_smoke_received_body_lock",
+                    format!("received body lock poisoned: {err}"),
+                )
+            })?
             .len();
 
         if received_count >= expected_bodies.len() {
@@ -161,7 +155,12 @@ async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {
 
     let received_bodies = received_bodies
         .lock()
-        .map_err(|err| RocketMQError::Internal(format!("received body lock poisoned: {err}")))?
+        .map_err(|err| {
+            RocketMQError::response_process_failed(
+                "request_code_smoke_received_body_lock",
+                format!("received body lock poisoned: {err}"),
+            )
+        })?
         .clone();
 
     producer.shutdown().await;
@@ -173,9 +172,13 @@ async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {
         .collect::<Vec<_>>();
 
     if !missing.is_empty() {
-        return Err(RocketMQError::Internal(format!(
-            "request-code smoke did not receive expected messages: missing={missing:?}, received={received_bodies:?}"
-        )));
+        return Err(RocketMQError::response_process_failed(
+            "request_code_smoke_receive",
+            format!(
+                "request-code smoke did not receive expected messages: missing={missing:?}, \
+                 received={received_bodies:?}"
+            ),
+        ));
     }
 
     println!(
@@ -200,10 +203,12 @@ impl MessageListenerConcurrently for SmokeListener {
         msgs: &[&MessageExt],
         _context: &ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
-        let mut received_bodies = self
-            .received_bodies
-            .lock()
-            .map_err(|err| RocketMQError::Internal(format!("received body lock poisoned: {err}")))?;
+        let mut received_bodies = self.received_bodies.lock().map_err(|err| {
+            RocketMQError::response_process_failed(
+                "request_code_smoke_received_body_lock",
+                format!("received body lock poisoned: {err}"),
+            )
+        })?;
 
         for message in msgs {
             if let Some(body) = message.get_body() {

--- a/rocketmq-example/examples/producer/request_callback_send.rs
+++ b/rocketmq-example/examples/producer/request_callback_send.rs
@@ -74,10 +74,13 @@ pub async fn main() -> RocketMQResult<()> {
 
     match tokio::time::timeout(Duration::from_millis(REQUEST_TIMEOUT_MS.saturating_mul(3)), rx.recv()).await {
         Ok(Some(Ok(()))) => {}
-        Ok(Some(Err(error))) => return Err(RocketMQError::Internal(error)),
+        Ok(Some(Err(error))) => {
+            return Err(RocketMQError::response_process_failed("request_callback_reply", error));
+        }
         Ok(None) => {
-            return Err(RocketMQError::Internal(
-                "request callback channel closed before receiving a reply".to_string(),
+            return Err(RocketMQError::response_process_failed(
+                "request_callback_reply",
+                "request callback channel closed before receiving a reply",
             ));
         }
         Err(_) => {


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7923

### Brief Description

- Changes Tauri standalone domain errors to keep `RocketMQError` instead of stringifying RocketMQ admin/client failures in service layers.
- Uses typed `ErrorKind::Network` and `ErrorKind::Timeout` for reconnect decisions while preserving the previous message heuristic as a fallback.
- Replaces affected example `RocketMQError::Internal` wrappers with direct typed propagation or `response_process_failed` for local response/channel/lock failures.
- Refreshes standalone lockfiles after the already-merged `rocketmq-common` public-anyhow cleanup.

### How Did You Test This Change?

- `cargo fmt --all` passed from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`.
- `cargo test --lib reconnect_error_detection_only_matches_transport_failures` passed from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`.
- `cargo clippy --all-targets --all-features -- -D warnings` passed from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`.
- `cargo test --lib` passed from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`.
- `cargo fmt --all` passed from `rocketmq-example`.
- `cargo build --example producer-request-callback-send` passed from `rocketmq-example`.
- `cargo build --example request-code-smoke` passed from `rocketmq-example`.
- `cargo clippy --all-targets -- -D warnings` passed from `rocketmq-example`.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across cluster, consumer, message, producer, and topic workflows for more reliable failures.
  * Reworked reconnect detection to better recognize network and timeout issues.
  * Added more structured error messages in example flows, including startup, send/receive, and callback handling.
  * Updated interop behavior so missing results and polling issues return clearer, more consistent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->