### PR TITLE
[ISSUE #8021]♻️Type NameServer task group errors

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -341,7 +341,7 @@ impl NameServerBootstrap {
             .inner
             .task_group()
             .map(|task_group| task_group.child("namesrv.shutdown-relay"))
-            .ok_or_else(|| RocketMQError::Internal("NameServer task group is unavailable".to_string()))?;
+            .ok_or_else(|| namesrv_task_group_unavailable("spawn shutdown relay"))?;
         relay_group
             .spawn_service(
                 "namesrv.shutdown-relay",
@@ -376,6 +376,12 @@ where
 fn namesrv_startup_failed(operation: &'static str, error: impl std::fmt::Display) -> RocketMQError {
     RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
         "NameServer {operation}: {error}"
+    )))
+}
+
+fn namesrv_task_group_unavailable(operation: &'static str) -> RocketMQError {
+    RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+        "NameServer {operation}: task group is unavailable"
     )))
 }
 
@@ -558,7 +564,7 @@ impl NameServerRuntime {
             .inner
             .task_group()
             .map(|task_group| task_group.child("namesrv.scheduled"))
-            .ok_or_else(|| RocketMQError::Internal("NameServer task group is unavailable".to_string()))?;
+            .ok_or_else(|| namesrv_task_group_unavailable("start scheduled tasks"))?;
         let scheduled_tasks = ScheduledTaskGroup::new(task_group);
         let mut config = ScheduledTaskConfig::fixed_rate_no_overlap(
             "namesrv.scan-not-active-broker",
@@ -642,7 +648,7 @@ impl NameServerRuntime {
             .inner
             .task_group()
             .map(|task_group| task_group.child("namesrv.server"))
-            .ok_or_else(|| RocketMQError::Internal("NameServer task group is unavailable".to_string()))?;
+            .ok_or_else(|| namesrv_task_group_unavailable("spawn server task"))?;
         let (server_report_tx, server_report_rx) = oneshot::channel();
         server_task_group
             .spawn_service("namesrv.server", async move {
@@ -1708,6 +1714,14 @@ mod tests {
 
         assert_eq!(error.kind(), ErrorKind::Service);
         assert!(error.to_string().contains("NameServer spawn test service"));
+    }
+
+    #[test]
+    fn namesrv_task_group_unavailable_uses_service_error_kind() {
+        let error = namesrv_task_group_unavailable("spawn test service");
+
+        assert_eq!(error.kind(), ErrorKind::Service);
+        assert!(error.to_string().contains("task group is unavailable"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8021

### Brief Description

This PR maps unavailable NameServer task groups to service startup failures instead of `Internal`.

The change uses a shared helper for shutdown relay, scheduled task, and server task group lookups and adds a unit test for the new classification.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-namesrv service_error_kind`
- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NameServer startup error handling when a required task group is unavailable.
  * Startup failures now return a clearer service-level error with a more specific message, making it easier to understand why initialization failed.
  * Added test coverage for the new error response and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->