### PR TITLE
[ISSUE #8039]♻️Type remoting boundary errors

### DIFF
--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -15,6 +15,7 @@
 pub use blocking_client::BlockingClient;
 use cheetah_string::CheetahString;
 pub use client::Client;
+use rocketmq_error::RocketMQError;
 
 use crate::base::response_future::ResponseFuture;
 use crate::protocol::remoting_command::RemotingCommand;
@@ -112,7 +113,7 @@ pub trait RemotingClient: RemotingService {
 
 impl<T> InvokeCallback for T
 where
-    T: Fn(Option<RemotingCommand>, Option<Box<dyn std::error::Error>>, Option<ResponseFuture>) + Send + Sync,
+    T: Fn(Option<RemotingCommand>, Option<RocketMQError>, Option<ResponseFuture>) + Send + Sync,
 {
     fn operation_complete(&self, response_future: ResponseFuture) {
         self(None, None, Some(response_future))
@@ -122,7 +123,7 @@ where
         self(Some(response), None, None)
     }
 
-    fn operation_fail(&self, throwable: Box<dyn std::error::Error>) {
+    fn operation_fail(&self, throwable: RocketMQError) {
         self(None, Some(throwable), None)
     }
 }

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -103,7 +103,7 @@ use crate::tls::TlsConfig;
 /// use rocketmq_remoting::clients::RocketmqDefaultClient;
 /// use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 ///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # async fn example() -> rocketmq_error::RocketMQResult<()> {
 /// let config = Arc::new(TokioClientConfig::default());
 /// let processor = Default::default();
 /// let client = RocketmqDefaultClient::new(config, processor);
@@ -1183,7 +1183,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
     /// ```rust,ignore
     /// # use rocketmq_remoting::clients::RocketmqDefaultClient;
     /// # use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-    /// # async fn example(client: &RocketmqDefaultClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(client: &RocketmqDefaultClient) -> rocketmq_error::RocketMQResult<()> {
     /// let request = RemotingCommand::create_request_command(/* ... */);
     /// let response = client.invoke_request(
     ///     Some(&"127.0.0.1:10911".into()),

--- a/rocketmq-remoting/src/error_helpers.rs
+++ b/rocketmq-remoting/src/error_helpers.rs
@@ -18,6 +18,7 @@
 //! for common remoting scenarios.
 
 use rocketmq_error::RocketMQError;
+use rocketmq_error::UnifiedServiceError;
 
 /// Create an I/O error from std::io::Error
 #[inline]
@@ -91,7 +92,11 @@ pub fn channel_recv_failed(msg: impl Into<String>) -> RocketMQError {
 /// Create an abort process error
 #[inline]
 pub fn abort_process_error(code: i32, msg: impl Into<String>) -> RocketMQError {
-    RocketMQError::Internal(format!("Abort process error {}: {}", code, msg.into()))
+    RocketMQError::Service(UnifiedServiceError::ShutdownFailed(format!(
+        "Abort process error {}: {}",
+        code,
+        msg.into()
+    )))
 }
 
 /// Create a remoting command encoder error
@@ -101,4 +106,22 @@ pub fn encoder_error(msg: impl Into<String>) -> RocketMQError {
         format: "command",
         message: msg.into(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::UnifiedServiceError;
+
+    use super::*;
+
+    #[test]
+    fn abort_process_error_uses_service_lifecycle_error() {
+        let error = abort_process_error(500, "shutdown requested");
+
+        assert!(matches!(
+            error,
+            RocketMQError::Service(UnifiedServiceError::ShutdownFailed(message))
+                if message.contains("Abort process error 500")
+        ));
+    }
 }

--- a/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
@@ -293,9 +293,9 @@ impl ConsumerRunningInfo {
     pub async fn analyze_subscription(
         cri_table: BTreeMap<String /* clientId */, ConsumerRunningInfo>,
     ) -> RocketMQResult<()> {
-        let first = cri_table.first_key_value().ok_or(RocketMQError::Internal(
-            "analyze_subscription err :cri_table is empty".to_string(),
-        ))?;
+        let first = cri_table.first_key_value().ok_or_else(|| {
+            RocketMQError::response_process_failed("analyze_subscription", "consumer running info table is empty")
+        })?;
         let prev = first.1;
 
         let push = matches!(prev.consume_type, ConsumeType::ConsumePassively);
@@ -307,8 +307,9 @@ impl ConsumerRunningInfo {
             for v in cri_table.values() {
                 if v.subscription_set != prev.subscription_set {
                     // Different subscription in the same group of consumer
-                    return Err(RocketMQError::Internal(
-                        "Different subscription in the same group of consumer".to_string(),
+                    return Err(RocketMQError::response_process_failed(
+                        "analyze_subscription",
+                        "different subscription in the same consumer group",
                     ));
                 }
 
@@ -360,6 +361,22 @@ impl ConsumerRunningInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn analyze_subscription_empty_table_uses_response_process_error() {
+        let error = ConsumerRunningInfo::analyze_subscription(BTreeMap::new())
+            .await
+            .expect_err("empty consumer running info should be rejected");
+
+        assert_eq!(error.kind(), rocketmq_error::ErrorKind::ResponseProcessFailed);
+        assert!(matches!(
+            error,
+            RocketMQError::ResponseProcessFailed {
+                operation: "analyze_subscription",
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn consumer_running_info_default() {

--- a/rocketmq-remoting/src/remoting.rs
+++ b/rocketmq-remoting/src/remoting.rs
@@ -65,7 +65,7 @@ pub trait RemotingService: Send {
 pub trait InvokeCallback {
     fn operation_complete(&self, response_future: ResponseFuture);
     fn operation_succeed(&self, response: RemotingCommand);
-    fn operation_fail(&self, throwable: Box<dyn std::error::Error>);
+    fn operation_fail(&self, throwable: rocketmq_error::RocketMQError);
 }
 
 #[allow(unused_variables)]
@@ -336,49 +336,21 @@ pub(crate) mod inner {
         exception: Option<RocketMQError>,
     ) -> HandleErrorResult {
         if let Some(exception_inner) = exception {
-            match exception_inner {
-                RocketMQError::Internal(message) if message.starts_with("Abort") => {
-                    let code = ResponseCode::SystemError;
-                    if oneway_rpc {
-                        return HandleErrorResult::ReturnMethod;
-                    }
-                    let response = RemotingCommand::create_response_command_with_code_remark(code, message);
-                    tokio::select! {
-                        result =ctx.connection_mut().send_command(response.set_opaque(opaque)) => match result{
-                            Ok(_) =>{},
-                            Err(err) => {
-                                match err {
-                                    RocketMQError::IO(io_error) => {
-                                        error!("send response failed: {}", io_error);
-                                        return HandleErrorResult::ReturnMethod;
-                                    }
-                                    _ => { error!("send response failed: {}", err);}
+            if !oneway_rpc {
+                let response = crate::error_response::command_from_error(&exception_inner);
+                tokio::select! {
+                    result =ctx.connection_mut().send_command(response.set_opaque(opaque)) => match result{
+                        Ok(_) =>{},
+                        Err(err) => {
+                            match err {
+                                RocketMQError::IO(io_error) => {
+                                    error!("send response failed: {}", io_error);
+                                    return HandleErrorResult::ReturnMethod;
                                 }
-                            },
+                                _ => { error!("send response failed: {}", err);}
+                            }
                         },
-                    }
-                }
-                _ => {
-                    if !oneway_rpc {
-                        let response = RemotingCommand::create_response_command_with_code_remark(
-                            ResponseCode::SystemError,
-                            exception_inner.to_string(),
-                        );
-                        tokio::select! {
-                            result =ctx.connection_mut().send_command(response.set_opaque(opaque)) => match result{
-                                Ok(_) =>{},
-                                Err(err) => {
-                                    match err {
-                                        RocketMQError::IO(io_error) => {
-                                            error!("send response failed: {}", io_error);
-                                            return HandleErrorResult::ReturnMethod;
-                                        }
-                                        _ => { error!("send response failed: {}", err);}
-                                    }
-                                },
-                            },
-                        }
-                    }
+                    },
                 }
             }
             HandleErrorResult::ReturnMethod

--- a/rocketmq-remoting/src/remoting_server.rs
+++ b/rocketmq-remoting/src/remoting_server.rs
@@ -41,16 +41,16 @@ pub trait RemotingServer: RemotingService {
         &mut self,
         request: RemotingCommand,
         timeout_millis: u64,
-    ) -> Result<RemotingCommand, Box<dyn std::error::Error>>;
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand>;
     fn invoke_async(
         &mut self,
         request: RemotingCommand,
         timeout_millis: u64,
         invoke_callback: Box<dyn InvokeCallback>,
-    ) -> Result<(), Box<dyn std::error::Error>>;
+    ) -> rocketmq_error::RocketMQResult<()>;
     fn invoke_oneway(
         &mut self,
         request: RemotingCommand,
         timeout_millis: u64,
-    ) -> Result<(), Box<dyn std::error::Error>>;*/
+    ) -> rocketmq_error::RocketMQResult<()>;*/
 }

--- a/rocketmq-remoting/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_utils.rs
@@ -97,15 +97,24 @@ mod tests {
 
     impl RemotingSerializable for FailingSerializable {
         fn encode(&self) -> RocketMQResult<Vec<u8>> {
-            Err(RocketMQError::Internal("forced encode failure".to_string()))
+            Err(RocketMQError::response_process_failed(
+                "encode remoting body",
+                "forced encode failure",
+            ))
         }
 
         fn serialize_json(&self) -> RocketMQResult<String> {
-            Err(RocketMQError::Internal("forced json failure".to_string()))
+            Err(RocketMQError::response_process_failed(
+                "serialize remoting body",
+                "forced json failure",
+            ))
         }
 
         fn serialize_json_pretty(&self) -> RocketMQResult<String> {
-            Err(RocketMQError::Internal("forced pretty json failure".to_string()))
+            Err(RocketMQError::response_process_failed(
+                "serialize remoting body pretty",
+                "forced pretty json failure",
+            ))
         }
     }
 

--- a/rocketmq-remoting/src/rpc/rpc_response.rs
+++ b/rocketmq-remoting/src/rpc/rpc_response.rs
@@ -116,9 +116,15 @@ mod tests {
 
     #[test]
     fn new_exception_uses_zero_code_for_non_broker_error() {
-        let response = RpcResponse::new_exception(Some(RocketMQError::Internal("local failure".to_string())));
+        let response = RpcResponse::new_exception(Some(RocketMQError::response_process_failed(
+            "rpc_response",
+            "local failure",
+        )));
 
         assert_eq!(response.code, 0);
-        assert!(matches!(response.exception, Some(RocketMQError::Internal(_))));
+        assert!(matches!(
+            response.exception,
+            Some(RocketMQError::ResponseProcessFailed { .. })
+        ));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8039

### Brief Description

- Replaces remoting abort-process helper internals with a typed service lifecycle error.
- Builds central remoting handler failure responses from `BoundaryErrorView` through `command_from_error()`, avoiding raw diagnostic `Display` text on the wire.
- Maps consumer running info analysis failures to `ResponseProcessFailed` and updates remoting RPC/callback tests to use typed RocketMQ errors.
- Updates ignored remoting examples and commented server signatures to use typed RocketMQ results.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-remoting abort_process_error_uses_service_lifecycle_error`
- `cargo test -p rocketmq-remoting analyze_subscription_empty_table_uses_response_process_error`
- `cargo test -p rocketmq-remoting new_exception_uses_zero_code_for_non_broker_error`
- `cargo test -p rocketmq-remoting try_encode_body_returns_serializable_error_without_panicking`
- `cargo test -p rocketmq-remoting error_response`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how request and response errors are reported, making failures more consistent and easier to diagnose.
  * Updated several error paths to return more specific failure messages instead of generic internal errors.
  * Refined handling for empty or invalid consumer subscription data so it now fails with clearer feedback.
  * Adjusted callback and server error behavior to better match the app’s standard result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->