### PR TITLE
[ISSUE #8027]♻️Type broker processor boundary errors

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -138,14 +138,14 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         }
 
         let max_item =
-            TopicQueueMappingUtils::find_logic_queue_mapping_item(&mapping_context.mapping_item_list, 0, true).ok_or(
-                rocketmq_error::RocketMQError::Internal(
-                    "Cannot find logic queue mapping item in static topic min offset request handling".to_string(),
-                ),
-            )?;
-        request_header.set_broker_name(max_item.bname.clone().ok_or(rocketmq_error::RocketMQError::Internal(
-            "Broker name is None in logic queue mapping item in static topic min offset request handling".to_string(),
-        ))?);
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&mapping_context.mapping_item_list, 0, true)
+                .ok_or_else(|| static_topic_offset_mapping_missing("static topic min offset request handling"))?;
+        request_header.set_broker_name(
+            max_item
+                .bname
+                .clone()
+                .ok_or_else(|| static_topic_offset_broker_name_missing("static topic min offset request handling"))?,
+        );
         request_header.set_lo(Some(false));
         request_header.queue_id = max_item.queue_id;
         let max_physical_offset = if max_item.bname == mapping_detail.topic_queue_mapping_info.bname {
@@ -206,12 +206,13 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
 
         let max_item =
             TopicQueueMappingUtils::find_logic_queue_mapping_item(&mapping_context.mapping_item_list, i64::MAX, true)
-                .ok_or(rocketmq_error::RocketMQError::Internal(
-                "Cannot find logic queue mapping item in static topic max offset request handling".to_string(),
-            ))?;
-        request_header.set_broker_name(max_item.bname.clone().ok_or(rocketmq_error::RocketMQError::Internal(
-            "Broker name is None in logic queue mapping item in static topic max offset request handling".to_string(),
-        ))?);
+                .ok_or_else(|| static_topic_offset_mapping_missing("static topic max offset request handling"))?;
+        request_header.set_broker_name(
+            max_item
+                .bname
+                .clone()
+                .ok_or_else(|| static_topic_offset_broker_name_missing("static topic max offset request handling"))?,
+        );
         request_header.set_lo(Some(false));
         request_header.queue_id = max_item.queue_id;
         let max_physical_offset = if max_item.bname == mapping_detail.topic_queue_mapping_info.bname {
@@ -415,9 +416,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
             mapping_item
                 .bname
                 .clone()
-                .ok_or(rocketmq_error::RocketMQError::Internal(
-                    "Broker name is None in logic queue mapping item in earliest msg storetime handling".to_string(),
-                ))?,
+                .ok_or_else(|| static_topic_offset_broker_name_missing("earliest msg storetime handling"))?,
         );
         request_header.set_lo(Some(false));
         request_header.queue_id = mapping_item.queue_id;
@@ -458,6 +457,19 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
             GetEarliestMsgStoretimeResponseHeader { timestamp },
         )))
     }
+}
+
+fn static_topic_offset_mapping_missing(operation: &'static str) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::RouteInconsistent {
+        topic: "static_topic_offset".to_string(),
+        reason: format!("Cannot find logic queue mapping item in {operation}"),
+    }
+}
+
+fn static_topic_offset_broker_name_missing(operation: &'static str) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::request_header_error(format!(
+        "Broker name is missing in logic queue mapping item for {operation}"
+    ))
 }
 
 #[cfg(test)]
@@ -522,6 +534,20 @@ mod tests {
         let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
         let inner = ArcMut::new(ChannelInner::new(connection, response_table));
         Channel::new(inner, local_addr, local_addr)
+    }
+
+    #[test]
+    fn static_topic_offset_mapping_missing_uses_route_inconsistent_kind() {
+        let error = static_topic_offset_mapping_missing("test operation");
+
+        assert_eq!(error.kind(), rocketmq_error::ErrorKind::RouteInconsistent);
+    }
+
+    #[test]
+    fn static_topic_offset_broker_name_missing_uses_request_header_kind() {
+        let error = static_topic_offset_broker_name_missing("test operation");
+
+        assert_eq!(error.kind(), rocketmq_error::ErrorKind::RequestHeaderError);
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -361,7 +361,7 @@ where
                 {
                     let response_header = response
                         .read_custom_header_mut::<RecallMessageResponseHeader>()
-                        .ok_or_else(|| RocketMQError::Internal("Response header missing".to_string()))?;
+                        .ok_or_else(recall_response_header_missing)?;
 
                     response_header.set_msg_id(message_id.as_str());
                 }
@@ -374,7 +374,7 @@ where
                 {
                     let response_header = response
                         .read_custom_header_mut::<RecallMessageResponseHeader>()
-                        .ok_or_else(|| RocketMQError::Internal("Response header missing".to_string()))?;
+                        .ok_or_else(recall_response_header_missing)?;
 
                     response_header.set_msg_id(message_id.as_str());
                 }
@@ -391,6 +391,10 @@ where
     }
 }
 
+fn recall_response_header_missing() -> RocketMQError {
+    RocketMQError::response_process_failed("RECALL_MESSAGE", "response header is missing")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -398,5 +402,12 @@ mod tests {
     #[test]
     fn test_recall_message_tag_constant() {
         assert_eq!(RECALL_MESSAGE_TAG, "_RECALL_TAG_");
+    }
+
+    #[test]
+    fn recall_response_header_missing_uses_response_process_failed_kind() {
+        let error = recall_response_header_missing();
+
+        assert_eq!(error.kind(), rocketmq_error::ErrorKind::ResponseProcessFailed);
     }
 }

--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -98,11 +98,10 @@ impl ProxyBrokerFacade {
         mut request: rocketmq_remoting::protocol::remoting_command::RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<rocketmq_remoting::protocol::remoting_command::RemotingCommand> {
         request.make_custom_header_to_net();
-        let mut processor = self.runtime.proxy_request_processor().ok_or_else(|| {
-            rocketmq_error::RocketMQError::Internal(
-                "embedded broker request processor is not ready; call start() first".to_owned(),
-            )
-        })?;
+        let mut processor = self
+            .runtime
+            .proxy_request_processor()
+            .ok_or_else(embedded_broker_request_processor_not_ready)?;
 
         let opaque = request.opaque();
         let mut harness = LocalRequestHarness::new().await?;
@@ -133,6 +132,10 @@ impl ProxyBrokerFacade {
     }
 }
 
+fn embedded_broker_request_processor_not_ready() -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::not_initialized("embedded_broker_request_processor")
+}
+
 fn build_topic_route(broker_config: &BrokerConfig, topic_config: &TopicConfig) -> TopicRouteData {
     let broker_name = broker_config.broker_identity.broker_name.clone();
     let broker_addr = CheetahString::from(format!(
@@ -157,5 +160,19 @@ fn build_topic_route(broker_config: &BrokerConfig, topic_config: &TopicConfig) -
             None,
         )],
         ..TopicRouteData::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn embedded_broker_request_processor_not_ready_uses_not_initialized_kind() {
+        let error = embedded_broker_request_processor_not_ready();
+
+        assert_eq!(error.kind(), ErrorKind::NotInitialized);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8027

### Brief Description

This PR maps related broker processor boundary failures to typed errors instead of `Internal`.

It covers recall response header construction, static topic offset request rewrite failures, and embedded proxy processor readiness.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-broker uses_`
- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
