### PR TITLE
[ISSUE #8045]♻️Type client callback errors

### DIFF
--- a/rocketmq-client/src/consumer/ack_callback.rs
+++ b/rocketmq-client/src/consumer/ack_callback.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
-
 use crate::consumer::ack_result::AckResult;
+use rocketmq_error::RocketMQError;
 
 /// Trait representing an acknowledgment callback.
 /// This trait defines two methods: `on_success` and `on_exception`.
@@ -31,7 +30,7 @@ pub trait AckCallback {
     /// # Arguments
     ///
     /// * `e` - The error that occurred.
-    fn on_exception(&self, e: Box<dyn Error>);
+    fn on_exception(&self, e: RocketMQError);
 }
 
 /// Type alias for a function that acts as an acknowledgment callback.
@@ -42,4 +41,4 @@ pub trait AckCallback {
 ///
 /// The function must be `Send` and `Sync` to ensure it can be safely used
 /// across threads.
-pub type AckCallbackFn = Box<dyn Fn(AckResult) -> Result<(), Box<dyn Error>> + Send + Sync>;
+pub type AckCallbackFn = Box<dyn Fn(AckResult) -> Result<(), RocketMQError> + Send + Sync>;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
 use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
@@ -565,7 +564,7 @@ impl ConsumeMessagePopConcurrentlyService {
         impl AckCallback for DefaultAckCallback {
             fn on_success(&self, ack_result: AckResult) {}
 
-            fn on_exception(&self, e: Box<dyn Error>) {
+            fn on_exception(&self, e: rocketmq_error::RocketMQError) {
                 error!("changePopInvisibleTime exception: {}", e);
             }
         }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -156,7 +156,7 @@ struct DefaultAckCallback;
 impl crate::consumer::ack_callback::AckCallback for DefaultAckCallback {
     fn on_success(&self, _ack_result: AckResult) {}
 
-    fn on_exception(&self, e: Box<dyn std::error::Error>) {
+    fn on_exception(&self, e: rocketmq_error::RocketMQError) {
         error!("change_invisible_time callback exception: {}", e);
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::error::Error;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -1742,7 +1741,7 @@ impl DefaultMQPushConsumerImpl {
         impl AckCallback for DefaultAckCallback {
             fn on_success(&self, _ack_result: AckResult) {}
 
-            fn on_exception(&self, _e: Box<dyn Error>) {}
+            fn on_exception(&self, _e: rocketmq_error::RocketMQError) {}
         }
         let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_mut() else {
             error!("ackAsync error: MQClientAPIImpl is not initialized");

--- a/rocketmq-client/src/hook/check_forbidden_context.rs
+++ b/rocketmq-client/src/hook/check_forbidden_context.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::producer::send_result::SendResult;
@@ -54,7 +55,7 @@ pub struct CheckForbiddenContext<'a> {
     /// Send result (available after sending)
     pub send_result: Option<SendResult>,
     /// Exception that occurred during sending
-    pub exception: Option<Box<dyn std::error::Error + Send + Sync>>,
+    pub exception: Option<RocketMQError>,
     /// Custom argument
     pub arg: Option<Box<dyn std::any::Any + Send + Sync>>,
     /// Whether unit mode is enabled

--- a/rocketmq-client/src/hook/send_message_context.rs
+++ b/rocketmq-client/src/hook/send_message_context.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::error::Error;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_enum::MessageType;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 use rocketmq_rust::ArcMut;
 
 use crate::implementation::communication_mode::CommunicationMode;
@@ -55,7 +55,7 @@ pub struct SendMessageContext<'a> {
     pub born_host: Option<CheetahString>,
     pub communication_mode: Option<CommunicationMode>,
     pub send_result: Option<&'a SendResult>,
-    pub exception: Option<Arc<Box<dyn Error + Send + Sync>>>,
+    pub exception: Option<Arc<RocketMQError>>,
     pub mq_trace_context: Option<Arc<Box<dyn std::any::Any + Send + Sync>>>,
     pub trace_start_time: Option<u64>,
     pub props: HashMap<CheetahString, CheetahString>,

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2605,11 +2605,7 @@ impl MQClientAPIImpl {
                     operation: "sendMessageAsync",
                     timeout_ms: timeout_millis,
                 };
-                Self::execute_async_send_hook_after(
-                    &context_data,
-                    None,
-                    Some(Self::boxed_context_error(err.to_string())),
-                );
+                Self::execute_async_send_hook_after(&context_data, None, Some(Self::context_error(err.to_string())));
                 Self::notify_send_callback_exception(&send_callback, &callback_executor, &err);
                 return;
             }
@@ -2644,7 +2640,7 @@ impl MQClientAPIImpl {
                             Self::execute_async_send_hook_after(
                                 &context_data,
                                 None,
-                                Some(Self::boxed_context_error(err_obj.to_string())),
+                                Some(Self::context_error(err_obj.to_string())),
                             );
                             Self::notify_send_callback_exception(&send_callback, &callback_executor, &err_obj);
                             return;
@@ -2684,7 +2680,7 @@ impl MQClientAPIImpl {
                                     Self::execute_async_send_hook_after(
                                         &context_data,
                                         None,
-                                        Some(Self::boxed_context_error(err_obj.to_string())),
+                                        Some(Self::context_error(err_obj.to_string())),
                                     );
                                     Self::notify_send_callback_exception(&send_callback, &callback_executor, &err_obj);
                                     return;
@@ -2720,7 +2716,7 @@ impl MQClientAPIImpl {
                             Self::execute_async_send_hook_after(
                                 &context_data,
                                 None,
-                                Some(Self::boxed_context_error(err_obj.to_string())),
+                                Some(Self::context_error(err_obj.to_string())),
                             );
                             Self::notify_send_callback_exception(&send_callback, &callback_executor, &err_obj);
                             return;
@@ -2759,11 +2755,7 @@ impl MQClientAPIImpl {
                         }
                     }
 
-                    Self::execute_async_send_hook_after(
-                        &context_data,
-                        None,
-                        Some(Self::boxed_context_error(e.to_string())),
-                    );
+                    Self::execute_async_send_hook_after(&context_data, None, Some(Self::context_error(e.to_string())));
                     Self::notify_send_callback_exception(&send_callback, &callback_executor, &e);
                     return;
                 }
@@ -2810,7 +2802,7 @@ impl MQClientAPIImpl {
     fn execute_async_send_hook_after(
         context_data: &Option<AsyncSendHookContext>,
         send_result: Option<&SendResult>,
-        exception: Option<Arc<Box<dyn StdError + Send + Sync>>>,
+        exception: Option<Arc<RocketMQError>>,
     ) {
         let Some(context_data) = context_data.as_ref() else {
             return;
@@ -2838,8 +2830,8 @@ impl MQClientAPIImpl {
         producer.execute_send_message_hook_after(&context);
     }
 
-    fn boxed_context_error(message: String) -> Arc<Box<dyn StdError + Send + Sync>> {
-        Arc::new(Box::new(std::io::Error::other(message)))
+    fn context_error(message: String) -> Arc<RocketMQError> {
+        Arc::new(RocketMQError::response_process_failed("send_callback", message))
     }
 
     fn spawn_api_background_task<F>(
@@ -4249,7 +4241,7 @@ impl MQClientAPIImpl {
                 ack_callback.on_success(ack_result);
             }
             Err(e) => {
-                ack_callback.on_exception(Box::new(e) as Box<dyn std::error::Error>);
+                ack_callback.on_exception(e);
             }
         };
         Ok(())
@@ -4749,7 +4741,7 @@ impl MQClientAPIImpl {
                 ack_callback.on_success(ack_result);
             }
             Err(e) => {
-                ack_callback.on_exception(Box::new(e) as Box<dyn std::error::Error>);
+                ack_callback.on_exception(e);
             }
         }
         Ok(())

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1729,7 +1729,7 @@ impl DefaultMQProducerImpl {
             Err(err) => {
                 if self.has_send_message_hook() {
                     if let Some(smc) = send_message_context.as_mut() {
-                        smc.exception = Some(Self::boxed_context_error(err.to_string()));
+                        smc.exception = Some(Self::context_error(err.to_string()));
                     }
                     self.execute_send_message_hook_after(&send_message_context);
                 }
@@ -1760,8 +1760,8 @@ impl DefaultMQProducerImpl {
         !self.send_message_hook_list.is_empty()
     }
 
-    fn boxed_context_error(message: String) -> Arc<Box<dyn std::error::Error + Send + Sync>> {
-        Arc::new(Box::new(std::io::Error::other(message)))
+    fn context_error(message: String) -> Arc<RocketMQError> {
+        Arc::new(RocketMQError::response_process_failed("send_message", message))
     }
 
     #[inline]
@@ -3838,7 +3838,7 @@ mod tests {
         });
         producer.send_message_hook_list = vec![hook].into();
         let context = Some(SendMessageContext {
-            exception: Some(DefaultMQProducerImpl::boxed_context_error(
+            exception: Some(DefaultMQProducerImpl::context_error(
                 "sendKernelImpl exception".to_string(),
             )),
             ..Default::default()

--- a/rocketmq-client/tests/public_api_exports_test.rs
+++ b/rocketmq-client/tests/public_api_exports_test.rs
@@ -98,7 +98,7 @@ impl AckCallback for RootAckCallback {
         assert_eq!(ack_result.status(), AckStatus::Ok);
     }
 
-    fn on_exception(&self, _e: Box<dyn std::error::Error>) {}
+    fn on_exception(&self, _e: rocketmq_error::RocketMQError) {}
 }
 
 struct RootMessageQueueListener;

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -38,10 +38,15 @@ fn client_public_api_does_not_export_dead_error_module() {
 
 #[test]
 fn client_callback_error_paths_use_typed_rocketmq_error() {
+    let ack_callback = include_str!("../src/consumer/ack_callback.rs");
     let pull_callback = include_str!("../src/consumer/pull_callback.rs");
     let pop_callback = include_str!("../src/consumer/pop_callback.rs");
     let request_callback = include_str!("../src/producer/request_callback.rs");
     let request_future = include_str!("../src/producer/request_response_future.rs");
+
+    assert!(ack_callback.contains("fn on_exception(&self, e: RocketMQError)"));
+    assert!(ack_callback.contains("Result<(), RocketMQError>"));
+    assert!(!ack_callback.contains("Box<dyn std::error::Error"));
 
     assert!(pull_callback.contains("fn on_exception(&mut self, e: RocketMQError)"));
     assert!(pull_callback.contains("fn broker_response_code(error: &RocketMQError)"));
@@ -56,4 +61,15 @@ fn client_callback_error_paths_use_typed_rocketmq_error() {
     assert!(request_callback.contains("Option<&RocketMQError>"));
     assert!(request_future.contains("type RequestCause = Arc<RocketMQError>"));
     assert!(!request_future.contains("type RequestCause = Arc<dyn"));
+}
+
+#[test]
+fn client_hook_contexts_store_typed_errors() {
+    let send_message_context = include_str!("../src/hook/send_message_context.rs");
+    let check_forbidden_context = include_str!("../src/hook/check_forbidden_context.rs");
+
+    assert!(send_message_context.contains("pub exception: Option<Arc<RocketMQError>>"));
+    assert!(check_forbidden_context.contains("pub exception: Option<RocketMQError>"));
+    assert!(!send_message_context.contains("Box<dyn Error + Send + Sync>"));
+    assert!(!check_forbidden_context.contains("Box<dyn std::error::Error + Send + Sync>"));
 }

--- a/rocketmq-common/src/common/future.rs
+++ b/rocketmq-common/src/common/future.rs
@@ -24,6 +24,8 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 
+use rocketmq_error::RocketMQError;
+
 /// Enumeration representing the state of a CompletableFuture.
 #[derive(Copy, Clone, PartialEq)]
 enum State {
@@ -43,7 +45,7 @@ struct CompletableFutureState<T> {
     data: Option<T>,
 
     /// An optional error value contained within the CompletableFuture upon completion.
-    error: Option<Box<dyn std::error::Error + Send + Sync>>,
+    error: Option<RocketMQError>,
 }
 
 fn lock_state<T>(state: &Mutex<CompletableFutureState<T>>) -> MutexGuard<'_, CompletableFutureState<T>> {
@@ -59,10 +61,7 @@ fn complete_state<T>(state: &Mutex<CompletableFutureState<T>>, data: T) {
     }
 }
 
-fn complete_exceptionally<T>(
-    state: &Mutex<CompletableFutureState<T>>,
-    error: Box<dyn std::error::Error + Send + Sync>,
-) {
+fn complete_exceptionally<T>(state: &Mutex<CompletableFutureState<T>>, error: RocketMQError) {
     let mut state = lock_state(state);
     state.completed = State::Ready;
     state.error = Some(error);
@@ -116,7 +115,7 @@ impl<T: Send + 'static> CompletableFuture<T> {
         complete_state(&self.state, result);
     }
 
-    pub fn complete_exceptionally(&mut self, error: Box<dyn std::error::Error + Send + Sync>) {
+    pub fn complete_exceptionally(&mut self, error: RocketMQError) {
         complete_exceptionally(&self.state, error);
     }
 }
@@ -213,5 +212,16 @@ mod tests {
         cf.complete(42);
 
         assert_eq!(futures::executor::block_on(cf), Some(42));
+    }
+
+    #[test]
+    fn completable_future_exceptional_completion_accepts_typed_error() {
+        let mut cf: CompletableFuture<i32> = CompletableFuture::new();
+        cf.complete_exceptionally(RocketMQError::response_process_failed(
+            "completable_future",
+            "test failure",
+        ));
+
+        assert_eq!(futures::executor::block_on(cf), None);
     }
 }

--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -1526,7 +1526,7 @@ impl AckCallback for AckResultCallback {
         self.send(Ok(ack_result));
     }
 
-    fn on_exception(&self, error: Box<dyn std::error::Error>) {
+    fn on_exception(&self, error: rocketmq_error::RocketMQError) {
         self.send(Err(ProxyError::Transport {
             message: error.to_string(),
         }));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8045

### Brief Description

Migrates client acknowledgement callbacks, send hook exception context, forbidden hook exception context, and `CompletableFuture` exceptional completion storage from boxed dynamic errors to `RocketMQError`.

This keeps callback and hook error data on the typed RocketMQ error path, updates affected client/proxy implementations, and adds regression coverage for the public callback API and typed hook context fields.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust --test public_api_exports_test`
- `cargo test -p rocketmq-client-rust --test typed_error_client_flow_tests`
- `cargo test -p rocketmq-common completable_future`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

Also ran `cargo test -p rocketmq-proxy --lib`; it compiled the changed proxy callback path, but the full suite still has five existing auth permission assertions that expect `BrokerPermissionDenied` instead of the current auth-specific error mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across async send, ack, and future operations by using a consistent typed error format.
  * Reduced mismatches in callback and context error reporting, helping failure cases behave more predictably.
  * Preserved existing error messages and logging while tightening error propagation.

* **Tests**
  * Expanded coverage for typed error handling in client flows and hook contexts.
  * Added validation for exceptional completion behavior in shared future handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->