### PR TITLE
[ISSUE #8055]♻️Type store group commit errors

### DIFF
--- a/rocketmq-store/src/log_file/group_commit_request.rs
+++ b/rocketmq-store/src/log_file/group_commit_request.rs
@@ -19,6 +19,11 @@ use tokio::sync::oneshot;
 use tracing::warn;
 
 use crate::base::message_status_enum::PutMessageStatus;
+use crate::store_error::StoreError;
+
+fn group_commit_invalid_state(reason: impl Into<String>) -> StoreError {
+    StoreError::InvalidState(format!("group commit response {}", reason.into()))
+}
 
 pub struct GroupCommitResponse {
     flush_ok_receiver: Option<oneshot::Receiver<PutMessageStatus>>,
@@ -37,21 +42,19 @@ impl GroupCommitResponse {
     }
 
     /// Get a future that resolves when the flush operation completes
-    pub async fn wait_for_result(mut self) -> Result<PutMessageStatus, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn wait_for_result(mut self) -> Result<PutMessageStatus, StoreError> {
         if let Some(receiver) = self.flush_ok_receiver.take() {
             match receiver.await {
                 Ok(status) => Ok(status),
-                Err(_) => Err("Sender was dropped before sending result".into()),
+                Err(_) => Err(group_commit_invalid_state("sender dropped before sending result")),
             }
         } else {
-            Err("Receiver was already consumed".into())
+            Err(group_commit_invalid_state("receiver was already consumed"))
         }
     }
 
     /// Get a future that resolves when the flush operation completes with timeout
-    pub async fn wait_for_result_with_timeout(
-        &mut self,
-    ) -> Result<PutMessageStatus, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn wait_for_result_with_timeout(&mut self) -> Result<PutMessageStatus, StoreError> {
         if let Some(receiver) = self.flush_ok_receiver.take() {
             let timeout_duration = if self.deadline > Instant::now() {
                 self.deadline - Instant::now()
@@ -61,11 +64,11 @@ impl GroupCommitResponse {
 
             match tokio::time::timeout(timeout_duration, receiver).await {
                 Ok(Ok(status)) => Ok(status),
-                Ok(Err(_)) => Err("Sender was dropped before sending result".into()),
+                Ok(Err(_)) => Err(group_commit_invalid_state("sender dropped before sending result")),
                 Err(_) => Ok(PutMessageStatus::FlushDiskTimeout),
             }
         } else {
-            Err("Receiver was already consumed".into())
+            Err(group_commit_invalid_state("receiver was already consumed"))
         }
     }
 }
@@ -198,5 +201,25 @@ mod tests {
 
         assert!(elapsed >= Duration::from_millis(90)); // Allow some tolerance
         assert!(matches!(result, Ok(PutMessageStatus::FlushDiskTimeout)));
+    }
+
+    #[tokio::test]
+    async fn wait_for_result_returns_typed_error_after_receiver_consumed() {
+        let (_request, mut response) = GroupCommitRequest::new(12345, 0);
+        let first = response.wait_for_result_with_timeout().await;
+        let second = response.wait_for_result_with_timeout().await;
+
+        assert!(matches!(first, Ok(PutMessageStatus::FlushDiskTimeout)));
+        assert!(
+            matches!(second, Err(StoreError::InvalidState(message)) if message.contains("receiver was already consumed"))
+        );
+    }
+
+    #[test]
+    fn group_commit_response_uses_typed_errors() {
+        let source = include_str!("group_commit_request.rs");
+
+        assert!(source.contains("Result<PutMessageStatus, StoreError>"));
+        assert!(!source.contains(concat!("Box<dyn std::error::", "Error")));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8055

### Brief Description

Migrates store group commit response wait helpers from boxed dynamic error results to `StoreError`.

Dropped sender and consumed receiver states now return typed store invalid-state errors, and regression coverage prevents the group commit response helpers from reintroducing boxed dynamic error results.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store group_commit_request --lib`
- `python scripts\error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit-wait error handling to return consistent, typed store errors.
  * Fixed cases where a commit response was already consumed or unavailable, with clearer failure messages.
  * Timeout handling now preserves the expected flush-timeout status while using the same error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->