### PR TITLE
[ISSUE #8033]♻️Type authorization provider errors

### DIFF
--- a/rocketmq-auth/src/authorization/provider.rs
+++ b/rocketmq-auth/src/authorization/provider.rs
@@ -78,9 +78,9 @@ pub enum AuthorizationError {
     #[error("Authorization provider not initialized: {0}")]
     NotInitialized(String),
 
-    /// Internal error during authorization processing.
-    #[error("Internal authorization error: {0}")]
-    InternalError(String),
+    /// Authorization provider runtime failed while processing a request.
+    #[error("Authorization provider runtime failed: {0}")]
+    ProviderRuntimeFailed(String),
 
     /// Authorization metadata read failed.
     #[error("Authorization metadata read failed for '{path}': {reason}")]
@@ -120,10 +120,9 @@ impl From<AuthorizationError> for RocketMQError {
             AuthorizationError::ConfigurationError(_) | AuthorizationError::NotInitialized(_) => {
                 RocketMQError::auth_config_invalid("auth.authorization", message)
             }
-            AuthorizationError::PolicyEvaluationFailed(_) => {
+            AuthorizationError::PolicyEvaluationFailed(_) | AuthorizationError::ProviderRuntimeFailed(_) => {
                 RocketMQError::Authentication(AuthError::AuthorizationFailed(message))
             }
-            AuthorizationError::InternalError(_) => RocketMQError::Authentication(AuthError::Other(message)),
             AuthorizationError::StorageReadFailed { path, reason } => RocketMQError::storage_read_failed(path, reason),
             AuthorizationError::StorageWriteFailed { path, reason } => {
                 RocketMQError::storage_write_failed(path, reason)
@@ -662,7 +661,7 @@ mod tests {
             AuthorizationError::PolicyEvaluationFailed("invalid policy".to_string()),
             AuthorizationError::ConfigurationError("missing config".to_string()),
             AuthorizationError::NotInitialized("provider not ready".to_string()),
-            AuthorizationError::InternalError("unexpected error".to_string()),
+            AuthorizationError::ProviderRuntimeFailed("unexpected error".to_string()),
             AuthorizationError::StorageReadFailed {
                 path: "acls.json".to_string(),
                 reason: "read failed".to_string(),
@@ -711,8 +710,13 @@ mod tests {
             }
         ));
 
-        let internal = RocketMQError::from(AuthorizationError::InternalError("unexpected error".to_string()));
-        assert!(matches!(internal, RocketMQError::Authentication(AuthError::Other(_))));
+        let provider_runtime = RocketMQError::from(AuthorizationError::ProviderRuntimeFailed(
+            "unexpected error".to_string(),
+        ));
+        assert!(matches!(
+            provider_runtime,
+            RocketMQError::Authentication(AuthError::AuthorizationFailed(_))
+        ));
 
         let storage = RocketMQError::from(AuthorizationError::StorageWriteFailed {
             path: "acls.json".to_string(),

--- a/rocketmq-auth/src/authorization/strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy.rs
@@ -41,6 +41,6 @@ pub(super) fn block_on_base_authorization(
     block_on_sync_bridge(
         || base.do_evaluate(context),
         |error| AuthorizationError::ConfigurationError(format!("failed to create authorization runtime: {error}")),
-        || AuthorizationError::InternalError("authorization provider thread panicked".to_string()),
+        || AuthorizationError::ProviderRuntimeFailed("authorization provider thread panicked".to_string()),
     )
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8033

### Brief Description

This PR removes the generic authorization internal error path from the auth provider layer:

- Replaces `AuthorizationError::InternalError(String)` with `AuthorizationError::ProviderRuntimeFailed(String)`.
- Maps provider runtime failures to `AuthError::AuthorizationFailed` instead of `AuthError::Other`.
- Keeps existing typed conversions for permission denied, configuration, storage, and serialization errors.
- Updates authorization error mapping tests to assert the new category.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-auth test_authorization_error_rocketmq_mapping_categories` passed.
- `cargo test -p rocketmq-auth test_authorization_error_variants` passed.
- `cargo test -p rocketmq-auth` passed.
- `rg -n "AuthorizationError::InternalError|InternalError\\(String\\)|AuthError::Other\\(message\\)" rocketmq-auth/src` returned no matches.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization runtime failures now return a clearer, more specific error category instead of being reported as a generic internal error.
  * Panic-related authorization failures are mapped consistently to authorization failure responses.
  * Updated error handling behavior improves the accuracy of reported authorization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->