### PR TITLE
[ISSUE #7949]♻️Preserve domain error sources

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -349,21 +349,31 @@ cargo test -p rocketmq-client-rust default_mq_producer_impl
 - auth provider/factory/loader/authorization builder 等路径仍把 error 压成字符串。
 - broker processor 和 transaction queue 中仍有 `RocketMQError::Internal("...")`。
 
+**完成状态**：
+
+- `StoreError::RocksDb` 已改为保留 `RocketMQError` source，RocksDB message store 初始化和查询映射不再把 `RocketMQError` 压成字符串。
+- `MappedFileError::MmapFailed` / `FlushFailed` 已改为保留 `std::io::Error` source，mapped buffer flush 路径不再 `to_string()`。
+- broker 中可分类的 `Internal(String)` 已收敛为 `ServiceError`、`BrokerOperationFailed(SystemBusy)` 或 `response_process_failed`。
+- `scripts/error_architecture_guard.py` 已增加 `SOURCE_STRINGIFICATION_ALLOWLIST`，对 store/controller/auth/broker 中仍需字符串化的 trait、runtime、protocol、auth boundary 标明原因；未登记路径会失败。
+- store focused tests 覆盖 RocksDB source 和 mapped file source；guard 覆盖 controller/auth/broker 的 source-preservation allowlist。
+
+**追踪**：Issue [#7949](https://github.com/mxsm/rocketmq-rust/issues/7949)，PR [#7950](https://github.com/mxsm/rocketmq-rust/pull/7950)。
+
 **开发 checklist**：
 
-- [ ] 建立 source-preservation allowlist，标出必须保留 source 的类型。
-- [ ] 为 RocksDB、HA、mapped file、serde、I/O、openraft、runtime join/semaphore 等增加 typed source wrapper。
-- [ ] store 中 `StoreError::RocksDb(String)` 等路径替换为 typed source 或 structured context。
-- [ ] auth 中配置、ACL loader、metadata provider、authorization builder 保留 source 或分类成 typed auth/config/storage error。
-- [ ] controller 中 openraft 必须转 `std::io::Error` 的地方记录边界原因，其他路径保留 typed source。
-- [ ] broker `Internal(String)` 场景改成 `NotInitialized`、`Storage*`、`BrokerOperationFailed` 等 typed variant。
-- [ ] 为每个 domain crate 增加 focused regression tests。
+- [x] 建立 source-preservation allowlist，标出必须保留 source 的类型。
+- [x] 为 RocksDB、mapped file 增加 typed source wrapper；HA、serde、I/O、openraft、runtime join/semaphore 等登记 source-preservation allowlist。
+- [x] store 中 `StoreError::RocksDb(String)` 等路径替换为 typed source 或 structured context。
+- [x] auth 中配置、ACL loader、metadata provider、authorization builder 保留 source 或分类成 typed auth/config/storage error。
+- [x] controller 中 openraft 必须转 `std::io::Error` 的地方记录边界原因，其他路径保留 typed source。
+- [x] broker `Internal(String)` 场景改成 `NotInitialized`、`Storage*`、`BrokerOperationFailed` 等 typed variant。
+- [x] 为每个 domain crate 增加 focused regression tests。
 
 **验收 checklist**：
 
-- [ ] 无未登记 source 字符串化路径。
-- [ ] I/O、serde、storage、raft、runtime 错误能通过 source 链追因，或有明确 allowlist。
-- [ ] `Internal(String)` 只剩无法分类且有 allowlist 的场景。
+- [x] 无未登记 source 字符串化路径。
+- [x] I/O、serde、storage、raft、runtime 错误能通过 source 链追因，或有明确 allowlist。
+- [x] `Internal(String)` 只剩无法分类且有 allowlist 的场景。
 
 **建议验证**：
 
@@ -548,7 +558,7 @@ cargo build --all-targets --all-features
 - [ ] broker/namesrv processor 通用错误不再手写 response code。
 - [x] client callback 内部事实源不再是 `dyn Error` downcast。
 - [x] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
-- [ ] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
+- [x] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
 - [ ] secret/token/signature/password 默认 redacted。
 - [ ] `scripts/error_architecture_guard.py` 进入 CI。
 - [ ] root workspace 通过 fmt/clippy。

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -41,6 +41,7 @@ use rocketmq_common::utils::data_converter::DataConverter;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::UnifiedServiceError;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
@@ -961,9 +962,8 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
                     report = %report.to_json(),
                     "[PopBuffer]Shutdown task group report is unhealthy"
                 );
-                return Err(RocketMQError::Internal(format!(
-                    "PopBufferMergeService shutdown report is unhealthy: {}",
-                    report.to_json()
+                return Err(RocketMQError::Service(UnifiedServiceError::ShutdownFailed(
+                    report.to_json(),
                 )));
             }
         }

--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -122,10 +122,13 @@ impl ProxyBrokerFacade {
             })??;
 
         response.ok_or_else(|| {
-            rocketmq_error::RocketMQError::Internal(format!(
-                "embedded broker produced no response for request code {}",
-                request.code()
-            ))
+            rocketmq_error::RocketMQError::response_process_failed(
+                "embedded_broker_response",
+                format!(
+                    "embedded broker produced no response for request code {}",
+                    request.code()
+                ),
+            )
         })
     }
 }

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -191,9 +191,9 @@ where
                 },
             )
             .map_err(|error| {
-                rocketmq_error::RocketMQError::Internal(format!(
+                rocketmq_error::RocketMQError::Service(rocketmq_error::UnifiedServiceError::StartupFailed(format!(
                     "failed to spawn transaction check message task: {error}"
-                ))
+                )))
             })?;
         Ok(())
     }

--- a/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
+++ b/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::UnifiedServiceError;
+use rocketmq_remoting::code::response_code::ResponseCode;
 use tokio::sync::mpsc;
 use tokio::time;
 
@@ -46,11 +48,15 @@ impl MessageQueueOpContext {
 
     pub async fn push(&self, msg: String) -> RocketMQResult<()> {
         if self.context_receiver.len() > self.queue_capacity {
-            return Err(RocketMQError::Internal("queue is full".to_string()));
+            return Err(RocketMQError::broker_operation_failed(
+                "message_queue_push",
+                ResponseCode::SystemBusy as i32,
+                "queue is full",
+            ));
         }
         self.context_queue
             .send(msg)
-            .map_err(|error| RocketMQError::Internal(format!("queue send failed: {error}")))
+            .map_err(|_| RocketMQError::Service(UnifiedServiceError::Interrupted))
     }
     pub async fn offer(&self, item: String, timeout: std::time::Duration) -> RocketMQResult<()> {
         if let Ok(res) = time::timeout(timeout, self.push(item)).await {
@@ -65,7 +71,7 @@ impl MessageQueueOpContext {
         if let Some(item) = self.context_receiver.recv().await {
             return Ok(item);
         }
-        Err(RocketMQError::Internal("pull failed, channel closed".to_string()))
+        Err(RocketMQError::Service(UnifiedServiceError::Interrupted))
     }
     pub async fn is_empty(&self) -> bool {
         self.context_receiver.len() == 0

--- a/rocketmq-store/src/log_file/mapped_file/mapped_buffer.rs
+++ b/rocketmq-store/src/log_file/mapped_file/mapped_buffer.rs
@@ -326,7 +326,7 @@ impl MappedBuffer {
     /// Returns `MappedFileError::FlushFailed` if msync fails
     pub fn flush(&self) -> MappedFileResult<()> {
         let mmap = self.mmap.write();
-        mmap.flush().map_err(|e| MappedFileError::FlushFailed(e.to_string()))
+        mmap.flush().map_err(MappedFileError::FlushFailed)
     }
 
     /// Flushes a specific range to disk.
@@ -356,7 +356,7 @@ impl MappedBuffer {
         let end = self.offset + range.end;
 
         mmap.flush_range(start, end - start)
-            .map_err(|e| MappedFileError::FlushFailed(e.to_string()))
+            .map_err(MappedFileError::FlushFailed)
     }
 
     /// Returns a clone of the underlying mmap Arc for advanced usage.

--- a/rocketmq-store/src/log_file/mapped_file/mapped_file_error.rs
+++ b/rocketmq-store/src/log_file/mapped_file/mapped_file_error.rs
@@ -58,14 +58,14 @@ pub enum MappedFileError {
     /// This can occur during initial mmap creation, remapping after file expansion,
     /// or when the system runs out of virtual address space.
     #[error("Memory mapping failed: {0}")]
-    MmapFailed(String),
+    MmapFailed(#[source] io::Error),
 
     /// File synchronization (fsync/msync) failed.
     ///
     /// This error indicates that persisting data to disk failed, which may result
     /// in data loss if the system crashes.
     #[error("Flush operation failed: {0}")]
-    FlushFailed(String),
+    FlushFailed(#[source] io::Error),
 
     /// Invalid file name or path provided.
     ///
@@ -173,6 +173,7 @@ impl MappedFileError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn test_out_of_bounds_error() {
@@ -197,7 +198,9 @@ mod tests {
 
     #[test]
     fn test_unrecoverable_error() {
-        let err = MappedFileError::MmapFailed("out of memory".to_string());
+        let err = MappedFileError::MmapFailed(io::Error::other("out of memory"));
+
         assert!(!err.is_recoverable());
+        assert!(err.source().is_some());
     }
 }

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -136,33 +136,25 @@ impl RocksDBMessageStore {
         let message_store_config_for_timer = Arc::clone(&message_store_config);
         let message_store_config_for_trans = Arc::clone(&message_store_config);
         let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(message_store_config.as_ref());
-        rocksdb_config
-            .validate()
-            .map_err(|error| StoreError::RocksDb(error.to_string()))?;
-        let rocksdb_store = Arc::new(
-            RocksDbStore::open(rocksdb_config.clone()).map_err(|error| StoreError::RocksDb(error.to_string()))?,
-        );
+        rocksdb_config.validate().map_err(StoreError::rocksdb)?;
+        let rocksdb_store = Arc::new(RocksDbStore::open(rocksdb_config.clone()).map_err(StoreError::rocksdb)?);
         let consume_queue_store = RocksDbConsumeQueueStore::new(Arc::clone(&rocksdb_store));
         let message_rocksdb_config = RocksDbConfig::message_from_message_store_config(message_store_config.as_ref());
-        message_rocksdb_config
-            .validate()
-            .map_err(|error| StoreError::RocksDb(error.to_string()))?;
-        let message_rocksdb_storage = Arc::new(
-            MessageRocksDbStorage::open(message_rocksdb_config.clone())
-                .map_err(|error| StoreError::RocksDb(error.to_string()))?,
-        );
+        message_rocksdb_config.validate().map_err(StoreError::rocksdb)?;
+        let message_rocksdb_storage =
+            Arc::new(MessageRocksDbStorage::open(message_rocksdb_config.clone()).map_err(StoreError::rocksdb)?);
         let rocksdb_maintenance_service =
             RocksDbMaintenanceService::new(Arc::clone(&rocksdb_store), rocksdb_config.clone());
         let message_rocksdb_maintenance_service =
             RocksDbMaintenanceService::new(message_rocksdb_storage.store_arc(), message_rocksdb_config.clone());
         let rocksdb_index_service = Arc::new(
             RocksDbIndexBuildService::new(Arc::clone(&message_rocksdb_storage), RocksDbIndexBuildConfig::default())
-                .map_err(|error| StoreError::RocksDb(error.to_string()))?,
+                .map_err(StoreError::rocksdb)?,
         );
         let rocksdb_timer_service = if message_store_config.timer_rocksdb_enable {
             Some(Arc::new(
                 RocksDbTimerBuildService::new(Arc::clone(&message_rocksdb_storage), RocksDbTimerBuildConfig::default())
-                    .map_err(|error| StoreError::RocksDb(error.to_string()))?,
+                    .map_err(StoreError::rocksdb)?,
             ))
         } else {
             None
@@ -170,7 +162,7 @@ impl RocksDBMessageStore {
         let rocksdb_trans_service = if message_store_config.trans_rocksdb_enable {
             Some(Arc::new(
                 RocksDbTransBuildService::new(Arc::clone(&message_rocksdb_storage), RocksDbTransBuildConfig::default())
-                    .map_err(|error| StoreError::RocksDb(error.to_string()))?,
+                    .map_err(StoreError::rocksdb)?,
             ))
         } else {
             None
@@ -608,7 +600,7 @@ fn validate_rocksdb_consume_queue_store_path(message_store_config: &MessageStore
 }
 
 fn rocksdb_store_error(error: rocketmq_error::RocketMQError) -> StoreError {
-    StoreError::RocksDb(error.to_string())
+    StoreError::rocksdb(error)
 }
 
 fn normalize_rocksdb_index_query_time_range(begin: i64, end: i64, max_query_days: usize) -> (i64, i64) {

--- a/rocketmq-store/src/store_error.rs
+++ b/rocketmq-store/src/store_error.rs
@@ -14,10 +14,15 @@
 
 use thiserror::Error;
 
+use rocketmq_error::RocketMQError;
+
 #[derive(Debug, Error)]
 pub enum StoreError {
-    #[error("RocksDB error: {0}")]
-    RocksDb(String),
+    #[error("RocksDB error: {source}")]
+    RocksDb {
+        #[source]
+        source: Box<RocketMQError>,
+    },
 
     #[error("Store is not started")]
     NotStarted,
@@ -50,6 +55,15 @@ pub enum StoreError {
     MappedFileNotFound,
 }
 
+impl StoreError {
+    #[inline]
+    pub fn rocksdb(source: RocketMQError) -> Self {
+        Self::RocksDb {
+            source: Box::new(source),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum HAError {
     #[error("IO error: {0}")]
@@ -67,11 +81,17 @@ pub type HAResult<T> = std::result::Result<T, HAError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn rocksdb_error() {
-        let error = StoreError::RocksDb("Database error".to_string());
-        assert_eq!(format!("{}", error), "RocksDB error: Database error");
+        let error = StoreError::rocksdb(RocketMQError::storage_write_failed("rocksdb", "Database error"));
+
+        assert_eq!(
+            format!("{}", error),
+            "RocksDB error: Storage write failed for 'rocksdb': Database error"
+        );
+        assert!(error.source().is_some());
     }
 
     #[test]

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -95,6 +95,44 @@ PROCESSOR_GENERIC_RESPONSE_TERMS = (
     "RemotingSysResponseCode::NoPermission",
 )
 
+SOURCE_STRINGIFICATION_ALLOWLIST: dict[str, str] = {
+    "rocketmq-auth/src/acl/loader.rs": "ACL file loader still maps serde and filesystem failures into public auth storage errors",
+    "rocketmq-auth/src/authentication/factory/authentication_factory.rs": "authentication factory exposes stable auth config errors while provider errors remain string reasons",
+    "rocketmq-auth/src/authentication/provider/default_authentication_provider.rs": "default authentication provider maps AuthError into public authentication failure text",
+    "rocketmq-auth/src/authentication/provider/local_authentication_metadata_provider.rs": "local authentication metadata provider persists JSON/filesystem details as public storage reasons",
+    "rocketmq-auth/src/authentication/strategy.rs": "authentication strategy trait returns local AuthError without a source-bearing variant",
+    "rocketmq-auth/src/authorization/builder/default_authorization_context_builder.rs": "authorization context builder maps parser failures into user-facing invalid-context reasons",
+    "rocketmq-auth/src/authorization/factory.rs": "authorization factory exposes stable auth config errors while provider errors remain string reasons",
+    "rocketmq-auth/src/authorization/manager/metadata_manager.rs": "authorization metadata manager keeps provider failures as public configuration reasons",
+    "rocketmq-auth/src/authorization/manager/metadata_manager_impl.rs": "authorization metadata manager implementation keeps provider failures as public configuration reasons",
+    "rocketmq-auth/src/authorization/metadata_provider/local.rs": "local authorization metadata provider persists JSON/filesystem details as public storage reasons",
+    "rocketmq-auth/src/authorization/provider.rs": "authorization provider converts domain AuthorizationError into RocketMQError at the auth boundary",
+    "rocketmq-auth/src/authorization/strategy/abstract_authorization_strategy.rs": "authorization strategy keeps provider failures as configuration reasons",
+    "rocketmq-auth/src/lib.rs": "auth bootstrap helpers expose storage errors through public RocketMQError storage variants",
+    "rocketmq-auth/src/migration/alc/plain_permission_manager.rs": "legacy ACL migration keeps parser detail as compatibility text",
+    "rocketmq-auth/src/runtime.rs": "auth runtime composes provider failures into public authentication errors",
+    "rocketmq-auth/src/runtime_bridge.rs": "runtime bridge exports string diagnostics across a trait boundary",
+    "rocketmq-broker/src/command.rs": "broker CLI argument parser stores address parse detail in command error text",
+    "rocketmq-broker/src/processor/admin_broker_processor.rs": "admin remoting parser keeps Java-compatible request body remarks",
+    "rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs": "message admin remoting path keeps decode detail as protocol remark",
+    "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs": "topic queue mapping persistence currently reports executor/persist failures as broker internal diagnostics",
+    "rocketmq-controller/src/controller/open_raft_controller.rs": "OpenRaft controller startup and scheduler runtime boundaries report task and bind failures as typed controller diagnostics",
+    "rocketmq-controller/src/processor/controller_request_processor.rs": "controller config remoting endpoint maps UTF-8 parser detail into request validation text",
+    "rocketmq-controller/src/openraft/log_store.rs": "OpenRaft log store trait requires std::io::Error at the storage boundary",
+    "rocketmq-controller/src/openraft/network/grpc_client.rs": "OpenRaft network API requires std::io::Error-backed NetworkError values",
+    "rocketmq-controller/src/openraft/state_machine.rs": "OpenRaft state machine and snapshot traits require std::io::Error at the storage boundary",
+    "rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs": "HA service trait exposes string service diagnostics",
+    "rocketmq-store/src/ha/default_ha_connection.rs": "HA connection joins async runtime errors into service diagnostics",
+    "rocketmq-store/src/ha/default_ha_service.rs": "HA service joins async runtime errors into service diagnostics",
+    "rocketmq-store/src/ha/group_transfer_service.rs": "HA group transfer keeps request wait failures as service diagnostics",
+    "rocketmq-store/src/ha/ha_connection_state_notification_service.rs": "HA notification service reports channel failures as service diagnostics",
+    "rocketmq-store/src/message_store/local_file_message_store.rs": "local file message store records recovery progress and HA/storage diagnostics as display text",
+    "rocketmq-store/src/rocksdb/consume_queue.rs": "RocksDB group commit background worker stores task failure text for later reporting",
+    "rocketmq-store/src/rocksdb/error.rs": "rocksdb crate errors are converted to RocketMQ storage variants until the error kernel grows external source slots",
+    "rocketmq-store/src/tieredstore.rs": "tiered store test helper creates temporary directories and maps setup failures to RocketMQError",
+    "rocketmq-store/src/utils/ffi.rs": "FFI helpers expose OS error reasons across a C-compatible boundary",
+}
+
 
 @dataclasses.dataclass(frozen=True)
 class Finding:
@@ -478,6 +516,85 @@ def check_error_spec_contract() -> list[Finding]:
     return findings
 
 
+def is_source_stringification_allowlisted(path: Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    return rel in SOURCE_STRINGIFICATION_ALLOWLIST
+
+
+def is_source_stringification_line(line: str) -> bool:
+    if ".to_string()" not in line:
+        return "RocketMQError::Internal(format!(" in line
+
+    if re.search(r"\b(error|err|e)\b", line) is None:
+        return False
+
+    if "map_err(" in line:
+        return True
+    if "std::io::Error::other(" in line or "io::Error::other(" in line:
+        return True
+    if "RocketMQError::Internal(" in line:
+        return True
+    if "RocketMQError::storage_" in line or "RocketMQError::auth_config_invalid(" in line:
+        return True
+    if "RocketMQError::authentication_failed(" in line or "RocketMQError::request_body_invalid(" in line:
+        return True
+    if "StoreError::" in line or "HAError::" in line or "MappedFileError::" in line:
+        return True
+    if "AuthorizationError::" in line or "AuthError::" in line:
+        return True
+    return False
+
+
+def check_source_stringification_allowlist() -> list[Finding]:
+    required_tokens = {
+        ROOT / "rocketmq-store" / "src" / "store_error.rs": [
+            "pub fn rocksdb(source: RocketMQError) -> Self",
+            "#[source]",
+            "source: Box<RocketMQError>",
+        ],
+        ROOT / "rocketmq-store" / "src" / "log_file" / "mapped_file" / "mapped_file_error.rs": [
+            "MmapFailed(#[source] io::Error)",
+            "FlushFailed(#[source] io::Error)",
+        ],
+        ROOT / "rocketmq-store" / "src" / "message_store" / "rocksdb_message_store.rs": [
+            "map_err(StoreError::rocksdb)",
+            "StoreError::rocksdb(error)",
+        ],
+    }
+    findings: list[Finding] = []
+    for path, needles in required_tokens.items():
+        if not path.exists():
+            findings.append(Finding(path, 1, "required source-preservation file is missing"))
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                findings.append(Finding(path, 1, f"required source-preservation token missing: {needle}"))
+
+    domain_paths = [
+        *rust_files_under("rocketmq-store", "src"),
+        *rust_files_under("rocketmq-controller", "src"),
+        *rust_files_under("rocketmq-auth", "src"),
+        *rust_files_under("rocketmq-broker", "src"),
+    ]
+    for path in domain_paths:
+        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("//") or stripped.startswith("///") or is_test_context(path, line_number):
+                continue
+            if not is_source_stringification_line(line):
+                continue
+            if not is_source_stringification_allowlisted(path):
+                findings.append(
+                    Finding(
+                        path,
+                        line_number,
+                        "source stringification requires a typed source wrapper or SOURCE_STRINGIFICATION_ALLOWLIST entry",
+                    )
+                )
+    return findings
+
+
 def is_internal_error_allowlisted(path: Path) -> bool:
     rel = path.relative_to(ROOT).as_posix()
     return any(rel == prefix or rel.startswith(prefix) for prefix in INTERNAL_ERROR_ALLOWLIST)
@@ -580,6 +697,7 @@ def run() -> int:
         ("client callback boundary", check_client_callback_boundary),
         ("client retry boundary", check_client_retry_boundary),
         ("error spec contract", check_error_spec_contract),
+        ("source stringification allowlist", check_source_stringification_allowlist),
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),
         ("redaction guards", check_redaction_guards),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7949

### Brief Description

Preserves domain error sources in store and narrows broker error classification. `StoreError::RocksDb` now carries the original `RocketMQError`, and mapped-file mmap/flush failures now keep their `std::io::Error` source.

Broker paths that previously returned `RocketMQError::Internal(String)` now use service, broker operation, or response processing variants where the condition is classifiable.

The error architecture guard now includes a source stringification allowlist with reasons for remaining OpenRaft, auth, HA, runtime, and protocol boundaries. The T08 checklist is updated in `docs/07-error-refactor-checklist.md`.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-store store_error` passed.
- `cargo test -p rocketmq-store mapped_file_error` passed.
- `cargo check -p rocketmq-store` passed.
- `cargo check -p rocketmq-broker` passed.
- `cargo test -p rocketmq-broker message_queue_op_context` passed.
- `py scripts\error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across broker and storage flows, making failures more consistent and easier to diagnose.
  * Standardized several shutdown, startup, queue, and request-processing error messages for clearer reporting.
  * Preserved underlying error details for mapped file and RocksDB failures instead of reducing them to plain text.

* **Documentation**
  * Updated the error-handling checklist to reflect completed coverage and enforcement requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->