### PR TITLE
[ISSUE #8072]🚀Add unified logging configuration model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,6 +4371,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-appender",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -5786,18 +5797,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,9 @@ tokio-util   = { version = "0.7.18", features = ["full"] }
 tokio-stream = { version = "0.1.18", features = ["full"] }
 
 tracing            = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["time"] }
+tracing-subscriber = { version = "0.3.23", features = ["time", "env-filter", "json", "registry", "tracing-log"] }
 tracing-appender   = "0.2.5"
+tracing-log        = "0.2.0"
 
 thiserror = "2.0.18"
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -2552,6 +2552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,6 +4155,8 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -5754,18 +5765,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2499,6 +2499,8 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tracing",
+ "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -3418,6 +3420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,6 +3439,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3434,6 +3448,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -1465,6 +1465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2352,8 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -3208,18 +3219,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rocketmq-observability/Cargo.toml
+++ b/rocketmq-observability/Cargo.toml
@@ -91,6 +91,8 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
+tracing-log.workspace = true
 tracing-subscriber.workspace = true
 
 opentelemetry = { workspace = true, optional = true }

--- a/rocketmq-observability/src/config.rs
+++ b/rocketmq-observability/src/config.rs
@@ -41,6 +41,59 @@ pub struct ObservabilityConfig {
     pub resource_attributes: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TelemetryBootstrapConfig {
+    pub observability: ObservabilityConfig,
+    pub logging: LoggingConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LoggingConfig {
+    pub enabled: bool,
+    pub filter: String,
+    pub console: ConsoleLogConfig,
+    pub file: FileLogConfig,
+    pub reload: ReloadConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ConsoleLogConfig {
+    pub enabled: bool,
+    pub format: LogFormat,
+    pub ansi: bool,
+    pub target: bool,
+    pub thread_ids: bool,
+    pub thread_names: bool,
+    pub line_number: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FileLogConfig {
+    pub enabled: bool,
+    pub directory: String,
+    pub file_name_prefix: String,
+    pub rotation: LogRotation,
+    pub format: LogFormat,
+    pub non_blocking: NonBlockingLogConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NonBlockingLogConfig {
+    pub buffered_lines_limit: usize,
+    pub lossy: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReloadConfig {
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MetricsConfig {
@@ -125,6 +178,24 @@ pub enum OtlpProtocol {
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    #[default]
+    Compact,
+    Pretty,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LogRotation {
+    Never,
+    Hourly,
+    #[default]
+    Daily,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum SubscriberInstallPolicy {
     Required,
     #[default]
@@ -165,6 +236,54 @@ impl Default for ObservabilityConfig {
             prometheus: PrometheusConfig::default(),
             subscriber_install_policy: SubscriberInstallPolicy::default(),
             resource_attributes: HashMap::new(),
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            filter: "info".to_string(),
+            console: ConsoleLogConfig::default(),
+            file: FileLogConfig::default(),
+            reload: ReloadConfig::default(),
+        }
+    }
+}
+
+impl Default for ConsoleLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            format: LogFormat::Compact,
+            ansi: true,
+            target: true,
+            thread_ids: true,
+            thread_names: true,
+            line_number: true,
+        }
+    }
+}
+
+impl Default for FileLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            directory: "logs".to_string(),
+            file_name_prefix: "rocketmq-rust".to_string(),
+            rotation: LogRotation::Daily,
+            format: LogFormat::Json,
+            non_blocking: NonBlockingLogConfig::default(),
+        }
+    }
+}
+
+impl Default for NonBlockingLogConfig {
+    fn default() -> Self {
+        Self {
+            buffered_lines_limit: 65_536,
+            lossy: false,
         }
     }
 }
@@ -287,6 +406,74 @@ mod tests {
             serde_json::to_string(&SubscriberInstallPolicy::BestEffort).expect("policy should serialize"),
             "\"best_effort\""
         );
+    }
+
+    #[test]
+    fn logging_config_defaults_to_console_info_filter() {
+        let config = LoggingConfig::default();
+
+        assert!(config.enabled);
+        assert_eq!(config.filter, "info");
+        assert!(config.console.enabled);
+        assert_eq!(config.console.format, LogFormat::Compact);
+        assert!(config.console.ansi);
+        assert!(config.console.target);
+        assert!(config.console.thread_ids);
+        assert!(config.console.thread_names);
+        assert!(config.console.line_number);
+        assert!(!config.file.enabled);
+        assert_eq!(config.file.rotation, LogRotation::Daily);
+        assert_eq!(config.file.format, LogFormat::Json);
+        assert_eq!(config.file.non_blocking.buffered_lines_limit, 65_536);
+        assert!(!config.file.non_blocking.lossy);
+        assert!(!config.reload.enabled);
+    }
+
+    #[test]
+    fn logging_config_serde_roundtrip_preserves_enums() {
+        let config = LoggingConfig {
+            filter: "rocketmq_store=debug,rocketmq_remoting=warn".to_string(),
+            console: ConsoleLogConfig {
+                format: LogFormat::Pretty,
+                ..ConsoleLogConfig::default()
+            },
+            file: FileLogConfig {
+                enabled: true,
+                rotation: LogRotation::Hourly,
+                format: LogFormat::Json,
+                non_blocking: NonBlockingLogConfig {
+                    buffered_lines_limit: 4_096,
+                    lossy: true,
+                },
+                ..FileLogConfig::default()
+            },
+            reload: ReloadConfig { enabled: true },
+            ..LoggingConfig::default()
+        };
+
+        let payload = serde_json::to_string(&config).expect("logging config should serialize");
+        assert!(payload.contains("\"pretty\""));
+        assert!(payload.contains("\"hourly\""));
+
+        let decoded = serde_json::from_str::<LoggingConfig>(&payload).expect("logging config should deserialize");
+
+        assert_eq!(decoded, config);
+    }
+
+    #[test]
+    fn invalid_logging_enum_values_are_rejected() {
+        assert!(serde_json::from_str::<LogFormat>("\"camelCase\"").is_err());
+        assert!(serde_json::from_str::<LogRotation>("\"weekly\"").is_err());
+    }
+
+    #[test]
+    fn telemetry_bootstrap_default_keeps_observability_disabled_and_logging_ready() {
+        let config = TelemetryBootstrapConfig::default();
+
+        assert!(!config.observability.enabled);
+        assert!(config.logging.enabled);
+        assert!(config.logging.console.enabled);
+        assert!(!config.logging.file.enabled);
     }
 
     #[test]

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -26,9 +26,17 @@ pub mod sampling;
 pub mod semantic;
 pub mod trace;
 
+pub use config::ConsoleLogConfig;
+pub use config::FileLogConfig;
+pub use config::LogFormat;
+pub use config::LogRotation;
+pub use config::LoggingConfig;
+pub use config::NonBlockingLogConfig;
 pub use config::ObservabilityConfig;
+pub use config::ReloadConfig;
 pub use config::SubscriberInstallPolicy;
 pub use config::SubscriberInstallStatus;
+pub use config::TelemetryBootstrapConfig;
 pub use error::ObservabilityError;
 pub use init::init_observability;
 #[cfg(feature = "otel-metrics")]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8072

### Brief Description

- Add `TelemetryBootstrapConfig` and reusable logging configuration types for console, file, reload, format, rotation, and non-blocking buffering options.
- Keep observability disabled by default while making local console logging ready by default with an `info` filter and file logging disabled.
- Export the new logging config types for later bootstrap and layer builder work.
- Enable `tracing-subscriber` filter, JSON, registry, and tracing-log features, and wire appender/log dependencies for the observability crate.
- Refresh related lockfiles so standalone projects that depend on the shared observability crate keep a consistent dependency graph.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-observability config --all-features`
- `cargo check -p rocketmq-observability --all-features`
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets -- -D warnings` from the example project
- `cargo clippy --all-targets --all-features -- -D warnings` from the Tauri backend project
- `cargo clippy --all-targets --all-features -- -D warnings` from the Web backend project
- `cargo build --all-targets --all-features` from the Web backend project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer telemetry and logging configuration with support for console and file output, log formatting options, rotation settings, and non-blocking buffering.
  * Expanded default logging behavior to make logging available out of the box with sensible defaults, including structured output options.
  * Exposed the new telemetry bootstrap configuration for easier application setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->