### PR TITLE
[ISSUE #8043]♻️Type admin operation errors

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
@@ -265,9 +265,9 @@ impl std::ops::DerefMut for AdminGuard {
 
 fn current_admin_guard_runtime() -> RocketMQResult<tokio::runtime::Handle> {
     tokio::runtime::Handle::try_current().map_err(|error| {
-        RocketMQError::Internal(format!(
+        RocketMQError::Service(rocketmq_error::UnifiedServiceError::StartupFailed(format!(
             "AdminGuard automatic shutdown requires an active Tokio runtime: {error}"
-        ))
+        )))
     })
 }
 
@@ -407,12 +407,12 @@ mod tests {
         let error = current_admin_guard_runtime()
             .expect_err("AdminGuard automatic shutdown should require an active Tokio runtime");
 
-        match error {
-            RocketMQError::Internal(message) => assert!(
-                message.contains("AdminGuard automatic shutdown requires an active Tokio runtime"),
-                "unexpected error message: {message}"
-            ),
-            other => panic!("unexpected error variant: {other}"),
-        }
+        assert_eq!(error.kind(), rocketmq_error::ErrorKind::Service);
+        assert!(
+            error
+                .to_string()
+                .contains("AdminGuard automatic shutdown requires an active Tokio runtime"),
+            "unexpected error message: {error}"
+        );
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/operations.rs
@@ -67,6 +67,7 @@ use super::types::ResetMasterFlushOffsetRequest;
 use super::types::SwitchTimerEngineRequest;
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::resolver::BrokerAddressResolver;
 use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
@@ -99,9 +100,7 @@ impl BrokerService {
             .delete_expired_commit_log(request.cluster_name().cloned(), request.broker_addr().cloned())
             .await
             .map(|success| BrokerBooleanOperationResult { success })
-            .map_err(|error| {
-                RocketMQError::Internal(format!("BrokerService: failed to delete expired commit log: {error}"))
-            });
+            .map_err(|error| errors::broker_operation_failed("delete_expired_commit_log", error.to_string()));
         admin.shutdown().await;
         result
     }
@@ -117,7 +116,7 @@ impl BrokerService {
             .clean_unused_topic(request.cluster_name().cloned(), request.broker_addr().cloned())
             .await
             .map(|success| BrokerBooleanOperationResult { success })
-            .map_err(|error| RocketMQError::Internal(format!("BrokerService: failed to clean unused topic: {error}")));
+            .map_err(|error| errors::broker_operation_failed("clean_unused_topic", error.to_string()));
         admin.shutdown().await;
         result
     }
@@ -133,11 +132,14 @@ impl BrokerService {
             .reset_master_flush_offset(request.broker_addr().clone(), request.master_flush_offset())
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to reset master flush offset for {}: {}",
-                    request.broker_addr(),
-                    error
-                ))
+                errors::broker_operation_failed(
+                    "reset_master_flush_offset",
+                    format!(
+                        "BrokerService: failed to reset master flush offset for {}: {}",
+                        request.broker_addr(),
+                        error
+                    ),
+                )
             });
         admin.shutdown().await;
         result
@@ -284,7 +286,7 @@ impl BrokerService {
             }
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 let master_and_slave_map =
                     BrokerAddressResolver::fetch_master_and_slave_distinguish(&cluster_info, cluster_name.as_str())?;
@@ -342,9 +344,10 @@ impl BrokerService {
         admin: &DefaultMQAdminExt,
         request: &BrokerEpochQueryRequest,
     ) -> RocketMQResult<BrokerEpochQueryResult> {
-        let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-            RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
-        })?;
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| errors::broker_operation_failed("examine_broker_cluster_info", error.to_string()))?;
         let mut broker_addrs = match request.target() {
             BrokerEpochQueryTarget::BrokerName(broker_name) => {
                 BrokerAddressResolver::fetch_master_and_slave_addr_by_broker_name(&cluster_info, broker_name.as_str())?
@@ -430,8 +433,9 @@ impl BrokerService {
         }
 
         if report.targets.is_empty() {
-            return Err(RocketMQError::Internal(
-                "BrokerService: no broker targets matched the cleanExpiredCQ scope".to_string(),
+            return Err(errors::admin_validation_failed(
+                "cleanExpiredCQTarget",
+                "no broker targets matched the cleanExpiredCQ scope",
             ));
         }
 
@@ -528,11 +532,14 @@ impl BrokerService {
             )
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to fetch consume stats from {}: {}",
-                    request.broker_addr(),
-                    error
-                ))
+                errors::broker_operation_failed(
+                    "fetch_consume_stats_in_broker",
+                    format!(
+                        "BrokerService: failed to fetch consume stats from {}: {}",
+                        request.broker_addr(),
+                        error
+                    ),
+                )
             })?;
 
         Ok(build_broker_consume_stats_result(
@@ -570,7 +577,7 @@ impl BrokerService {
             }
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 let mut broker_addrs =
                     BrokerAddressResolver::fetch_master_and_slave_addr_by_cluster_name(&cluster_info, cluster_name)?
@@ -611,7 +618,7 @@ impl BrokerService {
             }
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 let master_and_slave_map =
                     BrokerAddressResolver::fetch_master_and_slave_distinguish(&cluster_info, cluster_name.as_str())?;
@@ -763,26 +770,35 @@ impl BrokerService {
                     let base_error = format!("BrokerService: failed to update broker {}: {}", plan.broker_addr, error);
 
                     if !rollback_enabled {
-                        return Err(RocketMQError::Internal(format!(
-                            "{}. Automatic rollback is disabled, previous successful updates are retained.",
-                            base_error
-                        )));
+                        return Err(errors::admin_operation_failed(
+                            "update_broker_config",
+                            format!(
+                                "{}. Automatic rollback is disabled, previous successful updates are retained.",
+                                base_error
+                            ),
+                        ));
                     }
 
                     let rollback_failures = rollback_applied_updates(admin, &applied_updates).await;
                     if rollback_failures.is_empty() {
-                        return Err(RocketMQError::Internal(format!(
-                            "{}. Automatic rollback succeeded for {} previously updated broker(s).",
-                            base_error,
-                            applied_updates.len()
-                        )));
+                        return Err(errors::admin_operation_failed(
+                            "update_broker_config",
+                            format!(
+                                "{}. Automatic rollback succeeded for {} previously updated broker(s).",
+                                base_error,
+                                applied_updates.len()
+                            ),
+                        ));
                     }
 
-                    return Err(RocketMQError::Internal(format!(
-                        "{}. Rollback encountered issues: {}",
-                        base_error,
-                        rollback_failures.join("; ")
-                    )));
+                    return Err(errors::admin_operation_failed(
+                        "update_broker_config",
+                        format!(
+                            "{}. Rollback encountered issues: {}",
+                            base_error,
+                            rollback_failures.join("; ")
+                        ),
+                    ));
                 }
             }
         }
@@ -801,7 +817,7 @@ impl BrokerService {
             BrokerTarget::BrokerAddr(addr) => Ok(vec![addr.clone()]),
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
 
                 let mut broker_addrs =
@@ -813,9 +829,8 @@ impl BrokerService {
                 broker_addrs.dedup();
 
                 if broker_addrs.is_empty() {
-                    return Err(RocketMQError::Internal(format!(
-                        "BrokerService: cluster {} has no broker address",
-                        cluster_name
+                    return Err(errors::broker_not_found(format!(
+                        "cluster {cluster_name} broker address"
                     )));
                 }
 
@@ -832,7 +847,7 @@ impl BrokerService {
             BrokerTarget::BrokerAddr(addr) => Ok(vec![addr.clone()]),
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 let mut broker_addrs =
                     BrokerAddressResolver::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name.as_str())?;
@@ -849,10 +864,10 @@ impl BrokerService {
         key_pattern: Option<&Regex>,
     ) -> RocketMQResult<Vec<BrokerConfigEntry>> {
         let properties = admin.get_broker_config(broker_addr.clone()).await.map_err(|error| {
-            RocketMQError::Internal(format!(
-                "BrokerService: failed to get broker config for {}: {}",
-                broker_addr, error
-            ))
+            errors::broker_operation_failed(
+                "get_broker_config",
+                format!("BrokerService: failed to get broker config for {broker_addr}: {error}"),
+            )
         })?;
 
         Ok(filter_and_sort_properties(properties, key_pattern))
@@ -867,10 +882,10 @@ impl BrokerService {
             .get_cold_data_flow_ctr_info(broker_addr.clone())
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to get cold data flow ctr info from {}: {}",
-                    broker_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "get_cold_data_flow_ctr_info",
+                    format!("BrokerService: failed to get cold data flow ctr info from {broker_addr}: {error}"),
+                )
             })?;
 
         Ok(ColdDataFlowCtrInfoSection {
@@ -888,10 +903,10 @@ impl BrokerService {
             .get_broker_epoch_cache(broker_addr.clone())
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to get broker epoch cache from {}: {}",
-                    broker_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "get_broker_epoch_cache",
+                    format!("BrokerService: failed to get broker epoch cache from {broker_addr}: {error}"),
+                )
             })?;
 
         let max_offset = epoch_cache.get_max_offset();
@@ -926,19 +941,17 @@ impl BrokerService {
             if let Some(topic) = request.topic() {
                 let topic_targets = Self::fetch_topic_broker_targets(admin, topic).await?;
                 if !topic_targets.iter().any(|target| target == broker_addr) {
-                    return Err(RocketMQError::Internal(format!(
-                        "BrokerService: broker {} is not found in route info of topic {}",
-                        broker_addr, topic
-                    )));
+                    return Err(errors::broker_not_found(format!("{broker_addr} for topic {topic}")));
                 }
             }
             return Ok(vec![broker_addr.clone()]);
         }
 
         let cluster_targets = if let Some(cluster_name) = request.cluster_name() {
-            let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
-            })?;
+            let cluster_info = admin
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| errors::broker_operation_failed("examine_broker_cluster_info", error.to_string()))?;
             Some(BrokerAddressResolver::fetch_master_and_slave_addr_by_cluster_name(
                 &cluster_info,
                 cluster_name.as_str(),
@@ -968,9 +981,10 @@ impl BrokerService {
     }
 
     async fn fetch_all_broker_targets(admin: &DefaultMQAdminExt) -> RocketMQResult<Vec<CheetahString>> {
-        let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-            RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
-        })?;
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| errors::broker_operation_failed("examine_broker_cluster_info", error.to_string()))?;
         let mut targets = Vec::new();
         if let Some(broker_addr_table) = cluster_info.broker_addr_table {
             for broker_data in broker_addr_table.values() {
@@ -990,14 +1004,12 @@ impl BrokerService {
             .examine_topic_route_info(topic.clone())
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to examine topic route info for {}: {}",
-                    topic, error
-                ))
+                errors::broker_operation_failed(
+                    "examine_topic_route_info",
+                    format!("BrokerService: failed to examine topic route info for {topic}: {error}"),
+                )
             })?
-            .ok_or_else(|| {
-                RocketMQError::Internal(format!("BrokerService: topic {} route info is unavailable", topic))
-            })?;
+            .ok_or_else(|| errors::topic_route_not_found(topic.to_string()))?;
 
         let mut targets = Vec::new();
         for broker_data in route_data.broker_datas {
@@ -1006,10 +1018,10 @@ impl BrokerService {
         targets.sort();
         targets.dedup();
         if targets.is_empty() {
-            return Err(RocketMQError::Internal(format!(
-                "BrokerService: topic {} has no broker targets",
-                topic
-            )));
+            return Err(errors::topic_route_inconsistent(
+                topic.to_string(),
+                "topic has no broker targets",
+            ));
         }
         Ok(targets)
     }
@@ -1022,7 +1034,7 @@ impl BrokerService {
             BrokerTarget::BrokerAddr(addr) => Ok(vec![(BrokerConfigSectionTarget::Broker(addr.clone()), addr.clone())]),
             BrokerTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("BrokerService: failed to examine broker cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 let master_and_slave_map =
                     BrokerAddressResolver::fetch_master_and_slave_distinguish(&cluster_info, cluster_name.as_str())?;
@@ -1052,9 +1064,8 @@ impl BrokerService {
                 }
 
                 if targets.is_empty() {
-                    return Err(RocketMQError::Internal(format!(
-                        "BrokerService: cluster {} has no broker address",
-                        cluster_name
+                    return Err(errors::broker_not_found(format!(
+                        "cluster {cluster_name} broker address"
                     )));
                 }
                 Ok(targets)
@@ -1069,10 +1080,10 @@ impl BrokerService {
         broker_addr: CheetahString,
     ) -> RocketMQResult<CommitLogReadAheadSection> {
         let current_config = admin.get_broker_config(broker_addr.clone()).await.map_err(|error| {
-            RocketMQError::Internal(format!(
-                "BrokerService: failed to get broker config for {}: {}",
-                broker_addr, error
-            ))
+            errors::broker_operation_failed(
+                "get_broker_config",
+                format!("BrokerService: failed to get broker config for {broker_addr}: {error}"),
+            )
         })?;
         let size_key_for_update = resolve_read_ahead_size_key(request, &current_config)?;
 
@@ -1110,16 +1121,16 @@ impl BrokerService {
             .update_broker_config(broker_addr.clone(), properties)
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to update broker {}: {}",
-                    broker_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "update_broker_config",
+                    format!("BrokerService: failed to update broker {broker_addr}: {error}"),
+                )
             })?;
         let updated_config = admin.get_broker_config(broker_addr.clone()).await.map_err(|error| {
-            RocketMQError::Internal(format!(
-                "BrokerService: failed to fetch updated broker config for {}: {}",
-                broker_addr, error
-            ))
+            errors::broker_operation_failed(
+                "get_broker_config",
+                format!("BrokerService: failed to fetch updated broker config for {broker_addr}: {error}"),
+            )
         })?;
 
         Ok(CommitLogReadAheadSection {
@@ -1140,10 +1151,10 @@ impl BrokerService {
             .fetch_broker_runtime_stats(broker_addr.clone())
             .await
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "BrokerService: failed to fetch broker runtime stats from {}: {}",
-                    broker_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "fetch_broker_runtime_stats",
+                    format!("BrokerService: failed to fetch broker runtime stats from {broker_addr}: {error}"),
+                )
             })?;
 
         Ok(sort_runtime_stats_entries(kv_table.table))
@@ -1236,10 +1247,10 @@ async fn fetch_broker_config_snapshot(
     broker_addr: &CheetahString,
 ) -> RocketMQResult<HashMap<CheetahString, CheetahString>> {
     admin.get_broker_config(broker_addr.clone()).await.map_err(|error| {
-        RocketMQError::Internal(format!(
-            "BrokerService: failed to get broker config for {}: {}",
-            broker_addr, error
-        ))
+        errors::broker_operation_failed(
+            "get_broker_config",
+            format!("BrokerService: failed to get broker config for {broker_addr}: {error}"),
+        )
     })
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/cluster.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/cluster.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
-use crate::core::RocketMQError;
+use crate::core::errors;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -311,9 +311,10 @@ impl ClusterService {
         request: &ClusterSendMessageRtRequest,
         broker_names: &ClusterBrokerNameQueryResult,
     ) -> RocketMQResult<ClusterSendMessageRtResult> {
-        producer.start().await.map_err(|error| {
-            RocketMQError::Internal(format!("ClusterService: failed to start cluster RT producer: {error}"))
-        })?;
+        producer
+            .start()
+            .await
+            .map_err(|error| errors::admin_operation_failed("start_cluster_rt_producer", error.to_string()))?;
 
         let mut rows = Vec::new();
         for (cluster_name, broker_names) in &broker_names.broker_names_by_cluster {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/errors.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/errors.rs
@@ -1,4 +1,5 @@
 use rocketmq_error::RocketMQError;
+use rocketmq_error::SerializationError;
 use rocketmq_error::ToolsError;
 
 pub(crate) fn cluster_metadata_unavailable(reason: impl Into<String>) -> RocketMQError {
@@ -19,6 +20,18 @@ pub(crate) fn broker_not_found(broker: impl Into<String>) -> RocketMQError {
 
 pub(crate) fn broker_operation_failed(operation: &'static str, reason: impl Into<String>) -> RocketMQError {
     RocketMQError::broker_operation_failed(operation, 0, reason)
+}
+
+pub(crate) fn admin_operation_failed(operation: &'static str, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::response_process_failed(operation, reason)
+}
+
+pub(crate) fn admin_validation_failed(field: impl Into<String>, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::validation_error(field, reason)
+}
+
+pub(crate) fn admin_serialization_failed(format: &'static str, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::Serialization(SerializationError::encode_failed(format, reason))
 }
 
 pub(crate) fn topic_route_not_found(topic: impl Into<String>) -> RocketMQError {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
@@ -34,6 +34,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::resolver::BrokerAddressResolver;
 use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
@@ -746,8 +747,9 @@ impl ExportService {
         #[cfg(not(feature = "rocksdb-export"))]
         {
             let _ = config_type;
-            Err(RocketMQError::Internal(
-                "ExportService: RocksDB metadata export requires the rocksdb-export feature".to_string(),
+            Err(errors::admin_validation_failed(
+                "rocksdb-export",
+                "RocksDB metadata export requires the rocksdb-export feature",
             ))
         }
 
@@ -758,11 +760,7 @@ impl ExportService {
             opts.create_if_missing(false);
 
             let db = DB::open_for_read_only(&opts, &full_path, false).map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "ExportService: failed to open RocksDB path {}: {}",
-                    full_path.display(),
-                    error
-                ))
+                RocketMQError::storage_read_failed(full_path.display().to_string(), error.to_string())
             })?;
 
             let entries = Self::convert_rocksdb_metadata_entries(config_type, iterate_rocksdb_metadata(&db)?)?;
@@ -827,10 +825,10 @@ impl ExportService {
             }
 
             let master_properties = admin.get_broker_config(master_addr.clone()).await.map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "ExportService: Failed to get broker config for {}: {}",
-                    master_addr, error
-                ))
+                errors::broker_operation_failed(
+                    "get_broker_config",
+                    format!("ExportService: failed to get broker config for {master_addr}: {error}"),
+                )
             })?;
 
             master_broker_size += 1;
@@ -872,7 +870,7 @@ impl ExportService {
         let broker_addr_table = cluster_info
             .broker_addr_table
             .as_ref()
-            .ok_or_else(|| RocketMQError::Internal("ExportService: broker address table is empty".to_string()))?;
+            .ok_or_else(|| errors::broker_metadata_unavailable("broker address table is empty"))?;
 
         let mut result = ExportMetricsResult::default();
         for broker_name in broker_names {
@@ -1170,31 +1168,34 @@ impl ExportService {
     {
         let output_path = request.output_path();
         if output_path.is_dir() {
-            return Err(RocketMQError::Internal(format!(
-                "ExportService: output path {} is a directory",
-                output_path.display()
-            )));
+            return Err(RocketMQError::storage_write_failed(
+                output_path.display().to_string(),
+                "output path is a directory",
+            ));
         }
 
         if let Some(parent) = output_path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
             if !parent.exists() {
-                return Err(RocketMQError::Internal(format!(
-                    "ExportService: output directory {} does not exist",
-                    parent.display()
-                )));
+                return Err(RocketMQError::storage_write_failed(
+                    parent.display().to_string(),
+                    "output directory does not exist",
+                ));
             }
         }
 
         let overwritten = output_path.exists();
         if overwritten && !request.overwrite() {
-            return Err(RocketMQError::Internal(format!(
-                "ExportService: output file {} already exists; enable overwrite to replace it",
-                output_path.display()
-            )));
+            return Err(errors::admin_validation_failed(
+                "output",
+                format!(
+                    "output file {} already exists; enable overwrite to replace it",
+                    output_path.display()
+                ),
+            ));
         }
 
         let bytes = serde_json::to_vec_pretty(value)
-            .map_err(|error| RocketMQError::Internal(format!("ExportService: failed to serialize export: {error}")))?;
+            .map_err(|error| errors::admin_serialization_failed("JSON", error.to_string()))?;
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
@@ -1202,18 +1203,10 @@ impl ExportService {
             .create_new(!request.overwrite())
             .open(output_path)
             .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "ExportService: failed to open output file {}: {}",
-                    output_path.display(),
-                    error
-                ))
+                RocketMQError::storage_write_failed(output_path.display().to_string(), error.to_string())
             })?;
         file.write_all(&bytes).map_err(|error| {
-            RocketMQError::Internal(format!(
-                "ExportService: failed to write output file {}: {}",
-                output_path.display(),
-                error
-            ))
+            RocketMQError::storage_write_failed(output_path.display().to_string(), error.to_string())
         })?;
 
         Ok(ExportFileWriteResult {
@@ -1381,12 +1374,7 @@ fn resolve_export_metrics_broker_names(
         .cluster_addr_table
         .as_ref()
         .and_then(|cluster_addr_table| cluster_addr_table.get(cluster_name))
-        .ok_or_else(|| {
-            RocketMQError::Internal(format!(
-                "ExportService: cluster {} does not exist or has no brokers",
-                cluster_name
-            ))
-        })?;
+        .ok_or_else(|| errors::cluster_not_found(cluster_name.to_string()))?;
     let mut broker_names = broker_names.iter().cloned().collect::<Vec<_>>();
     broker_names.sort();
     Ok(broker_names)
@@ -1450,20 +1438,14 @@ fn normalize_client_info(client_info: Vec<String>) -> Vec<String> {
 
 fn convert_consumer_offset_entry(entry: ExportMetadataInRocksDbEntry) -> RocketMQResult<ExportMetadataInRocksDbEntry> {
     let wrapper = serde_json::from_str::<serde_json::Value>(&entry.value).map_err(|error| {
-        RocketMQError::Internal(format!(
-            "ExportService: failed to parse consumerOffsets entry {}: {}",
-            entry.key, error
-        ))
+        errors::admin_serialization_failed("JSON", format!("consumerOffsets entry {}: {error}", entry.key))
     })?;
     let offset_table = wrapper
         .get("offsetTable")
         .cloned()
         .unwrap_or_else(|| serde_json::json!({}));
     let value = serde_json::to_string(&offset_table).map_err(|error| {
-        RocketMQError::Internal(format!(
-            "ExportService: failed to serialize consumerOffsets entry {}: {}",
-            entry.key, error
-        ))
+        errors::admin_serialization_failed("JSON", format!("consumerOffsets entry {}: {error}", entry.key))
     })?;
 
     Ok(ExportMetadataInRocksDbEntry { key: entry.key, value })
@@ -1474,8 +1456,7 @@ fn iterate_rocksdb_metadata(db: &DB) -> RocketMQResult<Vec<ExportMetadataInRocks
     let mut entries = Vec::new();
     let iter = db.iterator(rocksdb::IteratorMode::Start);
     for item in iter {
-        let (key, value) =
-            item.map_err(|error| RocketMQError::Internal(format!("ExportService: RocksDB iterator error: {error}")))?;
+        let (key, value) = item.map_err(|error| RocketMQError::storage_read_failed("rocksdb", error.to_string()))?;
         entries.push(ExportMetadataInRocksDbEntry {
             key: String::from_utf8_lossy(&key).to_string(),
             value: String::from_utf8_lossy(&value).to_string(),

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/ha.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/ha.rs
@@ -26,8 +26,8 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::resolver::BrokerAddressResolver;
-use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -156,7 +156,7 @@ impl HaService {
             HaStatusTarget::BrokerAddr(broker_addr) => vec![broker_addr.clone()],
             HaStatusTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("HaService: Failed to get cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 BrokerAddressResolver::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name.as_str())?
             }
@@ -165,9 +165,10 @@ impl HaService {
         let mut entries = Vec::with_capacity(broker_addrs.len());
         for broker_addr in broker_addrs {
             let runtime_info = admin.get_broker_ha_status(broker_addr.clone()).await.map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "HaService: Failed to get broker HA status from {broker_addr}: {error}"
-                ))
+                errors::broker_operation_failed(
+                    "get_broker_ha_status",
+                    format!("HaService: failed to get broker HA status from {broker_addr}: {error}"),
+                )
             })?;
             entries.push(HaStatusEntry {
                 broker_addr,
@@ -198,7 +199,7 @@ impl HaService {
             SyncStateSetTarget::BrokerName(broker_name) => vec![broker_name.clone()],
             SyncStateSetTarget::ClusterName(cluster_name) => {
                 let cluster_info = admin.examine_broker_cluster_info().await.map_err(|error| {
-                    RocketMQError::Internal(format!("HaService: Failed to get cluster info: {error}"))
+                    errors::broker_operation_failed("examine_broker_cluster_info", error.to_string())
                 })?;
                 BrokerAddressResolver::fetch_broker_name_by_cluster_name(&cluster_info, cluster_name.as_str())?
                     .into_iter()
@@ -216,9 +217,7 @@ impl HaService {
         let broker_replicas_info = admin
             .get_in_sync_state_data(request.controller_address.clone(), brokers)
             .await
-            .map_err(|error| {
-                RocketMQError::Internal(format!("HaService: Failed to get in sync state data: {error}"))
-            })?;
+            .map_err(|error| errors::broker_operation_failed("get_in_sync_state_data", error.to_string()))?;
         Ok(SyncStateSetQueryResult {
             broker_replicas_info: Some(broker_replicas_info),
         })

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
@@ -46,6 +46,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
@@ -192,8 +193,8 @@ async fn resolve_message_queues(
     let topic_route = admin
         .examine_topic_route_info(CheetahString::from(route_topic))
         .await
-        .map_err(|error| RocketMQError::Internal(format!("Failed to get topic route info: {error}")))?
-        .ok_or_else(|| RocketMQError::Internal(format!("Topic route not found for: {route_topic}")))?;
+        .map_err(|error| errors::broker_operation_failed("examine_topic_route_info", error.to_string()))?
+        .ok_or_else(|| errors::topic_route_not_found(route_topic))?;
 
     Ok(route_topic_queues(&topic_route, topic))
 }
@@ -206,8 +207,8 @@ async fn resolve_broker_addr(
     let topic_route = admin
         .examine_topic_route_info(CheetahString::from(route_topic))
         .await
-        .map_err(|error| RocketMQError::Internal(format!("Failed to get topic route info: {error}")))?
-        .ok_or_else(|| RocketMQError::Internal(format!("Topic route not found for: {route_topic}")))?;
+        .map_err(|error| errors::broker_operation_failed("examine_topic_route_info", error.to_string()))?
+        .ok_or_else(|| errors::topic_route_not_found(route_topic))?;
 
     let broker_data = topic_route
         .broker_datas
@@ -221,7 +222,7 @@ async fn resolve_broker_addr(
 
     broker_data
         .select_broker_addr()
-        .ok_or_else(|| RocketMQError::Internal(format!("No available address for broker '{broker_name}'")))
+        .ok_or_else(|| errors::broker_not_found(format!("available address for broker {broker_name}")))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1082,22 +1083,21 @@ impl MessageService {
         };
 
         if !file_path.exists() {
-            return Err(RocketMQError::Internal(format!(
-                "file {} not exist.",
-                file_path.display()
-            )));
+            return Err(RocketMQError::storage_read_failed(
+                file_path.display().to_string(),
+                "file does not exist",
+            ));
         }
 
         if file_path.is_dir() {
-            return Err(RocketMQError::Internal(format!(
-                "file {} is a directory.",
-                file_path.display()
-            )));
+            return Err(RocketMQError::storage_read_failed(
+                file_path.display().to_string(),
+                "path is a directory",
+            ));
         }
 
-        let data = fs::read(file_path).map_err(|error| {
-            RocketMQError::Internal(format!("Failed to read file {}: {}", file_path.display(), error))
-        })?;
+        let data = fs::read(file_path)
+            .map_err(|error| RocketMQError::storage_read_failed(file_path.display().to_string(), error.to_string()))?;
 
         Ok(DumpCompactionLogResult {
             messages: decode_compaction_log_messages(data),
@@ -1133,7 +1133,7 @@ impl MessageService {
                 request.last_key.clone(),
             )
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to query message by key: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("query_message_by_key", error.to_string()))?;
 
         let rows = query_result
             .message_list()
@@ -1277,14 +1277,14 @@ impl MessageService {
             admin
                 .pull_message_from_queue(broker_addr.as_str(), &route_mq, "*", 0, 1, PULL_TIMEOUT_MILLIS)
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to warm up route topic pull: {error}")))?;
+                .map_err(|error| errors::broker_operation_failed("pull_route_topic_message", error.to_string()))?;
         }
 
         let mq = MessageQueue::from_parts(request.topic.clone(), request.broker_name.clone(), request.queue_id);
         let pull_result = admin
             .pull_message_from_queue(broker_addr.as_str(), &mq, "*", request.offset, 1, PULL_TIMEOUT_MILLIS)
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to pull message by offset: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("pull_message_by_offset", error.to_string()))?;
 
         let pull_status = *pull_result.pull_status();
         let message = if pull_status == PullStatus::Found {
@@ -1600,19 +1600,22 @@ impl MessageService {
         let route_topic = request.lmq_parent_topic.as_ref().unwrap_or(&request.topic);
         let message_queues = resolve_message_queues(admin, request.topic.as_str(), route_topic.as_str()).await?;
         if message_queues.is_empty() {
-            return Err(RocketMQError::Internal("No available message queue found".to_string()));
+            return Err(errors::topic_route_inconsistent(
+                request.topic.to_string(),
+                "no available message queue found",
+            ));
         }
 
         for (mq, broker_addr) in message_queues {
             let mut min_offset = admin
                 .min_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to get min offset: {error}")))?;
+                .map_err(|error| errors::broker_operation_failed("min_offset", error.to_string()))?;
 
             let mut max_offset = admin
                 .max_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to get max offset: {error}")))?;
+                .map_err(|error| errors::broker_operation_failed("max_offset", error.to_string()))?;
 
             if let Some(begin_timestamp) = request.begin_timestamp {
                 min_offset = admin
@@ -1624,7 +1627,7 @@ impl MessageService {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| RocketMQError::Internal(format!("Failed to search begin offset: {error}")))?
+                    .map_err(|error| errors::broker_operation_failed("search_begin_offset", error.to_string()))?
                     as i64;
             }
 
@@ -1638,7 +1641,7 @@ impl MessageService {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| RocketMQError::Internal(format!("Failed to search end offset: {error}")))?
+                    .map_err(|error| errors::broker_operation_failed("search_end_offset", error.to_string()))?
                     as i64;
             }
 
@@ -1732,11 +1735,11 @@ impl MessageService {
         let mut min_offset = admin
             .min_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to get min offset: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("min_offset", error.to_string()))?;
         let mut max_offset = admin
             .max_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to get max offset: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("max_offset", error.to_string()))?;
 
         if let Some(begin_timestamp) = request.begin_timestamp {
             min_offset = admin
@@ -1748,7 +1751,7 @@ impl MessageService {
                     PULL_TIMEOUT_MILLIS,
                 )
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to search begin offset: {error}")))?
+                .map_err(|error| errors::broker_operation_failed("search_begin_offset", error.to_string()))?
                 as i64;
         }
 
@@ -1762,7 +1765,7 @@ impl MessageService {
                     PULL_TIMEOUT_MILLIS,
                 )
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to search end offset: {error}")))?
+                .map_err(|error| errors::broker_operation_failed("search_end_offset", error.to_string()))?
                 as i64;
         }
 
@@ -1871,8 +1874,8 @@ impl MessageService {
         let topic_route = admin
             .examine_topic_route_info(request.topic.clone())
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to examine topic route info: {error}")))?
-            .ok_or_else(|| RocketMQError::Internal(format!("Topic route not found for: {}", request.topic)))?;
+            .map_err(|error| errors::broker_operation_failed("examine_topic_route_info", error.to_string()))?
+            .ok_or_else(|| errors::topic_route_not_found(request.topic.to_string()))?;
 
         let mut count_left = request.message_number;
         for (mq, broker_addr) in route_topic_queues(&topic_route, request.topic.as_str()) {
@@ -1883,11 +1886,11 @@ impl MessageService {
             let mut min_offset = admin
                 .min_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to get min offset: {error}")))?;
+                .map_err(|error| errors::broker_operation_failed("min_offset", error.to_string()))?;
             let mut max_offset = admin
                 .max_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
                 .await
-                .map_err(|error| RocketMQError::Internal(format!("Failed to get max offset: {error}")))?;
+                .map_err(|error| errors::broker_operation_failed("max_offset", error.to_string()))?;
 
             if let Some(begin_timestamp) = request.begin_timestamp {
                 if begin_timestamp > 0 {
@@ -1900,7 +1903,7 @@ impl MessageService {
                             PULL_TIMEOUT_MILLIS,
                         )
                         .await
-                        .map_err(|error| RocketMQError::Internal(format!("Failed to search begin offset: {error}")))?
+                        .map_err(|error| errors::broker_operation_failed("search_begin_offset", error.to_string()))?
                         as i64;
                 }
             }
@@ -1916,7 +1919,7 @@ impl MessageService {
                             PULL_TIMEOUT_MILLIS,
                         )
                         .await
-                        .map_err(|error| RocketMQError::Internal(format!("Failed to search end offset: {error}")))?
+                        .map_err(|error| errors::broker_operation_failed("search_end_offset", error.to_string()))?
                         as i64;
                 }
             }
@@ -1956,11 +1959,11 @@ impl MessageService {
         let mut min_offset = admin
             .min_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to get min offset: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("min_offset", error.to_string()))?;
         let mut max_offset = admin
             .max_offset(broker_addr.clone(), mq.clone(), PULL_TIMEOUT_MILLIS)
             .await
-            .map_err(|error| RocketMQError::Internal(format!("Failed to get max offset: {error}")))?;
+            .map_err(|error| errors::broker_operation_failed("max_offset", error.to_string()))?;
 
         if let Some(begin_timestamp) = request.begin_timestamp {
             if begin_timestamp > 0 {
@@ -1973,7 +1976,7 @@ impl MessageService {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| RocketMQError::Internal(format!("Failed to search begin offset: {error}")))?
+                    .map_err(|error| errors::broker_operation_failed("search_begin_offset", error.to_string()))?
                     as i64;
             }
         }
@@ -1989,7 +1992,7 @@ impl MessageService {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| RocketMQError::Internal(format!("Failed to search end offset: {error}")))?
+                    .map_err(|error| errors::broker_operation_failed("search_end_offset", error.to_string()))?
                     as i64;
             }
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/offset.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/offset.rs
@@ -28,6 +28,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
@@ -363,7 +364,7 @@ impl OffsetService {
                 request.offline(),
             )
             .await
-            .map_err(|error| RocketMQError::Internal(format!("OffsetService: failed to clone group offset: {error}")));
+            .map_err(|error| errors::broker_operation_failed("clone_group_offset", error.to_string()));
         admin.shutdown().await;
         result
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/producer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/producer.rs
@@ -31,7 +31,7 @@ use serde::Serialize;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
-use crate::core::RocketMQError;
+use crate::core::errors;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -168,7 +168,7 @@ impl SendMessageRequest {
         };
         builder
             .build()
-            .map_err(|error| RocketMQError::Internal(format!("SendMessageRequest: failed to build message: {error}")))
+            .map_err(|error| errors::admin_validation_failed("message", error.to_string()))
     }
 }
 
@@ -319,7 +319,7 @@ impl ProducerService {
         producer
             .start()
             .await
-            .map_err(|error| RocketMQError::Internal(format!("ProducerService: failed to start producer: {error}")))?;
+            .map_err(|error| errors::admin_operation_failed("start_producer", error.to_string()))?;
 
         let message = request.message()?;
         let send_result = if let (Some(broker_name), Some(queue_id)) = (request.broker_name(), request.queue_id()) {
@@ -328,7 +328,7 @@ impl ProducerService {
         } else {
             producer.send(message).await
         }
-        .map_err(|error| RocketMQError::Internal(format!("ProducerService: failed to send message: {error}")))?;
+        .map_err(|error| errors::broker_operation_failed("send_message", error.to_string()))?;
 
         let row = if let Some(result) = send_result {
             SendMessageResultRow {
@@ -389,16 +389,12 @@ impl ProducerService {
         producer
             .start()
             .await
-            .map_err(|error| RocketMQError::Internal(format!("ProducerService: failed to start producer: {error}")))?;
+            .map_err(|error| errors::admin_operation_failed("start_producer", error.to_string()))?;
 
         producer
             .send(build_diagnostic_message(request.broker_name().as_str(), 16))
             .await
-            .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "ProducerService: failed to warm up sendMsgStatus producer: {error}"
-                ))
-            })?;
+            .map_err(|error| errors::broker_operation_failed("send_message_status_warmup", error.to_string()))?;
 
         let mut rows = Vec::with_capacity(request.count() as usize);
         for _ in 0..request.count() {
@@ -409,9 +405,7 @@ impl ProducerService {
                     request.message_size(),
                 ))
                 .await
-                .map_err(|error| {
-                    RocketMQError::Internal(format!("ProducerService: sendMsgStatus command failed: {error}"))
-                })?;
+                .map_err(|error| errors::broker_operation_failed("send_message_status", error.to_string()))?;
             let rt_millis = current_millis() - begin;
             rows.push(SendMessageStatusRow {
                 rt_millis,
@@ -446,17 +440,13 @@ impl ProducerService {
         producer
             .start()
             .await
-            .map_err(|error| RocketMQError::Internal(format!("ProducerService: failed to start producer: {error}")))?;
+            .map_err(|error| errors::admin_operation_failed("start_producer", error.to_string()))?;
 
         let message = Message::builder()
             .topic(request.topic().as_str())
             .body_slice(&vec![b'a'; request.size()])
             .build()
-            .map_err(|error| {
-                RocketMQError::Internal(format!(
-                    "ProducerService: failed to build checkMsgSendRT message: {error}"
-                ))
-            })?;
+            .map_err(|error| errors::admin_validation_failed("message", error.to_string()))?;
         let broker_name_holder = Arc::new(Mutex::new(String::new()));
         let queue_id_holder = Arc::new(Mutex::new(0));
         let mut rows = Vec::with_capacity(request.amount() as usize);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/static_topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/static_topic.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
 use rocketmq_remoting::protocol::static_topic::topic_remapping_detail_wrapper;
 use rocketmq_remoting::protocol::static_topic::topic_remapping_detail_wrapper::TopicRemappingDetailWrapper;
@@ -18,6 +17,7 @@ use serde::Serialize;
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::admin::mq_admin_utils::MQAdminUtils;
 use crate::core::admin::AdminBuilder;
+use crate::core::errors;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -213,9 +213,9 @@ impl StaticTopicService {
         let cluster_addr_table = cluster_info
             .cluster_addr_table
             .as_ref()
-            .ok_or_else(|| RocketMQError::Internal("The Cluster info is empty".to_string()))?;
+            .ok_or_else(|| errors::cluster_metadata_unavailable("cluster address table is empty"))?;
         if cluster_addr_table.is_empty() {
-            return Err(RocketMQError::Internal("The Cluster info is empty".to_string()));
+            return Err(errors::cluster_metadata_unavailable("cluster address table is empty"));
         }
 
         let mut target_brokers: HashSet<CheetahString> = request.broker_names().iter().cloned().collect();
@@ -225,7 +225,7 @@ impl StaticTopicService {
             }
         }
         if target_brokers.is_empty() {
-            return Err(RocketMQError::Internal("Find none brokers, do nothing".to_string()));
+            return Err(errors::broker_not_found("static topic target brokers"));
         }
 
         let mut broker_config_map = MQAdminUtils::examine_topic_config_all(request.topic(), admin).await?;
@@ -311,9 +311,9 @@ impl StaticTopicService {
         let cluster_addr_table = cluster_info
             .cluster_addr_table
             .as_ref()
-            .ok_or_else(|| RocketMQError::Internal("The Cluster info is empty".to_string()))?;
+            .ok_or_else(|| errors::cluster_metadata_unavailable("cluster address table is empty"))?;
         if cluster_addr_table.is_empty() {
-            return Err(RocketMQError::Internal("The Cluster info is empty".to_string()));
+            return Err(errors::cluster_metadata_unavailable("cluster address table is empty"));
         }
 
         let client_metadata = ClientMetadata::new();
@@ -326,23 +326,18 @@ impl StaticTopicService {
             }
         }
         if target_brokers.is_empty() {
-            return Err(RocketMQError::Internal("Find none brokers, do nothing".to_string()));
+            return Err(errors::broker_not_found("static topic target brokers"));
         }
 
         for broker in &target_brokers {
             if client_metadata.find_master_broker_addr(broker).is_none() {
-                return Err(RocketMQError::Internal(format!(
-                    "Can't find addr for broker {}",
-                    broker
-                )));
+                return Err(errors::broker_not_found(format!("master address for broker {broker}")));
             }
         }
 
         let mut broker_config_map = MQAdminUtils::examine_topic_config_all(request.topic(), admin).await?;
         if broker_config_map.is_empty() {
-            return Err(RocketMQError::Internal(
-                "No topic route to do the remapping".to_string(),
-            ));
+            return Err(errors::topic_route_not_found(request.topic().to_string()));
         }
 
         let max_epoch_and_num =


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8043

### Brief Description

- Replaces remaining `RocketMQError::Internal` usage in admin-core operation wrappers with typed errors.
- Maps broker/admin RPC failures to broker operation or response-processing errors, route failures to route errors, output file failures to storage errors, and JSON failures to serialization errors.
- Updates AdminGuard runtime failure classification from generic internal to service lifecycle.
- Keeps admin CLI presentation diagnostics intact while preserving stable `ErrorKind` classification in admin core.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-admin-core --lib admin_guard_runtime_without_tokio_runtime_returns_error`
- `cargo test -p rocketmq-admin-core --lib missing_cluster_table_uses_typed_admin_error`
- `cargo test -p rocketmq-admin-core --lib`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin error reporting across broker, cluster, producer, message, offset, and static topic operations.
  * Missing brokers, routes, cluster metadata, and validation issues now return clearer, more specific errors.
  * Export and file-writing failures now surface more consistent read/write/serialization errors.
  * Runtime and producer startup failures are now categorized more accurately, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->