### PR TITLE
[ISSUE #7953]♻️Add error architecture guard to CI

### DIFF
--- a/.github/workflows/dashboard-web-ci.yml
+++ b/.github/workflows/dashboard-web-ci.yml
@@ -18,6 +18,7 @@ on:
       - 'rust-toolchain.toml'
       - 'rustfmt.toml'
       - '.clippy.toml'
+      - 'scripts/error_architecture_guard.py'
       - '.github/workflows/dashboard-web-ci.yml'
   pull_request:
     branches: [ "main" ]
@@ -33,6 +34,7 @@ on:
       - 'rust-toolchain.toml'
       - 'rustfmt.toml'
       - '.clippy.toml'
+      - 'scripts/error_architecture_guard.py'
       - '.github/workflows/dashboard-web-ci.yml'
 
 env:
@@ -119,6 +121,9 @@ jobs:
 
       - name: Format check
         run: cargo fmt --all -- --check
+
+      - name: Error architecture guard
+        run: python3 ../../../scripts/error_architecture_guard.py
 
       - name: Build backend
         run: cargo build --all-targets --all-features

--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -114,6 +114,9 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+      - name: Error architecture guard
+        run: python3 scripts/error_architecture_guard.py
+
       - name: Clippy (all features)
         run: cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
 

--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -438,22 +438,30 @@ py scripts\error_architecture_guard.py
 - 当前未在 `.github/workflows` 中看到调用。
 - guard 只覆盖部分范围：error/common public surface、processor unsupported-code、remoting/proxy adapter token、部分 redaction。
 
+**完成状态**：
+
+- root CI 已在 format check 后、clippy 前运行 `python3 scripts/error_architecture_guard.py`。
+- dashboard web backend CI 已运行同一个 guard，并将 `scripts/error_architecture_guard.py` 纳入 workflow 触发路径。
+- `docs/error-architecture-guard.md` 已说明本地运行方式、CI 入口、覆盖范围和 allowlist 规则。
+
+**追踪**：Issue [#7953](https://github.com/mxsm/rocketmq-rust/issues/7953)，PR [#7954](https://github.com/mxsm/rocketmq-rust/pull/7954)。
+
 **开发 checklist**：
 
-- [ ] 将 `py scripts\error_architecture_guard.py` 接入 root CI。
-- [ ] 如果 dashboard shared/backend 被纳入 guard，dashboard web CI 也调用对应检查。
-- [ ] 扩展 guard：library/shared public `anyhow` allowlist。
-- [ ] 扩展 guard：unmapped `ErrorKind`、missing `ErrorSpec`、missing protocol/recovery/observe/redaction。
-- [ ] 扩展 guard：processor 通用 `SystemError` / `InvalidParameter` 新增检查。
-- [ ] 扩展 guard：source stringification allowlist。
-- [ ] 扩展 guard：sensitive output allowlist。
-- [ ] 增加 guard 文档，说明如何新增 allowlist 以及何时不允许新增。
+- [x] 将 `py scripts\error_architecture_guard.py` 接入 root CI。
+- [x] 如果 dashboard shared/backend 被纳入 guard，dashboard web CI 也调用对应检查。
+- [x] 扩展 guard：library/shared public `anyhow` allowlist。
+- [x] 扩展 guard：unmapped `ErrorKind`、missing `ErrorSpec`、missing protocol/recovery/observe/redaction。
+- [x] 扩展 guard：processor 通用 `SystemError` / `InvalidParameter` 新增检查。
+- [x] 扩展 guard：source stringification allowlist。
+- [x] 扩展 guard：sensitive output allowlist。
+- [x] 增加 guard 文档，说明如何新增 allowlist 以及何时不允许新增。
 
 **验收 checklist**：
 
-- [ ] CI 中能看到 error architecture guard step。
-- [ ] guard 失败会输出 `path:line`。
-- [ ] guard 不依赖本机 `python` alias；Windows 上使用 `py` 或 CI 指定 Python。
+- [x] CI 中能看到 error architecture guard step。
+- [x] guard 失败会输出 `path:line`。
+- [x] guard 不依赖本机 `python` alias；Windows 上使用 `py` 或 CI 指定 Python。
 
 **建议验证**：
 
@@ -569,7 +577,7 @@ cargo build --all-targets --all-features
 - [x] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
 - [x] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
 - [x] secret/token/signature/password 默认 redacted。
-- [ ] `scripts/error_architecture_guard.py` 进入 CI。
+- [x] `scripts/error_architecture_guard.py` 进入 CI。
 - [ ] root workspace 通过 fmt/clippy。
 - [ ] 受影响 standalone 项目分别通过各自 clippy/build。
 

--- a/docs/error-architecture-guard.md
+++ b/docs/error-architecture-guard.md
@@ -1,0 +1,47 @@
+# Error Architecture Guard
+
+`scripts/error_architecture_guard.py` 用于阻止 error 重构中已经收口的架构约束回退。它是轻量静态检查，不编译 Rust 代码，失败时输出 `path:line`。
+
+## 本地运行
+
+Windows:
+
+```powershell
+py scripts\error_architecture_guard.py
+```
+
+Linux/macOS:
+
+```bash
+python3 scripts/error_architecture_guard.py
+```
+
+## CI 入口
+
+- Root workspace：`.github/workflows/rocketmq-rust-ci.yaml` 的 `Error architecture guard` step。
+- Dashboard web backend：`.github/workflows/dashboard-web-ci.yml` 的 `Error architecture guard` step。
+
+dashboard web CI 也会在 `scripts/error_architecture_guard.py` 变更时触发，因为 guard 已覆盖 dashboard backend HTTP boundary 与 sensitive output。
+
+## 覆盖范围
+
+当前 guard 覆盖：
+
+- legacy error alias/public `anyhow` 回归。
+- broker/namesrv processor 通用 response code 新增。
+- remoting/proxy/dashboard 外部 adapter 是否读取中心 spec。
+- callback/retry boundary 是否回退到 display string、downcast 或局部猜测。
+- `ErrorKind` 与 `ErrorSpec` 合约完整性。
+- source 字符串化 allowlist。
+- sensitive Debug/Display/API output redaction。
+
+## allowlist 规则
+
+新增 allowlist 前先判断是否能改成 typed error、source-preserving error 或 redacted context。只有满足下面任一条件才允许登记：
+
+- 外部 trait 或协议要求固定错误类型，无法携带原 source。
+- 兼容 Java remoting response code，且替换会改变 wire contract。
+- binary、build script、test、example 或 process outer boundary 保留 `anyhow`。
+- 字段名看起来敏感，但实际是算法、开关、元数据等非 secret 值。
+
+每条 allowlist 必须写清楚边界原因，不能只写“temporary”或“legacy”。新增或修改 allowlist 后必须运行 guard，并为对应行为补 focused regression test。


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7953

### Brief Description

This change makes the error architecture guard part of CI coverage.

- Runs `scripts/error_architecture_guard.py` in the root Rust CI before clippy.
- Runs the same guard in the dashboard web backend CI and triggers that workflow when the guard script changes.
- Adds `docs/error-architecture-guard.md` with local commands, CI entry points, covered checks, and allowlist rules.

### How Did You Test This Change?

- `py scripts\error_architecture_guard.py`
- `rg -n "error_architecture_guard" .github scripts docs`
- `git diff --check`
