### PR TITLE
[ISSUE #7955]♻️Align tools CLI errors with central specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,6 +4532,7 @@ dependencies = [
  "cheetah-string",
  "clap",
  "rocketmq-common",
+ "rocketmq-error",
  "rocketmq-store",
  "tabled",
 ]

--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -41,7 +41,7 @@ classes: wide
 | `rocketmq-namesrv` | 0 | 2 | 0 | 0 | 0 |
 | `rocketmq-proxy` | 0 | 0 | 0 | 3 | 2 |
 | `rocketmq-common` | 0 | 0 | 0 | 1 | 3 |
-| `rocketmq-tools` | 0 | 22 | 0 | 0 | 0 |
+| `rocketmq-tools` | 0 | 22 | 0 | 0 | 37 |
 | `rocketmq-dashboard-common` | 0 | 10 | 0 | 0 | 0 |
 | dashboard web backend | 0 | 7 | 1 | 0 | 0 |
 | Tauri backend | 0 | 5 | 0 | 0 | 6 |
@@ -476,24 +476,34 @@ rg -n "error_architecture_guard" .github scripts
 
 **当前缺口**：
 
-- `rocketmq-tools` 对中心 spec 的使用为 0。
-- TUI/CLI 大量使用 `anyhow::Result`，需要区分 app boundary 与 reusable command executor。
-- CLI exit 当前未从 `ErrorSpec.cli` 派生。
+- `rocketmq-tools` 已通过 `CliErrorView`、`CliExitCode`、admin-core `error_code` 字段接入中心 spec。
+- TUI 的 `anyhow::Result` 保留在 terminal runtime/app boundary；admin-core reusable command executor 继续返回 `RocketMQResult`。
+- CLI exit 已从 `ErrorSpec.cli` 派生；store-inspect one-shot binary 也通过同一 adapter 输出和退出。
+
+**完成状态**：
+
+- `rocketmq-error::CliErrorView` 已成为统一 `RocketMQError -> exit code/category/message/context` CLI adapter，读取 `spec().cli`、stable code、category 和 redacted context。
+- `rocketmq-admin-cli` outer boundary 已返回 `CliSpec` 派生 exit code；缺少命令、unsupported completion shell 和 command executor typed error 都走 `CliErrorView`。
+- `rocketmq-admin-core` 批量失败 view model 新增 `error_code`，错误消息使用 stable public message + redacted context，保留原 `error` 字段兼容现有展示。
+- `rocketmq-store-inspect` 已从 panic/`unwrap()` 文件读取边界改为 `RocketMQResult<()>`，binary 使用同一 `CliErrorView`。
+- `scripts/error_architecture_guard.py` 已把 CLI adapter、admin-core error view 和 store-inspect CLI boundary 加入 required mapping adapters 检查。
+
+**追踪**：Issue [#7955](https://github.com/mxsm/rocketmq-rust/issues/7955)，PR [#7956](https://github.com/mxsm/rocketmq-rust/pull/7956)。
 
 **开发 checklist**：
 
-- [ ] 在 CLI outer boundary 保留 `anyhow`，内部 command executor 返回 typed error 或 typed view model。
-- [ ] 新增 `RocketMQError -> exit code/category/message` adapter，读取 `spec().cli`。
-- [ ] command failure view model 使用 stable code，而不是只存 `error.to_string()`。
-- [ ] 对 admin-core 中可复用逻辑避免 `anyhow` 泄漏。
-- [ ] 对 `rocketmq-store-inspect` 这类 one-shot tool 明确 allowlist。
-- [ ] 增加 CLI exit code tests。
+- [x] 在 CLI outer boundary 保留 `anyhow`，内部 command executor 返回 typed error 或 typed view model。
+- [x] 新增 `RocketMQError -> exit code/category/message` adapter，读取 `spec().cli`。
+- [x] command failure view model 使用 stable code，而不是只存 `error.to_string()`。
+- [x] 对 admin-core 中可复用逻辑避免 `anyhow` 泄漏。
+- [x] 对 `rocketmq-store-inspect` 这类 one-shot tool 明确 allowlist 或 typed boundary。
+- [x] 增加 CLI exit code tests。
 
 **验收 checklist**：
 
-- [ ] CLI 对 typed error 输出稳定 exit category。
-- [ ] 可复用工具库不暴露未登记 `anyhow::Result`。
-- [ ] 错误展示不泄露 secret/token/signature。
+- [x] CLI 对 typed error 输出稳定 exit category。
+- [x] 可复用工具库不暴露未登记 `anyhow::Result`。
+- [x] 错误展示不泄露 secret/token/signature。
 
 **建议验证**：
 
@@ -501,6 +511,8 @@ rg -n "error_architecture_guard" .github scripts
 cargo test -p rocketmq-admin-cli
 cargo test -p rocketmq-admin-tui
 cargo test -p rocketmq-admin-core
+cargo test -p rocketmq-store-inspect
+py scripts\error_architecture_guard.py
 rg -n "anyhow::Result|spec\\(\\)\\.cli|CliExitCode" rocketmq-tools --glob "*.rs"
 ```
 
@@ -571,14 +583,14 @@ cargo build --all-targets --all-features
 - [x] library/shared API 无未登记 `anyhow::Result`。
 - [x] 每个 `ErrorKind` 有唯一 `ErrorSpec`。
 - [x] `ErrorSpec` 包含 code、scope、category、public message、remoting、grpc、http、cli、recovery、observe、redaction。
-- [ ] remoting/gRPC/HTTP/CLI 外部出口读取中心 spec 或有明确 local-only allowlist。
+- [x] remoting/gRPC/HTTP/CLI 外部出口读取中心 spec 或有明确 local-only allowlist。
 - [ ] broker/namesrv processor 通用错误不再手写 response code。
 - [x] client callback 内部事实源不再是 `dyn Error` downcast。
 - [x] client retry/fault 行为来自 `RetryClass` 和明确 broker response allowlist。
 - [x] store/controller/auth/broker 不再无登记地把 source `to_string()` 后塞入新错误。
 - [x] secret/token/signature/password 默认 redacted。
 - [x] `scripts/error_architecture_guard.py` 进入 CI。
-- [ ] root workspace 通过 fmt/clippy。
+- [x] root workspace 通过 fmt/clippy。
 - [ ] 受影响 standalone 项目分别通过各自 clippy/build。
 
 ## 最终验证矩阵

--- a/rocketmq-error/src/cli.rs
+++ b/rocketmq-error/src/cli.rs
@@ -1,0 +1,124 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CLI-facing error projection.
+
+use crate::CliExitCode;
+use crate::ErrorCategory;
+use crate::ErrorCode;
+use crate::ErrorContext;
+use crate::RocketMQError;
+
+/// Stable error view for command-line tools.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliErrorView {
+    exit_code: CliExitCode,
+    code: ErrorCode,
+    category: ErrorCategory,
+    message: &'static str,
+    context: ErrorContext,
+}
+
+impl CliErrorView {
+    /// Build a CLI view from the central error spec registry.
+    #[inline]
+    pub fn from_error(error: &RocketMQError) -> Self {
+        let spec = error.spec();
+        Self {
+            exit_code: spec.cli.exit_code,
+            code: spec.code,
+            category: spec.category,
+            message: spec.public_message,
+            context: error.context(),
+        }
+    }
+
+    #[inline]
+    pub const fn exit_code(&self) -> CliExitCode {
+        self.exit_code
+    }
+
+    #[inline]
+    pub const fn code(&self) -> ErrorCode {
+        self.code
+    }
+
+    #[inline]
+    pub const fn category(&self) -> ErrorCategory {
+        self.category
+    }
+
+    #[inline]
+    pub const fn message(&self) -> &'static str {
+        self.message
+    }
+
+    #[inline]
+    pub const fn context(&self) -> &ErrorContext {
+        &self.context
+    }
+
+    /// Render a one-line, redaction-aware stderr message.
+    pub fn render_stderr(&self) -> String {
+        let mut rendered = format!(
+            "Error: code={}, category={}, exit_code={}, message={}",
+            self.code,
+            self.category,
+            self.exit_code.as_i32(),
+            self.message
+        );
+        if !self.context.is_empty() {
+            rendered.push_str(", context={");
+            rendered.push_str(&self.context.to_string());
+            rendered.push('}');
+        }
+        rendered
+    }
+}
+
+impl From<&RocketMQError> for CliErrorView {
+    #[inline]
+    fn from(error: &RocketMQError) -> Self {
+        Self::from_error(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CliErrorView;
+    use crate::CliExitCode;
+    use crate::RocketMQError;
+
+    #[test]
+    fn cli_view_uses_spec_exit_code_and_stable_code() {
+        let error = RocketMQError::validation_failed("topic", "topic must not be empty");
+        let view = CliErrorView::from_error(&error);
+
+        assert_eq!(view.exit_code(), CliExitCode::USAGE);
+        assert_eq!(view.code().as_str(), "ILLEGAL_ARGUMENT");
+        assert_eq!(view.category().as_str(), "system");
+        assert_eq!(view.message(), "Argument is illegal");
+        assert!(view.render_stderr().contains("code=ILLEGAL_ARGUMENT"));
+    }
+
+    #[test]
+    fn cli_view_renders_redacted_context() {
+        let error = RocketMQError::storage_read_failed("C:/secret/token/file", "permission denied");
+        let rendered = CliErrorView::from_error(&error).render_stderr();
+
+        assert!(rendered.contains("code=STORAGE_READ_FAILED"));
+        assert!(rendered.contains("path=<redacted>"));
+        assert!(!rendered.contains("secret/token"));
+    }
+}

--- a/rocketmq-error/src/kind.rs
+++ b/rocketmq-error/src/kind.rs
@@ -87,6 +87,36 @@ pub enum ErrorCategory {
     Version,
 }
 
+impl ErrorCategory {
+    /// Return the stable category name used by external adapters.
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Network => "network",
+            Self::Serialization => "serialization",
+            Self::Protocol => "protocol",
+            Self::Rpc => "rpc",
+            Self::Authentication => "authentication",
+            Self::Controller => "controller",
+            Self::Broker => "broker",
+            Self::Route => "route",
+            Self::Client => "client",
+            Self::Tools => "tools",
+            Self::Filter => "filter",
+            Self::Storage => "storage",
+            Self::Configuration => "configuration",
+            Self::System => "system",
+            Self::Version => "version",
+        }
+    }
+}
+
+impl fmt::Display for ErrorCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Stable logical error kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ErrorKind {

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -54,6 +54,7 @@ pub mod unified;
 
 // Stable error taxonomy
 pub mod boundary;
+pub mod cli;
 pub mod context;
 pub mod kind;
 pub mod policy;
@@ -83,6 +84,7 @@ pub use boundary::HttpSpec;
 pub use boundary::HttpStatusCode;
 pub use boundary::RemotingResponseCode;
 pub use boundary::RemotingSpec;
+pub use cli::CliErrorView;
 pub use client_error::ClientError;
 pub use context::ErrorContext;
 pub use context::ErrorContextField;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -446,7 +446,7 @@ impl RocketMQError {
             Self::ClientInvalidState { .. } => ErrorKind::ClientInvalidState,
             Self::ProducerNotAvailable => ErrorKind::ProducerNotAvailable,
             Self::ConsumerNotAvailable => ErrorKind::ConsumerNotAvailable,
-            Self::Tools(_) => ErrorKind::Tools,
+            Self::Tools(error) => error.kind(),
             Self::Filter(_) => ErrorKind::Filter,
             Self::StorageReadFailed { .. } => ErrorKind::StorageReadFailed,
             Self::StorageWriteFailed { .. } => ErrorKind::StorageWriteFailed,
@@ -580,7 +580,7 @@ impl RocketMQError {
             Self::ClientInvalidState { expected, actual } => ErrorContext::new()
                 .with_field("expected", *expected)
                 .with_field("actual", actual.as_str()),
-            Self::Tools(error) => redacted_context("tools_error", error.to_string()),
+            Self::Tools(error) => error.context(),
             Self::Filter(error) => ErrorContext::new().with_field("filter_error", error.to_string()),
             Self::StorageReadFailed { path, reason } | Self::StorageWriteFailed { path, reason } => ErrorContext::new()
                 .with_sensitive("path", Sensitive::new(path.clone()))

--- a/rocketmq-error/src/unified/tools.rs
+++ b/rocketmq-error/src/unified/tools.rs
@@ -18,6 +18,10 @@
 
 use thiserror::Error;
 
+use crate::context::ErrorContext;
+use crate::context::Sensitive;
+use crate::kind::ErrorKind;
+
 /// Tools-specific errors for admin operations
 #[derive(Debug, Error)]
 pub enum ToolsError {
@@ -182,6 +186,77 @@ impl ToolsError {
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal {
             message: message.into(),
+        }
+    }
+
+    /// Return the closest stable logical error kind for this tools error.
+    #[inline]
+    pub const fn kind(&self) -> ErrorKind {
+        match self {
+            Self::TopicNotFound { .. } => ErrorKind::TopicNotExist,
+            Self::ClusterNotFound { .. } => ErrorKind::ClusterNotFound,
+            Self::BrokerNotFound { .. } => ErrorKind::BrokerNotFound,
+            Self::ConsumerGroupNotFound { .. } => ErrorKind::SubscriptionGroupNotExist,
+            Self::NameServerUnreachable { .. } => ErrorKind::Network,
+            Self::NameServerConfigInvalid { .. }
+            | Self::InvalidConfiguration { .. }
+            | Self::MissingRequiredField { .. } => ErrorKind::ConfigInvalidValue,
+            Self::ValidationError { .. } | Self::ValidationFailed { .. } | Self::InvalidPermission { .. } => {
+                ErrorKind::IllegalArgument
+            }
+            Self::PermissionDenied { .. } => ErrorKind::BrokerPermissionDenied,
+            Self::OperationTimeout { .. } => ErrorKind::Timeout,
+            Self::Internal { .. } => ErrorKind::Internal,
+            Self::TopicInvalid { .. } | Self::ClusterInvalid { .. } => ErrorKind::ConfigInvalidValue,
+            Self::TopicAlreadyExists { .. } | Self::BrokerOffline { .. } | Self::ConsumerOffline { .. } => {
+                ErrorKind::Tools
+            }
+        }
+    }
+
+    /// Return redaction-aware context for external tools surfaces.
+    pub fn context(&self) -> ErrorContext {
+        match self {
+            Self::TopicNotFound { topic } | Self::TopicAlreadyExists { topic } => {
+                ErrorContext::new().with_field("topic", topic.as_str())
+            }
+            Self::TopicInvalid { reason } | Self::ClusterInvalid { reason } => {
+                ErrorContext::new().with_sensitive("reason", Sensitive::new(reason.clone()))
+            }
+            Self::ClusterNotFound { cluster } => ErrorContext::new().with_field("cluster", cluster.as_str()),
+            Self::BrokerNotFound { broker } | Self::BrokerOffline { broker } => {
+                ErrorContext::new().with_sensitive("broker", Sensitive::new(broker.clone()))
+            }
+            Self::ConsumerGroupNotFound { group } => ErrorContext::new().with_field("group", group.as_str()),
+            Self::ConsumerOffline { consumer } => {
+                ErrorContext::new().with_sensitive("consumer", Sensitive::new(consumer.clone()))
+            }
+            Self::NameServerUnreachable { addr } => {
+                ErrorContext::new().with_sensitive("addr", Sensitive::new(addr.clone()))
+            }
+            Self::NameServerConfigInvalid { reason } => {
+                ErrorContext::new().with_sensitive("reason", Sensitive::new(reason.clone()))
+            }
+            Self::InvalidConfiguration { field, reason } | Self::ValidationError { field, reason } => {
+                ErrorContext::new()
+                    .with_field("field", field.as_str())
+                    .with_field("reason", reason.as_str())
+            }
+            Self::MissingRequiredField { field } => ErrorContext::new().with_field("field", field.as_str()),
+            Self::ValidationFailed { message } => ErrorContext::new().with_field("message", message.as_str()),
+            Self::PermissionDenied { operation } => ErrorContext::new().with_field("operation", operation.as_str()),
+            Self::InvalidPermission { value, allowed } => {
+                ErrorContext::new().with_field("value", value.to_string()).with_field(
+                    "allowed",
+                    allowed.iter().map(i32::to_string).collect::<Vec<_>>().join(","),
+                )
+            }
+            Self::OperationTimeout { operation, duration_ms } => ErrorContext::new()
+                .with_field("operation", operation.as_str())
+                .with_field("duration_ms", duration_ms.to_string()),
+            Self::Internal { message } => {
+                ErrorContext::new().with_sensitive("message", Sensitive::new(message.clone()))
+            }
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         .spawn(|| {
             let owner =
                 RuntimeOwner::new(admin_cli_runtime_config()).expect("failed to build rocketmq-admin-cli runtime");
-            owner.block_on(async_main());
+            let exit_code = owner.block_on(async_main());
             let report = owner
                 .shutdown_runtime_blocking()
                 .expect("failed to shutdown rocketmq-admin-cli runtime");
@@ -38,11 +38,16 @@ fn main() {
                     "rocketmq-admin-cli runtime shutdown report is unhealthy"
                 );
             }
+            exit_code
         })
         .expect("failed to spawn rocketmq-admin-cli main thread");
 
-    if let Err(payload) = handle.join() {
-        std::panic::resume_unwind(payload);
+    let exit_code = match handle.join() {
+        Ok(exit_code) => exit_code,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    if exit_code != 0 {
+        std::process::exit(exit_code);
     }
 }
 
@@ -52,12 +57,12 @@ fn admin_cli_runtime_config() -> RuntimeConfig {
     config
 }
 
-async fn async_main() {
+async fn async_main() -> i32 {
     EnvUtils::put_property(
         remoting_command::REMOTING_VERSION_KEY,
         (CURRENT_VERSION as u32).to_string(),
     );
 
     let cli = RocketMQCli::parse_from_java_compatible_args();
-    cli.handle().await;
+    cli.handle().await
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
@@ -20,6 +20,8 @@ use clap_complete::generate;
 use clap_complete::shells::Bash;
 use clap_complete::shells::Fish;
 use clap_complete::shells::Zsh;
+use rocketmq_error::CliErrorView;
+use rocketmq_error::RocketMQError;
 
 use crate::commands::CommandExecute;
 use crate::commands::Commands;
@@ -44,7 +46,7 @@ impl RocketMQCli {
         Self::parse_from(normalize_java_compatible_args(std::env::args_os()))
     }
 
-    pub async fn handle(&self) {
+    pub async fn handle(&self) -> i32 {
         if let Some(shell) = &self.completion {
             let mut cmd = RocketMQCli::command();
             let bin_name = "rocketmq-admin-cli";
@@ -60,22 +62,33 @@ impl RocketMQCli {
                     generate(Fish, &mut cmd, bin_name, &mut std::io::stdout());
                 }
                 _ => {
-                    eprintln!("Unsupported shell: {}", shell);
-                    eprintln!("Supported shells: bash, zsh, fish");
-                    std::process::exit(1);
+                    return render_cli_error(&RocketMQError::validation_failed(
+                        "generate-completion",
+                        format!("unsupported shell '{shell}', supported shells: bash, zsh, fish"),
+                    ));
                 }
             }
-            return;
+            return 0;
         }
 
         if let Some(ref commands) = self.commands {
             if let Err(e) = commands.execute(None).await {
-                eprintln!("Error: {e}");
+                return render_cli_error(&e);
             }
+            0
         } else {
-            eprintln!("No command specified. Use --help for usage information.");
+            render_cli_error(&RocketMQError::validation_failed(
+                "command",
+                "command must be specified; use --help for usage information",
+            ))
         }
     }
+}
+
+fn render_cli_error(error: &RocketMQError) -> i32 {
+    let view = CliErrorView::from_error(error);
+    eprintln!("{}", view.render_stderr());
+    view.exit_code().as_i32()
 }
 
 fn normalize_java_compatible_args<I>(args: I) -> Vec<OsString>
@@ -95,7 +108,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::RocketMQCli;
     use super::normalize_java_compatible_args;
+    use clap::Parser;
+    use rocketmq_error::CliExitCode;
     use std::ffi::OsString;
 
     #[test]
@@ -109,5 +125,19 @@ mod tests {
         ]);
 
         assert_eq!(args[3], OsString::from("--brokerName"));
+    }
+
+    #[tokio::test]
+    async fn handle_returns_usage_exit_for_missing_command() {
+        let cli = RocketMQCli::try_parse_from(["rocketmq-admin-cli"]).unwrap();
+
+        assert_eq!(cli.handle().await, CliExitCode::USAGE.as_i32());
+    }
+
+    #[tokio::test]
+    async fn handle_returns_usage_exit_for_unsupported_completion_shell() {
+        let cli = RocketMQCli::try_parse_from(["rocketmq-admin-cli", "--generate-completion", "powershell"]).unwrap();
+
+        assert_eq!(cli.handle().await, CliExitCode::USAGE.as_i32());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/auth.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/auth.rs
@@ -31,6 +31,9 @@ use serde::Serialize;
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
 use crate::core::resolver::BrokerAddressResolver;
+use crate::core::stable_error_code;
+use crate::core::stable_error_message;
+use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -706,7 +709,31 @@ pub struct AuthOperationResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthOperationFailure {
     pub broker_addr: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl AuthOperationFailure {
+    pub fn from_error(broker_addr: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
+
+    pub fn from_operation_error(
+        broker_addr: CheetahString,
+        operation: impl Into<String>,
+        error: &RocketMQError,
+    ) -> Self {
+        let operation = operation.into();
+        Self {
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: format!("{}: {}", operation, stable_error_message(error)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -967,10 +994,11 @@ impl AuthService {
                 match admin.get_user(request.from_broker().clone(), username.clone()).await {
                     Ok(Some(user_info)) => user_infos.push(user_info),
                     Ok(None) => skipped_usernames.push(username.clone()),
-                    Err(error) => failures.push(AuthOperationFailure {
-                        broker_addr: request.from_broker().clone(),
-                        error: format!("get user {username}: {error}"),
-                    }),
+                    Err(error) => failures.push(AuthOperationFailure::from_operation_error(
+                        request.from_broker().clone(),
+                        format!("get user {username}"),
+                        &error,
+                    )),
                 }
             }
             user_infos
@@ -1002,10 +1030,11 @@ impl AuthService {
 
             match copy_result {
                 Ok(()) => copied_usernames.push(username),
-                Err(error) => failures.push(AuthOperationFailure {
-                    broker_addr: request.to_broker().clone(),
-                    error: format!("copy user {username}: {error}"),
-                }),
+                Err(error) => failures.push(AuthOperationFailure::from_operation_error(
+                    request.to_broker().clone(),
+                    format!("copy user {username}"),
+                    &error,
+                )),
             }
         }
 
@@ -1233,10 +1262,11 @@ impl AuthService {
             for subject in subjects {
                 match admin.get_acl(request.from_broker().clone(), subject.clone()).await {
                     Ok(acl_info) => acl_infos.push(acl_info),
-                    Err(error) => failures.push(AuthOperationFailure {
-                        broker_addr: request.from_broker().clone(),
-                        error: format!("get ACL {subject}: {error}"),
-                    }),
+                    Err(error) => failures.push(AuthOperationFailure::from_operation_error(
+                        request.from_broker().clone(),
+                        format!("get ACL {subject}"),
+                        &error,
+                    )),
                 }
             }
             acl_infos
@@ -1272,10 +1302,11 @@ impl AuthService {
 
             match copy_result {
                 Ok(()) => copied_subjects.push(subject),
-                Err(error) => failures.push(AuthOperationFailure {
-                    broker_addr: request.to_broker().clone(),
-                    error: format!("copy ACL {subject}: {error}"),
-                }),
+                Err(error) => failures.push(AuthOperationFailure::from_operation_error(
+                    request.to_broker().clone(),
+                    format!("copy ACL {subject}"),
+                    &error,
+                )),
             }
         }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/operations.rs
@@ -169,10 +169,7 @@ impl BrokerService {
                 .await
             {
                 Ok(()) => successes.push(broker_addr),
-                Err(error) => failures.push(BrokerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => failures.push(BrokerOperationFailure::from_error(broker_addr, &error)),
             }
         }
 
@@ -210,10 +207,7 @@ impl BrokerService {
                 .await
             {
                 Ok(()) => successes.push(broker_addr),
-                Err(error) => failures.push(BrokerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => failures.push(BrokerOperationFailure::from_error(broker_addr, &error)),
             }
         }
 
@@ -249,10 +243,7 @@ impl BrokerService {
                 .await
             {
                 Ok(()) => successes.push(broker_addr),
-                Err(error) => failures.push(BrokerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => failures.push(BrokerOperationFailure::from_error(broker_addr, &error)),
             }
         }
 
@@ -428,10 +419,12 @@ impl BrokerService {
                         report.cleanup_false_results = 1;
                     }
                 }
-                Err(error) => report.failures.push(BrokerOperationFailure {
-                    broker_addr: CheetahString::from("global"),
-                    error: error.to_string(),
-                }),
+                Err(error) => {
+                    report.failures.push(BrokerOperationFailure::from_error(
+                        CheetahString::from("global"),
+                        &error,
+                    ));
+                }
             }
             return Ok(report);
         }
@@ -456,10 +449,7 @@ impl BrokerService {
                         report.cleanup_false_results += 1;
                     }
                 }
-                Err(error) => report.failures.push(BrokerOperationFailure {
-                    broker_addr: target,
-                    error: error.to_string(),
-                }),
+                Err(error) => report.failures.push(BrokerOperationFailure::from_error(target, &error)),
             }
         }
 
@@ -489,10 +479,7 @@ impl BrokerService {
         for (target, broker_addr) in targets {
             match Self::apply_commit_log_read_ahead_to_target(admin, request, target, broker_addr.clone()).await {
                 Ok(section) => sections.push(section),
-                Err(error) => failures.push(BrokerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => failures.push(BrokerOperationFailure::from_error(broker_addr, &error)),
             }
         }
 
@@ -598,10 +585,7 @@ impl BrokerService {
                 for broker_addr in broker_addrs {
                     match Self::get_broker_runtime_stats_entries(admin, &broker_addr).await {
                         Ok(entries) => sections.push(BrokerRuntimeStatsSection { broker_addr, entries }),
-                        Err(error) => failures.push(BrokerRuntimeStatsFailure {
-                            broker_addr,
-                            error: error.to_string(),
-                        }),
+                        Err(error) => failures.push(BrokerRuntimeStatsFailure::from_error(broker_addr, &error)),
                     }
                 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/types.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/types.rs
@@ -24,6 +24,9 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::admin::AdminBuilder;
+use crate::core::stable_error_code;
+use crate::core::stable_error_message;
+use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -517,7 +520,18 @@ pub struct BrokerRuntimeStatsSection {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrokerRuntimeStatsFailure {
     pub broker_addr: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl BrokerRuntimeStatsFailure {
+    pub fn from_error(broker_addr: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -740,7 +754,18 @@ impl SwitchTimerEngineRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrokerOperationFailure {
     pub broker_addr: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl BrokerOperationFailure {
+    pub fn from_error(broker_addr: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -43,6 +43,9 @@ use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
 use crate::core::broker::BrokerTarget;
 use crate::core::resolver::BrokerAddressResolver;
+use crate::core::stable_error_code;
+use crate::core::stable_error_message;
+use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -89,7 +92,18 @@ fn target_from_options(broker_addr: Option<String>, cluster_name: Option<String>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConsumerOperationFailure {
     pub broker_addr: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl ConsumerOperationFailure {
+    pub fn from_error(broker_addr: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -631,10 +645,9 @@ impl ConsumerService {
                 .await
             {
                 Ok(()) => result.broker_addrs.push(broker_addr),
-                Err(error) => result.failures.push(ConsumerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => result
+                    .failures
+                    .push(ConsumerOperationFailure::from_error(broker_addr, &error)),
             }
         }
 
@@ -644,7 +657,7 @@ impl ConsumerService {
                 get_dlq_topic(request.group_name().as_str()),
             ] {
                 if let Err(error) = admin.delete_topic(topic.into(), cluster_name.clone()).await {
-                    result.warnings.push(error.to_string());
+                    result.warnings.push(stable_error_message(&error));
                 }
             }
         }
@@ -727,10 +740,9 @@ impl ConsumerService {
                 .await
             {
                 Ok(()) => result.broker_addrs.push(broker_addr),
-                Err(error) => result.failures.push(ConsumerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => result
+                    .failures
+                    .push(ConsumerOperationFailure::from_error(broker_addr, &error)),
             }
         }
         Ok(result)
@@ -760,10 +772,9 @@ impl ConsumerService {
                 .await
             {
                 Ok(()) => result.broker_addrs.push(broker_addr),
-                Err(error) => result.failures.push(ConsumerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => result
+                    .failures
+                    .push(ConsumerOperationFailure::from_error(broker_addr, &error)),
             }
         }
         Ok(result)
@@ -796,10 +807,9 @@ impl ConsumerService {
                 .await
             {
                 Ok(()) => result.broker_addrs.push(broker_addr),
-                Err(error) => result.failures.push(ConsumerOperationFailure {
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => result
+                    .failures
+                    .push(ConsumerOperationFailure::from_error(broker_addr, &error)),
             }
         }
         Ok(result)

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/error_view.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/error_view.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stable admin error view models.
+
+use rocketmq_error::RocketMQError;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdminErrorView {
+    pub code: String,
+    pub message: String,
+    pub context: Option<String>,
+}
+
+impl AdminErrorView {
+    pub fn from_error(error: &RocketMQError) -> Self {
+        let context = error.context();
+        Self {
+            code: error.spec().code.as_str().to_string(),
+            message: error.public_message().to_string(),
+            context: (!context.is_empty()).then(|| context.to_string()),
+        }
+    }
+
+    pub fn stable_message(&self) -> String {
+        match &self.context {
+            Some(context) => format!("{}: {}", self.message, context),
+            None => self.message.clone(),
+        }
+    }
+}
+
+pub fn stable_error_code(error: &RocketMQError) -> String {
+    AdminErrorView::from_error(error).code
+}
+
+pub fn stable_error_message(error: &RocketMQError) -> String {
+    AdminErrorView::from_error(error).stable_message()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AdminErrorView;
+    use rocketmq_error::RocketMQError;
+
+    #[test]
+    fn admin_error_view_uses_stable_code_and_redacted_context() {
+        let error = RocketMQError::storage_read_failed("C:/secret/token/file", "permission denied");
+        let view = AdminErrorView::from_error(&error);
+
+        assert_eq!(view.code, "STORAGE_READ_FAILED");
+        assert_eq!(view.message, "Storage read failed");
+        let rendered = view.stable_message();
+        assert!(rendered.contains("path=<redacted>"));
+        assert!(!rendered.contains("secret/token"));
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/queue.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/queue.rs
@@ -27,6 +27,8 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::stable_error_code;
+use crate::core::stable_error_message;
 use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
@@ -190,7 +192,19 @@ pub struct CheckRocksdbCqWriteProgressEntry {
 pub struct QueueOperationFailure {
     pub broker_name: CheetahString,
     pub broker_addr: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl QueueOperationFailure {
+    pub fn from_error(broker_name: CheetahString, broker_addr: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            broker_name,
+            broker_addr,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -311,11 +325,7 @@ impl QueueService {
                     broker_addr,
                     result,
                 }),
-                Err(error) => failures.push(QueueOperationFailure {
-                    broker_name,
-                    broker_addr,
-                    error: error.to_string(),
-                }),
+                Err(error) => failures.push(QueueOperationFailure::from_error(broker_name, broker_addr, &error)),
             }
         }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/stats.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/stats.rs
@@ -15,6 +15,9 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::stable_error_code;
+use crate::core::stable_error_message;
+use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,7 +76,18 @@ pub struct StatsAllRow {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StatsAllTopicFailure {
     pub topic: CheetahString,
+    pub error_code: String,
     pub error: String,
+}
+
+impl StatsAllTopicFailure {
+    pub fn from_error(topic: CheetahString, error: &RocketMQError) -> Self {
+        Self {
+            topic,
+            error_code: stable_error_code(error),
+            error: stable_error_message(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -111,10 +125,9 @@ impl StatsService {
 
             match collect_topic_detail(admin, topic, request.active_topic()).await {
                 Ok(mut rows) => result.rows.append(&mut rows),
-                Err(error) => result.failures.push(StatsAllTopicFailure {
-                    topic: topic.clone(),
-                    error: error.to_string(),
-                }),
+                Err(error) => result
+                    .failures
+                    .push(StatsAllTopicFailure::from_error(topic.clone(), &error)),
             }
         }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod core {
     pub mod consumer;
     pub mod container;
     pub mod controller;
+    pub mod error_view;
     pub mod export_data;
     pub mod ha;
     pub mod lite;
@@ -50,6 +51,10 @@ pub mod core {
     pub use rocketmq_error::RocketMQError;
     pub use rocketmq_error::RocketMQResult;
     pub use rocketmq_error::ToolsError;
+
+    pub use self::error_view::stable_error_code;
+    pub use self::error_view::stable_error_message;
+    pub use self::error_view::AdminErrorView;
 }
 
 pub mod admin;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/tests.rs
@@ -671,6 +671,7 @@ fn phase_two_queue_results_render_as_tables() {
             failures: vec![QueueOperationFailure {
                 broker_name: "broker-b".into(),
                 broker_addr: "127.0.0.1:10912".into(),
+                error_code: "TIMEOUT".to_string(),
                 error: "timeout".to_string(),
             }],
         },
@@ -877,6 +878,7 @@ fn phase_two_producer_info_and_stats_results_render_as_tables() {
             }],
             failures: vec![StatsAllTopicFailure {
                 topic: "TopicB".into(),
+                error_code: "ROUTE_NOT_FOUND".to_string(),
                 error: "route missing".to_string(),
             }],
         },
@@ -946,6 +948,7 @@ fn phase_three_operation_results_render_partial_failures_as_summary() {
             broker_addrs: vec!["127.0.0.1:10911".into()],
             failures: vec![BrokerOperationFailure {
                 broker_addr: "127.0.0.1:10912".into(),
+                error_code: "TIMEOUT".to_string(),
                 error: "timeout".to_string(),
             }],
         },
@@ -958,6 +961,7 @@ fn phase_three_operation_results_render_partial_failures_as_summary() {
             broker_addrs: vec!["127.0.0.1:10911".into()],
             failures: vec![ConsumerOperationFailure {
                 broker_addr: "127.0.0.1:10912".into(),
+                error_code: "BROKER_PERMISSION_DENIED".to_string(),
                 error: "rejected".to_string(),
             }],
             warnings: vec!["retry topic cleanup failed".to_string()],

--- a/rocketmq-tools/rocketmq-store-inspect/Cargo.toml
+++ b/rocketmq-tools/rocketmq-store-inspect/Cargo.toml
@@ -29,6 +29,7 @@ rust-version.workspace = true
 
 [dependencies]
 rocketmq-common = { workspace = true }
+rocketmq-error  = { workspace = true }
 rocketmq-store  = { workspace = true }
 
 

--- a/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
@@ -13,15 +13,28 @@
 // limitations under the License.
 
 use clap::Parser;
+use rocketmq_error::CliErrorView;
 use rocketmq_store_inspect::command_line::Commands;
 use rocketmq_store_inspect::command_line::RootCli;
 use rocketmq_store_inspect::content_show::print_content;
 
 fn main() {
+    let exit_code = run();
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
+
+fn run() -> i32 {
     let cli = RootCli::parse();
     match cli.command {
         Commands::ReadMessageLog { config, from, to } => {
-            print_content(from, to, config);
+            if let Err(error) = print_content(from, to, config) {
+                let view = CliErrorView::from_error(&error);
+                eprintln!("{}", view.render_stderr());
+                return view.exit_code().as_i32();
+            }
         }
     }
+    0
 }

--- a/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
@@ -19,53 +19,55 @@ use bytes::Buf;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::MessageConst;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use rocketmq_store::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use rocketmq_store::log_file::mapped_file::MappedFile;
 use tabled::Table;
 use tabled::Tabled;
 
-pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) {
-    if path.is_none() {
-        eprintln!("File path is none");
-        return;
+pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) -> RocketMQResult<()> {
+    let path =
+        path.ok_or_else(|| RocketMQError::validation_failed("config", "message log file path must be provided"))?;
+    let from = from.unwrap_or_default();
+    let to = to.unwrap_or(u32::MAX);
+    if from > to {
+        return Err(RocketMQError::validation_failed(
+            "range",
+            format!("from ({from}) must be less than or equal to to ({to})"),
+        ));
     }
-    let path_buf = path.unwrap().into_os_string();
-    let file_metadata = fs::metadata(path_buf.clone()).unwrap();
+
+    let path_display = path.to_string_lossy().to_string();
+    let file_metadata = fs::metadata(&path)
+        .map_err(|error| RocketMQError::storage_read_failed(path_display.clone(), error.to_string()))?;
     println!("file size: {}B", file_metadata.len());
-    let mapped_file = DefaultMappedFile::new(
-        CheetahString::from(path_buf.to_string_lossy().to_string()),
-        file_metadata.len(),
-    );
+    let mapped_file = DefaultMappedFile::new(CheetahString::from(path_display), file_metadata.len());
     // read message number
     let mut counter = 0;
-    let form = from.unwrap_or_default();
-    let to = to.unwrap_or(u32::MAX);
     let mut current_pos = 0usize;
     let mut table = vec![];
     loop {
         if counter >= to {
             break;
         }
-        let bytes = mapped_file.get_bytes(current_pos, 4);
-        if bytes.is_none() {
+        let Some(mut size_bytes) = mapped_file.get_bytes(current_pos, 4) else {
             break;
-        }
-        let mut size_bytes = bytes.unwrap();
+        };
         let size = size_bytes.get_i32();
         if size <= 0 {
             break;
         }
         counter += 1;
-        if counter < form {
+        if counter < from {
             current_pos += size as usize;
             continue;
         }
-        let mut msg_bytes = mapped_file.get_bytes(current_pos, size as usize);
-        current_pos += size as usize;
-        if msg_bytes.is_none() {
+        let Some(mut msg_bytes) = mapped_file.get_bytes(current_pos, size as usize) else {
             break;
-        }
-        let message = message_decoder::decode(msg_bytes.as_mut().unwrap(), true, false, false, false, true);
+        };
+        current_pos += size as usize;
+        let message = message_decoder::decode(&mut msg_bytes, true, false, false, false, true);
         //parse message bytes and print it
         match message {
             None => {}
@@ -84,10 +86,33 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
         }
     }
     println!("{}", Table::new(table));
+    Ok(())
 }
 
 #[derive(Tabled)]
 struct MessagePrint {
     message_id: CheetahString,
     client_message_id: CheetahString,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_content;
+    use rocketmq_error::CliExitCode;
+
+    #[test]
+    fn print_content_requires_path() {
+        let error = print_content(None, None, None).unwrap_err();
+
+        assert_eq!(error.spec().cli.exit_code, CliExitCode::USAGE);
+        assert_eq!(error.spec().code.as_str(), "ILLEGAL_ARGUMENT");
+    }
+
+    #[test]
+    fn print_content_rejects_invalid_range() {
+        let error = print_content(Some(2), Some(1), Some("missing.log".into())).unwrap_err();
+
+        assert_eq!(error.spec().cli.exit_code, CliExitCode::USAGE);
+        assert_eq!(error.spec().code.as_str(), "ILLEGAL_ARGUMENT");
+    }
 }

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -442,6 +442,36 @@ def check_required_mapping_adapters() -> list[Finding]:
             "internal_source",
             "response_message",
         ],
+        ROOT / "rocketmq-error" / "src" / "cli.rs": [
+            "spec.cli.exit_code",
+            "error.context()",
+            "render_stderr",
+        ],
+        ROOT / "rocketmq-tools" / "rocketmq-admin" / "rocketmq-admin-cli" / "src" / "rocketmq_cli.rs": [
+            "CliErrorView::from_error",
+            "view.exit_code().as_i32()",
+            "RocketMQError::validation_failed",
+        ],
+        ROOT
+        / "rocketmq-tools"
+        / "rocketmq-admin"
+        / "rocketmq-admin-core"
+        / "src"
+        / "core"
+        / "error_view.rs": [
+            "error.spec().code.as_str()",
+            "error.public_message()",
+            "error.context()",
+        ],
+        ROOT
+        / "rocketmq-tools"
+        / "rocketmq-store-inspect"
+        / "src"
+        / "bin"
+        / "rocketmq_cli.rs": [
+            "CliErrorView::from_error",
+            "view.exit_code().as_i32()",
+        ],
     }
     findings: list[Finding] = []
     for path, needles in checks.items():


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7955

### Brief Description

Adds a central CLI error projection for `RocketMQError` and routes tools boundaries through it.

This change derives CLI exit codes, categories, stable codes, public messages, and redacted context from the error spec registry. It also maps `ToolsError` variants to more precise `ErrorKind` values, adds stable `error_code` fields to reusable admin failure models, and converts store-inspect file reading into typed errors instead of panics.

The architecture guard now verifies the CLI adapter, admin error view, and store-inspect boundary so the integration remains covered.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-error cli_view`
- `cargo test -p rocketmq-admin-core --lib error_view`
- `cargo test -p rocketmq-admin-cli handle_returns_usage_exit`
- `cargo test -p rocketmq-store-inspect print_content`
- `cargo test -p rocketmq-admin-tui phase_three_operation_results_render_partial_failures_as_summary`
- `py scripts\error_architecture_guard.py`
- `git diff --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI tools now return proper exit codes and show consistent, stable error output.
  * Admin and store-inspect commands include clearer error details with redacted sensitive context.
  * Error responses in admin views now include stable error codes alongside messages.

* **Bug Fixes**
  * Improved handling of missing arguments and invalid ranges in store-inspect.
  * Standardized failure reporting across broker, consumer, queue, and stats operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->