### PR TITLE
[ISSUE #7933]♻️Improve the error kernel metadata contract

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -1,0 +1,558 @@
+---
+title: "Error 架构重构推进清单"
+permalink: /docs/zh/error-refactor-checklist/
+excerpt: "RocketMQ Rust error 架构重构未完成项、任务拆分和开发验收 checklist。"
+last_modified_at: 2026-07-04T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# Error 架构重构推进清单
+
+## 当前判断
+
+本清单基于 2026-07-04 对当前仓库的静态扫描和关键文件抽查。
+
+当前项目已经完成了重构中的一批关键基础项：
+
+- `RocketmqError`、`LegacyRocketMQResult`、`LegacyResult` 在 Rust 源码中已清零。
+- `rocketmq-error` 已有 `ErrorKind`、`ErrorCode`、`ErrorScope`、`ErrorSpec`、协议 primitive、`RetryClass`、`ObserveSpec`、`Sensitive<T>`。
+- `rocketmq-error` 已有 registry、protocol、policy、redaction 合约测试。
+- `rocketmq-macros` 已生成 typed `RocketMQError`。
+- `rocketmq-remoting` 和 `rocketmq-proxy` 已有部分边界 adapter 接入中心 spec。
+- `rocketmq-client` 已有 `retry_decision` 读取 `RetryClass`。
+- `SessionCredentials` 的 `Display` / `Debug` 已对 secret、signature、security token 脱敏。
+
+但按目标架构定义，整个项目还没有完全完成。剩余工作重点是：补厚 error kernel 合约、扩大边界 adapter 消费面、清理 public `anyhow`、减少字符串化 source、统一 redaction/observability，并把 guard 接入 CI。
+
+## 本次扫描信号
+
+以下计数是架构信号，不等同于 bug 数量；`to_string()`、`anyhow::Result` 和 `dyn Error` 需要结合上下文判断是否允许。
+
+| 区域 | Legacy | `anyhow::Result` | `Internal/General(String)` | `dyn Error` / downcast | spec/policy 使用 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `rocketmq-error` | 0 | 0 | 2 | 0 | 236 |
+| `rocketmq-remoting` | 0 | 5 | 0 | 6 | 1 |
+| `rocketmq-client` | 0 | 0 | 0 | 47 | 10 |
+| `rocketmq-broker` | 0 | 3 | 0 | 9 | 2 |
+| `rocketmq-store` | 0 | 5 | 0 | 3 | 70 |
+| `rocketmq-auth` | 0 | 0 | 0 | 15 | 6 |
+| `rocketmq-controller` | 0 | 2 | 0 | 9 | 6 |
+| `rocketmq-namesrv` | 0 | 2 | 0 | 0 | 0 |
+| `rocketmq-proxy` | 0 | 0 | 0 | 3 | 2 |
+| `rocketmq-common` | 0 | 0 | 0 | 1 | 3 |
+| `rocketmq-tools` | 0 | 22 | 0 | 0 | 0 |
+| `rocketmq-dashboard-common` | 0 | 10 | 0 | 0 | 0 |
+| dashboard web backend | 0 | 7 | 1 | 0 | 0 |
+| Tauri backend | 0 | 5 | 0 | 0 | 6 |
+| GPUI dashboard | 0 | 1 | 0 | 0 | 0 |
+| `rocketmq-example` | 0 | 0 | 0 | 0 | 0 |
+
+## 推进原则
+
+- 每个任务完成后，相关 Cargo project 必须能独立编译并通过 clippy。
+- 保持 `rocketmq-error` 低层依赖方向，不让它依赖 remoting、proxy、dashboard 或 tools。
+- `anyhow` 只允许在 binary、CLI、测试和一次性工具最外层出现；共享库和公共业务 API 不使用它作为契约。
+- 外部协议边界只把中心 spec primitive 转成本地类型，不在边界重新定义错误语义。
+- `to_string()` 只能用于最终展示、日志摘要或明确 allowlist，不用于常规 source 链传递。
+- 敏感字段默认 redacted；所有例外必须有明确理由和测试。
+
+## 里程碑视图
+
+| 阶段 | 目标 | 当前状态 | 完成标志 |
+| --- | --- | --- | --- |
+| M1 | 补全 error kernel 合约 | 已有骨架，缺 category/redaction policy 深度集成 | `ErrorSpec` 覆盖 category、redaction、recovery、observe、protocol |
+| M2 | 清理 public `anyhow` | core error/common 基本通过，其他共享边界仍有命中 | library/shared API 无未登记 `anyhow::Result` |
+| M3 | remoting/broker/namesrv 统一出口 | remoting 有 adapter，processor 仍大量本地 response code | processor 失败统一走 `rocketmq_remoting::error_response` |
+| M4 | proxy gRPC 完整接入 | 部分使用 `spec().grpc`，仍有本地 override/table | `RocketMQError` 路径优先由中心 grpc spec 派生 |
+| M5 | dashboard HTTP 完整接入 | `DashboardError::RocketMq` typed，但 HTTP 映射本地硬编码 | RocketMQ 错误使用 `spec().http` 和 stable code |
+| M6 | client callback typed 化 | legacy downcast 已移除，仍有 `dyn Error` + typed downcast | callback 内部事实源改为 `RocketMQError` |
+| M7 | domain crate source preservation | store/auth/controller/broker 仍有 source 字符串化 | I/O、serde、rocksdb、raft、runtime source 有 typed 保留或 allowlist |
+| M8 | redaction 全仓库收口 | 重点模型已脱敏，未全量使用中心 `Sensitive<T>` | secret/token/signature/password Debug/Display/log 有 guard |
+| M9 | CI guard 收口 | `scripts/error_architecture_guard.py` 可通过，但未见 CI 调用 | root CI 和相关 dashboard CI 调用 guard |
+| M10 | standalone 验证 | 未全量校验 | 受影响 standalone project 按各自目录 clippy 通过 |
+
+## 任务卡与 Checklist
+
+### T01. 补全 `rocketmq-error` 内核合约
+
+**范围**：`rocketmq-error/src/kind.rs`、`spec.rs`、`context.rs`、`unified.rs`、相关 tests。
+
+**完成状态**：
+
+- `ErrorSpec` 已包含 `kind/code/scope/category/public_message/remoting/grpc/http/cli/recovery/observe/redact`。
+- `RocketMQError` 已提供 `public_message()` 和 redaction-aware `context()`，边界输出可避免继续读取 `Display` 作为机器契约。
+- `RocketMQError::Internal(String)` 已在 guard 中建立基线路径 allowlist；跨 crate 替换为 typed variant 的收敛继续归 T08。
+
+**开发 checklist**：
+
+- [x] 新增或确认 `ErrorCategory`，区分 network、storage、protocol、auth、config、system 等低基数分类。
+- [x] 在 `ErrorSpec` 中加入 `category`，并为所有 `ErrorKind::ALL` 填充。
+- [x] 新增 `RedactionPolicy` 或等价字段，并写入 `ErrorSpec`。
+- [x] 明确 `Display`、`Debug`、public message、structured context 的职责边界。
+- [x] 为 `RocketMQError` 增加统一 context 访问方式，或给关键 variant 挂载 `ErrorContext`。
+- [x] 对 `Internal(String)` 制定 allowlist；能建模的场景改成 typed variant。
+- [x] 补齐 registry completeness、category、redaction policy、Display/context 测试。
+
+**验收 checklist**：
+
+- [x] `ALL_ERROR_SPECS.len() == ErrorKind::ALL.len()` 仍通过。
+- [x] 每个 `ErrorKind` 都有 code、scope、category、recovery、observe、protocol、redaction。
+- [x] 新增错误时漏填任何 spec 字段会测试失败。
+- [x] 不新增 public `anyhow` alias。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-error
+py scripts\error_architecture_guard.py
+```
+
+### T02. 清理 public `anyhow::Result` 和边界 allowlist
+
+**范围**：`rocketmq-remoting`、`rocketmq-broker`、`rocketmq-controller`、`rocketmq-namesrv`、`rocketmq-dashboard-common`、dashboard web backend、`rocketmq-tools`、standalone dashboard。
+
+**当前缺口**：
+
+- `rocketmq-remoting/src/protocol/command_custom_header.rs` 仍有 `check_fields() -> anyhow::Result`。
+- `rocketmq-dashboard-common` 是共享 crate，但仍使用 `anyhow::Result`。
+- dashboard web backend 多个非入口层函数返回 `anyhow::Result`。
+- tools TUI 大量使用 `anyhow::Result`，需要区分 CLI app boundary 与可复用库边界。
+
+**开发 checklist**：
+
+- [ ] 建立 `anyhow` allowlist，明确 binary、test、example、CLI outer boundary 可保留。
+- [ ] 将共享库 API 改为 `RocketMQResult<T>` 或 crate-local typed result。
+- [ ] 将 `rocketmq-remoting` header validation 改为 typed error。
+- [ ] 将 `rocketmq-dashboard-common` 的 service/api/proxy/nameserver trait 改为 typed error。
+- [ ] dashboard web backend 内部服务层避免直接暴露 `anyhow::Result`，入口层可保留。
+- [ ] tools 中可复用 executor/core 逻辑避免 public `anyhow`；TUI main/run 可保留。
+- [ ] 扩展 guard，扫描 library/shared API 的 public `anyhow`，并允许配置 allowlist。
+
+**验收 checklist**：
+
+- [ ] 根 workspace library API 无未登记 `anyhow::Result`。
+- [ ] standalone/shared dashboard crate 无未登记 `anyhow::Result`。
+- [ ] 保留的 `anyhow` 全部有 allowlist 说明。
+
+**建议验证**：
+
+```powershell
+rg -n "anyhow::Result" --glob "*.rs"
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+### T03. 统一 remoting、broker、namesrv processor 错误出口
+
+**范围**：`rocketmq-remoting/src/error_response.rs`、`rocketmq-remoting/src/remoting.rs`、`rocketmq-broker/src/processor*`、`rocketmq-namesrv/src/processor*`。
+
+**当前缺口**：
+
+- `rocketmq-remoting/src/error_response.rs` 已读取 `error.spec().remoting`。
+- broker/namesrv processor 仍大量直接构造 `ResponseCode::SystemError`、`InvalidParameter`、`TopicNotExist` 等。
+- `admin_broker_processor` 仍有本地 `RocketMQError -> ResponseCode` match，并使用 `error.to_string()`。
+
+**开发 checklist**：
+
+- [ ] 给 `rocketmq_remoting::error_response` 增加统一 helper：typed error、unsupported request code、internal/system fallback、opaque 保留。
+- [ ] 先迁移通用失败路径：unsupported request、decode/header validation、serialization、auth/config error。
+- [ ] broker processor 中业务特定成功/空结果 code 保留本地，异常失败走 adapter。
+- [ ] namesrv processor 中通用 `SystemError`、`NoPermission`、`QueryNotFound` 逐步改为 typed error + adapter。
+- [ ] 删除或缩小本地 `RocketMQError -> ResponseCode` match。
+- [ ] 给 broker/namesrv 添加 mapper tests，验证典型 `ErrorKind` 到 `ResponseCode`。
+- [ ] 扩展 `error_architecture_guard.py`，禁止 processor 新增未 allowlist 的通用错误构造。
+
+**验收 checklist**：
+
+- [ ] processor 不再手写通用 `RequestCodeNotSupported`。
+- [ ] 通用 `SystemError` fallback 有明确 allowlist。
+- [ ] 每个对外 typed failure 都能由 `ErrorSpec.remoting` 得到 response code。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-remoting
+cargo test -p rocketmq-broker
+cargo test -p rocketmq-namesrv
+py scripts\error_architecture_guard.py
+```
+
+### T04. 收敛 proxy gRPC 映射
+
+**范围**：`rocketmq-proxy/src/status.rs`、`rocketmq-proxy/src/error.rs`、相关 gRPC tests。
+
+**当前缺口**：
+
+- `ProxyError::RocketMQ` 路径部分读取 `error.spec().grpc`。
+- `rocketmq_payload_override` 和 `tonic_code_from_payload_code` 仍保留本地映射表。
+- 部分 local `ProxyError` 仍直接映射 `v2::Code`，没有中心 metadata 或明确 local-only 分类。
+
+**开发 checklist**：
+
+- [ ] 区分 `RocketMQError` 通用路径与 proxy local-only 错误路径。
+- [ ] `RocketMQError` 默认 payload/status 从 `ErrorSpec.grpc` 派生。
+- [ ] 只保留必须基于 broker response code 的 override，并写清 allowlist。
+- [ ] 为 proxy local-only error 建立 `ProxyErrorKind` 或转换到 `RocketMQError`。
+- [ ] 避免新增旁路 gRPC 映射表。
+- [ ] 补齐 `v2::Code` 与 `tonic::Code` 的 focused tests。
+
+**验收 checklist**：
+
+- [ ] `RocketMQError` gRPC 输出不依赖 display string。
+- [ ] override 分支都有测试和注释说明。
+- [ ] 新增 proxy error 不会绕过中心 spec 或 local-only allowlist。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-proxy
+rg -n "v2::Code::|tonic::Code|rocketmq_payload_override" rocketmq-proxy/src/status.rs
+```
+
+### T05. 接入 dashboard HTTP boundary adapter
+
+**范围**：`rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs`、`rocketmq-dashboard-common`、dashboard backend service/config/admin 层。
+
+**当前缺口**：
+
+- `DashboardError::RocketMq(#[from] RocketMQError)` 已存在。
+- `status_code()` 对 `RocketMq` 当前固定返回 `BAD_GATEWAY`。
+- `code()` 返回本地字符串，例如 `ROCKETMQ_ERROR`，没有使用 `error.spec().code`。
+- HTTP response body 使用 `self.to_string()`，没有区分 public message 和内部 detail。
+
+**开发 checklist**：
+
+- [ ] 对 `DashboardError::RocketMq(error)` 使用 `error.spec().http.status` 生成 HTTP status。
+- [ ] API code 使用 `error.spec().code.as_str()`，或明确加 dashboard prefix。
+- [ ] response message 使用 `spec.public_message` + redacted context，避免泄露内部 detail。
+- [ ] 对 local `Validation/Config/Auth/NotFound/Internal` 建立稳定 code。
+- [ ] 配置读写、监控配置、admin client 的 `format!("...{error}")` 路径改成 typed source 或 redacted message。
+- [ ] 增加 dashboard backend HTTP error mapping tests。
+
+**验收 checklist**：
+
+- [ ] `RocketMQError::route_not_found` 等典型错误映射到正确 HTTP status/code。
+- [ ] dashboard API 不用 display text 作为机器契约。
+- [ ] secret/token/signature 不出现在 error body。
+
+**建议验证**：
+
+```powershell
+cd rocketmq-dashboard\rocketmq-dashboard-web\backend
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo build --all-targets --all-features
+```
+
+### T06. client callback 和 request future typed 化
+
+**范围**：`rocketmq-client/src/consumer/pull_callback.rs`、`pop_callback.rs`、producer/consumer callback API、相关 tests。
+
+**当前缺口**：
+
+- legacy downcast 已移除。
+- 仍存在 `dyn Error` + `downcast_ref::<RocketMQError>()`，内部事实源还不是 typed error。
+
+**开发 checklist**：
+
+- [ ] 修改 pull/pop callback 内部错误类型为 `RocketMQError`。
+- [ ] 移除 `broker_response_code(error: &(dyn Error + Send + 'static))` 这类 downcast helper。
+- [ ] 对 broker response code 使用 typed variant 或 `ErrorKind`/spec/recovery policy。
+- [ ] 更新 public callback trait；本轮重构允许 breaking change，不保留旧 ABI。
+- [ ] 更新调用方和测试，确保回调错误判断不依赖 runtime downcast。
+
+**验收 checklist**：
+
+- [ ] `pull_callback.rs`、`pop_callback.rs` 无 `dyn Error` downcast。
+- [ ] callback 错误路径可直接读取 `RocketMQError::kind()` / `spec()`。
+- [ ] 订阅落后、flow control 等 broker response 行为仍保持。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-client-rust pull_callback
+cargo test -p rocketmq-client-rust pop_callback
+cargo test -p rocketmq-client-rust typed_error_client_flow_tests
+```
+
+### T07. 收敛 client retry/fault 策略
+
+**范围**：`rocketmq-client/src/common/retry_decision.rs`、producer send retry、route refresh、broker switch 相关代码。
+
+**当前缺口**：
+
+- `ClientRetryDecision::from_error` 已读取 `error.kind().spec().recovery.retry`。
+- `BrokerOperationFailed { code }` 仍用 `retry_response_codes` allowlist 判断，这是 RocketMQ broker response 兼容路径，需要明确边界。
+- producer/consumer 中仍有局部 retry 判断和状态处理。
+
+**开发 checklist**：
+
+- [ ] 明确 `RetryClass` 与 broker response code allowlist 的优先级。
+- [ ] 将 route refresh、switch broker、refresh leader、backoff 行为集中在 retry decision 模块。
+- [ ] 避免 producer/consumer 新增文本或局部 variant 猜测。
+- [ ] 对 `RetryClass::RefreshRoute/SwitchBroker/RefreshLeader/AfterBackoff/Never` 增加行为测试。
+- [ ] 对 broker response allowlist 写明 Java compatibility 理由。
+
+**验收 checklist**：
+
+- [ ] client retry 不读取 display string。
+- [ ] 新增 `ErrorKind` 的 retry 行为来自 `ErrorSpec.recovery`。
+- [ ] broker response allowlist 有测试覆盖。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-client-rust retry_decision
+cargo test -p rocketmq-client-rust default_mq_producer_impl
+```
+
+### T08. store/controller/auth/broker source 链保留
+
+**范围**：`rocketmq-store`、`rocketmq-controller`、`rocketmq-auth`、`rocketmq-broker`。
+
+**当前缺口**：
+
+- 多处 `error.to_string()` 被用作新错误的 reason，可能丢失 source 链。
+- store RocksDB、HA、mapped file、local file consume queue 等路径仍有字符串化错误。
+- controller openraft/log store/state machine 会将 error 转成 `std::io::Error::other(error.to_string())`。
+- auth provider/factory/loader/authorization builder 等路径仍把 error 压成字符串。
+- broker processor 和 transaction queue 中仍有 `RocketMQError::Internal("...")`。
+
+**开发 checklist**：
+
+- [ ] 建立 source-preservation allowlist，标出必须保留 source 的类型。
+- [ ] 为 RocksDB、HA、mapped file、serde、I/O、openraft、runtime join/semaphore 等增加 typed source wrapper。
+- [ ] store 中 `StoreError::RocksDb(String)` 等路径替换为 typed source 或 structured context。
+- [ ] auth 中配置、ACL loader、metadata provider、authorization builder 保留 source 或分类成 typed auth/config/storage error。
+- [ ] controller 中 openraft 必须转 `std::io::Error` 的地方记录边界原因，其他路径保留 typed source。
+- [ ] broker `Internal(String)` 场景改成 `NotInitialized`、`Storage*`、`BrokerOperationFailed` 等 typed variant。
+- [ ] 为每个 domain crate 增加 focused regression tests。
+
+**验收 checklist**：
+
+- [ ] 无未登记 source 字符串化路径。
+- [ ] I/O、serde、storage、raft、runtime 错误能通过 source 链追因，或有明确 allowlist。
+- [ ] `Internal(String)` 只剩无法分类且有 allowlist 的场景。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-store
+cargo test -p rocketmq-controller
+cargo test -p rocketmq-auth
+cargo test -p rocketmq-broker
+rg -n "error\\.to_string\\(\\)|RocketMQError::Internal|StoreError::RocksDb\\(" rocketmq-store rocketmq-controller rocketmq-auth rocketmq-broker --glob "*.rs"
+```
+
+### T09. 全仓库 redaction 收口
+
+**范围**：`rocketmq-error`、`rocketmq-common`、`rocketmq-client`、`rocketmq-auth`、dashboard backend、logging/metrics 输出。
+
+**当前缺口**：
+
+- `Sensitive<T>` 已存在，但不少 auth/client/common 类型仍使用本地 redaction helper。
+- `plain_access_resource` 等 auth migration 类型仍需核对 signature/token/password 字段是否全部脱敏。
+- guard 当前主要覆盖 error/common/client/remoting 的敏感 Debug 字段，不覆盖 dashboard/tools 全部输出。
+
+**开发 checklist**：
+
+- [ ] 定义敏感字段关键词表：secret、password、token、signature、authorization、credential。
+- [ ] 将可复用模型迁移到 `Sensitive<T>` 或统一 helper。
+- [ ] 对 `Display`、`Debug`、tracing structured fields、API response、CLI output 分别建立 redaction 测试。
+- [ ] 修复 auth migration/context 中所有未脱敏 signature/token/password Debug 字段。
+- [ ] 扩展 guard 到 auth、dashboard backend、tools 的关键输出类型。
+- [ ] 确认测试 fixture 中明文 secret 只存在于测试输入，不进入输出断言。
+
+**验收 checklist**：
+
+- [ ] `SessionCredentials`、auth config、user/password、plain access config/resource 都有 no-secret tests。
+- [ ] guard 能阻止新增敏感 Debug field。
+- [ ] API/CLI/log 输出默认不含敏感原文。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-error error_context_redaction
+cargo test -p rocketmq-client-rust session_credentials
+cargo test -p rocketmq-auth redacts
+py scripts\error_architecture_guard.py
+```
+
+### T10. 扩展并接入 CI guard
+
+**范围**：`scripts/error_architecture_guard.py`、`.github/workflows/rocketmq-rust-ci.yaml`、dashboard CI workflows。
+
+**当前缺口**：
+
+- `scripts/error_architecture_guard.py` 本地可通过。
+- 当前未在 `.github/workflows` 中看到调用。
+- guard 只覆盖部分范围：error/common public surface、processor unsupported-code、remoting/proxy adapter token、部分 redaction。
+
+**开发 checklist**：
+
+- [ ] 将 `py scripts\error_architecture_guard.py` 接入 root CI。
+- [ ] 如果 dashboard shared/backend 被纳入 guard，dashboard web CI 也调用对应检查。
+- [ ] 扩展 guard：library/shared public `anyhow` allowlist。
+- [ ] 扩展 guard：unmapped `ErrorKind`、missing `ErrorSpec`、missing protocol/recovery/observe/redaction。
+- [ ] 扩展 guard：processor 通用 `SystemError` / `InvalidParameter` 新增检查。
+- [ ] 扩展 guard：source stringification allowlist。
+- [ ] 扩展 guard：sensitive output allowlist。
+- [ ] 增加 guard 文档，说明如何新增 allowlist 以及何时不允许新增。
+
+**验收 checklist**：
+
+- [ ] CI 中能看到 error architecture guard step。
+- [ ] guard 失败会输出 `path:line`。
+- [ ] guard 不依赖本机 `python` alias；Windows 上使用 `py` 或 CI 指定 Python。
+
+**建议验证**：
+
+```powershell
+py scripts\error_architecture_guard.py
+rg -n "error_architecture_guard" .github scripts
+```
+
+### T11. CLI/tools 错误出口接入 `CliSpec`
+
+**范围**：`rocketmq-tools/rocketmq-admin-*`、`rocketmq-tools/rocketmq-store-inspect`。
+
+**当前缺口**：
+
+- `rocketmq-tools` 对中心 spec 的使用为 0。
+- TUI/CLI 大量使用 `anyhow::Result`，需要区分 app boundary 与 reusable command executor。
+- CLI exit 当前未从 `ErrorSpec.cli` 派生。
+
+**开发 checklist**：
+
+- [ ] 在 CLI outer boundary 保留 `anyhow`，内部 command executor 返回 typed error 或 typed view model。
+- [ ] 新增 `RocketMQError -> exit code/category/message` adapter，读取 `spec().cli`。
+- [ ] command failure view model 使用 stable code，而不是只存 `error.to_string()`。
+- [ ] 对 admin-core 中可复用逻辑避免 `anyhow` 泄漏。
+- [ ] 对 `rocketmq-store-inspect` 这类 one-shot tool 明确 allowlist。
+- [ ] 增加 CLI exit code tests。
+
+**验收 checklist**：
+
+- [ ] CLI 对 typed error 输出稳定 exit category。
+- [ ] 可复用工具库不暴露未登记 `anyhow::Result`。
+- [ ] 错误展示不泄露 secret/token/signature。
+
+**建议验证**：
+
+```powershell
+cargo test -p rocketmq-admin-cli
+cargo test -p rocketmq-admin-tui
+cargo test -p rocketmq-admin-core
+rg -n "anyhow::Result|spec\\(\\)\\.cli|CliExitCode" rocketmq-tools --glob "*.rs"
+```
+
+### T12. standalone project 对齐和验证
+
+**范围**：`rocketmq-example`、dashboard GPUI、dashboard Tauri、dashboard web backend/common。
+
+**当前缺口**：
+
+- standalone 项目不由 root workspace clippy 覆盖。
+- dashboard common/web/tauri/gpui 中仍存在 `anyhow::Result`。
+- dashboard web backend HTTP boundary 未接入 `spec().http`。
+
+**开发 checklist**：
+
+- [ ] 根据共享 API 变更更新 `rocketmq-example`。
+- [ ] 根据 dashboard common typed result 变更更新 GPUI/Tauri/Web。
+- [ ] Tauri backend 中 `anyhow` 留在 app boundary，服务层按 typed error 收口。
+- [ ] Web backend 完成 HTTP adapter 后同步 common provider。
+- [ ] 分别运行各 standalone 目录的 clippy/build。
+
+**验收 checklist**：
+
+- [ ] root workspace validation 通过。
+- [ ] `rocketmq-example` standalone clippy 通过。
+- [ ] dashboard GPUI standalone clippy 通过。
+- [ ] dashboard Tauri `src-tauri` standalone clippy 通过。
+- [ ] dashboard web backend clippy/build 通过。
+
+**建议验证**：
+
+```powershell
+cd rocketmq-example
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+
+cd ..\rocketmq-dashboard\rocketmq-dashboard-gpui
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+
+cd ..\rocketmq-dashboard-tauri\src-tauri
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+
+cd ..\..\rocketmq-dashboard-web\backend
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo build --all-targets --all-features
+```
+
+## 推荐执行顺序
+
+1. T01：先补齐 `rocketmq-error` 合约字段和测试。
+2. T10：让现有 guard 进入 CI，先阻止 regression。
+3. T02：清理 public `anyhow`，同时建立 allowlist。
+4. T03：迁移 remoting/broker/namesrv 通用错误出口。
+5. T06 + T07：完成 client callback typed 化和 retry/fault 策略集中。
+6. T04：收敛 proxy gRPC mapper。
+7. T05：接入 dashboard HTTP mapper。
+8. T08：逐 crate 清理 source 字符串化。
+9. T09：全仓库 redaction guard 扩展。
+10. T11 + T12：tools/standalone 收口和最终验证。
+
+## 总体验收 Checklist
+
+- [ ] 全仓库无 `RocketmqError`、`LegacyRocketMQResult`、`LegacyResult`。
+- [ ] `rocketmq-error` 无 public `anyhow` alias。
+- [ ] library/shared API 无未登记 `anyhow::Result`。
+- [ ] 每个 `ErrorKind` 有唯一 `ErrorSpec`。
+- [ ] `ErrorSpec` 包含 code、scope、category、public message、remoting、grpc、http、cli、recovery、observe、redaction。
+- [ ] remoting/gRPC/HTTP/CLI 外部出口读取中心 spec 或有明确 local-only allowlist。
+- [ ] broker/namesrv processor 通用错误不再手写 response code。
+- [ ] client callback 内部事实源不再是 `dyn Error` downcast。
+- [ ] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
+- [ ] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
+- [ ] secret/token/signature/password 默认 redacted。
+- [ ] `scripts/error_architecture_guard.py` 进入 CI。
+- [ ] root workspace 通过 fmt/clippy。
+- [ ] 受影响 standalone 项目分别通过各自 clippy/build。
+
+## 最终验证矩阵
+
+```powershell
+# Root workspace
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+
+# Error architecture guard
+py scripts\error_architecture_guard.py
+
+# Focused root workspace tests
+cargo test -p rocketmq-error
+cargo test -p rocketmq-remoting
+cargo test -p rocketmq-client-rust
+cargo test -p rocketmq-broker
+cargo test -p rocketmq-namesrv
+cargo test -p rocketmq-store
+cargo test -p rocketmq-controller
+cargo test -p rocketmq-auth
+cargo test -p rocketmq-proxy
+
+# Static inspection gates
+rg -n "RocketmqError|LegacyRocketMQResult|LegacyResult" --glob "*.rs"
+rg -n "anyhow::Result" --glob "*.rs"
+rg -n "RocketMQError::Internal|error\\.to_string\\(\\)|map_err\\([^\\n]*to_string" --glob "*.rs"
+rg -n "secretKey|SecurityToken|signature|password|token" rocketmq-client rocketmq-auth rocketmq-dashboard --glob "*.rs"
+```
+
+## 维护要求
+
+- 每完成一个任务，在本文件对应 checklist 勾选，并补充 PR 或 commit 链接。
+- 如果某项无法清零，必须新增 allowlist，说明原因、责任 owner 和后续复查时间。
+- 每次修改 error kernel、boundary adapter、redaction guard 后，都要更新本文件和 contribution guide。

--- a/rocketmq-error/src/context.rs
+++ b/rocketmq-error/src/context.rs
@@ -14,6 +14,8 @@
 
 use std::fmt;
 
+use crate::kind::ErrorKind;
+
 pub const REDACTED: &str = "<redacted>";
 
 /// Wrapper for values that must never be formatted directly.
@@ -63,6 +65,64 @@ impl<T> fmt::Debug for Sensitive<T> {
 pub enum RedactionKind {
     Public,
     Sensitive,
+}
+
+/// Spec-level redaction policy for external error surfaces.
+///
+/// `Public` means the stable public message and explicitly public context fields
+/// are safe for API/CLI/log surfaces. `RedactSensitive` means external adapters
+/// must prefer `ErrorSpec::public_message` and redaction-aware context over raw
+/// `Display` or `Debug` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RedactionPolicy {
+    Public,
+    RedactSensitive,
+}
+
+impl RedactionPolicy {
+    /// Return the default external-surface redaction policy for an error kind.
+    #[inline]
+    pub const fn for_kind(kind: ErrorKind) -> Self {
+        match kind {
+            ErrorKind::Network
+            | ErrorKind::Serialization
+            | ErrorKind::Protocol
+            | ErrorKind::Rpc
+            | ErrorKind::Authentication
+            | ErrorKind::BrokerRegistrationFailed
+            | ErrorKind::BrokerOperationFailed
+            | ErrorKind::MessageValidationFailed
+            | ErrorKind::BrokerPermissionDenied
+            | ErrorKind::NotMasterBroker
+            | ErrorKind::TopicSendingForbidden
+            | ErrorKind::BrokerAsyncTaskFailed
+            | ErrorKind::RequestBodyInvalid
+            | ErrorKind::RequestHeaderError
+            | ErrorKind::ResponseProcessFailed
+            | ErrorKind::Filter
+            | ErrorKind::StorageReadFailed
+            | ErrorKind::StorageWriteFailed
+            | ErrorKind::StorageCorrupted
+            | ErrorKind::StorageOutOfSpace
+            | ErrorKind::StorageLockFailed
+            | ErrorKind::ConfigParseFailed
+            | ErrorKind::ConfigMissing
+            | ErrorKind::ConfigInvalidValue
+            | ErrorKind::AuthConfigInvalid
+            | ErrorKind::AuthHotReloadFailed
+            | ErrorKind::Controller
+            | ErrorKind::ControllerRaftError
+            | ErrorKind::ControllerConsensusTimeout
+            | ErrorKind::ControllerSnapshotFailed
+            | ErrorKind::Io
+            | ErrorKind::IllegalArgument
+            | ErrorKind::Internal
+            | ErrorKind::Service
+            | ErrorKind::NotInitialized
+            | ErrorKind::Tools => Self::RedactSensitive,
+            _ => Self::Public,
+        }
+    }
 }
 
 /// One structured error context field.

--- a/rocketmq-error/src/kind.rs
+++ b/rocketmq-error/src/kind.rs
@@ -63,6 +63,30 @@ pub enum ErrorScope {
     Version,
 }
 
+/// Low-cardinality domain category for metrics, logs, and external adapters.
+///
+/// `ErrorScope` points at the architectural boundary that produced the error.
+/// `ErrorCategory` is intentionally coarser and should remain stable enough for
+/// dashboards and alert grouping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorCategory {
+    Network,
+    Serialization,
+    Protocol,
+    Rpc,
+    Authentication,
+    Controller,
+    Broker,
+    Route,
+    Client,
+    Tools,
+    Filter,
+    Storage,
+    Configuration,
+    System,
+    Version,
+}
+
 /// Stable logical error kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ErrorKind {
@@ -325,6 +349,73 @@ impl ErrorKind {
             | Self::NotInitialized => ErrorScope::System,
             Self::InvalidVersionOrdinal => ErrorScope::Version,
             Self::MissingRequiredMessageProperty => ErrorScope::Protocol,
+        }
+    }
+
+    /// Low-cardinality domain category for this kind.
+    #[inline]
+    pub const fn category(self) -> ErrorCategory {
+        match self {
+            Self::Network => ErrorCategory::Network,
+            Self::Serialization => ErrorCategory::Serialization,
+            Self::Protocol
+            | Self::RequestBodyInvalid
+            | Self::RequestHeaderError
+            | Self::ResponseProcessFailed
+            | Self::MissingRequiredMessageProperty => ErrorCategory::Protocol,
+            Self::Rpc => ErrorCategory::Rpc,
+            Self::Authentication
+            | Self::AuthHotReloadFailed
+            | Self::BrokerPermissionDenied
+            | Self::TopicSendingForbidden => ErrorCategory::Authentication,
+            Self::Controller
+            | Self::ControllerNotLeader
+            | Self::ControllerRaftError
+            | Self::ControllerConsensusTimeout
+            | Self::ControllerSnapshotFailed => ErrorCategory::Controller,
+            Self::InvalidProperty
+            | Self::BrokerNotFound
+            | Self::BrokerRegistrationFailed
+            | Self::BrokerOperationFailed
+            | Self::TopicNotExist
+            | Self::QueueNotExist
+            | Self::SubscriptionGroupNotExist
+            | Self::QueueIdOutOfRange
+            | Self::MessageTooLarge
+            | Self::MessageValidationFailed
+            | Self::RetryLimitExceeded
+            | Self::TransactionRejected
+            | Self::NotMasterBroker
+            | Self::MessageLookupFailed
+            | Self::BrokerAsyncTaskFailed => ErrorCategory::Broker,
+            Self::RouteNotFound
+            | Self::RouteInconsistent
+            | Self::RouteRegistrationConflict
+            | Self::RouteVersionConflict
+            | Self::ClusterNotFound => ErrorCategory::Route,
+            Self::ClientNotStarted
+            | Self::ClientAlreadyStarted
+            | Self::ClientShuttingDown
+            | Self::ClientInvalidState
+            | Self::ProducerNotAvailable
+            | Self::ConsumerNotAvailable => ErrorCategory::Client,
+            Self::Tools => ErrorCategory::Tools,
+            Self::Filter => ErrorCategory::Filter,
+            Self::StorageReadFailed
+            | Self::StorageWriteFailed
+            | Self::StorageCorrupted
+            | Self::StorageOutOfSpace
+            | Self::StorageLockFailed => ErrorCategory::Storage,
+            Self::ConfigParseFailed | Self::ConfigMissing | Self::ConfigInvalidValue | Self::AuthConfigInvalid => {
+                ErrorCategory::Configuration
+            }
+            Self::Io
+            | Self::IllegalArgument
+            | Self::Timeout
+            | Self::Internal
+            | Self::Service
+            | Self::NotInitialized => ErrorCategory::System,
+            Self::InvalidVersionOrdinal => ErrorCategory::Version,
         }
     }
 

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -87,12 +87,14 @@ pub use client_error::ClientError;
 pub use context::ErrorContext;
 pub use context::ErrorContextField;
 pub use context::RedactionKind;
+pub use context::RedactionPolicy;
 pub use context::Sensitive;
 pub use context::REDACTED;
 pub use controller_error::ControllerError;
 pub use controller_error::ControllerResult;
 // Re-export filter error types
 pub use filter_error::FilterError;
+pub use kind::ErrorCategory;
 pub use kind::ErrorCode;
 pub use kind::ErrorKind;
 pub use kind::ErrorScope;

--- a/rocketmq-error/src/spec.rs
+++ b/rocketmq-error/src/spec.rs
@@ -16,6 +16,8 @@ use crate::boundary::CliSpec;
 use crate::boundary::GrpcSpec;
 use crate::boundary::HttpSpec;
 use crate::boundary::RemotingSpec;
+use crate::context::RedactionPolicy;
+use crate::kind::ErrorCategory;
 use crate::kind::ErrorCode;
 use crate::kind::ErrorKind;
 use crate::kind::ErrorScope;
@@ -32,6 +34,7 @@ pub struct ErrorSpec {
     pub kind: ErrorKind,
     pub code: ErrorCode,
     pub scope: ErrorScope,
+    pub category: ErrorCategory,
     pub public_message: &'static str,
     pub remoting: RemotingSpec,
     pub grpc: GrpcSpec,
@@ -39,6 +42,7 @@ pub struct ErrorSpec {
     pub cli: CliSpec,
     pub recovery: RecoverySpec,
     pub observe: ObserveSpec,
+    pub redact: RedactionPolicy,
 }
 
 impl ErrorSpec {
@@ -48,6 +52,7 @@ impl ErrorSpec {
             kind,
             code: kind.code(),
             scope: kind.scope(),
+            category: kind.category(),
             public_message,
             remoting: RemotingSpec::for_kind(kind),
             grpc: GrpcSpec::for_kind(kind),
@@ -55,6 +60,7 @@ impl ErrorSpec {
             cli: CliSpec::for_kind(kind),
             recovery: RecoverySpec::for_kind(kind),
             observe: ObserveSpec::for_kind(kind),
+            redact: RedactionPolicy::for_kind(kind),
         }
     }
 }

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -29,6 +29,8 @@ use std::io;
 // Re-export filter error
 pub use crate::filter_error::FilterError;
 
+use crate::context::ErrorContext;
+use crate::context::Sensitive;
 use crate::kind::ErrorKind;
 use crate::spec::ErrorSpec;
 pub use network::NetworkError;
@@ -472,6 +474,151 @@ impl RocketMQError {
         self.kind().spec()
     }
 
+    /// Return the stable external message for this error.
+    ///
+    /// `Display` and `Debug` remain diagnostic surfaces and may include local
+    /// details. Boundary adapters should use this public message together with
+    /// [`Self::context`] when building API, CLI, log, or protocol responses.
+    #[inline]
+    pub fn public_message(&self) -> &'static str {
+        self.spec().public_message
+    }
+
+    /// Return redaction-aware structured context for this error.
+    ///
+    /// The returned context is a snapshot derived from the current enum variant.
+    /// Sensitive details are represented through [`Sensitive`] so external
+    /// adapters can safely render the context without leaking raw values.
+    pub fn context(&self) -> ErrorContext {
+        match self {
+            Self::Network(error) => {
+                ErrorContext::new().with_sensitive("addr", Sensitive::new(error.addr().to_string()))
+            }
+            Self::Serialization(error) => redacted_context("serialization_error", error.to_string()),
+            Self::Protocol(error) => ErrorContext::new().with_field("protocol_error", error.to_string()),
+            Self::Rpc(error) => redacted_context("rpc_error", error.to_string()),
+            Self::Authentication(error) => redacted_context("auth_error", error.to_string()),
+            Self::Controller(error) => redacted_context("controller_error", error.to_string()),
+            Self::InvalidProperty(property) => ErrorContext::new().with_field("property", property.as_str()),
+            Self::BrokerNotFound { name } => ErrorContext::new().with_field("broker", name.as_str()),
+            Self::BrokerRegistrationFailed { name, reason } => ErrorContext::new()
+                .with_field("broker", name.as_str())
+                .with_field("reason", reason.as_str()),
+            Self::BrokerOperationFailed {
+                operation,
+                code,
+                message,
+                broker_addr,
+            } => {
+                let mut context = ErrorContext::new()
+                    .with_field("operation", *operation)
+                    .with_field("broker_code", code.to_string())
+                    .with_field("message", message.as_str());
+                if let Some(addr) = broker_addr {
+                    context = context.with_sensitive("broker_addr", Sensitive::new(addr.clone()));
+                }
+                context
+            }
+            Self::TopicNotExist { topic } => ErrorContext::new().with_field("topic", topic.as_str()),
+            Self::QueueNotExist { topic, queue_id } => ErrorContext::new()
+                .with_field("topic", topic.as_str())
+                .with_field("queue_id", queue_id.to_string()),
+            Self::SubscriptionGroupNotExist { group } => ErrorContext::new().with_field("group", group.as_str()),
+            Self::QueueIdOutOfRange { topic, queue_id, max } => ErrorContext::new()
+                .with_field("topic", topic.as_str())
+                .with_field("queue_id", queue_id.to_string())
+                .with_field("max_queue_id", max.to_string()),
+            Self::MessageTooLarge { actual, limit } => ErrorContext::new()
+                .with_field("actual_bytes", actual.to_string())
+                .with_field("limit_bytes", limit.to_string()),
+            Self::MessageValidationFailed { reason } => ErrorContext::new().with_field("reason", reason.as_str()),
+            Self::RetryLimitExceeded { group, current, max } => ErrorContext::new()
+                .with_field("group", group.as_str())
+                .with_field("current", current.to_string())
+                .with_field("max", max.to_string()),
+            Self::TransactionRejected => ErrorContext::new(),
+            Self::BrokerPermissionDenied { operation } => {
+                ErrorContext::new().with_field("operation", operation.as_str())
+            }
+            Self::NotMasterBroker { master_address } => {
+                ErrorContext::new().with_sensitive("master_address", Sensitive::new(master_address.clone()))
+            }
+            Self::MessageLookupFailed { offset } => ErrorContext::new().with_field("offset", offset.to_string()),
+            Self::TopicSendingForbidden { topic } => ErrorContext::new().with_field("topic", topic.as_str()),
+            Self::BrokerAsyncTaskFailed { task, context, .. } => ErrorContext::new()
+                .with_field("task", *task)
+                .with_sensitive("context", Sensitive::new(context.clone())),
+            Self::RequestBodyInvalid { operation, reason } => ErrorContext::new()
+                .with_field("operation", *operation)
+                .with_field("reason", reason.as_str()),
+            Self::RequestHeaderError(reason) => ErrorContext::new().with_field("reason", reason.as_str()),
+            Self::ResponseProcessFailed { operation, reason } => ErrorContext::new()
+                .with_field("operation", *operation)
+                .with_field("reason", reason.as_str()),
+            Self::RouteNotFound { topic } => ErrorContext::new().with_field("topic", topic.as_str()),
+            Self::RouteInconsistent { topic, reason } => ErrorContext::new()
+                .with_field("topic", topic.as_str())
+                .with_field("reason", reason.as_str()),
+            Self::RouteRegistrationConflict { broker_name, reason } => ErrorContext::new()
+                .with_field("broker", broker_name.as_str())
+                .with_field("reason", reason.as_str()),
+            Self::RouteVersionConflict { expected, actual } => ErrorContext::new()
+                .with_field("expected", expected.to_string())
+                .with_field("actual", actual.to_string()),
+            Self::ClusterNotFound { cluster } => ErrorContext::new().with_field("cluster", cluster.as_str()),
+            Self::ClientNotStarted
+            | Self::ClientAlreadyStarted
+            | Self::ClientShuttingDown
+            | Self::ProducerNotAvailable
+            | Self::ConsumerNotAvailable => ErrorContext::new(),
+            Self::ClientInvalidState { expected, actual } => ErrorContext::new()
+                .with_field("expected", *expected)
+                .with_field("actual", actual.as_str()),
+            Self::Tools(error) => redacted_context("tools_error", error.to_string()),
+            Self::Filter(error) => ErrorContext::new().with_field("filter_error", error.to_string()),
+            Self::StorageReadFailed { path, reason } | Self::StorageWriteFailed { path, reason } => ErrorContext::new()
+                .with_sensitive("path", Sensitive::new(path.clone()))
+                .with_sensitive("reason", Sensitive::new(reason.clone())),
+            Self::StorageCorrupted { path } | Self::StorageOutOfSpace { path } | Self::StorageLockFailed { path } => {
+                ErrorContext::new().with_sensitive("path", Sensitive::new(path.clone()))
+            }
+            Self::ConfigParseFailed { key, reason } => ErrorContext::new()
+                .with_field("key", *key)
+                .with_sensitive("reason", Sensitive::new(reason.clone())),
+            Self::ConfigMissing { key } => ErrorContext::new().with_field("key", *key),
+            Self::ConfigInvalidValue { key, value, reason } => ErrorContext::new()
+                .with_field("key", *key)
+                .with_sensitive("value", Sensitive::new(value.clone()))
+                .with_sensitive("reason", Sensitive::new(reason.clone())),
+            Self::AuthConfigInvalid { key, reason } => ErrorContext::new()
+                .with_field("key", *key)
+                .with_sensitive("reason", Sensitive::new(reason.clone())),
+            Self::AuthHotReloadFailed { path, reason } => ErrorContext::new()
+                .with_sensitive("path", Sensitive::new(path.clone()))
+                .with_sensitive("reason", Sensitive::new(reason.clone())),
+            Self::ControllerNotLeader { leader_id } => ErrorContext::new().with_field(
+                "leader_id",
+                leader_id.map_or_else(|| "unknown".to_string(), |id| id.to_string()),
+            ),
+            Self::ControllerRaftError { reason } | Self::ControllerSnapshotFailed { reason } => {
+                ErrorContext::new().with_sensitive("reason", Sensitive::new(reason.clone()))
+            }
+            Self::ControllerConsensusTimeout { operation, timeout_ms } => ErrorContext::new()
+                .with_field("operation", *operation)
+                .with_field("timeout_ms", timeout_ms.to_string()),
+            Self::IO(error) => redacted_context("io_error", error.to_string()),
+            Self::IllegalArgument(message) => ErrorContext::new().with_field("message", message.as_str()),
+            Self::Timeout { operation, timeout_ms } => ErrorContext::new()
+                .with_field("operation", *operation)
+                .with_field("timeout_ms", timeout_ms.to_string()),
+            Self::Internal(message) => redacted_context("internal_error", message.clone()),
+            Self::Service(error) => redacted_context("service_error", error.to_string()),
+            Self::InvalidVersionOrdinal(ordinal) => ErrorContext::new().with_field("ordinal", ordinal.to_string()),
+            Self::NotInitialized(reason) => ErrorContext::new().with_field("reason", reason.as_str()),
+            Self::MissingRequiredMessageProperty { property } => ErrorContext::new().with_field("property", *property),
+        }
+    }
+
     /// Create a network connection failed error
     #[inline]
     pub fn network_connection_failed(addr: impl Into<String>, reason: impl Into<String>) -> Self {
@@ -763,6 +910,10 @@ impl RocketMQError {
     pub fn filter_uninitialized() -> Self {
         Self::Filter(FilterError::uninitialized())
     }
+}
+
+fn redacted_context(key: &'static str, value: impl Into<String>) -> ErrorContext {
+    ErrorContext::new().with_sensitive(key, Sensitive::new(value.into()))
 }
 
 // ============================================================================

--- a/rocketmq-error/tests/error_context_redaction.rs
+++ b/rocketmq-error/tests/error_context_redaction.rs
@@ -1,5 +1,6 @@
 use rocketmq_error::ErrorContext;
 use rocketmq_error::RedactionKind;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::Sensitive;
 
 #[test]
@@ -36,4 +37,20 @@ fn error_context_redacts_sensitive_fields() {
     let debug = format!("{context:?}");
     assert!(!debug.contains("sk-123"));
     assert!(!debug.contains("token-456"));
+}
+
+#[test]
+fn rocketmq_error_exposes_public_message_and_redacted_context() {
+    let route = RocketMQError::route_not_found("TopicA");
+
+    assert_eq!(route.public_message(), "Route information was not found");
+    assert_eq!(route.context().to_string(), "topic=TopicA");
+
+    let internal = RocketMQError::Internal("password=plain-text".to_string());
+    let context = internal.context();
+
+    assert_eq!(internal.public_message(), "Internal error");
+    assert_eq!(context.fields()[0].redaction, RedactionKind::Sensitive);
+    assert_eq!(context.to_string(), "internal_error=<redacted>");
+    assert!(!context.to_string().contains("plain-text"));
 }

--- a/rocketmq-error/tests/error_kind_contract.rs
+++ b/rocketmq-error/tests/error_kind_contract.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use rocketmq_error::ErrorCategory;
 use rocketmq_error::ErrorCode;
 use rocketmq_error::ErrorKind;
 use rocketmq_error::ErrorScope;
@@ -15,29 +16,43 @@ fn error_code_is_a_stable_machine_code() {
 }
 
 #[test]
-fn error_kind_exposes_code_and_scope() {
+fn error_kind_exposes_code_scope_and_category() {
     let cases = [
         (
             ErrorKind::BrokerOperationFailed,
             ErrorScope::Broker,
+            ErrorCategory::Broker,
             "BROKER_OPERATION_FAILED",
         ),
-        (ErrorKind::RouteNotFound, ErrorScope::Route, "ROUTE_NOT_FOUND"),
+        (
+            ErrorKind::RouteNotFound,
+            ErrorScope::Route,
+            ErrorCategory::Route,
+            "ROUTE_NOT_FOUND",
+        ),
         (
             ErrorKind::StorageWriteFailed,
             ErrorScope::Storage,
+            ErrorCategory::Storage,
             "STORAGE_WRITE_FAILED",
         ),
         (
             ErrorKind::AuthConfigInvalid,
             ErrorScope::Configuration,
+            ErrorCategory::Configuration,
             "AUTH_CONFIG_INVALID",
         ),
-        (ErrorKind::Internal, ErrorScope::System, "INTERNAL"),
+        (
+            ErrorKind::Internal,
+            ErrorScope::System,
+            ErrorCategory::System,
+            "INTERNAL",
+        ),
     ];
 
-    for (kind, scope, code) in cases {
+    for (kind, scope, category, code) in cases {
         assert_eq!(kind.scope(), scope);
+        assert_eq!(kind.category(), category);
         assert_eq!(kind.code().as_str(), code);
     }
 }

--- a/rocketmq-error/tests/error_spec_registry.rs
+++ b/rocketmq-error/tests/error_spec_registry.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use rocketmq_error::error_spec;
 use rocketmq_error::ErrorKind;
 use rocketmq_error::ErrorSpec;
+use rocketmq_error::RedactionPolicy;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::ALL_ERROR_SPECS;
 
@@ -15,6 +16,8 @@ fn every_error_kind_has_one_spec() {
         assert!(kinds.insert(spec.kind), "duplicate spec for {:?}", spec.kind);
         assert_eq!(spec.code, spec.kind.code());
         assert_eq!(spec.scope, spec.kind.scope());
+        assert_eq!(spec.category, spec.kind.category());
+        assert_eq!(spec.redact, RedactionPolicy::for_kind(spec.kind));
         assert!(!spec.public_message.is_empty());
     }
 
@@ -29,6 +32,8 @@ fn error_spec_lookup_returns_static_spec() {
 
     assert_eq!(spec.kind, ErrorKind::RouteNotFound);
     assert_eq!(spec.code.as_str(), "ROUTE_NOT_FOUND");
+    assert_eq!(spec.category, ErrorKind::RouteNotFound.category());
+    assert_eq!(spec.redact, RedactionPolicy::Public);
     assert_eq!(spec.public_message, "Route information was not found");
 }
 
@@ -39,4 +44,18 @@ fn rocketmq_error_reports_spec() {
 
     assert_eq!(spec.kind, ErrorKind::RouteNotFound);
     assert_eq!(spec.code.as_str(), "ROUTE_NOT_FOUND");
+    assert_eq!(error.public_message(), spec.public_message);
+}
+
+#[test]
+fn sensitive_error_specs_require_redaction() {
+    assert_eq!(
+        ErrorKind::Authentication.spec().redact,
+        RedactionPolicy::RedactSensitive
+    );
+    assert_eq!(
+        ErrorKind::ConfigInvalidValue.spec().redact,
+        RedactionPolicy::RedactSensitive
+    );
+    assert_eq!(ErrorKind::Internal.spec().redact, RedactionPolicy::RedactSensitive);
 }

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -29,6 +29,24 @@ from typing import Iterable
 ROOT = Path(__file__).resolve().parents[1]
 RUST_SUFFIX = ".rs"
 
+INTERNAL_ERROR_ALLOWLIST = (
+    "rocketmq-auth/src/authorization/provider.rs",
+    "rocketmq-broker/src/",
+    "rocketmq-client/src/",
+    "rocketmq-common/src/common/controller/controller_config.rs",
+    "rocketmq-controller/src/",
+    "rocketmq-namesrv/src/",
+    "rocketmq-proxy/src/",
+    "rocketmq-remoting/src/",
+    "rocketmq-remoting/src/protocol/body/consumer_running_info.rs",
+    "rocketmq-remoting/src/protocol/static_topic/",
+    "rocketmq-tieredstore/src/",
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/",
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/",
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/",
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/",
+)
+
 
 @dataclasses.dataclass(frozen=True)
 class Finding:
@@ -50,6 +68,10 @@ def rust_files_under(*parts: str) -> list[Path]:
     if not root.exists():
         return []
     return sorted(path for path in root.rglob(f"*{RUST_SUFFIX}") if "target" not in path.parts)
+
+
+def rust_files() -> list[Path]:
+    return sorted(path for path in ROOT.rglob(f"*{RUST_SUFFIX}") if "target" not in path.parts)
 
 
 def is_test_context(path: Path, line_number: int) -> bool:
@@ -164,6 +186,67 @@ def check_required_mapping_adapters() -> list[Finding]:
     return findings
 
 
+def check_error_spec_contract() -> list[Finding]:
+    required_tokens = {
+        ROOT / "rocketmq-error" / "src" / "kind.rs": [
+            "pub enum ErrorCategory",
+            "pub const fn category(self) -> ErrorCategory",
+        ],
+        ROOT / "rocketmq-error" / "src" / "context.rs": [
+            "pub enum RedactionPolicy",
+            "pub const fn for_kind(kind: ErrorKind) -> Self",
+        ],
+        ROOT / "rocketmq-error" / "src" / "spec.rs": [
+            "pub category: ErrorCategory",
+            "pub redact: RedactionPolicy",
+            "category: kind.category()",
+            "redact: RedactionPolicy::for_kind(kind)",
+        ],
+        ROOT / "rocketmq-error" / "tests" / "error_spec_registry.rs": [
+            "assert_eq!(spec.category, spec.kind.category())",
+            "assert_eq!(spec.redact, RedactionPolicy::for_kind(spec.kind))",
+        ],
+        ROOT / "rocketmq-error" / "tests" / "error_context_redaction.rs": [
+            "rocketmq_error_exposes_public_message_and_redacted_context",
+            "internal_error=<redacted>",
+        ],
+    }
+    findings: list[Finding] = []
+    for path, needles in required_tokens.items():
+        if not path.exists():
+            findings.append(Finding(path, 1, "required error spec contract file is missing"))
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                findings.append(Finding(path, 1, f"required error spec contract token missing: {needle}"))
+    return findings
+
+
+def is_internal_error_allowlisted(path: Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    return any(rel == prefix or rel.startswith(prefix) for prefix in INTERNAL_ERROR_ALLOWLIST)
+
+
+def check_internal_error_allowlist() -> list[Finding]:
+    findings: list[Finding] = []
+    for path in rust_files():
+        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+            if "RocketMQError::Internal(" not in line:
+                continue
+            if is_test_context(path, line_number):
+                continue
+            if not is_internal_error_allowlisted(path):
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        "RocketMQError::Internal requires a typed variant or an internal-error allowlist entry",
+                    )
+                )
+    return findings
+
+
 def check_redaction_guards() -> list[Finding]:
     required_tokens = {
         ROOT / "rocketmq-error" / "src" / "context.rs": [
@@ -215,6 +298,8 @@ def run() -> int:
         ("core public surface", check_error_and_common_public_surface),
         ("processor boundary mappings", check_processor_boundary_mappings),
         ("required mapping adapters", check_required_mapping_adapters),
+        ("error spec contract", check_error_spec_contract),
+        ("internal error allowlist", check_internal_error_allowlist),
         ("redaction guards", check_redaction_guards),
     ]
     all_findings: list[Finding] = []


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7933

### Brief Description

- Adds ErrorCategory and RedactionPolicy to the central ErrorSpec registry.
- Adds RocketMQError public_message() and redaction-aware context() accessors for boundary adapters.
- Extends the error architecture guard with spec-contract checks and a baseline Internal usage allowlist.
- Adds docs/07-error-refactor-checklist.md and checks off the completed error kernel contract scope.

### How Did You Test This Change?

- cargo fmt --all
- cargo test -p rocketmq-error
- py scripts\error_architecture_guard.py
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured error metadata for category-based grouping and safer public-facing error messages.
  * Error contexts now support redaction for sensitive details in external outputs.

* **Bug Fixes**
  * Improved error handling consistency across reported messages and context output.
  * Added regression coverage to ensure sensitive values stay hidden and error contracts remain stable.

* **Documentation**
  * Added a release checklist for the error architecture rollout and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->