### PR TITLE
[ISSUE #7947]♻️Centralize client retry decisions

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -306,19 +306,29 @@ cargo test -p rocketmq-client-rust typed_error_client_flow_tests
 - `BrokerOperationFailed { code }` 仍用 `retry_response_codes` allowlist 判断，这是 RocketMQ broker response 兼容路径，需要明确边界。
 - producer/consumer 中仍有局部 retry 判断和状态处理。
 
+**完成状态**：
+
+- `ClientRetryDecision` 已补齐 `ClientRetryEffect`，将 retry、route refresh、switch broker、refresh leader、backoff 行为统一表达在 `retry_decision` 模块。
+- producer send 失败路径已改为先读取 `producer_send_retry_decision`，再由集中 `producer_send_fault_decision` 更新 fault strategy。
+- send 语境优先级已固定为：terminal send error 优先 `NoRetry`，`BrokerOperationFailed` 使用 Java 兼容 response code allowlist，其它错误回落到 `ErrorSpec.recovery.retry`。
+- `retry_decision` 单元测试覆盖 `RefreshRoute`、`SwitchBroker`、`RefreshLeader`、`AfterBackoff`、`Never`、broker response allowlist 和不读取 display text。
+- `scripts/error_architecture_guard.py` 已增加 client retry boundary 检查，防止 retry 决策回退到文本解析、runtime downcast 或绕开集中模块。
+
+**追踪**：Issue [#7947](https://github.com/mxsm/rocketmq-rust/issues/7947)，PR [#7948](https://github.com/mxsm/rocketmq-rust/pull/7948)。
+
 **开发 checklist**：
 
-- [ ] 明确 `RetryClass` 与 broker response code allowlist 的优先级。
-- [ ] 将 route refresh、switch broker、refresh leader、backoff 行为集中在 retry decision 模块。
-- [ ] 避免 producer/consumer 新增文本或局部 variant 猜测。
-- [ ] 对 `RetryClass::RefreshRoute/SwitchBroker/RefreshLeader/AfterBackoff/Never` 增加行为测试。
-- [ ] 对 broker response allowlist 写明 Java compatibility 理由。
+- [x] 明确 `RetryClass` 与 broker response code allowlist 的优先级。
+- [x] 将 route refresh、switch broker、refresh leader、backoff 行为集中在 retry decision 模块。
+- [x] 避免 producer/consumer 新增文本或局部 variant 猜测。
+- [x] 对 `RetryClass::RefreshRoute/SwitchBroker/RefreshLeader/AfterBackoff/Never` 增加行为测试。
+- [x] 对 broker response allowlist 写明 Java compatibility 理由。
 
 **验收 checklist**：
 
-- [ ] client retry 不读取 display string。
-- [ ] 新增 `ErrorKind` 的 retry 行为来自 `ErrorSpec.recovery`。
-- [ ] broker response allowlist 有测试覆盖。
+- [x] client retry 不读取 display string。
+- [x] 新增 `ErrorKind` 的 retry 行为来自 `ErrorSpec.recovery`。
+- [x] broker response allowlist 有测试覆盖。
 
 **建议验证**：
 
@@ -536,8 +546,8 @@ cargo build --all-targets --all-features
 - [x] `ErrorSpec` 包含 code、scope、category、public message、remoting、grpc、http、cli、recovery、observe、redaction。
 - [ ] remoting/gRPC/HTTP/CLI 外部出口读取中心 spec 或有明确 local-only allowlist。
 - [ ] broker/namesrv processor 通用错误不再手写 response code。
-- [ ] client callback 内部事实源不再是 `dyn Error` downcast。
-- [ ] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
+- [x] client callback 内部事实源不再是 `dyn Error` downcast。
+- [x] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
 - [ ] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
 - [ ] secret/token/signature/password 默认 redacted。
 - [ ] `scripts/error_architecture_guard.py` 进入 CI。

--- a/rocketmq-client/src/common/retry_decision.rs
+++ b/rocketmq-client/src/common/retry_decision.rs
@@ -28,10 +28,55 @@ pub(crate) enum ClientRetryDecision {
     RefreshLeader,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ClientRetryEffect {
+    pub(crate) retry: bool,
+    pub(crate) refresh_route: bool,
+    pub(crate) switch_broker: bool,
+    pub(crate) refresh_leader: bool,
+    pub(crate) backoff: bool,
+}
+
+impl ClientRetryEffect {
+    #[inline]
+    const fn none() -> Self {
+        Self {
+            retry: false,
+            refresh_route: false,
+            switch_broker: false,
+            refresh_leader: false,
+            backoff: false,
+        }
+    }
+
+    #[inline]
+    const fn retry() -> Self {
+        Self {
+            retry: true,
+            refresh_route: false,
+            switch_broker: false,
+            refresh_leader: false,
+            backoff: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProducerSendFaultDecision {
+    pub(crate) isolation: bool,
+    pub(crate) reachable: bool,
+    pub(crate) log_resend_immediately: bool,
+}
+
 impl ClientRetryDecision {
     #[inline]
     pub(crate) fn from_error(error: &RocketMQError) -> Self {
-        match error.kind().spec().recovery.retry {
+        Self::from_retry_class(error.kind().spec().recovery.retry)
+    }
+
+    #[inline]
+    pub(crate) const fn from_retry_class(retry: RetryClass) -> Self {
+        match retry {
             RetryClass::Never => Self::NoRetry,
             RetryClass::Immediate => Self::Immediate,
             RetryClass::AfterBackoff => Self::Backoff,
@@ -43,28 +88,111 @@ impl ClientRetryDecision {
 
     #[inline]
     pub(crate) const fn should_retry(self) -> bool {
-        !matches!(self, Self::NoRetry)
+        self.effect().retry
+    }
+
+    #[inline]
+    pub(crate) const fn effect(self) -> ClientRetryEffect {
+        match self {
+            Self::NoRetry => ClientRetryEffect::none(),
+            Self::Immediate => ClientRetryEffect::retry(),
+            Self::Backoff => ClientRetryEffect {
+                retry: true,
+                refresh_route: false,
+                switch_broker: false,
+                refresh_leader: false,
+                backoff: true,
+            },
+            Self::RefreshRoute => ClientRetryEffect {
+                retry: true,
+                refresh_route: true,
+                switch_broker: false,
+                refresh_leader: false,
+                backoff: false,
+            },
+            Self::SwitchBroker => ClientRetryEffect {
+                retry: true,
+                refresh_route: false,
+                switch_broker: true,
+                refresh_leader: false,
+                backoff: false,
+            },
+            Self::RefreshLeader => ClientRetryEffect {
+                retry: true,
+                refresh_route: false,
+                switch_broker: false,
+                refresh_leader: true,
+                backoff: false,
+            },
+        }
     }
 }
 
 #[inline]
 pub(crate) fn should_retry_async_send_error(error: &RocketMQError) -> bool {
+    async_send_retry_decision(error).should_retry()
+}
+
+#[inline]
+pub(crate) fn async_send_retry_decision(error: &RocketMQError) -> ClientRetryDecision {
     if is_terminal_send_error(error) {
-        return false;
+        return ClientRetryDecision::NoRetry;
     }
 
-    ClientRetryDecision::from_error(error).should_retry()
+    ClientRetryDecision::from_error(error)
 }
 
 #[inline]
 pub(crate) fn should_retry_producer_send_error(error: &RocketMQError, retry_response_codes: &HashSet<i32>) -> bool {
+    producer_send_retry_decision(error, retry_response_codes).should_retry()
+}
+
+#[inline]
+pub(crate) fn producer_send_retry_decision(
+    error: &RocketMQError,
+    retry_response_codes: &HashSet<i32>,
+) -> ClientRetryDecision {
     if is_terminal_send_error(error) {
-        return false;
+        return ClientRetryDecision::NoRetry;
     }
 
     match error {
-        RocketMQError::BrokerOperationFailed { code, .. } => retry_response_codes.contains(code),
-        _ => ClientRetryDecision::from_error(error).should_retry(),
+        RocketMQError::BrokerOperationFailed { code, .. } => {
+            // Java producer retries only configured broker response codes for send.
+            // This allowlist is the explicit broker-protocol compatibility boundary
+            // and intentionally overrides the generic BrokerOperationFailed RetryClass.
+            if retry_response_codes.contains(code) {
+                ClientRetryDecision::SwitchBroker
+            } else {
+                ClientRetryDecision::NoRetry
+            }
+        }
+        _ => ClientRetryDecision::from_error(error),
+    }
+}
+
+#[inline]
+pub(crate) fn producer_send_fault_decision(
+    error: &RocketMQError,
+    start_detector_enabled: bool,
+) -> Option<ProducerSendFaultDecision> {
+    match error {
+        RocketMQError::IllegalArgument(_) => Some(ProducerSendFaultDecision {
+            isolation: false,
+            reachable: true,
+            log_resend_immediately: true,
+        }),
+        RocketMQError::BrokerOperationFailed { .. } => Some(ProducerSendFaultDecision {
+            isolation: true,
+            reachable: false,
+            log_resend_immediately: false,
+        }),
+        RocketMQError::Network(_) => Some(ProducerSendFaultDecision {
+            isolation: true,
+            reachable: !start_detector_enabled,
+            log_resend_immediately: false,
+        }),
+        _ => None,
     }
 }
 
@@ -86,6 +214,22 @@ fn is_terminal_send_error(error: &RocketMQError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const fn effect(
+        retry: bool,
+        refresh_route: bool,
+        switch_broker: bool,
+        refresh_leader: bool,
+        backoff: bool,
+    ) -> ClientRetryEffect {
+        ClientRetryEffect {
+            retry,
+            refresh_route,
+            switch_broker,
+            refresh_leader,
+            backoff,
+        }
+    }
 
     #[test]
     fn retry_decision_uses_error_recovery_policy() {
@@ -111,11 +255,11 @@ mod tests {
     fn async_send_retry_excludes_terminal_send_errors() {
         let retryable = RocketMQError::Network(NetworkError::send_failed("broker-a:10911", "write failed"));
         let request_timeout = RocketMQError::Network(NetworkError::RequestTimeout {
-            addr: "broker-a:10911".to_string(),
+            addr: "broker-a:10911".into(),
             timeout_ms: 3_000,
         });
         let too_many_requests = RocketMQError::Network(NetworkError::TooManyRequests {
-            addr: "broker-a:10911".to_string(),
+            addr: "broker-a:10911".into(),
             limit: 1,
         });
 
@@ -133,5 +277,135 @@ mod tests {
 
         assert!(should_retry_producer_send_error(&error, &retry_codes));
         assert!(!should_retry_producer_send_error(&error, &non_retry_codes));
+    }
+
+    #[test]
+    fn retry_effects_cover_recovery_classes() {
+        let cases = vec![
+            (
+                RocketMQError::route_not_found("TopicA"),
+                ClientRetryDecision::RefreshRoute,
+                effect(true, true, false, false, false),
+            ),
+            (
+                RocketMQError::BrokerNotFound {
+                    name: "broker-a".into(),
+                },
+                ClientRetryDecision::SwitchBroker,
+                effect(true, false, true, false, false),
+            ),
+            (
+                RocketMQError::NotMasterBroker {
+                    master_address: "broker-b:10911".into(),
+                },
+                ClientRetryDecision::RefreshLeader,
+                effect(true, false, false, true, false),
+            ),
+            (
+                RocketMQError::network_connection_failed("broker-a:10911", "connection failed"),
+                ClientRetryDecision::Backoff,
+                effect(true, false, false, false, true),
+            ),
+            (
+                RocketMQError::ClientNotStarted,
+                ClientRetryDecision::NoRetry,
+                effect(false, false, false, false, false),
+            ),
+        ];
+
+        for (error, expected_decision, expected_effect) in cases {
+            assert_eq!(ClientRetryDecision::from_error(&error), expected_decision);
+            assert_eq!(
+                ClientRetryDecision::from_retry_class(error.kind().spec().recovery.retry),
+                expected_decision
+            );
+            assert_eq!(expected_decision.effect(), expected_effect);
+        }
+    }
+
+    #[test]
+    fn producer_send_retry_priority_is_terminal_then_broker_allowlist_then_spec() {
+        let timeout = RocketMQError::Timeout {
+            operation: "SEND_MESSAGE",
+            timeout_ms: 3_000,
+        };
+        let broker_error = RocketMQError::broker_operation_failed("SEND_MESSAGE", 12, "system busy");
+        let network_error = RocketMQError::network_connection_failed("broker-a:10911", "connection failed");
+
+        assert_eq!(ClientRetryDecision::from_error(&timeout), ClientRetryDecision::Backoff);
+        assert_eq!(
+            producer_send_retry_decision(&timeout, &HashSet::from([12])),
+            ClientRetryDecision::NoRetry
+        );
+
+        assert_eq!(
+            ClientRetryDecision::from_error(&broker_error),
+            ClientRetryDecision::SwitchBroker
+        );
+        assert_eq!(
+            producer_send_retry_decision(&broker_error, &HashSet::from([13])),
+            ClientRetryDecision::NoRetry
+        );
+        assert_eq!(
+            producer_send_retry_decision(&broker_error, &HashSet::from([12])),
+            ClientRetryDecision::SwitchBroker
+        );
+
+        assert_eq!(
+            producer_send_retry_decision(&network_error, &HashSet::new()),
+            ClientRetryDecision::Backoff
+        );
+    }
+
+    #[test]
+    fn producer_send_fault_decision_is_centralized() {
+        let illegal_argument = RocketMQError::illegal_argument("bad request");
+        let broker_error = RocketMQError::broker_operation_failed("SEND_MESSAGE", 12, "system busy");
+        let network_error = RocketMQError::Network(NetworkError::send_failed("broker-a:10911", "write failed"));
+
+        assert_eq!(
+            producer_send_fault_decision(&illegal_argument, false),
+            Some(ProducerSendFaultDecision {
+                isolation: false,
+                reachable: true,
+                log_resend_immediately: true,
+            })
+        );
+        assert_eq!(
+            producer_send_fault_decision(&broker_error, false),
+            Some(ProducerSendFaultDecision {
+                isolation: true,
+                reachable: false,
+                log_resend_immediately: false,
+            })
+        );
+        assert_eq!(
+            producer_send_fault_decision(&network_error, false),
+            Some(ProducerSendFaultDecision {
+                isolation: true,
+                reachable: true,
+                log_resend_immediately: false,
+            })
+        );
+        assert_eq!(
+            producer_send_fault_decision(&network_error, true),
+            Some(ProducerSendFaultDecision {
+                isolation: true,
+                reachable: false,
+                log_resend_immediately: false,
+            })
+        );
+        assert_eq!(
+            producer_send_fault_decision(&RocketMQError::ClientNotStarted, false),
+            None
+        );
+    }
+
+    #[test]
+    fn retry_decision_module_does_not_parse_display_text() {
+        let source = include_str!("retry_decision.rs");
+
+        assert!(!source.contains(concat!("to_", "string(")));
+        assert!(!source.contains(concat!("format", "!(")));
     }
 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -71,6 +71,9 @@ use crate::base::client_config::ClientConfig;
 use crate::base::query_result::QueryResult;
 use crate::base::validators::Validators;
 use crate::common::client_error_code::ClientErrorCode;
+use crate::common::retry_decision::producer_send_fault_decision;
+use crate::common::retry_decision::producer_send_retry_decision;
+use crate::common::retry_decision::ClientRetryDecision;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::hook::check_forbidden_context::CheckForbiddenContext;
 use crate::hook::check_forbidden_hook::CheckForbiddenHook;
@@ -1345,10 +1348,12 @@ impl DefaultMQProducerImpl {
                     return Ok(result);
                 }
                 Err(e) => {
+                    let retry_decision = self.retry_decision_on_error(&e);
+
                     // Handle send error
                     self.handle_send_error(&mq, &e, elapsed, ctx.invoke_id).await;
 
-                    if !self.should_retry_on_error(&e) {
+                    if !retry_decision.should_retry() {
                         return Err(e);
                     }
 
@@ -1401,32 +1406,27 @@ impl DefaultMQProducerImpl {
     ) {
         let broker_name = mq.broker_name();
 
-        match error {
-            rocketmq_error::RocketMQError::IllegalArgument(_) => {
-                self.update_fault_item(broker_name, elapsed, false, true).await;
-                warn!(
-                    "sendKernelImpl exception, resend at once, InvokeID: {}, RT: {}ms, Broker: {:?}, {}",
-                    invoke_id, elapsed, mq, error
-                );
-            }
-            rocketmq_error::RocketMQError::BrokerOperationFailed { .. } => {
-                self.update_fault_item(broker_name, elapsed, true, false).await;
-            }
-            rocketmq_error::RocketMQError::Network(_) => {
-                let reachable = !self.mq_fault_strategy.is_start_detector_enable();
-                self.update_fault_item(broker_name, elapsed, true, reachable).await;
-            }
-            _ => {}
+        let Some(fault_decision) =
+            producer_send_fault_decision(error, self.mq_fault_strategy.is_start_detector_enable())
+        else {
+            return;
+        };
+
+        self.update_fault_item(broker_name, elapsed, fault_decision.isolation, fault_decision.reachable)
+            .await;
+
+        if fault_decision.log_resend_immediately {
+            warn!(
+                "sendKernelImpl exception, resend at once, InvokeID: {}, RT: {}ms, Broker: {:?}, {}",
+                invoke_id, elapsed, mq, error
+            );
         }
     }
 
-    /// Check if should retry based on error type
+    /// Build retry decision for producer send failures.
     #[inline]
-    fn should_retry_on_error(&self, error: &rocketmq_error::RocketMQError) -> bool {
-        crate::common::retry_decision::should_retry_producer_send_error(
-            error,
-            self.producer_config.retry_response_codes(),
-        )
+    fn retry_decision_on_error(&self, error: &RocketMQError) -> ClientRetryDecision {
+        producer_send_retry_decision(error, self.producer_config.retry_response_codes())
     }
 
     /// Check if should retry based on send result

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -402,6 +402,45 @@ def check_client_callback_boundary() -> list[Finding]:
     return [*findings, *scan_forbidden_terms(guarded_paths, forbidden)]
 
 
+def check_client_retry_boundary() -> list[Finding]:
+    required_tokens = {
+        ROOT / "rocketmq-client" / "src" / "common" / "retry_decision.rs": [
+            "error.kind().spec().recovery.retry",
+            "pub(crate) struct ClientRetryEffect",
+            "pub(crate) fn producer_send_retry_decision",
+            "pub(crate) fn producer_send_fault_decision",
+            "retry_response_codes.contains(code)",
+            "Java producer retries only configured broker response codes for send.",
+        ],
+        ROOT
+        / "rocketmq-client"
+        / "src"
+        / "producer"
+        / "producer_impl"
+        / "default_mq_producer_impl.rs": [
+            "producer_send_retry_decision(error, self.producer_config.retry_response_codes())",
+            "producer_send_fault_decision(error, self.mq_fault_strategy.is_start_detector_enable())",
+        ],
+    }
+    findings: list[Finding] = []
+    for path, needles in required_tokens.items():
+        if not path.exists():
+            findings.append(Finding(path, 1, "client retry boundary file is missing"))
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                findings.append(Finding(path, 1, f"required client retry boundary token missing: {needle}"))
+
+    forbidden = {
+        "to_string()": "client retry decisions must not parse or build display strings",
+        "format!(": "client retry decisions must use ErrorSpec recovery policy, not local text construction",
+        "downcast_ref": "client retry decisions must not use runtime downcast",
+    }
+    retry_path = ROOT / "rocketmq-client" / "src" / "common" / "retry_decision.rs"
+    return [*findings, *scan_forbidden_terms([retry_path], forbidden)]
+
+
 def check_error_spec_contract() -> list[Finding]:
     required_tokens = {
         ROOT / "rocketmq-error" / "src" / "kind.rs": [
@@ -539,6 +578,7 @@ def run() -> int:
         ("proxy grpc boundary", check_proxy_grpc_boundary),
         ("dashboard http boundary", check_dashboard_http_boundary),
         ("client callback boundary", check_client_callback_boundary),
+        ("client retry boundary", check_client_retry_boundary),
         ("error spec contract", check_error_spec_contract),
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7947

### Brief Description

Centralizes client retry and fault policy for producer send failures. `retry_decision` now exposes retry effects for retry, route refresh, broker switch, leader refresh, and backoff semantics.

The producer send path now consumes `producer_send_retry_decision` and `producer_send_fault_decision`, keeping terminal send errors, Java-compatible broker response allowlist behavior, and `ErrorSpec.recovery` fallback in one module. The error architecture guard now checks the client retry boundary to prevent regressions back to display text parsing or runtime downcast.

`docs/07-error-refactor-checklist.md` is updated to mark the client retry and fault checklist complete.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-client-rust retry_decision` passed.
- `cargo test -p rocketmq-client-rust default_mq_producer_impl` passed.
- `py scripts\error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
