### PR TITLE
[ISSUE #7943]♻️Align dashboard HTTP error responses with central specs

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -226,27 +226,30 @@ rg -n "v2::Code::|tonic::Code|rocketmq_payload_override" rocketmq-proxy/src/stat
 
 **范围**：`rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs`、`rocketmq-dashboard-common`、dashboard backend service/config/admin 层。
 
-**当前缺口**：
+**完成状态**：
 
-- `DashboardError::RocketMq(#[from] RocketMQError)` 已存在。
-- `status_code()` 对 `RocketMq` 当前固定返回 `BAD_GATEWAY`。
-- `code()` 返回本地字符串，例如 `ROCKETMQ_ERROR`，没有使用 `error.spec().code`。
-- HTTP response body 使用 `self.to_string()`，没有区分 public message 和内部 detail。
+- `DashboardError::RocketMq` 的 HTTP status 已由 `error.spec().http.status` 派生，API code 已使用 `error.spec().code.as_str()`。
+- HTTP response body 已改为 `RocketMQError::public_message()` + redacted context，不再使用 `Display` 作为外部契约。
+- local `Validation/Config/Auth/NotFound/Internal` 保留稳定 code/status；配置与内部 source error 通过 `ConfigSource/InternalSource` 保留 source，但响应体只暴露安全消息。
+- 配置读写、SQLite 配置、monitor 配置与 dashboard task manager 的底层错误文本不再直接拼接进 HTTP error body。
+- `scripts/error_architecture_guard.py` 已加入 dashboard HTTP boundary 回归检查，阻止回退到 `BAD_GATEWAY/ROCKETMQ_ERROR/self.to_string()` 路径。
+
+**追踪**：Issue [#7943](https://github.com/mxsm/rocketmq-rust/issues/7943)，PR [#7944](https://github.com/mxsm/rocketmq-rust/pull/7944)。
 
 **开发 checklist**：
 
-- [ ] 对 `DashboardError::RocketMq(error)` 使用 `error.spec().http.status` 生成 HTTP status。
-- [ ] API code 使用 `error.spec().code.as_str()`，或明确加 dashboard prefix。
-- [ ] response message 使用 `spec.public_message` + redacted context，避免泄露内部 detail。
-- [ ] 对 local `Validation/Config/Auth/NotFound/Internal` 建立稳定 code。
-- [ ] 配置读写、监控配置、admin client 的 `format!("...{error}")` 路径改成 typed source 或 redacted message。
-- [ ] 增加 dashboard backend HTTP error mapping tests。
+- [x] 对 `DashboardError::RocketMq(error)` 使用 `error.spec().http.status` 生成 HTTP status。
+- [x] API code 使用 `error.spec().code.as_str()`，或明确加 dashboard prefix。
+- [x] response message 使用 `spec.public_message` + redacted context，避免泄露内部 detail。
+- [x] 对 local `Validation/Config/Auth/NotFound/Internal` 建立稳定 code。
+- [x] 配置读写、监控配置、admin client 的 `format!("...{error}")` 路径改成 typed source 或 redacted message。
+- [x] 增加 dashboard backend HTTP error mapping tests。
 
 **验收 checklist**：
 
-- [ ] `RocketMQError::route_not_found` 等典型错误映射到正确 HTTP status/code。
-- [ ] dashboard API 不用 display text 作为机器契约。
-- [ ] secret/token/signature 不出现在 error body。
+- [x] `RocketMQError::route_not_found` 等典型错误映射到正确 HTTP status/code。
+- [x] dashboard API 不用 display text 作为机器契约。
+- [x] secret/token/signature 不出现在 error body。
 
 **建议验证**：
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
@@ -153,20 +153,20 @@ impl FileConfigStore {
         }
 
         let content = fs::read_to_string(&self.path)
-            .map_err(|error| DashboardError::Config(format!("Failed to read config file: {error}")))?;
+            .map_err(|error| DashboardError::config_source("Failed to read config file", error))?;
         serde_json::from_str(&content)
-            .map_err(|error| DashboardError::Config(format!("Failed to parse config file: {error}")))
+            .map_err(|error| DashboardError::config_source("Failed to parse config file", error))
     }
 
     fn save(&self, config: &DashboardConfigView) -> Result<(), DashboardError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)
-                .map_err(|error| DashboardError::Config(format!("Failed to create config directory: {error}")))?;
+                .map_err(|error| DashboardError::config_source("Failed to create config directory", error))?;
         }
         let content = serde_json::to_string_pretty(config)
-            .map_err(|error| DashboardError::Internal(format!("Failed to serialize config: {error}")))?;
+            .map_err(|error| DashboardError::internal_source("Failed to serialize config", error))?;
         fs::write(&self.path, content)
-            .map_err(|error| DashboardError::Config(format!("Failed to write config file: {error}")))
+            .map_err(|error| DashboardError::config_source("Failed to write config file", error))
     }
 }
 
@@ -186,7 +186,7 @@ impl SqliteConfigStore {
                 )",
                 [],
             )
-            .map_err(|error| DashboardError::Config(format!("Failed to initialize config table: {error}")))?;
+            .map_err(|error| DashboardError::config_source("Failed to initialize config table", error))?;
 
         let payload = connection
             .query_row("SELECT payload FROM dashboard_config WHERE id = 1", [], |row| {
@@ -196,7 +196,7 @@ impl SqliteConfigStore {
 
         if let Some(payload) = payload {
             return serde_json::from_str(&payload)
-                .map_err(|error| DashboardError::Config(format!("Failed to parse SQLite config payload: {error}")));
+                .map_err(|error| DashboardError::config_source("Failed to parse SQLite config payload", error));
         }
 
         self.save(default_config)?;
@@ -206,7 +206,7 @@ impl SqliteConfigStore {
     fn save(&self, config: &DashboardConfigView) -> Result<(), DashboardError> {
         let connection = self.open_connection()?;
         let payload = serde_json::to_string_pretty(config)
-            .map_err(|error| DashboardError::Internal(format!("Failed to serialize config: {error}")))?;
+            .map_err(|error| DashboardError::internal_source("Failed to serialize config", error))?;
         connection
             .execute(
                 "CREATE TABLE IF NOT EXISTS dashboard_config (
@@ -215,24 +215,24 @@ impl SqliteConfigStore {
                 )",
                 [],
             )
-            .map_err(|error| DashboardError::Config(format!("Failed to initialize config table: {error}")))?;
+            .map_err(|error| DashboardError::config_source("Failed to initialize config table", error))?;
         connection
             .execute(
                 "INSERT INTO dashboard_config (id, payload) VALUES (1, ?1)
                  ON CONFLICT(id) DO UPDATE SET payload = excluded.payload",
                 [payload],
             )
-            .map_err(|error| DashboardError::Config(format!("Failed to write SQLite config: {error}")))?;
+            .map_err(|error| DashboardError::config_source("Failed to write SQLite config", error))?;
         Ok(())
     }
 
     fn open_connection(&self) -> Result<rusqlite::Connection, DashboardError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)
-                .map_err(|error| DashboardError::Config(format!("Failed to create SQLite directory: {error}")))?;
+                .map_err(|error| DashboardError::config_source("Failed to create SQLite directory", error))?;
         }
         rusqlite::Connection::open(&self.path)
-            .map_err(|error| DashboardError::Config(format!("Failed to open SQLite config store: {error}")))
+            .map_err(|error| DashboardError::config_source("Failed to open SQLite config store", error))
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -16,8 +16,12 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use rocketmq_dashboard_common::DashboardCommonError;
+use rocketmq_error::HttpStatusCode;
 use rocketmq_error::RocketMQError;
+use std::error::Error as StdError;
 use thiserror::Error;
+
+type DashboardErrorSource = Box<dyn StdError + Send + Sync + 'static>;
 
 #[derive(Debug, Error)]
 pub enum DashboardError {
@@ -25,6 +29,12 @@ pub enum DashboardError {
     Validation(String),
     #[error("{0}")]
     Config(String),
+    #[error("{message}")]
+    ConfigSource {
+        message: &'static str,
+        #[source]
+        source: DashboardErrorSource,
+    },
     #[error(transparent)]
     RocketMq(#[from] RocketMQError),
     #[error("{0}")]
@@ -35,6 +45,12 @@ pub enum DashboardError {
     NotImplemented(String),
     #[error("{0}")]
     Internal(String),
+    #[error("{message}")]
+    InternalSource {
+        message: &'static str,
+        #[source]
+        source: DashboardErrorSource,
+    },
 }
 
 impl From<DashboardCommonError> for DashboardError {
@@ -50,27 +66,60 @@ impl From<DashboardCommonError> for DashboardError {
 }
 
 impl DashboardError {
+    pub fn config_source<E>(message: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::ConfigSource {
+            message,
+            source: Box::new(source),
+        }
+    }
+
+    pub fn internal_source<E>(message: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::InternalSource {
+            message,
+            source: Box::new(source),
+        }
+    }
+
     pub fn code(&self) -> &'static str {
         match self {
             Self::Validation(_) => "VALIDATION_ERROR",
-            Self::Config(_) => "CONFIG_ERROR",
-            Self::RocketMq(_) => "ROCKETMQ_ERROR",
+            Self::Config(_) | Self::ConfigSource { .. } => "CONFIG_ERROR",
+            Self::RocketMq(error) => error.spec().code.as_str(),
             Self::NotFound(_) => "NOT_FOUND",
             Self::Auth(_) => "AUTH_ERROR",
             Self::NotImplemented(_) => "NOT_IMPLEMENTED",
-            Self::Internal(_) => "INTERNAL_ERROR",
+            Self::Internal(_) | Self::InternalSource { .. } => "INTERNAL_ERROR",
         }
     }
 
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Validation(_) => StatusCode::BAD_REQUEST,
-            Self::Config(_) => StatusCode::BAD_REQUEST,
-            Self::RocketMq(_) => StatusCode::BAD_GATEWAY,
+            Self::Config(_) | Self::ConfigSource { .. } => StatusCode::BAD_REQUEST,
+            Self::RocketMq(error) => status_code_from_spec(error.spec().http.status),
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Auth(_) => StatusCode::UNAUTHORIZED,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
-            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Internal(_) | Self::InternalSource { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn response_message(&self) -> String {
+        match self {
+            Self::Validation(message)
+            | Self::Config(message)
+            | Self::NotFound(message)
+            | Self::Auth(message)
+            | Self::NotImplemented(message)
+            | Self::Internal(message) => message.clone(),
+            Self::ConfigSource { message, .. } | Self::InternalSource { message, .. } => (*message).to_string(),
+            Self::RocketMq(error) => rocketmq_response_message(error),
         }
     }
 }
@@ -78,7 +127,126 @@ impl DashboardError {
 impl IntoResponse for DashboardError {
     fn into_response(self) -> axum::response::Response {
         let status = self.status_code();
-        let body = ApiResponse::failure(self.code(), self.to_string());
+        let body = ApiResponse::failure(self.code(), self.response_message());
         (status, Json(body)).into_response()
+    }
+}
+
+fn status_code_from_spec(status: HttpStatusCode) -> StatusCode {
+    StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn rocketmq_response_message(error: &RocketMQError) -> String {
+    let context = error.context();
+    if context.is_empty() {
+        error.public_message().to_string()
+    } else {
+        format!("{} ({context})", error.public_message())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DashboardError;
+    use crate::model::ApiResponse;
+    use axum::body::to_bytes;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use rocketmq_error::REDACTED;
+    use rocketmq_error::RocketMQError;
+    use serde_json::Value;
+    use std::io;
+
+    async fn failure_response(error: DashboardError) -> (StatusCode, ApiResponse<Value>) {
+        let response = error.into_response();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body = serde_json::from_slice(&bytes).expect("deserialize error response");
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn rocketmq_error_uses_central_http_spec_and_code() {
+        let error = RocketMQError::route_not_found("TopicA");
+        let public_message = error.public_message();
+
+        let (status, body) = failure_response(DashboardError::from(error)).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(!body.success);
+        assert_eq!(body.code, "ROUTE_NOT_FOUND");
+        assert!(body.message.starts_with(public_message));
+        assert!(body.message.contains("topic=TopicA"));
+    }
+
+    #[tokio::test]
+    async fn rocketmq_error_response_uses_redacted_context() {
+        let (status, body) = failure_response(DashboardError::from(RocketMQError::Internal(
+            "password=plain-text".to_string(),
+        )))
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.code, "INTERNAL");
+        assert!(body.message.contains(REDACTED));
+        assert!(!body.message.contains("password=plain-text"));
+    }
+
+    #[tokio::test]
+    async fn local_source_error_response_hides_source_detail() {
+        let error = DashboardError::config_source(
+            "Failed to read config file",
+            io::Error::new(io::ErrorKind::PermissionDenied, "token=plain-text"),
+        );
+
+        let (status, body) = failure_response(error).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body.code, "CONFIG_ERROR");
+        assert_eq!(body.message, "Failed to read config file");
+        assert!(!body.message.contains("token=plain-text"));
+    }
+
+    #[test]
+    fn local_error_codes_are_stable() {
+        let cases = [
+            (
+                DashboardError::Validation("invalid".to_string()),
+                "VALIDATION_ERROR",
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                DashboardError::Config("bad config".to_string()),
+                "CONFIG_ERROR",
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                DashboardError::NotFound("missing".to_string()),
+                "NOT_FOUND",
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                DashboardError::Auth("denied".to_string()),
+                "AUTH_ERROR",
+                StatusCode::UNAUTHORIZED,
+            ),
+            (
+                DashboardError::NotImplemented("todo".to_string()),
+                "NOT_IMPLEMENTED",
+                StatusCode::NOT_IMPLEMENTED,
+            ),
+            (
+                DashboardError::Internal("failed".to_string()),
+                "INTERNAL_ERROR",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, code, status) in cases {
+            assert_eq!(error.code(), code);
+            assert_eq!(error.status_code(), status);
+        }
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
@@ -70,9 +70,9 @@ impl DashboardTaskManager {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        let mut abort_handles = self.inner.abort_handles.lock().map_err(|error| {
+        let mut abort_handles = self.inner.abort_handles.lock().map_err(|_| {
             DashboardError::Internal(format!(
-                "dashboard task manager lock poisoned while spawning {task_name}: {error}"
+                "dashboard task manager lock poisoned while spawning {task_name}"
             ))
         })?;
         let handle = tokio::task::spawn(async move {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/monitor_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/monitor_service.rs
@@ -132,23 +132,23 @@ fn load_entries(path: &PathBuf) -> Result<BTreeMap<String, ConsumerMonitorConfig
     }
 
     let content = fs::read_to_string(path)
-        .map_err(|error| DashboardError::Config(format!("Failed to read monitor config file: {error}")))?;
+        .map_err(|error| DashboardError::config_source("Failed to read monitor config file", error))?;
     if content.trim().is_empty() {
         return Ok(BTreeMap::new());
     }
     serde_json::from_str(&content)
-        .map_err(|error| DashboardError::Config(format!("Failed to parse monitor config file: {error}")))
+        .map_err(|error| DashboardError::config_source("Failed to parse monitor config file", error))
 }
 
 fn save_entries(path: &PathBuf, entries: &BTreeMap<String, ConsumerMonitorConfig>) -> Result<(), DashboardError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
-            .map_err(|error| DashboardError::Config(format!("Failed to create monitor config directory: {error}")))?;
+            .map_err(|error| DashboardError::config_source("Failed to create monitor config directory", error))?;
     }
     let content = serde_json::to_string_pretty(entries)
-        .map_err(|error| DashboardError::Internal(format!("Failed to serialize monitor config: {error}")))?;
+        .map_err(|error| DashboardError::internal_source("Failed to serialize monitor config", error))?;
     fs::write(path, content)
-        .map_err(|error| DashboardError::Config(format!("Failed to write monitor config file: {error}")))
+        .map_err(|error| DashboardError::config_source("Failed to write monitor config file", error))
 }
 
 #[cfg(test)]

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -282,6 +282,21 @@ def check_required_mapping_adapters() -> list[Finding]:
             "local_error_grpc_mapping",
             "public_message()",
         ],
+        ROOT
+        / "rocketmq-dashboard"
+        / "rocketmq-dashboard-web"
+        / "backend"
+        / "src"
+        / "error"
+        / "dashboard_error.rs": [
+            "error.spec().http.status",
+            "error.spec().code.as_str()",
+            "error.public_message()",
+            "error.context()",
+            "config_source",
+            "internal_source",
+            "response_message",
+        ],
     }
     findings: list[Finding] = []
     for path, needles in checks.items():
@@ -305,6 +320,44 @@ def check_proxy_grpc_boundary() -> list[Finding]:
         "is_topic_route_not_found_message": "RocketMQ gRPC mapping must not parse display text for topic-route errors",
     }
     return scan_forbidden_terms([path], forbidden)
+
+
+def check_dashboard_http_boundary() -> list[Finding]:
+    error_path = (
+        ROOT
+        / "rocketmq-dashboard"
+        / "rocketmq-dashboard-web"
+        / "backend"
+        / "src"
+        / "error"
+        / "dashboard_error.rs"
+    )
+    if not error_path.exists():
+        return [Finding(error_path, 1, "dashboard HTTP error mapper is missing")]
+
+    forbidden = {
+        'Self::RocketMq(_) => "ROCKETMQ_ERROR"': "dashboard RocketMQ API code must come from ErrorSpec.code",
+        "Self::RocketMq(_) => StatusCode::BAD_GATEWAY": "dashboard RocketMQ HTTP status must come from ErrorSpec.http",
+        "ApiResponse::failure(self.code(), self.to_string())": "dashboard error body must use public/redacted response messages",
+    }
+    findings = scan_forbidden_terms([error_path], forbidden)
+
+    backend_paths = rust_files_under("rocketmq-dashboard", "rocketmq-dashboard-web", "backend", "src")
+    for path in backend_paths:
+        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+            if is_test_context(path, line_number):
+                continue
+            if "{error}" not in line:
+                continue
+            if "DashboardError::Config(format!" in line or "DashboardError::Internal(format!" in line:
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        "dashboard config/internal source errors must use typed source or redacted response messages",
+                    )
+                )
+    return findings
 
 
 def check_error_spec_contract() -> list[Finding]:
@@ -442,6 +495,7 @@ def run() -> int:
         ("processor generic response allowlist", check_processor_generic_response_allowlist),
         ("required mapping adapters", check_required_mapping_adapters),
         ("proxy grpc boundary", check_proxy_grpc_boundary),
+        ("dashboard http boundary", check_dashboard_http_boundary),
         ("error spec contract", check_error_spec_contract),
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7943

### Brief Description

- Derives dashboard RocketMQ HTTP status and API code from the central `ErrorSpec` contract.
- Renders RocketMQ response messages from `public_message()` plus redacted context instead of diagnostic display text.
- Adds source-preserving dashboard config and internal error variants for safe response messages.
- Removes direct source error formatting from config, monitor, and dashboard service response paths.
- Adds focused dashboard HTTP error mapping tests and architecture guard coverage.

### How Did You Test This Change?

- `cargo fmt --all` passed in `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo test error::dashboard_error` passed in `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `py scripts\error_architecture_guard.py` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed in `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo build --all-targets --all-features` passed in `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
