### PR TITLE
[ISSUE #8066]🧪Track observability subscriber installation coverage

### DIFF
--- a/rocketmq-observability/tests/architecture_guards.rs
+++ b/rocketmq-observability/tests/architecture_guards.rs
@@ -59,6 +59,21 @@ const METRIC_CONSTANT_CANONICAL_FILES: &[&str] = &[
 
 const METRIC_CONSTANT_LEGACY_ALLOWLIST: &[&str] = &[];
 
+const SUBSCRIBER_INSTALL_PATTERNS: &[&str] = &[
+    "tracing_subscriber::fmt()",
+    "tracing_subscriber::registry()",
+    "tracing::subscriber::set_global_default",
+    "tracing_subscriber::subscriber::set_global_default",
+];
+
+const SUBSCRIBER_INSTALL_ALLOWLIST: &[&str] = &[
+    // Legacy local logging entrypoint. This is tracked until the unified logging bootstrap replaces it.
+    "rocketmq-common/src/log.rs",
+    // Current OpenTelemetry trace/log layer installation sites. Task 1 makes their install status explicit.
+    "rocketmq-observability/src/init.rs",
+    "rocketmq-observability/src/trace.rs",
+];
+
 const CONTROLLER_METRIC_LITERAL_MARKERS: &[&str] = &[
     "\"role\"",
     "\"dledger_disk_usage\"",
@@ -114,6 +129,37 @@ fn business_crates_do_not_add_direct_opentelemetry_usage() {
         unexpected_files.is_empty(),
         "direct OpenTelemetry usage must live in rocketmq-observability; migrate or explicitly track legacy files \
          before adding new usages:\n{}",
+        format_paths(&unexpected_files)
+    );
+}
+
+#[test]
+fn subscriber_installation_sites_are_tracked() {
+    let workspace_root = workspace_root();
+    let mut allowed_files = path_set(SUBSCRIBER_INSTALL_ALLOWLIST);
+    let mut scan_dirs = WORKSPACE_CRATE_DIRS.to_vec();
+    scan_dirs.push("rocketmq-observability");
+
+    let mut unexpected_files = BTreeSet::new();
+    for file in workspace_src_files(&workspace_root, &scan_dirs) {
+        let relative_path = relative_slash_path(&workspace_root, &file);
+        if allowed_files.remove(relative_path.as_str()) {
+            continue;
+        }
+
+        let source =
+            fs::read_to_string(&file).unwrap_or_else(|error| panic!("failed to read {}: {error}", file.display()));
+        if SUBSCRIBER_INSTALL_PATTERNS
+            .iter()
+            .any(|pattern| source.contains(pattern))
+        {
+            unexpected_files.insert(relative_path);
+        }
+    }
+
+    assert!(
+        unexpected_files.is_empty(),
+        "tracing subscriber installation must stay in tracked bootstrap files:\n{}",
         format_paths(&unexpected_files)
     );
 }

--- a/rocketmq-observability/tests/logging_bootstrap_guards.rs
+++ b/rocketmq-observability/tests/logging_bootstrap_guards.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "otel-traces")]
+#[test]
+fn enabled_traces_still_initialize_when_subscriber_install_is_blocked() {
+    let _ = tracing_subscriber::fmt().with_writer(std::io::sink).try_init();
+
+    let mut config = rocketmq_observability::ObservabilityConfig {
+        enabled: true,
+        ..rocketmq_observability::ObservabilityConfig::default()
+    };
+    config.traces.enabled = true;
+    config.traces.exporter = rocketmq_observability::config::TraceExporter::Disable;
+
+    let guard = rocketmq_observability::init_observability(&config)
+        .expect("current init path does not report subscriber install failure");
+
+    assert!(
+        guard.tracer_provider().is_some(),
+        "the tracer provider initializes even though the tracing subscriber layer is blocked"
+    );
+
+    guard.shutdown().expect("trace provider shutdown should succeed");
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8066

### Brief Description

Adds observability tests that capture the current tracing subscriber installation gap before the unified logging bootstrap work continues. The new regression test documents that trace provider initialization can still succeed when the global tracing subscriber is already occupied, and the architecture guard now tracks the currently allowed direct subscriber installation sites.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability --test logging_bootstrap_guards --all-features` passed.
- `cargo test -p rocketmq-observability --test architecture_guards` passed.
- `cargo fmt --all` passed.
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` was attempted, but the local Windows shell failed while building `librocksdb-sys` because the MSVC/Windows SDK environment variables were unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation around observability startup to ensure tracing remains initialized in more edge cases.
  * Added additional coverage to detect unintended changes to tracing subscriber setup locations, helping prevent regressions in observability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->