### PR TITLE
[ISSUE #7941]♻️Consolidate proxy gRPC error mapping

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -191,26 +191,29 @@ py scripts\error_architecture_guard.py
 
 **范围**：`rocketmq-proxy/src/status.rs`、`rocketmq-proxy/src/error.rs`、相关 gRPC tests。
 
-**当前缺口**：
+**完成状态**：
 
-- `ProxyError::RocketMQ` 路径部分读取 `error.spec().grpc`。
-- `rocketmq_payload_override` 和 `tonic_code_from_payload_code` 仍保留本地映射表。
-- 部分 local `ProxyError` 仍直接映射 `v2::Code`，没有中心 metadata 或明确 local-only 分类。
+- `ProxyError::RocketMQ` 默认 payload/status 已由 `ErrorSpec.grpc` 派生，payload message 使用 `RocketMQError::public_message()`，不再依赖 `Display` 文本。
+- broker response code 兼容路径已收敛为显式 `broker_response_payload_override` allowlist，并同时声明 payload code 与 tonic status。
+- proxy local-only 错误已建立 `ProxyErrorKind`，本地映射集中在 `local_error_grpc_mapping`。
+- 旧的 `tonic_code_from_payload_code` 旁路 helper 和 display-string topic-route 推断已移除，并由 `scripts/error_architecture_guard.py` 阻止回退。
+
+**追踪**：Issue [#7941](https://github.com/mxsm/rocketmq-rust/issues/7941)，PR [#7942](https://github.com/mxsm/rocketmq-rust/pull/7942)。
 
 **开发 checklist**：
 
-- [ ] 区分 `RocketMQError` 通用路径与 proxy local-only 错误路径。
-- [ ] `RocketMQError` 默认 payload/status 从 `ErrorSpec.grpc` 派生。
-- [ ] 只保留必须基于 broker response code 的 override，并写清 allowlist。
-- [ ] 为 proxy local-only error 建立 `ProxyErrorKind` 或转换到 `RocketMQError`。
-- [ ] 避免新增旁路 gRPC 映射表。
-- [ ] 补齐 `v2::Code` 与 `tonic::Code` 的 focused tests。
+- [x] 区分 `RocketMQError` 通用路径与 proxy local-only 错误路径。
+- [x] `RocketMQError` 默认 payload/status 从 `ErrorSpec.grpc` 派生。
+- [x] 只保留必须基于 broker response code 的 override，并写清 allowlist。
+- [x] 为 proxy local-only error 建立 `ProxyErrorKind` 或转换到 `RocketMQError`。
+- [x] 避免新增旁路 gRPC 映射表。
+- [x] 补齐 `v2::Code` 与 `tonic::Code` 的 focused tests。
 
 **验收 checklist**：
 
-- [ ] `RocketMQError` gRPC 输出不依赖 display string。
-- [ ] override 分支都有测试和注释说明。
-- [ ] 新增 proxy error 不会绕过中心 spec 或 local-only allowlist。
+- [x] `RocketMQError` gRPC 输出不依赖 display string。
+- [x] override 分支都有测试和注释说明。
+- [x] 新增 proxy error 不会绕过中心 spec 或 local-only allowlist。
 
 **建议验证**：
 

--- a/rocketmq-proxy/src/auth.rs
+++ b/rocketmq-proxy/src/auth.rs
@@ -1053,7 +1053,10 @@ mod tests {
 
         let internal =
             map_authorization_error(AuthorizationError::PolicyEvaluationFailed("invalid policy".to_string()));
-        assert!(matches!(internal, ProxyError::RocketMQ(RocketMQError::Internal(_))));
+        assert!(matches!(
+            internal,
+            ProxyError::RocketMQ(RocketMQError::Authentication(AuthError::AuthorizationFailed(_)))
+        ));
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/src/error.rs
+++ b/rocketmq-proxy/src/error.rs
@@ -17,6 +17,28 @@ use thiserror::Error;
 
 pub type ProxyResult<T> = std::result::Result<T, ProxyError>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProxyErrorKind {
+    ClientIdRequired,
+    UnrecognizedClientType,
+    NotImplemented,
+    TooManyRequests,
+    InvalidMetadata,
+    Transport,
+    IllegalMessageId,
+    InvalidTransactionId,
+    IllegalMessageGroup,
+    IllegalDeliveryTime,
+    IllegalPollingTime,
+    IllegalOffset,
+    IllegalInvisibleTime,
+    IllegalFilterExpression,
+    InvalidReceiptHandle,
+    IllegalLiteTopic,
+    LiteSubscriptionQuotaExceeded,
+    MessagePropertyConflictWithType,
+}
+
 #[derive(Debug, Error)]
 pub enum ProxyError {
     #[error(transparent)]
@@ -78,6 +100,30 @@ pub enum ProxyError {
 }
 
 impl ProxyError {
+    pub fn local_kind(&self) -> Option<ProxyErrorKind> {
+        Some(match self {
+            Self::RocketMQ(_) => return None,
+            Self::ClientIdRequired => ProxyErrorKind::ClientIdRequired,
+            Self::UnrecognizedClientType(_) => ProxyErrorKind::UnrecognizedClientType,
+            Self::NotImplemented { .. } => ProxyErrorKind::NotImplemented,
+            Self::TooManyRequests { .. } => ProxyErrorKind::TooManyRequests,
+            Self::InvalidMetadata { .. } => ProxyErrorKind::InvalidMetadata,
+            Self::Transport { .. } => ProxyErrorKind::Transport,
+            Self::IllegalMessageId { .. } => ProxyErrorKind::IllegalMessageId,
+            Self::InvalidTransactionId { .. } => ProxyErrorKind::InvalidTransactionId,
+            Self::IllegalMessageGroup { .. } => ProxyErrorKind::IllegalMessageGroup,
+            Self::IllegalDeliveryTime { .. } => ProxyErrorKind::IllegalDeliveryTime,
+            Self::IllegalPollingTime { .. } => ProxyErrorKind::IllegalPollingTime,
+            Self::IllegalOffset { .. } => ProxyErrorKind::IllegalOffset,
+            Self::IllegalInvisibleTime { .. } => ProxyErrorKind::IllegalInvisibleTime,
+            Self::IllegalFilterExpression { .. } => ProxyErrorKind::IllegalFilterExpression,
+            Self::InvalidReceiptHandle { .. } => ProxyErrorKind::InvalidReceiptHandle,
+            Self::IllegalLiteTopic { .. } => ProxyErrorKind::IllegalLiteTopic,
+            Self::LiteSubscriptionQuotaExceeded { .. } => ProxyErrorKind::LiteSubscriptionQuotaExceeded,
+            Self::MessagePropertyConflictWithType { .. } => ProxyErrorKind::MessagePropertyConflictWithType,
+        })
+    }
+
     pub fn not_implemented(feature: &'static str) -> Self {
         Self::NotImplemented { feature }
     }

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -22,6 +22,7 @@ use tonic::Code as TonicCode;
 use tonic::Status as TonicStatus;
 
 use crate::error::ProxyError;
+use crate::error::ProxyErrorKind;
 use crate::proto::v2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +58,18 @@ impl From<ProxyPayloadStatus> for v2::Status {
             code: value.code,
             message: value.message,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProxyGrpcMapping {
+    payload: v2::Code,
+    status: TonicCode,
+}
+
+impl ProxyGrpcMapping {
+    const fn new(payload: v2::Code, status: TonicCode) -> Self {
+        Self { payload, status }
     }
 }
 
@@ -99,28 +112,22 @@ impl ProxyStatusMapper {
     }
 
     pub fn from_error_payload(error: &ProxyError) -> ProxyPayloadStatus {
-        let code = match error {
-            ProxyError::ClientIdRequired => v2::Code::ClientIdRequired,
-            ProxyError::UnrecognizedClientType(_) => v2::Code::UnrecognizedClientType,
-            ProxyError::NotImplemented { .. } => v2::Code::NotImplemented,
-            ProxyError::TooManyRequests { .. } => v2::Code::TooManyRequests,
-            ProxyError::InvalidMetadata { .. } => v2::Code::BadRequest,
-            ProxyError::Transport { .. } => v2::Code::InternalError,
-            ProxyError::IllegalMessageId { .. } => v2::Code::IllegalMessageId,
-            ProxyError::InvalidTransactionId { .. } => v2::Code::InvalidTransactionId,
-            ProxyError::IllegalMessageGroup { .. } => v2::Code::IllegalMessageGroup,
-            ProxyError::IllegalDeliveryTime { .. } => v2::Code::IllegalDeliveryTime,
-            ProxyError::IllegalPollingTime { .. } => v2::Code::IllegalPollingTime,
-            ProxyError::IllegalOffset { .. } => v2::Code::IllegalOffset,
-            ProxyError::IllegalInvisibleTime { .. } => v2::Code::IllegalInvisibleTime,
-            ProxyError::IllegalFilterExpression { .. } => v2::Code::IllegalFilterExpression,
-            ProxyError::InvalidReceiptHandle { .. } => v2::Code::InvalidReceiptHandle,
-            ProxyError::IllegalLiteTopic { .. } => v2::Code::IllegalLiteTopic,
-            ProxyError::LiteSubscriptionQuotaExceeded { .. } => v2::Code::LiteSubscriptionQuotaExceeded,
-            ProxyError::MessagePropertyConflictWithType { .. } => v2::Code::MessagePropertyConflictWithType,
-            ProxyError::RocketMQ(inner) => Self::from_rocketmq_error(inner),
+        let (code, message) = match error {
+            ProxyError::RocketMQ(inner) => (
+                Self::rocketmq_error_grpc_mapping(inner).payload,
+                inner.public_message().to_owned(),
+            ),
+            local => (
+                Self::local_error_grpc_mapping(
+                    local
+                        .local_kind()
+                        .expect("non-RocketMQ proxy errors must expose local kind"),
+                )
+                .payload,
+                local.to_string(),
+            ),
         };
-        Self::from_payload_code(code, error.to_string())
+        Self::from_payload_code(code, message)
     }
 
     pub fn from_error(error: &ProxyError) -> v2::Status {
@@ -139,81 +146,109 @@ impl ProxyStatusMapper {
         }
 
         let payload = Self::from_error(error);
-        let payload_code = v2::Code::try_from(payload.code).unwrap_or(v2::Code::InternalError);
-        let tonic_code = Self::tonic_code_for_error(error, payload_code);
+        let tonic_code = match error {
+            ProxyError::RocketMQ(inner) => Self::rocketmq_error_grpc_mapping(inner).status,
+            local => {
+                Self::local_error_grpc_mapping(
+                    local
+                        .local_kind()
+                        .expect("non-RocketMQ proxy errors must expose local kind"),
+                )
+                .status
+            }
+        };
 
         TonicStatus::new(tonic_code, payload.message)
     }
 
-    fn tonic_code_for_error(error: &ProxyError, payload_code: v2::Code) -> TonicCode {
-        match error {
-            ProxyError::RocketMQ(inner) if Self::rocketmq_payload_override(inner).is_none() => {
-                Self::grpc_status_to_tonic_code(inner.spec().grpc.status)
+    fn local_error_grpc_mapping(kind: ProxyErrorKind) -> ProxyGrpcMapping {
+        match kind {
+            ProxyErrorKind::ClientIdRequired => {
+                ProxyGrpcMapping::new(v2::Code::ClientIdRequired, TonicCode::InvalidArgument)
             }
-            _ => Self::tonic_code_from_payload_code(payload_code),
+            ProxyErrorKind::UnrecognizedClientType => {
+                ProxyGrpcMapping::new(v2::Code::UnrecognizedClientType, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::NotImplemented => ProxyGrpcMapping::new(v2::Code::NotImplemented, TonicCode::Unimplemented),
+            ProxyErrorKind::TooManyRequests => {
+                ProxyGrpcMapping::new(v2::Code::TooManyRequests, TonicCode::ResourceExhausted)
+            }
+            ProxyErrorKind::InvalidMetadata => ProxyGrpcMapping::new(v2::Code::BadRequest, TonicCode::InvalidArgument),
+            ProxyErrorKind::Transport => ProxyGrpcMapping::new(v2::Code::InternalError, TonicCode::Unavailable),
+            ProxyErrorKind::IllegalMessageId => {
+                ProxyGrpcMapping::new(v2::Code::IllegalMessageId, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::InvalidTransactionId => {
+                ProxyGrpcMapping::new(v2::Code::InvalidTransactionId, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalMessageGroup => {
+                ProxyGrpcMapping::new(v2::Code::IllegalMessageGroup, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalDeliveryTime => {
+                ProxyGrpcMapping::new(v2::Code::IllegalDeliveryTime, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalPollingTime => {
+                ProxyGrpcMapping::new(v2::Code::IllegalPollingTime, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalOffset => ProxyGrpcMapping::new(v2::Code::IllegalOffset, TonicCode::InvalidArgument),
+            ProxyErrorKind::IllegalInvisibleTime => {
+                ProxyGrpcMapping::new(v2::Code::IllegalInvisibleTime, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalFilterExpression => {
+                ProxyGrpcMapping::new(v2::Code::IllegalFilterExpression, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::InvalidReceiptHandle => {
+                ProxyGrpcMapping::new(v2::Code::InvalidReceiptHandle, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::IllegalLiteTopic => {
+                ProxyGrpcMapping::new(v2::Code::IllegalLiteTopic, TonicCode::InvalidArgument)
+            }
+            ProxyErrorKind::LiteSubscriptionQuotaExceeded => {
+                ProxyGrpcMapping::new(v2::Code::LiteSubscriptionQuotaExceeded, TonicCode::ResourceExhausted)
+            }
+            ProxyErrorKind::MessagePropertyConflictWithType => {
+                ProxyGrpcMapping::new(v2::Code::MessagePropertyConflictWithType, TonicCode::InvalidArgument)
+            }
         }
     }
 
-    fn tonic_code_from_payload_code(payload_code: v2::Code) -> TonicCode {
-        match payload_code {
-            v2::Code::BadRequest
-            | v2::Code::IllegalAccessPoint
-            | v2::Code::IllegalTopic
-            | v2::Code::IllegalConsumerGroup
-            | v2::Code::IllegalMessageTag
-            | v2::Code::IllegalMessageKey
-            | v2::Code::IllegalMessageGroup
-            | v2::Code::IllegalMessagePropertyKey
-            | v2::Code::InvalidTransactionId
-            | v2::Code::IllegalMessageId
-            | v2::Code::IllegalFilterExpression
-            | v2::Code::IllegalInvisibleTime
-            | v2::Code::IllegalDeliveryTime
-            | v2::Code::InvalidReceiptHandle
-            | v2::Code::MessagePropertyConflictWithType
-            | v2::Code::UnrecognizedClientType
-            | v2::Code::ClientIdRequired
-            | v2::Code::IllegalPollingTime
-            | v2::Code::IllegalOffset
-            | v2::Code::IllegalLiteTopic => TonicCode::InvalidArgument,
-            v2::Code::Unauthorized => TonicCode::Unauthenticated,
-            v2::Code::Forbidden => TonicCode::PermissionDenied,
-            v2::Code::NotFound
-            | v2::Code::MessageNotFound
-            | v2::Code::TopicNotFound
-            | v2::Code::ConsumerGroupNotFound
-            | v2::Code::OffsetNotFound => TonicCode::NotFound,
-            v2::Code::RequestTimeout | v2::Code::ProxyTimeout => TonicCode::DeadlineExceeded,
-            v2::Code::MessageBodyTooLarge
-            | v2::Code::TooManyRequests
-            | v2::Code::LiteTopicQuotaExceeded
-            | v2::Code::LiteSubscriptionQuotaExceeded => TonicCode::ResourceExhausted,
-            v2::Code::NotImplemented
-            | v2::Code::Unsupported
-            | v2::Code::VersionUnsupported
-            | v2::Code::VerifyFifoMessageUnsupported => TonicCode::Unimplemented,
-            _ => TonicCode::Internal,
-        }
+    fn rocketmq_error_grpc_mapping(error: &RocketMQError) -> ProxyGrpcMapping {
+        Self::broker_response_payload_override(error).unwrap_or_else(|| {
+            let grpc = error.spec().grpc;
+            ProxyGrpcMapping::new(
+                Self::grpc_payload_to_code(grpc.payload),
+                Self::grpc_status_to_tonic_code(grpc.status),
+            )
+        })
     }
 
-    fn from_rocketmq_error(error: &RocketMQError) -> v2::Code {
-        Self::rocketmq_payload_override(error).unwrap_or_else(|| Self::grpc_payload_to_code(error.spec().grpc.payload))
-    }
-
-    fn rocketmq_payload_override(error: &RocketMQError) -> Option<v2::Code> {
+    fn broker_response_payload_override(error: &RocketMQError) -> Option<ProxyGrpcMapping> {
         match error {
-            RocketMQError::IllegalArgument(message) if is_topic_route_not_found_message(message) => {
-                Some(v2::Code::TopicNotFound)
-            }
             RocketMQError::BrokerOperationFailed { code, .. } => match ResponseCode::from(*code) {
-                ResponseCode::NoPermission => Some(v2::Code::Forbidden),
-                ResponseCode::TopicNotExist => Some(v2::Code::TopicNotFound),
-                ResponseCode::SubscriptionGroupNotExist => Some(v2::Code::ConsumerGroupNotFound),
-                ResponseCode::UserNotExist | ResponseCode::PolicyNotExist => Some(v2::Code::NotFound),
-                ResponseCode::QueryNotFound => Some(v2::Code::OffsetNotFound),
-                ResponseCode::PullOffsetMoved => Some(v2::Code::IllegalOffset),
-                ResponseCode::RequestCodeNotSupported => Some(v2::Code::Unsupported),
-                _ => Some(v2::Code::InternalError),
+                ResponseCode::NoPermission => {
+                    Some(ProxyGrpcMapping::new(v2::Code::Forbidden, TonicCode::PermissionDenied))
+                }
+                ResponseCode::TopicNotExist => {
+                    Some(ProxyGrpcMapping::new(v2::Code::TopicNotFound, TonicCode::NotFound))
+                }
+                ResponseCode::SubscriptionGroupNotExist => Some(ProxyGrpcMapping::new(
+                    v2::Code::ConsumerGroupNotFound,
+                    TonicCode::NotFound,
+                )),
+                ResponseCode::UserNotExist | ResponseCode::PolicyNotExist => {
+                    Some(ProxyGrpcMapping::new(v2::Code::NotFound, TonicCode::NotFound))
+                }
+                ResponseCode::QueryNotFound => {
+                    Some(ProxyGrpcMapping::new(v2::Code::OffsetNotFound, TonicCode::NotFound))
+                }
+                ResponseCode::PullOffsetMoved => Some(ProxyGrpcMapping::new(
+                    v2::Code::IllegalOffset,
+                    TonicCode::InvalidArgument,
+                )),
+                ResponseCode::RequestCodeNotSupported => {
+                    Some(ProxyGrpcMapping::new(v2::Code::Unsupported, TonicCode::Unimplemented))
+                }
+                _ => Some(ProxyGrpcMapping::new(v2::Code::InternalError, TonicCode::Internal)),
             },
             _ => None,
         }
@@ -253,12 +288,6 @@ impl ProxyStatusMapper {
     }
 }
 
-fn is_topic_route_not_found_message(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    (lower.contains("code: 17") || lower.contains("code:17"))
-        && (lower.contains("no topic route info") || lower.contains("no route info"))
-}
-
 #[cfg(test)]
 mod tests {
     use rocketmq_error::RocketMQError;
@@ -266,6 +295,7 @@ mod tests {
 
     use super::ProxyStatusMapper;
     use crate::error::ProxyError;
+    use crate::error::ProxyErrorKind;
     use crate::proto::v2;
 
     #[test]
@@ -281,12 +311,19 @@ mod tests {
     }
 
     #[test]
-    fn namesrv_topic_route_illegal_argument_maps_to_topic_not_found() {
+    fn route_not_found_requires_typed_error_instead_of_display_text() {
         let status = ProxyStatusMapper::from_error(&ProxyError::RocketMQ(RocketMQError::illegal_argument(
             "CODE: 17  DESC: No topic route info in name server for the topic: TestTopic",
         )));
 
-        assert_eq!(status.code, v2::Code::TopicNotFound as i32);
+        assert_eq!(status.code, v2::Code::BadRequest as i32);
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&ProxyError::RocketMQ(RocketMQError::illegal_argument(
+                "CODE: 17  DESC: No topic route info in name server for the topic: TestTopic",
+            )))
+            .code(),
+            tonic::Code::InvalidArgument
+        );
     }
 
     #[test]
@@ -349,6 +386,36 @@ mod tests {
     }
 
     #[test]
+    fn broker_response_overrides_have_explicit_payload_and_tonic_status() {
+        for (response_code, expected_grpc_code, expected_tonic_code) in [
+            (
+                ResponseCode::QueryNotFound,
+                v2::Code::OffsetNotFound,
+                tonic::Code::NotFound,
+            ),
+            (
+                ResponseCode::PullOffsetMoved,
+                v2::Code::IllegalOffset,
+                tonic::Code::InvalidArgument,
+            ),
+            (
+                ResponseCode::RequestCodeNotSupported,
+                v2::Code::Unsupported,
+                tonic::Code::Unimplemented,
+            ),
+        ] {
+            let error = ProxyError::RocketMQ(RocketMQError::broker_operation_failed(
+                "BROKER",
+                response_code.to_i32(),
+                "broker response override",
+            ));
+            let payload_status = ProxyStatusMapper::from_error(&error);
+            assert_eq!(payload_status.code, expected_grpc_code as i32);
+            assert_eq!(ProxyStatusMapper::to_tonic_status(&error).code(), expected_tonic_code);
+        }
+    }
+
+    #[test]
     fn auth_config_errors_map_to_bad_request_payload_and_transport_status() {
         for error in [
             ProxyError::RocketMQ(RocketMQError::ConfigInvalidValue {
@@ -392,6 +459,42 @@ mod tests {
         assert_eq!(
             ProxyStatusMapper::to_tonic_status(&not_master).code(),
             tonic::Code::FailedPrecondition
+        );
+    }
+
+    #[test]
+    fn rocketmq_error_payload_message_uses_public_message() {
+        let inner = RocketMQError::ConfigInvalidValue {
+            key: "auth.authorization",
+            value: "local".to_owned(),
+            reason: "provider not ready".to_owned(),
+        };
+        let expected_message = inner.public_message().to_owned();
+        let error = ProxyError::RocketMQ(inner);
+
+        let status = ProxyStatusMapper::from_error(&error);
+
+        assert_eq!(status.message, expected_message);
+    }
+
+    #[test]
+    fn local_proxy_errors_use_local_only_kind_mapping() {
+        let lite_topic = ProxyError::illegal_lite_topic("not an LMQ");
+        assert_eq!(lite_topic.local_kind(), Some(ProxyErrorKind::IllegalLiteTopic));
+        let lite_topic_status = ProxyStatusMapper::from_error(&lite_topic);
+        assert_eq!(lite_topic_status.code, v2::Code::IllegalLiteTopic as i32);
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&lite_topic).code(),
+            tonic::Code::InvalidArgument
+        );
+
+        let quota = ProxyError::lite_subscription_quota_exceeded("subscription limit reached");
+        assert_eq!(quota.local_kind(), Some(ProxyErrorKind::LiteSubscriptionQuotaExceeded));
+        let quota_status = ProxyStatusMapper::from_error(&quota);
+        assert_eq!(quota_status.code, v2::Code::LiteSubscriptionQuotaExceeded as i32);
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&quota).code(),
+            tonic::Code::ResourceExhausted
         );
     }
 }

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -274,9 +274,13 @@ def check_required_mapping_adapters() -> list[Finding]:
             "internal_error_with_opaque",
         ],
         ROOT / "rocketmq-proxy" / "src" / "status.rs": [
+            "ProxyErrorKind",
+            "broker_response_payload_override",
             "error.spec().grpc",
             "grpc_payload_to_code",
             "grpc_status_to_tonic_code",
+            "local_error_grpc_mapping",
+            "public_message()",
         ],
     }
     findings: list[Finding] = []
@@ -289,6 +293,18 @@ def check_required_mapping_adapters() -> list[Finding]:
             if needle not in text:
                 findings.append(Finding(path, 1, f"required mapping adapter token missing: {needle}"))
     return findings
+
+
+def check_proxy_grpc_boundary() -> list[Finding]:
+    path = ROOT / "rocketmq-proxy" / "src" / "status.rs"
+    if not path.exists():
+        return [Finding(path, 1, "proxy gRPC status mapper is missing")]
+
+    forbidden = {
+        "tonic_code_from_payload_code": "proxy gRPC transport status must come from central spec, broker override, or local-only kind",
+        "is_topic_route_not_found_message": "RocketMQ gRPC mapping must not parse display text for topic-route errors",
+    }
+    return scan_forbidden_terms([path], forbidden)
 
 
 def check_error_spec_contract() -> list[Finding]:
@@ -425,6 +441,7 @@ def run() -> int:
         ("processor boundary mappings", check_processor_boundary_mappings),
         ("processor generic response allowlist", check_processor_generic_response_allowlist),
         ("required mapping adapters", check_required_mapping_adapters),
+        ("proxy grpc boundary", check_proxy_grpc_boundary),
         ("error spec contract", check_error_spec_contract),
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7941

### Brief Description

- Adds `ProxyErrorKind` for local-only proxy errors and routes those mappings through one local-only gRPC mapping.
- Derives `RocketMQError` proxy payload and tonic status from `ErrorSpec.grpc` by default.
- Keeps broker response compatibility overrides in an explicit allowlist that pairs payload codes with tonic status codes.
- Removes display-text parsing for topic-route failures and uses typed `RouteNotFound` instead.
- Uses `RocketMQError::public_message()` for proxy payload messages and extends the architecture guard.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy status` passed.
- `cargo test -p rocketmq-proxy` passed.
- `py scripts\error_architecture_guard.py` passed.
- `rg -n "v2::Code::|tonic::Code|rocketmq_payload_override|tonic_code_from_payload_code|is_topic_route_not_found_message" rocketmq-proxy/src/status.rs` showed only intended `v2::Code` and `tonic::Code` mappings.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy error responses so status codes and messages are more consistent and accurate.
  * Authorization failures now surface as the correct authentication-related error instead of an internal error.
  * Some broker response cases now return clearer, more reliable client-facing codes.
  * Route-related errors now map more consistently, reducing confusing fallback behavior.

* **Documentation**
  * Updated the error-handling checklist to reflect completed validation and mapping changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->