### PR TITLE
[ISSUE #8049]♻️Type client rebalance errors

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -20,6 +20,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::UnifiedServiceError;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::Shutdown;
 use serde::Serialize;
@@ -39,6 +42,18 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     spawn_client_tracked_task("rocketmq-client-rebalance-service", task)
+}
+
+fn rebalance_service_startup_failed(error: impl std::fmt::Display) -> RocketMQError {
+    RocketMQError::Service(UnifiedServiceError::StartupFailed(format!(
+        "RebalanceService start: {error}"
+    )))
+}
+
+fn rebalance_service_shutdown_failed(reason: impl std::fmt::Display) -> RocketMQError {
+    RocketMQError::Service(UnifiedServiceError::ShutdownFailed(format!(
+        "RebalanceService shutdown: {reason}"
+    )))
 }
 
 /// Configuration for RebalanceService.
@@ -220,10 +235,7 @@ impl RebalanceService {
         &self.config
     }
 
-    pub async fn start(
-        &mut self,
-        mut instance: ArcMut<MQClientInstance>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn start(&mut self, mut instance: ArcMut<MQClientInstance>) -> RocketMQResult<()> {
         // Prevent duplicate starts
         if self.started.swap(true, Ordering::SeqCst) {
             warn!("RebalanceService already started, ignoring duplicate start call");
@@ -323,7 +335,7 @@ impl RebalanceService {
             Err(error) => {
                 self.started.store(false, Ordering::SeqCst);
                 self.tx_shutdown = None;
-                return Err(Box::new(error));
+                return Err(rebalance_service_startup_failed(error));
             }
         };
 
@@ -344,7 +356,7 @@ impl RebalanceService {
         self.notify.notify_waiters();
     }
 
-    pub async fn shutdown(&self, timeout_ms: u64) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn shutdown(&self, timeout_ms: u64) -> RocketMQResult<()> {
         // If not started, return directly
         if !self.started.load(Ordering::SeqCst) {
             info!("RebalanceService not started, shutdown skipped");
@@ -374,7 +386,7 @@ impl RebalanceService {
                 report = %report.to_json(),
                 "RebalanceService shutdown report is unhealthy"
             );
-            return Err("Shutdown timeout".into());
+            return Err(rebalance_service_shutdown_failed("task group did not stop cleanly"));
         }
 
         // Fallback for older or failed starts where no handle was captured.
@@ -385,7 +397,9 @@ impl RebalanceService {
                 Ok(()) => {}
                 Err(_) => {
                     warn!("RebalanceService shutdown timeout after {}ms", timeout_ms);
-                    return Err("Shutdown timeout".into());
+                    return Err(rebalance_service_shutdown_failed(
+                        "timeout waiting for stopped notification",
+                    ));
                 }
             }
         }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -37,6 +37,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use rocketmq_error::UnifiedServiceError;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -2045,7 +2046,7 @@ impl MQClientInstance {
         Ok(())
     }
 
-    pub async fn do_rebalance(&mut self) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn do_rebalance(&mut self) -> RocketMQResult<bool> {
         let mut balanced = true;
         for entry in self.consumer_table.iter() {
             match entry.value().try_rebalance().await {

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -78,3 +78,16 @@ fn client_hook_contexts_store_typed_errors() {
     assert!(!send_message_context.contains("Box<dyn Error + Send + Sync>"));
     assert!(!check_forbidden_context.contains("Box<dyn std::error::Error + Send + Sync>"));
 }
+
+#[test]
+fn client_rebalance_service_uses_typed_errors() {
+    let mq_client_instance = include_str!("../src/factory/mq_client_instance.rs");
+    let rebalance_service = include_str!("../src/consumer/consumer_impl/re_balance/rebalance_service.rs");
+
+    assert!(mq_client_instance.contains("pub async fn do_rebalance(&mut self) -> RocketMQResult<bool>"));
+    assert!(rebalance_service
+        .contains("pub async fn start(&mut self, mut instance: ArcMut<MQClientInstance>) -> RocketMQResult<()>"));
+    assert!(rebalance_service.contains("pub async fn shutdown(&self, timeout_ms: u64) -> RocketMQResult<()>"));
+    assert!(!mq_client_instance.contains("do_rebalance(&mut self) -> Result<bool, Box<dyn std::error::Error"));
+    assert!(!rebalance_service.contains("Box<dyn std::error::Error + Send + Sync>"));
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8049

### Brief Description

Migrates client rebalance service APIs from boxed dynamic error results to `RocketMQResult`.

`MQClientInstance::do_rebalance`, `RebalanceService::start`, and `RebalanceService::shutdown` now stay on the typed RocketMQ error path, and rebalance service startup/shutdown failures map to typed service lifecycle errors. Source-level regression coverage prevents the rebalance service from reintroducing boxed dynamic errors.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust --test typed_error_client_flow_tests`
- `cargo test -p rocketmq-client-rust rebalance_service --lib`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebalance and shutdown error handling with consistent, structured failures.
  * Rebalance startup and shutdown now report clearer service errors instead of generic boxed errors.
  * Client rebalance operations now use the same unified error format across the flow.

* **Tests**
  * Added coverage to ensure rebalance-related APIs continue using typed error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->