### PR TITLE
[ISSUE #7969]♻️Add shared public error boundary view

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -90,7 +90,7 @@ impl DashboardError {
         match self {
             Self::Validation(_) => "VALIDATION_ERROR",
             Self::Config(_) | Self::ConfigSource { .. } => "CONFIG_ERROR",
-            Self::RocketMq(error) => error.spec().code.as_str(),
+            Self::RocketMq(error) => error.boundary_view().code().as_str(),
             Self::NotFound(_) => "NOT_FOUND",
             Self::Auth(_) => "AUTH_ERROR",
             Self::NotImplemented(_) => "NOT_IMPLEMENTED",
@@ -102,7 +102,7 @@ impl DashboardError {
         match self {
             Self::Validation(_) => StatusCode::BAD_REQUEST,
             Self::Config(_) | Self::ConfigSource { .. } => StatusCode::BAD_REQUEST,
-            Self::RocketMq(error) => status_code_from_spec(error.spec().http.status),
+            Self::RocketMq(error) => status_code_from_spec(error.boundary_view().http().status),
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Auth(_) => StatusCode::UNAUTHORIZED,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
@@ -137,11 +137,11 @@ fn status_code_from_spec(status: HttpStatusCode) -> StatusCode {
 }
 
 fn rocketmq_response_message(error: &RocketMQError) -> String {
-    let context = error.context();
-    if context.is_empty() {
-        error.public_message().to_string()
+    let view = error.boundary_view();
+    if view.context().is_empty() {
+        view.message().to_string()
     } else {
-        format!("{} ({context})", error.public_message())
+        format!("{} ({})", view.message(), view.context())
     }
 }
 

--- a/rocketmq-error/src/boundary.rs
+++ b/rocketmq-error/src/boundary.rs
@@ -12,7 +12,137 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ErrorCategory;
+use crate::ErrorCode;
+use crate::ErrorContext;
 use crate::ErrorKind;
+use crate::ErrorSeverity;
+use crate::ObserveSpec;
+use crate::RecoverySpec;
+use crate::RetryClass;
+
+/// Public, redaction-aware projection of a typed RocketMQ error.
+///
+/// Boundary adapters should use this view instead of formatting
+/// [`RocketMQError`](crate::RocketMQError) directly. `Display` remains a
+/// diagnostic surface and can contain internal details; this view contains only
+/// stable metadata, public messages, and redacted context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundaryErrorView {
+    kind: ErrorKind,
+    code: ErrorCode,
+    category: ErrorCategory,
+    message: &'static str,
+    context: ErrorContext,
+    remoting: RemotingSpec,
+    grpc: GrpcSpec,
+    http: HttpSpec,
+    cli: CliSpec,
+    recovery: RecoverySpec,
+    observe: ObserveSpec,
+}
+
+impl BoundaryErrorView {
+    #[allow(clippy::too_many_arguments)]
+    #[inline]
+    pub(crate) fn new(
+        kind: ErrorKind,
+        code: ErrorCode,
+        category: ErrorCategory,
+        message: &'static str,
+        context: ErrorContext,
+        remoting: RemotingSpec,
+        grpc: GrpcSpec,
+        http: HttpSpec,
+        cli: CliSpec,
+        recovery: RecoverySpec,
+        observe: ObserveSpec,
+    ) -> Self {
+        Self {
+            kind,
+            code,
+            category,
+            message,
+            context,
+            remoting,
+            grpc,
+            http,
+            cli,
+            recovery,
+            observe,
+        }
+    }
+
+    #[inline]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    #[inline]
+    pub const fn code(&self) -> ErrorCode {
+        self.code
+    }
+
+    #[inline]
+    pub const fn category(&self) -> ErrorCategory {
+        self.category
+    }
+
+    #[inline]
+    pub const fn message(&self) -> &'static str {
+        self.message
+    }
+
+    #[inline]
+    pub const fn context(&self) -> &ErrorContext {
+        &self.context
+    }
+
+    #[inline]
+    pub const fn remoting(&self) -> RemotingSpec {
+        self.remoting
+    }
+
+    #[inline]
+    pub const fn grpc(&self) -> GrpcSpec {
+        self.grpc
+    }
+
+    #[inline]
+    pub const fn http(&self) -> HttpSpec {
+        self.http
+    }
+
+    #[inline]
+    pub const fn cli(&self) -> CliSpec {
+        self.cli
+    }
+
+    #[inline]
+    pub const fn recovery(&self) -> RecoverySpec {
+        self.recovery
+    }
+
+    #[inline]
+    pub const fn retry(&self) -> RetryClass {
+        self.recovery.retry
+    }
+
+    #[inline]
+    pub const fn is_retryable(&self) -> bool {
+        !matches!(self.retry(), RetryClass::Never)
+    }
+
+    #[inline]
+    pub const fn observe(&self) -> ObserveSpec {
+        self.observe
+    }
+
+    #[inline]
+    pub const fn severity(&self) -> ErrorSeverity {
+        self.observe.severity
+    }
+}
 
 /// Remoting response-code primitive.
 ///

--- a/rocketmq-error/src/cli.rs
+++ b/rocketmq-error/src/cli.rs
@@ -34,13 +34,13 @@ impl CliErrorView {
     /// Build a CLI view from the central error spec registry.
     #[inline]
     pub fn from_error(error: &RocketMQError) -> Self {
-        let spec = error.spec();
+        let view = error.boundary_view();
         Self {
-            exit_code: spec.cli.exit_code,
-            code: spec.code,
-            category: spec.category,
-            message: spec.public_message,
-            context: error.context(),
+            exit_code: view.cli().exit_code,
+            code: view.code(),
+            category: view.category(),
+            message: view.message(),
+            context: view.context().clone(),
         }
     }
 

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -75,6 +75,7 @@ pub mod client_error;
 // Re-export new error types as primary API
 // Re-export auth error types from unified module
 // Re-export controller error types
+pub use boundary::BoundaryErrorView;
 pub use boundary::CliExitCode;
 pub use boundary::CliSpec;
 pub use boundary::GrpcPayloadCode;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -29,6 +29,7 @@ use std::io;
 // Re-export filter error
 pub use crate::filter_error::FilterError;
 
+use crate::boundary::BoundaryErrorView;
 use crate::context::ErrorContext;
 use crate::context::Sensitive;
 use crate::kind::ErrorKind;
@@ -623,6 +624,26 @@ impl RocketMQError {
             Self::NotInitialized(reason) => ErrorContext::new().with_field("reason", reason.as_str()),
             Self::MissingRequiredMessageProperty { property } => ErrorContext::new().with_field("property", *property),
         }
+    }
+
+    /// Return a public, redaction-aware snapshot for protocol and UI
+    /// boundaries.
+    #[inline]
+    pub fn boundary_view(&self) -> BoundaryErrorView {
+        let spec = self.spec();
+        BoundaryErrorView::new(
+            spec.kind,
+            spec.code,
+            spec.category,
+            spec.public_message,
+            self.context(),
+            spec.remoting,
+            spec.grpc,
+            spec.http,
+            spec.cli,
+            spec.recovery,
+            spec.observe,
+        )
     }
 
     /// Create a network connection failed error

--- a/rocketmq-error/tests/error_context_redaction.rs
+++ b/rocketmq-error/tests/error_context_redaction.rs
@@ -54,3 +54,15 @@ fn rocketmq_error_exposes_public_message_and_redacted_context() {
     assert_eq!(context.to_string(), "internal_error=<redacted>");
     assert!(!context.to_string().contains("plain-text"));
 }
+
+#[test]
+fn boundary_view_exposes_public_message_and_redacted_context() {
+    let error = RocketMQError::Internal("password=plain-text".to_string());
+    let view = error.boundary_view();
+
+    assert_eq!(view.code().as_str(), "INTERNAL");
+    assert_eq!(view.message(), "Internal error");
+    assert_eq!(view.context().to_string(), "internal_error=<redacted>");
+    assert!(!view.context().to_string().contains("plain-text"));
+    assert!(!view.is_retryable());
+}

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -113,10 +113,13 @@ impl ProxyStatusMapper {
 
     pub fn from_error_payload(error: &ProxyError) -> ProxyPayloadStatus {
         let (code, message) = match error {
-            ProxyError::RocketMQ(inner) => (
-                Self::rocketmq_error_grpc_mapping(inner).payload,
-                inner.public_message().to_owned(),
-            ),
+            ProxyError::RocketMQ(inner) => {
+                let view = inner.boundary_view();
+                (
+                    Self::rocketmq_error_grpc_mapping(inner).payload,
+                    view.message().to_owned(),
+                )
+            }
             local => (
                 Self::local_error_grpc_mapping(
                     local
@@ -214,7 +217,7 @@ impl ProxyStatusMapper {
 
     fn rocketmq_error_grpc_mapping(error: &RocketMQError) -> ProxyGrpcMapping {
         Self::broker_response_payload_override(error).unwrap_or_else(|| {
-            let grpc = error.spec().grpc;
+            let grpc = error.boundary_view().grpc();
             ProxyGrpcMapping::new(
                 Self::grpc_payload_to_code(grpc.payload),
                 Self::grpc_status_to_tonic_code(grpc.status),

--- a/rocketmq-remoting/src/error_response.rs
+++ b/rocketmq-remoting/src/error_response.rs
@@ -19,7 +19,8 @@ use crate::protocol::remoting_command::RemotingCommand;
 
 /// Convert a typed RocketMQ error into a remoting response command.
 pub fn command_from_error(error: &RocketMQError) -> RemotingCommand {
-    command_from_error_with_remark(error, error.public_message())
+    let view = error.boundary_view();
+    RemotingCommand::create_response_command_with_code_remark(view.remoting().code.as_i32(), view.message())
 }
 
 /// Convert a typed RocketMQ error into a remoting response command and preserve
@@ -31,7 +32,8 @@ pub fn command_from_error_with_opaque(error: &RocketMQError, opaque: i32) -> Rem
 /// Convert a typed RocketMQ error into a remoting response command with an
 /// explicit wire remark.
 pub fn command_from_error_with_remark(error: &RocketMQError, remark: impl Into<String>) -> RemotingCommand {
-    RemotingCommand::create_response_command_with_code_remark(error.spec().remoting.code.as_i32(), remark.into())
+    let view = error.boundary_view();
+    RemotingCommand::create_response_command_with_code_remark(view.remoting().code.as_i32(), remark.into())
 }
 
 /// Apply a typed RocketMQ error mapping to an existing remoting response.
@@ -40,8 +42,9 @@ pub fn apply_error_to_response(
     error: &RocketMQError,
     remark: impl Into<String>,
 ) -> RemotingCommand {
+    let view = error.boundary_view();
     response
-        .set_code(error.spec().remoting.code.as_i32())
+        .set_code(view.remoting().code.as_i32())
         .set_remark(remark.into())
 }
 

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -411,8 +411,7 @@ def check_processor_generic_response_allowlist() -> list[Finding]:
 def check_required_mapping_adapters() -> list[Finding]:
     checks = {
         ROOT / "rocketmq-remoting" / "src" / "error_response.rs": [
-            "error.spec().remoting.code.as_i32()",
-            "error.public_message()",
+            "error.boundary_view()",
             "apply_error_to_response",
             "invalid_parameter_with_remark",
             "request_code_not_supported_with_remark",
@@ -422,11 +421,11 @@ def check_required_mapping_adapters() -> list[Finding]:
         ROOT / "rocketmq-proxy" / "src" / "status.rs": [
             "ProxyErrorKind",
             "broker_response_payload_override",
-            "error.spec().grpc",
+            "boundary_view().grpc()",
             "grpc_payload_to_code",
             "grpc_status_to_tonic_code",
             "local_error_grpc_mapping",
-            "public_message()",
+            "view.message()",
         ],
         ROOT
         / "rocketmq-dashboard"
@@ -435,17 +434,17 @@ def check_required_mapping_adapters() -> list[Finding]:
         / "src"
         / "error"
         / "dashboard_error.rs": [
-            "error.spec().http.status",
-            "error.spec().code.as_str()",
-            "error.public_message()",
-            "error.context()",
+            "error.boundary_view().http().status",
+            "error.boundary_view().code().as_str()",
+            "view.message()",
+            "view.context()",
             "config_source",
             "internal_source",
             "response_message",
         ],
         ROOT / "rocketmq-error" / "src" / "cli.rs": [
-            "spec.cli.exit_code",
-            "error.context()",
+            "error.boundary_view()",
+            "view.cli().exit_code",
             "render_stderr",
         ],
         ROOT / "rocketmq-tools" / "rocketmq-admin" / "rocketmq-admin-cli" / "src" / "rocketmq_cli.rs": [


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7969

### Brief Description

This PR adds a shared `BoundaryErrorView` projection to `rocketmq-error` and exposes it through `RocketMQError::boundary_view()`. The view carries stable error identity, public message, redacted context, protocol mapping specs, retry policy, and severity. Remoting, CLI, proxy gRPC, and dashboard HTTP adapters now consume this shared public view for RocketMQ errors while preserving proxy broker-response overrides.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-error` passed.
- `cargo test -p rocketmq-remoting error_response` passed.
- `cargo test -p rocketmq-proxy status` passed.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend`: `cargo fmt --all` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend`: `cargo clippy --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-dashboard/rocketmq-dashboard-web/backend`: `cargo build --all-targets --all-features` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how RocketMQ errors are translated into dashboard, proxy, CLI, and remoting responses.
  * Error messages and HTTP/gRPC/remoting status values are now more consistent and less likely to expose sensitive details.
  * Redacted context is now preserved in user-facing error output, with clearer formatting when extra context is present.
  * Added coverage to verify sensitive values are not leaked in error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->