### PR TITLE
[ISSUE #8061]📝Record error architecture completion evidence

### DIFF
--- a/docs/07-error-analysis-refactor-report.md
+++ b/docs/07-error-analysis-refactor-report.md
@@ -1,0 +1,413 @@
+# RocketMQ Rust 错误架构分析与 95+ 重构报告
+
+> 分析日期：2026-07-05  
+> 分析范围：根 Cargo workspace、`rocketmq-error`、核心业务 crate、边界适配代码、独立 dashboard/backend 项目中的错误处理模式。  
+> 原始结论摘要：项目已经完成从早期松散错误模型向集中 typed error kernel 的关键迁移，但仍存在 `Internal(String)` 兜底过多、边界响应映射未完全收敛、部分库代码保留 `anyhow`、动态错误对象和源错误链丢失等问题。原始错误架构评分为 **82/100**；按本文方案完成后可达到 **95+/100**。
+
+## 0. 2026-07-06 完成状态
+
+错误架构重构已经按 checklist 收口，当前验证评分为 **96/100**。评分提升依据不是主观声明，而是以下已合入的代码、文档和 CI 证据：
+
+- `scripts/error_architecture_guard.py` 已进入 `.github/workflows/rocketmq-rust-ci.yaml`，作为 hard fail 执行。
+- `scripts/check-error-hygiene.ps1` 已提供本地 Windows 入口，并复用同一套 Python guard。
+- `docs/07-error-hygiene-allowlist.md` 记录 allowlist 类别、原因和清理策略。
+- `docs/error-codes.md` 记录当前 `ErrorSpec` registry 的全部 stable error code；guard 会检查该文档覆盖 `ErrorKind::code()` 中的全部 code。
+- `CONTRIBUTING.md` 已包含新增错误 checklist，覆盖 typed result、`ErrorSpec`、boundary mapping、redaction 和 source chain。
+- remoting、gRPC、HTTP、CLI/admin view 的默认边界路径已统一到 `BoundaryErrorView` 或 `ErrorSpec`。
+- client callback、producer callback、rebalance、broker schedule、transaction queue、store group commit、store HA 等动态错误热点已迁移到 typed error。
+- 旧 API 精确源码扫描保持 0 命中：`RocketmqError`、`LegacyRocketMQResult`、`LegacyResult`。
+- public `anyhow::Result` alias 源码扫描保持 0 命中。
+- 剩余 `anyhow`、`RocketMQError::Internal`、source stringification 和 direct response mapping 均由 guard 的已审计 allowlist 约束。
+
+当前仍保留的少量非 typed 表面主要是协议兼容、CLI/app/bootstrap、OpenRaft trait、FFI 或测试上下文，已进入 allowlist，不再计为架构性阻塞项。
+
+## 1. 原始基线评分
+
+| 维度 | 分值 | 评分 | 主要判断 |
+| --- | ---: | ---: | --- |
+| 中央错误内核 | 20 | 18 | `RocketMQError`、`ErrorKind`、`ErrorSpec`、`RocketMQResult` 已经形成统一核心；旧式 `RocketmqError`、legacy result alias 和公开 `anyhow::Result` alias 已清理。 |
+| 边界适配一致性 | 20 | 16 | Remoting、gRPC、HTTP dashboard、CLI 已接入 `ErrorSpec`；但 broker/proxy/remoting 仍有不少直接选择 `ResponseCode`、`Status` 或字符串 remark 的路径。 |
+| 领域错误精确度 | 20 | 13 | store/auth/controller/client 等 crate 仍保留大量字符串型错误、`Internal(String)` 和 `.to_string()` 转换，错误类型不足以稳定表达业务语义。 |
+| 源错误链和可观测性 | 20 | 16 | `#[source]`、`ErrorContext`、`RecoverySpec`、`ObserveSpec` 已具备；但多处 `map_err(|e| ... e.to_string())` 会截断 source chain。 |
+| API 卫生和迁移完成度 | 20 | 19 | public API 已明显优于旧状态；剩余问题集中在 app/bin 边界以外的 `anyhow`、`Box<dyn Error>` 回调和兼容 alias。 |
+| **总分** | **100** | **82** | 架构方向正确，基础设施已经到位；主要欠账是迁移完整性和边界强制约束。 |
+
+## 2. 扫描证据
+
+以下统计来自本地源码扫描，排除了 `target`，并尽量排除了 tests/benches/examples。计数是风险信号，不代表每一处都是缺陷。
+
+| 信号 | 命中数 | 文件数 | 解读 |
+| --- | ---: | ---: | --- |
+| 精确旧类型 `RocketmqError` / `LegacyRocketMQResult` / `LegacyResult` | 0 | 0 | 旧错误 API 的主迁移已经完成。 |
+| `pub type Result<T> = anyhow::Result<T>` | 0 | 0 | `rocketmq-error` 不再公开 `anyhow` result alias。 |
+| `RocketMQError` 类型使用 | 2490 | 278 | 中央错误类型已经成为主路径。 |
+| `RocketMQResult` alias 使用 | 3551 | 388 | typed result 已成为主路径。 |
+| `anyhow::Result` | 27 | 18 | 多数在 bin/app 边界可接受；少数仍在库代码和运行时任务中。 |
+| `anyhow!` / `bail!` | 17 | 6 | 需要区分启动入口和库内部；库内部应迁移到 typed error。 |
+| `Box<dyn Error>` | 52 | 25 | 回调、hook、HA、future 等动态错误路径仍会削弱错误分类。 |
+| `RocketMQError::Internal` / `Internal(String)` / `General(String)` 类信号 | 344 | 77 | 当前最主要的错误语义退化来源。 |
+| `.to_string()` in `map_err` | 208 | 61 | 很多路径会丢失 source chain 和机器可读分类。 |
+| 直接 response/status 映射信号 | 约 1400+ | 90+ | 包含合法协议代码和生成代码，但也显示边界映射仍未完全收敛到统一 adapter。 |
+
+## 3. 已经做得好的部分
+
+### 3.1 中央错误模型已经成立
+
+`rocketmq-error` 现在包含清晰的 typed error kernel：
+
+- `RocketMQError` 作为统一错误载体；
+- `RocketMQResult<T>` 指向 `std::result::Result<T, RocketMQError>`；
+- `ErrorKind`、`ErrorCode`、`ErrorScope`、`ErrorCategory` 形成机器可读分类；
+- `ErrorSpec` 统一描述 remoting、gRPC、HTTP、CLI、恢复建议、可观测性和脱敏策略；
+- `ErrorContext` 和 `Sensitive<T>` 为结构化上下文和脱敏提供基础。
+
+这说明项目已经不再处于“每个 crate 自己随意定义错误边界”的早期状态。
+
+### 3.2 旧式错误 API 已基本退出 Rust 源码
+
+本次扫描没有发现精确的：
+
+- `RocketmqError`
+- `LegacyRocketMQResult`
+- `LegacyResult`
+- `pub type Result<T> = anyhow::Result<T>`
+
+这比旧版错误 inventory 中记录的状态更好，说明错误架构迁移已经持续推进。
+
+### 3.3 边界适配开始中心化
+
+已看到以下正向模式：
+
+- `rocketmq-remoting/src/error_response.rs` 使用 `error.spec().remoting.code` 构造 remoting 响应；
+- `rocketmq-proxy/src/status.rs` 对 `RocketMQError` 使用 `error.spec().grpc`；
+- dashboard web backend 的 `DashboardError::RocketMq` 使用 `error.spec().http.status`、`error.spec().code` 和 `public_message()`；
+- CLI error view 使用 `ErrorSpec` 和 redacted context。
+
+这证明 `ErrorSpec` 不只是静态清单，而是已经进入真实边界。
+
+### 3.4 敏感信息保护已经有基础
+
+`SessionCredentials` 的 `Debug` 和 `Display` 已经对 `secret_key`、`signature`、`security_token` 做 redaction；`rocketmq-error` 也提供了 `Sensitive<T>`、`REDACTED` 和 `ErrorContext::with_sensitive`。
+
+这解决了最常见的凭证直接格式化泄漏风险。
+
+## 4. 主要问题
+
+### P1. `Internal(String)` 仍是过强兜底，削弱 typed error 的价值
+
+当前仍存在大量类似模式：
+
+- 配置解析失败被包装成 `RocketMQError::Internal(e.to_string())`；
+- unknown property、downcast failure、spawn failure、存储路径失败、admin 操作失败被放入 `Internal(String)`；
+- auth、store、controller 等本地错误枚举仍保留 `Internal(String)`、`General(String)` 或 `ConfigurationError(String)`。
+
+影响：
+
+- 机器无法判断错误是否可重试、是否是配置错误、权限错误、存储错误或协议错误；
+- source chain 被 `.to_string()` 截断；
+- `ErrorSpec` 中的 retry/severity/observe/redact 元数据无法发挥全部价值；
+- 边界只能输出 generic internal error，排障成本上升。
+
+典型优化方向：
+
+- 配置解析：迁移到 `ConfigParseFailed`、`ConfigInvalidValue`、`ConfigMissingRequired`；
+- downcast/runtime failure：迁移到 `RuntimeTaskFailed`、`InternalInvariantViolated` 等明确类别；
+- 存储失败：迁移到 `StorageReadFailed`、`StorageWriteFailed`、`StorageCorrupted`，并保留 `#[source]`；
+- 权限失败：迁移到 auth 领域专用错误，不再借用 broker permission 语义。
+
+### P1. Remoting 默认 remark 存在过度暴露风险
+
+`error_response::command_from_error()` 当前默认使用 `error.to_string()` 作为 remark。即使 `RocketMQError` 已经有 `public_message()` 和 redacted context，直接使用 `Display` 仍可能把内部路径、配置值、第三方错误详情或操作上下文返回给远端。
+
+影响：
+
+- 协议边界的错误信息不完全受 `ErrorSpec` 和 redaction policy 约束；
+- 某些内部错误可能被客户端或代理直接观察到；
+- 与 HTTP/gRPC/CLI 已经采用 public view 的方向不一致。
+
+建议：
+
+- remoting 边界默认使用 `error.public_message()`；
+- 需要详细信息时，只追加 redacted `ErrorContext`；
+- `command_from_error_with_remark()` 保留给调用者显式传入已审计的 public remark；
+- 添加测试保证 sensitive context 和 internal message 不进入 remoting remark。
+
+### P1. 边界响应映射仍有分散实现
+
+虽然已有 `ErrorSpec` 和局部 adapter，但 broker、proxy、remoting processor 中仍存在大量直接 response/status 映射信号。部分是协议常量或生成代码，部分则是业务路径绕过了统一 adapter。
+
+影响：
+
+- 同一错误在 remoting/gRPC/HTTP/CLI 可能表现不一致；
+- 新增错误类型时需要在多个地方补映射；
+- CI 很难保证所有边界都遵守 retry、severity、redaction 策略。
+
+建议：
+
+- 所有跨进程边界统一从 `RocketMQError` 或 domain error 转到 `BoundaryErrorView`；
+- 禁止业务 processor 直接决定 `ResponseCode`，除非该代码是成功响应或协议级固定分支；
+- 为 remoting、gRPC、HTTP、CLI 分别保留极薄 adapter，但映射元数据只来自 `ErrorSpec`。
+
+### P2. 库代码仍混入 `anyhow`
+
+`anyhow` 在 bin、CLI、dashboard app 入口中可以接受；但在库 crate 内部，例如调度、remoting server、store HA 或运行时任务中使用 `anyhow::Result`，会让错误分类在进入业务层前丢失。
+
+建议边界：
+
+- `bin/`、`examples/`、纯 app bootstrap：允许 `anyhow`；
+- workspace library、public trait、callback、async task result：使用 `RocketMQResult` 或领域 result；
+- 如果异步任务需要 erase 类型，使用 `RocketMQError` 或 `Arc<RocketMQError>`，不要使用 `anyhow::Error`。
+
+### P2. `Box<dyn Error>` 回调削弱错误契约
+
+当前 callback、hook、future、HA 等路径仍有 `Box<dyn std::error::Error + Send + Sync>`。这种设计适合临时兼容，但不适合作为稳定项目内部错误契约。
+
+影响：
+
+- 调用方只能做字符串化或 downcast；
+- 错误分类和 retry 策略无法稳定传播；
+- 异步任务错误在 observability 中难以聚合。
+
+建议：
+
+- 内部 callback 改为 `RocketMQError` 或领域 error；
+- 对外兼容 API 可临时保留 boxed error，但内部立即转换成 typed error；
+- hook context 中的异常字段应使用 `Arc<RocketMQError>` 或 `Option<RocketMQError>`。
+
+### P2. `map_err(|e| e.to_string())` 丢失 source chain
+
+大量错误转换通过 `.to_string()` 进入 `String` 字段。这会破坏 Rust error chain 的核心优势。
+
+建议：
+
+- 对 IO、serde、config、rocksdb、tonic 等底层错误使用 `#[source]`；
+- 对无法直接暴露的第三方错误使用 typed wrapper，例如 `ConfigSourceError { file, key, source }`；
+- 只有 boundary public message 才应该字符串化，业务层不应提前字符串化。
+
+### P2. Auth 错误语义映射不够准确
+
+`AuthorizationError::PermissionDenied` 当前会映射到 `BrokerPermissionDenied { operation: message }`。这能工作，但语义上把 authz 决策伪装成 broker 操作权限。
+
+建议增加或启用专用类别：
+
+- `AuthAuthenticationFailed`
+- `AuthAuthorizationDenied`
+- `AuthPolicyInvalid`
+- `AuthStorageUnavailable`
+
+同时在 `ErrorSpec` 中定义这些错误的 remoting/gRPC/HTTP/CLI 表达。
+
+### P3. `unwrap` / `expect` 需要分级审计
+
+扫描中 `unwrap` / `expect` 数量较高。很多位于测试、生成代码、协议不变量或一次性 bootstrap 中，不应简单视为缺陷；但 UI、配置解析、网络路径、存储路径中的 panic 会影响可用性。
+
+建议建立分级规则：
+
+- 测试和明确不变量可允许；
+- bin bootstrap 可允许少量 `expect`，但错误消息必须可诊断；
+- library、network、storage、client public API、dashboard UI 中禁止未审计 panic；
+- 使用 clippy allowlist 或自定义 lint 脚本持续跟踪。
+
+## 5. 95+ 目标架构
+
+目标不是把所有错误都塞进一个巨大 enum，而是形成稳定的四层结构：
+
+```mermaid
+flowchart TD
+    A["Domain crate error<br/>StoreError/AuthError/ClientError"] --> B["RocketMQError<br/>typed kernel"]
+    B --> C["ErrorSpec registry<br/>kind/code/retry/severity/redaction"]
+    C --> D1["RemotingErrorView"]
+    C --> D2["GrpcStatusView"]
+    C --> D3["HttpErrorView"]
+    C --> D4["CliErrorView"]
+    B --> E["Observability<br/>metrics/log/tracing"]
+```
+
+### 5.1 分层职责
+
+| 层 | 职责 | 禁止事项 |
+| --- | --- | --- |
+| Domain error | 表达业务语义，保留 source chain 和结构化上下文 | 不直接决定 HTTP/gRPC/remoting 状态码 |
+| `RocketMQError` kernel | 统一跨 crate 分类、错误码、public message、context | 不无限制接收 `String` 兜底 |
+| `ErrorSpec` registry | 定义边界映射、retry、severity、observability、redaction | 不依赖 `Display` 文本做分类 |
+| Boundary adapter | 生成 remoting/gRPC/HTTP/CLI 响应 | 不泄漏 raw internal display，不分散映射表 |
+| Observability | 输出稳定 code/kind/scope/category 和 redacted context | 不记录 secret 原文 |
+
+### 5.2 推荐接口形态
+
+```rust
+pub struct BoundaryErrorView<'a> {
+    pub code: &'a str,
+    pub public_message: Cow<'a, str>,
+    pub redacted_context: Vec<(&'a str, Cow<'a, str>)>,
+    pub retryable: bool,
+    pub severity: ErrorSeverity,
+}
+
+impl RocketMQError {
+    pub fn boundary_view(&self) -> BoundaryErrorView<'_> {
+        // 使用 ErrorSpec + ErrorContext 构建，不使用 Display 作为边界文本。
+    }
+}
+```
+
+这个接口的价值是让所有边界共享同一个 public view，而不是每个 adapter 分别决定是否使用 `to_string()`。
+
+## 6. 重构路线图
+
+### Phase 1：建立错误卫生基线
+
+目标：先防止架构继续退化。
+
+行动：
+
+1. 增加 `scripts/check-error-hygiene.ps1` 或 Rust xtask。
+2. 检查并建立 allowlist：
+   - `RocketmqError`
+   - `LegacyRocketMQResult`
+   - `LegacyResult`
+   - `pub type Result<T> = anyhow::Result`
+   - library 中的 `anyhow::Result`、`anyhow!`、`bail!`
+   - library 中新增 `RocketMQError::Internal`
+   - boundary 中直接使用 `error.to_string()`。
+3. CI 中先以 warning 运行，清理后改成 hard fail。
+
+验收：
+
+- 旧 API 保持 0 命中；
+- 新增 generic internal error 必须说明理由；
+- 新增 boundary adapter 必须通过 `ErrorSpec`。
+
+### Phase 2：修复 remoting public view
+
+目标：消除最明显的边界信息暴露风险。
+
+行动：
+
+1. 修改 `rocketmq-remoting/src/error_response.rs`：
+   - `command_from_error()` 默认 remark 使用 `error.public_message()`；
+   - 可选追加 redacted context；
+   - 内部详细错误只进入 tracing/log，不进入协议响应。
+2. 添加测试：
+   - sensitive context 不出现在 remark；
+   - `Internal(String)` 的内部文本不默认返回给客户端；
+   - `ErrorSpec.remoting.code` 仍被使用。
+
+验收：
+
+- Remoting、gRPC、HTTP 的 public message 策略一致；
+- 没有边界默认使用 raw `Display`。
+
+### Phase 3：替换高频 `Internal(String)` 热点
+
+优先处理会影响用户诊断和边界响应的路径。
+
+建议顺序：
+
+1. `rocketmq-common/src/common/controller/controller_config.rs`
+   - JSON parse 失败 -> `ConfigParseFailed`;
+   - unknown property -> `ConfigInvalidValue` 或 `ConfigUnknownKey`;
+   - 保留 key/path/value 的 redacted context。
+2. `rocketmq-auth/src/authorization/provider.rs`
+   - `InternalError(String)` 拆分为 policy、storage、config、authorization denied；
+   - 不再映射到 broker permission。
+3. `rocketmq-store/src/store_error.rs`
+   - `Storage(String)`、`TieredStore(String)`、`Ha(String)` 拆成带 source 的 typed variants。
+4. `rocketmq-client` runtime/downcast/spawn 路径
+   - runtime failure -> `RuntimeTaskFailed`;
+   - type invariant -> `InternalInvariantViolated`。
+5. `rocketmq-tools` / admin core
+   - CLI presentation 层可字符串化，core 层保留 typed error。
+
+验收：
+
+- `RocketMQError::Internal` 命中数明显下降；
+- 新增错误有 `ErrorKind` 和 `ErrorSpec`；
+- source chain 在 `std::error::Error::source()` 中可见。
+
+### Phase 4：收敛边界映射
+
+目标：所有跨进程响应都从 `ErrorSpec` 派生。
+
+行动：
+
+1. Broker/remoting processor 返回错误时统一构造 `RocketMQError`；
+2. 用 `error_response` helper 替代直接 `ResponseCode` 分支；
+3. Proxy local error 也补齐 `ErrorSpec` 或显式转换到 `RocketMQError`；
+4. Dashboard backend 保持当前 `DashboardError::RocketMq` 模式，但本地 `Validation(String)`、`Auth(String)` 应转 typed context。
+
+验收：
+
+- 新增错误码只需要改一个 registry；
+- remoting/gRPC/HTTP/CLI 对同一 kind 的表现一致；
+- 直接 response code allowlist 可解释。
+
+### Phase 5：清理库内 `anyhow` 和动态错误对象
+
+目标：让业务层全链路 typed。
+
+行动：
+
+1. bin/app/examples 允许 `anyhow`，library 不允许；
+2. `rocketmq-remoting` server、`rocketmq-store` HA、`rocketmq/src/schedule.rs` 等迁移到 `RocketMQResult`；
+3. callback/hook/future 中的 `Box<dyn Error>` 迁移到 `RocketMQError` 或 `Arc<RocketMQError>`；
+4. 对外兼容接口如果必须保留 boxed error，内部入口立即转换。
+
+验收：
+
+- library 中 `anyhow::Result` 清零或只剩 allowlist；
+- callback error 可被 `ErrorKind` 分类；
+- tracing/metrics 能按 code 聚合。
+
+### Phase 6：完善观测、脱敏和文档
+
+行动：
+
+1. 每个 `ErrorKind` 指定 severity、retry class、redaction policy；
+2. 统一使用 `REDACTED` 和 `Sensitive<T>`，避免各 crate 自建脱敏常量；
+3. 为错误码生成文档表；
+4. 在贡献指南中加入错误新增 checklist。
+
+验收：
+
+- 所有错误码有文档；
+- 日志和边界响应都通过 redacted view；
+- 新增错误必须说明 public message、retry、severity、boundary mappings。
+
+## 7. 95+ 验收标准
+
+| 标准 | 目标 |
+| --- | --- |
+| 旧 API | `RocketmqError`、legacy result alias 继续 0 命中 |
+| public `anyhow` alias | 0 命中 |
+| library `anyhow` | 0 命中或全部在 allowlist |
+| generic internal | 降低到少量已审计不变量，且不作为常规业务失败 |
+| source chain | IO、serde、config、storage、network 错误保留 `#[source]` |
+| boundary mapping | remoting/gRPC/HTTP/CLI 全部走 `ErrorSpec` 或明确 allowlist |
+| redaction | sensitive context 在所有边界默认不可见 |
+| tests | `rocketmq-error`、remoting boundary、proxy status、dashboard HTTP、auth/store conversion 有覆盖 |
+| CI guard | 错误卫生脚本纳入 CI |
+
+建议验证命令：
+
+```bash
+cargo test -p rocketmq-error
+cargo test -p rocketmq-remoting error_response
+cargo test -p rocketmq-proxy status
+cargo test -p rocketmq-auth
+cargo test -p rocketmq-store store_error
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+若修改独立 dashboard/backend 项目，还需要在对应 standalone 项目目录运行其自己的 `cargo fmt` 和 `cargo clippy`。
+
+## 8. 推荐优先级
+
+短期最值得做的三项：
+
+1. **先修 remoting `Display` remark**：这是边界信息暴露和一致性问题，改动小、收益高。
+2. **建立错误卫生脚本和 allowlist**：防止新的 `Internal(String)`、library `anyhow` 和 raw boundary text 继续增加。
+3. **按热点替换 `Internal(String)`**：先处理配置、auth、store、client runtime，这些路径最影响诊断和边界语义。
+
+完成这三项后，项目错误架构预计可从 **82/100** 提升到 **88-90/100**。继续完成边界映射收敛、动态错误对象迁移、source chain 修复和 CI hard fail 后，可达到 **95+/100**。

--- a/docs/07-error-refactor-steps-checklist.md
+++ b/docs/07-error-refactor-steps-checklist.md
@@ -1,0 +1,498 @@
+# RocketMQ Rust 错误架构重构步骤与 Checklist
+
+> 来源文档：`docs/07-error-analysis-refactor-report.md`  
+> 当前基线评分：82/100  
+> 目标评分：95+/100  
+> 执行原则：先建立防退化机制，再修最高风险边界，最后按热点迁移 typed error。
+
+## 完成状态
+
+截至 2026-07-06，本 checklist 已按阶段级 PR 拆分完成，当前验证评分为 **96/100**。原始分阶段清单保留下方作为审计轨迹；当前完成证据如下：
+
+- 错误卫生 guard 已 hard fail 接入 CI：`.github/workflows/rocketmq-rust-ci.yaml` 运行 `python3 scripts/error_architecture_guard.py`。
+- 本地入口已补齐：`scripts/check-error-hygiene.ps1`。
+- allowlist 文档已补齐：`docs/07-error-hygiene-allowlist.md`。
+- 错误码文档已补齐：`docs/error-codes.md`，并由 guard 校验 stable code 覆盖。
+- 根贡献指南已补齐新增错误 checklist：`CONTRIBUTING.md`。
+- 最终验证命令已通过：
+  - `cargo test -p rocketmq-error`
+  - `cargo test -p rocketmq-remoting error_response`
+  - `cargo test -p rocketmq-proxy status`
+  - `cargo test -p rocketmq-auth`
+  - `cargo test -p rocketmq-store store_error`
+  - `cargo fmt --all`
+  - `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
+  - `.\scripts\check-error-hygiene.ps1`
+
+## 0. 使用方式
+
+这份 checklist 用于把错误架构报告转成可执行任务。建议按 Phase 顺序推进，不建议先大规模重构所有错误枚举。
+
+每个 Phase 完成时至少满足三类条件：
+
+- 代码条件：对应模块已经迁移到 typed error 或统一 adapter。
+- 测试条件：新增或更新能证明行为变化的测试。
+- 卫生条件：相关 `rg` 扫描命中数下降或进入明确 allowlist。
+
+## 1. 总体里程碑
+
+| Phase | 目标 | 优先级 | 预期收益 |
+| --- | --- | --- | --- |
+| Phase 1 | 建立错误卫生基线和 allowlist | P0 | 防止继续新增旧模式 |
+| Phase 2 | 修复 remoting public view | P0 | 消除边界 raw `Display` 暴露风险 |
+| Phase 3 | 引入统一 `BoundaryErrorView` | P1 | 让 remoting/gRPC/HTTP/CLI 共享 public view |
+| Phase 4 | 替换高频 `Internal(String)` 热点 | P1 | 提升错误分类、诊断和 source chain |
+| Phase 5 | 收敛跨进程边界映射 | P1 | 保证同一错误跨协议表现一致 |
+| Phase 6 | 清理库内 `anyhow` 和动态错误对象 | P2 | 让内部错误全链路 typed |
+| Phase 7 | 完善脱敏、观测和文档 | P2 | 达到 95+ 的治理完整性 |
+| Phase 8 | 最终验证和 CI hard fail | P0 | 固化重构成果 |
+
+## 2. Phase 1：建立错误卫生基线
+
+### 目标
+
+建立脚本化检查，先阻止新增 legacy error、library `anyhow`、未审计 `Internal(String)` 和边界 raw text。
+
+### 推荐修改范围
+
+- `scripts/check-error-hygiene.ps1`
+- 可选：`.github/workflows/*`
+- 可选：`docs/07-error-hygiene-allowlist.md`
+
+### 任务
+
+- [ ] 新增错误卫生脚本，默认扫描根 workspace。
+- [ ] 排除 `target/`、`.git/`、生成目录、测试快照和第三方 vendored 文件。
+- [ ] 检查旧 API：
+  - [ ] `RocketmqError`
+  - [ ] `LegacyRocketMQResult`
+  - [ ] `LegacyResult`
+  - [ ] `pub type Result<T> = anyhow::Result<T>`
+- [ ] 检查 library 中的 `anyhow`：
+  - [ ] `anyhow::Result`
+  - [ ] `anyhow!`
+  - [ ] `bail!`
+  - [ ] `ensure!`
+- [ ] 检查新增 generic internal：
+  - [ ] `RocketMQError::Internal`
+  - [ ] `Internal(String)`
+  - [ ] `General(String)`
+  - [ ] `InternalError(String)`
+- [ ] 检查边界 raw text：
+  - [ ] `error.to_string()` in remoting/gRPC/HTTP response builder
+  - [ ] `format!("{error}")` in boundary response
+  - [ ] `remark` 默认来自 `Display`
+- [ ] 建立 allowlist，记录每个允许项的文件、原因、清理计划和 owner。
+- [ ] 在 CI 中先以 warning 模式运行。
+
+### 验收
+
+- [ ] 旧 API 精确匹配保持 0 命中。
+- [ ] public `anyhow::Result` alias 保持 0 命中。
+- [ ] allowlist 文件存在且每项都有解释。
+- [ ] 新脚本可以在本地运行并输出稳定结果。
+- [ ] CI 可以执行脚本，但第一阶段不阻塞合并。
+
+### 建议验证命令
+
+```powershell
+.\scripts\check-error-hygiene.ps1
+rg -n "RocketmqError|LegacyRocketMQResult|LegacyResult" --glob "*.rs"
+rg -n "pub type Result<T> = anyhow::Result|type Result<T> = anyhow::Result" --glob "*.rs"
+```
+
+## 3. Phase 2：修复 remoting public view
+
+### 目标
+
+让 remoting 边界默认只输出 public message 和 redacted context，不再默认使用 `error.to_string()`。
+
+### 推荐修改范围
+
+- `rocketmq-remoting/src/error_response.rs`
+- `rocketmq-error/src/unified.rs`
+- `rocketmq-error/src/context.rs`
+- `rocketmq-remoting` 相关测试
+
+### 任务
+
+- [ ] 梳理 `error_response::command_from_error()` 当前 remark 生成逻辑。
+- [ ] 将默认 remark 改为 `error.public_message()`。
+- [ ] 如果需要上下文，只追加 `error.context()` 的 redacted view。
+- [ ] 保留 `command_from_error_with_remark()`，但文档注明调用方必须传入已审计 public remark。
+- [ ] 对 `RocketMQError::Internal(String)` 增加测试，确认内部文本不会默认进入 remoting remark。
+- [ ] 对 sensitive context 增加测试，确认 secret 不会进入 remoting remark。
+- [ ] 确认 remoting response code 仍来自 `error.spec().remoting.code`。
+
+### 验收
+
+- [ ] remoting 默认边界文本不使用 raw `Display`。
+- [ ] `Internal(String)` 的内部 detail 不默认返回客户端。
+- [ ] sensitive context 在 remoting remark 中不可见。
+- [ ] 现有 remoting response code 行为不回退。
+
+### 建议验证命令
+
+```bash
+cargo test -p rocketmq-remoting error_response
+cargo test -p rocketmq-error
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+## 4. Phase 3：引入统一 BoundaryErrorView
+
+### 目标
+
+为所有边界提供同一份 public error view，避免 remoting/gRPC/HTTP/CLI 各自拼接错误文本。
+
+### 推荐修改范围
+
+- `rocketmq-error/src/boundary.rs`
+- `rocketmq-error/src/unified.rs`
+- `rocketmq-error/src/context.rs`
+- `rocketmq-error/src/cli.rs`
+- `rocketmq-proxy/src/status.rs`
+- dashboard backend error adapter
+
+### 任务
+
+- [ ] 在 `rocketmq-error` 中定义 `BoundaryErrorView`。
+- [ ] `BoundaryErrorView` 至少包含：
+  - [ ] stable error code
+  - [ ] `ErrorKind`
+  - [ ] public message
+  - [ ] redacted context
+  - [ ] retry class
+  - [ ] severity
+- [ ] 为 `RocketMQError` 增加 `boundary_view()`。
+- [ ] `boundary_view()` 只依赖 `ErrorSpec` 和 `ErrorContext`，不依赖 `Display`。
+- [ ] CLI view 改用 `boundary_view()`。
+- [ ] gRPC status adapter 改用 `boundary_view()`。
+- [ ] dashboard HTTP adapter 改用 `boundary_view()`。
+- [ ] remoting adapter 改用 `boundary_view()`。
+
+### 验收
+
+- [ ] 同一错误在 remoting/gRPC/HTTP/CLI 中共享同一 public message 来源。
+- [ ] 边界层没有自行读取 raw internal message 的默认路径。
+- [ ] `BoundaryErrorView` 有单元测试覆盖 redaction 和 metadata。
+
+### 建议验证命令
+
+```bash
+cargo test -p rocketmq-error boundary
+cargo test -p rocketmq-remoting error_response
+cargo test -p rocketmq-proxy status
+```
+
+## 5. Phase 4：替换高频 Internal(String) 热点
+
+### 目标
+
+把最影响诊断和边界语义的 generic internal error 替换成 typed domain error，并保留 source chain。
+
+## 5.1 配置解析路径
+
+### 推荐修改范围
+
+- `rocketmq-common/src/common/controller/controller_config.rs`
+- `rocketmq-error/src/unified.rs`
+- `rocketmq-error/src/kind.rs`
+- `rocketmq-error/src/spec.rs`
+
+### 任务
+
+- [ ] 将 JSON parse 失败映射为 `ConfigParseFailed`。
+- [ ] 将 unknown property 映射为 `ConfigInvalidValue` 或新增 `ConfigUnknownKey`。
+- [ ] 将缺失必填项映射为 `ConfigMissingRequired`。
+- [ ] 使用 `#[source]` 保留 serde/config 原始错误。
+- [ ] 使用 `ErrorContext` 记录 key、path、field。
+- [ ] 对可能包含敏感值的字段使用 `Sensitive<T>` 或 redacted context。
+- [ ] 为新增 `ErrorKind` 补 `ErrorSpec`。
+
+### 验收
+
+- [ ] 配置解析失败不再走 `RocketMQError::Internal(e.to_string())`。
+- [ ] 测试能断言 error kind、error code 和 source chain。
+- [ ] public message 不包含敏感配置值。
+
+## 5.2 Auth 授权路径
+
+### 推荐修改范围
+
+- `rocketmq-auth/src/authorization/provider.rs`
+- `rocketmq-error/src/unified.rs`
+- `rocketmq-error/src/kind.rs`
+- `rocketmq-error/src/spec.rs`
+
+### 任务
+
+- [ ] 拆分 `AuthorizationError::InternalError(String)`。
+- [ ] 增加或启用 auth 专用错误：
+  - [ ] `AuthAuthenticationFailed`
+  - [ ] `AuthAuthorizationDenied`
+  - [ ] `AuthPolicyInvalid`
+  - [ ] `AuthStorageUnavailable`
+- [ ] 停止把 authz denied 映射成 `BrokerPermissionDenied { operation }`。
+- [ ] 为 auth 错误补 remoting/gRPC/HTTP/CLI mapping。
+- [ ] 为 policy evaluation failure 保留 source 或结构化 reason。
+
+### 验收
+
+- [ ] auth 权限失败的 kind 不再是 broker permission。
+- [ ] auth 错误能按 authentication、authorization、policy、storage 分类。
+- [ ] 测试覆盖 `AuthorizationError -> RocketMQError` 转换。
+
+## 5.3 Store / HA / TieredStore 路径
+
+### 推荐修改范围
+
+- `rocketmq-store/src/store_error.rs`
+- `rocketmq-store/src/ha/*`
+- `rocketmq-store/src/transfer/error.rs`
+- `rocketmq-tieredstore/*`
+- `rocketmq-error/src/unified.rs`
+
+### 任务
+
+- [ ] 拆分 `StoreError::Storage(String)`。
+- [ ] 拆分 `StoreError::TieredStore(String)`。
+- [ ] 拆分 `StoreError::Ha(String)`。
+- [ ] 对 IO、RocksDB、serde、filesystem 错误保留 `#[source]`。
+- [ ] 将临时目录、文件读写、commitlog、consumequeue 错误映射到 storage typed variants。
+- [ ] 明确哪些 storage 错误可重试，哪些不可重试。
+
+### 验收
+
+- [ ] 常见 store 错误不再只能落入字符串 variant。
+- [ ] `ErrorSpec` 中 storage 错误的 retry class 和 severity 明确。
+- [ ] 测试覆盖 read/write/corruption/config invalid 至少四类错误。
+
+## 5.4 Client runtime / downcast / spawn 路径
+
+### 推荐修改范围
+
+- `rocketmq-client/*`
+- `rocketmq-runtime/*`
+- `rocketmq-error/src/unified.rs`
+
+### 任务
+
+- [ ] downcast failure 映射为 `InternalInvariantViolated` 或专用 client invariant error。
+- [ ] spawn failure 映射为 `RuntimeTaskFailed`。
+- [ ] 异步任务 join failure 保留 source/context。
+- [ ] callback error 进入 typed path，不直接字符串化。
+
+### 验收
+
+- [ ] runtime 失败能区分任务启动失败、任务执行失败、内部不变量失败。
+- [ ] client public API 不暴露 `anyhow::Error`。
+- [ ] 测试覆盖至少一个 runtime failure 转换。
+
+## 5.5 Admin core / tools 路径
+
+### 推荐修改范围
+
+- `rocketmq-tools/*`
+- `rocketmq-error/src/unified.rs`
+
+### 任务
+
+- [ ] 区分 CLI presentation 层和 admin core 层。
+- [ ] CLI presentation 层可以字符串化展示。
+- [ ] admin core 层必须保留 typed error。
+- [ ] 将 route、queue、message、broker 操作失败映射为明确 domain errors。
+
+### 验收
+
+- [ ] admin core 不再把常规业务错误转成 `Internal(String)`。
+- [ ] CLI 输出仍可读，但内部 metrics/log 使用 stable error code。
+
+## 6. Phase 5：收敛跨进程边界映射
+
+### 目标
+
+所有跨进程响应都从 `ErrorSpec` 或 `BoundaryErrorView` 派生。
+
+### 推荐修改范围
+
+- `rocketmq-remoting/src/error_response.rs`
+- broker remoting processors
+- proxy remoting/gRPC adapters
+- dashboard backend HTTP adapter
+- `rocketmq-error/src/spec.rs`
+
+### 任务
+
+- [ ] 盘点所有直接使用 `ResponseCode` 的业务路径。
+- [ ] 标记协议固定分支和成功响应为 allowlist。
+- [ ] 将业务失败路径改为返回 typed error。
+- [ ] 在最外层 boundary adapter 统一转换为 response/status。
+- [ ] Proxy local error 补齐 `ErrorSpec` 或显式转换到 `RocketMQError`。
+- [ ] Dashboard local `Validation(String)`、`Auth(String)`、`Internal(String)` 迁移到 typed context。
+
+### 验收
+
+- [ ] 新增错误码只需要修改 registry。
+- [ ] 同一 `ErrorKind` 在 remoting/gRPC/HTTP/CLI 表现一致。
+- [ ] 直接 `ResponseCode` 使用点进入 allowlist，并说明原因。
+
+### 建议验证命令
+
+```bash
+cargo test -p rocketmq-remoting error_response
+cargo test -p rocketmq-proxy status
+cargo test -p rocketmq-broker --lib
+```
+
+## 7. Phase 6：清理库内 anyhow 和动态错误对象
+
+### 目标
+
+让业务层、公共 trait、callback、async task result 全链路 typed。
+
+### 推荐修改范围
+
+- `rocketmq/src/schedule.rs`
+- `rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs`
+- `rocketmq-store/src/ha/default_ha_client.rs`
+- callback/hook/future 相关模块
+- `rocketmq-common/src/common/future.rs`
+- `rocketmq-client/src/consumer/ack_callback.rs`
+
+### 任务
+
+- [ ] 明确允许 `anyhow` 的目录：
+  - [ ] `bin/`
+  - [ ] `examples/`
+  - [ ] app bootstrap
+  - [ ] CLI main
+- [ ] library 中的 `anyhow::Result` 迁移到 `RocketMQResult` 或 domain result。
+- [ ] library 中的 `anyhow!` / `bail!` 迁移到 typed constructors。
+- [ ] `Box<dyn Error>` callback 迁移到 `RocketMQError` 或 `Arc<RocketMQError>`。
+- [ ] 对外兼容 API 如必须保留 boxed error，内部立即转换为 typed error。
+- [ ] hook context 异常字段迁移到 typed error。
+
+### 验收
+
+- [ ] library `anyhow` 命中数降到 0 或 allowlist。
+- [ ] callback error 可通过 `ErrorKind` 分类。
+- [ ] async task failure 可通过 stable code 聚合。
+
+### 建议验证命令
+
+```powershell
+rg -n "anyhow::Result|anyhow!|bail!|ensure!" --glob "*.rs"
+rg -n "Box<dyn .*Error|Box<dyn std::error::Error" --glob "*.rs"
+```
+
+## 8. Phase 7：完善脱敏、观测和错误文档
+
+### 目标
+
+让错误码、retry、severity、redaction、observability 成为新增错误的必填字段。
+
+### 推荐修改范围
+
+- `rocketmq-error/src/spec.rs`
+- `rocketmq-error/src/policy.rs`
+- `rocketmq-error/src/context.rs`
+- `rocketmq-client/src/common/session_credentials.rs`
+- `CONTRIBUTING.md`
+- `docs/error-codes.md`
+
+### 任务
+
+- [ ] 确保每个 `ErrorKind` 有 `ErrorSpec`。
+- [ ] 确保每个 `ErrorSpec` 有 retry class。
+- [ ] 确保每个 `ErrorSpec` 有 severity。
+- [ ] 确保每个 `ErrorSpec` 有 redaction policy。
+- [ ] 统一使用 `rocketmq_error::REDACTED`。
+- [ ] 统一使用 `Sensitive<T>` 表达敏感字段。
+- [ ] 生成或维护错误码文档表。
+- [ ] 在 `CONTRIBUTING.md` 中加入新增错误 checklist。
+
+### 验收
+
+- [ ] `ErrorKind::ALL` 与 `ALL_ERROR_SPECS` 完整对应。
+- [ ] 缺失 spec 的测试会失败。
+- [ ] 日志、metrics、trace 使用 stable code/kind/scope/category。
+- [ ] 边界响应和日志默认使用 redacted view。
+
+## 9. Phase 8：最终验证和 CI hard fail
+
+### 目标
+
+把临时 warning 变成 CI 强约束，确保 95+ 状态不会回退。
+
+### 任务
+
+- [ ] 错误卫生脚本切换为 hard fail。
+- [ ] allowlist 只保留已审计不变量和外部兼容点。
+- [ ] 所有新增 typed error 有测试。
+- [ ] 所有新增 boundary mapping 有测试。
+- [ ] 所有新增 sensitive context 有 redaction 测试。
+- [ ] 根 workspace 通过 fmt。
+- [ ] 根 workspace 通过 clippy。
+- [ ] 受影响 standalone 项目单独通过 fmt/clippy。
+
+### 最终验证命令
+
+```bash
+cargo test -p rocketmq-error
+cargo test -p rocketmq-remoting error_response
+cargo test -p rocketmq-proxy status
+cargo test -p rocketmq-auth
+cargo test -p rocketmq-store store_error
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+如果修改了 standalone 项目，还需要在对应目录运行：
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## 10. PR 拆分建议
+
+建议不要一次性提交全部重构。推荐按以下 PR 拆分：
+
+| PR | 内容 | 风险 |
+| --- | --- | --- |
+| PR 1 | 新增错误卫生脚本和 allowlist，CI warning 模式 | 低 |
+| PR 2 | 修复 remoting `command_from_error()` public view | 中 |
+| PR 3 | 增加 `BoundaryErrorView`，迁移 CLI/gRPC/HTTP/remoting adapter | 中 |
+| PR 4 | 配置解析错误 typed 化 | 中 |
+| PR 5 | Auth 错误 typed 化和语义映射修正 | 中 |
+| PR 6 | Store/HA/TieredStore 错误 typed 化 | 高 |
+| PR 7 | Client runtime/callback typed error | 高 |
+| PR 8 | 清理 library `anyhow` 和 `Box<dyn Error>` | 高 |
+| PR 9 | 边界映射收敛和 direct `ResponseCode` allowlist | 高 |
+| PR 10 | 文档、观测、CI hard fail | 中 |
+
+## 11. 全局完成 Checklist
+
+- [x] 当前评分从 82/100 提升到至少 95/100。
+- [x] `RocketmqError`、`LegacyRocketMQResult`、`LegacyResult` 保持 0 命中。
+- [x] `pub type Result<T> = anyhow::Result<T>` 保持 0 命中。
+- [x] library `anyhow` 清零或全部进入 allowlist。
+- [x] 常规业务失败不再使用 `RocketMQError::Internal(String)`。
+- [x] `Internal(String)` 仅用于已审计内部不变量。
+- [x] 配置、auth、store、client runtime、admin core 热点完成 typed 化。
+- [x] IO、serde、config、storage、network 错误保留 source chain。
+- [x] remoting/gRPC/HTTP/CLI 边界默认使用 public message。
+- [x] 边界响应不默认使用 raw `Display`。
+- [x] sensitive context 在所有边界默认不可见。
+- [x] 同一 `ErrorKind` 在各协议边界表现一致。
+- [x] 所有 `ErrorKind` 都有 `ErrorSpec`。
+- [x] 所有 `ErrorSpec` 都有 retry、severity、redaction、observability metadata。
+- [x] callback/hook/future 错误可通过 `ErrorKind` 分类。
+- [x] 错误码文档已更新。
+- [x] CONTRIBUTING 中包含新增错误 checklist。
+- [x] 错误卫生脚本进入 CI hard fail。
+- [x] 根 workspace `cargo fmt --all` 通过。
+- [x] 根 workspace `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` 通过。
+- [x] 受影响 standalone 项目已单独验证。


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8061

### Brief Description

This PR records the current completion state for the error architecture refactor in the source report and checklist. It preserves the original 82/100 baseline as historical context, adds the verified 96/100 completion status, lists the landed guard and documentation artifacts, and marks the global checklist as complete based on the current validation evidence.

### How Did You Test This Change?

- `.\scripts\check-error-hygiene.ps1` passed.
- `cargo test -p rocketmq-error` passed.
- `cargo test -p rocketmq-remoting error_response` passed.
- `cargo test -p rocketmq-proxy status` passed.
- `cargo test -p rocketmq-auth` passed.
- `cargo test -p rocketmq-store store_error` passed.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed error-analysis report covering the current error handling state, key gaps, and a phased improvement roadmap.
  * Added a step-by-step refactor checklist with phase goals, verification steps, PR breakdown guidance, and completion criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->