### PR TITLE
[ISSUE #7979]♻️Type HA client worker errors

### DIFF
--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::bail;
 use bytes::BufMut;
 use bytes::BytesMut;
 use futures_util::SinkExt;
@@ -46,7 +45,9 @@ use crate::ha::default_ha_connection::transfer_header_size;
 use crate::ha::flow_monitor::FlowMonitor;
 use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state::HAConnectionState;
+use crate::ha::HAConnectionError;
 use crate::message_store::local_file_message_store::LocalFileMessageStore;
+use crate::store_error::StoreError;
 
 /// Report header buffer size. Schema: slaveMaxOffset. Format:
 /// ┌───────────────────────────────────────────────┐
@@ -61,6 +62,8 @@ pub const CONTROLLER_REPORT_HEADER_SIZE: usize = 16;
 
 /// Maximum read buffer size (4MB)
 const READ_MAX_BUFFER_SIZE: usize = 1024 * 1024 * 4;
+
+type HAClientTaskResult<T> = Result<T, HAClientError>;
 
 /// Default HA Client implementation using bytes crate
 pub struct DefaultHAClient {
@@ -348,7 +351,7 @@ impl HAClient for DefaultHAClient {
                             let (kick_tx, kick_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
                             // use reader/writer to send errors back to main loop
-                            let (err_tx, mut err_rx) = tokio::sync::mpsc::unbounded_channel::<anyhow::Error>();
+                            let (err_tx, mut err_rx) = tokio::sync::mpsc::unbounded_channel::<HAClientError>();
                             let connection_group = service_loop_group.child("ha-client-connection");
 
                             // reader task: read data from master and dispatch to message store
@@ -606,7 +609,7 @@ struct ReaderTask {
     buf: BytesMut,
     dispatch_pos: usize,
     offset_tx: tokio::sync::mpsc::UnboundedSender<i64>,
-    err_tx: tokio::sync::mpsc::UnboundedSender<anyhow::Error>,
+    err_tx: tokio::sync::mpsc::UnboundedSender<HAClientError>,
     store: ArcMut<LocalFileMessageStore>,
     flow_monitor: Arc<FlowMonitor>,
     /// Last time slave read data from master
@@ -615,7 +618,7 @@ struct ReaderTask {
 }
 
 impl ReaderTask {
-    async fn run(&mut self) -> anyhow::Result<()> {
+    async fn run(&mut self) -> HAClientTaskResult<()> {
         loop {
             match self.reader.next().await {
                 Some(Ok(bytes)) => {
@@ -625,21 +628,21 @@ impl ReaderTask {
                     self.buf.extend_from_slice(&bytes);
 
                     if !self.dispatch_read().await? {
-                        bail!("dispatchReadRequest error");
+                        return Err(HAClientError::Service("dispatchReadRequest error".to_string()));
                     }
                     self.last_read_timestamp.store(current_millis(), Ordering::SeqCst);
                 }
                 Some(Err(e)) => {
-                    bail!(e);
+                    return Err(HAClientError::Io(e));
                 }
                 None => {
-                    bail!("read EOF");
+                    return Err(HAClientError::Connection("read EOF".to_string()));
                 }
             }
         }
     }
 
-    async fn dispatch_read(&mut self) -> anyhow::Result<bool> {
+    async fn dispatch_read(&mut self) -> HAClientTaskResult<bool> {
         loop {
             let header_size = transfer_header_size(self.enable_controller_mode);
             let diff = self.buf.len().saturating_sub(self.dispatch_pos);
@@ -657,11 +660,10 @@ impl ReaderTask {
 
             let slave_phy_offset = self.store.get_max_phy_offset();
             if slave_phy_offset != 0 && slave_phy_offset != master_phy_offset {
-                bail!(
+                return Err(HAClientError::Service(format!(
                     "master pushed offset != slave max, slave: {}, master: {}",
-                    slave_phy_offset,
-                    master_phy_offset
-                );
+                    slave_phy_offset, master_phy_offset
+                )));
             }
 
             if diff < header_size + body_size {
@@ -739,7 +741,7 @@ struct WriterTask {
 }
 
 impl WriterTask {
-    async fn run(&mut self) -> anyhow::Result<()> {
+    async fn run(&mut self) -> HAClientTaskResult<()> {
         let mut ticker = interval(Duration::from_millis(self.cfg.heartbeat_interval_ms.max(1000)));
 
         loop {
@@ -762,7 +764,7 @@ impl WriterTask {
         }
     }
 
-    async fn send_offset(&mut self, max_off: i64) -> anyhow::Result<()> {
+    async fn send_offset(&mut self, max_off: i64) -> HAClientTaskResult<()> {
         let broker_id = self.reported_broker_id_ref.load(Ordering::Relaxed);
         let bytes = Self::encode_offset_report(
             &mut self.report_offset,
@@ -795,6 +797,10 @@ impl WriterTask {
 pub enum HAClientError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    #[error(transparent)]
+    HAConnection(#[from] HAConnectionError),
     #[error("Connection error: {0}")]
     Connection(String),
     #[error("Service error: {0}")]

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -69,7 +69,6 @@ ANYHOW_RESULT_ALLOWLIST: dict[str, str] = {
     "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/service.rs": "standalone Tauri boundary pending dashboard alignment",
     "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/lib.rs": "web backend process boundary",
     "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/main.rs": "web backend process boundary",
-    "rocketmq-store/src/ha/default_ha_client.rs": "internal HA replication worker boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs": "TUI process boundary",
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs": "TUI terminal runtime boundary",
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7979

### Brief Description

This PR migrates the HA client reader and writer worker boundary away from `anyhow`.

The worker result type and subtask error channel now carry `HAClientError`, store and HA connection errors are converted through explicit typed variants, and the HA client file is removed from the error architecture guard `anyhow` allowlist.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `rg -n "anyhow::Result|anyhow::Error|anyhow!|bail!|ensure!|use anyhow::Result|use anyhow::bail" rocketmq-store/src/ha/default_ha_client.rs` returned no matches.
- `cargo test -p rocketmq-store default_ha_client` passed.
- `python scripts/error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-availability sync error handling for more reliable recovery and clearer failure reporting.
  * Reduced the chance of generic sync errors by using more specific error responses when read/write operations fail.
  * Added better handling for master/slave offset mismatches during replication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->