### PR TITLE
[ISSUE #7981]♻️Type proxy configuration load errors

### DIFF
--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -441,17 +441,24 @@ impl ProxyConfig {
     pub fn load_from_file(path: impl AsRef<Path>) -> ProxyResult<Self> {
         let path = path.as_ref();
         let builder = config::Config::builder().add_source(config::File::from(path));
-        let config = builder.build().map_err(|error| {
-            RocketMQError::Internal(format!("failed to build proxy config from {}: {error}", path.display()))
-        })?;
+        let config = builder
+            .build()
+            .map_err(|error| proxy_config_parse_failed("build", path, error))?;
 
-        config.try_deserialize().map_err(|error| {
-            RocketMQError::Internal(format!(
-                "failed to deserialize proxy config from {}: {error}",
-                path.display()
-            ))
-            .into()
-        })
+        config
+            .try_deserialize()
+            .map_err(|error| proxy_config_parse_failed("deserialize", path, error).into())
+    }
+}
+
+fn proxy_config_parse_failed(stage: &'static str, path: &Path, error: config::ConfigError) -> RocketMQError {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("proxy config");
+    RocketMQError::ConfigParseFailed {
+        key: "proxy.config",
+        reason: format!("failed to {stage} proxy config {file_name}: {error}"),
     }
 }
 
@@ -608,6 +615,26 @@ enableAclRpcHookForClusterMode: true
     }
 
     #[test]
+    fn proxy_config_load_missing_file_uses_config_parse_error() {
+        let path = unique_proxy_config_path("missing");
+
+        let error = ProxyConfig::load_from_file(path).expect_err("missing proxy config should fail");
+
+        assert_proxy_config_parse_error(error, "build");
+    }
+
+    #[test]
+    fn proxy_config_load_invalid_shape_uses_config_parse_error() {
+        let path = unique_proxy_config_path("invalid-shape");
+        std::fs::write(&path, "grpc: 1\n").expect("write invalid proxy config");
+
+        let error = ProxyConfig::load_from_file(&path).expect_err("invalid proxy config should fail");
+        let _ = std::fs::remove_file(path);
+
+        assert_proxy_config_parse_error(error, "deserialize");
+    }
+
+    #[test]
     fn proxy_auth_config_debug_redacts_embedded_credentials() {
         let config = ProxyAuthConfig {
             init_authentication_user: "admin:init-secret".to_owned(),
@@ -620,5 +647,29 @@ enableAclRpcHookForClusterMode: true
         assert!(!output.contains("init-secret"));
         assert!(!output.contains("inner-secret"));
         assert!(output.contains("<redacted>"));
+    }
+
+    fn unique_proxy_config_path(name: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("rocketmq-proxy-{name}-{nonce}.yaml"))
+    }
+
+    fn assert_proxy_config_parse_error(error: crate::error::ProxyError, expected_stage: &str) {
+        match error {
+            crate::error::ProxyError::RocketMQ(error) => {
+                assert_eq!(error.kind(), rocketmq_error::ErrorKind::ConfigParseFailed);
+                match error {
+                    RocketMQError::ConfigParseFailed { key, reason } => {
+                        assert_eq!(key, "proxy.config");
+                        assert!(reason.contains(expected_stage), "{reason}");
+                    }
+                    other => panic!("expected ConfigParseFailed, got {other:?}"),
+                }
+            }
+            other => panic!("expected RocketMQ proxy error, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7981

### Brief Description

This PR changes proxy configuration loading failures from generic internal errors to typed configuration parse errors.

`ProxyConfig::load_from_file` now maps config builder and deserialization failures to `RocketMQError::ConfigParseFailed` with the `proxy.config` key, and new tests assert the error kind for missing and invalid proxy config files.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-proxy proxy_config_load` passed.
- `rg -n "RocketMQError::Internal" rocketmq-proxy/src/config.rs` returned no matches.
- `python scripts/error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading errors for the proxy, making failures clearer and more consistent.
  * Error messages now include whether the issue happened during config loading or parsing, along with the config file name when available.
  * Added coverage for missing and invalid proxy configuration cases to ensure the new error messages stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->