### PR TITLE
[ISSUE #8070]🚀Report tracing subscriber installation status

### DIFF
--- a/rocketmq-observability/src/config.rs
+++ b/rocketmq-observability/src/config.rs
@@ -37,6 +37,7 @@ pub struct ObservabilityConfig {
     pub logs: LogsConfig,
     pub otlp: OtlpConfig,
     pub prometheus: PrometheusConfig,
+    pub subscriber_install_policy: SubscriberInstallPolicy,
     pub resource_attributes: HashMap<String, String>,
 }
 
@@ -122,6 +123,29 @@ pub enum OtlpProtocol {
     HttpJson,
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriberInstallPolicy {
+    Required,
+    #[default]
+    BestEffort,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SubscriberInstallStatus {
+    pub attempted: bool,
+    pub installed: bool,
+}
+
+impl SubscriberInstallStatus {
+    pub fn attempted(installed: bool) -> Self {
+        Self {
+            attempted: true,
+            installed,
+        }
+    }
+}
+
 impl Default for ObservabilityConfig {
     fn default() -> Self {
         Self {
@@ -139,6 +163,7 @@ impl Default for ObservabilityConfig {
             logs: LogsConfig::default(),
             otlp: OtlpConfig::default(),
             prometheus: PrometheusConfig::default(),
+            subscriber_install_policy: SubscriberInstallPolicy::default(),
             resource_attributes: HashMap::new(),
         }
     }
@@ -249,6 +274,19 @@ mod tests {
         assert_eq!(config.prometheus.host, "127.0.0.1");
         assert!(!config.traces.record_message_id);
         assert!(!config.traces.record_message_keys);
+        assert_eq!(config.subscriber_install_policy, SubscriberInstallPolicy::BestEffort);
+    }
+
+    #[test]
+    fn subscriber_install_policy_uses_snake_case_serde() {
+        let policy = serde_json::from_str::<SubscriberInstallPolicy>("\"required\"")
+            .expect("required policy should deserialize");
+
+        assert_eq!(policy, SubscriberInstallPolicy::Required);
+        assert_eq!(
+            serde_json::to_string(&SubscriberInstallPolicy::BestEffort).expect("policy should serialize"),
+            "\"best_effort\""
+        );
     }
 
     #[test]

--- a/rocketmq-observability/src/error.rs
+++ b/rocketmq-observability/src/error.rs
@@ -14,6 +14,8 @@
 
 use thiserror::Error;
 
+use crate::config::SubscriberInstallStatus;
+
 #[derive(Debug, Error)]
 pub enum ObservabilityError {
     #[error("observability feature '{0}' is not enabled")]
@@ -30,6 +32,9 @@ pub enum ObservabilityError {
 
     #[error("logs initialization failed: {0}")]
     LogsInit(String),
+
+    #[error("tracing subscriber installation failed: attempted={attempted}, installed={installed}")]
+    SubscriberInstallFailed { attempted: bool, installed: bool },
 
     #[error("metrics shutdown failed: {0}")]
     MetricsShutdown(String),
@@ -56,6 +61,13 @@ impl ObservabilityError {
 
     pub fn logs_init(error: impl ToString) -> Self {
         Self::LogsInit(error.to_string())
+    }
+
+    pub fn subscriber_install_failed(status: SubscriberInstallStatus) -> Self {
+        Self::SubscriberInstallFailed {
+            attempted: status.attempted,
+            installed: status.installed,
+        }
     }
 
     pub fn metrics_shutdown(error: impl ToString) -> Self {

--- a/rocketmq-observability/src/init.rs
+++ b/rocketmq-observability/src/init.rs
@@ -16,10 +16,13 @@
 use crate::config::LogsExporter;
 use crate::config::MetricsExporter;
 use crate::config::ObservabilityConfig;
+use crate::config::SubscriberInstallPolicy;
+use crate::config::SubscriberInstallStatus;
 use crate::error::ObservabilityError;
 
 #[derive(Debug, Default)]
 pub struct TelemetryGuard {
+    subscriber_install_status: SubscriberInstallStatus,
     #[cfg(feature = "otel-metrics")]
     meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
     #[cfg(feature = "prometheus")]
@@ -37,6 +40,10 @@ impl TelemetryGuard {
 
     pub fn shutdown(self) -> Result<(), ObservabilityError> {
         self.shutdown_inner()
+    }
+
+    pub fn subscriber_install_status(&self) -> SubscriberInstallStatus {
+        self.subscriber_install_status
     }
 
     #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
@@ -103,10 +110,7 @@ pub fn init_observability(config: &ObservabilityConfig) -> Result<TelemetryGuard
         return Ok(TelemetryGuard::noop());
     }
 
-    #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
     let mut guard = TelemetryGuard::noop();
-    #[cfg(not(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs")))]
-    let guard = TelemetryGuard::noop();
 
     if config.metrics.enabled {
         #[cfg(feature = "otel-metrics")]
@@ -153,16 +157,53 @@ pub fn init_observability(config: &ObservabilityConfig) -> Result<TelemetryGuard
     }
 
     #[cfg(all(feature = "otel-traces", feature = "otel-logs"))]
-    let _installed =
+    let subscriber_install_status =
         try_init_observability_subscriber(config, guard.tracer_provider.as_ref(), guard.logger_provider.as_ref());
 
     #[cfg(all(feature = "otel-traces", not(feature = "otel-logs")))]
-    let _installed = try_init_observability_subscriber(config, guard.tracer_provider.as_ref());
+    let subscriber_install_status = try_init_observability_subscriber(config, guard.tracer_provider.as_ref());
 
     #[cfg(all(not(feature = "otel-traces"), feature = "otel-logs"))]
-    let _installed = try_init_observability_subscriber(guard.logger_provider.as_ref());
+    let subscriber_install_status = try_init_observability_subscriber(guard.logger_provider.as_ref());
+
+    #[cfg(not(any(feature = "otel-traces", feature = "otel-logs")))]
+    let subscriber_install_status = SubscriberInstallStatus::default();
+
+    guard.subscriber_install_status = subscriber_install_status;
+    if let Err(error) = enforce_subscriber_install_policy(config, guard.subscriber_install_status) {
+        let _ = guard.shutdown();
+        return Err(error);
+    }
 
     Ok(guard)
+}
+
+fn enforce_subscriber_install_policy(
+    config: &ObservabilityConfig,
+    status: SubscriberInstallStatus,
+) -> Result<(), ObservabilityError> {
+    if !subscriber_install_required(config) || status.installed {
+        return Ok(());
+    }
+
+    match config.subscriber_install_policy {
+        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(status)),
+        SubscriberInstallPolicy::BestEffort => {
+            if status.attempted {
+                tracing::warn!(
+                    target: "rocketmq_observability",
+                    attempted = status.attempted,
+                    installed = status.installed,
+                    "tracing subscriber was already initialized; OpenTelemetry trace/log layers were not installed"
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn subscriber_install_required(config: &ObservabilityConfig) -> bool {
+    config.traces.enabled || config.logs.enabled
 }
 
 fn validate_config(config: &ObservabilityConfig) -> Result<(), ObservabilityError> {
@@ -334,7 +375,7 @@ fn try_init_observability_subscriber(
     config: &ObservabilityConfig,
     tracer_provider: Option<&opentelemetry_sdk::trace::SdkTracerProvider>,
     logger_provider: Option<&opentelemetry_sdk::logs::SdkLoggerProvider>,
-) -> bool {
+) -> SubscriberInstallStatus {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -367,19 +408,19 @@ fn try_init_observability_subscriber(
                     .with_thread_names(true),
             )
             .try_init(),
-        (None, None) => return false,
+        (None, None) => return SubscriberInstallStatus::default(),
     };
 
-    log_subscriber_init_result(result)
+    SubscriberInstallStatus::attempted(log_subscriber_init_result(result))
 }
 
 #[cfg(all(feature = "otel-traces", not(feature = "otel-logs")))]
 fn try_init_observability_subscriber(
     config: &ObservabilityConfig,
     tracer_provider: Option<&opentelemetry_sdk::trace::SdkTracerProvider>,
-) -> bool {
+) -> SubscriberInstallStatus {
     let Some(tracer_provider) = tracer_provider else {
-        return false;
+        return SubscriberInstallStatus::default();
     };
 
     let installed = crate::trace::try_init_tracing_subscriber(config, tracer_provider);
@@ -389,16 +430,18 @@ fn try_init_observability_subscriber(
             "tracing subscriber already initialized; OpenTelemetry tracing layer was not installed"
         );
     }
-    installed
+    SubscriberInstallStatus::attempted(installed)
 }
 
 #[cfg(all(not(feature = "otel-traces"), feature = "otel-logs"))]
-fn try_init_observability_subscriber(logger_provider: Option<&opentelemetry_sdk::logs::SdkLoggerProvider>) -> bool {
+fn try_init_observability_subscriber(
+    logger_provider: Option<&opentelemetry_sdk::logs::SdkLoggerProvider>,
+) -> SubscriberInstallStatus {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
     let Some(logger_provider) = logger_provider else {
-        return false;
+        return SubscriberInstallStatus::default();
     };
 
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -406,12 +449,12 @@ fn try_init_observability_subscriber(logger_provider: Option<&opentelemetry_sdk:
         .with_thread_ids(true)
         .with_thread_names(true);
 
-    log_subscriber_init_result(
+    SubscriberInstallStatus::attempted(log_subscriber_init_result(
         tracing_subscriber::registry()
             .with(crate::logs::bridge::build_logs_layer(logger_provider))
             .with(fmt_layer)
             .try_init(),
-    )
+    ))
 }
 
 #[cfg(any(
@@ -443,6 +486,13 @@ mod tests {
     fn disabled_config_returns_noop_guard() {
         let guard = init_observability(&ObservabilityConfig::default()).expect("noop init should succeed");
 
+        assert_eq!(
+            guard.subscriber_install_status(),
+            SubscriberInstallStatus {
+                attempted: false,
+                installed: false,
+            }
+        );
         guard.shutdown().expect("noop shutdown should succeed");
     }
 

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -27,6 +27,8 @@ pub mod semantic;
 pub mod trace;
 
 pub use config::ObservabilityConfig;
+pub use config::SubscriberInstallPolicy;
+pub use config::SubscriberInstallStatus;
 pub use error::ObservabilityError;
 pub use init::init_observability;
 #[cfg(feature = "otel-metrics")]

--- a/rocketmq-observability/tests/logging_bootstrap_guards.rs
+++ b/rocketmq-observability/tests/logging_bootstrap_guards.rs
@@ -14,23 +14,63 @@
 
 #[cfg(feature = "otel-traces")]
 #[test]
-fn enabled_traces_still_initialize_when_subscriber_install_is_blocked() {
-    let _ = tracing_subscriber::fmt().with_writer(std::io::sink).try_init();
+fn best_effort_traces_report_blocked_subscriber_install_status() {
+    install_blocking_subscriber();
 
+    let config = traces_config(rocketmq_observability::SubscriberInstallPolicy::BestEffort);
+
+    let guard = rocketmq_observability::init_observability(&config)
+        .expect("best-effort mode should keep existing compatibility behavior");
+
+    assert!(
+        guard.tracer_provider().is_some(),
+        "the tracer provider initializes even though the tracing subscriber layer is blocked"
+    );
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: false,
+        }
+    );
+
+    guard.shutdown().expect("trace provider shutdown should succeed");
+}
+
+#[cfg(feature = "otel-traces")]
+#[test]
+fn required_traces_report_subscriber_install_failure() {
+    install_blocking_subscriber();
+
+    let config = traces_config(rocketmq_observability::SubscriberInstallPolicy::Required);
+
+    let error = rocketmq_observability::init_observability(&config)
+        .expect_err("required mode should fail when the subscriber layer cannot be installed");
+
+    assert!(matches!(
+        error,
+        rocketmq_observability::ObservabilityError::SubscriberInstallFailed {
+            attempted: true,
+            installed: false
+        }
+    ));
+}
+
+#[cfg(feature = "otel-traces")]
+fn traces_config(
+    subscriber_install_policy: rocketmq_observability::SubscriberInstallPolicy,
+) -> rocketmq_observability::ObservabilityConfig {
     let mut config = rocketmq_observability::ObservabilityConfig {
         enabled: true,
         ..rocketmq_observability::ObservabilityConfig::default()
     };
     config.traces.enabled = true;
     config.traces.exporter = rocketmq_observability::config::TraceExporter::Disable;
+    config.subscriber_install_policy = subscriber_install_policy;
+    config
+}
 
-    let guard = rocketmq_observability::init_observability(&config)
-        .expect("current init path does not report subscriber install failure");
-
-    assert!(
-        guard.tracer_provider().is_some(),
-        "the tracer provider initializes even though the tracing subscriber layer is blocked"
-    );
-
-    guard.shutdown().expect("trace provider shutdown should succeed");
+#[cfg(feature = "otel-traces")]
+fn install_blocking_subscriber() {
+    let _ = tracing_subscriber::fmt().with_writer(std::io::sink).try_init();
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8070

### Brief Description

- Add a `SubscriberInstallPolicy` with `BestEffort` compatibility behavior and `Required` fail-fast behavior.
- Add `SubscriberInstallStatus` to report whether global subscriber installation was attempted and installed.
- Expose subscriber installation status from `TelemetryGuard` and return a typed `SubscriberInstallFailed` error when required installation is blocked.
- Update the subscriber conflict integration tests to cover both best-effort status reporting and required-mode failure.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-observability init --all-features`
- `cargo test -p rocketmq-observability config --all-features`
- `cargo test -p rocketmq-observability --test logging_bootstrap_guards --all-features`
- `cargo test -p rocketmq-observability --test architecture_guards`
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new observability setting to control whether subscriber setup is optional or required.
  * Exposed subscriber installation status so apps can inspect whether setup was attempted and completed.
  * Added clearer subscriber installation errors with more detail.

* **Bug Fixes**
  * Improved behavior when tracing/logging subscriber setup is blocked, including better handling for optional vs. required modes.

* **Tests**
  * Expanded coverage for default settings, serialization behavior, and subscriber installation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->