### PR TITLE
[ISSUE #7929]📝Publish error guide and runbooks

### DIFF
--- a/rocketmq-doc/README.md
+++ b/rocketmq-doc/README.md
@@ -58,6 +58,8 @@ rocketmq-doc/
 
 #### Contributing (19-*)
 - Contribution Guidelines
+- Error Architecture Contribution Guide
+- Error Architecture Runbooks
 - Code Review Process
 - Documentation Standards
 
@@ -87,6 +89,8 @@ We welcome contributions to improve our documentation! Please:
 - [Components](en/02-components.md)
 - [Error Architecture Redesign ADR](en/07-error-architecture-adr.md)
 - [Error Architecture Inventory](en/07-error-inventory.md)
+- [Error Architecture Contribution Guide](en/19-error-contribution-guide.md)
+- [Error Architecture Runbooks](en/19-error-runbooks.md)
 - [Running with Docker](en/01-run-rocketmq-rust-docker.md)
 - [Running on Kubernetes](en/01-run-rocketmq-rust-k8s.md)
 - [Contributing Guide](en/19-contribute-guide.md)

--- a/rocketmq-doc/en/19-error-contribution-guide.md
+++ b/rocketmq-doc/en/19-error-contribution-guide.md
@@ -1,0 +1,114 @@
+---
+title: "Error Architecture Contribution Guide"
+permalink: /docs/error-contribution-guide/
+excerpt: "How to add, map, test, and review typed RocketMQ Rust errors."
+last_modified_at: 2026-07-04T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# Error Architecture Contribution Guide
+
+This guide is the contribution contract for RocketMQ Rust error changes. The
+current direction is no-compatibility typed errors: new code must use the
+central `RocketMQError` architecture instead of adding legacy aliases or local
+string-only mappings.
+
+## Core Rules
+
+1. Use `rocketmq_error::RocketMQError` and `RocketMQResult<T>` for library
+   error contracts.
+2. Do not reintroduce `RocketmqError`, `RocketMqError`,
+   `LegacyRocketMQResult`, `LegacyResult`, or `rocketmq_error::Result`.
+3. Keep `anyhow` at application, binary, test, and one-shot tool boundaries.
+   Core library crates such as `rocketmq-error` and `rocketmq-common` must not
+   expose public `anyhow::Result` contracts.
+4. Add or reuse an `ErrorKind` and `ErrorSpec` entry before exposing a new
+   cross-boundary error.
+5. Boundary crates must map from `ErrorSpec` primitives instead of parsing
+   display text.
+6. Sensitive fields such as secret keys, tokens, signatures, and passwords must
+   be redacted in `Display`, `Debug`, logs, and exported diagnostics.
+
+## Where Changes Belong
+
+| Change type | Owner |
+| --- | --- |
+| New stable kind, code, severity, retry class, or redaction contract | `rocketmq-error` |
+| Remoting response code and remark conversion | `rocketmq-remoting::error_response` |
+| gRPC payload/status conversion | `rocketmq-proxy::status` |
+| Broker or NameServer external response conversion | Processor code using `rocketmq_remoting::error_response` |
+| Dashboard or HTTP conversion | Dashboard boundary error wrapper |
+| CLI display and exit behavior | CLI/tool boundary |
+| Domain-local storage, auth, controller, or client source preservation | Owning crate, then convert to `RocketMQError` at the boundary |
+
+## Adding A New Error
+
+Use this sequence for any new cross-boundary error:
+
+1. Add or reuse an `ErrorKind`.
+2. Add a stable `ErrorCode` and `ErrorSpec` entry.
+3. Define retry, severity, observability, remoting, gRPC, HTTP, and CLI
+   primitive metadata.
+4. Add a typed `RocketMQError` variant or domain error conversion.
+5. Update the relevant boundary adapter if the default metadata is not enough.
+6. Add focused tests for the new kind and the affected boundary.
+7. Run the error guard and the relevant Cargo validation.
+
+```powershell
+python scripts/error_architecture_guard.py
+cargo fmt --all
+cargo test -p rocketmq-error
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+## Boundary Mapping Pattern
+
+Boundary code should look up the spec and convert primitive metadata into local
+wire types.
+
+```rust
+use rocketmq_error::RocketMQError;
+use rocketmq_remoting::error_response;
+
+fn to_response(error: &RocketMQError, opaque: i32) -> RemotingCommand {
+    error_response::command_from_error_with_opaque(error, opaque)
+}
+```
+
+Do not add new mapping tables beside the boundary adapters unless the adapter
+itself is being extended.
+
+## Redaction Pattern
+
+Prefer `Sensitive<T>` or a small local redaction helper. Never format secret
+material directly.
+
+```rust
+use rocketmq_error::Sensitive;
+
+let secret = Sensitive::new(secret_key);
+tracing::warn!(secret = %secret, "authentication failed");
+```
+
+For custom `Debug` implementations, sensitive fields must render as
+`<redacted>` or route through an equivalent helper.
+
+## Review Checklist
+
+- Does the change add a typed error instead of a string-only internal error?
+- Does the new error have a stable `ErrorKind` and `ErrorSpec`?
+- Do remoting, gRPC, HTTP, CLI, retry, severity, and observability mappings
+  come from the central spec?
+- Are source errors preserved where they help debugging?
+- Are credentials, tokens, signatures, passwords, and authorization values
+  redacted?
+- Does the change avoid public `anyhow` in library APIs?
+- Did `python scripts/error_architecture_guard.py` pass?
+- Did the affected crate tests and required clippy command pass?
+
+## Useful References
+
+- [Error Architecture Redesign ADR](07-error-architecture-adr.md)
+- [Error Architecture Inventory](07-error-inventory.md)
+- [Error Architecture Runbooks](19-error-runbooks.md)

--- a/rocketmq-doc/en/19-error-runbooks.md
+++ b/rocketmq-doc/en/19-error-runbooks.md
@@ -1,0 +1,137 @@
+---
+title: "Error Architecture Runbooks"
+permalink: /docs/error-runbooks/
+excerpt: "Operational and CI runbooks for typed RocketMQ Rust errors."
+last_modified_at: 2026-07-04T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# Error Architecture Runbooks
+
+Use these runbooks when a typed error guard, boundary mapping, or redaction
+check fails.
+
+## Runbook: Error Guard Fails
+
+Command:
+
+```powershell
+python scripts/error_architecture_guard.py
+```
+
+Expected success markers:
+
+```text
+ERROR_ARCHITECTURE_GUARD_OK core public surface
+ERROR_ARCHITECTURE_GUARD_OK processor boundary mappings
+ERROR_ARCHITECTURE_GUARD_OK required mapping adapters
+ERROR_ARCHITECTURE_GUARD_OK redaction guards
+ERROR_ARCHITECTURE_GUARD_OK all
+```
+
+If the guard fails:
+
+1. Read the reported `path:line`.
+2. Identify the failed section name.
+3. Fix the source regression rather than weakening the guard.
+4. Add or update a focused test when the failure exposed missing coverage.
+5. Re-run the guard and the relevant Cargo command.
+
+## Runbook: Legacy Or Public Anyhow Regression
+
+Symptoms:
+
+- `RocketmqError`, `RocketMqError`, or `rocketmq_error::Result` appears in core
+  error/common code.
+- `anyhow::Result` or `anyhow::Error` appears in `rocketmq-error` or
+  `rocketmq-common` public contracts.
+
+Action:
+
+1. Replace the old type with `RocketMQError` or `RocketMQResult<T>`.
+2. If a domain crate needs private error detail, keep it local and convert to
+   `RocketMQError` at the boundary.
+3. If the code is a binary or tool entry point, keep `anyhow` at that boundary
+   and avoid exporting it back into library APIs.
+
+## Runbook: Processor Mapping Regression
+
+Symptoms:
+
+- The guard reports direct `RequestCodeNotSupported` use in broker or namesrv
+  processor production code.
+- A processor constructs a generic remoting error by hand.
+
+Action:
+
+1. Convert unsupported request-code responses with
+   `rocketmq_remoting::error_response::request_code_not_supported*`.
+2. Convert typed failures with
+   `rocketmq_remoting::error_response::command_from_error*`.
+3. Preserve request `opaque` where the old response did so.
+4. Keep business-specific success and domain response codes in the owning
+   processor.
+5. Run focused broker or namesrv tests plus the guard.
+
+## Runbook: gRPC Mapping Regression
+
+Symptoms:
+
+- Proxy returns the wrong `v2::Code` or `tonic::Code` for a `RocketMQError`.
+- A new proxy mapping table appears outside `rocketmq-proxy::status`.
+
+Action:
+
+1. Check the `ErrorKind` and `ErrorSpec.grpc` entry.
+2. Update central metadata first when the mapping is generic.
+3. Update `rocketmq-proxy::status` only when local gRPC translation is needed.
+4. Add a proxy status test for the affected error.
+
+## Runbook: Redaction Regression
+
+Symptoms:
+
+- Sensitive values appear in `Display`, `Debug`, logs, or test output.
+- The guard reports an unredacted `secret`, `password`, `token`, or
+  `signature` debug field.
+
+Action:
+
+1. Wrap sensitive values with `Sensitive<T>` or a local helper that returns
+   `<redacted>`.
+2. Update `Display` and `Debug` implementations together.
+3. Add a test that checks the secret value is absent and `<redacted>` is
+   present.
+4. Run:
+
+```powershell
+cargo test -p rocketmq-error error_context_redaction
+cargo test -p rocketmq-common debug_and_display_redact_secret_key
+python scripts/error_architecture_guard.py
+```
+
+## Runbook: New Error Kind Needs Mapping
+
+Action:
+
+1. Add the `ErrorKind`.
+2. Add the `ErrorSpec` row.
+3. Fill remoting, gRPC, HTTP, CLI, retry, severity, and observability metadata.
+4. Add registry completeness tests.
+5. Add at least one boundary test if the error crosses remoting, gRPC, HTTP, or
+   CLI.
+
+## Pull Request Evidence
+
+Every error architecture PR should include:
+
+- Issue link.
+- A short description of the affected boundary or domain.
+- Focused tests for the changed crate.
+- `python scripts/error_architecture_guard.py`.
+- `cargo fmt --all` for Rust changes.
+- Required clippy command for affected Rust projects.
+
+Use [Error Architecture Contribution Guide](19-error-contribution-guide.md) as
+the authoring checklist.


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7929

### Brief Description

Publishes the error architecture contribution guide and operational runbooks. The new docs explain typed error authoring rules, boundary adapter usage, redaction expectations, guard failure response, and required PR evidence. The documentation README now links the new guide and runbook.

### How Did You Test This Change?

- `git diff --check` passed.
- Verified `rocketmq-doc/en/19-error-contribution-guide.md` exists.
- Verified `rocketmq-doc/en/19-error-runbooks.md` exists.
- Verified `rocketmq-doc/README.md` links both new documents.
- Cargo validation was not run because this PR only changes Markdown documentation.
