### PR TITLE
[ISSUE #8090]♻️Report telemetry shutdown health and dropped log lines

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -111,6 +111,7 @@ async fn run(service_context: ServiceContext) -> Result<()> {
     if let Err(error) = verify_rocketmq_home() {
         telemetry_guard
             .shutdown()
+            .into_result()
             .context("failed to shutdown broker telemetry bootstrap after ROCKETMQ_HOME validation failed")?;
         return Err(error);
     }
@@ -120,6 +121,7 @@ async fn run(service_context: ServiceContext) -> Result<()> {
         print_config(&broker_config, &message_store_config, args.print_important_config);
         telemetry_guard
             .shutdown()
+            .into_result()
             .context("failed to shutdown broker telemetry bootstrap after printing broker configuration")?;
         return Ok(());
     }

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -520,6 +520,17 @@ impl BrokerShutdownComponentReport {
         }
     }
 
+    pub(crate) fn completed_with_detail(name: &'static str, elapsed: Duration, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            present: true,
+            healthy: true,
+            timed_out: false,
+            elapsed,
+            detail: Some(detail.into()),
+        }
+    }
+
     pub(crate) fn unhealthy(name: &'static str, elapsed: Duration, detail: impl Into<String>) -> Self {
         Self {
             name,
@@ -553,6 +564,18 @@ impl BrokerShutdownComponentReport {
             Self::completed(name, elapsed)
         } else {
             Self::unhealthy(name, elapsed, report.to_json())
+        }
+    }
+
+    pub(crate) fn from_telemetry_shutdown_report(
+        report: &rocketmq_observability::TelemetryShutdownReport,
+        elapsed: Duration,
+    ) -> Self {
+        let detail = report.to_json();
+        if report.is_healthy() {
+            Self::completed_with_detail("observability", elapsed, detail)
+        } else {
+            Self::unhealthy("observability", elapsed, detail)
         }
     }
 }
@@ -971,14 +994,15 @@ impl BrokerRuntime {
         {
             let started = Instant::now();
             if let Some(guard) = self.inner.observability_guard.take() {
-                if let Err(error) = guard.shutdown() {
-                    warn!("Failed to shutdown observability runtime: {error}");
-                    shutdown_report.observability =
-                        BrokerShutdownComponentReport::unhealthy("observability", started.elapsed(), error.to_string());
-                } else {
-                    shutdown_report.observability =
-                        BrokerShutdownComponentReport::completed("observability", started.elapsed());
+                let telemetry_report = guard.shutdown();
+                if !telemetry_report.is_healthy() {
+                    warn!(
+                        report = %telemetry_report.to_json(),
+                        "Failed to shutdown observability runtime cleanly"
+                    );
                 }
+                shutdown_report.observability =
+                    BrokerShutdownComponentReport::from_telemetry_shutdown_report(&telemetry_report, started.elapsed());
             } else {
                 shutdown_report.observability = BrokerShutdownComponentReport::skipped("observability");
             }
@@ -5146,6 +5170,57 @@ mod tests {
             vec!["message_store", "fast_failure"]
         );
         assert_eq!(report.timed_out_component_names(), vec!["message_store"]);
+    }
+
+    #[test]
+    fn broker_shutdown_report_records_healthy_telemetry_detail() {
+        let telemetry_report = rocketmq_observability::TelemetryShutdownReport {
+            subscriber_installed: true,
+            file_log_enabled: true,
+            dropped_log_lines: 0,
+            logs_shutdown_ok: true,
+            traces_shutdown_ok: true,
+            metrics_shutdown_ok: true,
+            logs_shutdown_error: None,
+            traces_shutdown_error: None,
+            metrics_shutdown_error: None,
+        };
+
+        let component =
+            BrokerShutdownComponentReport::from_telemetry_shutdown_report(&telemetry_report, Duration::from_millis(4));
+
+        assert!(component.present);
+        assert!(component.healthy);
+        assert_eq!(component.name, "observability");
+        let detail = component.detail.expect("telemetry detail should be recorded");
+        assert!(detail.contains("\"subscriber_installed\": true"));
+        assert!(detail.contains("\"file_log_enabled\": true"));
+    }
+
+    #[test]
+    fn broker_shutdown_report_marks_telemetry_provider_failure_unhealthy() {
+        let telemetry_report = rocketmq_observability::TelemetryShutdownReport {
+            subscriber_installed: true,
+            file_log_enabled: false,
+            dropped_log_lines: 0,
+            logs_shutdown_ok: false,
+            traces_shutdown_ok: true,
+            metrics_shutdown_ok: true,
+            logs_shutdown_error: Some("logger provider failed".to_string()),
+            traces_shutdown_error: None,
+            metrics_shutdown_error: None,
+        };
+
+        let component =
+            BrokerShutdownComponentReport::from_telemetry_shutdown_report(&telemetry_report, Duration::from_millis(5));
+
+        assert!(component.present);
+        assert!(!component.healthy);
+        assert_eq!(component.name, "observability");
+        assert!(component
+            .detail
+            .expect("telemetry failure detail should be recorded")
+            .contains("logger provider failed"));
     }
 
     #[tokio::test]

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -128,12 +128,13 @@ async fn run(service_context: ServiceContext) -> Result<()> {
     let controller_result = run_controller(config, service_context).await;
     let shutdown_result = telemetry_guard
         .shutdown()
+        .into_result()
         .context("failed to shutdown controller telemetry bootstrap");
 
     match (controller_result, shutdown_result) {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Ok(_report)) => Ok(()),
     }
 }
 

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -138,12 +138,13 @@ async fn run(service_context: ServiceContext) -> Result<()> {
         .map_err(anyhow::Error::from);
     let shutdown_result = telemetry_guard
         .shutdown()
+        .into_result()
         .context("failed to shutdown namesrv telemetry bootstrap");
 
     match (boot_result, shutdown_result) {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Ok(_report)) => Ok(()),
     }
 }
 

--- a/rocketmq-observability/src/init.rs
+++ b/rocketmq-observability/src/init.rs
@@ -20,6 +20,48 @@ use crate::config::SubscriberInstallPolicy;
 use crate::config::SubscriberInstallStatus;
 use crate::error::ObservabilityError;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TelemetryProviderShutdownReport {
+    pub(crate) logs_shutdown_ok: bool,
+    pub(crate) traces_shutdown_ok: bool,
+    pub(crate) metrics_shutdown_ok: bool,
+    pub(crate) logs_shutdown_error: Option<String>,
+    pub(crate) traces_shutdown_error: Option<String>,
+    pub(crate) metrics_shutdown_error: Option<String>,
+}
+
+impl Default for TelemetryProviderShutdownReport {
+    fn default() -> Self {
+        Self {
+            logs_shutdown_ok: true,
+            traces_shutdown_ok: true,
+            metrics_shutdown_ok: true,
+            logs_shutdown_error: None,
+            traces_shutdown_error: None,
+            metrics_shutdown_error: None,
+        }
+    }
+}
+
+impl TelemetryProviderShutdownReport {
+    pub(crate) fn is_healthy(&self) -> bool {
+        self.logs_shutdown_ok && self.traces_shutdown_ok && self.metrics_shutdown_ok
+    }
+
+    pub(crate) fn into_result(self) -> Result<(), ObservabilityError> {
+        if let Some(error) = self.logs_shutdown_error {
+            return Err(ObservabilityError::logs_shutdown(error));
+        }
+        if let Some(error) = self.traces_shutdown_error {
+            return Err(ObservabilityError::traces_shutdown(error));
+        }
+        if let Some(error) = self.metrics_shutdown_error {
+            return Err(ObservabilityError::metrics_shutdown(error));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct TelemetryGuard {
     subscriber_install_status: SubscriberInstallStatus,
@@ -39,6 +81,10 @@ impl TelemetryGuard {
     }
 
     pub fn shutdown(self) -> Result<(), ObservabilityError> {
+        self.shutdown_with_report().into_result()
+    }
+
+    pub(crate) fn shutdown_with_report(self) -> TelemetryProviderShutdownReport {
         self.shutdown_inner()
     }
 
@@ -51,33 +97,44 @@ impl TelemetryGuard {
     }
 
     #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
-    fn shutdown_inner(mut self) -> Result<(), ObservabilityError> {
+    fn shutdown_inner(mut self) -> TelemetryProviderShutdownReport {
+        let mut report = TelemetryProviderShutdownReport::default();
+
+        #[cfg(feature = "otel-logs")]
+        if let Some(provider) = self.logger_provider.take() {
+            if let Err(error) = provider.shutdown() {
+                report.logs_shutdown_ok = false;
+                report.logs_shutdown_error = Some(error.to_string());
+            }
+        }
+
+        #[cfg(feature = "otel-traces")]
+        if let Some(provider) = self.tracer_provider.take() {
+            if let Err(error) = provider.shutdown() {
+                report.traces_shutdown_ok = false;
+                report.traces_shutdown_error = Some(error.to_string());
+            }
+        }
+
+        #[cfg(feature = "otel-metrics")]
+        if let Some(provider) = self.meter_provider.take() {
+            if let Err(error) = provider.shutdown() {
+                report.metrics_shutdown_ok = false;
+                report.metrics_shutdown_error = Some(error.to_string());
+            }
+        }
+
         #[cfg(feature = "prometheus")]
         if let Some(prometheus_http) = self.prometheus_http.take() {
             prometheus_http.shutdown();
         }
 
-        #[cfg(feature = "otel-metrics")]
-        if let Some(provider) = self.meter_provider.take() {
-            provider.shutdown().map_err(ObservabilityError::metrics_shutdown)?;
-        }
-
-        #[cfg(feature = "otel-traces")]
-        if let Some(provider) = self.tracer_provider.take() {
-            provider.shutdown().map_err(ObservabilityError::traces_shutdown)?;
-        }
-
-        #[cfg(feature = "otel-logs")]
-        if let Some(provider) = self.logger_provider.take() {
-            provider.shutdown().map_err(ObservabilityError::logs_shutdown)?;
-        }
-
-        Ok(())
+        report
     }
 
     #[cfg(not(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs")))]
-    fn shutdown_inner(self) -> Result<(), ObservabilityError> {
-        Ok(())
+    fn shutdown_inner(self) -> TelemetryProviderShutdownReport {
+        TelemetryProviderShutdownReport::default()
     }
 
     #[cfg(feature = "otel-metrics")]

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -47,6 +47,7 @@ pub use logging::install_global;
 pub use logging::FileLogLayer;
 pub use logging::LoggingGuard;
 pub use logging::TelemetryRuntimeGuard;
+pub use logging::TelemetryShutdownReport;
 
 #[cfg(feature = "prometheus")]
 #[doc(hidden)]

--- a/rocketmq-observability/src/logging.rs
+++ b/rocketmq-observability/src/logging.rs
@@ -22,6 +22,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 
+use serde::Serialize;
+
 use crate::config::ConsoleLogConfig;
 use crate::config::FileLogConfig;
 use crate::config::LogFormat;
@@ -31,6 +33,7 @@ use crate::config::SubscriberInstallStatus;
 use crate::config::TelemetryBootstrapConfig;
 use crate::error::ObservabilityError;
 use crate::init::TelemetryGuard;
+use crate::init::TelemetryProviderShutdownReport;
 
 pub type BoxedRegistryLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
@@ -274,6 +277,61 @@ pub struct TelemetryRuntimeGuard {
     logging_guard: LoggingGuard,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TelemetryShutdownReport {
+    pub subscriber_installed: bool,
+    pub file_log_enabled: bool,
+    pub dropped_log_lines: usize,
+    pub logs_shutdown_ok: bool,
+    pub traces_shutdown_ok: bool,
+    pub metrics_shutdown_ok: bool,
+    pub logs_shutdown_error: Option<String>,
+    pub traces_shutdown_error: Option<String>,
+    pub metrics_shutdown_error: Option<String>,
+}
+
+impl TelemetryShutdownReport {
+    fn new(
+        subscriber_install_status: SubscriberInstallStatus,
+        file_log_enabled: bool,
+        dropped_log_lines: usize,
+        provider_report: TelemetryProviderShutdownReport,
+    ) -> Self {
+        Self {
+            subscriber_installed: subscriber_install_status.installed,
+            file_log_enabled,
+            dropped_log_lines,
+            logs_shutdown_ok: provider_report.logs_shutdown_ok,
+            traces_shutdown_ok: provider_report.traces_shutdown_ok,
+            metrics_shutdown_ok: provider_report.metrics_shutdown_ok,
+            logs_shutdown_error: provider_report.logs_shutdown_error,
+            traces_shutdown_error: provider_report.traces_shutdown_error,
+            metrics_shutdown_error: provider_report.metrics_shutdown_error,
+        }
+    }
+
+    pub fn is_healthy(&self) -> bool {
+        self.logs_shutdown_ok && self.traces_shutdown_ok && self.metrics_shutdown_ok
+    }
+
+    pub fn into_result(self) -> Result<Self, ObservabilityError> {
+        if let Some(error) = self.logs_shutdown_error.as_ref() {
+            return Err(ObservabilityError::logs_shutdown(error));
+        }
+        if let Some(error) = self.traces_shutdown_error.as_ref() {
+            return Err(ObservabilityError::traces_shutdown(error));
+        }
+        if let Some(error) = self.metrics_shutdown_error.as_ref() {
+            return Err(ObservabilityError::metrics_shutdown(error));
+        }
+        Ok(self)
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|error| format!("{{\"serialization_error\":\"{error}\"}}"))
+    }
+}
+
 impl TelemetryRuntimeGuard {
     pub fn new(telemetry_guard: TelemetryGuard, logging_guard: LoggingGuard) -> Self {
         Self {
@@ -302,15 +360,40 @@ impl TelemetryRuntimeGuard {
         self.logging_guard.dropped_log_lines()
     }
 
-    pub fn shutdown(self) -> Result<(), ObservabilityError> {
+    pub fn shutdown(self) -> TelemetryShutdownReport {
         let Self {
             telemetry_guard,
             logging_guard,
         } = self;
 
-        let shutdown_result = telemetry_guard.shutdown();
+        let subscriber_install_status = telemetry_guard.subscriber_install_status();
+        let file_log_enabled = logging_guard.file_sink_count() > 0;
+        let dropped_log_lines = logging_guard.dropped_log_lines();
+        if dropped_log_lines > 0 {
+            tracing::warn!(
+                dropped_log_lines,
+                "telemetry logging guard reported dropped log lines before shutdown"
+            );
+        }
+
+        // Drop local file logging guards before shutting down OpenTelemetry providers so
+        // non-blocking file writers are flushed and joined under explicit runtime ownership.
         drop(logging_guard);
-        shutdown_result
+        let provider_report = telemetry_guard.shutdown_with_report();
+        let provider_shutdown_healthy = provider_report.is_healthy();
+        let report = TelemetryShutdownReport::new(
+            subscriber_install_status,
+            file_log_enabled,
+            dropped_log_lines,
+            provider_report,
+        );
+        if !provider_shutdown_healthy {
+            tracing::warn!(
+                report = %report.to_json(),
+                "telemetry provider shutdown report is unhealthy"
+            );
+        }
+        report
     }
 }
 
@@ -516,9 +599,36 @@ mod tests {
 
     #[test]
     fn noop_runtime_guard_shutdown_succeeds() {
-        TelemetryRuntimeGuard::noop()
-            .shutdown()
+        let report = TelemetryRuntimeGuard::noop().shutdown();
+
+        assert!(report.is_healthy());
+        assert_eq!(report.dropped_log_lines, 0);
+        assert!(!report.file_log_enabled);
+        assert!(!report.subscriber_installed);
+        report
+            .into_result()
             .expect("noop runtime guard shutdown should succeed");
+    }
+
+    #[test]
+    fn runtime_shutdown_report_preserves_provider_failure() {
+        let report = TelemetryShutdownReport {
+            subscriber_installed: true,
+            file_log_enabled: true,
+            dropped_log_lines: 3,
+            logs_shutdown_ok: false,
+            traces_shutdown_ok: true,
+            metrics_shutdown_ok: true,
+            logs_shutdown_error: Some("logger provider failed".to_string()),
+            traces_shutdown_error: None,
+            metrics_shutdown_error: None,
+        };
+
+        assert!(!report.is_healthy());
+        assert!(matches!(
+            report.into_result(),
+            Err(ObservabilityError::LogsShutdown(message)) if message == "logger provider failed"
+        ));
     }
 
     fn unique_temp_log_dir(test_name: &str) -> PathBuf {

--- a/rocketmq-observability/tests/logging_bootstrap_guards.rs
+++ b/rocketmq-observability/tests/logging_bootstrap_guards.rs
@@ -185,7 +185,10 @@ fn bootstrap_console_only() {
     );
     assert_eq!(guard.logging_guard().file_sink_count(), 0);
 
-    guard.shutdown().expect("console-only shutdown should succeed");
+    let report = guard.shutdown();
+    assert!(report.is_healthy());
+    assert!(!report.file_log_enabled);
+    report.into_result().expect("console-only shutdown should succeed");
 }
 
 fn bootstrap_file_only() {
@@ -209,7 +212,10 @@ fn bootstrap_file_only() {
     assert_eq!(guard.logging_guard().file_sink_count(), 1);
     assert!(directory.join("bootstrap.log").exists());
 
-    guard.shutdown().expect("file-only shutdown should succeed");
+    let report = guard.shutdown();
+    assert!(report.is_healthy());
+    assert!(report.file_log_enabled);
+    report.into_result().expect("file-only shutdown should succeed");
     cleanup_temp_log_dir(directory);
 }
 
@@ -232,7 +238,10 @@ fn bootstrap_metrics_only() {
         }
     );
 
-    guard.shutdown().expect("metrics-only shutdown should succeed");
+    guard
+        .shutdown()
+        .into_result()
+        .expect("metrics-only shutdown should succeed");
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -257,7 +266,10 @@ fn bootstrap_metrics_best_effort_conflict() {
         }
     );
 
-    guard.shutdown().expect("metrics conflict shutdown should succeed");
+    guard
+        .shutdown()
+        .into_result()
+        .expect("metrics conflict shutdown should succeed");
 }
 
 #[cfg(feature = "otel-traces")]
@@ -278,7 +290,10 @@ fn bootstrap_traces_enabled() {
         }
     );
 
-    guard.shutdown().expect("trace bootstrap shutdown should succeed");
+    guard
+        .shutdown()
+        .into_result()
+        .expect("trace bootstrap shutdown should succeed");
 }
 
 #[cfg(feature = "otel-logs")]
@@ -299,7 +314,10 @@ fn bootstrap_logs_enabled() {
         }
     );
 
-    guard.shutdown().expect("logs bootstrap shutdown should succeed");
+    guard
+        .shutdown()
+        .into_result()
+        .expect("logs bootstrap shutdown should succeed");
 }
 
 fn bootstrap_required_conflict() {

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -100,14 +100,17 @@ async fn run(service_context: ServiceContext) -> ProxyResult<()> {
             }
         })
         .await;
-    let shutdown_result = telemetry_guard.shutdown().map_err(|error| ProxyError::Transport {
-        message: format!("failed to shutdown proxy telemetry bootstrap: {error}"),
-    });
+    let shutdown_result = telemetry_guard
+        .shutdown()
+        .into_result()
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to shutdown proxy telemetry bootstrap: {error}"),
+        });
 
     match (serve_result, shutdown_result) {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Ok(_report)) => Ok(()),
     }
 }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8090

### Brief Description

This PR makes telemetry shutdown produce structured evidence instead of only returning success or failure.

Changes include:

- Add `TelemetryShutdownReport` with subscriber, file sink, dropped log line, and provider shutdown fields.
- Drop local file logging guards before shutting down OpenTelemetry logs, traces, metrics, and Prometheus handles.
- Preserve logs, traces, and metrics shutdown errors in the report while still exposing `into_result` for fail-fast callers.
- Record telemetry shutdown detail inside the broker shutdown report and mark the observability component unhealthy when provider shutdown fails.
- Update Broker, NameServer, Proxy, and Controller entrypoints to consume the structured shutdown report.
- Extend observability and broker tests for file sink reporting, no-op shutdown, and telemetry provider failure reporting.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-observability logging --all-features` passed.
- `cargo test -p rocketmq-broker shutdown --all-features` passed.
- `cargo test -p rocketmq-observability --test logging_bootstrap_guards --all-features` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed with `CARGO_TARGET_DIR` set to a fresh C drive temporary target directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry shutdown now produces richer health reports, including per-provider status and detailed error information.
  * Broker shutdown summaries now include observability details for easier troubleshooting.

* **Bug Fixes**
  * Improved shutdown handling so telemetry cleanup continues across components even if one part fails.
  * Added clearer warnings when dropped log lines or unhealthy telemetry shutdowns are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->