### PR TITLE
[ISSUE #7925]♻️Route processor failures through adapter

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use rocketmq_auth::AuthRuntime;
 use rocketmq_remoting::code::request_code::RequestCode;
-use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -307,11 +307,7 @@ where
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if let Some(auth_runtime) = &self.auth_runtime {
             if let Err(error) = auth_runtime.check_remoting(&ctx, request).await {
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::NoPermission,
-                    error.to_string(),
-                )
-                .set_opaque(request.opaque());
+                let response = error_response::command_from_error_with_opaque(&error, request.opaque());
                 return Ok(Some(response));
             }
         }
@@ -341,11 +337,9 @@ where
                     .await
                 }
                 None => {
-                    let response_command = RemotingCommand::create_response_command_with_code_remark(
-                        rocketmq_remoting::code::response_code::ResponseCode::RequestCodeNotSupported,
-                        format!("The request code {} is not supported.", request.code_ref()),
-                    );
-                    Ok(Some(response_command.set_opaque(request.opaque())))
+                    let response =
+                        error_response::request_code_not_supported_with_opaque(request.code(), request.opaque());
+                    Ok(Some(response))
                 }
             },
         }
@@ -358,11 +352,7 @@ where
                 if let Some(default_processor) = &self.default_request_processor {
                     default_processor.reject_request(code)
                 } else {
-                    let response_command = RemotingCommand::create_response_command_with_code_remark(
-                        rocketmq_remoting::code::response_code::ResponseCode::RequestCodeNotSupported,
-                        format!("The request code {code} is not supported."),
-                    );
-                    (true, Some(response_command))
+                    (true, Some(error_response::request_code_not_supported(code)))
                 }
             }
         }
@@ -583,8 +573,7 @@ fn fast_failure_queue_kind(request_code: i32, default_processor: bool) -> Option
 }
 
 fn system_error_response(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
-    RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, remark.into())
-        .set_opaque(opaque)
+    error_response::internal_error_with_opaque(opaque, remark)
 }
 
 #[cfg(test)]
@@ -592,6 +581,7 @@ mod tests {
     use super::*;
     use rocketmq_auth::config::AuthConfig;
     use rocketmq_auth::AuthRuntimeBuilder;
+    use rocketmq_remoting::code::response_code::ResponseCode;
     use rocketmq_remoting::local::LocalRequestHarness;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -28,6 +28,7 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::batch_ack::BatchAck;
 use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
@@ -78,11 +79,11 @@ where
             }
             _ => {
                 warn!("AckMessageProcessor received unknown request code: {:?}", request_code);
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                Ok(Some(error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("AckMessageProcessor request code {} not supported", request.code()),
-                );
-                Ok(Some(response.set_opaque(request.opaque())))
+                    request.opaque(),
+                )))
             }
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -45,6 +45,7 @@ use rocketmq_error::AuthError;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -612,8 +613,8 @@ fn get_unknown_cmd_response(request_code: RequestCode) -> Option<RemotingCommand
         request_code,
         request_code.to_i32()
     );
-    Some(RemotingCommand::create_response_command_with_code_remark(
-        ResponseCode::RequestCodeNotSupported,
+    Some(error_response::request_code_not_supported_with_remark(
+        request_code.to_i32(),
         format!(" request type {} not supported", request_code.to_i32()),
     ))
 }
@@ -625,8 +626,8 @@ fn get_legacy_acl_cmd_response(request_code: RequestCode, remark: &str) -> Optio
         request_code.to_i32(),
         remark
     );
-    Some(RemotingCommand::create_response_command_with_code_remark(
-        ResponseCode::RequestCodeNotSupported,
+    Some(error_response::request_code_not_supported_with_remark(
+        request_code.to_i32(),
         remark,
     ))
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -22,6 +22,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
 use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
@@ -286,10 +287,12 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         let _ = config_types;
 
         Ok(Some(
-            response.set_code(ResponseCode::RequestCodeNotSupported).set_remark(
+            error_response::request_code_not_supported_with_remark(
+                request.code(),
                 "EXPORT_ROCKSDB_CONFIG_TO_JSON requires a real RocksDB config backend; current Rust broker uses \
                  file-backed config managers",
-            ),
+            )
+            .set_opaque(request.opaque()),
         ))
     }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -15,6 +15,7 @@
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_remoting::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader;
@@ -344,11 +345,14 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let _request_header = request.decode_command_custom_header::<CheckRocksdbCqWriteProgressRequestHeader>()?;
-        Ok(Some(RemotingCommand::create_response_command_with_code_remark(
-            ResponseCode::RequestCodeNotSupported,
-            "CHECK_ROCKSDB_CQ_WRITE_PROGRESS requires a real RocksDB consume queue backend; current Rust broker uses \
-             file-backed consume queues",
-        )))
+        Ok(Some(
+            error_response::request_code_not_supported_with_remark(
+                request.code(),
+                "CHECK_ROCKSDB_CQ_WRITE_PROGRESS requires a real RocksDB consume queue backend; current Rust broker \
+                 uses file-backed consume queues",
+            )
+            .set_opaque(request.opaque()),
+        ))
     }
 
     pub async fn get_all_subscription_group_config(

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -23,6 +23,7 @@ use rocketmq_common::common::FAQUrl;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
 use rocketmq_remoting::protocol::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
@@ -69,14 +70,15 @@ where
                     "ChangeInvisibleTimeProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!(
                         "ChangeInvisibleTimeProcessor request code {} not supported",
                         request.code()
                     ),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -26,6 +26,7 @@ use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_filter::filter::FilterFactory;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
 use rocketmq_remoting::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
@@ -69,11 +70,12 @@ where
                     "ClientManageProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("ClientManageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }
@@ -106,13 +108,11 @@ where
             RequestCode::HeartBeat => self.heart_beat(channel, ctx, request).await,
             RequestCode::UnregisterClient => self.unregister_client(channel, ctx, request),
             RequestCode::CheckClientConfig => self.check_client_config(request),
-            _ => Ok(Some(
-                RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
-                    format!("ClientManageProcessor request code {} not supported", request.code()),
-                )
-                .set_opaque(request.opaque()),
-            )),
+            _ => Ok(Some(error_response::request_code_not_supported_with_remark_and_opaque(
+                request.code(),
+                format!("ClientManageProcessor request code {} not supported", request.code()),
+                request.opaque(),
+            ))),
         }
     }
 

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -14,6 +14,7 @@
 
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
@@ -61,11 +62,12 @@ where
                     "ConsumerManageProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("ConsumerManageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -25,6 +25,7 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -68,11 +69,12 @@ where
                     "EndTransactionProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -24,6 +24,7 @@ use rocketmq_common::common::lite::get_lite_topic;
 use rocketmq_common::common::lite::to_lmq_name;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::admin::topic_offset::TopicOffset;
@@ -78,10 +79,10 @@ impl<MS: MessageStore> RequestProcessor for LiteManagerProcessor<MS> {
             RequestCode::TriggerLiteDispatch => self.trigger_lite_dispatch(request),
             request_code => {
                 warn!("LiteManagerProcessor received unknown request code: {:?}", request_code);
-                Ok(Some(self.response_with_code(
-                    request,
-                    ResponseCode::RequestCodeNotSupported,
+                Ok(Some(error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("LiteManagerProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 )))
             }
         }

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -21,7 +21,9 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::FAQUrl;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::peek_message_request_header::PeekMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_response_header::PopMessageResponseHeader;
@@ -89,11 +91,13 @@ impl<MS: MessageStore> PeekMessageProcessor<MS> {
                     e,
                     channel.remote_address()
                 );
-                return Ok(Some(
-                    response
-                        .set_code(ResponseCode::RequestCodeNotSupported)
-                        .set_remark(format!("decode request header failed: {:?}", e)),
-                ));
+                let remark = format!("decode request header failed: {:?}", e);
+                let error = RocketMQError::request_header_error(remark.clone());
+                return Ok(Some(error_response::command_from_error_with_remark_and_opaque(
+                    &error,
+                    remark,
+                    request.opaque(),
+                )));
             }
         };
 

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -29,6 +29,7 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
 use rocketmq_remoting::protocol::forbidden_type::ForbiddenType;
@@ -144,11 +145,12 @@ where
             }
             _ => {
                 warn!("PullMessageProcessor received unknown request code: {:?}", request_code);
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("ClientManageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -29,6 +29,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
@@ -89,11 +90,12 @@ where
                     "QueryAssignmentProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("QueryAssignmentProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -17,6 +17,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::mix_all::UNIQUE_MSG_QUERY_FLAG;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::query_message_request_header::QueryMessageRequestHeader;
 use rocketmq_remoting::protocol::header::query_message_response_header::QueryMessageResponseHeader;
@@ -80,11 +81,12 @@ where
                     "QueryMessageProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("QueryMessageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -27,6 +27,7 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
@@ -81,14 +82,15 @@ where
                     "RecallMessageProcessor received unexpected request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!(
                         "RecallMessageProcessor does not support request code {}",
                         request.code()
                     ),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -22,6 +22,7 @@ use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
@@ -110,11 +111,12 @@ where
                     "ReplyMessageProcessor received unknown request code: {:?}",
                     request_code
                 );
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("ReplyMessageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -55,6 +55,7 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode::SystemError;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::parse_request_header;
@@ -136,11 +137,12 @@ where
             | RequestCode::ConsumerSendMsgBack => self.process_request_inner(channel, ctx, request_code, request).await,
             _ => {
                 warn!("SendMessageProcessor received unknown request code: {:?}", request_code);
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::RequestCodeNotSupported,
+                let response = error_response::request_code_not_supported_with_remark_and_opaque(
+                    request.code(),
                     format!("request code {} not supported", request.code()),
+                    request.opaque(),
                 );
-                Ok(Some(response.set_opaque(request.opaque())))
+                Ok(Some(response))
             }
         }
     }

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use rocketmq_remoting::code::request_code::RequestCode;
-use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -128,11 +128,9 @@ impl RequestProcessor for NameServerRequestProcessor {
         let response = match self.processor_table.get_mut(request.code_ref()) {
             None => match self.default_request_processor.as_mut() {
                 None => {
-                    let response_command = RemotingCommand::create_response_command_with_code_remark(
-                        ResponseCode::SystemError,
-                        format!("The request code {} is not supported.", request.code_ref()),
-                    );
-                    Ok(Some(response_command.set_opaque(request.opaque())))
+                    let response =
+                        error_response::request_code_not_supported_with_opaque(request.code(), request.opaque());
+                    Ok(Some(response))
                 }
                 Some(processor) => RequestProcessor::process_request(processor, channel, ctx, request).await,
             },

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -23,6 +23,7 @@ use rocketmq_common::CRC32Utils;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
 use rocketmq_remoting::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
@@ -114,8 +115,8 @@ impl DefaultRequestProcessor {
             RequestCode::GetHasUnitSubUnunitTopicList => self.get_has_unit_sub_un_unit_topic_list(request),
             RequestCode::UpdateNamesrvConfig => self.update_config(request),
             RequestCode::GetNamesrvConfig => self.get_config(request),
-            _ => Ok(RemotingCommand::create_response_command_with_code_remark(
-                RemotingSysResponseCode::RequestCodeNotSupported,
+            _ => Ok(error_response::request_code_not_supported_with_remark(
+                request.code(),
                 format!(" request type {} not supported", request.code()),
             )),
         }?;

--- a/rocketmq-remoting/src/error_response.rs
+++ b/rocketmq-remoting/src/error_response.rs
@@ -1,0 +1,130 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::ProtocolError;
+use rocketmq_error::RocketMQError;
+
+use crate::protocol::remoting_command::RemotingCommand;
+
+/// Convert a typed RocketMQ error into a remoting response command.
+pub fn command_from_error(error: &RocketMQError) -> RemotingCommand {
+    command_from_error_with_remark(error, error.to_string())
+}
+
+/// Convert a typed RocketMQ error into a remoting response command and preserve
+/// the request opaque.
+pub fn command_from_error_with_opaque(error: &RocketMQError, opaque: i32) -> RemotingCommand {
+    command_from_error(error).set_opaque(opaque)
+}
+
+/// Convert a typed RocketMQ error into a remoting response command with an
+/// explicit wire remark.
+pub fn command_from_error_with_remark(error: &RocketMQError, remark: impl Into<String>) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(error.spec().remoting.code.as_i32(), remark.into())
+}
+
+/// Convert a typed RocketMQ error into a remoting response command with an
+/// explicit wire remark and request opaque.
+pub fn command_from_error_with_remark_and_opaque(
+    error: &RocketMQError,
+    remark: impl Into<String>,
+    opaque: i32,
+) -> RemotingCommand {
+    command_from_error_with_remark(error, remark).set_opaque(opaque)
+}
+
+/// Build the standard unsupported-request-code response from the central
+/// remoting boundary mapping.
+pub fn request_code_not_supported(request_code: i32) -> RemotingCommand {
+    request_code_not_supported_with_remark(
+        request_code,
+        format!("The request code {request_code} is not supported."),
+    )
+}
+
+/// Build an unsupported-request-code response with a caller-specific remark.
+pub fn request_code_not_supported_with_remark(request_code: i32, remark: impl Into<String>) -> RemotingCommand {
+    let error = RocketMQError::Protocol(ProtocolError::invalid_command(request_code));
+    command_from_error_with_remark(&error, remark)
+}
+
+/// Build the standard unsupported-request-code response and preserve request
+/// opaque.
+pub fn request_code_not_supported_with_opaque(request_code: i32, opaque: i32) -> RemotingCommand {
+    request_code_not_supported(request_code).set_opaque(opaque)
+}
+
+/// Build an unsupported-request-code response with a caller-specific remark and
+/// request opaque.
+pub fn request_code_not_supported_with_remark_and_opaque(
+    request_code: i32,
+    remark: impl Into<String>,
+    opaque: i32,
+) -> RemotingCommand {
+    request_code_not_supported_with_remark(request_code, remark).set_opaque(opaque)
+}
+
+/// Build a generic internal-error response from the central remoting boundary
+/// mapping.
+pub fn internal_error_with_opaque(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
+    let remark = remark.into();
+    let error = RocketMQError::Internal(remark.clone());
+    command_from_error_with_remark_and_opaque(&error, remark, opaque)
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::RemotingResponseCode;
+
+    use super::*;
+    use crate::code::response_code::ResponseCode;
+
+    #[test]
+    fn command_from_error_uses_central_remoting_spec() {
+        let response = command_from_error(&RocketMQError::response_process_failed("decode", "bad header"));
+
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::from(RemotingResponseCode::InvalidParameter.as_i32())
+        );
+        assert!(response
+            .remark()
+            .expect("remark should be set")
+            .contains("Response decode failed"));
+    }
+
+    #[test]
+    fn request_code_not_supported_uses_protocol_spec_mapping() {
+        let response = request_code_not_supported_with_opaque(999, 7);
+
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert_eq!(response.opaque(), 7);
+        assert_eq!(
+            response.remark().map(|remark| remark.as_str()),
+            Some("The request code 999 is not supported.")
+        );
+    }
+
+    #[test]
+    fn internal_error_uses_system_error_mapping() {
+        let response = internal_error_with_opaque(9, "worker failed");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert_eq!(response.opaque(), 9);
+        assert_eq!(response.remark().map(|remark| remark.as_str()), Some("worker failed"));
+    }
+}

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -21,6 +21,7 @@ pub mod clients;
 pub mod code;
 pub mod codec;
 pub mod connection;
+pub mod error_response;
 pub mod net;
 pub mod prelude;
 pub mod protocol;


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7925

### Brief Description

Adds a shared remoting error-response adapter that converts `RocketMQError` into `RemotingCommand` via `ErrorSpec.remoting`, then routes broker and namesrv processor unsupported-code and generic failure responses through it. This removes duplicated processor-side unsupported request-code mappings and reclassifies peek header decode failures as typed request-header errors.

### How Did You Test This Change?

- `cargo test -p rocketmq-remoting error_response` passed.
- `cargo test -p rocketmq-broker legacy_acl_responses_are_explicitly_deprecated` passed.
- `cargo test -p rocketmq-broker check_rocksdb_cq_write_progress_without_rocksdb_returns_not_supported` passed.
- `cargo test -p rocketmq-broker export_rocksdb_config_without_rocksdb_returns_not_supported` passed.
- `cargo test -p rocketmq-namesrv processor` passed.
- `cargo fmt --all` passed.
- `git diff --check` passed.
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized error responses across broker and name server request handling.
  * Improved request tracking by preserving request identifiers in more failure cases.

* **Bug Fixes**
  * Unsupported or unknown requests now return more consistent, user-friendly error messages.
  * Internal and authentication failures now produce clearer error replies with preserved context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->