### PR TITLE
[ISSUE #8041]♻️Type admin routing errors

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/mq_admin_utils.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/mq_admin_utils.rs
@@ -18,7 +18,6 @@ use std::collections::HashSet;
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
-use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::static_topic::logic_queue_mapping_item::LogicQueueMappingItem;
 use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
@@ -29,6 +28,7 @@ use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
 use rocketmq_rust::ArcMut;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::core::errors;
 
 pub struct MQAdminUtils {}
 impl MQAdminUtils {
@@ -38,9 +38,7 @@ impl MQAdminUtils {
     ) -> RocketMQResult<HashSet<CheetahString>> {
         let cluster_info = default_mq_admin_ext.examine_broker_cluster_info().await?;
         if cluster_info.cluster_addr_table.is_none() {
-            return Err(rocketmq_error::RocketMQError::Internal(
-                "The Cluster info is empty".to_string(),
-            ));
+            return Err(errors::cluster_metadata_unavailable("cluster address table is empty"));
         } else if let Some(c_table) = &cluster_info.cluster_addr_table {
             let mut all_brokers = HashSet::new();
             for broker in &brokers {
@@ -56,8 +54,8 @@ impl MQAdminUtils {
             }
             return Ok(all_brokers);
         }
-        Err(rocketmq_error::RocketMQError::Internal(
-            "get_all_brokers_in_same_cluster err".to_string(),
+        Err(errors::cluster_metadata_unavailable(
+            "cluster address table could not be read",
         ))
     }
     pub async fn complete_no_target_brokers(
@@ -102,12 +100,12 @@ impl MQAdminUtils {
         default_mq_admin_ext: &DefaultMQAdminExt,
         client_metadata: &ClientMetadata,
     ) -> RocketMQResult<()> {
-        let cluster_info = default_mq_admin_ext.examine_broker_cluster_info().await;
-        if let Ok(info) = &cluster_info {
-            client_metadata.refresh_cluster_info(Some(info));
-            return Ok(());
-        }
-        Err(RocketMQError::Internal("The Cluster info is empty".to_string()))
+        let cluster_info = default_mq_admin_ext
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| errors::broker_operation_failed("examine_broker_cluster_info", error.to_string()))?;
+        client_metadata.refresh_cluster_info(Some(&cluster_info));
+        Ok(())
     }
     pub async fn get_broker_metadata(default_mq_admin_ext: &DefaultMQAdminExt) -> RocketMQResult<ClientMetadata> {
         let client_metadata = ClientMetadata::new();
@@ -118,10 +116,7 @@ impl MQAdminUtils {
         for broker in &brokers {
             let addr = client_metadata.find_master_broker_addr(broker);
             if addr.is_none() {
-                return Err(RocketMQError::Internal(format!(
-                    "Can't find addr for broker {}",
-                    broker
-                )));
+                return Err(errors::broker_not_found(format!("master address for broker {broker}")));
             }
         }
         Ok(())
@@ -277,11 +272,14 @@ impl MQAdminUtils {
 
                                     if let Some(topic_offset) = topic_offset {
                                         if topic_offset.get_max_offset() < old_leader.start_offset {
-                                            return Err(RocketMQError::Internal(format!(
-                                                "The max offset is smaller than the start offset {:?} {}",
-                                                old_leader,
-                                                topic_offset.get_max_offset()
-                                            )));
+                                            return Err(errors::topic_route_inconsistent(
+                                                topic.to_string(),
+                                                format!(
+                                                    "max offset is smaller than start offset for {:?}: {}",
+                                                    old_leader,
+                                                    topic_offset.get_max_offset()
+                                                ),
+                                            ));
                                         }
                                         new_leader.logic_offset = TopicQueueMappingUtils::block_seq_round_up(
                                             old_leader
@@ -298,10 +296,10 @@ impl MQAdminUtils {
                                             ));
                                         }
                                     } else {
-                                        return Err(RocketMQError::Internal(format!(
-                                            "Cannot get the max offset for old leader {:?}",
-                                            old_leader
-                                        )));
+                                        return Err(errors::topic_route_inconsistent(
+                                            topic.to_string(),
+                                            format!("max offset is unavailable for old leader {old_leader:?}"),
+                                        ));
                                     }
                                 }
                             }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/errors.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/errors.rs
@@ -1,0 +1,33 @@
+use rocketmq_error::RocketMQError;
+use rocketmq_error::ToolsError;
+
+pub(crate) fn cluster_metadata_unavailable(reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::Tools(ToolsError::ClusterInvalid { reason: reason.into() })
+}
+
+pub(crate) fn cluster_not_found(cluster: impl Into<String>) -> RocketMQError {
+    RocketMQError::Tools(ToolsError::cluster_not_found(cluster))
+}
+
+pub(crate) fn broker_metadata_unavailable(reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::Tools(ToolsError::BrokerNotFound { broker: reason.into() })
+}
+
+pub(crate) fn broker_not_found(broker: impl Into<String>) -> RocketMQError {
+    RocketMQError::Tools(ToolsError::broker_not_found(broker))
+}
+
+pub(crate) fn broker_operation_failed(operation: &'static str, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::broker_operation_failed(operation, 0, reason)
+}
+
+pub(crate) fn topic_route_not_found(topic: impl Into<String>) -> RocketMQError {
+    RocketMQError::RouteNotFound { topic: topic.into() }
+}
+
+pub(crate) fn topic_route_inconsistent(topic: impl Into<String>, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::RouteInconsistent {
+        topic: topic.into(),
+        reason: reason.into(),
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/queue.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/queue.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::stable_error_code;
 use crate::core::stable_error_message;
 use crate::core::RocketMQError;
@@ -249,10 +250,10 @@ impl QueueService {
             )
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "QueueService: failed to query consume queue from {}: {}",
-                    broker_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "query_consume_queue",
+                    format!("failed to query consume queue from {broker_addr}: {error}"),
+                )
             })?;
 
         Ok(QueryConsumeQueueResult {
@@ -277,9 +278,10 @@ impl QueueService {
         admin: &DefaultMQAdminExt,
         request: &CheckRocksdbCqWriteProgressRequest,
     ) -> RocketMQResult<CheckRocksdbCqWriteProgressResult> {
-        let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-            RocketMQError::Internal(format!("QueueService: failed to examine broker cluster info: {error}"))
-        })?;
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| errors::broker_operation_failed("examine_broker_cluster_info", error.to_string()))?;
         let Some(cluster_addr_table) = cluster_info.cluster_addr_table.as_ref() else {
             return Ok(CheckRocksdbCqWriteProgressResult {
                 cluster_found: false,
@@ -296,7 +298,7 @@ impl QueueService {
         };
 
         let Some(broker_addr_table) = cluster_info.broker_addr_table.as_ref() else {
-            return Err(RocketMQError::Internal("brokerAddrTable is empty".into()));
+            return Err(errors::broker_metadata_unavailable("broker address table is empty"));
         };
 
         let mut broker_names = cluster_broker_names.iter().cloned().collect::<Vec<_>>();
@@ -341,14 +343,16 @@ async fn resolve_topic_master_broker(
     admin: &DefaultMQAdminExt,
     topic: &CheetahString,
 ) -> RocketMQResult<CheetahString> {
-    let topic_route_data = admin.examine_topic_route_info(topic.clone()).await.map_err(|error| {
-        RocketMQError::Internal(format!("QueueService: failed to examine topic route info: {error}"))
-    })?;
+    let topic_route_data = admin
+        .examine_topic_route_info(topic.clone())
+        .await
+        .map_err(|error| errors::broker_operation_failed("examine_topic_route_info", error.to_string()))?;
 
-    let topic_route_data = topic_route_data.ok_or_else(|| RocketMQError::Internal("No topic route data!".into()))?;
+    let topic_route_data = topic_route_data.ok_or_else(|| errors::topic_route_not_found(topic.to_string()))?;
     if topic_route_data.broker_datas.is_empty() {
-        return Err(RocketMQError::Internal(
-            "No topic route data! broker_datas is empty".into(),
+        return Err(errors::topic_route_inconsistent(
+            topic.to_string(),
+            "broker data list is empty",
         ));
     }
 
@@ -356,7 +360,7 @@ async fn resolve_topic_master_broker(
         .broker_addrs()
         .get(&0u64)
         .cloned()
-        .ok_or_else(|| RocketMQError::Internal("No master broker address found in topic route data".into()))
+        .ok_or_else(|| errors::broker_not_found(format!("master broker for topic {topic}")))
 }
 
 fn admin_builder_with_rpc_hook(builder: AdminBuilder, rpc_hook: Option<Arc<dyn RPCHook>>) -> AdminBuilder {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/resolver.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/resolver.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
-use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+
+use crate::core::errors;
 
 pub struct BrokerAddressResolver;
 
@@ -16,17 +17,13 @@ impl BrokerAddressResolver {
         cluster_name: &str,
     ) -> RocketMQResult<Vec<CheetahString>> {
         let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No cluster address table available from nameserver.".into())
+            errors::cluster_metadata_unavailable("cluster address table is unavailable from nameserver")
         })?;
-        let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
-            RocketMQError::Internal(format!(
-                "BrokerAddressResolver: Make sure the specified clusterName exists or the nameserver which connected \
-                 to is correct. Cluster: {}",
-                cluster_name
-            ))
-        })?;
+        let broker_names = cluster_addr_table
+            .get(cluster_name)
+            .ok_or_else(|| errors::cluster_not_found(cluster_name))?;
         let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No broker address table available from nameserver.".into())
+            errors::broker_metadata_unavailable("broker address table is unavailable from nameserver")
         })?;
 
         let mut master_addrs = Vec::new();
@@ -51,10 +48,7 @@ impl BrokerAddressResolver {
                 }
             }
         }
-        Err(RocketMQError::Internal(format!(
-            "BrokerAddressResolver: No broker address for broker name: {}",
-            broker_name
-        )))
+        Err(errors::broker_not_found(broker_name))
     }
 
     pub fn fetch_master_and_slave_addr_by_broker_name(
@@ -62,14 +56,11 @@ impl BrokerAddressResolver {
         broker_name: &str,
     ) -> RocketMQResult<Vec<CheetahString>> {
         let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No broker address table available from nameserver.".into())
+            errors::broker_metadata_unavailable("broker address table is unavailable from nameserver")
         })?;
-        let broker_data = broker_addr_table.get(broker_name).ok_or_else(|| {
-            RocketMQError::Internal(format!(
-                "BrokerAddressResolver: No broker data found for broker name: {}",
-                broker_name
-            ))
-        })?;
+        let broker_data = broker_addr_table
+            .get(broker_name)
+            .ok_or_else(|| errors::broker_not_found(broker_name))?;
         let mut addrs: Vec<CheetahString> = broker_data.broker_addrs().values().cloned().collect();
         addrs.sort();
         addrs.dedup();
@@ -85,11 +76,7 @@ impl BrokerAddressResolver {
                 return Ok(broker_names.iter().map(ToString::to_string).collect());
             }
         }
-        Err(RocketMQError::Internal(format!(
-            "BrokerAddressResolver: Make sure the specified clusterName exists or the nameserver which connected to \
-             is correct. Cluster: {}",
-            cluster_name
-        )))
+        Err(errors::cluster_not_found(cluster_name))
     }
 
     pub fn fetch_broker_name_by_addr(cluster_info: &ClusterInfo, broker_addr: &str) -> RocketMQResult<String> {
@@ -102,10 +89,7 @@ impl BrokerAddressResolver {
                 }
             }
         }
-        Err(RocketMQError::Internal(format!(
-            "BrokerAddressResolver: Make sure the specified broker address exists. Address: {}",
-            broker_addr
-        )))
+        Err(errors::broker_not_found(broker_addr))
     }
 
     pub fn fetch_master_and_slave_addr_by_cluster_name(
@@ -113,17 +97,13 @@ impl BrokerAddressResolver {
         cluster_name: &str,
     ) -> RocketMQResult<Vec<CheetahString>> {
         let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No cluster address table available from nameserver.".into())
+            errors::cluster_metadata_unavailable("cluster address table is unavailable from nameserver")
         })?;
-        let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
-            RocketMQError::Internal(format!(
-                "BrokerAddressResolver: Make sure the specified clusterName exists or the nameserver which connected \
-                 to is correct. Cluster: {}",
-                cluster_name
-            ))
-        })?;
+        let broker_names = cluster_addr_table
+            .get(cluster_name)
+            .ok_or_else(|| errors::cluster_not_found(cluster_name))?;
         let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No broker address table available from nameserver.".into())
+            errors::broker_metadata_unavailable("broker address table is unavailable from nameserver")
         })?;
 
         let mut all_addrs = Vec::new();
@@ -142,19 +122,15 @@ impl BrokerAddressResolver {
         let mut master_and_slave_map = HashMap::new();
 
         let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No cluster address table available from nameserver.".into())
+            errors::cluster_metadata_unavailable("cluster address table is unavailable from nameserver")
         })?;
 
-        let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
-            RocketMQError::Internal(format!(
-                "BrokerAddressResolver: Make sure the specified clusterName exists or the nameserver which connected \
-                 to is correct. Cluster: {}",
-                cluster_name
-            ))
-        })?;
+        let broker_names = cluster_addr_table
+            .get(cluster_name)
+            .ok_or_else(|| errors::cluster_not_found(cluster_name))?;
 
         let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
-            RocketMQError::Internal("BrokerAddressResolver: No broker address table available from nameserver.".into())
+            errors::broker_metadata_unavailable("broker address table is unavailable from nameserver")
         })?;
 
         for broker_name in broker_names {
@@ -196,6 +172,7 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
 
+    use rocketmq_error::ErrorKind;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
 
     use super::*;
@@ -228,6 +205,24 @@ mod tests {
         let result = BrokerAddressResolver::fetch_master_addr_by_cluster_name(&cluster_info, "DefaultCluster").unwrap();
 
         assert_eq!(result[0].as_str(), "192.168.1.1:10911");
+    }
+
+    #[test]
+    fn missing_cluster_table_uses_typed_admin_error() {
+        let cluster_info = ClusterInfo::new(None, None);
+        let error =
+            BrokerAddressResolver::fetch_master_addr_by_cluster_name(&cluster_info, "DefaultCluster").unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ConfigInvalidValue);
+    }
+
+    #[test]
+    fn missing_broker_name_uses_typed_admin_error() {
+        let cluster_info = create_test_cluster_info();
+        let error =
+            BrokerAddressResolver::fetch_master_addr_by_broker_name(&cluster_info, "missing-broker").unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::BrokerNotFound);
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod core {
     pub mod container;
     pub mod controller;
     pub mod error_view;
+    pub(crate) mod errors;
     pub mod export_data;
     pub mod ha;
     pub mod lite;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8041

### Brief Description

- Adds shared admin-core typed error helpers for cluster metadata, broker lookup, route lookup, route inconsistency, and admin broker operations.
- Replaces generic internal errors in admin routing resolver and queue metadata code with typed RocketMQ errors.
- Updates shared `MQAdminUtils` cluster refresh, broker master lookup, and static topic offset validation to use typed errors.
- Adds resolver tests covering missing cluster metadata and missing broker master address classifications.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-admin-core --lib missing_cluster_table_uses_typed_admin_error`
- `cargo test -p rocketmq-admin-core --lib missing_broker_name_uses_typed_admin_error`
- `cargo test -p rocketmq-admin-core --lib`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

Note: `cargo test -p rocketmq-admin-core missing_cluster_table_uses_typed_admin_error` ran the matching lib test successfully, then failed while launching an existing integration-test executable on Windows with `os error 740`; the scoped `--lib` command above avoids that unrelated executable-launch issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across admin operations with clearer, typed error messages.
  * Better handling for missing cluster, broker, topic route, and master broker information.
  * Updated several failure cases to return more specific, consistent errors instead of generic internal messages.

* **Tests**
  * Added coverage to verify the correct error types are returned for missing metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->