### PR TITLE
[ISSUE #7939]♻️Route processor failures through typed remoting adapters

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -153,27 +153,30 @@ cargo build --all-targets --all-features
 
 **范围**：`rocketmq-remoting/src/error_response.rs`、`rocketmq-remoting/src/remoting.rs`、`rocketmq-broker/src/processor*`、`rocketmq-namesrv/src/processor*`。
 
-**当前缺口**：
+**完成状态**：
 
-- `rocketmq-remoting/src/error_response.rs` 已读取 `error.spec().remoting`。
-- broker/namesrv processor 仍大量直接构造 `ResponseCode::SystemError`、`InvalidParameter`、`TopicNotExist` 等。
-- `admin_broker_processor` 仍有本地 `RocketMQError -> ResponseCode` match，并使用 `error.to_string()`。
+- `rocketmq-remoting/src/error_response.rs` 已提供基于 `error.spec().remoting` 的统一 response helper，覆盖 typed error、unsupported request code、internal fallback 和 opaque 保留。
+- broker fast-failure fallback 与 auth-admin 通用失败映射已改为通过 remoting adapter 输出；仅保留 `UserNotExist` 这类 Java-compatible 本地业务 response code。
+- namesrv processor 中通用 `SystemError`、`InvalidParameter`、`NoPermission`、`QueryNotFound` 路径已迁移到 typed error 或统一 adapter。
+- `scripts/error_architecture_guard.py` 已增加 processor generic response allowlist，禁止新增未登记的通用 response code 构造。
+
+**追踪**：Issue [#7939](https://github.com/mxsm/rocketmq-rust/issues/7939)，PR [#7940](https://github.com/mxsm/rocketmq-rust/pull/7940)。
 
 **开发 checklist**：
 
-- [ ] 给 `rocketmq_remoting::error_response` 增加统一 helper：typed error、unsupported request code、internal/system fallback、opaque 保留。
-- [ ] 先迁移通用失败路径：unsupported request、decode/header validation、serialization、auth/config error。
-- [ ] broker processor 中业务特定成功/空结果 code 保留本地，异常失败走 adapter。
-- [ ] namesrv processor 中通用 `SystemError`、`NoPermission`、`QueryNotFound` 逐步改为 typed error + adapter。
-- [ ] 删除或缩小本地 `RocketMQError -> ResponseCode` match。
-- [ ] 给 broker/namesrv 添加 mapper tests，验证典型 `ErrorKind` 到 `ResponseCode`。
-- [ ] 扩展 `error_architecture_guard.py`，禁止 processor 新增未 allowlist 的通用错误构造。
+- [x] 给 `rocketmq_remoting::error_response` 增加统一 helper：typed error、unsupported request code、internal/system fallback、opaque 保留。
+- [x] 先迁移通用失败路径：unsupported request、decode/header validation、serialization、auth/config error。
+- [x] broker processor 中业务特定成功/空结果 code 保留本地，异常失败走 adapter。
+- [x] namesrv processor 中通用 `SystemError`、`NoPermission`、`QueryNotFound` 逐步改为 typed error + adapter。
+- [x] 删除或缩小本地 `RocketMQError -> ResponseCode` match。
+- [x] 给 broker/namesrv 添加 mapper tests，验证典型 `ErrorKind` 到 `ResponseCode`。
+- [x] 扩展 `error_architecture_guard.py`，禁止 processor 新增未 allowlist 的通用错误构造。
 
 **验收 checklist**：
 
-- [ ] processor 不再手写通用 `RequestCodeNotSupported`。
-- [ ] 通用 `SystemError` fallback 有明确 allowlist。
-- [ ] 每个对外 typed failure 都能由 `ErrorSpec.remoting` 得到 response code。
+- [x] processor 不再手写通用 `RequestCodeNotSupported`。
+- [x] 通用 `SystemError` fallback 有明确 allowlist。
+- [x] 每个对外 typed failure 都能由 `ErrorSpec.remoting` 得到 response code。
 
 **建议验证**：
 

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -539,7 +539,7 @@ where
 
         let response = match processor.process_request(channel, ctx, &mut queued_request).await {
             Ok(response) => response,
-            Err(error) => Some(system_error_response(opaque, error.to_string())),
+            Err(error) => Some(error_response::command_from_error_with_opaque(&error, opaque)),
         };
         broker_fast_failure.complete(queue_kind, &task, response);
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -633,24 +633,29 @@ fn get_legacy_acl_cmd_response(request_code: RequestCode, remark: &str) -> Optio
 }
 
 fn map_auth_admin_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    let (code, remark) = match &error {
-        RocketMQError::IllegalArgument(message) | RocketMQError::RequestHeaderError(message) => {
-            (ResponseCode::InvalidParameter, message.clone())
-        }
-        RocketMQError::RequestBodyInvalid { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
-        RocketMQError::ConfigParseFailed { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
-        RocketMQError::ConfigMissing { key } => (ResponseCode::InvalidParameter, (*key).to_owned()),
-        RocketMQError::ConfigInvalidValue { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
-        RocketMQError::AuthConfigInvalid { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
-        RocketMQError::AuthHotReloadFailed { reason, .. } => (ResponseCode::SystemError, reason.clone()),
-        RocketMQError::Serialization(_) => (ResponseCode::InvalidParameter, error.to_string()),
-        RocketMQError::Authentication(AuthError::UserNotFound(_)) => (ResponseCode::UserNotExist, error.to_string()),
-        RocketMQError::Authentication(_) => (ResponseCode::NoPermission, error.to_string()),
-        RocketMQError::BrokerPermissionDenied { operation } => (ResponseCode::NoPermission, operation.clone()),
-        other => (ResponseCode::SystemError, other.to_string()),
+    if matches!(error, RocketMQError::Authentication(AuthError::UserNotFound(_))) {
+        return response
+            .set_code(ResponseCode::UserNotExist)
+            .set_remark(error.to_string());
+    }
+
+    let remark = match &error {
+        RocketMQError::IllegalArgument(message) | RocketMQError::RequestHeaderError(message) => message.clone(),
+        RocketMQError::RequestBodyInvalid { reason, .. }
+        | RocketMQError::ConfigParseFailed { reason, .. }
+        | RocketMQError::ConfigInvalidValue { reason, .. }
+        | RocketMQError::AuthConfigInvalid { reason, .. }
+        | RocketMQError::AuthHotReloadFailed { reason, .. } => reason.clone(),
+        RocketMQError::ConfigMissing { key } => (*key).to_owned(),
+        RocketMQError::BrokerPermissionDenied { operation } => operation.clone(),
+        other => other.to_string(),
     };
 
-    response.set_code(code).set_remark(remark)
+    error_response::apply_error_to_response(response, &error, remark)
+}
+
+fn auth_admin_body_decode_error(operation: &'static str, error: RocketMQError) -> RocketMQError {
+    RocketMQError::request_body_invalid(operation, error.to_string())
 }
 
 #[cfg(test)]
@@ -715,7 +720,7 @@ mod tests {
 
         let response = map_auth_admin_error_response(
             RemotingCommand::create_response_command(),
-            RocketMQError::deserialization_failed("JSON", "malformed auth admin body"),
+            RocketMQError::request_body_invalid("decode", "malformed auth admin body"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -72,7 +72,12 @@ impl<MS: MessageStore> CreateAclRequestHandler<MS> {
         };
         let acl_info = match AclInfo::decode(body) {
             Ok(acl_info) => acl_info,
-            Err(error) => return Ok(Some(map_error_response(response, error))),
+            Err(error) => {
+                return Ok(Some(map_error_response(
+                    response,
+                    super::auth_admin_body_decode_error("decode acl body", error),
+                )));
+            }
         };
         let acl = match AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str()) {
             Ok(acl) => acl,

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -61,7 +61,12 @@ impl<MS: MessageStore> CreateUserRequestHandler<MS> {
 
         let mut user_info: UserInfo = match UserInfo::decode(body) {
             Ok(user_info) => user_info,
-            Err(error) => return Ok(Some(map_error_response(response, error))),
+            Err(error) => {
+                return Ok(Some(map_error_response(
+                    response,
+                    super::auth_admin_body_decode_error("decode user body", error),
+                )));
+            }
         };
         user_info.username = Some(request_header.username);
         let user = UserConverter::convert_user(&user_info);

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -72,7 +72,12 @@ impl<MS: MessageStore> UpdateAclRequestHandler<MS> {
         };
         let acl_info = match AclInfo::decode(body) {
             Ok(acl_info) => acl_info,
-            Err(error) => return Ok(Some(map_error_response(response, error))),
+            Err(error) => {
+                return Ok(Some(map_error_response(
+                    response,
+                    super::auth_admin_body_decode_error("decode acl body", error),
+                )));
+            }
         };
         let acl = match AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str()) {
             Ok(acl) => acl,

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -63,7 +63,12 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
         };
         let mut user_info: UserInfo = match UserInfo::decode(body) {
             Ok(user_info) => user_info,
-            Err(error) => return Ok(Some(map_error_response(response, error))),
+            Err(error) => {
+                return Ok(Some(map_error_response(
+                    response,
+                    super::auth_admin_body_decode_error("decode user body", error),
+                )));
+            }
         };
 
         user_info.username = Option::from(request_header.username);

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -4897,9 +4897,9 @@ dependencies = [
 name = "rocketmq-dashboard-common"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -4077,9 +4077,9 @@ dependencies = [
 name = "rocketmq-dashboard-common"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
@@ -14,6 +14,8 @@
 
 use anyhow::Result;
 use chrono::Utc;
+use rocketmq_dashboard_common::DashboardCommonError;
+use rocketmq_dashboard_common::DashboardCommonResult;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use rocketmq_dashboard_common::NameServerConfigStore;
 use rocketmq_dashboard_common::NameServerConfigTransaction;
@@ -117,32 +119,32 @@ struct SqliteNameServerTransaction<'tx> {
 }
 
 impl NameServerConfigTransaction for SqliteNameServerTransaction<'_> {
-    fn load_snapshot(&mut self) -> Result<NameServerConfigSnapshot> {
+    fn load_snapshot(&mut self) -> DashboardCommonResult<NameServerConfigSnapshot> {
         load_snapshot_from_connection(&self.transaction)
     }
 
-    fn save_snapshot(&mut self, snapshot: &NameServerConfigSnapshot) -> Result<()> {
+    fn save_snapshot(&mut self, snapshot: &NameServerConfigSnapshot) -> DashboardCommonResult<()> {
         save_snapshot_to_transaction(&self.transaction, snapshot)
     }
 }
 
 impl NameServerConfigStore for SqliteNameServerStore {
-    fn load_snapshot(&self) -> Result<NameServerConfigSnapshot> {
-        let connection = self.db.connection()?;
+    fn load_snapshot(&self) -> DashboardCommonResult<NameServerConfigSnapshot> {
+        let connection = self.db.connection().map_err(store_error)?;
         load_snapshot_from_connection(&connection)
     }
 
-    fn run_in_transaction<T, F>(&self, operation: F) -> Result<T>
+    fn run_in_transaction<T, F>(&self, operation: F) -> DashboardCommonResult<T>
     where
-        F: FnOnce(&mut dyn NameServerConfigTransaction) -> Result<T>,
+        F: FnOnce(&mut dyn NameServerConfigTransaction) -> DashboardCommonResult<T>,
     {
-        let mut connection = self.db.connection()?;
-        let transaction = connection.transaction()?;
+        let mut connection = self.db.connection().map_err(store_error)?;
+        let transaction = connection.transaction().map_err(store_error)?;
         let mut tx_store = SqliteNameServerTransaction { transaction };
 
         match operation(&mut tx_store) {
             Ok(value) => {
-                tx_store.transaction.commit()?;
+                tx_store.transaction.commit().map_err(store_error)?;
                 Ok(value)
             }
             Err(error) => Err(error),
@@ -150,21 +152,23 @@ impl NameServerConfigStore for SqliteNameServerStore {
     }
 }
 
-fn load_snapshot_from_connection(connection: &Connection) -> Result<NameServerConfigSnapshot> {
-    let mut statement = connection.prepare(
-        "
+fn load_snapshot_from_connection(connection: &Connection) -> DashboardCommonResult<NameServerConfigSnapshot> {
+    let mut statement = connection
+        .prepare(
+            "
         SELECT address, is_current
         FROM nameserver_addresses
         ORDER BY sort_order ASC, id ASC
         ",
-    )?;
-    let mut rows = statement.query([])?;
+        )
+        .map_err(store_error)?;
+    let mut rows = statement.query([]).map_err(store_error)?;
     let mut current_namesrv = None;
     let mut namesrv_addr_list = Vec::new();
 
-    while let Some(row) = rows.next()? {
-        let address: String = row.get(0)?;
-        let is_current = row.get::<_, i64>(1)? != 0;
+    while let Some(row) = rows.next().map_err(store_error)? {
+        let address: String = row.get(0).map_err(store_error)?;
+        let is_current = row.get::<_, i64>(1).map_err(store_error)? != 0;
         if is_current && current_namesrv.is_none() {
             current_namesrv = Some(address.clone());
         }
@@ -181,7 +185,8 @@ fn load_snapshot_from_connection(connection: &Connection) -> Result<NameServerCo
             [],
             |row| Ok((row.get::<_, i64>(0)? != 0, row.get::<_, i64>(1)? != 0)),
         )
-        .optional()?;
+        .optional()
+        .map_err(store_error)?;
 
     let (use_vip_channel, use_tls) = settings.unwrap_or((true, false));
 
@@ -193,29 +198,37 @@ fn load_snapshot_from_connection(connection: &Connection) -> Result<NameServerCo
     })
 }
 
-fn save_snapshot_to_transaction(transaction: &Transaction<'_>, snapshot: &NameServerConfigSnapshot) -> Result<()> {
+fn save_snapshot_to_transaction(
+    transaction: &Transaction<'_>,
+    snapshot: &NameServerConfigSnapshot,
+) -> DashboardCommonResult<()> {
     let snapshot = canonicalize_snapshot(snapshot)?;
     let now = Utc::now().to_rfc3339();
 
-    transaction.execute("DELETE FROM nameserver_addresses", [])?;
+    transaction
+        .execute("DELETE FROM nameserver_addresses", [])
+        .map_err(store_error)?;
 
     for (index, address) in snapshot.namesrv_addr_list.iter().enumerate() {
-        transaction.execute(
-            "
+        transaction
+            .execute(
+                "
             INSERT INTO nameserver_addresses (address, is_current, sort_order, created_at, updated_at)
             VALUES (?1, ?2, ?3, ?4, ?4)
             ",
-            params![
-                address,
-                bool_to_i64(snapshot.current_namesrv.as_deref() == Some(address.as_str())),
-                index as i64,
-                now
-            ],
-        )?;
+                params![
+                    address,
+                    bool_to_i64(snapshot.current_namesrv.as_deref() == Some(address.as_str())),
+                    index as i64,
+                    now
+                ],
+            )
+            .map_err(store_error)?;
     }
 
-    transaction.execute(
-        "
+    transaction
+        .execute(
+            "
         INSERT INTO nameserver_settings (id, use_vip_channel, use_tls, created_at, updated_at)
         VALUES (1, ?1, ?2, ?3, ?3)
         ON CONFLICT(id) DO UPDATE SET
@@ -223,14 +236,19 @@ fn save_snapshot_to_transaction(transaction: &Transaction<'_>, snapshot: &NameSe
             use_tls = excluded.use_tls,
             updated_at = excluded.updated_at
         ",
-        params![
-            bool_to_i64(snapshot.use_vip_channel),
-            bool_to_i64(snapshot.use_tls),
-            now
-        ],
-    )?;
+            params![
+                bool_to_i64(snapshot.use_vip_channel),
+                bool_to_i64(snapshot.use_tls),
+                now
+            ],
+        )
+        .map_err(store_error)?;
 
     Ok(())
+}
+
+fn store_error(error: impl std::fmt::Display) -> DashboardCommonError {
+    DashboardCommonError::store(error.to_string())
 }
 
 fn repair_snapshot_tables(transaction: &Transaction<'_>) -> Result<()> {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
 use rocketmq_common::common::mix_all;
+use rocketmq_dashboard_common::DashboardCommonResult;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use rocketmq_dashboard_common::NameServerRuntimeAdapter;
 use std::env;
@@ -81,7 +81,7 @@ impl NameServerRuntimeState {
 }
 
 impl NameServerRuntimeAdapter for NameServerRuntimeState {
-    fn apply_snapshot(&self, snapshot: &NameServerConfigSnapshot) -> Result<()> {
+    fn apply_snapshot(&self, snapshot: &NameServerConfigSnapshot) -> DashboardCommonResult<()> {
         {
             let mut state = self.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
             state.snapshot = snapshot.clone();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -143,23 +143,23 @@ impl NameServerManager {
     }
 
     pub(crate) fn add_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
-        self.service.add_nameserver(address)
+        Ok(self.service.add_nameserver(address)?)
     }
 
     pub(crate) fn switch_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
-        self.service.update_current_nameserver(address)
+        Ok(self.service.update_current_nameserver(address)?)
     }
 
     pub(crate) fn delete_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
-        self.service.delete_nameserver(address)
+        Ok(self.service.delete_nameserver(address)?)
     }
 
     pub(crate) fn update_vip_channel(&self, enabled: bool) -> Result<NameServerMutationResult> {
-        self.service.update_use_vip_channel(enabled)
+        Ok(self.service.update_use_vip_channel(enabled)?)
     }
 
     pub(crate) fn update_use_tls(&self, enabled: bool) -> Result<NameServerMutationResult> {
-        self.service.update_use_tls(enabled)
+        Ok(self.service.update_use_tls(enabled)?)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
@@ -130,10 +130,10 @@ fn load_snapshot_from_connection(connection: &Connection) -> Result<ProxyConfigS
         proxy_addr_list.push(address);
     }
 
-    canonicalize_proxy_snapshot(&ProxyConfigSnapshot {
+    Ok(canonicalize_proxy_snapshot(&ProxyConfigSnapshot {
         current_proxy_addr,
         proxy_addr_list,
-    })
+    })?)
 }
 
 fn save_snapshot_to_transaction(transaction: &Transaction<'_>, snapshot: &ProxyConfigSnapshot) -> Result<()> {

--- a/rocketmq-error/src/boundary.rs
+++ b/rocketmq-error/src/boundary.rs
@@ -63,7 +63,9 @@ impl RemotingSpec {
             ErrorKind::TopicNotExist | ErrorKind::RouteNotFound => RemotingResponseCode::TopicNotExist,
             ErrorKind::SubscriptionGroupNotExist => RemotingResponseCode::SubscriptionGroupNotExist,
             ErrorKind::BrokerNotFound | ErrorKind::ClusterNotFound => RemotingResponseCode::BrokerNotExist,
-            ErrorKind::QueueNotExist | ErrorKind::MessageLookupFailed => RemotingResponseCode::QueryNotFound,
+            ErrorKind::QueueNotExist | ErrorKind::MessageLookupFailed | ErrorKind::QueryNotFound => {
+                RemotingResponseCode::QueryNotFound
+            }
             ErrorKind::MessageTooLarge | ErrorKind::MessageValidationFailed | ErrorKind::InvalidProperty => {
                 RemotingResponseCode::MessageIllegal
             }
@@ -153,7 +155,8 @@ impl GrpcSpec {
             ErrorKind::BrokerNotFound
             | ErrorKind::QueueNotExist
             | ErrorKind::ClusterNotFound
-            | ErrorKind::MessageLookupFailed => Self::new(GrpcPayloadCode::NotFound, GrpcStatusCode::NotFound),
+            | ErrorKind::MessageLookupFailed
+            | ErrorKind::QueryNotFound => Self::new(GrpcPayloadCode::NotFound, GrpcStatusCode::NotFound),
             ErrorKind::MessageTooLarge => {
                 Self::new(GrpcPayloadCode::MessageBodyTooLarge, GrpcStatusCode::ResourceExhausted)
             }
@@ -237,7 +240,8 @@ impl HttpSpec {
             | ErrorKind::BrokerNotFound
             | ErrorKind::QueueNotExist
             | ErrorKind::ClusterNotFound
-            | ErrorKind::MessageLookupFailed => HttpStatusCode::NOT_FOUND,
+            | ErrorKind::MessageLookupFailed
+            | ErrorKind::QueryNotFound => HttpStatusCode::NOT_FOUND,
             ErrorKind::RouteRegistrationConflict
             | ErrorKind::RouteVersionConflict
             | ErrorKind::ClientAlreadyStarted
@@ -313,7 +317,8 @@ impl CliSpec {
             | ErrorKind::BrokerNotFound
             | ErrorKind::QueueNotExist
             | ErrorKind::ClusterNotFound
-            | ErrorKind::MessageLookupFailed => CliExitCode::NOT_FOUND,
+            | ErrorKind::MessageLookupFailed
+            | ErrorKind::QueryNotFound => CliExitCode::NOT_FOUND,
             ErrorKind::IllegalArgument
             | ErrorKind::InvalidProperty
             | ErrorKind::MessageValidationFailed

--- a/rocketmq-error/src/kind.rs
+++ b/rocketmq-error/src/kind.rs
@@ -111,6 +111,7 @@ pub enum ErrorKind {
     BrokerPermissionDenied,
     NotMasterBroker,
     MessageLookupFailed,
+    QueryNotFound,
     TopicSendingForbidden,
     BrokerAsyncTaskFailed,
     RequestBodyInvalid,
@@ -177,6 +178,7 @@ impl ErrorKind {
         Self::BrokerPermissionDenied,
         Self::NotMasterBroker,
         Self::MessageLookupFailed,
+        Self::QueryNotFound,
         Self::TopicSendingForbidden,
         Self::BrokerAsyncTaskFailed,
         Self::RequestBodyInvalid,
@@ -244,6 +246,7 @@ impl ErrorKind {
             Self::BrokerPermissionDenied => "BROKER_PERMISSION_DENIED",
             Self::NotMasterBroker => "NOT_MASTER_BROKER",
             Self::MessageLookupFailed => "MESSAGE_LOOKUP_FAILED",
+            Self::QueryNotFound => "QUERY_NOT_FOUND",
             Self::TopicSendingForbidden => "TOPIC_SENDING_FORBIDDEN",
             Self::BrokerAsyncTaskFailed => "BROKER_ASYNC_TASK_FAILED",
             Self::RequestBodyInvalid => "REQUEST_BODY_INVALID",
@@ -316,6 +319,7 @@ impl ErrorKind {
             | Self::BrokerPermissionDenied
             | Self::NotMasterBroker
             | Self::MessageLookupFailed
+            | Self::QueryNotFound
             | Self::TopicSendingForbidden
             | Self::BrokerAsyncTaskFailed => ErrorScope::Broker,
             Self::RequestBodyInvalid | Self::RequestHeaderError | Self::ResponseProcessFailed => ErrorScope::Request,
@@ -387,6 +391,7 @@ impl ErrorKind {
             | Self::TransactionRejected
             | Self::NotMasterBroker
             | Self::MessageLookupFailed
+            | Self::QueryNotFound
             | Self::BrokerAsyncTaskFailed => ErrorCategory::Broker,
             Self::RouteNotFound
             | Self::RouteInconsistent

--- a/rocketmq-error/src/policy.rs
+++ b/rocketmq-error/src/policy.rs
@@ -56,7 +56,9 @@ impl RecoverySpec {
             | ErrorKind::RetryLimitExceeded
             | ErrorKind::StorageLockFailed
             | ErrorKind::Tools => RetryClass::AfterBackoff,
-            ErrorKind::MessageLookupFailed | ErrorKind::SubscriptionGroupNotExist => RetryClass::Immediate,
+            ErrorKind::MessageLookupFailed | ErrorKind::QueryNotFound | ErrorKind::SubscriptionGroupNotExist => {
+                RetryClass::Immediate
+            }
             _ => RetryClass::Never,
         })
     }
@@ -106,6 +108,7 @@ const fn observe_severity(kind: ErrorKind) -> ErrorSeverity {
         | ErrorKind::SubscriptionGroupNotExist
         | ErrorKind::QueueNotExist
         | ErrorKind::MessageLookupFailed
+        | ErrorKind::QueryNotFound
         | ErrorKind::Network
         | ErrorKind::Timeout
         | ErrorKind::RetryLimitExceeded

--- a/rocketmq-error/src/spec.rs
+++ b/rocketmq-error/src/spec.rs
@@ -94,6 +94,7 @@ pub const ALL_ERROR_SPECS: &[ErrorSpec] = &[
     spec!(BrokerPermissionDenied, "Broker permission was denied"),
     spec!(NotMasterBroker, "Broker is not the master"),
     spec!(MessageLookupFailed, "Message lookup failed"),
+    spec!(QueryNotFound, "Query result was not found"),
     spec!(TopicSendingForbidden, "Topic sending is forbidden"),
     spec!(BrokerAsyncTaskFailed, "Broker asynchronous operation failed"),
     spec!(RequestBodyInvalid, "Request body is invalid"),

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -197,6 +197,10 @@ pub enum RocketMQError {
     #[error("Message lookup failed at offset {offset}")]
     MessageLookupFailed { offset: i64 },
 
+    /// Query result was not found
+    #[error("Query result was not found: {resource}")]
+    QueryNotFound { resource: String },
+
     /// Topic sending forbidden
     #[error("Sending to topic '{topic}' is forbidden")]
     TopicSendingForbidden { topic: String },
@@ -425,6 +429,7 @@ impl RocketMQError {
             Self::BrokerPermissionDenied { .. } => ErrorKind::BrokerPermissionDenied,
             Self::NotMasterBroker { .. } => ErrorKind::NotMasterBroker,
             Self::MessageLookupFailed { .. } => ErrorKind::MessageLookupFailed,
+            Self::QueryNotFound { .. } => ErrorKind::QueryNotFound,
             Self::TopicSendingForbidden { .. } => ErrorKind::TopicSendingForbidden,
             Self::BrokerAsyncTaskFailed { .. } => ErrorKind::BrokerAsyncTaskFailed,
             Self::RequestBodyInvalid { .. } => ErrorKind::RequestBodyInvalid,
@@ -544,6 +549,7 @@ impl RocketMQError {
                 ErrorContext::new().with_sensitive("master_address", Sensitive::new(master_address.clone()))
             }
             Self::MessageLookupFailed { offset } => ErrorContext::new().with_field("offset", offset.to_string()),
+            Self::QueryNotFound { resource } => ErrorContext::new().with_field("resource", resource.as_str()),
             Self::TopicSendingForbidden { topic } => ErrorContext::new().with_field("topic", topic.as_str()),
             Self::BrokerAsyncTaskFailed { task, context, .. } => ErrorContext::new()
                 .with_field("task", *task)
@@ -688,6 +694,14 @@ impl RocketMQError {
     #[inline]
     pub fn route_not_found(topic: impl Into<String>) -> Self {
         Self::RouteNotFound { topic: topic.into() }
+    }
+
+    /// Create a generic query-not-found error.
+    #[inline]
+    pub fn query_not_found(resource: impl Into<String>) -> Self {
+        Self::QueryNotFound {
+            resource: resource.into(),
+        }
     }
 
     /// Create a route registration conflict error

--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -20,8 +20,8 @@ use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::common::FAQUrl;
 use rocketmq_common::TimeUtils;
 use rocketmq_remoting::code::request_code::RequestCode;
-use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -98,10 +98,11 @@ impl ClientRequestProcessor {
 
             if !namesrv_ready {
                 warn!("name server not ready. request code {}", request.code());
-                return Ok(Some(
-                    RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                        .set_remark("name server not ready"),
-                ));
+                let error = rocketmq_error::RocketMQError::not_initialized("name server not ready");
+                return Ok(Some(error_response::command_from_error_with_remark(
+                    &error,
+                    "name server not ready",
+                )));
             }
         }
 

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -22,7 +22,6 @@ use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::CRC32Utils;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
-use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::error_response;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
@@ -130,10 +129,9 @@ impl DefaultRequestProcessor {
         let request_header = request.decode_command_custom_header::<PutKVConfigRequestHeader>()?;
         //check namespace and key, need?
         if request_header.namespace.is_empty() || request_header.key.is_empty() {
-            return Ok(
-                RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                    .set_remark(CheetahString::from_static_str("namespace or key is empty")),
-            );
+            return Ok(error_response::invalid_parameter_with_remark(
+                "namespace or key is empty",
+            ));
         }
 
         self.name_server_runtime_inner.kvconfig_manager_mut().put_kv_config(
@@ -156,12 +154,10 @@ impl DefaultRequestProcessor {
             return Ok(RemotingCommand::create_response_command()
                 .set_command_custom_header(GetKVConfigResponseHeader::new(value)));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(ResponseCode::QueryNotFound).set_remark(format!(
-                "No config item, Namespace: {} Key: {}",
-                request_header.namespace, request_header.key
-            )),
-        )
+        Ok(error_response::query_not_found_with_remark(format!(
+            "No config item, Namespace: {} Key: {}",
+            request_header.namespace, request_header.key
+        )))
     }
 
     fn delete_kv_config(&mut self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
@@ -241,10 +237,7 @@ impl DefaultRequestProcessor {
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header = request.decode_command_custom_header::<RegisterBrokerRequestHeader>()?;
         if !check_sum_crc32(request, &request_header) {
-            return Ok(
-                RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                    .set_remark(CheetahString::from_static_str("crc32 not match")),
-            );
+            return Ok(error_response::invalid_parameter_with_remark("crc32 not match"));
         }
 
         let mut response_command = RemotingCommand::create_response_command();
@@ -274,9 +267,7 @@ impl DefaultRequestProcessor {
             channel,
         );
         let Some(register_broker_result) = result else {
-            return Ok(response_command
-                .set_code(RemotingSysResponseCode::SystemError)
-                .set_remark(CheetahString::from_static_str("register broker failed")));
+            return Ok(error_response::internal_error("register broker failed"));
         };
         if self
             .name_server_runtime_inner
@@ -310,8 +301,8 @@ impl DefaultRequestProcessor {
             .submit_unregister_broker_request(request_header)
         {
             warn!("Couldn't submit the unregister broker request to handler");
-            return Ok(RemotingCommand::create_response_command_with_code(
-                ResponseCode::SystemError,
+            return Ok(error_response::internal_error(
+                "could not submit unregister broker request to handler",
             ));
         }
         Ok(RemotingCommand::create_response_command())
@@ -396,10 +387,7 @@ impl DefaultRequestProcessor {
             let body = topics.encode()?;
             return Ok(RemotingCommand::create_response_command().set_body(body));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                .set_remark(CheetahString::from_static_str("disable")),
-        )
+        Ok(error_response::internal_error("disable"))
     }
 
     fn delete_topic_in_name_srv(
@@ -446,20 +434,15 @@ impl DefaultRequestProcessor {
         if let Some(value) = value {
             return Ok(RemotingCommand::create_response_command().set_body(value));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(ResponseCode::QueryNotFound).set_remark(format!(
-                "No config item, Namespace: {}",
-                request_header.namespace.as_str()
-            )),
-        )
+        Ok(error_response::query_not_found_with_remark(format!(
+            "No config item, Namespace: {}",
+            request_header.namespace.as_str()
+        )))
     }
 
     fn get_topics_by_cluster(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if !self.name_server_runtime_inner.name_server_config().enable_topic_list {
-            return Ok(
-                RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                    .set_remark(CheetahString::from_static_str("disable")),
-            );
+            return Ok(error_response::internal_error("disable"));
         }
 
         let request_header = request.decode_command_custom_header::<GetTopicsByClusterRequestHeader>()?;
@@ -489,10 +472,7 @@ impl DefaultRequestProcessor {
             let body = topic_list.encode()?;
             return Ok(RemotingCommand::create_response_command().set_body(body));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                .set_remark("disable"),
-        )
+        Ok(error_response::internal_error("disable"))
     }
 
     fn get_has_unit_sub_topic_list(
@@ -507,10 +487,7 @@ impl DefaultRequestProcessor {
             let body = topic_list.encode()?;
             return Ok(RemotingCommand::create_response_command().set_body(body));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                .set_remark("disable"),
-        )
+        Ok(error_response::internal_error("disable"))
     }
 
     fn get_has_unit_sub_un_unit_topic_list(
@@ -524,10 +501,7 @@ impl DefaultRequestProcessor {
                 .get_has_unit_sub_un_unit_topic_list();
             return Ok(RemotingCommand::create_response_command().set_body(topic_list.encode()?));
         }
-        Ok(
-            RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                .set_remark("disable"),
-        )
+        Ok(error_response::internal_error("disable"))
     }
 
     fn update_config(&mut self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
@@ -535,38 +509,32 @@ impl DefaultRequestProcessor {
             let body_str = match str::from_utf8(body) {
                 Ok(s) => s,
                 Err(e) => {
-                    return Ok(RemotingCommand::create_response_command_with_code(
-                        RemotingSysResponseCode::SystemError,
-                    )
-                    .set_remark(format!("UnsupportedEncodingException {e:?}")));
+                    return Ok(error_response::invalid_parameter_with_remark(format!(
+                        "UnsupportedEncodingException {e:?}"
+                    )));
                 }
             };
 
             let properties = match string_to_properties(body_str) {
                 Some(props) => props,
                 None => {
-                    return Ok(RemotingCommand::create_response_command_with_code(
-                        RemotingSysResponseCode::SystemError,
-                    )
-                    .set_remark("string_to_properties error".to_string()));
+                    return Ok(error_response::invalid_parameter_with_remark(
+                        "string_to_properties error",
+                    ));
                 }
             };
             if validate_blacklist_config_exist(
                 &properties,
                 &build_effective_config_blacklist(self.name_server_runtime_inner.name_server_config()),
             ) {
-                return Ok(
-                    RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::NoPermission)
-                        .set_remark("Cannot update config in blacklist.".to_string()),
-                );
+                return Ok(error_response::no_permission_with_remark(
+                    "Cannot update config in blacklist.",
+                ));
             }
 
             let result = self.name_server_runtime_inner.update_runtime_config(properties);
             if let Err(e) = result {
-                return Ok(
-                    RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::SystemError)
-                        .set_remark(format!("Update error {e:?}")),
-                );
+                return Ok(error_response::internal_error(format!("Update error {e:?}")));
             }
         }
 
@@ -583,10 +551,7 @@ impl DefaultRequestProcessor {
 
         let result = match self.name_server_runtime_inner.get_all_configs_format_string() {
             Ok(content) => create_namesrv_config_success_response(Some(content.into_bytes())),
-            Err(e) => RemotingCommand::create_response_command_with_code_remark(
-                ResponseCode::SystemError,
-                format!("UnsupportedEncodingException {e}"),
-            ),
+            Err(e) => error_response::internal_error(format!("UnsupportedEncodingException {e}")),
         };
         Ok(result)
     }
@@ -724,6 +689,7 @@ fn create_namesrv_config_success_response(body: Option<Vec<u8>>) -> RemotingComm
 #[cfg(test)]
 mod tests {
     use rocketmq_remoting::code::request_code::RequestCode;
+    use rocketmq_remoting::code::response_code::ResponseCode;
     use rocketmq_remoting::protocol::header::namesrv::config_header::GetNamesrvConfigRequestHeader;
     use rocketmq_remoting::protocol::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;
 

--- a/rocketmq-remoting/src/error_response.rs
+++ b/rocketmq-remoting/src/error_response.rs
@@ -34,6 +34,17 @@ pub fn command_from_error_with_remark(error: &RocketMQError, remark: impl Into<S
     RemotingCommand::create_response_command_with_code_remark(error.spec().remoting.code.as_i32(), remark.into())
 }
 
+/// Apply a typed RocketMQ error mapping to an existing remoting response.
+pub fn apply_error_to_response(
+    response: RemotingCommand,
+    error: &RocketMQError,
+    remark: impl Into<String>,
+) -> RemotingCommand {
+    response
+        .set_code(error.spec().remoting.code.as_i32())
+        .set_remark(remark.into())
+}
+
 /// Convert a typed RocketMQ error into a remoting response command with an
 /// explicit wire remark and request opaque.
 pub fn command_from_error_with_remark_and_opaque(
@@ -75,12 +86,57 @@ pub fn request_code_not_supported_with_remark_and_opaque(
     request_code_not_supported_with_remark(request_code, remark).set_opaque(opaque)
 }
 
+/// Build an invalid-parameter response from the central remoting boundary
+/// mapping.
+pub fn invalid_parameter_with_remark(remark: impl Into<String>) -> RemotingCommand {
+    let remark = remark.into();
+    let error = RocketMQError::illegal_argument(remark.clone());
+    command_from_error_with_remark(&error, remark)
+}
+
+/// Build an invalid-parameter response and preserve request opaque.
+pub fn invalid_parameter_with_remark_and_opaque(remark: impl Into<String>, opaque: i32) -> RemotingCommand {
+    invalid_parameter_with_remark(remark).set_opaque(opaque)
+}
+
+/// Build a no-permission response from the central remoting boundary mapping.
+pub fn no_permission_with_remark(remark: impl Into<String>) -> RemotingCommand {
+    let remark = remark.into();
+    let error = RocketMQError::BrokerPermissionDenied {
+        operation: remark.clone(),
+    };
+    command_from_error_with_remark(&error, remark)
+}
+
+/// Build a no-permission response and preserve request opaque.
+pub fn no_permission_with_remark_and_opaque(remark: impl Into<String>, opaque: i32) -> RemotingCommand {
+    no_permission_with_remark(remark).set_opaque(opaque)
+}
+
+/// Build a query-not-found response from the central remoting boundary mapping.
+pub fn query_not_found_with_remark(remark: impl Into<String>) -> RemotingCommand {
+    let remark = remark.into();
+    let error = RocketMQError::query_not_found(remark.clone());
+    command_from_error_with_remark(&error, remark)
+}
+
+/// Build a query-not-found response and preserve request opaque.
+pub fn query_not_found_with_remark_and_opaque(remark: impl Into<String>, opaque: i32) -> RemotingCommand {
+    query_not_found_with_remark(remark).set_opaque(opaque)
+}
+
 /// Build a generic internal-error response from the central remoting boundary
 /// mapping.
-pub fn internal_error_with_opaque(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
+pub fn internal_error(remark: impl Into<String>) -> RemotingCommand {
     let remark = remark.into();
     let error = RocketMQError::Internal(remark.clone());
-    command_from_error_with_remark_and_opaque(&error, remark, opaque)
+    command_from_error_with_remark(&error, remark)
+}
+
+/// Build a generic internal-error response from the central remoting boundary
+/// mapping and preserve request opaque.
+pub fn internal_error_with_opaque(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
+    internal_error(remark).set_opaque(opaque)
 }
 
 #[cfg(test)]
@@ -126,5 +182,33 @@ mod tests {
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
         assert_eq!(response.opaque(), 9);
         assert_eq!(response.remark().map(|remark| remark.as_str()), Some("worker failed"));
+    }
+
+    #[test]
+    fn common_response_helpers_use_central_remoting_spec() {
+        let invalid = invalid_parameter_with_remark_and_opaque("bad argument", 11);
+        assert_eq!(ResponseCode::from(invalid.code()), ResponseCode::InvalidParameter);
+        assert_eq!(invalid.opaque(), 11);
+
+        let denied = no_permission_with_remark_and_opaque("forbidden", 12);
+        assert_eq!(ResponseCode::from(denied.code()), ResponseCode::NoPermission);
+        assert_eq!(denied.opaque(), 12);
+
+        let missing = query_not_found_with_remark_and_opaque("missing kv", 13);
+        assert_eq!(ResponseCode::from(missing.code()), ResponseCode::QueryNotFound);
+        assert_eq!(missing.opaque(), 13);
+    }
+
+    #[test]
+    fn apply_error_to_response_preserves_existing_response_shape() {
+        let response = apply_error_to_response(
+            RemotingCommand::create_response_command().set_opaque(23),
+            &RocketMQError::illegal_argument("bad field"),
+            "bad field",
+        );
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+        assert_eq!(response.opaque(), 23);
+        assert_eq!(response.remark().map(|remark| remark.as_str()), Some("bad field"));
     }
 }

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -65,6 +65,36 @@ ANYHOW_RESULT_ALLOWLIST: dict[str, str] = {
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs": "TUI terminal runtime boundary",
 }
 
+PROCESSOR_GENERIC_RESPONSE_ALLOWLIST: dict[str, str] = {
+    "rocketmq-broker/src/processor/admin_broker_processor/": "admin remoting APIs retain Java-compatible local response codes pending typed handler migration",
+    "rocketmq-broker/src/processor/change_invisible_time_processor.rs": "pop invisible-time protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/client_manage_processor.rs": "client management protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/consumer_manage_processor.rs": "consumer management protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/end_transaction_processor.rs": "transaction end protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/lite_manager_processor.rs": "lite management protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs": "lite subscription protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/notification_processor.rs": "long-poll notification protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/peek_message_processor.rs": "peek message protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/polling_info_processor.rs": "polling info protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/pop_lite_message_processor.rs": "lite pop protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/pop_message_processor.rs": "pop message protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/pull_message_processor.rs": "pull message protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/query_assignment_processor.rs": "assignment query protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/query_message_processor.rs": "message query protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/recall_message_processor.rs": "recall message protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/reply_message_processor.rs": "reply message protocol keeps Java-compatible broker response codes",
+    "rocketmq-broker/src/processor/send_message_processor.rs": "send message protocol keeps Java-compatible broker response codes",
+}
+
+PROCESSOR_GENERIC_RESPONSE_TERMS = (
+    "ResponseCode::SystemError",
+    "ResponseCode::InvalidParameter",
+    "ResponseCode::NoPermission",
+    "ResponseCode::QueryNotFound",
+    "RemotingSysResponseCode::SystemError",
+    "RemotingSysResponseCode::NoPermission",
+)
+
 
 @dataclasses.dataclass(frozen=True)
 class Finding:
@@ -138,6 +168,11 @@ def is_anyhow_result_allowlisted(path: Path) -> bool:
     return rel in ANYHOW_RESULT_ALLOWLIST
 
 
+def is_processor_generic_response_allowlisted(path: Path) -> bool:
+    rel = rel_path(path)
+    return any(rel == prefix or rel.startswith(prefix) for prefix in PROCESSOR_GENERIC_RESPONSE_ALLOWLIST)
+
+
 def scan_forbidden_terms(paths: Iterable[Path], forbidden: dict[str, str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in paths:
@@ -195,11 +230,47 @@ def check_processor_boundary_mappings() -> list[Finding]:
     return findings
 
 
+def check_processor_generic_response_allowlist() -> list[Finding]:
+    findings: list[Finding] = []
+    processor_roots = [
+        ROOT / "rocketmq-broker" / "src" / "processor.rs",
+        ROOT / "rocketmq-broker" / "src" / "processor",
+        ROOT / "rocketmq-namesrv" / "src" / "processor.rs",
+        ROOT / "rocketmq-namesrv" / "src" / "processor",
+    ]
+    paths: list[Path] = []
+    for root in processor_roots:
+        if root.is_file():
+            paths.append(root)
+        elif root.is_dir():
+            paths.extend(rust_files_under(*root.relative_to(ROOT).parts))
+
+    for path in sorted(set(paths)):
+        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("//") or is_test_context(path, line_number):
+                continue
+            if not any(term in line for term in PROCESSOR_GENERIC_RESPONSE_TERMS):
+                continue
+            if not is_processor_generic_response_allowlisted(path):
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        "generic processor response codes require typed error_response helpers or an allowlist entry",
+                    )
+                )
+    return findings
+
+
 def check_required_mapping_adapters() -> list[Finding]:
     checks = {
         ROOT / "rocketmq-remoting" / "src" / "error_response.rs": [
             "error.spec().remoting.code.as_i32()",
+            "apply_error_to_response",
+            "invalid_parameter_with_remark",
             "request_code_not_supported_with_remark",
+            "query_not_found_with_remark",
             "internal_error_with_opaque",
         ],
         ROOT / "rocketmq-proxy" / "src" / "status.rs": [
@@ -352,6 +423,7 @@ def run() -> int:
     checks = [
         ("core public surface", check_error_and_common_public_surface),
         ("processor boundary mappings", check_processor_boundary_mappings),
+        ("processor generic response allowlist", check_processor_generic_response_allowlist),
         ("required mapping adapters", check_required_mapping_adapters),
         ("error spec contract", check_error_spec_contract),
         ("internal error allowlist", check_internal_error_allowlist),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7939

### Brief Description

- Adds a typed `QueryNotFound` error kind and wires it through remoting, gRPC, HTTP, CLI, recovery, and observe specs.
- Expands `rocketmq_remoting::error_response` with reusable helpers that derive generic remoting failures from `ErrorSpec.remoting`.
- Routes NameServer generic failures and broker typed fallback/auth-admin failures through the central remoting adapter while preserving Java-compatible local response codes on an explicit guard allowlist.
- Aligns the Tauri dashboard NameServer adapters and dashboard lockfiles with the typed `rocketmq-dashboard-common` result contract.
- Marks the processor boundary checklist as complete.

### How Did You Test This Change?

- `cargo test -p rocketmq-error` passed.
- `cargo test -p rocketmq-remoting error_response` passed.
- `cargo test -p rocketmq-namesrv default_request_processor` passed.
- `cargo test -p rocketmq-broker auth_admin_error_response` passed.
- `cargo test -p rocketmq-broker auth_admin_handlers_return_invalid_parameter_for_malformed_body` passed.
- `cargo test -p rocketmq-remoting` passed.
- `cargo test -p rocketmq-namesrv` passed.
- `cargo test -p rocketmq-broker` passed.
- `py scripts\error_architecture_guard.py` passed.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` passed in `rocketmq-example`.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` passed in `rocketmq-dashboard/rocketmq-dashboard-gpui`.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` passed in `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`.
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo build --all-targets --all-features` passed in `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
