### PR TITLE
[ISSUE #8035]♻️Type client runtime invariant errors

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -159,6 +159,13 @@ const SOCKS_PROXY_JSON: &str = "socksProxyJson";
 const NAMESPACE_ORDER_TOPIC_CONFIG: &str = "ORDER_TOPIC_CONFIG";
 const ROCKSDB_CONFIG_TYPE_CONSUMER_OFFSETS: &str = "consumerOffsets";
 
+fn sync_pull_result_missing(operation: &'static str) -> RocketMQError {
+    RocketMQError::ClientInvalidState {
+        expected: "PullResultExt returned by sync pull_message",
+        actual: format!("{operation} returned None"),
+    }
+}
+
 fn encode_topic_attributes(attributes: &HashMap<CheetahString, CheetahString>) -> Option<CheetahString> {
     if attributes.is_empty() {
         return None;
@@ -756,7 +763,7 @@ impl DefaultMQAdminExtImpl {
             NoopPullCallback,
         )
         .await?
-        .ok_or_else(|| rocketmq_error::RocketMQError::Internal("pull_message returned None in sync mode".into()))?;
+        .ok_or_else(|| sync_pull_result_missing("DefaultMQAdminExtImpl::pull_message_from_queue"))?;
 
         if result.pull_result.pull_status == PullStatus::Found {
             if let Some(mut message_binary) = result.message_binary.take() {
@@ -3978,6 +3985,7 @@ mod tests {
     use super::retain_java_user_topic_config;
     use super::search_offset_timestamp_to_java_long;
     use super::select_consumer_direct_connection;
+    use super::sync_pull_result_missing;
     use super::timeout_millis_to_u64;
     use super::timestamp_to_java_long;
     use super::topic_list_from_lite_topic_names;
@@ -3994,6 +4002,16 @@ mod tests {
 
         assert_eq!(error.kind(), ErrorKind::RouteNotFound);
         assert!(error.to_string().contains("RouteTopic"));
+    }
+
+    #[test]
+    fn sync_pull_result_missing_uses_client_invalid_state() {
+        let error = sync_pull_result_missing("DefaultMQAdminExtImpl::pull_message_from_queue");
+
+        assert_eq!(error.kind(), ErrorKind::ClientInvalidState);
+        assert!(error
+            .to_string()
+            .contains("DefaultMQAdminExtImpl::pull_message_from_queue returned None"));
     }
 
     fn new_unstarted_admin() -> DefaultMQAdminExtImpl {

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -36,6 +36,8 @@ use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssi
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::UnifiedServiceError;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -96,6 +98,19 @@ use crate::stat::consumer_stats_manager::ConsumerStatsManager;
 const LOCK_TIMEOUT_MILLIS: u64 = 3000;
 const SCHEDULED_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const ROUTE_REFRESH_MAX_TOPICS_PER_ROUND: usize = 64;
+
+fn client_scheduled_task_startup_failed(task: &'static str, error: impl std::fmt::Display) -> RocketMQError {
+    RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+        "MQClientInstance scheduled task {task}: {error}"
+    )))
+}
+
+fn sync_pull_result_missing(operation: &'static str) -> RocketMQError {
+    RocketMQError::ClientInvalidState {
+        expected: "PullResultExt returned by sync pull_message",
+        actual: format!("{operation} returned None"),
+    }
+}
 
 fn get_topic_config_request_header(topic: CheetahString) -> GetTopicConfigRequestHeader {
     let mut request_header = GetTopicConfigRequestHeader {
@@ -705,11 +720,7 @@ impl MQClientInstance {
                         api.fetch_name_server_addr().await;
                         Ok(())
                     })
-                    .map_err(|error| {
-                        rocketmq_error::RocketMQError::Internal(format!(
-                            "failed to start fetchNameServerAddr scheduled task: {error}"
-                        ))
-                    })?;
+                    .map_err(|error| client_scheduled_task_startup_failed("fetchNameServerAddr", error))?;
             } else {
                 warn!(
                     "ScheduledTask: fetchNameServerAddr skipped because mq_client_api_impl is None. [{}]",
@@ -731,11 +742,7 @@ impl MQClientInstance {
                     Ok(())
                 },
             )
-            .map_err(|error| {
-                rocketmq_error::RocketMQError::Internal(format!(
-                    "failed to start update_topic_route_info_from_name_server scheduled task: {error}"
-                ))
-            })?;
+            .map_err(|error| client_scheduled_task_startup_failed("update_topic_route_info_from_name_server", error))?;
 
         let client_instance = this.clone();
         let heartbeat_broker_interval = self.client_config.heartbeat_broker_interval;
@@ -751,11 +758,7 @@ impl MQClientInstance {
                     Ok(())
                 },
             )
-            .map_err(|error| {
-                rocketmq_error::RocketMQError::Internal(format!(
-                    "failed to start clean_offline_broker_and_send_heartbeat scheduled task: {error}"
-                ))
-            })?;
+            .map_err(|error| client_scheduled_task_startup_failed("clean_offline_broker_and_send_heartbeat", error))?;
 
         let client_instance = this;
         let persist_consumer_offset_interval = self.client_config.persist_consumer_offset_interval as u64;
@@ -770,11 +773,7 @@ impl MQClientInstance {
                     Ok(())
                 },
             )
-            .map_err(|error| {
-                rocketmq_error::RocketMQError::Internal(format!(
-                    "failed to start persistAllConsumerOffset scheduled task: {error}"
-                ))
-            })?;
+            .map_err(|error| client_scheduled_task_startup_failed("persistAllConsumerOffset", error))?;
 
         info!(
             "All scheduled tasks started, total tasks: {}",
@@ -1308,7 +1307,7 @@ impl MQClientInstance {
             NoopPullCallback,
         )
         .await?
-        .ok_or_else(|| rocketmq_error::RocketMQError::Internal("pull_message returned None in sync mode".into()))?;
+        .ok_or_else(|| sync_pull_result_missing("MQClientInstance::pull_message"))?;
 
         if result.pull_result.pull_status == PullStatus::Found {
             if let Some(mut message_binary) = result.message_binary.take() {
@@ -2659,6 +2658,7 @@ pub fn run_heartbeat_route_index_probe(
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_error::ErrorKind;
     use rocketmq_error::RocketMQError;
     use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
@@ -2670,6 +2670,24 @@ mod tests {
     use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
     use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
     use crate::producer::producer_impl::mq_producer_inner::MQProducerInner;
+
+    #[test]
+    fn client_scheduled_task_startup_failed_uses_service_error_kind() {
+        let error = client_scheduled_task_startup_failed("fetchNameServerAddr", "scheduler closed");
+
+        assert_eq!(error.kind(), ErrorKind::Service);
+        assert!(error.to_string().contains("fetchNameServerAddr"));
+    }
+
+    #[test]
+    fn sync_pull_result_missing_uses_client_invalid_state() {
+        let error = sync_pull_result_missing("MQClientInstance::pull_message");
+
+        assert_eq!(error.kind(), ErrorKind::ClientInvalidState);
+        assert!(error
+            .to_string()
+            .contains("MQClientInstance::pull_message returned None"));
+    }
 
     #[tokio::test]
     async fn get_mq_client_api_impl_returns_client_not_started_instead_of_panicking() {

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -3553,10 +3553,7 @@ impl MQClientAPIImpl {
                 let response_header = response
                     .decode_command_custom_header::<QueryMessageResponseHeader>()
                     .map_err(|e| {
-                        rocketmq_error::RocketMQError::Internal(format!(
-                            "decode QueryMessageResponseHeader failed: {}",
-                            e
-                        ))
+                        RocketMQError::response_process_failed("decode QueryMessageResponseHeader", e.to_string())
                     })?;
                 let body = response.body().cloned();
                 Ok(Some((response_header, body)))

--- a/rocketmq-client/src/producer/producer_impl/timeout_utils.rs
+++ b/rocketmq-client/src/producer/producer_impl/timeout_utils.rs
@@ -257,16 +257,20 @@ mod tests {
     #[tokio::test]
     async fn test_with_timeout_propagates_error() {
         async fn failing_operation() -> RocketMQResult<String> {
-            Err(RocketMQError::Internal("Test error".to_string()))
+            Err(RocketMQError::ClientInvalidState {
+                expected: "ready test operation",
+                actual: "failed test operation".to_string(),
+            })
         }
 
         let result = with_timeout(Duration::from_millis(100), failing_operation()).await;
         assert!(result.is_err());
         match result.unwrap_err() {
-            RocketMQError::Internal(msg) => {
-                assert_eq!(msg, "Test error");
+            RocketMQError::ClientInvalidState { expected, actual } => {
+                assert_eq!(expected, "ready test operation");
+                assert_eq!(actual, "failed test operation");
             }
-            _ => panic!("Expected internal error"),
+            _ => panic!("Expected client invalid state error"),
         }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8035

### Brief Description

This PR replaces client-side generic internal errors with typed classifications:

- Maps `MQClientInstance` scheduled task registration failures to service startup errors.
- Maps sync-mode missing pull results to `ClientInvalidState` in both client and admin pull paths.
- Maps `QueryMessageResponseHeader` decode failures to `ResponseProcessFailed`.
- Updates timeout utility tests to assert typed error propagation instead of `Internal`.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-client-rust client_scheduled_task_startup_failed_uses_service_error_kind` passed.
- `cargo test -p rocketmq-client-rust sync_pull_result_missing_uses_client_invalid_state` passed.
- `cargo test -p rocketmq-client-rust test_with_timeout_propagates_error` passed.
- `rg -n "RocketMQError::Internal|rocketmq_error::RocketMQError::Internal" rocketmq-client/src/factory/mq_client_instance.rs rocketmq-client/src/implementation/mq_client_api_impl.rs rocketmq-client/src/admin/default_mq_admin_ext_impl.rs rocketmq-client/src/producer/producer_impl/timeout_utils.rs` returned no matches.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for message pulling and message queries, making failures report clearer, more specific status information.
  * Synchronous pull operations now surface a clearer “invalid state” error when no result is returned.
  * Query message decode failures now return a more precise response-processing error instead of a generic internal error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->