### PR TITLE
[ISSUE #8037]♻️Type controller manager runtime errors

### DIFF
--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -477,7 +477,7 @@ impl ControllerManager {
         let metadata = Arc::new(
             MetadataStore::new(config.clone())
                 .await
-                .map_err(|e| ControllerError::Internal(format!("Failed to create metadata store: {}", e)))?,
+                .map_err(|e| ControllerError::storage_source("create metadata store", e))?,
         );
 
         // Initialize processor manager (needs Arc<RaftController>)
@@ -557,7 +557,7 @@ impl ControllerManager {
             parent_task_group.child("rocketmq-controller.manager")
         } else {
             let handle = tokio::runtime::Handle::try_current().map_err(|error| {
-                ControllerError::Internal(format!("No Tokio runtime for controller tasks: {error}"))
+                ControllerError::runtime_error(format!("No Tokio runtime for controller tasks: {error}"))
             })?;
             TaskGroup::root("rocketmq-controller.manager", RuntimeHandle::new(handle))
         };
@@ -756,9 +756,8 @@ impl ControllerManager {
         // Start Raft controller first (critical for leader election)
         if let Err(e) = self.raft_controller.mut_from_ref().startup().await {
             self.running.store(false, Ordering::SeqCst);
-            return Err(ControllerError::Internal(format!(
-                "Failed to start Raft controller: {}",
-                e
+            return Err(ControllerError::runtime_error(format!(
+                "Failed to start Raft controller: {e}"
             )));
         }
         info!("Raft controller started");
@@ -772,19 +771,15 @@ impl ControllerManager {
         // Start metadata store
         if let Err(e) = self.metadata.start().await {
             self.running.store(false, Ordering::SeqCst);
-            return Err(ControllerError::Internal(format!(
-                "Failed to start metadata store: {}",
-                e
-            )));
+            return Err(ControllerError::storage_source("start metadata store", e));
         }
         info!("Metadata store started");
 
         // Start processor manager (for request handling)
         if let Err(e) = self.processor.start().await {
             self.running.store(false, Ordering::SeqCst);
-            return Err(ControllerError::Internal(format!(
-                "Failed to start processor manager: {}",
-                e
+            return Err(ControllerError::runtime_error(format!(
+                "Failed to start processor manager: {e}"
             )));
         }
         info!("Processor manager started");
@@ -819,7 +814,7 @@ impl ControllerManager {
                     _ => {}
                 }
             }) {
-                return Err(ControllerError::Internal(format!(
+                return Err(ControllerError::runtime_error(format!(
                     "Failed to spawn controller remoting server task: {error}"
                 )));
             }
@@ -1103,7 +1098,9 @@ impl ControllerManager {
                     }
                 }
             })
-            .map_err(|error| ControllerError::Internal(format!("Failed to schedule leadership watch task: {error}")))?;
+            .map_err(|error| {
+                ControllerError::runtime_error(format!("Failed to schedule leadership watch task: {error}"))
+            })?;
 
         *self.leadership_watch_tasks.lock() = Some(scheduled_tasks);
         Ok(())
@@ -1112,12 +1109,12 @@ impl ControllerManager {
     async fn apply_leadership_state(&self, is_leader: bool) -> Result<()> {
         if is_leader {
             self.raft_controller.start_scheduling().await.map_err(|error| {
-                ControllerError::Internal(format!("Failed to start controller scheduling: {}", error))
+                ControllerError::runtime_error(format!("Failed to start controller scheduling: {error}"))
             })?;
             info!("Leader-only scheduling enabled on controller {}", self.config.node_id);
         } else {
             self.raft_controller.stop_scheduling().await.map_err(|error| {
-                ControllerError::Internal(format!("Failed to stop controller scheduling: {}", error))
+                ControllerError::runtime_error(format!("Failed to stop controller scheduling: {error}"))
             })?;
             self.reset_notify_dispatch_state();
             info!(
@@ -1192,10 +1189,10 @@ impl ControllerManager {
             .notify_dispatch_tx
             .lock()
             .clone()
-            .ok_or_else(|| ControllerError::Internal("Notify worker is not initialized".to_string()))?;
+            .ok_or_else(|| ControllerError::NotInitialized("Notify worker is not initialized".to_string()))?;
         sender
             .send(task)
-            .map_err(|error| ControllerError::Internal(format!("Failed to enqueue notify task: {}", error)))
+            .map_err(|error| ControllerError::runtime_error(format!("Failed to enqueue notify task: {error}")))
     }
 
     fn notify_retry_delay(&self, attempt: u32) -> Duration {
@@ -1305,7 +1302,7 @@ impl ControllerManager {
                     manager.process_notify_task(task).await;
                 }
             })
-            .map_err(|error| ControllerError::Internal(format!("Failed to spawn notify worker task: {error}")))?;
+            .map_err(|error| ControllerError::runtime_error(format!("Failed to spawn notify worker task: {error}")))?;
         Ok(())
     }
 
@@ -1314,10 +1311,10 @@ impl ControllerManager {
         let response_header = response
             .decode_command_custom_header::<ElectMasterResponseHeader>()
             .map_err(|error| {
-                ControllerError::Internal(format!(
-                    "Failed to decode elect-master response header for broker role notify: {:?}",
-                    error
-                ))
+                ControllerError::serialization_source(
+                    "decode elect-master response header for broker role notify",
+                    error,
+                )
             })?;
 
         let Some(body) = response.body() else {
@@ -1325,10 +1322,7 @@ impl ControllerManager {
         };
 
         let response_body = ElectMasterResponseBody::decode(body).map_err(|error| {
-            ControllerError::Internal(format!(
-                "Failed to decode elect-master response body for broker role notify: {}",
-                error
-            ))
+            ControllerError::serialization_source("decode elect-master response body for broker role notify", error)
         })?;
 
         let Some(member_group) = response_body.broker_member_group else {
@@ -1349,10 +1343,7 @@ impl ControllerManager {
         let sync_state_set = SyncStateSet::with_values(response_body.sync_state_set, sync_state_set_epoch)
             .encode()
             .map_err(|error| {
-                ControllerError::Internal(format!(
-                    "Failed to encode sync state set for broker role notify: {}",
-                    error
-                ))
+                ControllerError::serialization_source("encode sync state set for broker role notify", error)
             })?;
 
         for (broker_id, broker_addr) in member_group.broker_addrs {

--- a/rocketmq-controller/src/metadata/broker.rs
+++ b/rocketmq-controller/src/metadata/broker.rs
@@ -128,7 +128,7 @@ impl BrokerManager {
             parent_task_group.child("rocketmq-controller.metadata.broker")
         } else {
             let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
-                ControllerError::Internal(format!(
+                ControllerError::runtime_error(format!(
                     "No Tokio runtime for broker manager heartbeat checker: {error}"
                 ))
             })?;
@@ -148,7 +148,9 @@ impl BrokerManager {
                     }
                 },
             )
-            .map_err(|error| ControllerError::Internal(format!("Failed to spawn broker heartbeat checker: {error}")))?;
+            .map_err(|error| {
+                ControllerError::runtime_error(format!("Failed to spawn broker heartbeat checker: {error}"))
+            })?;
         *self.scheduled_tasks.lock() = Some(scheduled_tasks);
         *self.task_group.lock() = Some(task_group);
 

--- a/rocketmq-controller/src/rpc/server.rs
+++ b/rocketmq-controller/src/rpc/server.rs
@@ -124,7 +124,7 @@ impl RpcServer {
             parent_task_group.child("rocketmq-controller.rpc-server")
         } else {
             let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
-                ControllerError::Internal(format!("No Tokio runtime for RPC server tasks: {error}"))
+                ControllerError::runtime_error(format!("No Tokio runtime for RPC server tasks: {error}"))
             })?;
             TaskGroup::root("rocketmq-controller.rpc-server", RuntimeHandle::new(runtime))
         };
@@ -177,7 +177,7 @@ impl RpcServer {
                     }
                 }
             })
-            .map_err(|error| ControllerError::Internal(format!("Failed to spawn RPC accept loop: {error}")))?;
+            .map_err(|error| ControllerError::runtime_error(format!("Failed to spawn RPC accept loop: {error}")))?;
         *self.task_group.lock() = Some(task_group);
 
         Ok(())

--- a/rocketmq-error/src/controller_error.rs
+++ b/rocketmq-error/src/controller_error.rs
@@ -115,6 +115,10 @@ pub enum ControllerError {
     #[error("Operation timeout after {timeout_ms}ms")]
     Timeout { timeout_ms: u64 },
 
+    /// Controller runtime or task lifecycle error.
+    #[error("Runtime error: {0}")]
+    RuntimeError(String),
+
     /// Internal error
     #[error("Internal error: {0}")]
     Internal(String),
@@ -155,6 +159,11 @@ impl ControllerError {
             message: message.into(),
             source: Box::new(source),
         }
+    }
+
+    #[inline]
+    pub fn runtime_error(message: impl Into<String>) -> Self {
+        Self::RuntimeError(message.into())
     }
 }
 
@@ -226,6 +235,9 @@ mod tests {
 
         let err = ControllerError::Timeout { timeout_ms: 5000 };
         assert_eq!(err.to_string(), "Operation timeout after 5000ms");
+
+        let err = ControllerError::runtime_error("task group closed");
+        assert_eq!(err.to_string(), "Runtime error: task group closed");
 
         let err = ControllerError::Internal("panic".to_string());
         assert_eq!(err.to_string(), "Internal error: panic");

--- a/rocketmq-error/tests/controller_integration_test.rs
+++ b/rocketmq-error/tests/controller_integration_test.rs
@@ -113,6 +113,7 @@ fn test_all_controller_error_variants_convert() {
         ControllerError::StorageError("storage error".to_string()),
         ControllerError::NetworkError("network error".to_string()),
         ControllerError::Timeout { timeout_ms: 1000 },
+        ControllerError::RuntimeError("runtime error".to_string()),
         ControllerError::Internal("internal".to_string()),
         ControllerError::Shutdown,
     ];


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8037

### Brief Description

This PR replaces controller manager generic internal errors with typed controller classifications:

- Adds `ControllerError::RuntimeError` for controller runtime and task lifecycle failures.
- Maps controller metadata store creation and startup failures to storage errors with source preservation.
- Maps broker role notification header/body decode and sync-state encode failures to serialization errors with source preservation.
- Replaces controller manager, RPC server, and broker metadata heartbeat checker `ControllerError::Internal` call sites with typed variants.
- Extends controller error tests for the new runtime variant.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-error controller_error` passed.
- `cargo test -p rocketmq-controller controller_manager` passed.
- `rg -n "ControllerError::Internal" rocketmq-controller/src/controller/controller_manager.rs rocketmq-controller/src/rpc/server.rs rocketmq-controller/src/metadata/broker.rs` returned no matches.
- `python scripts/error_architecture_guard.py` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for controller startup, scheduling, RPC, and notification flows.
  * Runtime/task launch failures now surface clearer, more specific messages instead of generic internal errors.
  * Serialization and metadata store issues are now reported with better context.

* **Tests**
  * Extended error conversion coverage to include the new runtime error case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->