### PR TITLE
[ISSUE #7935]✨Enforce English content validation

### DIFF
--- a/.agents/skills/rocketmq-rust-issue-generator/SKILL.md
+++ b/.agents/skills/rocketmq-rust-issue-generator/SKILL.md
@@ -13,6 +13,7 @@ Generate GitHub issue drafts from the repository's real issue forms. Template-dr
 - User's rough draft mentions generic sections or non-existent template names — must be converted to real forms
 - Issue must preserve exact template title prefix (including emoji), label set, and field order
 - Local filesystem paths must be audited and removed before publishing
+- Public issue titles and body content must be English-only
 
 **When NOT to use:** Non-rocketmq-rust repositories, pure discussion/questions that should not become GitHub issues, or requests where the user explicitly says not to apply issue templates.
 
@@ -58,14 +59,15 @@ Rules:
 - Never mark prerequisite/contribution checkboxes complete unless confirmed or actually performed.
 - Tasks must be actionable: name affected modules, expected behavior, tests, and validation commands.
 - Use RocketMQ domain vocabulary (broker, namesrv, commitlog, consume queue, Tokio runtime, etc.) only where it helps the form.
+- Write all public issue title/body text in English. Repository-relative paths, code identifiers, commands, issue numbers, Markdown punctuation, and the template emoji are allowed; Chinese or other non-English prose is not allowed.
 
 ### 3. Remove Local Paths
 
 Strip Windows/Unix home paths, `file://` links, user-home env vars, local screenshot/temp/IDE paths. Rewrite to repository-relative paths or generic descriptions ("local broker log").
 
-Audit before publishing:
+Audit before publishing, including the title when available:
 ```bash
-python <skill-dir>/scripts/audit_issue_paths.py <draft.md>
+python <skill-dir>/scripts/audit_issue_paths.py --title "<title>" <draft.md>
 ```
 Fix every finding.
 
@@ -82,6 +84,7 @@ Fix every finding.
 | Inventing template names (e.g., `architecture.yml`) | Verify files exist in checkout; use only real filenames |
 | Marking checkboxes complete without confirmation | List unconfirmed items as missing |
 | Leaving a local Windows user path in draft | Run `audit_issue_paths.py` before finalizing |
+| Writing issue prose in Chinese or mixed language | Rewrite the title/body in English and rerun the audit |
 | Using feature_request for test-only work | Unit test additions → `unit_test.yml` |
 | Copying mojibake emoji from terminal | Re-read file with UTF-8 or use file content directly |
 
@@ -98,5 +101,6 @@ Fix every finding.
 - Labels match the selected template.
 - Body fields appear in template order.
 - Required fields have content or are listed under `Missing info`.
+- Title/body are English-only.
 - Checkboxes are not falsely marked complete.
-- Path audit passes with no local absolute paths or machine-specific roots.
+- Path and English audit passes with no local absolute paths, machine-specific roots, or non-English prose.

--- a/.agents/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
+++ b/.agents/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Detect local filesystem paths in a GitHub issue draft."""
+"""Detect local filesystem paths and non-English text in a GitHub issue draft."""
 
 from __future__ import annotations
 
@@ -43,6 +43,8 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
 ]
 
+ALLOWED_NON_ASCII = frozenset("🐛📝✨🚀♻️🧪\ufe0f\ufeff")
+
 
 def read_input(path_arg: str) -> tuple[str, str]:
     if path_arg == "-":
@@ -61,9 +63,24 @@ def scan_text(text: str) -> list[tuple[int, str, str]]:
     return findings
 
 
+def find_non_english_text(text: str) -> list[tuple[int, str, str]]:
+    findings: list[tuple[int, str, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for char in line:
+            if ord(char) < 128 or char in ALLOWED_NON_ASCII:
+                continue
+            findings.append((line_no, "non-English character", f"U+{ord(char):04X} {char!r}"))
+    return findings
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Fail if a GitHub issue draft contains local filesystem paths.",
+        description="Fail if a GitHub issue draft contains local filesystem paths or non-English text.",
+    )
+    parser.add_argument(
+        "--title",
+        default="",
+        help="Optional issue title to include in the audit.",
     )
     parser.add_argument(
         "draft",
@@ -72,15 +89,22 @@ def main() -> int:
     args = parser.parse_args()
 
     source, text = read_input(args.draft)
-    findings = scan_text(text)
+    audited_text = f"{args.title}\n{text}" if args.title else text
+    findings = scan_text(audited_text)
+    english_findings = find_non_english_text(audited_text)
 
-    if not findings:
-        print(f"OK: no local paths detected in {source}")
+    if not findings and not english_findings:
+        print(f"OK: no local paths or non-English text detected in {source}")
         return 0
 
-    print(f"Local path findings in {source}:", file=sys.stderr)
-    for line_no, name, value in findings:
-        print(f"  line {line_no}: {name}: {value}", file=sys.stderr)
+    if findings:
+        print(f"Local path findings in {source}:", file=sys.stderr)
+        for line_no, name, value in findings:
+            print(f"  line {line_no}: {name}: {value}", file=sys.stderr)
+    if english_findings:
+        print(f"Non-English text findings in {source}:", file=sys.stderr)
+        for line_no, name, value in english_findings:
+            print(f"  line {line_no}: {name}: {value}", file=sys.stderr)
     return 1
 
 

--- a/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
+++ b/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
@@ -13,6 +13,7 @@ Prepare RocketMQ Rust PR titles, commit messages, and bodies from `.github/PULL_
 - PR title or commit message must follow `[ISSUE #issue_id]<emoji><summary>` format
 - PR body must follow the repository's real PR template (not a custom format)
 - Issue id is available from user request, branch name, or commit history
+- Public PR titles, commit messages, and body content must be English-only
 
 **When NOT to use:** Simple branch merges without a linked issue. PRs for repos that don't use the RocketMQ Rust PR template convention.
 
@@ -46,6 +47,8 @@ Priority order: user request → branch name (`issue-7544`, `fix-7544`) → comm
 ```
 Do not put spaces between `]`, the emoji, and the summary. No extra prefixes (conventional commit, branch name). Keep the summary short and action-oriented.
 
+Write the title and commit-message summary in English only. The required emoji is allowed; Chinese or other non-English prose is not allowed.
+
 If creating a commit as part of the PR workflow, use the exact same compact format for the commit message:
 
 ```
@@ -68,6 +71,8 @@ If creating a commit as part of the PR workflow, use the exact same compact form
 ```
 Preserve template headings exactly. Keep paths repository-relative. In the test section, list commands and results; say "validation not run" honestly if applicable.
 
+Write all public body prose in English. Repository-relative paths, code identifiers, commands, issue numbers, Markdown punctuation, and the required emoji are allowed.
+
 ### 5. Validate and Publish
 1. Confirm branch, target branch, and issue id.
 2. Validate title/body:
@@ -85,6 +90,7 @@ Preserve template headings exactly. Keep paths repository-relative. In the test 
 | Leaving `#issue_id` placeholder | Replace with numeric id in both title and body |
 | Creating draft PR by default | Normal ready-for-review PR unless user says "draft PR" |
 | Claiming unrun validation passed | State "validation not run" honestly in test section |
+| Writing PR prose in Chinese or mixed language | Rewrite the title/body in English and rerun validation |
 | Adding spaces or extra prefixes | Only `[ISSUE #id]<emoji><summary>` for PR titles and commit messages |
 | Wrong emoji for change type | Match to linked issue type; default to ✨ |
 
@@ -108,5 +114,6 @@ Body:
 - Title matches `[ISSUE #number]<emoji><summary>`
 - Commit message, when created, matches `[ISSUE #number]<emoji><summary>`
 - Body includes three PR template headings in order with `- Fixes #number`
+- Title/body are English-only.
 - Test section doesn't claim unrun commands passed
-- No local absolute paths or machine-specific roots
+- No local absolute paths, machine-specific roots, or non-English prose

--- a/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
+++ b/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
@@ -53,6 +53,8 @@ REQUIRED_HEADINGS = [
     "### How Did You Test This Change?",
 ]
 
+ALLOWED_NON_ASCII = frozenset("🐛📝✨🚀♻️🧪\ufe0f\ufeff")
+
 
 def find_local_paths(text: str) -> list[str]:
     findings: list[str] = []
@@ -60,6 +62,16 @@ def find_local_paths(text: str) -> list[str]:
         for name, pattern in LOCAL_PATH_PATTERNS:
             for match in pattern.finditer(line):
                 findings.append(f"line {line_no}: {name}: {match.group(0)}")
+    return findings
+
+
+def find_non_english_text(text: str) -> list[str]:
+    findings: list[str] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for char in line:
+            if ord(char) < 128 or char in ALLOWED_NON_ASCII:
+                continue
+            findings.append(f"line {line_no}: non-English character: U+{ord(char):04X} {char!r}")
     return findings
 
 
@@ -116,6 +128,8 @@ def main() -> int:
 
     for finding in find_local_paths(args.title + "\n" + body):
         errors.append(f"local path leak: {finding}")
+    for finding in find_non_english_text(args.title + "\n" + body):
+        errors.append(f"non-English text: {finding}")
 
     if errors:
         print("PR content validation failed:", file=sys.stderr)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7935

### Brief Description

Adds English-only public content requirements to the RocketMQ Rust issue and PR helper skills. The issue audit script now accepts an optional title and rejects non-English text in the audited title and body. The PR validation script now rejects non-English text in the PR title and body while keeping the existing template, issue-link, and local-path checks.

### How Did You Test This Change?

- Parsed both Python validation scripts with `compile(...)`.
- Ran `git diff --check`.
- Verified the issue audit accepts English content and rejects Unicode non-English content.
- Verified the PR validator accepts English content and rejects Unicode non-English content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English-only checks for generated issue and PR text, including titles and body content.
  * Validation now also scans drafts for non-English characters while still allowing approved symbols and emoji.

* **Bug Fixes**
  * Improved draft auditing so path checks and language checks run together before publishing.
  * Updated review guidance to catch mixed-language content earlier and reduce invalid submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->