### PR TITLE
[ISSUE #7967]♻️Harden remoting error guardrails

### DIFF
--- a/rocketmq-remoting/src/error_response.rs
+++ b/rocketmq-remoting/src/error_response.rs
@@ -19,7 +19,7 @@ use crate::protocol::remoting_command::RemotingCommand;
 
 /// Convert a typed RocketMQ error into a remoting response command.
 pub fn command_from_error(error: &RocketMQError) -> RemotingCommand {
-    command_from_error_with_remark(error, error.to_string())
+    command_from_error_with_remark(error, error.public_message())
 }
 
 /// Convert a typed RocketMQ error into a remoting response command and preserve
@@ -154,10 +154,21 @@ mod tests {
             ResponseCode::from(response.code()),
             ResponseCode::from(RemotingResponseCode::InvalidParameter.as_i32())
         );
-        assert!(response
-            .remark()
-            .expect("remark should be set")
-            .contains("Response decode failed"));
+        assert_eq!(
+            response.remark().map(|remark| remark.as_str()),
+            Some("Response processing failed")
+        );
+    }
+
+    #[test]
+    fn command_from_error_uses_public_remark_for_internal_errors() {
+        let response = command_from_error(&RocketMQError::Internal(
+            "password=plain-text; worker failed".to_string(),
+        ));
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert_eq!(response.remark().map(|remark| remark.as_str()), Some("Internal error"));
+        assert!(!response.remark().expect("remark should be set").contains("plain-text"));
     }
 
     #[test]

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -412,6 +412,7 @@ def check_required_mapping_adapters() -> list[Finding]:
     checks = {
         ROOT / "rocketmq-remoting" / "src" / "error_response.rs": [
             "error.spec().remoting.code.as_i32()",
+            "error.public_message()",
             "apply_error_to_response",
             "invalid_parameter_with_remark",
             "request_code_not_supported_with_remark",
@@ -482,6 +483,16 @@ def check_required_mapping_adapters() -> list[Finding]:
         for needle in needles:
             if needle not in text:
                 findings.append(Finding(path, 1, f"required mapping adapter token missing: {needle}"))
+        if path == ROOT / "rocketmq-remoting" / "src" / "error_response.rs":
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                if "command_from_error_with_remark(error, error.to_string())" in line:
+                    findings.append(
+                        Finding(
+                            path,
+                            line_number,
+                            "remoting default error response must use public_message(), not raw Display",
+                        )
+                    )
     return findings
 
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7967

### Brief Description

This PR hardens the typed error boundary for remoting responses. The default `command_from_error` path now uses `RocketMQError::public_message()` instead of raw `Display`, so internal details are not returned as the default wire remark. The error architecture guard also checks that the remoting default response path does not regress to `error.to_string()`.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `python scripts/error_architecture_guard.py` passed.
- `cargo test -p rocketmq-remoting error_response` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated remoting error responses to show a generic public message for internal errors instead of exposing underlying error details.
  * Kept existing error code mapping behavior unchanged while improving what is returned in the response remark.
  * Strengthened automated checks to ensure future error responses continue using the public-facing message format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->