### PR TITLE
[ISSUE #7985]♻️Type TieredStore runtime lifecycle errors

### DIFF
--- a/rocketmq-tieredstore/src/runtime.rs
+++ b/rocketmq-tieredstore/src/runtime.rs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 use rocketmq_error::RocketMQError;
+use rocketmq_error::UnifiedServiceError;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 
 pub(crate) fn task_group(name: &'static str) -> Result<TaskGroup, RocketMQError> {
-    let handle = tokio::runtime::Handle::try_current()
-        .map_err(|error| RocketMQError::Internal(format!("{name} requires a Tokio runtime: {error}")))?;
+    let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+        RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+            "{name} requires a Tokio runtime: {error}"
+        )))
+    })?;
     Ok(TaskGroup::root(name, RuntimeHandle::new(handle)))
 }
 
@@ -28,16 +32,33 @@ pub(crate) fn task_group_with_parent(name: &'static str, parent_task_group: &Tas
 }
 
 pub(crate) fn shutdown_report_result(component: &'static str, report: ShutdownReport) -> Result<(), RocketMQError> {
-    report
-        .assert_no_task_leak()
-        .map_err(|error| RocketMQError::Internal(format!("{component} shutdown failed: {error}")))
+    report.assert_no_task_leak().map_err(|error| {
+        RocketMQError::Service(UnifiedServiceError::ShutdownFailed(format!(
+            "{component} shutdown failed: {error}"
+        )))
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_error::ErrorKind;
     use rocketmq_runtime::RuntimeContext;
 
     use super::*;
+
+    #[test]
+    fn task_group_without_tokio_runtime_returns_service_error() {
+        let error = match task_group("rocketmq-tieredstore.test") {
+            Ok(_) => panic!("task group should require an ambient Tokio runtime"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), ErrorKind::Service);
+        assert!(matches!(
+            error,
+            RocketMQError::Service(UnifiedServiceError::StartupFailed(_))
+        ));
+    }
 
     #[tokio::test]
     async fn task_group_with_parent_creates_child_group() {
@@ -49,5 +70,20 @@ mod tests {
         assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
         let report = service.task_group().shutdown(std::time::Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[test]
+    fn shutdown_report_result_maps_unhealthy_report_to_service_error() {
+        let mut report = ShutdownReport::new("tieredstore-runtime-test", std::time::Duration::ZERO);
+        report.leaked = 1;
+
+        let error = shutdown_report_result("tieredstore runtime test", report)
+            .expect_err("unhealthy shutdown report should fail");
+
+        assert_eq!(error.kind(), ErrorKind::Service);
+        assert!(matches!(
+            error,
+            RocketMQError::Service(UnifiedServiceError::ShutdownFailed(_))
+        ));
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7985

### Brief Description

This PR maps TieredStore runtime lifecycle failures to typed service errors instead of `RocketMQError::Internal`.

Missing Tokio runtime errors now become `UnifiedServiceError::StartupFailed`, unhealthy shutdown reports become `UnifiedServiceError::ShutdownFailed`, and focused tests assert the service error variants.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-tieredstore runtime` passed.
- `rg -n "RocketMQError::Internal" rocketmq-tieredstore/src/runtime.rs` returned no matches.
- `python scripts/error_architecture_guard.py` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup error reporting when the service is launched without an available runtime, now surfacing a clearer startup failure message.
  - Improved shutdown error reporting when tasks remain unfinished, now returning a clearer shutdown failure message.
  - Updated tests to cover these error cases and confirm the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->