### PR TITLE
[ISSUE #8094]♻️Show unified telemetry bootstrap in examples

### DIFF
--- a/rocketmq-client/examples/producer/send_callback_examples.rs
+++ b/rocketmq-client/examples/producer/send_callback_examples.rs
@@ -37,11 +37,19 @@ const TAG: &str = "TagA";
 const NAME_SERVER: &str = "127.0.0.1:9876";
 
 #[rocketmq::main]
-async fn main() -> RocketMQResult<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .init();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    let telemetry_guard = rocketmq_observability::install_global(&config)?;
 
+    let run_result = run().await;
+    let shutdown_result = telemetry_guard.shutdown().into_result();
+
+    run_result?;
+    shutdown_result?;
+    Ok(())
+}
+
+async fn run() -> RocketMQResult<()> {
     info!("=== SendCallback Examples ===\n");
 
     let mut producer = setup_producer().await?;

--- a/rocketmq-client/examples/producer/simple_producer.rs
+++ b/rocketmq-client/examples/producer/simple_producer.rs
@@ -23,12 +23,20 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
-pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    let telemetry_guard = rocketmq_observability::install_global(&config)?;
 
+    let run_result = run().await;
+    let shutdown_result = telemetry_guard.shutdown().into_result();
+
+    run_result?;
+    shutdown_result?;
+    Ok(())
+}
+
+async fn run() -> RocketMQResult<()> {
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 

--- a/rocketmq-controller/examples/single_node.rs
+++ b/rocketmq-controller/examples/single_node.rs
@@ -25,8 +25,18 @@ use rocketmq_rust::ArcMut;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
+    let config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    let telemetry_guard = rocketmq_observability::install_global(&config)?;
 
+    let run_result = run().await;
+    let shutdown_result = telemetry_guard.shutdown().into_result();
+
+    run_result?;
+    shutdown_result?;
+    Ok(())
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== OpenRaft Single Node Example ===\n");
 
     let node_id = 1;

--- a/rocketmq-observability/examples/logging_bootstrap.rs
+++ b/rocketmq-observability/examples/logging_bootstrap.rs
@@ -1,0 +1,27 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() -> Result<(), rocketmq_observability::ObservabilityError> {
+    let config = rocketmq_observability::TelemetryBootstrapConfig::default();
+    let guard = rocketmq_observability::install_global(&config)?;
+
+    tracing::info!(
+        service = "logging-bootstrap-example",
+        subscriber_installed = guard.subscriber_install_status().installed,
+        file_log_enabled = guard.logging_guard().file_sink_count() > 0,
+        "logging bootstrap initialized"
+    );
+
+    guard.shutdown().into_result().map(|_| ())
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8094

### Brief Description

This PR updates selected examples to demonstrate the unified telemetry logging bootstrap instead of direct subscriber setup or compatibility logger helpers.

Changes include:

- Add `rocketmq-observability/examples/logging_bootstrap.rs` as a minimal `TelemetryBootstrapConfig` and `install_global` example.
- Update the simple producer example to hold `TelemetryRuntimeGuard` until completion and shut it down explicitly.
- Update the send callback producer example to use the unified bootstrap before emitting tracing events.
- Update the controller single-node example to use the unified bootstrap while preserving stdout example output.
- Keep documentation files untouched per repository workflow for this refactor slice.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-observability --examples --all-features` passed.
- `cargo test -p rocketmq-client-rust --examples --all-features` passed.
- `cargo test -p rocketmq-controller --examples --all-features` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
