### PR TITLE
[ISSUE #8080]♻️Add unified telemetry logging bootstrap

### DIFF
--- a/rocketmq-observability/src/init.rs
+++ b/rocketmq-observability/src/init.rs
@@ -46,6 +46,10 @@ impl TelemetryGuard {
         self.subscriber_install_status
     }
 
+    pub(crate) fn set_subscriber_install_status(&mut self, status: SubscriberInstallStatus) {
+        self.subscriber_install_status = status;
+    }
+
     #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
     fn shutdown_inner(mut self) -> Result<(), ObservabilityError> {
         #[cfg(feature = "prometheus")]
@@ -102,7 +106,37 @@ pub fn meter(
     provider.meter(name)
 }
 
+/// Initializes observability providers and keeps the legacy best-effort subscriber install
+/// behavior.
+///
+/// New service entrypoints that need local console/file logging and OpenTelemetry trace/log layers
+/// in one subscriber should use `crate::logging::install_global` instead.
 pub fn init_observability(config: &ObservabilityConfig) -> Result<TelemetryGuard, ObservabilityError> {
+    let mut guard = init_telemetry_providers(config)?;
+
+    #[cfg(all(feature = "otel-traces", feature = "otel-logs"))]
+    let subscriber_install_status =
+        try_init_observability_subscriber(config, guard.tracer_provider.as_ref(), guard.logger_provider.as_ref());
+
+    #[cfg(all(feature = "otel-traces", not(feature = "otel-logs")))]
+    let subscriber_install_status = try_init_observability_subscriber(config, guard.tracer_provider.as_ref());
+
+    #[cfg(all(not(feature = "otel-traces"), feature = "otel-logs"))]
+    let subscriber_install_status = try_init_observability_subscriber(guard.logger_provider.as_ref());
+
+    #[cfg(not(any(feature = "otel-traces", feature = "otel-logs")))]
+    let subscriber_install_status = SubscriberInstallStatus::default();
+
+    guard.set_subscriber_install_status(subscriber_install_status);
+    if let Err(error) = enforce_subscriber_install_policy(config, guard.subscriber_install_status()) {
+        let _ = guard.shutdown();
+        return Err(error);
+    }
+
+    Ok(guard)
+}
+
+pub(crate) fn init_telemetry_providers(config: &ObservabilityConfig) -> Result<TelemetryGuard, ObservabilityError> {
     validate_config(config)?;
     crate::trace::configure_message_span_recording(&config.traces);
 
@@ -156,29 +190,10 @@ pub fn init_observability(config: &ObservabilityConfig) -> Result<TelemetryGuard
         return Err(ObservabilityError::FeatureDisabled("otel-logs"));
     }
 
-    #[cfg(all(feature = "otel-traces", feature = "otel-logs"))]
-    let subscriber_install_status =
-        try_init_observability_subscriber(config, guard.tracer_provider.as_ref(), guard.logger_provider.as_ref());
-
-    #[cfg(all(feature = "otel-traces", not(feature = "otel-logs")))]
-    let subscriber_install_status = try_init_observability_subscriber(config, guard.tracer_provider.as_ref());
-
-    #[cfg(all(not(feature = "otel-traces"), feature = "otel-logs"))]
-    let subscriber_install_status = try_init_observability_subscriber(guard.logger_provider.as_ref());
-
-    #[cfg(not(any(feature = "otel-traces", feature = "otel-logs")))]
-    let subscriber_install_status = SubscriberInstallStatus::default();
-
-    guard.subscriber_install_status = subscriber_install_status;
-    if let Err(error) = enforce_subscriber_install_policy(config, guard.subscriber_install_status) {
-        let _ = guard.shutdown();
-        return Err(error);
-    }
-
     Ok(guard)
 }
 
-fn enforce_subscriber_install_policy(
+pub(crate) fn enforce_subscriber_install_policy(
     config: &ObservabilityConfig,
     status: SubscriberInstallStatus,
 ) -> Result<(), ObservabilityError> {

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -43,6 +43,7 @@ pub use init::init_observability;
 #[cfg(feature = "otel-metrics")]
 pub use init::meter;
 pub use init::TelemetryGuard;
+pub use logging::install_global;
 pub use logging::FileLogLayer;
 pub use logging::LoggingGuard;
 pub use logging::TelemetryRuntimeGuard;

--- a/rocketmq-observability/src/logging.rs
+++ b/rocketmq-observability/src/logging.rs
@@ -18,6 +18,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_appender::rolling::Rotation;
 use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 
@@ -25,7 +26,9 @@ use crate::config::ConsoleLogConfig;
 use crate::config::FileLogConfig;
 use crate::config::LogFormat;
 use crate::config::LogRotation;
+use crate::config::SubscriberInstallPolicy;
 use crate::config::SubscriberInstallStatus;
+use crate::config::TelemetryBootstrapConfig;
 use crate::error::ObservabilityError;
 use crate::init::TelemetryGuard;
 
@@ -47,6 +50,11 @@ impl LoggingGuard {
             worker_guards,
             dropped_log_counters,
         }
+    }
+
+    pub(crate) fn append(&mut self, mut other: Self) {
+        self.worker_guards.append(&mut other.worker_guards);
+        self.dropped_log_counters.append(&mut other.dropped_log_counters);
     }
 
     pub fn dropped_log_lines(&self) -> usize {
@@ -98,6 +106,108 @@ pub fn build_console_layer(config: &ConsoleLogConfig) -> Option<BoxedRegistryLay
         LogFormat::Compact => Some(Box::new(layer.compact())),
         LogFormat::Pretty => Some(Box::new(layer.pretty())),
         LogFormat::Json => Some(Box::new(layer.json())),
+    }
+}
+
+pub fn install_global(config: &TelemetryBootstrapConfig) -> Result<TelemetryRuntimeGuard, ObservabilityError> {
+    init_log_tracer();
+
+    let mut telemetry_guard = crate::init::init_telemetry_providers(&config.observability)?;
+    let (layers, logging_guard) = match build_subscriber_layers(config, &telemetry_guard) {
+        Ok(layers) => layers,
+        Err(error) => {
+            let _ = telemetry_guard.shutdown();
+            return Err(error);
+        }
+    };
+
+    let subscriber_install_status = install_subscriber_layers(layers);
+    telemetry_guard.set_subscriber_install_status(subscriber_install_status);
+
+    if let Err(error) = enforce_bootstrap_subscriber_policy(config, subscriber_install_status) {
+        let _ = telemetry_guard.shutdown();
+        drop(logging_guard);
+        return Err(error);
+    }
+
+    Ok(TelemetryRuntimeGuard::new(telemetry_guard, logging_guard))
+}
+
+fn init_log_tracer() {
+    if let Err(error) = tracing_log::LogTracer::init() {
+        tracing::debug!(
+            target: "rocketmq_observability",
+            %error,
+            "log tracer was already initialized; keeping the existing log facade bridge"
+        );
+    }
+}
+
+fn build_subscriber_layers(
+    config: &TelemetryBootstrapConfig,
+    telemetry_guard: &TelemetryGuard,
+) -> Result<(Vec<BoxedRegistryLayer>, LoggingGuard), ObservabilityError> {
+    let mut layers = Vec::new();
+    let mut logging_guard = LoggingGuard::noop();
+
+    if config.logging.enabled {
+        layers.push(Box::new(build_env_filter(config.logging.filter.as_str())?) as BoxedRegistryLayer);
+
+        if let Some(console_layer) = build_console_layer(&config.logging.console) {
+            layers.push(console_layer);
+        }
+
+        if let Some(file_layer) = build_file_layer(&config.logging.file)? {
+            let (layer, file_logging_guard) = file_layer.into_parts();
+            layers.push(layer);
+            logging_guard.append(file_logging_guard);
+        }
+    }
+
+    #[cfg(feature = "otel-traces")]
+    if let Some(tracer_provider) = telemetry_guard.tracer_provider() {
+        layers.push(Box::new(crate::trace::build_tracing_layer(
+            &config.observability,
+            tracer_provider,
+        )));
+    }
+
+    #[cfg(feature = "otel-logs")]
+    if let Some(logger_provider) = telemetry_guard.logger_provider() {
+        layers.push(Box::new(crate::logs::bridge::build_logs_layer(logger_provider)));
+    }
+
+    Ok((layers, logging_guard))
+}
+
+fn install_subscriber_layers(layers: Vec<BoxedRegistryLayer>) -> SubscriberInstallStatus {
+    if layers.is_empty() {
+        return SubscriberInstallStatus::default();
+    }
+
+    let result = tracing::subscriber::set_global_default(tracing_subscriber::registry().with(layers));
+    SubscriberInstallStatus::attempted(result.is_ok())
+}
+
+fn enforce_bootstrap_subscriber_policy(
+    config: &TelemetryBootstrapConfig,
+    status: SubscriberInstallStatus,
+) -> Result<(), ObservabilityError> {
+    if !status.attempted || status.installed {
+        return Ok(());
+    }
+
+    match config.observability.subscriber_install_policy {
+        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(status)),
+        SubscriberInstallPolicy::BestEffort => {
+            tracing::warn!(
+                target: "rocketmq_observability",
+                attempted = status.attempted,
+                installed = status.installed,
+                "tracing subscriber was already initialized; unified logging and OpenTelemetry layers were not installed"
+            );
+            Ok(())
+        }
     }
 }
 
@@ -213,7 +323,6 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::time::SystemTime;
     use std::time::UNIX_EPOCH;
-    use tracing_subscriber::prelude::*;
 
     static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/rocketmq-observability/tests/architecture_guards.rs
+++ b/rocketmq-observability/tests/architecture_guards.rs
@@ -71,6 +71,8 @@ const SUBSCRIBER_INSTALL_ALLOWLIST: &[&str] = &[
     "rocketmq-common/src/log.rs",
     // Current OpenTelemetry trace/log layer installation sites. Task 1 makes their install status explicit.
     "rocketmq-observability/src/init.rs",
+    // Unified logging and telemetry bootstrap owns the new production subscriber installation path.
+    "rocketmq-observability/src/logging.rs",
     "rocketmq-observability/src/trace.rs",
 ];
 

--- a/rocketmq-observability/tests/logging_bootstrap_guards.rs
+++ b/rocketmq-observability/tests/logging_bootstrap_guards.rs
@@ -12,6 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Output;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn install_global_supports_console_only_logging() {
+    assert_bootstrap_case("console_only");
+}
+
+#[test]
+fn install_global_supports_file_only_logging() {
+    assert_bootstrap_case("file_only");
+}
+
+#[cfg(feature = "otel-metrics")]
+#[test]
+fn install_global_supports_metrics_without_subscriber_layers() {
+    assert_bootstrap_case("metrics_only");
+}
+
+#[cfg(feature = "otel-metrics")]
+#[test]
+fn install_global_keeps_metrics_when_best_effort_subscriber_install_is_blocked() {
+    let output = assert_bootstrap_case("metrics_best_effort_conflict");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("unified logging and OpenTelemetry layers were not installed"),
+        "best-effort conflict should emit a warning, stderr={stderr}"
+    );
+}
+
+#[cfg(feature = "otel-traces")]
+#[test]
+fn install_global_supports_tracing_layer() {
+    assert_bootstrap_case("traces_enabled");
+}
+
+#[cfg(feature = "otel-logs")]
+#[test]
+fn install_global_supports_logs_layer() {
+    assert_bootstrap_case("logs_enabled");
+}
+
+#[test]
+fn install_global_required_policy_fails_when_subscriber_is_blocked() {
+    assert_bootstrap_case("required_conflict");
+}
+
+#[test]
+#[ignore]
+fn install_global_bootstrap_child() {
+    let case = std::env::var("ROCKETMQ_OBSERVABILITY_BOOTSTRAP_CASE")
+        .expect("bootstrap child case should be provided by parent test");
+
+    match case.as_str() {
+        "console_only" => bootstrap_console_only(),
+        "file_only" => bootstrap_file_only(),
+        #[cfg(feature = "otel-metrics")]
+        "metrics_only" => bootstrap_metrics_only(),
+        #[cfg(feature = "otel-metrics")]
+        "metrics_best_effort_conflict" => bootstrap_metrics_best_effort_conflict(),
+        #[cfg(feature = "otel-traces")]
+        "traces_enabled" => bootstrap_traces_enabled(),
+        #[cfg(feature = "otel-logs")]
+        "logs_enabled" => bootstrap_logs_enabled(),
+        "required_conflict" => bootstrap_required_conflict(),
+        other => panic!("unknown bootstrap child case: {other}"),
+    }
+}
+
 #[cfg(feature = "otel-traces")]
 #[test]
 fn best_effort_traces_report_blocked_subscriber_install_status() {
@@ -73,4 +150,196 @@ fn traces_config(
 #[cfg(feature = "otel-traces")]
 fn install_blocking_subscriber() {
     let _ = tracing_subscriber::fmt().with_writer(std::io::sink).try_init();
+}
+
+fn assert_bootstrap_case(case: &str) -> Output {
+    let output = Command::new(std::env::current_exe().expect("current test executable should be available"))
+        .arg("--exact")
+        .arg("install_global_bootstrap_child")
+        .arg("--ignored")
+        .env("ROCKETMQ_OBSERVABILITY_BOOTSTRAP_CASE", case)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run bootstrap child case {case}: {error}"));
+
+    assert!(
+        output.status.success(),
+        "bootstrap child case {case} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    output
+}
+
+fn bootstrap_console_only() {
+    let config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    let guard = rocketmq_observability::install_global(&config).expect("console-only bootstrap should install");
+
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: true,
+        }
+    );
+    assert_eq!(guard.logging_guard().file_sink_count(), 0);
+
+    guard.shutdown().expect("console-only shutdown should succeed");
+}
+
+fn bootstrap_file_only() {
+    let directory = unique_temp_log_dir("install-global-file-only");
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.logging.console.enabled = false;
+    config.logging.file.enabled = true;
+    config.logging.file.directory = directory.to_string_lossy().into_owned();
+    config.logging.file.file_name_prefix = "bootstrap.log".to_string();
+    config.logging.file.rotation = rocketmq_observability::LogRotation::Never;
+
+    let guard = rocketmq_observability::install_global(&config).expect("file-only bootstrap should install");
+
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: true,
+        }
+    );
+    assert_eq!(guard.logging_guard().file_sink_count(), 1);
+    assert!(directory.join("bootstrap.log").exists());
+
+    guard.shutdown().expect("file-only shutdown should succeed");
+    cleanup_temp_log_dir(directory);
+}
+
+#[cfg(feature = "otel-metrics")]
+fn bootstrap_metrics_only() {
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.logging.enabled = false;
+    config.observability.enabled = true;
+    config.observability.metrics.enabled = true;
+    config.observability.metrics.exporter = rocketmq_observability::config::MetricsExporter::Disable;
+
+    let guard = rocketmq_observability::install_global(&config).expect("metrics-only bootstrap should initialize");
+
+    assert!(guard.telemetry_guard().meter_provider().is_some());
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: false,
+            installed: false,
+        }
+    );
+
+    guard.shutdown().expect("metrics-only shutdown should succeed");
+}
+
+#[cfg(feature = "otel-metrics")]
+fn bootstrap_metrics_best_effort_conflict() {
+    install_stderr_blocking_subscriber();
+
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.observability.enabled = true;
+    config.observability.metrics.enabled = true;
+    config.observability.metrics.exporter = rocketmq_observability::config::MetricsExporter::Disable;
+    config.observability.subscriber_install_policy = rocketmq_observability::SubscriberInstallPolicy::BestEffort;
+
+    let guard = rocketmq_observability::install_global(&config)
+        .expect("best-effort conflict should keep initialized providers");
+
+    assert!(guard.telemetry_guard().meter_provider().is_some());
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: false,
+        }
+    );
+
+    guard.shutdown().expect("metrics conflict shutdown should succeed");
+}
+
+#[cfg(feature = "otel-traces")]
+fn bootstrap_traces_enabled() {
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.observability.enabled = true;
+    config.observability.traces.enabled = true;
+    config.observability.traces.exporter = rocketmq_observability::config::TraceExporter::Disable;
+
+    let guard = rocketmq_observability::install_global(&config).expect("trace bootstrap should install");
+
+    assert!(guard.telemetry_guard().tracer_provider().is_some());
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: true,
+        }
+    );
+
+    guard.shutdown().expect("trace bootstrap shutdown should succeed");
+}
+
+#[cfg(feature = "otel-logs")]
+fn bootstrap_logs_enabled() {
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.observability.enabled = true;
+    config.observability.logs.enabled = true;
+    config.observability.logs.exporter = rocketmq_observability::config::LogsExporter::Disable;
+
+    let guard = rocketmq_observability::install_global(&config).expect("logs bootstrap should install");
+
+    assert!(guard.telemetry_guard().logger_provider().is_some());
+    assert_eq!(
+        guard.subscriber_install_status(),
+        rocketmq_observability::SubscriberInstallStatus {
+            attempted: true,
+            installed: true,
+        }
+    );
+
+    guard.shutdown().expect("logs bootstrap shutdown should succeed");
+}
+
+fn bootstrap_required_conflict() {
+    install_stderr_blocking_subscriber();
+
+    let mut config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    config.observability.subscriber_install_policy = rocketmq_observability::SubscriberInstallPolicy::Required;
+
+    let error = match rocketmq_observability::install_global(&config) {
+        Ok(_) => panic!("required mode should fail when the global subscriber already exists"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        rocketmq_observability::ObservabilityError::SubscriberInstallFailed {
+            attempted: true,
+            installed: false
+        }
+    ));
+}
+
+fn install_stderr_blocking_subscriber() {
+    let _ = tracing_subscriber::fmt().with_writer(std::io::stderr).try_init();
+}
+
+fn unique_temp_log_dir(test_name: &str) -> PathBuf {
+    let id = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rocketmq-observability-{test_name}-{}-{id}-{nanos}",
+        std::process::id()
+    ))
+}
+
+fn cleanup_temp_log_dir(directory: PathBuf) {
+    if directory.exists() {
+        std::fs::remove_dir_all(&directory).expect("temporary log directory should be removable");
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8080

### Brief Description

This PR adds the unified observability bootstrap API, `rocketmq_observability::install_global`, so local logging and OpenTelemetry trace/log layers can be assembled into one subscriber path. It splits provider-only telemetry initialization out of `init_observability` and keeps the existing entrypoint as a documented compatibility path.

The new bootstrap installs `LogTracer` compatibly, builds logging layers from `TelemetryBootstrapConfig`, attaches trace and OpenTelemetry logs layers when their providers are enabled, records subscriber install status on `TelemetryRuntimeGuard`, and applies required versus best-effort conflict behavior. The architecture guard now tracks `rocketmq-observability/src/logging.rs` as the explicit owner of the new subscriber installation path.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability --test logging_bootstrap_guards --all-features` passed.
- `cargo test -p rocketmq-observability logging --all-features` passed.
- `cargo test -p rocketmq-observability --test architecture_guards --all-features` passed.
- `cargo fmt --all --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed with `CARGO_TARGET_DIR` set to a temporary target directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified observability startup path for logging and telemetry, with support for console, file, tracing, and metrics combinations.
  * Exposed a new global logging setup entry point for easier application initialization.

* **Bug Fixes**
  * Improved startup handling so observability components now fail fast or continue safely based on configuration.
  * Better cleanup on initialization errors to avoid leaving background workers running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->