### PR TITLE
[ISSUE #8074]🚀Add telemetry runtime guard types

### DIFF
--- a/rocketmq-observability/src/error.rs
+++ b/rocketmq-observability/src/error.rs
@@ -33,6 +33,12 @@ pub enum ObservabilityError {
     #[error("logs initialization failed: {0}")]
     LogsInit(String),
 
+    #[error("logging initialization failed: {0}")]
+    LoggingInit(String),
+
+    #[error("invalid log filter '{filter}': {error}")]
+    InvalidLogFilter { filter: String, error: String },
+
     #[error("tracing subscriber installation failed: attempted={attempted}, installed={installed}")]
     SubscriberInstallFailed { attempted: bool, installed: bool },
 
@@ -63,6 +69,17 @@ impl ObservabilityError {
         Self::LogsInit(error.to_string())
     }
 
+    pub fn logging_init(error: impl ToString) -> Self {
+        Self::LoggingInit(error.to_string())
+    }
+
+    pub fn invalid_log_filter(filter: impl Into<String>, error: impl ToString) -> Self {
+        Self::InvalidLogFilter {
+            filter: filter.into(),
+            error: error.to_string(),
+        }
+    }
+
     pub fn subscriber_install_failed(status: SubscriberInstallStatus) -> Self {
         Self::SubscriberInstallFailed {
             attempted: status.attempted,
@@ -80,5 +97,28 @@ impl ObservabilityError {
 
     pub fn logs_shutdown(error: impl ToString) -> Self {
         Self::LogsShutdown(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_log_filter_error_preserves_filter_and_reason() {
+        let error = ObservabilityError::invalid_log_filter("rocketmq_store==debug", "invalid directive");
+
+        assert!(matches!(
+            error,
+            ObservabilityError::InvalidLogFilter { filter, error }
+                if filter == "rocketmq_store==debug" && error == "invalid directive"
+        ));
+    }
+
+    #[test]
+    fn logging_init_error_is_distinct_from_otel_logs_init() {
+        let error = ObservabilityError::logging_init("writer failed");
+
+        assert!(matches!(error, ObservabilityError::LoggingInit(message) if message == "writer failed"));
     }
 }

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod error;
 pub mod exporter;
 pub mod init;
+pub mod logging;
 pub mod logs;
 pub mod metrics;
 pub mod noop;
@@ -42,6 +43,8 @@ pub use init::init_observability;
 #[cfg(feature = "otel-metrics")]
 pub use init::meter;
 pub use init::TelemetryGuard;
+pub use logging::LoggingGuard;
+pub use logging::TelemetryRuntimeGuard;
 
 #[cfg(feature = "prometheus")]
 #[doc(hidden)]

--- a/rocketmq-observability/src/logging.rs
+++ b/rocketmq-observability/src/logging.rs
@@ -1,0 +1,136 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tracing_appender::non_blocking::ErrorCounter;
+use tracing_appender::non_blocking::WorkerGuard;
+
+use crate::config::SubscriberInstallStatus;
+use crate::error::ObservabilityError;
+use crate::init::TelemetryGuard;
+
+#[derive(Default)]
+pub struct LoggingGuard {
+    worker_guards: Vec<WorkerGuard>,
+    dropped_log_counters: Vec<ErrorCounter>,
+}
+
+impl LoggingGuard {
+    pub fn noop() -> Self {
+        Self::new(Vec::new(), Vec::new())
+    }
+
+    pub(crate) fn new(worker_guards: Vec<WorkerGuard>, dropped_log_counters: Vec<ErrorCounter>) -> Self {
+        Self {
+            worker_guards,
+            dropped_log_counters,
+        }
+    }
+
+    pub fn dropped_log_lines(&self) -> usize {
+        self.dropped_log_counters.iter().map(ErrorCounter::dropped_lines).sum()
+    }
+
+    pub fn file_sink_count(&self) -> usize {
+        self.worker_guards.len()
+    }
+}
+
+pub struct TelemetryRuntimeGuard {
+    telemetry_guard: TelemetryGuard,
+    logging_guard: LoggingGuard,
+}
+
+impl TelemetryRuntimeGuard {
+    pub fn new(telemetry_guard: TelemetryGuard, logging_guard: LoggingGuard) -> Self {
+        Self {
+            telemetry_guard,
+            logging_guard,
+        }
+    }
+
+    pub fn noop() -> Self {
+        Self::new(TelemetryGuard::noop(), LoggingGuard::noop())
+    }
+
+    pub fn telemetry_guard(&self) -> &TelemetryGuard {
+        &self.telemetry_guard
+    }
+
+    pub fn logging_guard(&self) -> &LoggingGuard {
+        &self.logging_guard
+    }
+
+    pub fn subscriber_install_status(&self) -> SubscriberInstallStatus {
+        self.telemetry_guard.subscriber_install_status()
+    }
+
+    pub fn dropped_log_lines(&self) -> usize {
+        self.logging_guard.dropped_log_lines()
+    }
+
+    pub fn shutdown(self) -> Result<(), ObservabilityError> {
+        let Self {
+            telemetry_guard,
+            logging_guard,
+        } = self;
+
+        let shutdown_result = telemetry_guard.shutdown();
+        drop(logging_guard);
+        shutdown_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_logging_guard_reports_zero_dropped_lines() {
+        let guard = LoggingGuard::noop();
+
+        assert_eq!(guard.file_sink_count(), 0);
+        assert_eq!(guard.dropped_log_lines(), 0);
+    }
+
+    #[test]
+    fn logging_guard_tracks_worker_guards_without_static_storage() {
+        let (writer, worker_guard) = tracing_appender::non_blocking(std::io::sink());
+        let error_counter = writer.error_counter();
+        let guard = LoggingGuard::new(vec![worker_guard], vec![error_counter]);
+
+        assert_eq!(guard.file_sink_count(), 1);
+        assert_eq!(guard.dropped_log_lines(), 0);
+    }
+
+    #[test]
+    fn noop_runtime_guard_exposes_zero_logging_and_subscriber_status() {
+        let guard = TelemetryRuntimeGuard::noop();
+
+        assert_eq!(guard.dropped_log_lines(), 0);
+        assert_eq!(
+            guard.subscriber_install_status(),
+            SubscriberInstallStatus {
+                attempted: false,
+                installed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn noop_runtime_guard_shutdown_succeeds() {
+        TelemetryRuntimeGuard::noop()
+            .shutdown()
+            .expect("noop runtime guard shutdown should succeed");
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8074

### Brief Description

- Add `LoggingGuard` to own non-blocking file sink worker guards and dropped log counters without static storage.
- Add `TelemetryRuntimeGuard` to combine logging guard ownership with the existing telemetry provider guard.
- Expose dropped log line totals and subscriber installation status through the runtime guard.
- Add typed `LoggingInit` and `InvalidLogFilter` errors for upcoming logging bootstrap builders.
- Add unit coverage for no-op guard behavior, dropped counter reporting, and error semantics.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-observability logging --all-features`
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability logging support with runtime guards for managing logging and telemetry together.
  * Exposed new status and shutdown controls, plus visibility into dropped log lines and configured file sinks.
* **Bug Fixes**
  * Improved error reporting for invalid log filters, including the filter value and validation reason.
  * Clarified logging initialization errors so they are distinguishable from other telemetry startup failures.
* **Tests**
  * Added coverage for log-filter error handling and runtime guard shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->