### PR TITLE
[ISSUE #8029]♻️Type TieredStore domain helper errors

### DIFF
--- a/rocketmq-tieredstore/src/error.rs
+++ b/rocketmq-tieredstore/src/error.rs
@@ -42,6 +42,21 @@ pub fn storage_write_failed(path: impl Into<String>, reason: impl Into<String>) 
 }
 
 #[inline]
+pub fn storage_corrupted(path: impl Into<String>) -> RocketMQError {
+    RocketMQError::StorageCorrupted { path: path.into() }
+}
+
+#[inline]
+pub fn storage_out_of_space(path: impl Into<String>) -> RocketMQError {
+    RocketMQError::StorageOutOfSpace { path: path.into() }
+}
+
+#[inline]
+pub fn invalid_segment_type(message: impl Into<String>) -> RocketMQError {
+    illegal_argument(message)
+}
+
+#[inline]
 pub fn internal(message: impl Into<String>) -> RocketMQError {
     RocketMQError::Internal(message.into())
 }
@@ -53,10 +68,39 @@ pub fn from_kind(kind: TieredStoreErrorKind, path: impl Into<String>, message: i
         TieredStoreErrorKind::IllegalOffset => illegal_argument(message),
         TieredStoreErrorKind::ProviderReadFailed => storage_read_failed(path, message),
         TieredStoreErrorKind::ProviderWriteFailed => storage_write_failed(path, message),
-        TieredStoreErrorKind::SegmentFull
-        | TieredStoreErrorKind::SegmentClosed
-        | TieredStoreErrorKind::SegmentDeleted
-        | TieredStoreErrorKind::MetadataCorrupted
-        | TieredStoreErrorKind::Internal => internal(message),
+        TieredStoreErrorKind::SegmentFull => storage_out_of_space(path),
+        TieredStoreErrorKind::SegmentClosed | TieredStoreErrorKind::SegmentDeleted => {
+            storage_read_failed(path, message)
+        }
+        TieredStoreErrorKind::MetadataCorrupted => storage_corrupted(path),
+        TieredStoreErrorKind::Internal => internal(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn from_kind_maps_segment_full_to_storage_out_of_space() {
+        let error = from_kind(TieredStoreErrorKind::SegmentFull, "tiered-segment", "full");
+
+        assert_eq!(error.kind(), ErrorKind::StorageOutOfSpace);
+    }
+
+    #[test]
+    fn from_kind_maps_metadata_corrupted_to_storage_corrupted() {
+        let error = from_kind(TieredStoreErrorKind::MetadataCorrupted, "tiered-metadata", "bad json");
+
+        assert_eq!(error.kind(), ErrorKind::StorageCorrupted);
+    }
+
+    #[test]
+    fn invalid_segment_type_uses_illegal_argument() {
+        let error = invalid_segment_type("index segment is not supported");
+
+        assert_eq!(error.kind(), ErrorKind::IllegalArgument);
     }
 }

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -422,7 +422,11 @@ where
         let existing = match segment_type {
             FileSegmentType::CommitLog => self.commit_log_segments.lock().last().cloned(),
             FileSegmentType::ConsumeQueue => self.consume_queue_segments.lock().last().cloned(),
-            FileSegmentType::Index => return Err(error::internal("index segment is managed by tiered index service")),
+            FileSegmentType::Index => {
+                return Err(error::invalid_segment_type(
+                    "index segment is managed by tiered index service",
+                ));
+            }
         };
         if let Some(segment) = existing {
             if segment.can_hold(absolute_offset, append_len) {
@@ -480,7 +484,9 @@ where
         match segment_type {
             FileSegmentType::CommitLog => Ok(self.config.commit_log_segment_size),
             FileSegmentType::ConsumeQueue => Ok(self.config.consume_queue_segment_size),
-            FileSegmentType::Index => Err(error::internal("index segment is managed by tiered index service")),
+            FileSegmentType::Index => Err(error::invalid_segment_type(
+                "index segment is managed by tiered index service",
+            )),
         }
     }
 

--- a/rocketmq-tieredstore/src/file/index_file_segment.rs
+++ b/rocketmq-tieredstore/src/file/index_file_segment.rs
@@ -155,7 +155,7 @@ where
 
         for _ in 0..2 {
             let Some(timestamp) = segment_timestamps.last().copied() else {
-                return Err(error::internal("tiered index manifest is unexpectedly empty"));
+                return Err(error::storage_corrupted(self.manifest_path()));
             };
             let path = self.segment_path(timestamp);
             match self.try_append_to_segment(&path, timestamp, entry).await? {
@@ -168,7 +168,10 @@ where
             }
         }
 
-        Err(error::internal("failed to append tiered index entry after rolling"))
+        Err(error::storage_write_failed(
+            self.directory.clone(),
+            "failed to append tiered index entry after rolling",
+        ))
     }
 
     pub async fn load_entries(&self) -> Result<Vec<TieredIndexEntry>, RocketMQError> {

--- a/rocketmq-tieredstore/src/metadata/metadata_store.rs
+++ b/rocketmq-tieredstore/src/metadata/metadata_store.rs
@@ -116,8 +116,8 @@ impl TieredMetadataStore for JsonMetadataStore {
             let data = fs::read(&self.path)
                 .await
                 .map_err(|err| error::storage_read_failed(path_to_string(&self.path), err.to_string()))?;
-            let state =
-                serde_json::from_slice::<MetadataState>(&data).map_err(|err| error::internal(err.to_string()))?;
+            let state = serde_json::from_slice::<MetadataState>(&data)
+                .map_err(|_| error::storage_corrupted(path_to_string(&self.path)))?;
             *self.state.write() = state;
         }
 
@@ -139,7 +139,8 @@ impl TieredMetadataStore for JsonMetadataStore {
         #[cfg(feature = "serde")]
         {
             let snapshot = self.state.read().clone();
-            let data = serde_json::to_vec_pretty(&snapshot).map_err(|err| error::internal(err.to_string()))?;
+            let data = serde_json::to_vec_pretty(&snapshot)
+                .map_err(|err| error::storage_write_failed(path_to_string(&self.path), err.to_string()))?;
             let tmp_path = self.path.with_extension("json.tmp");
             fs::write(&tmp_path, data)
                 .await


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8029

### Brief Description

This PR maps TieredStore domain helper failures to typed storage and argument errors instead of generic internal errors.

It covers segment capacity, metadata corruption and persistence, tiered index append failures, and invalid flat-file index segment usage.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-tieredstore`
- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage error reporting for tiered storage and metadata operations, with clearer messages for corrupted data, out-of-space conditions, and write failures.
  * Index segments are now consistently treated as invalid in write and size checks, reducing unexpected internal errors.
  * Failed metadata loads and index append retries now surface more accurate storage-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->