### PR TITLE
[ISSUE #8047]♻️Type producer send callback errors

### DIFF
--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -44,6 +44,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -352,7 +353,7 @@ fn bench_async_backpressure_envelope(c: &mut Criterion) {
 fn bench_callback_dispatch(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
     let send_result = SendResult::default();
-    let callback: ArcSendCallback = Arc::new(|result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
+    let callback: ArcSendCallback = Arc::new(|result: Option<&SendResult>, error: Option<&RocketMQError>| {
         black_box(result.is_some());
         black_box(error.is_some());
     });

--- a/rocketmq-client/examples/benchmark/client_production_benchmark.rs
+++ b/rocketmq-client/examples/benchmark/client_production_benchmark.rs
@@ -238,7 +238,7 @@ async fn run_async(producer: &mut DefaultMQProducer, config: &Config, body: &[u8
         if let Err(error) = producer
             .send_with_callback_timeout(
                 message(&config.topic, "RustAsyncBenchmark", body),
-                move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
+                move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
                     let elapsed_ms = elapsed_ms_u64(begin.elapsed());
                     total_rt_ms_inner.fetch_add(elapsed_ms, Ordering::Relaxed);
                     update_max(&max_rt_ms_inner, elapsed_ms);

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::error::Error as StdError;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -2882,7 +2881,7 @@ impl MQClientAPIImpl {
     fn notify_send_callback_exception(
         send_callback: &Option<ArcSendCallback>,
         callback_executor: &Option<tokio::runtime::Handle>,
-        error: &dyn StdError,
+        error: &RocketMQError,
     ) {
         let Some(callback) = send_callback.as_ref().cloned() else {
             return;
@@ -2891,7 +2890,7 @@ impl MQClientAPIImpl {
         if let Some(executor) = callback_executor.as_ref() {
             let message = error.to_string();
             executor.spawn(async move {
-                let error = std::io::Error::other(message);
+                let error = RocketMQError::response_process_failed("send_callback", message);
                 callback.on_exception(&error);
             });
         } else {
@@ -7093,16 +7092,14 @@ mod tests {
             .build()
             .expect("callback runtime should build");
         let (tx, rx) = std::sync::mpsc::channel();
-        let callback: ArcSendCallback = Arc::new(
-            move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                tx.send((
-                    std::thread::current().name().unwrap_or_default().to_string(),
-                    result.is_some(),
-                    error.is_some(),
-                ))
-                .expect("test receiver should be alive");
-            },
-        );
+        let callback: ArcSendCallback = Arc::new(move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            tx.send((
+                std::thread::current().name().unwrap_or_default().to_string(),
+                result.is_some(),
+                error.is_some(),
+            ))
+            .expect("test receiver should be alive");
+        });
 
         MQClientAPIImpl::notify_send_callback_success(
             &Some(callback),
@@ -7127,17 +7124,15 @@ mod tests {
             .build()
             .expect("callback runtime should build");
         let (tx, rx) = std::sync::mpsc::channel();
-        let callback: ArcSendCallback = Arc::new(
-            move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                tx.send((
-                    std::thread::current().name().unwrap_or_default().to_string(),
-                    result.is_some(),
-                    error.map(ToString::to_string),
-                ))
-                .expect("test receiver should be alive");
-            },
-        );
-        let error = std::io::Error::other("callback failure");
+        let callback: ArcSendCallback = Arc::new(move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            tx.send((
+                std::thread::current().name().unwrap_or_default().to_string(),
+                result.is_some(),
+                error.map(ToString::to_string),
+            ))
+            .expect("test receiver should be alive");
+        });
+        let error = RocketMQError::network_request_failed("broker-a", "callback failure");
 
         MQClientAPIImpl::notify_send_callback_exception(&Some(callback), &Some(runtime.handle().clone()), &error);
 
@@ -7146,7 +7141,10 @@ mod tests {
             .expect("callback should execute on configured runtime");
         assert_eq!(thread_name, "rocketmq-callback-error");
         assert!(!has_result);
-        assert_eq!(error.as_deref(), Some("callback failure"));
+        assert_eq!(
+            error.as_deref(),
+            Some("Response send_callback failed: Send failed to broker-a: callback failure")
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -469,7 +469,7 @@ impl DefaultMQProducer {
     pub async fn send_with_callback<M, F>(&mut self, msg: M, send_callback: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_with_callback(self, msg, send_callback).await
     }
@@ -481,7 +481,7 @@ impl DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         <Self as MQProducer>::send_with_callback_timeout(self, msg, send_callback, timeout).await
@@ -525,7 +525,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_to_queue_with_callback(self, msg, mq, send_callback).await
     }
@@ -539,7 +539,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_to_queue_with_callback_timeout(self, msg, mq, send_callback, timeout).await
     }
@@ -682,7 +682,7 @@ impl DefaultMQProducer {
     pub async fn send_batch_with_callback<M, F>(&mut self, msgs: Vec<M>, f: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_batch_with_callback(self, msgs, f).await
     }
@@ -695,7 +695,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_batch_with_callback_timeout(self, msgs, f, timeout).await
     }
@@ -708,7 +708,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_batch_to_queue_with_callback(self, msgs, mq, f).await
     }
@@ -722,7 +722,7 @@ impl DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         <Self as MQProducer>::send_batch_to_queue_with_callback_timeout(self, msgs, mq, f, timeout).await
     }
@@ -1811,7 +1811,7 @@ impl MQProducer for DefaultMQProducer {
     async fn send_with_callback<M, F>(&mut self, mut msg: M, send_callback: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         msg.set_topic(self.with_namespace(msg.topic()));
         let send_callback_inner = Arc::new(send_callback);
@@ -1840,7 +1840,7 @@ impl MQProducer for DefaultMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         msg.set_topic(self.with_namespace(msg.topic().as_str()));
@@ -1908,7 +1908,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
@@ -1932,7 +1932,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
@@ -2159,7 +2159,7 @@ impl MQProducer for DefaultMQProducer {
     async fn send_batch_with_callback<M, F>(&mut self, msgs: Vec<M>, f: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         let batch = self.batch(msgs)?;
         self.default_mqproducer_impl
@@ -2178,7 +2178,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         let batch = self.batch(msgs)?;
         self.default_mqproducer_impl
@@ -2197,7 +2197,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         let batch = self.batch(msgs)?;
         let mq = self.client_config.queue_with_namespace(mq);
@@ -2217,7 +2217,7 @@ impl MQProducer for DefaultMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         let batch = self.batch(msgs)?;
         let mq = self.client_config.queue_with_namespace(mq);
@@ -2424,7 +2424,7 @@ mod facade_tests {
                 .await,
         );
 
-        let callback = |_result: Option<&SendResult>, _err: Option<&dyn std::error::Error>| {};
+        let callback = |_result: Option<&SendResult>, _err: Option<&RocketMQError>| {};
         assert_not_initialized(
             unstarted_producer()
                 .send_batch_to_queue_with_callback_timeout(vec![message()], queue(), callback, 1000)
@@ -2547,7 +2547,7 @@ mod tests {
             .topic("test-topic")
             .body(Bytes::from_static(b"Hello world"))
             .build_unchecked();
-        let callback = |_msg: Option<&SendResult>, _err: Option<&dyn std::error::Error>| {
+        let callback = |_msg: Option<&SendResult>, _err: Option<&RocketMQError>| {
             // no-op
         };
         let result: RocketMQResult<()> = producer.send_batch_with_callback(vec![msg], callback).await;
@@ -2622,7 +2622,7 @@ mod tests {
             .topic("test-topic")
             .body(Bytes::from_static(b"Hello world"))
             .build_unchecked();
-        let callback = |_msg: Option<&SendResult>, _err: Option<&dyn std::error::Error>| {
+        let callback = |_msg: Option<&SendResult>, _err: Option<&RocketMQError>| {
             // no-op
         };
         let result: RocketMQResult<()> = producer
@@ -2650,7 +2650,7 @@ mod tests {
             .topic("test-topic")
             .body(Bytes::from_static(b"Hello world"))
             .build_unchecked();
-        let callback = |_msg: Option<&SendResult>, _err: Option<&dyn std::error::Error>| {
+        let callback = |_msg: Option<&SendResult>, _err: Option<&RocketMQError>| {
             // no-op
         };
         let mq = MessageQueue::new();

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -19,6 +19,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 
 use crate::base::query_result::QueryResult;
 use crate::producer::send_callback::ArcSendCallback;
@@ -173,7 +174,7 @@ pub trait MQProducer {
     async fn send_with_callback<M, F>(&mut self, msg: M, send_callback: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a message with a callback and a timeout.
     ///
@@ -197,7 +198,7 @@ pub trait MQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync;
 
     /// Sends a message without waiting for a response.
@@ -290,7 +291,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a message to a specific message queue with a callback and a timeout.
     ///
@@ -318,7 +319,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a message to a specific message queue without waiting for a response.
     ///
@@ -596,7 +597,7 @@ pub trait MQProducer {
     async fn send_batch_with_callback<M, F>(&mut self, msgs: Vec<M>, f: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a batch of messages with a callback and a timeout.
     ///
@@ -617,7 +618,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a batch of messages to a specific message queue with a callback.
     ///
@@ -638,7 +639,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a batch of messages to a specific message queue with a callback and a timeout.
     ///
@@ -661,7 +662,7 @@ pub trait MQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static;
 
     /// Sends a request message.
     ///

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -34,6 +34,7 @@ use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
 use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -594,7 +595,7 @@ impl ProduceAccumulator {
         let callbacks_for_send_error = callbacks.clone();
 
         // Create combined callback
-        let combined_callback = move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
+        let combined_callback = move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
             release_hold_size(&callback_currently_hold_size, total_size);
             // Invoke all registered callbacks
             if let Some(result) = result {
@@ -1031,12 +1032,10 @@ mod tests {
             MessageAccumulation::new(aggregate_key.clone(), ArcMut::new(DefaultMQProducer::default()));
         let callback_invoked = Arc::new(AtomicBool::new(false));
         let callback_invoked_for_callback = callback_invoked.clone();
-        let callback: ArcSendCallback = Arc::new(
-            move |_result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                assert!(error.is_some());
-                callback_invoked_for_callback.store(true, Ordering::Release);
-            },
-        );
+        let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            assert!(error.is_some());
+            callback_invoked_for_callback.store(true, Ordering::Release);
+        });
         let message = Message::builder()
             .topic("test-topic")
             .body_slice(b"hello")
@@ -1972,7 +1971,7 @@ impl GuardForAsyncSendService {
         let callbacks_for_send_error = callbacks.clone();
 
         // Create combined callback
-        let combined_callback = move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
+        let combined_callback = move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
             release_hold_size(&callback_currently_hold_size, total_size);
             if let Some(result) = result {
                 match split_send_results(result, callbacks.len()) {

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -464,7 +464,7 @@ impl DefaultMQProducerImpl {
     }
 
     #[inline]
-    fn notify_callback_exception(send_callback: &Option<ArcSendCallback>, error: &dyn std::error::Error) {
+    fn notify_callback_exception(send_callback: &Option<ArcSendCallback>, error: &RocketMQError) {
         if let Some(send_callback) = send_callback.as_ref() {
             send_callback.on_exception(error);
         } else {
@@ -478,8 +478,8 @@ impl DefaultMQProducerImpl {
     }
 
     #[inline]
-    fn request_cause_from_error(error: &dyn std::error::Error) -> RocketMQError {
-        RocketMQError::illegal_argument(error.to_string())
+    fn request_cause_from_error(error: &RocketMQError) -> RocketMQError {
+        RocketMQError::response_process_failed("request_response_callback", error.to_string())
     }
 
     #[inline]
@@ -2152,7 +2152,7 @@ impl DefaultMQProducerImpl {
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
         let request_response_future_inner = request_response_future.clone();
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future_inner.set_send_request_ok(true);
                 return;
@@ -2212,7 +2212,7 @@ impl DefaultMQProducerImpl {
         REQUEST_FUTURE_HOLDER
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future.set_send_request_ok(true);
                 return;
@@ -2254,7 +2254,7 @@ impl DefaultMQProducerImpl {
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
         let request_response_future_inner = request_response_future.clone();
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future_inner.set_send_request_ok(true);
                 return;
@@ -2311,7 +2311,7 @@ impl DefaultMQProducerImpl {
         REQUEST_FUTURE_HOLDER
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future.set_send_request_ok(true);
                 return;
@@ -2356,7 +2356,7 @@ impl DefaultMQProducerImpl {
         REQUEST_FUTURE_HOLDER
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future.set_send_request_ok(true);
                 request_response_future.execute_request_callback();
@@ -2405,7 +2405,7 @@ impl DefaultMQProducerImpl {
             .put_request(correlation_id.to_string(), request_response_future.clone())
             .await;
         let request_response_future_inner = request_response_future.clone();
-        let send_callback = move |result: Option<&SendResult>, err: Option<&dyn std::error::Error>| {
+        let send_callback = move |result: Option<&SendResult>, err: Option<&RocketMQError>| {
             if result.is_some() {
                 request_response_future_inner.set_send_request_ok(true);
                 return;
@@ -3624,10 +3624,19 @@ mod tests {
 
     #[test]
     fn request_cause_from_error_uses_typed_error() {
-        let error = DefaultMQProducerImpl::request_cause_from_error(&std::io::Error::other("send failed"));
+        let error = DefaultMQProducerImpl::request_cause_from_error(&RocketMQError::network_request_failed(
+            "broker-a",
+            "send failed",
+        ));
 
-        assert!(matches!(error, rocketmq_error::RocketMQError::IllegalArgument(_)));
-        assert_eq!(error.to_string(), "Illegal argument: send failed");
+        assert!(matches!(
+            error,
+            rocketmq_error::RocketMQError::ResponseProcessFailed { .. }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Response request_response_callback failed: Send failed to broker-a: send failed"
+        );
     }
 
     #[test]
@@ -3851,7 +3860,7 @@ mod tests {
                 .lock()
                 .expect("exception message lock should not be poisoned")
                 .as_deref(),
-            Some("sendKernelImpl exception")
+            Some("Response send_message failed: sendKernelImpl exception")
         );
     }
 
@@ -4071,16 +4080,14 @@ mod tests {
         let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
         let notify_for_callback = notify.clone();
         let seen_for_callback = seen_error.clone();
-        let callback: ArcSendCallback = Arc::new(
-            move |_result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                if let Some(error) = error {
-                    *seen_for_callback
-                        .lock()
-                        .expect("seen error lock should not be poisoned") = Some(error.to_string());
-                    notify_for_callback.notify_one();
-                }
-            },
-        );
+        let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            if let Some(error) = error {
+                *seen_for_callback
+                    .lock()
+                    .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                notify_for_callback.notify_one();
+            }
+        });
         let msg = Message::builder().topic("TopicTest").empty_body().build_unchecked();
         let mq = MessageQueue::from_parts("TopicTest", "broker-a", 0);
 
@@ -4109,16 +4116,14 @@ mod tests {
         let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
         let notify_for_callback = notify.clone();
         let seen_for_callback = seen_error.clone();
-        let callback: ArcSendCallback = Arc::new(
-            move |_result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                if let Some(error) = error {
-                    *seen_for_callback
-                        .lock()
-                        .expect("seen error lock should not be poisoned") = Some(error.to_string());
-                    notify_for_callback.notify_one();
-                }
-            },
-        );
+        let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            if let Some(error) = error {
+                *seen_for_callback
+                    .lock()
+                    .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                notify_for_callback.notify_one();
+            }
+        });
         let msg = Message::builder().topic("TopicA").body_slice(b"body").build_unchecked();
         let mq = MessageQueue::from_parts("TopicB", "broker-a", 0);
 
@@ -4150,16 +4155,14 @@ mod tests {
         let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
         let notify_for_callback = notify.clone();
         let seen_for_callback = seen_error.clone();
-        let callback: ArcSendCallback = Arc::new(
-            move |_result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
-                if let Some(error) = error {
-                    *seen_for_callback
-                        .lock()
-                        .expect("seen error lock should not be poisoned") = Some(error.to_string());
-                    notify_for_callback.notify_one();
-                }
-            },
-        );
+        let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&RocketMQError>| {
+            if let Some(error) = error {
+                *seen_for_callback
+                    .lock()
+                    .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                notify_for_callback.notify_one();
+            }
+        });
         let msg = Message::builder()
             .topic("TopicTest")
             .body_slice(b"body")

--- a/rocketmq-client/src/producer/send_callback.rs
+++ b/rocketmq-client/src/producer/send_callback.rs
@@ -21,6 +21,8 @@
 
 use std::sync::Arc;
 
+use rocketmq_error::RocketMQError;
+
 use crate::producer::send_result::SendResult;
 
 /// Callback trait for handling asynchronous message send results.
@@ -57,7 +59,7 @@ use crate::producer::send_result::SendResult;
 ///         log::info!("Message sent: {:?}", send_result.msg_id);
 ///     }
 ///
-///     fn on_exception(&self, error: &dyn std::error::Error) {
+///     fn on_exception(&self, error: &RocketMQError) {
 ///         log::error!("Send failed: {}", error);
 ///     }
 /// }
@@ -75,22 +77,22 @@ pub trait SendCallback: Send + Sync {
     /// # Arguments
     ///
     /// * `error` - The error that caused the send failure.
-    fn on_exception(&self, error: &dyn std::error::Error);
+    fn on_exception(&self, error: &RocketMQError);
 }
 
 // Blanket implementation allowing closures to act as callbacks.
 //
-// Closures receive `Option<&SendResult>` and `Option<&dyn Error>` parameters,
+// Closures receive `Option<&SendResult>` and `Option<&RocketMQError>` parameters,
 // where exactly one is `Some` and the other is `None`.
 impl<F> SendCallback for F
 where
-    F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync,
+    F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync,
 {
     fn on_success(&self, send_result: &SendResult) {
         self(Some(send_result), None)
     }
 
-    fn on_exception(&self, error: &dyn std::error::Error) {
+    fn on_exception(&self, error: &RocketMQError) {
         self(None, Some(error))
     }
 }
@@ -134,4 +136,4 @@ pub type ArcSendCallback = Arc<dyn SendCallback>;
 /// fn my_function<CB: SendCallback + 'static>(callback: CB) { /* ... */ }
 /// ```
 #[deprecated(since = "0.8.0", note = "Use ArcSendCallback or generic SendCallback bound instead")]
-pub type SendMessageCallback = Arc<dyn Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync>;
+pub type SendMessageCallback = Arc<dyn Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync>;

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -334,7 +334,7 @@ impl MQProducer for TransactionMQProducer {
     async fn send_with_callback<M, F>(&mut self, msg: M, send_callback: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer.send_with_callback(msg, send_callback).await
     }
@@ -346,7 +346,7 @@ impl MQProducer for TransactionMQProducer {
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
         self.default_producer
@@ -388,7 +388,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer
             .send_to_queue_with_callback(msg, mq, send_callback)
@@ -404,7 +404,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer
             .send_to_queue_with_callback_timeout(msg, mq, send_callback, timeout)
@@ -571,7 +571,7 @@ impl MQProducer for TransactionMQProducer {
     async fn send_batch_with_callback<M, F>(&mut self, msgs: Vec<M>, f: F) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer.send_batch_with_callback(msgs, f).await
     }
@@ -584,7 +584,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer
             .send_batch_with_callback_timeout(msgs, f, timeout)
@@ -599,7 +599,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer
             .send_batch_to_queue_with_callback(msgs, mq, f)
@@ -615,7 +615,7 @@ impl MQProducer for TransactionMQProducer {
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
-        F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
+        F: Fn(Option<&SendResult>, Option<&RocketMQError>) + Send + Sync + 'static,
     {
         self.default_producer
             .send_batch_to_queue_with_callback_timeout(msgs, mq, f, timeout)

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -43,6 +43,7 @@ fn client_callback_error_paths_use_typed_rocketmq_error() {
     let pop_callback = include_str!("../src/consumer/pop_callback.rs");
     let request_callback = include_str!("../src/producer/request_callback.rs");
     let request_future = include_str!("../src/producer/request_response_future.rs");
+    let send_callback = include_str!("../src/producer/send_callback.rs");
 
     assert!(ack_callback.contains("fn on_exception(&self, e: RocketMQError)"));
     assert!(ack_callback.contains("Result<(), RocketMQError>"));
@@ -61,6 +62,10 @@ fn client_callback_error_paths_use_typed_rocketmq_error() {
     assert!(request_callback.contains("Option<&RocketMQError>"));
     assert!(request_future.contains("type RequestCause = Arc<RocketMQError>"));
     assert!(!request_future.contains("type RequestCause = Arc<dyn"));
+
+    assert!(send_callback.contains("fn on_exception(&self, error: &RocketMQError)"));
+    assert!(send_callback.contains("Option<&RocketMQError>"));
+    assert!(!send_callback.contains("Option<&dyn std::error::Error>"));
 }
 
 #[test]

--- a/rocketmq-example/examples/producer/basic_send.rs
+++ b/rocketmq-example/examples/producer/basic_send.rs
@@ -24,6 +24,7 @@
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::rocketmq;
 
@@ -132,7 +133,7 @@ async fn send_with_callback(producer: &mut DefaultMQProducer) -> RocketMQResult<
     producer
         .send_with_callback(
             message,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),
@@ -162,7 +163,7 @@ async fn send_with_callback_timeout(producer: &mut DefaultMQProducer) -> RocketM
     producer
         .send_with_callback_timeout(
             message,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),

--- a/rocketmq-example/examples/producer/batch_send.rs
+++ b/rocketmq-example/examples/producer/batch_send.rs
@@ -29,6 +29,7 @@ use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::rocketmq;
 
@@ -234,7 +235,7 @@ async fn batch_send_with_callback(producer: &mut DefaultMQProducer) -> RocketMQR
     producer
         .send_batch_with_callback(
             messages,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),
@@ -270,7 +271,7 @@ async fn batch_send_with_callback_timeout(producer: &mut DefaultMQProducer) -> R
     producer
         .send_batch_with_callback_timeout(
             messages,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),
@@ -311,7 +312,7 @@ async fn batch_send_to_queue_with_callback(
         .send_batch_to_queue_with_callback(
             messages,
             queue,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),
@@ -354,7 +355,7 @@ async fn batch_send_to_queue_with_callback_timeout(
         .send_batch_to_queue_with_callback_timeout(
             messages,
             queue,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),

--- a/rocketmq-example/examples/producer/send_to_queue.rs
+++ b/rocketmq-example/examples/producer/send_to_queue.rs
@@ -25,6 +25,7 @@ use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::rocketmq;
 
@@ -140,7 +141,7 @@ async fn send_to_queue_with_callback(producer: &mut DefaultMQProducer, queue: Me
         .send_to_queue_with_callback(
             message,
             queue,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),
@@ -173,7 +174,7 @@ async fn send_to_queue_with_callback_timeout(
         .send_to_queue_with_callback_timeout(
             message,
             queue,
-            |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
                 (Some(r), None) => println!("   Callback: Success - {:?}", r),
                 (None, Some(e)) => println!("   Callback: Error - {}", e),
                 _ => println!("   Callback: Unknown state"),

--- a/rocketmq-example/examples/producer/send_with_selector.rs
+++ b/rocketmq-example/examples/producer/send_with_selector.rs
@@ -28,6 +28,7 @@ use rocketmq_client_rust::producer::send_callback::ArcSendCallback;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::rocketmq;
 
@@ -156,13 +157,14 @@ async fn send_with_selector_callback(producer: &mut DefaultMQProducer) -> Rocket
 
     let arg = "selector-arg";
 
-    let callback: ArcSendCallback = Arc::new(
-        |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
-            (Some(r), None) => println!("   Callback: Success - {:?}", r),
-            (None, Some(e)) => println!("   Callback: Error - {}", e),
-            _ => println!("   Callback: Unknown state"),
-        },
-    );
+    let callback: ArcSendCallback =
+        Arc::new(
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
+                (Some(r), None) => println!("   Callback: Success - {:?}", r),
+                (None, Some(e)) => println!("   Callback: Error - {}", e),
+                _ => println!("   Callback: Unknown state"),
+            },
+        );
 
     producer
         .send_with_selector_callback(message, selector, arg, Some(callback))
@@ -194,13 +196,14 @@ async fn send_with_selector_callback_timeout(producer: &mut DefaultMQProducer) -
 
     let arg = "selector-arg";
 
-    let callback: ArcSendCallback = Arc::new(
-        |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
-            (Some(r), None) => println!("   Callback: Success - {:?}", r),
-            (None, Some(e)) => println!("   Callback: Error - {}", e),
-            _ => println!("   Callback: Unknown state"),
-        },
-    );
+    let callback: ArcSendCallback =
+        Arc::new(
+            |result: Option<&SendResult>, error: Option<&RocketMQError>| match (result, error) {
+                (Some(r), None) => println!("   Callback: Success - {:?}", r),
+                (None, Some(e)) => println!("   Callback: Error - {}", e),
+                _ => println!("   Callback: Unknown state"),
+            },
+        );
 
     producer
         .send_with_selector_callback_timeout(message, selector, arg, Some(callback), TIMEOUT_MS)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8047

### Brief Description

Migrates producer send callbacks from dynamic error references to `RocketMQError` references across the client producer API, implementation call sites, accumulator forwarding, request-response helper callbacks, examples, benches, and standalone producer examples.

The request-response future failure path now stores a typed response-processing error instead of converting callback errors through a generic illegal-argument string, and typed error source-level regression coverage now includes producer send callbacks.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust --test typed_error_client_flow_tests`
- `cargo test -p rocketmq-client-rust --test public_api_exports_test`
- `cargo test -p rocketmq-client-rust request_cause_from_error_uses_typed_error --lib`
- `cargo test -p rocketmq-client-rust async_send_callback_exception_uses_configured_callback_executor_like_java --lib`
- `cargo test -p rocketmq-client-rust --lib`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all` from `rocketmq-example`
- `cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-example`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send callback error handling to use a consistent RocketMQ-specific error type across producer APIs, examples, and benchmarks.
  * Updated callback behavior so error details are reported more consistently during async send, batch send, request, and selector flows.
  * Aligned tests with the new error reporting behavior to better validate callback outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->