### PR TITLE
[ISSUE #8076]🚀Add console logging layer builder

### DIFF
--- a/rocketmq-observability/src/logging.rs
+++ b/rocketmq-observability/src/logging.rs
@@ -14,10 +14,17 @@
 
 use tracing_appender::non_blocking::ErrorCounter;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::Registry;
 
+use crate::config::ConsoleLogConfig;
+use crate::config::LogFormat;
 use crate::config::SubscriberInstallStatus;
 use crate::error::ObservabilityError;
 use crate::init::TelemetryGuard;
+
+pub type BoxedRegistryLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
 #[derive(Default)]
 pub struct LoggingGuard {
@@ -43,6 +50,30 @@ impl LoggingGuard {
 
     pub fn file_sink_count(&self) -> usize {
         self.worker_guards.len()
+    }
+}
+
+pub fn build_env_filter(filter: &str) -> Result<EnvFilter, ObservabilityError> {
+    EnvFilter::try_new(filter).map_err(|error| ObservabilityError::invalid_log_filter(filter, error))
+}
+
+pub fn build_console_layer(config: &ConsoleLogConfig) -> Option<BoxedRegistryLayer> {
+    if !config.enabled {
+        return None;
+    }
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(config.ansi)
+        .with_target(config.target)
+        .with_thread_ids(config.thread_ids)
+        .with_thread_names(config.thread_names)
+        .with_line_number(config.line_number);
+
+    match config.format {
+        LogFormat::Compact => Some(Box::new(layer.compact())),
+        LogFormat::Pretty => Some(Box::new(layer.pretty())),
+        LogFormat::Json => Some(Box::new(layer.json())),
     }
 }
 
@@ -111,6 +142,46 @@ mod tests {
 
         assert_eq!(guard.file_sink_count(), 1);
         assert_eq!(guard.dropped_log_lines(), 0);
+    }
+
+    #[test]
+    fn env_filter_accepts_target_directives() {
+        let filter =
+            build_env_filter("rocketmq_store=debug,rocketmq_remoting=warn").expect("target directives should parse");
+
+        assert!(filter.to_string().contains("rocketmq_store=debug"));
+    }
+
+    #[test]
+    fn invalid_env_filter_returns_typed_error() {
+        let error = build_env_filter("rocketmq_store==debug").expect_err("invalid filter should fail");
+
+        assert!(matches!(
+            error,
+            ObservabilityError::InvalidLogFilter { filter, .. } if filter == "rocketmq_store==debug"
+        ));
+    }
+
+    #[test]
+    fn disabled_console_config_builds_no_layer() {
+        let config = ConsoleLogConfig {
+            enabled: false,
+            ..ConsoleLogConfig::default()
+        };
+
+        assert!(build_console_layer(&config).is_none());
+    }
+
+    #[test]
+    fn console_layer_builder_supports_all_formats() {
+        for format in [LogFormat::Compact, LogFormat::Pretty, LogFormat::Json] {
+            let config = ConsoleLogConfig {
+                format,
+                ..ConsoleLogConfig::default()
+            };
+
+            assert!(build_console_layer(&config).is_some());
+        }
     }
 
     #[test]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8076

### Brief Description

- Add `build_env_filter` for tracing filter directive parsing with typed invalid-filter errors.
- Add `build_console_layer` for console logging output based on `ConsoleLogConfig`.
- Support compact, pretty, and JSON console formats.
- Honor console enabled state, ANSI, target, thread id, thread name, and line number settings.
- Keep console logging on stderr for clean separation from command output.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-observability logging --all-features`
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable console logging support with multiple output formats, including compact, pretty, and JSON.
  * Logging can now be turned off cleanly through configuration.
  * Added clearer handling for invalid log filter settings, with user-friendly errors instead of crashes.

* **Bug Fixes**
  * Improved validation for log filter strings to help prevent misconfiguration.
  * Expanded test coverage for logging setup across supported formats and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->