### PR TITLE
[ISSUE #8007]♻️Type client admin route lookup errors

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -818,9 +818,7 @@ impl DefaultMQAdminExtImpl {
         let topic_route_data = self
             .examine_topic_route_info(route_topic.clone())
             .await?
-            .ok_or_else(|| {
-                rocketmq_error::RocketMQError::Internal(format!("Topic route not found for: {}", route_topic))
-            })?;
+            .ok_or_else(|| admin_route_not_found(&route_topic))?;
 
         let mut message_list: Vec<MessageExt> = Vec::new();
         let mut index_last_update_timestamp: u64 = 0;
@@ -3909,6 +3907,10 @@ fn retain_java_user_topic_config(
     });
 }
 
+fn admin_route_not_found(route_topic: &CheetahString) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::route_not_found(route_topic.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -3949,6 +3951,7 @@ mod tests {
     use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
     use rocketmq_rust::ArcMut;
 
+    use super::admin_route_not_found;
     use super::broker_addrs_for_cluster;
     use super::broker_operator_result;
     use super::choose_min_broker_notify_addrs;
@@ -3982,7 +3985,16 @@ mod tests {
     use super::update_group_forbidden_request_header;
     use super::validate_acl_file_path_for_global_white_addr_config;
     use super::DefaultMQAdminExtImpl;
+    use rocketmq_error::ErrorKind;
     use rocketmq_error::RocketMQError;
+
+    #[test]
+    fn admin_route_not_found_uses_route_error_kind() {
+        let error = admin_route_not_found(&CheetahString::from_static_str("RouteTopic"));
+
+        assert_eq!(error.kind(), ErrorKind::RouteNotFound);
+        assert!(error.to_string().contains("RouteTopic"));
+    }
 
     fn new_unstarted_admin() -> DefaultMQAdminExtImpl {
         DefaultMQAdminExtImpl::new(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8007

### Brief Description

This PR maps missing admin query-by-key topic route data to `RocketMQError::route_not_found` instead of `Internal`.

The helper keeps the queried route topic in the typed route error context.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust admin_route_not_found_uses_route_error_kind`
- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a message query cannot find a topic route, returning a clearer, typed route-not-found error instead of a generic internal error.
  * Error messages now include the relevant topic information for easier troubleshooting.

* **Tests**
  * Added coverage to verify the new route-not-found error behavior and message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->