### PR TITLE
[ISSUE #7961]♻️Confirm error kernel contract coverage

### DIFF
--- a/docs/07-error-refactor-checklist.md
+++ b/docs/07-error-refactor-checklist.md
@@ -84,6 +84,8 @@ classes: wide
 - `RocketMQError` 已提供 `public_message()` 和 redaction-aware `context()`，边界输出可避免继续读取 `Display` 作为机器契约。
 - `RocketMQError::Internal(String)` 已在 guard 中建立基线路径 allowlist；跨 crate 替换为 typed variant 的收敛继续归 T08。
 
+**追踪**：Issue [#7961](https://github.com/mxsm/rocketmq-rust/issues/7961)，PR [#7962](https://github.com/mxsm/rocketmq-rust/pull/7962)。
+
 **开发 checklist**：
 
 - [x] 新增或确认 `ErrorCategory`，区分 network、storage、protocol、auth、config、system 等低基数分类。


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7961

### Brief Description

Adds the missing tracking link for the completed error kernel contract entry in the error refactor checklist.

The checklist already records the completed kernel contract coverage. This change makes the tracking data consistent with the rest of the completed entries.

### How Did You Test This Change?

- `git diff --check`
- Previously verified on the same latest main lineage:
  - `cargo fmt --all`
  - `py scripts\error_architecture_guard.py`
  - `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
