### PR TITLE
[ISSUE #7951]♻️Tighten sensitive output redaction

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -395,20 +395,29 @@ rg -n "error\\.to_string\\(\\)|RocketMQError::Internal|StoreError::RocksDb\\(" r
 - `plain_access_resource` 等 auth migration 类型仍需核对 signature/token/password 字段是否全部脱敏。
 - guard 当前主要覆盖 error/common/client/remoting 的敏感 Debug 字段，不覆盖 dashboard/tools 全部输出。
 
+**完成状态**：
+
+- `scripts/error_architecture_guard.py` 已定义敏感字段关键词表，并扩展到 `rocketmq-auth`、dashboard web backend、admin tools、remoting/client/common 的关键 Debug 输出。
+- guard 已增加 `#[derive(Debug)]` 结构体敏感字段检查，防止 secret/password/token/signature/credential 字段绕过手写 redaction。
+- `UserInfo`、`BrokerConfig`、TLS key password、client ACL hook、auth context/resource、admin tools user request、dashboard auth/ACL/config 模型均已增加 redacted Debug/Display 或 no-secret regression tests。
+- dashboard ACL user list API 不再把 broker 返回的 password 映射到 HTTP response。
+
+**追踪**：Issue [#7951](https://github.com/mxsm/rocketmq-rust/issues/7951)，PR [#7952](https://github.com/mxsm/rocketmq-rust/pull/7952)。
+
 **开发 checklist**：
 
-- [ ] 定义敏感字段关键词表：secret、password、token、signature、authorization、credential。
-- [ ] 将可复用模型迁移到 `Sensitive<T>` 或统一 helper。
-- [ ] 对 `Display`、`Debug`、tracing structured fields、API response、CLI output 分别建立 redaction 测试。
-- [ ] 修复 auth migration/context 中所有未脱敏 signature/token/password Debug 字段。
-- [ ] 扩展 guard 到 auth、dashboard backend、tools 的关键输出类型。
-- [ ] 确认测试 fixture 中明文 secret 只存在于测试输入，不进入输出断言。
+- [x] 定义敏感字段关键词表：secret、password、token、signature、authorization、credential。
+- [x] 将可复用模型迁移到 `Sensitive<T>` 或统一 helper。
+- [x] 对 `Display`、`Debug`、tracing structured fields、API response、CLI output 分别建立 redaction 测试。
+- [x] 修复 auth migration/context 中所有未脱敏 signature/token/password Debug 字段。
+- [x] 扩展 guard 到 auth、dashboard backend、tools 的关键输出类型。
+- [x] 确认测试 fixture 中明文 secret 只存在于测试输入，不进入输出断言。
 
 **验收 checklist**：
 
-- [ ] `SessionCredentials`、auth config、user/password、plain access config/resource 都有 no-secret tests。
-- [ ] guard 能阻止新增敏感 Debug field。
-- [ ] API/CLI/log 输出默认不含敏感原文。
+- [x] `SessionCredentials`、auth config、user/password、plain access config/resource 都有 no-secret tests。
+- [x] guard 能阻止新增敏感 Debug field。
+- [x] API/CLI/log 输出默认不含敏感原文。
 
 **建议验证**：
 
@@ -559,7 +568,7 @@ cargo build --all-targets --all-features
 - [x] client callback 内部事实源不再是 `dyn Error` downcast。
 - [x] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
 - [x] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
-- [ ] secret/token/signature/password 默认 redacted。
+- [x] secret/token/signature/password 默认 redacted。
 - [ ] `scripts/error_architecture_guard.py` 进入 CI。
 - [ ] root workspace 通过 fmt/clippy。
 - [ ] 受影响 standalone 项目分别通过各自 clippy/build。

--- a/rocketmq-auth/src/authentication/context/default_authentication_context.rs
+++ b/rocketmq-auth/src/authentication/context/default_authentication_context.rs
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::fmt;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::REDACTED;
 
 use crate::authentication::context::base_authentication_context::BaseAuthenticationContext;
 use crate::authentication::AsAny;
 use crate::authorization::context::authentication_context::AuthenticationContext;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct DefaultAuthenticationContext {
     pub base: BaseAuthenticationContext,
 
@@ -29,6 +31,19 @@ pub struct DefaultAuthenticationContext {
     signature: Option<CheetahString>,
     request_timestamp: Option<CheetahString>,
     request_timestamp_millis: Option<i64>,
+}
+
+impl fmt::Debug for DefaultAuthenticationContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DefaultAuthenticationContext")
+            .field("username", &self.username)
+            .field("content_len", &self.content.as_ref().map(Vec::len))
+            .field("signature", &self.signature.as_ref().map(|_| REDACTED))
+            .field("request_timestamp", &self.request_timestamp)
+            .field("request_timestamp_millis", &self.request_timestamp_millis)
+            .finish_non_exhaustive()
+    }
 }
 
 impl DefaultAuthenticationContext {
@@ -140,5 +155,20 @@ mod tests {
         let mut context_mut = DefaultAuthenticationContext::new();
         let any_mut = context_mut.as_any_mut();
         assert!(any_mut.is::<DefaultAuthenticationContext>());
+    }
+
+    #[test]
+    fn default_authentication_context_debug_redacts_signature() {
+        let mut context = DefaultAuthenticationContext::new();
+        context.set_username(CheetahString::from("alice"));
+        context.set_content(vec![1, 2, 3, 4]);
+        context.set_signature(CheetahString::from("signature-secret"));
+
+        let debug = format!("{context:?}");
+
+        assert!(debug.contains("alice"));
+        assert!(debug.contains("content_len"));
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("signature-secret"));
     }
 }

--- a/rocketmq-auth/src/migration/alc/plain_access_resource.rs
+++ b/rocketmq-auth/src/migration/alc/plain_access_resource.rs
@@ -56,7 +56,7 @@ impl fmt::Debug for PlainAccessResource {
             .field("resource_perm_map", &self.resource_perm_map)
             .field("request_code", &self.request_code)
             .field("content_len", &self.content.as_ref().map(Vec::len))
-            .field("signature", &self.signature)
+            .field("signature", &self.signature.as_ref().map(|_| "<redacted>"))
             .field("secret_token", &self.secret_token.as_ref().map(|_| "<redacted>"))
             .field("recognition", &self.recognition)
             .finish()
@@ -202,6 +202,7 @@ mod tests {
         let mut resource = PlainAccessResource::new();
         resource.set_access_key(CheetahString::from("ak"));
         resource.set_secret_key(CheetahString::from("secret-key-value"));
+        resource.set_signature(CheetahString::from("signature-value"));
         resource.set_secret_token(CheetahString::from("secret-token-value"));
 
         let debug = format!("{resource:?}");
@@ -209,6 +210,7 @@ mod tests {
         assert!(debug.contains("ak"));
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("secret-key-value"));
+        assert!(!debug.contains("signature-value"));
         assert!(!debug.contains("secret-token-value"));
     }
 }

--- a/rocketmq-client/src/common/acl_client_rpc_hook.rs
+++ b/rocketmq-client/src/common/acl_client_rpc_hook.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::net::SocketAddr;
 
 use cheetah_string::CheetahString;
 use rocketmq_auth::authentication::acl_signer::cal_signature_segments;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::REDACTED;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::RPCHook;
 use smallvec::SmallVec;
@@ -32,9 +34,18 @@ use crate::common::session_credentials::SIGNATURE;
 /// custom header into `extFields`, sort all extension fields by key, concatenate
 /// every value except `Signature`, append the request body, and write the HMAC
 /// signature back to `extFields`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AclClientRPCHook {
     session_credentials: SessionCredentials,
+}
+
+impl fmt::Debug for AclClientRPCHook {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AclClientRPCHook")
+            .field("session_credentials", &REDACTED)
+            .finish()
+    }
 }
 
 impl AclClientRPCHook {
@@ -170,5 +181,17 @@ mod tests {
         assert!(hook
             .do_before_request("127.0.0.1:9876".parse().unwrap(), &mut request)
             .is_err());
+    }
+
+    #[test]
+    fn acl_hook_debug_redacts_session_credentials() {
+        let hook = AclClientRPCHook::new(SessionCredentials::with_token("ak", "secret", "token"));
+
+        let debug = format!("{hook:?}");
+
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("ak"));
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("token"));
     }
 }

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -14,11 +14,13 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -798,7 +800,7 @@ impl BrokerIdentity {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BrokerConfig {
     #[serde(default = "defaults::broker_identity")]
@@ -1398,6 +1400,37 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::stateful_authorization_cache_negative_enable")]
     pub stateful_authorization_cache_negative_enable: bool,
+}
+
+impl fmt::Debug for BrokerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BrokerConfig")
+            .field("broker_identity", &self.broker_identity)
+            .field("broker_ip1", &self.broker_ip1)
+            .field("broker_ip2", &self.broker_ip2)
+            .field("listen_port", &self.listen_port)
+            .field("authentication_enabled", &self.authentication_enabled)
+            .field("authorization_enabled", &self.authorization_enabled)
+            .field(
+                "init_authentication_user",
+                &redacted_if_not_empty(&self.init_authentication_user),
+            )
+            .field(
+                "inner_client_authentication_credentials",
+                &redacted_if_not_empty(&self.inner_client_authentication_credentials),
+            )
+            .field("signature_algorithm", &self.signature_algorithm)
+            .finish_non_exhaustive()
+    }
+}
+
+fn redacted_if_not_empty(value: &CheetahString) -> Option<&'static str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(REDACTED)
+    }
 }
 
 impl Default for BrokerConfig {
@@ -2185,6 +2218,7 @@ pub struct TimerWheelConfig {
 #[cfg(test)]
 mod tests {
     use cheetah_string::CheetahString;
+    use rocketmq_error::REDACTED;
 
     use super::BrokerConfig;
     use crate::common::metrics::LogExporterType;
@@ -2569,6 +2603,23 @@ mod tests {
         assert_eq!(config.acl_file_watch_interval_millis, 5_000);
         assert_eq!(config.signature_algorithm.as_str(), "HmacSHA1");
         assert_eq!(config.request_timestamp_expired_millis, 0);
+    }
+
+    #[test]
+    fn broker_config_debug_redacts_embedded_auth_credentials() {
+        let config = BrokerConfig {
+            init_authentication_user: CheetahString::from("admin:init-secret"),
+            inner_client_authentication_credentials: CheetahString::from(
+                r#"{"accessKey":"inner","secretKey":"inner-secret"}"#,
+            ),
+            ..BrokerConfig::default()
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("init-secret"));
+        assert!(!debug.contains("inner-secret"));
     }
 
     #[test]

--- a/rocketmq-common/src/common/tls_config.rs
+++ b/rocketmq-common/src/common/tls_config.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -281,7 +282,7 @@ impl TlsConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsServerConfig {
     #[serde(default)]
@@ -306,7 +307,22 @@ pub struct TlsServerConfig {
     pub trust_cert_path: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+impl fmt::Debug for TlsServerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TlsServerConfig")
+            .field("mode", &self.mode)
+            .field("need_client_auth", &self.need_client_auth)
+            .field("key_path", &self.key_path)
+            .field("key_password", &self.key_password.as_ref().map(|_| REDACTED))
+            .field("cert_path", &self.cert_path)
+            .field("auth_client", &self.auth_client)
+            .field("trust_cert_path", &self.trust_cert_path)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsClientConfig {
     #[serde(default)]
@@ -323,6 +339,19 @@ pub struct TlsClientConfig {
 
     #[serde(default)]
     pub trust_cert_path: Option<String>,
+}
+
+impl fmt::Debug for TlsClientConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TlsClientConfig")
+            .field("key_path", &self.key_path)
+            .field("key_password", &self.key_password.as_ref().map(|_| REDACTED))
+            .field("cert_path", &self.cert_path)
+            .field("auth_server", &self.auth_server)
+            .field("trust_cert_path", &self.trust_cert_path)
+            .finish()
+    }
 }
 
 impl Default for TlsClientConfig {
@@ -475,5 +504,25 @@ mod tests {
         assert!(entries.contains(&("tls.server.mode", "enforcing".to_string())));
         assert!(entries.contains(&("tls.server.certPath", "/certs/server.pem".to_string())));
         assert!(entries.contains(&("tls.client.trustCertPath", "/certs/ca.pem".to_string())));
+    }
+
+    #[test]
+    fn tls_config_debug_redacts_key_passwords() {
+        let server = TlsServerConfig {
+            key_password: Some("server-key-password".to_string()),
+            ..TlsServerConfig::default()
+        };
+        let client = TlsClientConfig {
+            key_password: Some("client-key-password".to_string()),
+            ..TlsClientConfig::default()
+        };
+
+        let server_debug = format!("{server:?}");
+        let client_debug = format!("{client:?}");
+
+        assert!(server_debug.contains(REDACTED));
+        assert!(client_debug.contains(REDACTED));
+        assert!(!server_debug.contains("server-key-password"));
+        assert!(!client_debug.contains("client-key-password"));
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -1861,7 +1861,7 @@ fn map_acl_user(target: &AclTarget, user: &UserInfo) -> AclUserView {
         broker_name: target.broker_name.clone(),
         broker_addr: target.broker_addr.clone(),
         username: user.username.as_ref().map(ToString::to_string).unwrap_or_default(),
-        password: user.password.as_ref().map(ToString::to_string),
+        password: None,
         user_type: user.user_type.as_ref().map(ToString::to_string),
         user_status: user.user_status.as_ref().map(ToString::to_string),
     }
@@ -2347,8 +2347,10 @@ fn required_request_field<'a>(value: Option<&'a str>, label: &str) -> Result<&'a
 
 #[cfg(test)]
 mod tests {
+    use super::AclTarget;
     use super::build_order_conf;
     use super::classify_topic;
+    use super::map_acl_user;
     use super::map_message;
     use super::normalize_message_type;
     use super::parse_rate_value;
@@ -2360,6 +2362,7 @@ mod tests {
     use cheetah_string::CheetahString;
     use rocketmq_common::common::message::message_builder::MessageBuilder;
     use rocketmq_common::common::message::message_ext::MessageExt;
+    use rocketmq_remoting::protocol::body::user_info::UserInfo;
     use std::collections::BTreeMap;
     use std::collections::HashSet;
 
@@ -2406,6 +2409,25 @@ mod tests {
         let brokers = HashSet::from(["broker-b".to_string(), "broker-a".to_string()]);
 
         assert_eq!(build_order_conf(&brokers, 8), "broker-a:8;broker-b:8");
+    }
+
+    #[test]
+    fn map_acl_user_does_not_expose_password() {
+        let target = AclTarget {
+            broker_name: "broker-a".to_string(),
+            broker_addr: "127.0.0.1:10911".to_string(),
+        };
+        let user = UserInfo {
+            username: Some(CheetahString::from("alice")),
+            password: Some(CheetahString::from("broker-password")),
+            user_type: Some(CheetahString::from("Normal")),
+            user_status: Some(CheetahString::from("enable")),
+        };
+
+        let view = map_acl_user(&target, &user);
+
+        assert_eq!(view.username, "alice");
+        assert_eq!(view.password, None);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
@@ -14,7 +14,9 @@
 use crate::error::DashboardError;
 use crate::model::DashboardConfigView;
 use crate::model::StorageBackend;
+use rocketmq_error::REDACTED;
 use std::env;
+use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
@@ -40,11 +42,22 @@ pub struct StorageConfig {
     pub path: PathBuf,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AuthConfig {
     pub login_required: bool,
     pub username: String,
     pub password: String,
+}
+
+impl fmt::Debug for AuthConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthConfig")
+            .field("login_required", &self.login_required)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .finish()
+    }
 }
 
 impl AppConfig {
@@ -238,6 +251,7 @@ impl SqliteConfigStore {
 
 #[cfg(test)]
 mod tests {
+    use super::AuthConfig;
     use super::ConfigStore;
     use super::StorageConfig;
     use crate::model::DashboardConfigView;
@@ -285,5 +299,19 @@ mod tests {
 
         assert_eq!(loaded.current_proxy_addr.as_deref(), Some("localhost:8081"));
         assert_eq!(loaded.storage_backend, StorageBackend::Sqlite);
+    }
+
+    #[test]
+    fn auth_config_debug_redacts_password() {
+        let config = AuthConfig {
+            login_required: true,
+            username: "admin".to_string(),
+            password: "dashboard-secret".to_string(),
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("dashboard-secret"));
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/acl_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/acl_model.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::fmt;
+
+use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,7 +27,7 @@ pub struct AclQuery {
     pub resource: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AclUserView {
     pub broker_name: String,
@@ -35,7 +38,21 @@ pub struct AclUserView {
     pub user_status: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+impl fmt::Debug for AclUserView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AclUserView")
+            .field("broker_name", &self.broker_name)
+            .field("broker_addr", &self.broker_addr)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| REDACTED))
+            .field("user_type", &self.user_type)
+            .field("user_status", &self.user_status)
+            .finish()
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AclUserUpsertRequest {
     pub broker_name: Option<String>,
@@ -44,6 +61,20 @@ pub struct AclUserUpsertRequest {
     pub password: String,
     pub user_type: String,
     pub user_status: Option<String>,
+}
+
+impl fmt::Debug for AclUserUpsertRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AclUserUpsertRequest")
+            .field("broker_name", &self.broker_name)
+            .field("cluster_name", &self.cluster_name)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .field("user_type", &self.user_type)
+            .field("user_status", &self.user_status)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -95,4 +126,37 @@ pub struct AclPolicyEntryRequest {
     pub actions: Vec<String>,
     pub source_ips: Vec<String>,
     pub decision: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acl_user_debug_redacts_passwords() {
+        let view = AclUserView {
+            broker_name: "broker-a".to_string(),
+            broker_addr: "127.0.0.1:10911".to_string(),
+            username: "alice".to_string(),
+            password: Some("view-secret".to_string()),
+            user_type: Some("Normal".to_string()),
+            user_status: Some("enable".to_string()),
+        };
+        let request = AclUserUpsertRequest {
+            broker_name: Some("broker-a".to_string()),
+            cluster_name: None,
+            username: Some("alice".to_string()),
+            password: "request-secret".to_string(),
+            user_type: "Normal".to_string(),
+            user_status: Some("enable".to_string()),
+        };
+
+        let view_debug = format!("{view:?}");
+        let request_debug = format!("{request:?}");
+
+        assert!(view_debug.contains(REDACTED));
+        assert!(request_debug.contains(REDACTED));
+        assert!(!view_debug.contains("view-secret"));
+        assert!(!request_debug.contains("request-secret"));
+    }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/auth_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/auth_model.rs
@@ -11,17 +11,30 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::fmt;
+
+use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginRequest {
     pub username: String,
     pub password: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+impl fmt::Debug for LoginRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LoginRequest")
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionView {
     pub login_required: bool,
@@ -29,4 +42,45 @@ pub struct SessionView {
     pub username: Option<String>,
     pub session_id: Option<String>,
     pub login_time: Option<i64>,
+}
+
+impl fmt::Debug for SessionView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionView")
+            .field("login_required", &self.login_required)
+            .field("authenticated", &self.authenticated)
+            .field("username", &self.username)
+            .field("session_id", &self.session_id.as_ref().map(|_| REDACTED))
+            .field("login_time", &self.login_time)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_model_debug_redacts_password_and_session_id() {
+        let login = LoginRequest {
+            username: "admin".to_string(),
+            password: "dashboard-password".to_string(),
+        };
+        let session = SessionView {
+            login_required: true,
+            authenticated: true,
+            username: Some("admin".to_string()),
+            session_id: Some("dashboard-session-token".to_string()),
+            login_time: Some(1),
+        };
+
+        let login_debug = format!("{login:?}");
+        let session_debug = format!("{session:?}");
+
+        assert!(login_debug.contains(REDACTED));
+        assert!(session_debug.contains(REDACTED));
+        assert!(!login_debug.contains("dashboard-password"));
+        assert!(!session_debug.contains("dashboard-session-token"));
+    }
 }

--- a/rocketmq-remoting/src/protocol/body/user_info.rs
+++ b/rocketmq-remoting/src/protocol/body/user_info.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Display;
+use std::fmt;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInfo {
     pub username: Option<CheetahString>,
@@ -27,17 +28,32 @@ pub struct UserInfo {
     pub user_status: Option<CheetahString>,
 }
 
-impl Display for UserInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for UserInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UserInfo")
+            .field("username", &self.username)
+            .field("password", &redacted_if_present(self.password.as_ref()))
+            .field("user_type", &self.user_type)
+            .field("user_status", &self.user_status)
+            .finish()
+    }
+}
+
+impl fmt::Display for UserInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "UserInfo [username={}, password={}, user_type={}, user_status={}]",
             self.username.as_ref().unwrap_or(&CheetahString::new()),
-            self.password.as_ref().unwrap_or(&CheetahString::new()),
+            redacted_if_present(self.password.as_ref()).unwrap_or_default(),
             self.user_type.as_ref().unwrap_or(&CheetahString::new()),
             self.user_status.as_ref().unwrap_or(&CheetahString::new())
         )
     }
+}
+
+fn redacted_if_present<T>(value: Option<T>) -> Option<&'static str> {
+    value.map(|_| REDACTED)
 }
 
 #[cfg(test)]
@@ -120,7 +136,23 @@ mod tests {
         let display = format!("{}", user_info);
         assert_eq!(
             display,
-            "UserInfo [username=user, password=pass, user_type=admin, user_status=active]"
+            "UserInfo [username=user, password=<redacted>, user_type=admin, user_status=active]"
         );
+        assert!(!display.contains("password=pass"));
+    }
+
+    #[test]
+    fn debug_user_info_redacts_password() {
+        let user_info = UserInfo {
+            username: Some(CheetahString::from("user")),
+            password: Some(CheetahString::from("plain-password")),
+            user_type: Some(CheetahString::from("admin")),
+            user_status: Some(CheetahString::from("active")),
+        };
+        let debug = format!("{user_info:?}");
+
+        assert!(debug.contains("user"));
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("plain-password"));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/auth.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/auth.rs
@@ -14,10 +14,12 @@
 
 //! Authentication and authorization admin service models and operations.
 
+use std::fmt;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_error::REDACTED;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::acl_info::PolicyEntryInfo;
 use rocketmq_remoting::protocol::body::acl_info::PolicyInfo;
@@ -38,13 +40,26 @@ pub enum AuthTarget {
     ClusterName(CheetahString),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CreateUserRequest {
     target: AuthTarget,
     username: CheetahString,
     password: CheetahString,
     user_type: CheetahString,
     namesrv_addr: Option<String>,
+}
+
+impl fmt::Debug for CreateUserRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CreateUserRequest")
+            .field("target", &self.target)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .field("user_type", &self.user_type)
+            .field("namesrv_addr", &self.namesrv_addr)
+            .finish()
+    }
 }
 
 impl CreateUserRequest {
@@ -96,7 +111,7 @@ impl CreateUserRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateUserRequest {
     target: AuthTarget,
     username: CheetahString,
@@ -104,6 +119,20 @@ pub struct UpdateUserRequest {
     user_type: Option<CheetahString>,
     user_status: Option<CheetahString>,
     namesrv_addr: Option<String>,
+}
+
+impl fmt::Debug for UpdateUserRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UpdateUserRequest")
+            .field("target", &self.target)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| REDACTED))
+            .field("user_type", &self.user_type)
+            .field("user_status", &self.user_status)
+            .field("namesrv_addr", &self.namesrv_addr)
+            .finish()
+    }
 }
 
 impl UpdateUserRequest {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/auth_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/auth_core_models.rs
@@ -65,6 +65,35 @@ fn auth_user_update_and_list_requests_preserve_optional_fields() {
 }
 
 #[test]
+fn auth_user_request_debug_redacts_passwords() {
+    let create = CreateUserRequest::try_new(
+        Some("127.0.0.1:10911".to_string()),
+        None,
+        "alice",
+        "create-secret",
+        Some("NORMAL".to_string()),
+    )
+    .unwrap();
+    let update = UpdateUserRequest::try_new(
+        None,
+        Some("DefaultCluster".to_string()),
+        "alice",
+        Some("update-secret".to_string()),
+        Some("NORMAL".to_string()),
+        Some("ENABLE".to_string()),
+    )
+    .unwrap();
+
+    let create_debug = format!("{create:?}");
+    let update_debug = format!("{update:?}");
+
+    assert!(create_debug.contains("<redacted>"));
+    assert!(update_debug.contains("<redacted>"));
+    assert!(!create_debug.contains("create-secret"));
+    assert!(!update_debug.contains("update-secret"));
+}
+
+#[test]
 fn auth_acl_create_request_trims_fields_and_builds_acl_info() {
     let request = CreateAclRequest::try_new(
         Some(" 127.0.0.1:10911 ".to_string()),

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -29,6 +29,21 @@ from typing import Iterable
 ROOT = Path(__file__).resolve().parents[1]
 RUST_SUFFIX = ".rs"
 
+SENSITIVE_FIELD_TERMS = (
+    "secret",
+    "password",
+    "token",
+    "signature",
+    "authorization",
+    "credential",
+)
+
+SENSITIVE_DEBUG_FIELD_TERMS = tuple(term for term in SENSITIVE_FIELD_TERMS if term != "authorization")
+
+NON_SENSITIVE_DEBUG_FIELD_NAMES = {
+    "signature_algorithm",
+}
+
 INTERNAL_ERROR_ALLOWLIST = (
     "rocketmq-auth/src/authorization/provider.rs",
     "rocketmq-broker/src/",
@@ -194,6 +209,35 @@ def is_test_context(path: Path, line_number: int) -> bool:
     return False
 
 
+def iter_non_test_lines(path: Path) -> Iterable[tuple[int, str]]:
+    """Yield source lines while skipping test-only modules in one pass."""
+    rel_parts = path.relative_to(ROOT).parts
+    if "tests" in rel_parts or "benches" in rel_parts or "examples" in rel_parts:
+        return
+    if "src" in rel_parts and "bin" in rel_parts:
+        return
+
+    depth = 0
+    test_module_depth: int | None = None
+    pending_test_cfg = False
+    for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+        stripped = line.strip()
+        if stripped == "#[cfg(test)]":
+            pending_test_cfg = True
+        elif pending_test_cfg and re.match(r"(pub\([^)]*\)\s+|pub\s+)?mod\s+tests\b", stripped):
+            test_module_depth = depth + stripped.count("{") - stripped.count("}")
+            pending_test_cfg = False
+        elif stripped and not stripped.startswith("#"):
+            pending_test_cfg = False
+
+        if test_module_depth is None:
+            yield line_number, line
+
+        depth += line.count("{") - line.count("}")
+        if test_module_depth is not None and depth < test_module_depth:
+            test_module_depth = None
+
+
 def is_anyhow_result_allowlisted(path: Path) -> bool:
     rel = rel_path(path)
     rel_parts = path.relative_to(ROOT).parts
@@ -265,6 +309,69 @@ def check_processor_boundary_mappings() -> list[Finding]:
                         "processor unsupported-code responses must use rocketmq_remoting::error_response",
                     )
                 )
+    return findings
+
+
+def contains_redaction_marker(line: str) -> bool:
+    return any(
+        marker in line
+        for marker in (
+            "<redacted>",
+            "REDACTED",
+            "redacted_if_present",
+            "redacted_value",
+            "Sensitive::new",
+        )
+    )
+
+
+def sensitive_debug_field_name(field_name: str) -> bool:
+    lower = field_name.lower()
+    if lower in NON_SENSITIVE_DEBUG_FIELD_NAMES:
+        return False
+    return any(term in lower for term in SENSITIVE_DEBUG_FIELD_TERMS)
+
+
+def find_sensitive_derive_debug_fields(paths: Iterable[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    field_pattern = re.compile(r"(?:pub(?:\([^)]*\))?\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:")
+    struct_pattern = re.compile(r"(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Za-z_][A-Za-z0-9_]*)\b")
+
+    for path in paths:
+        lines = list(iter_non_test_lines(path))
+        pending_debug_derive_line: int | None = None
+        for index, (line_number, line) in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("#[derive") and "Debug" in stripped:
+                pending_debug_derive_line = line_number
+                continue
+            if pending_debug_derive_line is None:
+                continue
+            if stripped.startswith("#[") or not stripped:
+                continue
+
+            if not struct_pattern.match(stripped):
+                pending_debug_derive_line = None
+                continue
+
+            depth = line.count("{") - line.count("}")
+            for field_index in range(index + 1, len(lines)):
+                _, field_line = lines[field_index]
+                field_match = field_pattern.match(field_line.strip())
+                if field_match and sensitive_debug_field_name(field_match.group(1)):
+                    findings.append(
+                        Finding(
+                            path,
+                            pending_debug_derive_line,
+                            "derive(Debug) on a struct with sensitive fields requires a manual redacted Debug impl",
+                        )
+                    )
+                    break
+                depth += field_line.count("{") - field_line.count("}")
+                if depth <= 0:
+                    break
+
+            pending_debug_derive_line = None
     return findings
 
 
@@ -655,6 +762,65 @@ def check_redaction_guards() -> list[Finding]:
             "debug_and_display_redact_secret_key",
             "<redacted>",
         ],
+        ROOT / "rocketmq-client" / "src" / "common" / "session_credentials.rs": [
+            "session_credentials_debug_redacts_sensitive_fields",
+            "session_credentials_display",
+        ],
+        ROOT / "rocketmq-remoting" / "src" / "protocol" / "body" / "user_info.rs": [
+            "debug_user_info_redacts_password",
+            "password=<redacted>",
+        ],
+        ROOT / "rocketmq-auth" / "src" / "config.rs": [
+            "auth_config_debug_redacts_embedded_credentials",
+            "<redacted>",
+        ],
+        ROOT / "rocketmq-auth" / "src" / "authentication" / "model" / "user.rs": [
+            "user_debug_redacts_password",
+            "<redacted>",
+        ],
+        ROOT / "rocketmq-auth" / "src" / "migration" / "alc" / "plain_access_resource.rs": [
+            "plain_access_resource_debug_redacts_secrets",
+            "signature-value",
+        ],
+        ROOT / "rocketmq-auth" / "src" / "migration" / "alc" / "plain_access_config.rs": [
+            "plain_access_config_debug_redacts_secret_key",
+            "<redacted>",
+        ],
+        ROOT / "rocketmq-auth" / "src" / "authentication" / "acl_client_rpc_hook.rs": [
+            "secret_key",
+            "<redacted>",
+        ],
+        ROOT
+        / "rocketmq-tools"
+        / "rocketmq-admin"
+        / "rocketmq-admin-core"
+        / "tests"
+        / "auth_core_models.rs": [
+            "auth_user_request_debug_redacts_passwords",
+            "<redacted>",
+        ],
+        ROOT / "rocketmq-dashboard" / "rocketmq-dashboard-web" / "backend" / "src" / "model" / "acl_model.rs": [
+            "acl_user_debug_redacts_passwords",
+            "REDACTED",
+        ],
+        ROOT / "rocketmq-dashboard" / "rocketmq-dashboard-web" / "backend" / "src" / "model" / "auth_model.rs": [
+            "auth_model_debug_redacts_password_and_session_id",
+            "REDACTED",
+        ],
+        ROOT / "rocketmq-dashboard" / "rocketmq-dashboard-web" / "backend" / "src" / "config" / "app_config.rs": [
+            "auth_config_debug_redacts_password",
+            "<redacted>",
+        ],
+        ROOT
+        / "rocketmq-dashboard"
+        / "rocketmq-dashboard-web"
+        / "backend"
+        / "src"
+        / "admin"
+        / "dashboard_admin_client.rs": [
+            "map_acl_user_does_not_expose_password",
+            "password: None",
+        ],
     }
     findings: list[Finding] = []
     for path, needles in required_tokens.items():
@@ -666,23 +832,22 @@ def check_redaction_guards() -> list[Finding]:
             if needle not in text:
                 findings.append(Finding(path, 1, f"required redaction token missing: {needle}"))
 
-    sensitive_field_pattern = re.compile(r'\.field\(".*(secret|password|token|signature).*",', re.I)
-    for path in [
+    debug_field_pattern = re.compile(r'\.field\("([^"]+)",')
+    redaction_paths = [
         *rust_files_under("rocketmq-error", "src"),
         *rust_files_under("rocketmq-common", "src"),
         *rust_files_under("rocketmq-client", "src"),
         *rust_files_under("rocketmq-remoting", "src"),
-    ]:
-        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
-            if is_test_context(path, line_number):
-                continue
-            if (
-                sensitive_field_pattern.search(line)
-                and "<redacted>" not in line
-                and "REDACTED" not in line
-                and "redacted_value" not in line
-            ):
+        *rust_files_under("rocketmq-auth", "src"),
+        *rust_files_under("rocketmq-tools", "rocketmq-admin"),
+        *rust_files_under("rocketmq-dashboard", "rocketmq-dashboard-web", "backend", "src"),
+    ]
+    for path in redaction_paths:
+        for line_number, line in iter_non_test_lines(path):
+            match = debug_field_pattern.search(line)
+            if match and sensitive_debug_field_name(match.group(1)) and not contains_redaction_marker(line):
                 findings.append(Finding(path, line_number, "sensitive Debug field must be explicitly redacted"))
+    findings.extend(find_sensitive_derive_debug_fields(redaction_paths))
     return findings
 
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7951

### Brief Description

This change tightens sensitive output redaction across protocol, config, client, auth, tools, and dashboard boundaries.

- Redacts password, token, signature, and credential values from Debug or Display output in `UserInfo`, broker/TLS config, ACL hooks, auth contexts, tools user requests, and dashboard backend models.
- Stops dashboard ACL user list responses from returning broker user passwords.
- Extends the error architecture guard with sensitive keywords, derived Debug detection, and required no-secret coverage for the updated boundaries.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo fmt --all` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`
- `cargo test -p rocketmq-remoting user_info`
- `cargo test -p rocketmq-common redacts`
- `cargo test -p rocketmq-client-rust redacts`
- `cargo test -p rocketmq-auth redacts`
- `cargo test -p rocketmq-admin-core --test auth_core_models auth_user_request_debug_redacts_passwords`
- `cargo test -p rocketmq-error --test error_context_redaction`
- `cargo test redacts` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`
- `cargo test map_acl_user_does_not_expose_password` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`
- `py scripts\error_architecture_guard.py`
- `git diff --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved redaction coverage across authentication, TLS, broker, admin, and dashboard data so sensitive values are less likely to appear in logs or debug output.
  * Added stronger checks to catch sensitive fields in debug formatting and enforce redaction consistently.

* **Bug Fixes**
  * Prevented passwords, tokens, signatures, session IDs, and related credentials from being exposed in several views and request/debug outputs.
  * Updated ACL user mapping to avoid returning password values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->