### PR TITLE
[ISSUE #8086]♻️Mark common logging helpers as compatibility-only

### DIFF
--- a/rocketmq-client/examples/batch/callback_batch_producer.rs
+++ b/rocketmq-client/examples/batch/callback_batch_producer.rs
@@ -27,6 +27,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/batch/simple_batch_producer.rs
+++ b/rocketmq-client/examples/batch/simple_batch_producer.rs
@@ -22,6 +22,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/broadcast/push_consumer.rs
+++ b/rocketmq-client/examples/broadcast/push_consumer.rs
@@ -33,6 +33,7 @@ pub const TOPIC: &str = "TopicTest";
 //pub const SUB_EXPRESSION: &str = "TagA || TagC || TagD";
 pub const SUB_EXPRESSION: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -30,6 +30,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
@@ -22,6 +22,7 @@ pub const PRODUCER_GROUP: &str = "please_rename_unique_group_name";
 pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/producer/simple_producer.rs
+++ b/rocketmq-client/examples/producer/simple_producer.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -30,6 +30,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/quickstart/producer.rs
+++ b/rocketmq-client/examples/quickstart/producer.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/rpc/request_callback_producer.rs
+++ b/rocketmq-client/examples/rpc/request_callback_producer.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "RequestTopic";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/rpc/request_producer.rs
+++ b/rocketmq-client/examples/rpc/request_producer.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "RequestTopic";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-client/examples/transaction/transaction_producer.rs
+++ b/rocketmq-client/examples/transaction/transaction_producer.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-common/src/log.rs
+++ b/rocketmq-common/src/log.rs
@@ -31,8 +31,11 @@ use chrono_tz::Tz;
 use time::UtcOffset;
 use tracing_subscriber::fmt::time::OffsetTime;
 
-/// Static storage for the worker guard to prevent premature log flushing.
-/// This ensures logs are properly written before the program exits.
+/// Compatibility-only storage for the legacy file logger worker guard.
+///
+/// New process entrypoints should hold the `TelemetryRuntimeGuard` returned by
+/// `rocketmq_observability::logging::install_global` instead of extending this
+/// static guard path.
 static WORKER_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 /// Cached local timezone to avoid repeated system calls
@@ -48,6 +51,10 @@ static LOCAL_TIMEZONE: OnceLock<Tz> = OnceLock::new();
 /// # Returns
 ///
 /// Returns `Ok(())` on success, or a `RocketMQError` if initialization fails.
+#[deprecated(
+    since = "1.0.0",
+    note = "use rocketmq_observability::logging::install_global with TelemetryBootstrapConfig"
+)]
 pub fn init_logger() -> RocketMQResult<()> {
     let info_level = std::env::var("RUST_LOG").unwrap_or_else(|_| String::from("INFO"));
     let level = tracing::Level::from_str(&info_level)
@@ -79,6 +86,10 @@ pub fn init_logger() -> RocketMQResult<()> {
 /// # Returns
 ///
 /// Returns `Ok(())` on success, or a `RocketMQError` if initialization fails.
+#[deprecated(
+    since = "1.0.0",
+    note = "use rocketmq_observability::logging::install_global with TelemetryBootstrapConfig"
+)]
 pub fn init_logger_with_level(level: Level) -> RocketMQResult<()> {
     let tracing_level = level.to_tracing_level()?;
 
@@ -115,6 +126,10 @@ pub fn init_logger_with_level(level: Level) -> RocketMQResult<()> {
 /// This function creates a non-blocking file writer to improve performance.
 /// The worker guard is stored in a static `OnceLock` to prevent premature flushing.
 /// This ensures logs are properly written before the program exits.
+#[deprecated(
+    since = "1.0.0",
+    note = "use rocketmq_observability::logging::install_global with TelemetryBootstrapConfig"
+)]
 pub fn init_logger_with_file(
     level: Level,
     directory: impl AsRef<Path>,

--- a/rocketmq-example/examples/consumer/broadcast_consumer.rs
+++ b/rocketmq-example/examples/consumer/broadcast_consumer.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "BroadcastConsumerTestTopic";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/consumer/consumer_cluster.rs
+++ b/rocketmq-example/examples/consumer/consumer_cluster.rs
@@ -59,6 +59,7 @@ const USE_CLOSURE: bool = false;
 /// 1. Start multiple instances of this consumer (with the same consumer group)
 /// 2. Send messages to the topic using a producer
 /// 3. Observe that messages are distributed among the consumer instances
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     // Initialize logger

--- a/rocketmq-example/examples/consumer/lite_pull_consumer.rs
+++ b/rocketmq-example/examples/consumer/lite_pull_consumer.rs
@@ -31,6 +31,7 @@ pub const TOPIC: &str = "LitePullConsumerTestTopic";
 pub const TAG_EXPRESSION: &str = "LitePullTag";
 pub const POLL_TIMEOUT_MS: u64 = 1000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/consumer/orderly_consumer.rs
+++ b/rocketmq-example/examples/consumer/orderly_consumer.rs
@@ -35,6 +35,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "OrderSendTestTopic";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-example/examples/consumer/request_reply_responder.rs
+++ b/rocketmq-example/examples/consumer/request_reply_responder.rs
@@ -39,6 +39,7 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "*";
 pub const REPLY_TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/consumer/sql_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/sql_filter_consumer.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "SqlFilterConsumerTestTopic";
 pub const SQL_EXPRESSION: &str = "region = 'cn' AND priority >= 3";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/consumer/tag_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/tag_filter_consumer.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TagFilterConsumerTestTopic";
 pub const TAG_EXPRESSION: &str = "TagA || TagB";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/interop/request_code_smoke.rs
+++ b/rocketmq-example/examples/interop/request_code_smoke.rs
@@ -77,6 +77,7 @@ impl SmokeConfig {
     }
 }
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/basic_send.rs
+++ b/rocketmq-example/examples/producer/basic_send.rs
@@ -34,6 +34,7 @@ pub const TOPIC: &str = "BasicSendTestTopic";
 pub const TAG: &str = "BasicTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/batch_send.rs
+++ b/rocketmq-example/examples/producer/batch_send.rs
@@ -39,6 +39,7 @@ pub const TOPIC: &str = "BatchSendTestTopic";
 pub const TAG: &str = "BatchTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/delay_send.rs
+++ b/rocketmq-example/examples/producer/delay_send.rs
@@ -28,6 +28,7 @@ pub const TOPIC: &str = "DelaySendTestTopic";
 pub const TAG: &str = "DelayTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/order_send.rs
+++ b/rocketmq-example/examples/producer/order_send.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "OrderSendTestTopic";
 pub const TAG: &str = "OrderTag";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/producer_simple.rs
+++ b/rocketmq-example/examples/producer/producer_simple.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "ProducerSimpleTest";
 pub const TAG: &str = "TagA";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     //init logger

--- a/rocketmq-example/examples/producer/producer_with_timeout.rs
+++ b/rocketmq-example/examples/producer/producer_with_timeout.rs
@@ -26,6 +26,7 @@ pub const TAG: &str = "TagA";
 // Send timeout in milliseconds
 pub const SEND_TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     // init logger

--- a/rocketmq-example/examples/producer/request_callback_send.rs
+++ b/rocketmq-example/examples/producer/request_callback_send.rs
@@ -29,6 +29,7 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "RequestTag";
 pub const REQUEST_TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/request_send.rs
+++ b/rocketmq-example/examples/producer/request_send.rs
@@ -25,6 +25,7 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "RequestTag";
 pub const REQUEST_TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/send_to_queue.rs
+++ b/rocketmq-example/examples/producer/send_to_queue.rs
@@ -35,6 +35,7 @@ pub const TOPIC: &str = "SendToQueueTestTopic";
 pub const TAG: &str = "QueueTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/send_with_selector.rs
+++ b/rocketmq-example/examples/producer/send_with_selector.rs
@@ -38,6 +38,7 @@ pub const TOPIC: &str = "SendWithSelectorTestTopic";
 pub const TAG: &str = "SelectorTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/send_with_selector_advanced.rs
+++ b/rocketmq-example/examples/producer/send_with_selector_advanced.rs
@@ -46,6 +46,7 @@ pub const PRODUCER_GROUP: &str = "producer_advanced_selector";
 pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "AdvancedSelectorTestTopic";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;

--- a/rocketmq-example/examples/producer/transaction_send.rs
+++ b/rocketmq-example/examples/producer/transaction_send.rs
@@ -36,6 +36,7 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TransactionSendTestTopic";
 pub const TAG: &str = "TransactionTag";
 
+#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     rocketmq_common::log::init_logger()?;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8086

### Brief Description

This PR marks the legacy `rocketmq-common::log` initialization helpers as compatibility-only APIs.

Changes include:

- Deprecate `init_logger`, `init_logger_with_level`, and `init_logger_with_file` with guidance to use `rocketmq_observability::logging::install_global` and `TelemetryBootstrapConfig`.
- Document the legacy static file logger guard as compatibility-only so new runtime lifecycle work remains in `rocketmq-observability`.
- Keep root workspace and standalone examples clippy-clean by explicitly allowing deprecated use where they still call the legacy helper.
- Avoid adding a `rocketmq-common -> rocketmq-observability` dependency or new OpenTelemetry runtime behavior to `rocketmq-common`.

### How Did You Test This Change?

- From the repository root, `cargo fmt --all` passed.
- From the repository root, `cargo test -p rocketmq-common log` passed.
- From the repository root, `cargo clippy -p rocketmq-client-rust --examples --all-features -- -D warnings` passed.
- From the repository root, `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- From `rocketmq-example/`, `cargo fmt --all` passed.
- From `rocketmq-example/`, `cargo clippy --all-targets -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed deprecation warnings across many example entry points, resulting in cleaner builds and less console noise.
  * Updated logging guidance to steer users toward the newer global logging setup, with legacy logger helpers now clearly marked as deprecated.

* **Documentation**
  * Clarified that the older log guard is kept for compatibility only and that new applications should use the recommended logging initialization path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->