### PR TITLE
[ISSUE #7977]♻️Type remoting accept loop errors

### DIFF
--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_common::common::server::config::ServerConfig;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
@@ -306,7 +308,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
     /// - Accept loop: Single-threaded (TcpListener)
     /// - Handler tasks: Multi-threaded (Tokio runtime)
     /// - Event dispatcher: Independent task (non-blocking)
-    async fn run(&mut self) -> anyhow::Result<()> {
+    async fn run(&mut self) -> RocketMQResult<()> {
         info!("Server ready to accept connections");
 
         // Event notification channel (unbounded to prevent accept() blocking)
@@ -487,7 +489,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
     /// # Performance
     /// - Fast path: Single syscall when no errors
     /// - Slow path: Exponential backoff prevents thundering herd
-    async fn accept(&mut self) -> anyhow::Result<(TcpStream, SocketAddr)> {
+    async fn accept(&mut self) -> RocketMQResult<(TcpStream, SocketAddr)> {
         let mut backoff = 1;
         const MAX_BACKOFF: u64 = 64;
 
@@ -516,12 +518,10 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
     }
 }
 
-async fn acquire_connection_permit(limit_connections: &Arc<Semaphore>) -> anyhow::Result<OwnedSemaphorePermit> {
-    limit_connections
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|err| anyhow::anyhow!("connection limit semaphore closed: {err}"))
+async fn acquire_connection_permit(limit_connections: &Arc<Semaphore>) -> RocketMQResult<OwnedSemaphorePermit> {
+    limit_connections.clone().acquire_owned().await.map_err(|err| {
+        RocketMQError::network_connection_failed("remoting-server", format!("connection limit semaphore closed: {err}"))
+    })
 }
 
 pub struct RocketMQServer<RP> {

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -69,7 +69,6 @@ ANYHOW_RESULT_ALLOWLIST: dict[str, str] = {
     "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/service.rs": "standalone Tauri boundary pending dashboard alignment",
     "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/lib.rs": "web backend process boundary",
     "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/main.rs": "web backend process boundary",
-    "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs": "internal remoting accept-loop worker boundary",
     "rocketmq-store/src/ha/default_ha_client.rs": "internal HA replication worker boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs": "TUI process boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs": "TUI terminal runtime boundary",


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7977

### Brief Description

This PR migrates the remoting Tokio server accept-loop boundary from `anyhow::Result` to `RocketMQResult`.

The listener `run`, `accept`, and connection permit helper now return typed RocketMQ errors, closed semaphore acquisition maps to a network error, and the remoting server file is removed from the error architecture guard `anyhow` allowlist.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `rg -n "anyhow::Result|anyhow::Error|anyhow!|bail!|ensure!|use anyhow::Result" rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs` returned no matches.
- `cargo test -p rocketmq-remoting remoting_server` passed.
- `cargo test -p rocketmq-remoting acquire_connection_permit_closed_semaphore_returns_error_without_panicking` passed.
- `python scripts/error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling and error reporting in the remoting server, making network-related failures more consistent and reliable.
* **Chores**
  * Updated internal error-handling allowances to reflect current architecture boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->