### PR TITLE
[ISSUE #7945]♻️Type client callback error boundaries

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -264,24 +264,29 @@ cargo build --all-targets --all-features
 
 **范围**：`rocketmq-client/src/consumer/pull_callback.rs`、`pop_callback.rs`、producer/consumer callback API、相关 tests。
 
-**当前缺口**：
+**完成状态**：
 
-- legacy downcast 已移除。
-- 仍存在 `dyn Error` + `downcast_ref::<RocketMQError>()`，内部事实源还不是 typed error。
+- `PullCallback` / `PopCallback` 的 public error 参数已改为 `RocketMQError`，默认回调不再接收 boxed `dyn Error`。
+- pull/pop 的 broker response code 判断已直接匹配 `RocketMQError::BrokerOperationFailed`，移除了 runtime downcast helper。
+- request-response callback API 已改为 `Option<&RocketMQError>`，`RequestResponseFuture` 的 cause 直接存储 `Arc<RocketMQError>`。
+- request future timeout scan 与 async request 失败路径都写入 typed `RocketMQError` cause。
+- `typed_error_client_flow_tests` 和 `scripts/error_architecture_guard.py` 已覆盖 callback typed boundary，阻止回退到 dyn/downcast。
+
+**追踪**：Issue [#7945](https://github.com/mxsm/rocketmq-rust/issues/7945)，PR [#7946](https://github.com/mxsm/rocketmq-rust/pull/7946)。
 
 **开发 checklist**：
 
-- [ ] 修改 pull/pop callback 内部错误类型为 `RocketMQError`。
-- [ ] 移除 `broker_response_code(error: &(dyn Error + Send + 'static))` 这类 downcast helper。
-- [ ] 对 broker response code 使用 typed variant 或 `ErrorKind`/spec/recovery policy。
-- [ ] 更新 public callback trait；本轮重构允许 breaking change，不保留旧 ABI。
-- [ ] 更新调用方和测试，确保回调错误判断不依赖 runtime downcast。
+- [x] 修改 pull/pop callback 内部错误类型为 `RocketMQError`。
+- [x] 移除 `broker_response_code(error: &(dyn Error + Send + 'static))` 这类 downcast helper。
+- [x] 对 broker response code 使用 typed variant 或 `ErrorKind`/spec/recovery policy。
+- [x] 更新 public callback trait；本轮重构允许 breaking change，不保留旧 ABI。
+- [x] 更新调用方和测试，确保回调错误判断不依赖 runtime downcast。
 
 **验收 checklist**：
 
-- [ ] `pull_callback.rs`、`pop_callback.rs` 无 `dyn Error` downcast。
-- [ ] callback 错误路径可直接读取 `RocketMQError::kind()` / `spec()`。
-- [ ] 订阅落后、flow control 等 broker response 行为仍保持。
+- [x] `pull_callback.rs`、`pop_callback.rs` 无 `dyn Error` downcast。
+- [x] callback 错误路径可直接读取 `RocketMQError::kind()` / `spec()`。
+- [x] 订阅落后、flow control 等 broker response 行为仍保持。
 
 **建议验证**：
 

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -742,7 +742,7 @@ impl DefaultMQAdminExtImpl {
         struct NoopPullCallback;
         impl PullCallback for NoopPullCallback {
             async fn on_success(&mut self, _pull_result: PullResultExt) {}
-            fn on_exception(&mut self, _e: Box<dyn std::error::Error + Send>) {}
+            fn on_exception(&mut self, _e: rocketmq_error::RocketMQError) {}
         }
 
         let api_impl = self.mq_client_api()?;

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -1516,7 +1516,7 @@ impl DefaultLitePullConsumerImpl {
         impl PullCallback for NoopPullCallback {
             async fn on_success(&mut self, _pull_result: crate::PullResultExt) {}
 
-            fn on_exception(&mut self, _e: Box<dyn std::error::Error + Send>) {}
+            fn on_exception(&mut self, _e: rocketmq_error::RocketMQError) {}
         }
 
         self.make_sure_state_ok()?;

--- a/rocketmq-client/src/consumer/pop_callback.rs
+++ b/rocketmq-client/src/consumer/pop_callback.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -48,12 +47,12 @@ pub trait PopCallbackInner {
     /// # Arguments
     ///
     /// * `e` - The error encountered during the pop operation.
-    fn on_error(&mut self, e: Box<dyn std::error::Error + Send>);
+    fn on_error(&mut self, e: RocketMQError);
 }
 
 /*impl<F, Fut> PopCallback for F
 where
-    F: Fn(Option<PopResult>, Option<Box<dyn std::error::Error + Send>>) -> Fut + Send + Sync,
+    F: Fn(Option<PopResult>, Option<RocketMQError>) -> Fut + Send + Sync,
     Fut: Future<Output = ()> + Send,
 {
     /// Calls the function with the pop result when the pop operation is successful.
@@ -70,7 +69,7 @@ where
     /// # Arguments
     ///
     /// * `e` - The error encountered during the pop operation.
-    fn on_error(&self, e: Box<dyn std::error::Error + Send>) {
+    fn on_error(&self, e: RocketMQError) {
         (*self)(None, Some(e));
     }
 }*/
@@ -79,16 +78,14 @@ where
 ///
 /// This type alias defines a callback function that takes a `PopResult` and returns a boxed future.
 pub type PopCallbackFn = Arc<
-    dyn Fn(Option<PopResult>, Option<Box<dyn std::error::Error>>) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>>
-        + Send
-        + Sync,
+    dyn Fn(Option<PopResult>, Option<RocketMQError>) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> + Send + Sync,
 >;
 
-fn broker_response_code(error: &(dyn Error + Send + 'static)) -> Option<ResponseCode> {
-    error.downcast_ref::<RocketMQError>().and_then(|error| match error {
+fn broker_response_code(error: &RocketMQError) -> Option<ResponseCode> {
+    match error {
         RocketMQError::BrokerOperationFailed { code, .. } => Some(ResponseCode::from(*code)),
         _ => None,
-    })
+    }
 }
 
 pub struct DefaultPopCallback {
@@ -168,7 +165,7 @@ impl PopCallback for DefaultPopCallback {
         }
     }
 
-    fn on_error(&mut self, err: Box<dyn std::error::Error + Send>) {
+    fn on_error(&mut self, err: RocketMQError) {
         let mut push_consumer_impl = self.push_consumer_impl.clone();
 
         let Some(message_queue_inner) = self.message_queue_inner.take() else {
@@ -183,7 +180,7 @@ impl PopCallback for DefaultPopCallback {
             return;
         };
         let topic = message_queue_inner.topic_str();
-        let broker_code = broker_response_code(err.as_ref());
+        let broker_code = broker_response_code(&err);
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             if broker_code == Some(ResponseCode::SubscriptionNotLatest) {
                 warn!(
@@ -209,8 +206,6 @@ impl PopCallback for DefaultPopCallback {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
-
     use cheetah_string::CheetahString;
     use rocketmq_common::common::message::message_ext::MessageExt;
 
@@ -249,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn broker_response_code_reads_typed_broker_error() {
+    fn broker_response_code_reads_broker_error_without_downcast() {
         let error = rocketmq_error::RocketMQError::broker_operation_failed(
             "POP_MESSAGE",
             ResponseCode::SubscriptionNotLatest.to_i32(),
@@ -303,7 +298,7 @@ mod tests {
     fn error_without_message_queue_is_ignored_without_panic() {
         let mut callback = new_callback();
 
-        PopCallback::on_error(&mut callback, Box::new(io::Error::other("test error")));
+        PopCallback::on_error(&mut callback, RocketMQError::illegal_argument("test error"));
     }
 
     #[test]
@@ -311,6 +306,6 @@ mod tests {
         let mut callback = new_callback();
         callback.message_queue_inner = Some(message_queue());
 
-        PopCallback::on_error(&mut callback, Box::new(io::Error::other("test error")));
+        PopCallback::on_error(&mut callback, RocketMQError::illegal_argument("test error"));
     }
 }

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::sync::Arc;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
@@ -30,20 +29,19 @@ use crate::consumer::consumer_impl::pull_request_ext::PullResultExt;
 use crate::consumer::consumer_impl::re_balance::Rebalance;
 use crate::consumer::pull_status::PullStatus;
 
-pub type PullCallbackFn =
-    Arc<dyn FnOnce(Option<PullResultExt>, Option<Box<dyn std::error::Error + Send>>) + Send + Sync>;
+pub type PullCallbackFn = Arc<dyn FnOnce(Option<PullResultExt>, Option<RocketMQError>) + Send + Sync>;
 
-fn broker_response_code(error: &(dyn Error + Send + 'static)) -> Option<ResponseCode> {
-    error.downcast_ref::<RocketMQError>().and_then(|error| match error {
+fn broker_response_code(error: &RocketMQError) -> Option<ResponseCode> {
+    match error {
         RocketMQError::BrokerOperationFailed { code, .. } => Some(ResponseCode::from(*code)),
         _ => None,
-    })
+    }
 }
 
 #[trait_variant::make(PullCallback: Send)]
 pub trait PullCallbackLocal: Sync {
     async fn on_success(&mut self, pull_result: PullResultExt);
-    fn on_exception(&mut self, e: Box<dyn std::error::Error + Send>);
+    fn on_exception(&mut self, e: RocketMQError);
 }
 
 pub(crate) struct DefaultPullCallback {
@@ -190,7 +188,7 @@ impl PullCallback for DefaultPullCallback {
         };
     }
 
-    fn on_exception(&mut self, err: Box<dyn std::error::Error + Send>) {
+    fn on_exception(&mut self, err: RocketMQError) {
         let Some(message_queue_inner) = self.message_queue_inner.take() else {
             warn!(
                 "pull callback exception ignored: message queue is missing, error={}",
@@ -206,7 +204,7 @@ impl PullCallback for DefaultPullCallback {
             return;
         };
         let topic = message_queue_inner.topic_str();
-        let broker_code = broker_response_code(err.as_ref());
+        let broker_code = broker_response_code(&err);
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             if broker_code == Some(ResponseCode::SubscriptionNotLatest) {
                 warn!(
@@ -233,8 +231,6 @@ impl PullCallback for DefaultPullCallback {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
-
     use bytes::Bytes;
 
     use super::*;
@@ -258,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn broker_response_code_reads_typed_broker_error() {
+    fn broker_response_code_reads_broker_error_without_downcast() {
         let error = rocketmq_error::RocketMQError::broker_operation_failed(
             "PULL_MESSAGE",
             ResponseCode::FlowControl.to_i32(),
@@ -286,6 +282,6 @@ mod tests {
         let mut callback = new_callback();
         callback.message_queue_inner = Some(MessageQueue::from_parts("topic", "broker-a", 0));
 
-        PullCallback::on_exception(&mut callback, Box::new(io::Error::other("test error")));
+        PullCallback::on_exception(&mut callback, RocketMQError::illegal_argument("test error"));
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1291,7 +1291,7 @@ impl MQClientInstance {
         impl PullCallback for NoopPullCallback {
             async fn on_success(&mut self, _pull_result: PullResultExt) {}
 
-            fn on_exception(&mut self, _e: Box<dyn std::error::Error + Send>) {}
+            fn on_exception(&mut self, _e: rocketmq_error::RocketMQError) {}
         }
 
         let api_impl = self

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -3645,12 +3645,12 @@ impl MQClientAPIImpl {
                         pull_callback.on_success(pull_result).await;
                     }
                     Err(error) => {
-                        pull_callback.on_exception(Box::new(error));
+                        pull_callback.on_exception(error);
                     }
                 }
             }
             Err(err) => {
-                pull_callback.on_exception(Box::new(err));
+                pull_callback.on_exception(err);
             }
         }
         Ok(())
@@ -4284,12 +4284,12 @@ impl MQClientAPIImpl {
                         pop_callback.on_success(pop_result).await;
                     }
                     Err(e) => {
-                        pop_callback.on_error(Box::new(e));
+                        pop_callback.on_error(e);
                     }
                 }
             }
             Err(e) => {
-                pop_callback.on_error(Box::new(e));
+                pop_callback.on_error(e);
             }
         }
         Ok(())
@@ -4320,12 +4320,12 @@ impl MQClientAPIImpl {
                         pop_callback.on_success(pop_result).await;
                     }
                     Err(e) => {
-                        pop_callback.on_error(Box::new(e));
+                        pop_callback.on_error(e);
                     }
                 }
             }
             Err(e) => {
-                pop_callback.on_error(Box::new(e));
+                pop_callback.on_error(e);
             }
         }
         Ok(())

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -745,7 +745,7 @@ impl DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         <Self as MQProducer>::request_with_callback(self, msg, request_callback, timeout).await
@@ -776,7 +776,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         S: Fn(&[MessageQueue], &M, &T) -> Option<MessageQueue> + Send + Sync + 'static,
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         T: Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
@@ -803,7 +803,7 @@ impl DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         <Self as MQProducer>::request_to_queue_with_callback(self, msg, mq, request_callback, timeout).await
@@ -2251,7 +2251,7 @@ impl MQProducer for DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         msg.set_topic(self.with_namespace(msg.topic()));
@@ -2292,7 +2292,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         S: Fn(&[MessageQueue], &M, &T) -> Option<MessageQueue> + Send + Sync + 'static,
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         T: Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
@@ -2330,7 +2330,7 @@ impl MQProducer for DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         msg.set_topic(self.with_namespace(msg.topic()));
@@ -2434,7 +2434,7 @@ mod facade_tests {
 
     #[tokio::test]
     async fn default_mq_producer_exposes_modern_java_request_facade_methods_without_trait_import() {
-        let request_callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&dyn std::error::Error>| {};
+        let request_callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&rocketmq_error::RocketMQError>| {};
         assert_not_initialized(
             unstarted_producer()
                 .request_with_callback(message(), request_callback, 1000)
@@ -2450,7 +2450,7 @@ mod facade_tests {
 
         assert_not_initialized(unstarted_producer().request_to_queue(message(), queue(), 1000).await);
 
-        let request_callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&dyn std::error::Error>| {};
+        let request_callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&rocketmq_error::RocketMQError>| {};
         assert_not_initialized(
             unstarted_producer()
                 .request_to_queue_with_callback(message(), queue(), request_callback, 1000)
@@ -2474,7 +2474,7 @@ mod tests {
             default_mqproducer_impl: None,
         };
         let msg = Message::builder().topic("test-topic").empty_body().build_unchecked();
-        let callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&dyn std::error::Error>| {
+        let callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&rocketmq_error::RocketMQError>| {
             // no-op
         };
         let result = producer.request_with_callback(msg, callback, 1000).await;
@@ -2519,7 +2519,7 @@ mod tests {
         };
         let msg = Message::builder().topic("test-topic").empty_body().build_unchecked();
         let selector = |_queues: &[MessageQueue], _msg: &Message, _arg: &i32| -> Option<MessageQueue> { None };
-        let callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&dyn std::error::Error>| {
+        let callback = |_msg: Option<&dyn MessageTrait>, _err: Option<&rocketmq_error::RocketMQError>| {
             // no-op
         };
         let result = producer

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -709,7 +709,7 @@ pub trait MQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync;
 
     /// Sends a request message with a selector function to choose the message queue.
@@ -773,7 +773,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         S: Fn(&[MessageQueue], &M, &T) -> Option<MessageQueue> + Send + Sync + 'static,
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         T: Send + Sync + 'static,
         M: MessageTrait + Send + Sync;
 
@@ -827,7 +827,7 @@ pub trait MQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync;
 
     /// Returns a reference to the object as a trait object of type `Any`.

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -475,8 +475,8 @@ impl DefaultMQProducerImpl {
     }
 
     #[inline]
-    fn request_cause_from_error(error: &dyn std::error::Error) -> Box<dyn std::error::Error + Send + Sync> {
-        Box::new(RocketMQError::illegal_argument(error.to_string()))
+    fn request_cause_from_error(error: &dyn std::error::Error) -> RocketMQError {
+        RocketMQError::illegal_argument(error.to_string())
     }
 
     #[inline]
@@ -3624,10 +3624,7 @@ mod tests {
 
     #[test]
     fn request_cause_from_error_uses_typed_error() {
-        let cause = DefaultMQProducerImpl::request_cause_from_error(&std::io::Error::other("send failed"));
-        let error = cause
-            .downcast_ref::<rocketmq_error::RocketMQError>()
-            .expect("request cause should use RocketMQError");
+        let error = DefaultMQProducerImpl::request_cause_from_error(&std::io::Error::other("send failed"));
 
         assert!(matches!(error, rocketmq_error::RocketMQError::IllegalArgument(_)));
         assert_eq!(error.to_string(), "Illegal argument: send failed");

--- a/rocketmq-client/src/producer/request_callback.rs
+++ b/rocketmq-client/src/producer/request_callback.rs
@@ -16,10 +16,11 @@ use std::sync::Arc;
 
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 
-pub type RequestCallbackFn = Arc<dyn Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync>;
+pub type RequestCallbackFn = Arc<dyn Fn(Option<&dyn MessageTrait>, Option<&RocketMQError>) + Send + Sync>;
 
 pub trait RequestCallback: Sync + Send {
     fn on_success(&self, response: &Message);
-    fn on_exception(&self, e: &rocketmq_error::RocketMQError);
+    fn on_exception(&self, e: &RocketMQError);
 }

--- a/rocketmq-client/src/producer/request_future_holder.rs
+++ b/rocketmq-client/src/producer/request_future_holder.rs
@@ -140,10 +140,10 @@ impl RequestFutureHolder {
         }
 
         for rf in rf_list {
-            let cause = Box::new(rocketmq_error::RocketMQError::Timeout {
+            let cause = rocketmq_error::RocketMQError::Timeout {
                 operation: "request_reply",
                 timeout_ms: rf.get_timeout_millis(),
-            });
+            };
             rf.set_cause(cause);
             rf.execute_request_callback();
         }
@@ -338,7 +338,7 @@ pub async fn run_request_future_holder_scan_probe(
         let callback_count = Arc::clone(&callbacks);
         let callback = Arc::new(
             move |_response: Option<&dyn rocketmq_common::common::message::MessageTrait>,
-                  _error: Option<&dyn std::error::Error>| {
+                  _error: Option<&rocketmq_error::RocketMQError>| {
                 callback_count.fetch_add(1, Ordering::Relaxed);
             },
         );
@@ -447,10 +447,16 @@ mod tests {
         let callback_called = Arc::new(AtomicBool::new(false));
         let callback_called_inner = Arc::clone(&callback_called);
         let callback = Arc::new(
-            move |response: Option<&dyn MessageTrait>, error: Option<&dyn std::error::Error>| {
+            move |response: Option<&dyn MessageTrait>, error: Option<&rocketmq_error::RocketMQError>| {
                 assert!(response.is_none());
                 let error = error.expect("timeout scan should pass timeout cause");
-                assert!(error.to_string().contains("request_reply"));
+                assert!(matches!(
+                    error,
+                    rocketmq_error::RocketMQError::Timeout {
+                        operation: "request_reply",
+                        ..
+                    }
+                ));
                 callback_called_inner.store(true, Ordering::SeqCst);
             },
         );
@@ -470,7 +476,7 @@ mod tests {
         let callback_count = Arc::new(AtomicUsize::new(0));
         let callback_count_inner = Arc::clone(&callback_count);
         let callback = Arc::new(
-            move |_response: Option<&dyn MessageTrait>, _error: Option<&dyn std::error::Error>| {
+            move |_response: Option<&dyn MessageTrait>, _error: Option<&rocketmq_error::RocketMQError>| {
                 callback_count_inner.fetch_add(1, Ordering::SeqCst);
             },
         );
@@ -491,7 +497,7 @@ mod tests {
         let callback_count = Arc::new(AtomicUsize::new(0));
         let callback_count_inner = Arc::clone(&callback_count);
         let old_callback = Arc::new(
-            move |_response: Option<&dyn MessageTrait>, _error: Option<&dyn std::error::Error>| {
+            move |_response: Option<&dyn MessageTrait>, _error: Option<&rocketmq_error::RocketMQError>| {
                 callback_count_inner.fetch_add(1, Ordering::SeqCst);
             },
         );
@@ -523,7 +529,7 @@ mod tests {
         let callback_count = Arc::new(AtomicUsize::new(0));
         let callback_count_inner = Arc::clone(&callback_count);
         let callback = Arc::new(
-            move |_response: Option<&dyn MessageTrait>, _error: Option<&dyn std::error::Error>| {
+            move |_response: Option<&dyn MessageTrait>, _error: Option<&rocketmq_error::RocketMQError>| {
                 callback_count_inner.fetch_add(1, Ordering::SeqCst);
             },
         );

--- a/rocketmq-client/src/producer/request_response_future.rs
+++ b/rocketmq-client/src/producer/request_response_future.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -23,12 +22,13 @@ use std::time::Instant;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 use tokio::sync::Notify;
 
 use crate::producer::request_callback::RequestCallbackFn;
 
 type ResponseMessage = Box<dyn MessageTrait + Send>;
-type RequestCause = Arc<dyn Error + Send + Sync>;
+type RequestCause = Arc<RocketMQError>;
 
 pub struct RequestResponseFuture {
     correlation_id: CheetahString,
@@ -75,10 +75,7 @@ impl RequestResponseFuture {
                     None,
                 );
             } else {
-                callback(
-                    None,
-                    cause.as_ref().map(|cause| cause.as_ref() as &dyn std::error::Error),
-                );
+                callback(None, cause.as_deref());
             }
         }
     }
@@ -90,8 +87,11 @@ impl RequestResponseFuture {
     pub async fn wait_response_message(&self, timeout: Duration) -> Option<Box<dyn MessageTrait + Send>> {
         match tokio::time::timeout(timeout, self.notify.notified()).await {
             Ok(_) => self.get_response_msg(),
-            Err(error) => {
-                self.set_cause(Box::new(error));
+            Err(_) => {
+                self.set_cause(RocketMQError::Timeout {
+                    operation: "request_reply_wait",
+                    timeout_ms: timeout.as_millis() as u64,
+                });
                 None
             }
         }
@@ -175,9 +175,9 @@ impl RequestResponseFuture {
             .clone()
     }
 
-    pub fn set_cause(&self, cause: Box<dyn Error + Send + Sync>) {
+    pub fn set_cause(&self, cause: RocketMQError) {
         let mut stored_cause = self.cause.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        *stored_cause = Some(Arc::from(cause));
+        *stored_cause = Some(Arc::new(cause));
     }
 }
 

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -636,7 +636,7 @@ impl MQProducer for TransactionMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         self.default_producer
@@ -671,7 +671,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         S: Fn(&[MessageQueue], &M, &T) -> Option<MessageQueue> + Send + Sync + 'static,
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         T: Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
@@ -700,7 +700,7 @@ impl MQProducer for TransactionMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&dyn MessageTrait>, Option<&rocketmq_error::RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         self.default_producer

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -35,3 +35,25 @@ fn client_public_api_does_not_export_dead_error_module() {
 
     assert!(!lib.contains(concat!("pub mod client", "_error;")));
 }
+
+#[test]
+fn client_callback_error_paths_use_typed_rocketmq_error() {
+    let pull_callback = include_str!("../src/consumer/pull_callback.rs");
+    let pop_callback = include_str!("../src/consumer/pop_callback.rs");
+    let request_callback = include_str!("../src/producer/request_callback.rs");
+    let request_future = include_str!("../src/producer/request_response_future.rs");
+
+    assert!(pull_callback.contains("fn on_exception(&mut self, e: RocketMQError)"));
+    assert!(pull_callback.contains("fn broker_response_code(error: &RocketMQError)"));
+    assert!(!pull_callback.contains("downcast_ref::<RocketMQError>"));
+    assert!(!pull_callback.contains("Box<dyn std::error::Error + Send>"));
+
+    assert!(pop_callback.contains("fn on_error(&mut self, e: RocketMQError)"));
+    assert!(pop_callback.contains("fn broker_response_code(error: &RocketMQError)"));
+    assert!(!pop_callback.contains("downcast_ref::<RocketMQError>"));
+    assert!(!pop_callback.contains("Box<dyn std::error::Error + Send>"));
+
+    assert!(request_callback.contains("Option<&RocketMQError>"));
+    assert!(request_future.contains("type RequestCause = Arc<RocketMQError>"));
+    assert!(!request_future.contains("type RequestCause = Arc<dyn"));
+}

--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -1494,7 +1494,7 @@ impl PopCallback for PopResultCallback {
         }
     }
 
-    fn on_error(&mut self, error: Box<dyn std::error::Error + Send>) {
+    fn on_error(&mut self, error: rocketmq_error::RocketMQError) {
         if let Some(sender) = self.sender.take() {
             let _ = sender.send(Err(ProxyError::Transport {
                 message: error.to_string(),

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -360,6 +360,48 @@ def check_dashboard_http_boundary() -> list[Finding]:
     return findings
 
 
+def check_client_callback_boundary() -> list[Finding]:
+    required_tokens = {
+        ROOT / "rocketmq-client" / "src" / "consumer" / "pull_callback.rs": [
+            "fn on_exception(&mut self, e: RocketMQError)",
+            "fn broker_response_code(error: &RocketMQError)",
+            "RocketMQError::BrokerOperationFailed",
+        ],
+        ROOT / "rocketmq-client" / "src" / "consumer" / "pop_callback.rs": [
+            "fn on_error(&mut self, e: RocketMQError)",
+            "fn broker_response_code(error: &RocketMQError)",
+            "RocketMQError::BrokerOperationFailed",
+        ],
+        ROOT / "rocketmq-client" / "src" / "producer" / "request_callback.rs": [
+            "Option<&RocketMQError>",
+        ],
+        ROOT / "rocketmq-client" / "src" / "producer" / "request_response_future.rs": [
+            "type RequestCause = Arc<RocketMQError>",
+            "pub fn set_cause(&self, cause: RocketMQError)",
+        ],
+    }
+    findings: list[Finding] = []
+    for path, needles in required_tokens.items():
+        if not path.exists():
+            findings.append(Finding(path, 1, "client callback boundary file is missing"))
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                findings.append(Finding(path, 1, f"required client callback boundary token missing: {needle}"))
+
+    forbidden = {
+        "downcast_ref::<RocketMQError>": "client callback error paths must use typed RocketMQError directly",
+        "downcast_ref::<rocketmq_error::RocketMQError>": "client callback error paths must use typed RocketMQError directly",
+        "broker_response_code(error: &(dyn": "client broker response code lookup must not downcast dyn Error",
+        "type RequestCause = Arc<dyn": "request future cause must store RocketMQError directly",
+        "Option<&dyn std::error::Error>": "request callback must expose RocketMQError directly",
+        "Box<dyn std::error::Error + Send>": "pull/pop callbacks must expose RocketMQError directly",
+    }
+    guarded_paths = list(required_tokens)
+    return [*findings, *scan_forbidden_terms(guarded_paths, forbidden)]
+
+
 def check_error_spec_contract() -> list[Finding]:
     required_tokens = {
         ROOT / "rocketmq-error" / "src" / "kind.rs": [
@@ -496,6 +538,7 @@ def run() -> int:
         ("required mapping adapters", check_required_mapping_adapters),
         ("proxy grpc boundary", check_proxy_grpc_boundary),
         ("dashboard http boundary", check_dashboard_http_boundary),
+        ("client callback boundary", check_client_callback_boundary),
         ("error spec contract", check_error_spec_contract),
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7945

### Brief Description

- Changes pull and pop callback error parameters to `RocketMQError`.
- Removes dynamic-error downcast from pull and pop broker response code handling.
- Changes request callback errors to `Option<&RocketMQError>`.
- Stores request future causes as `Arc<RocketMQError>` and writes typed timeout causes.
- Updates client and proxy callback implementations for the typed callback ABI.
- Adds tests and architecture guard coverage for callback typed boundaries.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo check -p rocketmq-client-rust` passed.
- `cargo test -p rocketmq-client-rust pull_callback` passed.
- `cargo test -p rocketmq-client-rust pop_callback` passed.
- `cargo test -p rocketmq-client-rust request_response_future` passed.
- `cargo test -p rocketmq-client-rust request_future_holder` passed.
- `cargo test -p rocketmq-client-rust --test typed_error_client_flow_tests` passed.
- `cargo check -p rocketmq-proxy` passed.
- `py scripts\error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
