### PR TITLE
[ISSUE #8068]✨Decouple CI guard and harden automation titles

### DIFF
--- a/.agents/skills/rocketmq-rust-issue-generator/SKILL.md
+++ b/.agents/skills/rocketmq-rust-issue-generator/SKILL.md
@@ -57,6 +57,7 @@ Rules:
 - Every template field, in order. Required fields must have content or be listed as missing.
 - Use `Not applicable` only when a field clearly does not apply.
 - Never mark prerequisite/contribution checkboxes complete unless confirmed or actually performed.
+- Generate the title summary from the actual bug, feature, test gap, doc change, or refactor. Do not use sequencing-marker wording such as `task 1`, `stage 1`, `phase 1`, `step 3`, or `part 4`, even when the user's rough draft contains those words.
 - Tasks must be actionable: name affected modules, expected behavior, tests, and validation commands.
 - Use RocketMQ domain vocabulary (broker, namesrv, commitlog, consume queue, Tokio runtime, etc.) only where it helps the form.
 - Write all public issue title/body text in English. Repository-relative paths, code identifiers, commands, issue numbers, Markdown punctuation, and the template emoji are allowed; Chinese or other non-English prose is not allowed.
@@ -85,6 +86,7 @@ Fix every finding.
 | Marking checkboxes complete without confirmation | List unconfirmed items as missing |
 | Leaving a local Windows user path in draft | Run `audit_issue_paths.py` before finalizing |
 | Writing issue prose in Chinese or mixed language | Rewrite the title/body in English and rerun the audit |
+| Using process labels like `task 1`, `stage 1`, or `phase 1` in the title | Replace them with a concise summary of the actual change or problem |
 | Using feature_request for test-only work | Unit test additions → `unit_test.yml` |
 | Copying mojibake emoji from terminal | Re-read file with UTF-8 or use file content directly |
 
@@ -98,6 +100,7 @@ Fix every finding.
 
 - Selected template filename is real in the current checkout.
 - Title keeps the selected template prefix exactly, including emoji.
+- Title summary describes the actual change/problem and does not contain sequencing markers like `task 1`, `stage 1`, or `phase 1`.
 - Labels match the selected template.
 - Body fields appear in template order.
 - Required fields have content or are listed under `Missing info`.

--- a/.agents/skills/rocketmq-rust-issue-generator/evals/evals.json
+++ b/.agents/skills/rocketmq-rust-issue-generator/evals/evals.json
@@ -24,6 +24,12 @@
       "prompt": "Generate an issue for missing unit tests around consume queue recovery in rocketmq-rust. Use the repo's ISSUE_TEMPLATE files and make it suitable for GitHub.",
       "expected_output": "Selects the unit test template, keeps the `[Test🧪] ` title prefix, fills Test Scope and Test Cases with actionable items, includes all required fields, and uses only crate/module names or repository-relative paths when useful.",
       "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Generate an issue title for task 1 stage 1 phase 1 of fixing nightly atomic API warnings in rocketmq-rust.",
+      "expected_output": "Keeps the correct template prefix and produces a content-based title such as fixing nightly atomic API warnings. The title must not include `task 1`, `stage 1`, `phase 1`, or similar sequencing markers.",
+      "files": []
     }
   ]
 }

--- a/.agents/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
+++ b/.agents/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
@@ -46,6 +46,12 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 ALLOWED_NON_ASCII = frozenset("🐛📝✨🚀♻️🧪\ufe0f\ufeff")
 
 
+TITLE_MARKER_RE = re.compile(
+    r"\b(?:task|phase|stage|step|part|milestone)\s*[-_:]?\s*(?:\d+|[ivxlcdm]+)\b",
+    re.IGNORECASE,
+)
+
+
 def read_input(path_arg: str) -> tuple[str, str]:
     if path_arg == "-":
         return "<stdin>", sys.stdin.read()
@@ -73,6 +79,10 @@ def find_non_english_text(text: str) -> list[tuple[int, str, str]]:
     return findings
 
 
+def find_title_markers(title: str) -> list[str]:
+    return [match.group(0) for match in TITLE_MARKER_RE.finditer(title)]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Fail if a GitHub issue draft contains local filesystem paths or non-English text.",
@@ -92,9 +102,10 @@ def main() -> int:
     audited_text = f"{args.title}\n{text}" if args.title else text
     findings = scan_text(audited_text)
     english_findings = find_non_english_text(audited_text)
+    title_marker_findings = find_title_markers(args.title) if args.title else []
 
-    if not findings and not english_findings:
-        print(f"OK: no local paths or non-English text detected in {source}")
+    if not findings and not english_findings and not title_marker_findings:
+        print(f"OK: no local paths, title markers, or non-English text detected in {source}")
         return 0
 
     if findings:
@@ -105,6 +116,10 @@ def main() -> int:
         print(f"Non-English text findings in {source}:", file=sys.stderr)
         for line_no, name, value in english_findings:
             print(f"  line {line_no}: {name}: {value}", file=sys.stderr)
+    if title_marker_findings:
+        print(f"Sequencing-marker title findings in {source}:", file=sys.stderr)
+        for value in title_marker_findings:
+            print(f"  title: {value}", file=sys.stderr)
     return 1
 
 

--- a/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
+++ b/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
@@ -47,6 +47,8 @@ Priority order: user request → branch name (`issue-7544`, `fix-7544`) → comm
 ```
 Do not put spaces between `]`, the emoji, and the summary. No extra prefixes (conventional commit, branch name). Keep the summary short and action-oriented.
 
+Generate the summary from the actual PR change: affected subsystem, behavior fixed, test coverage added, docs updated, or refactor performed. Do not use sequencing-marker wording such as `task 1`, `stage 1`, `phase 1`, `step 3`, or `part 4`, even if the branch name, issue text, or user draft contains those words.
+
 Write the title and commit-message summary in English only. The required emoji is allowed; Chinese or other non-English prose is not allowed.
 
 If creating a commit as part of the PR workflow, use the exact same compact format for the commit message:
@@ -92,6 +94,7 @@ Write all public body prose in English. Repository-relative paths, code identifi
 | Claiming unrun validation passed | State "validation not run" honestly in test section |
 | Writing PR prose in Chinese or mixed language | Rewrite the title/body in English and rerun validation |
 | Adding spaces or extra prefixes | Only `[ISSUE #id]<emoji><summary>` for PR titles and commit messages |
+| Using process labels like `task 1`, `stage 1`, or `phase 1` as the summary | Replace them with a concise summary of the actual code, docs, tests, or behavior change |
 | Wrong emoji for change type | Match to linked issue type; default to ✨ |
 
 ## Output Format
@@ -113,6 +116,7 @@ Body:
 
 - Title matches `[ISSUE #number]<emoji><summary>`
 - Commit message, when created, matches `[ISSUE #number]<emoji><summary>`
+- Title and commit summary describe the actual change and do not contain sequencing markers like `task 1`, `stage 1`, or `phase 1`.
 - Body includes three PR template headings in order with `- Fixes #number`
 - Title/body are English-only.
 - Test section doesn't claim unrun commands passed

--- a/.agents/skills/rocketmq-rust-pr-submitter/evals/evals.json
+++ b/.agents/skills/rocketmq-rust-pr-submitter/evals/evals.json
@@ -24,6 +24,12 @@
       "prompt": "Create ready-to-submit PR title/body for issue 8300. The source notes mention a local file C:\\repo\\target\\debug\\broker.log, but the public PR body must not expose local paths.",
       "expected_output": "Uses `[ISSUE #8300]` with an appropriate emoji, preserves the PR template headings, rewrites the local log path generically, and leaves no local absolute path in the title or body.",
       "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Create a PR title for issue 8400. The branch name says phase-1-task-1-nightly-atomic-api, and the change fixes nightly atomic API warnings.",
+      "expected_output": "Returns title candidates matching `[ISSUE #8400]<emoji><summary>` where the summary describes fixing nightly atomic API warnings. The title must not include `task 1`, `stage 1`, `phase 1`, or similar sequencing markers.",
+      "files": []
     }
   ]
 }

--- a/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
+++ b/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
@@ -13,6 +13,12 @@ TITLE_RE = re.compile(
     r"^\[ISSUE #(?P<issue>\d+)\](?P<emoji>🐛|📝|✨|🚀|♻️|🧪)(?P<summary>\S(?:.*\S)?)$",
 )
 
+TITLE_MARKER_RE = re.compile(
+    r"\b(?:task|phase|stage|step|part|milestone)\s*[-_:]?\s*(?:\d+|[ivxlcdm]+)\b",
+    re.IGNORECASE,
+)
+
+
 LOCAL_PATH_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
         "windows drive path",
@@ -109,8 +115,13 @@ def main() -> int:
         title_issue = None
     else:
         title_issue = title_match.group("issue")
-        if not title_match.group("summary").strip():
+        summary = title_match.group("summary").strip()
+        if not summary:
             errors.append("title summary must not be empty")
+        if TITLE_MARKER_RE.search(summary):
+            errors.append(
+                "title summary must describe the actual change and not use sequencing markers like task 1, stage 1, or phase 1",
+            )
 
     errors.extend(validate_heading_order(body))
 

--- a/.claude/skills/rocketmq-rust-issue-generator/SKILL.md
+++ b/.claude/skills/rocketmq-rust-issue-generator/SKILL.md
@@ -57,6 +57,7 @@ Rules:
 - Every template field, in order. Required fields must have content or be listed as missing.
 - Use `Not applicable` only when a field clearly does not apply.
 - Never mark prerequisite/contribution checkboxes complete unless confirmed or actually performed.
+- Generate the title summary from the actual bug, feature, test gap, doc change, or refactor. Do not use sequencing-marker wording such as `task 1`, `stage 1`, `phase 1`, `step 3`, or `part 4`, even when the user's rough draft contains those words.
 - Tasks must be actionable: name affected modules, expected behavior, tests, and validation commands.
 - Use RocketMQ domain vocabulary (broker, namesrv, commitlog, consume queue, Tokio runtime, etc.) only where it helps the form.
 - Write all public issue title/body text in English. Repository-relative paths, code identifiers, commands, issue numbers, Markdown punctuation, and the template emoji are allowed; Chinese or other non-English prose is not allowed.
@@ -85,6 +86,7 @@ Fix every finding.
 | Marking checkboxes complete without confirmation | List unconfirmed items as missing |
 | Leaving a local Windows user path in draft | Run `audit_issue_paths.py` before finalizing |
 | Writing issue prose in Chinese or mixed language | Rewrite the title/body in English and rerun the audit |
+| Using process labels like `task 1`, `stage 1`, or `phase 1` in the title | Replace them with a concise summary of the actual change or problem |
 | Using feature_request for test-only work | Unit test additions → `unit_test.yml` |
 | Copying mojibake emoji from terminal | Re-read file with UTF-8 or use file content directly |
 
@@ -98,6 +100,7 @@ Fix every finding.
 
 - Selected template filename is real in the current checkout.
 - Title keeps the selected template prefix exactly, including emoji.
+- Title summary describes the actual change/problem and does not contain sequencing markers like `task 1`, `stage 1`, or `phase 1`.
 - Labels match the selected template.
 - Body fields appear in template order.
 - Required fields have content or are listed under `Missing info`.

--- a/.claude/skills/rocketmq-rust-issue-generator/evals/evals.json
+++ b/.claude/skills/rocketmq-rust-issue-generator/evals/evals.json
@@ -24,6 +24,12 @@
       "prompt": "Generate an issue for missing unit tests around consume queue recovery in rocketmq-rust. Use the repo's ISSUE_TEMPLATE files and make it suitable for GitHub.",
       "expected_output": "Selects the unit test template, keeps the `[Test🧪] ` title prefix, fills Test Scope and Test Cases with actionable items, includes all required fields, and uses only crate/module names or repository-relative paths when useful.",
       "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Generate an issue title for task 1 stage 1 phase 1 of fixing nightly atomic API warnings in rocketmq-rust.",
+      "expected_output": "Keeps the correct template prefix and produces a content-based title such as fixing nightly atomic API warnings. The title must not include `task 1`, `stage 1`, `phase 1`, or similar sequencing markers.",
+      "files": []
     }
   ]
 }

--- a/.claude/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
+++ b/.claude/skills/rocketmq-rust-issue-generator/scripts/audit_issue_paths.py
@@ -46,6 +46,12 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 ALLOWED_NON_ASCII = frozenset("\U0001F41B\U0001F4DD\u2728\U0001F680\u267B\uFE0F\U0001F9EA\ufeff")
 
 
+TITLE_MARKER_RE = re.compile(
+    r"\b(?:task|phase|stage|step|part|milestone)\s*[-_:]?\s*(?:\d+|[ivxlcdm]+)\b",
+    re.IGNORECASE,
+)
+
+
 def read_input(path_arg: str) -> tuple[str, str]:
     if path_arg == "-":
         return "<stdin>", sys.stdin.read()
@@ -73,6 +79,10 @@ def find_non_english_text(text: str) -> list[tuple[int, str, str]]:
     return findings
 
 
+def find_title_markers(title: str) -> list[str]:
+    return [match.group(0) for match in TITLE_MARKER_RE.finditer(title)]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Fail if a GitHub issue draft contains local filesystem paths or non-English text.",
@@ -92,9 +102,10 @@ def main() -> int:
     audited_text = f"{args.title}\n{text}" if args.title else text
     findings = scan_text(audited_text)
     english_findings = find_non_english_text(audited_text)
+    title_marker_findings = find_title_markers(args.title) if args.title else []
 
-    if not findings and not english_findings:
-        print(f"OK: no local paths or non-English text detected in {source}")
+    if not findings and not english_findings and not title_marker_findings:
+        print(f"OK: no local paths, title markers, or non-English text detected in {source}")
         return 0
 
     if findings:
@@ -105,6 +116,10 @@ def main() -> int:
         print(f"Non-English text findings in {source}:", file=sys.stderr)
         for line_no, name, value in english_findings:
             print(f"  line {line_no}: {name}: {value}", file=sys.stderr)
+    if title_marker_findings:
+        print(f"Sequencing-marker title findings in {source}:", file=sys.stderr)
+        for value in title_marker_findings:
+            print(f"  title: {value}", file=sys.stderr)
     return 1
 
 

--- a/.claude/skills/rocketmq-rust-pr-submitter/SKILL.md
+++ b/.claude/skills/rocketmq-rust-pr-submitter/SKILL.md
@@ -47,6 +47,8 @@ Priority order: user request → branch name (`issue-7544`, `fix-7544`) → comm
 ```
 Do not put spaces between `]`, the emoji, and the summary. No extra prefixes (conventional commit, branch name). Keep the summary short and action-oriented.
 
+Generate the summary from the actual PR change: affected subsystem, behavior fixed, test coverage added, docs updated, or refactor performed. Do not use sequencing-marker wording such as `task 1`, `stage 1`, `phase 1`, `step 3`, or `part 4`, even if the branch name, issue text, or user draft contains those words.
+
 Write the title and commit-message summary in English only. The required emoji is allowed; Chinese or other non-English prose is not allowed.
 
 If creating a commit as part of the PR workflow, use the exact same compact format for the commit message:
@@ -92,6 +94,7 @@ Write all public body prose in English. Repository-relative paths, code identifi
 | Claiming unrun validation passed | State "validation not run" honestly in test section |
 | Writing PR prose in Chinese or mixed language | Rewrite the title/body in English and rerun validation |
 | Adding spaces or extra prefixes | Only `[ISSUE #id]<emoji><summary>` for PR titles and commit messages |
+| Using process labels like `task 1`, `stage 1`, or `phase 1` as the summary | Replace them with a concise summary of the actual code, docs, tests, or behavior change |
 | Wrong emoji for change type | Match to linked issue type; default to ✨ |
 
 ## Output Format
@@ -113,6 +116,7 @@ Body:
 
 - Title matches `[ISSUE #number]<emoji><summary>`
 - Commit message, when created, matches `[ISSUE #number]<emoji><summary>`
+- Title and commit summary describe the actual change and do not contain sequencing markers like `task 1`, `stage 1`, or `phase 1`.
 - Body includes three PR template headings in order with `- Fixes #number`
 - Title/body are English-only.
 - Test section doesn't claim unrun commands passed

--- a/.claude/skills/rocketmq-rust-pr-submitter/evals/evals.json
+++ b/.claude/skills/rocketmq-rust-pr-submitter/evals/evals.json
@@ -24,6 +24,12 @@
       "prompt": "Create ready-to-submit PR title/body for issue 8300. The source notes mention a local file C:\\repo\\target\\debug\\broker.log, but the public PR body must not expose local paths.",
       "expected_output": "Uses `[ISSUE #8300]` with an appropriate emoji, preserves the PR template headings, rewrites the local log path generically, and leaves no local absolute path in the title or body.",
       "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Create a PR title for issue 8400. The branch name says phase-1-task-1-nightly-atomic-api, and the change fixes nightly atomic API warnings.",
+      "expected_output": "Returns title candidates matching `[ISSUE #8400]<emoji><summary>` where the summary describes fixing nightly atomic API warnings. The title must not include `task 1`, `stage 1`, `phase 1`, or similar sequencing markers.",
+      "files": []
     }
   ]
 }

--- a/.claude/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
+++ b/.claude/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
@@ -13,6 +13,12 @@ TITLE_RE = re.compile(
     r"^\[ISSUE #(?P<issue>\d+)\](?P<emoji>🐛|📝|✨|🚀|♻️|🧪)(?P<summary>\S(?:.*\S)?)$",
 )
 
+TITLE_MARKER_RE = re.compile(
+    r"\b(?:task|phase|stage|step|part|milestone)\s*[-_:]?\s*(?:\d+|[ivxlcdm]+)\b",
+    re.IGNORECASE,
+)
+
+
 LOCAL_PATH_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
         "windows drive path",
@@ -109,8 +115,13 @@ def main() -> int:
         title_issue = None
     else:
         title_issue = title_match.group("issue")
-        if not title_match.group("summary").strip():
+        summary = title_match.group("summary").strip()
+        if not summary:
             errors.append("title summary must not be empty")
+        if TITLE_MARKER_RE.search(summary):
+            errors.append(
+                "title summary must describe the actual change and not use sequencing markers like task 1, stage 1, or phase 1",
+            )
 
     errors.extend(validate_heading_order(body))
 

--- a/.github/workflows/dashboard-web-ci.yml
+++ b/.github/workflows/dashboard-web-ci.yml
@@ -18,7 +18,6 @@ on:
       - 'rust-toolchain.toml'
       - 'rustfmt.toml'
       - '.clippy.toml'
-      - 'scripts/error_architecture_guard.py'
       - '.github/workflows/dashboard-web-ci.yml'
   pull_request:
     branches: [ "main" ]
@@ -34,7 +33,6 @@ on:
       - 'rust-toolchain.toml'
       - 'rustfmt.toml'
       - '.clippy.toml'
-      - 'scripts/error_architecture_guard.py'
       - '.github/workflows/dashboard-web-ci.yml'
 
 env:
@@ -121,9 +119,6 @@ jobs:
 
       - name: Format check
         run: cargo fmt --all -- --check
-
-      - name: Error architecture guard
-        run: python3 ../../../scripts/error_architecture_guard.py
 
       - name: Build backend
         run: cargo build --all-targets --all-features

--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -114,9 +114,6 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Error architecture guard
-        run: python3 scripts/error_architecture_guard.py
-
       - name: Clippy (all features)
         run: cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8068

### Brief Description

Remove the `error_architecture_guard.py` execution step from the root and dashboard web GitHub Actions workflows. The dashboard web workflow no longer uses changes to that script as a path trigger.

Update both `.agents` and `.claude` copies of the rocketmq-rust issue and PR helper skills so generated titles must summarize the actual change instead of using sequencing markers such as `task 1`, `stage 1`, or `phase 1`. The helper validation scripts now reject those markers, and both skill eval suites include coverage for the new rule.

### How Did You Test This Change?

Passed:

- `python -m py_compile .agents\skillsocketmq-rust-issue-generator\scriptsudit_issue_paths.py .agents\skillsocketmq-rust-pr-submitter\scriptsalidate_pr_content.py .claude\skillsocketmq-rust-issue-generator\scriptsudit_issue_paths.py .claude\skillsocketmq-rust-pr-submitter\scriptsalidate_pr_content.py`
- `python -m json.tool` for both `.agents` and `.claude` skill eval files
- Frontmatter check for both `.agents` and `.claude` skill `SKILL.md` files
- Positive and negative title-marker behavior checks for both issue and PR validation scripts
- `rg "error_architecture_guard\.py|Error architecture guard|check-error-hygiene" .github/workflows -g "*.yml" -g "*.yaml"` returned no workflow matches
- `git diff --check`

Not run:

- GitHub workflow YAML parsing with `actionlint`, `PyYAML`, or Ruby because those tools are not available in the local environment.
- Cargo validation because this change only updates GitHub Actions and helper skill files.
