### PR TITLE
[ISSUE #7963]🐛Stabilize RocksDB missing runtime test

### DIFF
--- a/rocketmq-controller/src/storage/rocksdb_backend.rs
+++ b/rocketmq-controller/src/storage/rocksdb_backend.rs
@@ -367,7 +367,18 @@ mod tests {
         let error = RocksDBBackend::new_blocking_executor(None)
             .expect_err("RocksDB blocking executor should require an ambient Tokio runtime");
 
-        assert!(error.to_string().contains("no current Tokio runtime"));
+        match error {
+            ControllerError::StorageSource { message, source } => {
+                assert_eq!(message, "RocksDB blocking task failed");
+                assert!(
+                    source
+                        .downcast_ref::<RuntimeError>()
+                        .is_some_and(|error| matches!(error, RuntimeError::NoCurrentRuntime)),
+                    "expected missing Tokio runtime source, got: {source}"
+                );
+            }
+            error => panic!("expected storage error, got: {error}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7963

### Brief Description

Update the RocksDB missing-runtime test to assert the stable `ControllerError::StorageSource` wrapper and the preserved `RuntimeError::NoCurrentRuntime` source instead of matching source text through the outer display string.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-controller --lib --all-features blocking_executor_without_tokio_runtime_returns_error -- --nocapture` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error validation in a storage-related unit test to check the exact error type and underlying runtime failure.
  * Added stricter assertions for the reported message when a blocking task runs without an available runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->