### PR TITLE
[ISSUE #8059]♻️Codify error governance artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,29 @@ cargo test
   cargo install taplo-cli --locked
   taplo format -o align_entries=true **/Cargo.toml
   ```
+
+### Error architecture
+
+When adding or changing an error that can cross crate, process, protocol, or CLI
+boundaries:
+
+- Prefer `RocketMQResult` or a domain-specific result type in library code.
+- Do not add legacy aliases such as `RocketmqError`, `LegacyRocketMQResult`, or `LegacyResult`.
+- Do not expose `anyhow::Result` from library or public business APIs.
+- Add or reuse an `ErrorKind` and one `ErrorSpec` entry before exposing a new public error.
+- Use `BoundaryErrorView` or `ErrorSpec` protocol primitives for remoting, gRPC, HTTP, and CLI responses.
+- Keep sensitive values in `Sensitive<T>` or redacted `ErrorContext` fields.
+- Preserve source chains with typed wrappers and `#[source]` instead of early stringification.
+- Keep `RocketMQError::Internal` for audited internal invariants, not ordinary business failures.
+
+Run the error hygiene guard before opening a pull request:
+
+```shell
+python scripts/error_architecture_guard.py
+```
+
+On Windows, the same guard is available through:
+
+```powershell
+.\scripts\check-error-hygiene.ps1
+```

--- a/docs/07-error-hygiene-allowlist.md
+++ b/docs/07-error-hygiene-allowlist.md
@@ -1,0 +1,57 @@
+# Error Hygiene Allowlist
+
+This document explains the allowlist classes enforced by `scripts/error_architecture_guard.py`.
+The Python guard is the source of truth and is wired into `.github/workflows/rocketmq-rust-ci.yaml`.
+The PowerShell entry point `scripts/check-error-hygiene.ps1` runs the same guard locally on Windows.
+
+## Review Rules
+
+- Each new allowlist entry must name a repository-relative path or path prefix.
+- Each new entry must explain why the exception is safe, temporary, or externally required.
+- Boundary paths must prefer `BoundaryErrorView`, `ErrorSpec`, and redacted context over raw `Display`.
+- Library code must use `RocketMQResult` or a domain result unless the path is a process, CLI, build, example, or compatibility boundary.
+- `RocketMQError::Internal` is allowed only for audited invariants, compatibility surfaces, or presentation-layer diagnostics.
+
+## Guard Categories
+
+| Category | Enforced rule | Cleanup policy |
+| --- | --- | --- |
+| Core public surface | `rocketmq-error` and `rocketmq-common` must not expose legacy aliases or public `anyhow` contracts. | No allowlist. New hits are regressions. |
+| Processor boundary mappings | Unsupported request-code paths must use central remoting helpers. | No allowlist for new unsupported-code responses. |
+| Generic processor response codes | Java-compatible protocol branches may keep fixed `ResponseCode` values. | New business failures should return typed errors and convert at the boundary. |
+| Required mapping adapters | Remoting, gRPC, HTTP, CLI, and admin views must keep tokens that prove `BoundaryErrorView` or `ErrorSpec` usage. | Missing tokens are regressions. |
+| Source stringification | Domain layers must not stringify source errors unless the file has an audited compatibility reason. | Prefer typed wrappers with `#[source]`; shrink entries as domain errors mature. |
+| Internal errors | `RocketMQError::Internal` must be in an audited path prefix or test context. | Replace common business failures with typed variants. |
+| `anyhow` results | `anyhow::Result` and `anyhow::Error` are limited to process, CLI, build, dashboard, example, and explicit app boundaries. | Library/public APIs should use typed results. |
+| Redaction guards | Sensitive fields must use `Sensitive<T>`, `REDACTED`, or a manual redacted `Debug` implementation. | New sensitive fields need tests. |
+
+## Current Path Allowlist
+
+The guard keeps path-level entries inline so that CI can fail atomically when a path is removed or renamed.
+The current audited classes are:
+
+| Path or prefix | Reason |
+| --- | --- |
+| `rocketmq-broker/src/processor/admin_broker_processor/` | Admin remoting APIs retain Java-compatible local response codes pending typed handler migration. |
+| `rocketmq-broker/src/processor/*` protocol handlers | Pop, pull, send, query, reply, recall, transaction, notification, and lite-management protocols keep Java-compatible broker response codes where the branch is protocol-defined. |
+| `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/` | CLI presentation commands may format local diagnostics for terminal output while admin core keeps typed views. |
+| `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/` | Admin core still has audited compatibility adapters; new business failures should use domain errors. |
+| `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/` | TUI process and terminal runtime boundaries may use `anyhow` or local display diagnostics. |
+| `rocketmq-dashboard/rocketmq-dashboard-web/backend/src/lib.rs` and `main.rs` | Web backend process boundary. |
+| `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/**` dashboard service files | Standalone Tauri boundary pending dashboard alignment. |
+| `rocketmq-dashboard/rocketmq-dashboard-gpui/build.rs` and other `build.rs` files | Build script boundary. |
+| `rocketmq-auth/src/**` selected loader, provider, strategy, migration, and runtime bridge files | Auth compatibility paths convert provider or legacy ACL details into stable public auth errors while provider internals are still being split. |
+| `rocketmq-store/src/ha/**` selected service files | HA service traits and async runtime joins still expose service diagnostics at compatibility boundaries. |
+| `rocketmq-store/src/message_store/local_file_message_store.rs` | Recovery progress and HA/storage diagnostics are preserved as display text until all local recovery errors have typed wrappers. |
+| `rocketmq-store/src/rocksdb/**` selected files | RocksDB integration keeps task failure text or wraps external errors through storage variants pending richer external source slots. |
+| `rocketmq-store/src/utils/ffi.rs` | FFI helpers expose OS error reasons across a C-compatible boundary. |
+| `rocketmq-controller/src/openraft/**` selected files | OpenRaft traits require `std::io::Error` or network error values at the storage/network boundary. |
+| `rocketmq-controller/src/processor/controller_request_processor.rs` | Controller config remoting endpoint maps UTF-8 parser details into request validation text. |
+
+## Local Verification
+
+```powershell
+.\scripts\check-error-hygiene.ps1
+```
+
+The command should end with `ERROR_ARCHITECTURE_GUARD_OK all`. Any `ERROR_ARCHITECTURE_GUARD_FAIL` output must be fixed or explicitly justified with a new allowlist entry and tests.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,91 @@
+# Error Codes
+
+The canonical registry lives in `rocketmq-error/src/spec.rs`.
+Every public `ErrorKind` must have exactly one `ErrorSpec`, and the registry tests enforce this invariant.
+Boundary adapters must use `RocketMQError::boundary_view()` to build a `BoundaryErrorView`, or use `ErrorSpec` protocol primitives directly, instead of parsing `Display` text.
+
+Each `ErrorSpec` provides:
+
+- stable machine-readable code from `ErrorKind::code()`;
+- scope and low-cardinality category from `ErrorKind`;
+- public message for protocol and CLI surfaces;
+- remoting, gRPC, HTTP, and CLI mapping primitives;
+- retry policy through `RecoverySpec`;
+- severity and metric label through `ObserveSpec`;
+- redaction policy through `RedactionPolicy`.
+
+## Registry
+
+| Error kind | Stable code | Public message |
+| --- | --- | --- |
+| `Network` | `NETWORK_CONNECTION_FAILED` | Network operation failed |
+| `Serialization` | `SERIALIZATION_FAILED` | Serialization failed |
+| `Protocol` | `PROTOCOL_ERROR` | Protocol error |
+| `Rpc` | `RPC_ERROR` | RPC operation failed |
+| `Authentication` | `AUTHENTICATION_FAILED` | Authentication failed |
+| `Controller` | `CONTROLLER_ERROR` | Controller operation failed |
+| `InvalidProperty` | `INVALID_PROPERTY` | Message property is invalid |
+| `BrokerNotFound` | `BROKER_NOT_FOUND` | Broker was not found |
+| `BrokerRegistrationFailed` | `BROKER_REGISTRATION_FAILED` | Broker registration failed |
+| `BrokerOperationFailed` | `BROKER_OPERATION_FAILED` | Broker operation failed |
+| `TopicNotExist` | `TOPIC_NOT_EXIST` | Topic does not exist |
+| `QueueNotExist` | `QUEUE_NOT_EXIST` | Queue does not exist |
+| `SubscriptionGroupNotExist` | `SUBSCRIPTION_GROUP_NOT_EXIST` | Subscription group does not exist |
+| `QueueIdOutOfRange` | `QUEUE_ID_OUT_OF_RANGE` | Queue id is out of range |
+| `MessageTooLarge` | `MESSAGE_TOO_LARGE` | Message body is too large |
+| `MessageValidationFailed` | `MESSAGE_VALIDATION_FAILED` | Message validation failed |
+| `RetryLimitExceeded` | `RETRY_LIMIT_EXCEEDED` | Retry limit was exceeded |
+| `TransactionRejected` | `TRANSACTION_REJECTED` | Transaction message was rejected |
+| `BrokerPermissionDenied` | `BROKER_PERMISSION_DENIED` | Broker permission was denied |
+| `NotMasterBroker` | `NOT_MASTER_BROKER` | Broker is not the master |
+| `MessageLookupFailed` | `MESSAGE_LOOKUP_FAILED` | Message lookup failed |
+| `QueryNotFound` | `QUERY_NOT_FOUND` | Query result was not found |
+| `TopicSendingForbidden` | `TOPIC_SENDING_FORBIDDEN` | Topic sending is forbidden |
+| `BrokerAsyncTaskFailed` | `BROKER_ASYNC_TASK_FAILED` | Broker asynchronous operation failed |
+| `RequestBodyInvalid` | `REQUEST_BODY_INVALID` | Request body is invalid |
+| `RequestHeaderError` | `REQUEST_HEADER_ERROR` | Request header is invalid |
+| `ResponseProcessFailed` | `RESPONSE_PROCESS_FAILED` | Response processing failed |
+| `RouteNotFound` | `ROUTE_NOT_FOUND` | Route information was not found |
+| `RouteInconsistent` | `ROUTE_INCONSISTENT` | Route data is inconsistent |
+| `RouteRegistrationConflict` | `ROUTE_REGISTRATION_CONFLICT` | Route registration conflict |
+| `RouteVersionConflict` | `ROUTE_VERSION_CONFLICT` | Route version conflict |
+| `ClusterNotFound` | `CLUSTER_NOT_FOUND` | Cluster was not found |
+| `ClientNotStarted` | `CLIENT_NOT_STARTED` | Client is not started |
+| `ClientAlreadyStarted` | `CLIENT_ALREADY_STARTED` | Client is already started |
+| `ClientShuttingDown` | `CLIENT_SHUTTING_DOWN` | Client is shutting down |
+| `ClientInvalidState` | `CLIENT_INVALID_STATE` | Client state is invalid |
+| `ProducerNotAvailable` | `PRODUCER_NOT_AVAILABLE` | Producer is not available |
+| `ConsumerNotAvailable` | `CONSUMER_NOT_AVAILABLE` | Consumer is not available |
+| `Tools` | `TOOLS_ERROR` | Tools operation failed |
+| `Filter` | `FILTER_ERROR` | Filter operation failed |
+| `StorageReadFailed` | `STORAGE_READ_FAILED` | Storage read failed |
+| `StorageWriteFailed` | `STORAGE_WRITE_FAILED` | Storage write failed |
+| `StorageCorrupted` | `STORAGE_CORRUPTED` | Storage data is corrupted |
+| `StorageOutOfSpace` | `STORAGE_OUT_OF_SPACE` | Storage is out of space |
+| `StorageLockFailed` | `STORAGE_LOCK_FAILED` | Storage lock failed |
+| `ConfigParseFailed` | `CONFIG_PARSE_FAILED` | Configuration parsing failed |
+| `ConfigMissing` | `CONFIG_MISSING` | Required configuration is missing |
+| `ConfigInvalidValue` | `CONFIG_INVALID_VALUE` | Configuration value is invalid |
+| `AuthConfigInvalid` | `AUTH_CONFIG_INVALID` | Authentication configuration is invalid |
+| `AuthHotReloadFailed` | `AUTH_HOT_RELOAD_FAILED` | Authentication hot reload failed |
+| `ControllerNotLeader` | `CONTROLLER_NOT_LEADER` | Controller is not the leader |
+| `ControllerRaftError` | `CONTROLLER_RAFT_ERROR` | Controller raft operation failed |
+| `ControllerConsensusTimeout` | `CONTROLLER_CONSENSUS_TIMEOUT` | Controller consensus operation timed out |
+| `ControllerSnapshotFailed` | `CONTROLLER_SNAPSHOT_FAILED` | Controller snapshot operation failed |
+| `Io` | `IO_ERROR` | I/O operation failed |
+| `IllegalArgument` | `ILLEGAL_ARGUMENT` | Argument is illegal |
+| `Timeout` | `TIMEOUT` | Operation timed out |
+| `Internal` | `INTERNAL` | Internal error |
+| `Service` | `SERVICE_ERROR` | Service lifecycle operation failed |
+| `InvalidVersionOrdinal` | `INVALID_VERSION_ORDINAL` | Version ordinal is invalid |
+| `NotInitialized` | `NOT_INITIALIZED` | Component is not initialized |
+| `MissingRequiredMessageProperty` | `MISSING_REQUIRED_MESSAGE_PROPERTY` | Message is missing a required property |
+
+## Update Checklist
+
+- Add the new `ErrorKind` variant and stable code.
+- Add one `ErrorSpec` entry with a public message.
+- Confirm remoting, gRPC, HTTP, and CLI mappings are correct for the kind.
+- Confirm retry class, severity, metric label, and redaction policy are correct.
+- Add or update tests under `rocketmq-error/tests`.
+- Run `python scripts/error_architecture_guard.py`.

--- a/scripts/check-error-hygiene.ps1
+++ b/scripts/check-error-hygiene.ps1
@@ -1,0 +1,46 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Guard = Join-Path $RepoRoot "scripts\error_architecture_guard.py"
+
+if (-not (Test-Path -LiteralPath $Guard)) {
+    throw "error architecture guard not found: $Guard"
+}
+
+$Python = $null
+foreach ($Name in @("python", "python3")) {
+    $Candidate = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -ne $Candidate -and $Candidate.Source -notlike "*\WindowsApps\*") {
+        $Python = $Candidate.Source
+        break
+    }
+}
+
+if ($null -eq $Python) {
+    $PyLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($null -eq $PyLauncher) {
+        throw "python, python3, or py was not found"
+    }
+    & $PyLauncher.Source -3 $Guard
+    exit $LASTEXITCODE
+}
+
+& $Python $Guard
+exit $LASTEXITCODE

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -884,6 +884,71 @@ def check_redaction_guards() -> list[Finding]:
     return findings
 
 
+def current_error_codes() -> list[str]:
+    kind_path = ROOT / "rocketmq-error" / "src" / "kind.rs"
+    match = re.search(
+        r"pub const fn code\(self\).*?ErrorCode::new\(match self \{(.*?)\}\)\s*\}",
+        read_text(kind_path),
+        re.DOTALL,
+    )
+    if match is None:
+        return []
+    return re.findall(r'Self::\w+\s*=>\s*"([^"]+)"', match.group(1))
+
+
+def check_error_governance_artifacts() -> list[Finding]:
+    required_tokens = {
+        ROOT / "scripts" / "check-error-hygiene.ps1": [
+            "error_architecture_guard.py",
+            "python3",
+            "python",
+        ],
+        ROOT / "docs" / "07-error-hygiene-allowlist.md": [
+            "Current Path Allowlist",
+            "ERROR_ARCHITECTURE_GUARD_OK all",
+            "scripts/check-error-hygiene.ps1",
+        ],
+        ROOT / "docs" / "error-codes.md": [
+            "ErrorKind",
+            "ErrorSpec",
+            "BoundaryErrorView",
+            "Update Checklist",
+        ],
+        ROOT / "CONTRIBUTING.md": [
+            "### Error architecture",
+            "python scripts/error_architecture_guard.py",
+            r".\scripts\check-error-hygiene.ps1",
+        ],
+    }
+    findings: list[Finding] = []
+    for path, needles in required_tokens.items():
+        if not path.exists():
+            findings.append(Finding(path, 1, "required error governance artifact is missing"))
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                findings.append(Finding(path, 1, f"required error governance token missing: {needle}"))
+
+    error_codes_doc = ROOT / "docs" / "error-codes.md"
+    if error_codes_doc.exists():
+        text = read_text(error_codes_doc)
+        codes = current_error_codes()
+        if not codes:
+            findings.append(
+                Finding(
+                    ROOT / "rocketmq-error" / "src" / "kind.rs",
+                    1,
+                    "unable to parse stable error codes for documentation coverage",
+                )
+            )
+        for code in codes:
+            if f"`{code}`" not in text:
+                findings.append(Finding(error_codes_doc, 1, f"stable error code missing from docs: {code}"))
+
+    return findings
+
+
 def run() -> int:
     checks = [
         ("core public surface", check_error_and_common_public_surface),
@@ -899,6 +964,7 @@ def run() -> int:
         ("internal error allowlist", check_internal_error_allowlist),
         ("anyhow result allowlist", check_anyhow_result_allowlist),
         ("redaction guards", check_redaction_guards),
+        ("error governance artifacts", check_error_governance_artifacts),
     ]
     all_findings: list[Finding] = []
     for name, check in checks:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8059

### Brief Description

This PR codifies the remaining error governance artifacts from the refactor checklist. It adds a Windows hygiene wrapper for the existing architecture guard, documents the audited allowlist categories, adds a root error-code reference for the current `ErrorSpec` registry, extends the contribution guide with an error checklist, and makes the guard verify these artifacts and stable-code documentation coverage.

### How Did You Test This Change?

- `.\scripts\check-error-hygiene.ps1` passed.
- `python scripts\error_architecture_guard.py` passed.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for error handling best practices in contributor docs.
  * Added a reference page for error-code standards and the approved error-hygiene allowlist.

* **Chores**
  * Added a local check script to verify error-hygiene rules on Windows.
  * Expanded automated validation to ensure governance docs stay in sync with stable error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->