### PR TITLE
[ISSUE #7973]♻️Normalize authorization provider errors

### DIFF
--- a/rocketmq-auth/src/authorization/provider.rs
+++ b/rocketmq-auth/src/authorization/provider.rs
@@ -111,7 +111,9 @@ impl From<AuthorizationError> for RocketMQError {
     fn from(error: AuthorizationError) -> Self {
         let message = error.to_string();
         match error {
-            AuthorizationError::PermissionDenied { .. } => RocketMQError::BrokerPermissionDenied { operation: message },
+            AuthorizationError::PermissionDenied { .. } => {
+                RocketMQError::Authentication(AuthError::AuthorizationFailed(message))
+            }
             AuthorizationError::SubjectNotFound(_)
             | AuthorizationError::ResourceNotFound(_)
             | AuthorizationError::InvalidContext(_) => RocketMQError::illegal_argument(message),
@@ -121,7 +123,7 @@ impl From<AuthorizationError> for RocketMQError {
             AuthorizationError::PolicyEvaluationFailed(_) => {
                 RocketMQError::Authentication(AuthError::AuthorizationFailed(message))
             }
-            AuthorizationError::InternalError(_) => RocketMQError::Internal(message),
+            AuthorizationError::InternalError(_) => RocketMQError::Authentication(AuthError::Other(message)),
             AuthorizationError::StorageReadFailed { path, reason } => RocketMQError::storage_read_failed(path, reason),
             AuthorizationError::StorageWriteFailed { path, reason } => {
                 RocketMQError::storage_write_failed(path, reason)
@@ -692,7 +694,10 @@ mod tests {
             resource: "topic:test".to_string(),
             reason: "insufficient permissions".to_string(),
         });
-        assert!(matches!(denied, RocketMQError::BrokerPermissionDenied { .. }));
+        assert!(matches!(
+            denied,
+            RocketMQError::Authentication(AuthError::AuthorizationFailed(_))
+        ));
 
         let invalid = RocketMQError::from(AuthorizationError::InvalidContext("missing subject".to_string()));
         assert!(matches!(invalid, RocketMQError::IllegalArgument(_)));
@@ -707,7 +712,7 @@ mod tests {
         ));
 
         let internal = RocketMQError::from(AuthorizationError::InternalError("unexpected error".to_string()));
-        assert!(matches!(internal, RocketMQError::Internal(_)));
+        assert!(matches!(internal, RocketMQError::Authentication(AuthError::Other(_))));
 
         let storage = RocketMQError::from(AuthorizationError::StorageWriteFailed {
             path: "acls.json".to_string(),

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -45,7 +45,6 @@ NON_SENSITIVE_DEBUG_FIELD_NAMES = {
 }
 
 INTERNAL_ERROR_ALLOWLIST = (
-    "rocketmq-auth/src/authorization/provider.rs",
     "rocketmq-broker/src/",
     "rocketmq-client/src/",
     "rocketmq-controller/src/",


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7973

### Brief Description

This PR keeps authorization provider failures in the auth error domain. Authorization denials now map to `AuthError::AuthorizationFailed` instead of broker permission errors, and provider internal authorization failures map to `AuthError::Other` instead of `RocketMQError::Internal`. The error architecture guard no longer allowlists the provider as an internal-error hotspot.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `rg -n "RocketMQError::Internal" rocketmq-auth/src/authorization/provider.rs` returned no matches.
- `cargo test -p rocketmq-auth test_authorization_error_rocketmq_mapping_categories` passed.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization failures are now reported under a more consistent authentication error category.
  * Internal authorization errors now surface as authentication-related errors instead of general internal or broker permission errors.
  * Updated error checks to match the new error categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->