### PR TITLE
[ISSUE #8084]♻️Route core service entries through unified telemetry bootstrap

### DIFF
--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -15,11 +15,15 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_controller::parse_command_line;
 use rocketmq_controller::typ::Node;
+use rocketmq_controller::ControllerCli;
+use rocketmq_controller::ControllerConfig;
 use rocketmq_controller::ControllerManager;
 use rocketmq_error::ControllerError;
 use rocketmq_remoting::protocol::remoting_command;
@@ -50,6 +54,14 @@ use tracing::info;
 /// rocketmq-controller-rust --print-config-item
 /// ```
 const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+const LOGO: &str = r#"
+        ______           _        _  ___  ________       ______          _     _____             _             _ _
+        | ___ \         | |      | | |  \/  |  _  |      | ___ \        | |   /  __ \           | |           | | |
+        | |_/ /___   ___| | _____| |_| .  . | | | |______| |_/ /   _ ___| |_  | /  \/ ___  _ __ | |_ _ __ ___ | | | ___ _ __
+        |    // _ \ / __| |/ / _ \ __| |\/| | | | |______|    / | | / __| __| | |    / _ \| '_ \| __| '__/ _ \| | |/ _ \ '__|
+        | |\ \ (_) | (__|   <  __/ |_| |  | \ \/' /      | |\ \ |_| \__ \ |_  | \__/\ (_) | | | | |_| | | (_) | | |  __/ |
+        \_| \_\___/ \___|_|\_\___|\__\_|  |_/\_/\_\      \_| \_\__,_|___/\__|  \____/\___/|_| |_|\__|_|  \___/|_|_|\___|_|
+    "#;
 
 pub fn main() -> Result<()> {
     let owner = RuntimeOwner::new(controller_runtime_config())
@@ -83,20 +95,6 @@ fn controller_runtime_config() -> RuntimeConfig {
 }
 
 async fn run(service_context: ServiceContext) -> Result<()> {
-    // Initialize logger
-    rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
-
-    // Print banner
-    const LOGO: &str = r#"
-        ______           _        _  ___  ________       ______          _     _____             _             _ _
-        | ___ \         | |      | | |  \/  |  _  |      | ___ \        | |   /  __ \           | |           | | |
-        | |_/ /___   ___| | _____| |_| .  . | | | |______| |_/ /   _ ___| |_  | /  \/ ___  _ __ | |_ _ __ ___ | | | ___ _ __
-        |    // _ \ / __| |/ / _ \ __| |\/| | | | |______|    / | | / __| __| | |    / _ \| '_ \| __| '__/ _ \| | |/ _ \ '__|
-        | |\ \ (_) | (__|   <  __/ |_| |  | \ \/' /      | |\ \ |_| \__ \ |_  | \__/\ (_) | | | | |_| | | (_) | | |  __/ |
-        \_| \_\___/ \___|_|\_\___|\__\_|  |_/\_/\_\      \_| \_\__,_|___/\__|  \____/\___/|_| |_|\__|_|  \___/|_|_|\___|_|
-    "#;
-    println!("{}", LOGO);
-
     // Set remoting version
     EnvUtils::put_property(
         remoting_command::REMOTING_VERSION_KEY,
@@ -104,21 +102,42 @@ async fn run(service_context: ServiceContext) -> Result<()> {
     );
 
     // Parse command line and load configuration
-    info!("Parsing command line arguments...");
-    let (_cli, config) = parse_command_line()?;
+    let (cli, config) = parse_command_line()?;
 
-    info!("RocketMQ Controller configuration loaded successfully");
-    info!("Node ID: {}, Listen Address: {}", config.node_id, config.listen_addr);
+    if cli.print_config_item {
+        ControllerCli::print_config(&config);
+        return Ok(());
+    }
 
     let rocketmq_home = &config.rocketmq_home;
     if rocketmq_home.is_empty() {
-        eprintln!("Please set the ROCKETMQ_HOME environment variable!");
-        eprintln!("   Example: export ROCKETMQ_HOME=/opt/rocketmq");
-        std::process::exit(-1);
+        bail!("Please set the ROCKETMQ_HOME environment variable. Example: export ROCKETMQ_HOME=/opt/rocketmq");
     }
 
+    let bootstrap_config = build_controller_telemetry_bootstrap_config(&config);
+    let telemetry_guard = rocketmq_observability::logging::install_global(&bootstrap_config)
+        .context("failed to initialize controller telemetry bootstrap")?;
+    log_telemetry_bootstrap(&bootstrap_config, telemetry_guard.subscriber_install_status());
+
+    println!("{}", LOGO);
+
+    info!("RocketMQ Controller configuration loaded successfully");
+    info!("Node ID: {}, Listen Address: {}", config.node_id, config.listen_addr);
     info!("ROCKETMQ_HOME: {}", rocketmq_home);
 
+    let controller_result = run_controller(config, service_context).await;
+    let shutdown_result = telemetry_guard
+        .shutdown()
+        .context("failed to shutdown controller telemetry bootstrap");
+
+    match (controller_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+async fn run_controller(config: ControllerConfig, service_context: ServiceContext) -> Result<()> {
     // Create controller manager
     info!("Creating Controller Manager...");
     let controller_manager = ControllerManager::new_with_service_context(config, service_context).await?;
@@ -128,9 +147,8 @@ async fn run(service_context: ServiceContext) -> Result<()> {
 
     let init_result = ControllerManager::initialize(ArcMut::clone(&controller_manager)).await?;
     if !init_result {
-        eprintln!("Controller initialization failed!");
         controller_manager.shutdown().await?;
-        std::process::exit(-3);
+        bail!("Controller initialization failed");
     }
 
     ControllerManager::start(ArcMut::clone(&controller_manager)).await?;
@@ -147,18 +165,58 @@ async fn run(service_context: ServiceContext) -> Result<()> {
             info!("Received shutdown signal, shutting down controller...");
         }
         Err(err) => {
-            eprintln!("Failed to listen for shutdown signal: {}", err);
+            tracing::warn!(error = %err, "failed to listen for shutdown signal");
         }
     }
 
     // Graceful shutdown
-    if let Err(e) = controller_manager.shutdown().await {
-        eprintln!("Error during shutdown: {}", e);
-        std::process::exit(1);
-    }
+    controller_manager.shutdown().await?;
 
     info!("Controller shutdown completed.");
     Ok(())
+}
+
+fn build_controller_telemetry_bootstrap_config(
+    controller_config: &ControllerConfig,
+) -> rocketmq_observability::TelemetryBootstrapConfig {
+    let mut observability = rocketmq_observability::ObservabilityConfig {
+        service_name: "rocketmq-controller".to_string(),
+        service_namespace: "rocketmq".to_string(),
+        node_type: "controller".to_string(),
+        node_id: controller_config.node_id.to_string(),
+        ..rocketmq_observability::ObservabilityConfig::default()
+    };
+    observability.subscriber_install_policy = rocketmq_observability::SubscriberInstallPolicy::Required;
+
+    let mut logging = rocketmq_observability::LoggingConfig::default();
+    logging.file.directory = controller_log_directory(controller_config);
+    logging.file.file_name_prefix = "rocketmq-controller".to_string();
+
+    rocketmq_observability::TelemetryBootstrapConfig { observability, logging }
+}
+
+fn controller_log_directory(controller_config: &ControllerConfig) -> String {
+    if controller_config.rocketmq_home.trim().is_empty() {
+        return "logs".to_string();
+    }
+    std::path::PathBuf::from(controller_config.rocketmq_home.as_str())
+        .join("logs")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn log_telemetry_bootstrap(
+    config: &rocketmq_observability::TelemetryBootstrapConfig,
+    subscriber_install_status: rocketmq_observability::SubscriberInstallStatus,
+) {
+    info!(
+        metrics_exporter = ?config.observability.metrics.exporter,
+        trace_exporter = ?config.observability.traces.exporter,
+        log_exporter = ?config.observability.logs.exporter,
+        subscriber_installed = subscriber_install_status.installed,
+        file_log_enabled = config.logging.file.enabled,
+        "controller telemetry bootstrap initialized"
+    );
 }
 
 async fn initialize_single_node_cluster_if_configured(controller_manager: &ArcMut<ControllerManager>) -> Result<()> {
@@ -196,4 +254,36 @@ async fn initialize_single_node_cluster_if_configured(controller_manager: &ArcMu
     }
 
     Err(ControllerError::Internal("single-node controller did not become leader after bootstrap".to_string()).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn controller_telemetry_bootstrap_uses_required_logging_defaults() {
+        let mut controller_config = ControllerConfig::default();
+        controller_config.rocketmq_home = "target/controller-telemetry-bootstrap".to_string();
+        controller_config.node_id = 7;
+
+        let config = build_controller_telemetry_bootstrap_config(&controller_config);
+
+        assert_eq!(config.observability.service_name, "rocketmq-controller");
+        assert_eq!(config.observability.node_id, "7");
+        assert_eq!(
+            config.observability.subscriber_install_policy,
+            rocketmq_observability::SubscriberInstallPolicy::Required
+        );
+        assert!(!config.observability.enabled);
+        assert!(config.logging.enabled);
+        assert!(config.logging.console.enabled);
+        assert!(!config.logging.file.enabled);
+        assert_eq!(config.logging.file.file_name_prefix, "rocketmq-controller");
+
+        let expected_log_dir = std::path::PathBuf::from("target/controller-telemetry-bootstrap").join("logs");
+        assert_eq!(
+            std::path::PathBuf::from(config.logging.file.directory.as_str()),
+            expected_log_dir
+        );
+    }
 }

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -16,7 +16,6 @@
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::process;
 
 use anyhow::bail;
 use anyhow::Context;
@@ -39,7 +38,6 @@ use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_runtime::ServiceContext;
 use serde::Deserialize;
-use tracing::error;
 use tracing::info;
 
 const LOGO: &str = r#"
@@ -87,60 +85,106 @@ async fn run(service_context: ServiceContext) -> Result<()> {
     // Parse command line arguments first
     let args = Args::parse();
 
-    // Initialize the logger
-    rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
-
-    println!("{}", LOGO);
     EnvUtils::put_property(
         remoting_command::REMOTING_VERSION_KEY,
         (CURRENT_VERSION as u32).to_string(),
     );
 
     // Parse and merge configurations
-    match parse_and_merge_config(&args) {
-        Ok((namesrv_config, server_config, controller_config)) => {
-            // Handle print config item mode
-            if args.print_config_item {
-                print_config_and_exit(&namesrv_config, &server_config, controller_config.as_ref());
-            }
+    let (namesrv_config, server_config, controller_config) =
+        parse_and_merge_config(&args).context("failed to parse namesrv configuration")?;
 
-            // Validate ROCKETMQ_HOME is set
-            if namesrv_config.rocketmq_home.is_empty() {
-                error!(
-                    "Please set the ROCKETMQ_HOME variable in your environment to match the location of the RocketMQ \
-                     installation"
-                );
-                process::exit(-2);
-            }
-
-            info!("===== RocketMQ Name Server(Rust) Configuration =====");
-            info!("RocketMQ Home: {}", namesrv_config.rocketmq_home);
-            info!(
-                "Listen Address: {}:{}",
-                server_config.bind_address, server_config.listen_port
-            );
-            info!("KV Config Path: {}", namesrv_config.kv_config_path);
-            info!("Config Store Path: {}", namesrv_config.config_store_path);
-            info!("Use RouteInfoManager V2: {}", namesrv_config.use_route_info_manager_v2);
-            info!("===============================================");
-
-            // Start the name server
-            Builder::new()
-                .set_name_server_config(namesrv_config)
-                .set_server_config(server_config)
-                .set_controller_config_opt(controller_config)
-                .set_service_context(service_context)
-                .build()
-                .boot()
-                .await?;
-
-            Ok(())
-        }
-        Err(e) => {
-            error!("Failed to parse configuration: {}", e);
-            process::exit(-1);
-        }
+    // Handle print config item mode
+    if args.print_config_item {
+        print_config(&namesrv_config, &server_config, controller_config.as_ref());
+        return Ok(());
     }
+
+    // Validate ROCKETMQ_HOME is set
+    if namesrv_config.rocketmq_home.is_empty() {
+        bail!(
+            "Please set the ROCKETMQ_HOME variable in your environment to match the location of the RocketMQ \
+             installation"
+        );
+    }
+
+    let bootstrap_config = build_namesrv_telemetry_bootstrap_config(&namesrv_config);
+    let telemetry_guard = rocketmq_observability::logging::install_global(&bootstrap_config)
+        .context("failed to initialize namesrv telemetry bootstrap")?;
+    log_telemetry_bootstrap(&bootstrap_config, telemetry_guard.subscriber_install_status());
+
+    println!("{}", LOGO);
+
+    info!("===== RocketMQ Name Server(Rust) Configuration =====");
+    info!("RocketMQ Home: {}", namesrv_config.rocketmq_home);
+    info!(
+        "Listen Address: {}:{}",
+        server_config.bind_address, server_config.listen_port
+    );
+    info!("KV Config Path: {}", namesrv_config.kv_config_path);
+    info!("Config Store Path: {}", namesrv_config.config_store_path);
+    info!("Use RouteInfoManager V2: {}", namesrv_config.use_route_info_manager_v2);
+    info!("===============================================");
+
+    // Start the name server
+    let boot_result = Builder::new()
+        .set_name_server_config(namesrv_config)
+        .set_server_config(server_config)
+        .set_controller_config_opt(controller_config)
+        .set_service_context(service_context)
+        .build()
+        .boot()
+        .await
+        .map_err(anyhow::Error::from);
+    let shutdown_result = telemetry_guard
+        .shutdown()
+        .context("failed to shutdown namesrv telemetry bootstrap");
+
+    match (boot_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn build_namesrv_telemetry_bootstrap_config(
+    namesrv_config: &NamesrvConfig,
+) -> rocketmq_observability::TelemetryBootstrapConfig {
+    let mut observability = rocketmq_observability::ObservabilityConfig {
+        service_name: "rocketmq-namesrv".to_string(),
+        service_namespace: "rocketmq".to_string(),
+        node_type: "namesrv".to_string(),
+        node_id: format!("{}:{}", "namesrv", namesrv_config.rocketmq_home),
+        ..rocketmq_observability::ObservabilityConfig::default()
+    };
+    observability.subscriber_install_policy = rocketmq_observability::SubscriberInstallPolicy::Required;
+
+    let mut logging = rocketmq_observability::LoggingConfig::default();
+    logging.file.directory = service_log_directory(namesrv_config.rocketmq_home.as_str());
+    logging.file.file_name_prefix = "rocketmq-namesrv".to_string();
+
+    rocketmq_observability::TelemetryBootstrapConfig { observability, logging }
+}
+
+fn service_log_directory(rocketmq_home: &str) -> String {
+    if rocketmq_home.trim().is_empty() {
+        return "logs".to_string();
+    }
+    PathBuf::from(rocketmq_home).join("logs").to_string_lossy().into_owned()
+}
+
+fn log_telemetry_bootstrap(
+    config: &rocketmq_observability::TelemetryBootstrapConfig,
+    subscriber_install_status: rocketmq_observability::SubscriberInstallStatus,
+) {
+    info!(
+        metrics_exporter = ?config.observability.metrics.exporter,
+        trace_exporter = ?config.observability.traces.exporter,
+        log_exporter = ?config.observability.logs.exporter,
+        subscriber_installed = subscriber_install_status.installed,
+        file_log_enabled = config.logging.file.enabled,
+        "namesrv telemetry bootstrap initialized"
+    );
 }
 
 /// Parse configuration file and merge with command line arguments
@@ -194,8 +238,8 @@ fn apply_tls_properties_from_file(server_config: &mut ServerConfig, config_file:
     Ok(())
 }
 
-/// Print all configuration items and exit
-fn print_config_and_exit(
+/// Print all configuration items
+fn print_config(
     namesrv_config: &NamesrvConfig,
     server_config: &ServerConfig,
     controller_config: Option<&ControllerConfig>,
@@ -260,7 +304,6 @@ fn print_config_and_exit(
     }
 
     println!("\n===========================================\n");
-    process::exit(0);
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -501,4 +544,33 @@ struct Args {
     /// Command line override for kvConfigPath
     #[arg(long = "kvConfigPath", value_name = "PATH", help = "KV config file path")]
     kv_config_path: Option<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namesrv_telemetry_bootstrap_uses_required_logging_defaults() {
+        let namesrv_config = NamesrvConfig {
+            rocketmq_home: "target/namesrv-telemetry-bootstrap".to_string(),
+            ..NamesrvConfig::default()
+        };
+
+        let config = build_namesrv_telemetry_bootstrap_config(&namesrv_config);
+
+        assert_eq!(config.observability.service_name, "rocketmq-namesrv");
+        assert_eq!(
+            config.observability.subscriber_install_policy,
+            rocketmq_observability::SubscriberInstallPolicy::Required
+        );
+        assert!(!config.observability.enabled);
+        assert!(config.logging.enabled);
+        assert!(config.logging.console.enabled);
+        assert!(!config.logging.file.enabled);
+        assert_eq!(config.logging.file.file_name_prefix, "rocketmq-namesrv");
+
+        let expected_log_dir = PathBuf::from("target/namesrv-telemetry-bootstrap").join("logs");
+        assert_eq!(PathBuf::from(config.logging.file.directory.as_str()), expected_log_dir);
+    }
 }

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -67,8 +67,6 @@ fn proxy_runtime_error(action: &'static str) -> impl FnOnce(rocketmq_runtime::Ru
 }
 
 async fn run(service_context: ServiceContext) -> ProxyResult<()> {
-    rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
-
     let args = Args::parse()?;
     let mut config = match args.config_file {
         Some(ref path) => ProxyConfig::load_from_file(path)?,
@@ -81,20 +79,66 @@ async fn run(service_context: ServiceContext) -> ProxyResult<()> {
         return Ok(());
     }
 
+    let bootstrap_config = build_proxy_telemetry_bootstrap_config(&config);
+    let telemetry_guard =
+        rocketmq_observability::logging::install_global(&bootstrap_config).map_err(|error| ProxyError::Transport {
+            message: format!("failed to initialize proxy telemetry bootstrap: {error}"),
+        })?;
+    log_telemetry_bootstrap(&bootstrap_config, telemetry_guard.subscriber_install_status());
+
     info!(
         "Starting RocketMQ proxy: mode={:?}, grpc={}, remotingEnabled={}, remoting={}",
         config.mode, config.grpc.listen_addr, config.remoting.enabled, config.remoting.listen_addr
     );
 
-    ProxyRuntime::builder(config)
+    let serve_result = ProxyRuntime::builder(config)
         .with_service_context(service_context)
         .build()
         .serve_with_shutdown(async {
             if let Err(error) = tokio::signal::ctrl_c().await {
-                eprintln!("failed to listen for ctrl-c: {error}");
+                tracing::warn!(error = %error, "failed to listen for ctrl-c");
             }
         })
-        .await
+        .await;
+    let shutdown_result = telemetry_guard.shutdown().map_err(|error| ProxyError::Transport {
+        message: format!("failed to shutdown proxy telemetry bootstrap: {error}"),
+    });
+
+    match (serve_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn build_proxy_telemetry_bootstrap_config(_config: &ProxyConfig) -> rocketmq_observability::TelemetryBootstrapConfig {
+    let mut observability = rocketmq_observability::ObservabilityConfig {
+        service_name: "rocketmq-proxy".to_string(),
+        service_namespace: "rocketmq".to_string(),
+        node_type: "proxy".to_string(),
+        node_id: "proxy".to_string(),
+        ..rocketmq_observability::ObservabilityConfig::default()
+    };
+    observability.subscriber_install_policy = rocketmq_observability::SubscriberInstallPolicy::Required;
+
+    let mut logging = rocketmq_observability::LoggingConfig::default();
+    logging.file.file_name_prefix = "rocketmq-proxy".to_string();
+
+    rocketmq_observability::TelemetryBootstrapConfig { observability, logging }
+}
+
+fn log_telemetry_bootstrap(
+    config: &rocketmq_observability::TelemetryBootstrapConfig,
+    subscriber_install_status: rocketmq_observability::SubscriberInstallStatus,
+) {
+    info!(
+        metrics_exporter = ?config.observability.metrics.exporter,
+        trace_exporter = ?config.observability.traces.exporter,
+        log_exporter = ?config.observability.logs.exporter,
+        subscriber_installed = subscriber_install_status.installed,
+        file_log_enabled = config.logging.file.enabled,
+        "proxy telemetry bootstrap initialized"
+    );
 }
 
 struct Args {
@@ -198,4 +242,25 @@ fn print_config(config: &ProxyConfig) {
     println!("remoting.enabled = {}", config.remoting.enabled);
     println!("remoting.listenAddr = {}", config.remoting.listen_addr);
     println!("cluster.namesrvAddr = {:?}", config.cluster.namesrv_addr);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_telemetry_bootstrap_uses_required_logging_defaults() {
+        let config = build_proxy_telemetry_bootstrap_config(&ProxyConfig::default());
+
+        assert_eq!(config.observability.service_name, "rocketmq-proxy");
+        assert_eq!(
+            config.observability.subscriber_install_policy,
+            rocketmq_observability::SubscriberInstallPolicy::Required
+        );
+        assert!(!config.observability.enabled);
+        assert!(config.logging.enabled);
+        assert!(config.logging.console.enabled);
+        assert!(!config.logging.file.enabled);
+        assert_eq!(config.logging.file.file_name_prefix, "rocketmq-proxy");
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8084

### Brief Description

This PR routes the NameServer, Proxy, and Controller binary entries through the unified telemetry logging bootstrap.

Changes include:

- Build service-specific `TelemetryBootstrapConfig` values for NameServer, Proxy, and Controller.
- Require global subscriber installation for these core service entries.
- Keep print-config paths free of global telemetry side effects.
- Hold the telemetry guard until service shutdown and propagate bootstrap shutdown errors.
- Replace remaining stderr-only shutdown diagnostics with structured tracing warnings.
- Add focused binary tests for the bootstrap defaults used by each service.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-namesrv --all-features` passed.
- `cargo test -p rocketmq-controller --all-features` passed.
- `cargo test -p rocketmq-proxy --bin rocketmq-proxy-rust --all-features` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed with a clean C-drive temporary target directory.
- `cargo test -p rocketmq-proxy --all-features` was also run, but it fails in existing auth and ACL library tests unrelated to this PR. The failure was reproduced on clean `main` with `cargo test -p rocketmq-proxy auth::tests::map_authorization_error_preserves_proxy_error_category --all-features`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup logging and telemetry across the controller, NameServer, and proxy.
  * Added clearer configuration output during launch for easier troubleshooting.

* **Bug Fixes**
  * Replaced abrupt exit handling with more graceful startup and shutdown behavior.
  * Improved Ctrl-C handling so shutdown warnings are logged consistently.
  * Added better validation for required environment setup before services start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->