### PR TITLE
[ISSUE #7975]♻️Type scheduled task manager results

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -45,6 +45,7 @@ use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_common::common::statistics::state_getter::StateGetter;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::compute_next_morning_time_millis;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
@@ -2217,7 +2218,7 @@ impl BrokerRuntime {
         }
     }
 
-    fn log_scheduled_task_start(task_name: &str, task_id: anyhow::Result<u64>) {
+    fn log_scheduled_task_start(task_name: &str, task_id: RocketMQResult<u64>) {
         if let Err(error) = task_id {
             error!("Failed to start scheduled task {task_name}: {error}");
         }
@@ -5125,7 +5126,7 @@ mod tests {
                     async move {
                         let _marker = DropMarker(dropped);
                         started.store(true, Ordering::Release);
-                        future::pending::<anyhow::Result<()>>().await
+                        future::pending::<RocketMQResult<()>>().await
                     }
                 }
             })

--- a/rocketmq-store/src/stats/broker_stats_manager.rs
+++ b/rocketmq-store/src/stats/broker_stats_manager.rs
@@ -31,6 +31,7 @@ use rocketmq_common::common::stats::stats_item::StatsItem;
 use rocketmq_common::common::stats::stats_item_set::StatsItemSet;
 use rocketmq_common::common::stats::Stats;
 use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_error::RocketMQResult;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
 use tokio::time::Duration;
 use tracing::info;
@@ -169,7 +170,7 @@ impl BrokerStatsManager {
         );
     }
 
-    fn track_sampling_task(&self, task_id: anyhow::Result<TaskId>, task_name: &str) {
+    fn track_sampling_task(&self, task_id: RocketMQResult<TaskId>, task_name: &str) {
         match task_id {
             Ok(task_id) => self.task_ids.lock().push(task_id),
             Err(error) => warn!("Failed to start BrokerStatsManager scheduled task {task_name}: {error}"),

--- a/rocketmq/src/schedule.rs
+++ b/rocketmq/src/schedule.rs
@@ -60,9 +60,10 @@ pub mod simple_scheduler {
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
-    use anyhow::anyhow;
-    use anyhow::Result;
     use parking_lot::RwLock;
+    use rocketmq_error::RocketMQError;
+    use rocketmq_error::RocketMQResult;
+    use rocketmq_error::UnifiedServiceError;
     use rocketmq_runtime::RuntimeHandle;
     use rocketmq_runtime::ShutdownReport;
     use rocketmq_runtime::TaskGroup;
@@ -78,6 +79,8 @@ pub mod simple_scheduler {
     use tracing::info;
 
     use crate::ArcMut;
+
+    type Result<T> = RocketMQResult<T>;
 
     #[derive(Debug, Clone, Copy)]
     pub enum ScheduleMode {
@@ -129,9 +132,11 @@ pub mod simple_scheduler {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        task_group
-            .spawn_service(task_name, future)
-            .map_err(|error| anyhow!("{operation} failed to spawn scheduled task driver: {error}"))
+        task_group.spawn_service(task_name, future).map_err(|error| {
+            RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+                "{operation} failed to spawn scheduled task driver: {error}"
+            )))
+        })
     }
 
     #[derive(Debug, Clone)]
@@ -216,8 +221,11 @@ pub mod simple_scheduler {
                 return Ok(task_group.clone());
             }
 
-            let handle = tokio::runtime::Handle::try_current()
-                .map_err(|error| anyhow!("{operation} requires a Tokio runtime: {error}"))?;
+            let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+                RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+                    "{operation} requires a Tokio runtime: {error}"
+                )))
+            })?;
             let new_group = TaskGroup::root("rocketmq.simple-scheduled-task-manager", RuntimeHandle::new(handle));
             *task_group = Some(new_group.clone());
             Ok(new_group)
@@ -882,6 +890,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use rocketmq_error::RocketMQResult;
     use rocketmq_runtime::RuntimeContext;
     use tokio::time;
 
@@ -1148,7 +1157,7 @@ mod tests {
                     async move {
                         let _marker = DropMarker(dropped);
                         started.store(true, Ordering::Release);
-                        future::pending::<anyhow::Result<()>>().await
+                        future::pending::<RocketMQResult<()>>().await
                     }
                 }
             })
@@ -1185,7 +1194,7 @@ mod tests {
                     let started = Arc::clone(&started);
                     async move {
                         started.store(true, Ordering::Release);
-                        future::pending::<anyhow::Result<()>>().await
+                        future::pending::<RocketMQResult<()>>().await
                     }
                 }
             })

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -61,8 +61,6 @@ INTERNAL_ERROR_ALLOWLIST = (
 )
 
 ANYHOW_RESULT_ALLOWLIST: dict[str, str] = {
-    "rocketmq/src/schedule.rs": "internal scheduler futures use anyhow at the outer async worker boundary",
-    "rocketmq-broker/src/broker_runtime.rs": "broker runtime stores scheduled worker handles and placeholders",
     "rocketmq-dashboard/rocketmq-dashboard-gpui/build.rs": "build script boundary",
     "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs": "standalone Tauri boundary pending dashboard alignment",
     "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs": "standalone Tauri boundary pending dashboard alignment",
@@ -73,7 +71,6 @@ ANYHOW_RESULT_ALLOWLIST: dict[str, str] = {
     "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/main.rs": "web backend process boundary",
     "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs": "internal remoting accept-loop worker boundary",
     "rocketmq-store/src/ha/default_ha_client.rs": "internal HA replication worker boundary",
-    "rocketmq-store/src/stats/broker_stats_manager.rs": "internal scheduled worker handle boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs": "TUI process boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs": "TUI terminal runtime boundary",
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7975

### Brief Description

This PR migrates the scheduled task manager result boundary from `anyhow::Result` to `RocketMQResult`.

It maps scheduled task spawn and Tokio runtime acquisition failures to `RocketMQError::Service(UnifiedServiceError::StartupFailed(...))`, updates broker and store scheduled-task call sites to accept typed task ids, and removes the migrated files from the error architecture guard `anyhow` allowlist.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `rg -n "anyhow::Result|anyhow::Error|anyhow!|bail!|ensure!|use anyhow::Result" rocketmq/src/schedule.rs rocketmq-store/src/stats/broker_stats_manager.rs rocketmq-broker/src/broker_runtime.rs` returned no matches.
- `cargo test -p rocketmq-rust schedule::` passed.
- `cargo test -p rocketmq-store broker_stats_manager` passed.
- `cargo test -p rocketmq-broker shutdown_scheduled_tasks_waits_for_running_task_drop` passed.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled task and broker shutdown handling by standardizing error responses, which should make failures more consistent and easier to diagnose.
  * Updated internal task tracking and scheduling paths to use a unified result format, reducing mismatches during runtime and tests.

* **Chores**
  * Tightened error-handling checks so these areas are no longer exempt from architecture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->