### PR TITLE
[ISSUE #8096]♻️Replace legacy logger setup in root examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,13 +4483,13 @@ dependencies = [
  "cron",
  "parking_lot",
  "rocketmq-error",
+ "rocketmq-observability",
  "rocketmq-runtime",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 

--- a/rocketmq-client/examples/batch/callback_batch_producer.rs
+++ b/rocketmq-client/examples/batch/callback_batch_producer.rs
@@ -27,12 +27,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -120,5 +119,10 @@ pub async fn main() -> RocketMQResult<()> {
     sleep(std::time::Duration::from_secs(6));
     let i = counter.load(std::sync::atomic::Ordering::SeqCst);
     println!("send message count: {}", i);
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-client/examples/batch/simple_batch_producer.rs
+++ b/rocketmq-client/examples/batch/simple_batch_producer.rs
@@ -22,12 +22,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -59,5 +58,10 @@ pub async fn main() -> RocketMQResult<()> {
     ];
     let send_result = producer.send_batch(messages).await?;
     println!("send result: {}", send_result);
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-client/examples/broadcast/push_consumer.rs
+++ b/rocketmq-client/examples/broadcast/push_consumer.rs
@@ -33,12 +33,11 @@ pub const TOPIC: &str = "TopicTest";
 //pub const SUB_EXPRESSION: &str = "TagA || TagC || TagD";
 pub const SUB_EXPRESSION: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
 
@@ -52,6 +51,11 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -30,12 +30,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
 
@@ -49,6 +48,11 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -37,12 +37,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
 
@@ -56,6 +55,11 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.register_message_listener_orderly(MyMessageListener::new());
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
@@ -22,12 +22,11 @@ pub const PRODUCER_GROUP: &str = "please_rename_unique_group_name";
 pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -64,6 +63,11 @@ pub async fn main() -> RocketMQResult<()> {
         );
     }
     producer.shutdown().await;
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -30,12 +30,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
 
@@ -47,6 +46,11 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-client/examples/quickstart/producer.rs
+++ b/rocketmq-client/examples/quickstart/producer.rs
@@ -23,12 +23,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -50,6 +49,11 @@ pub async fn main() -> RocketMQResult<()> {
         println!("send result: {:?}", send_result);
     }
     producer.shutdown().await;
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-client/examples/rpc/request_callback_producer.rs
+++ b/rocketmq-client/examples/rpc/request_callback_producer.rs
@@ -23,12 +23,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "RequestTopic";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -57,6 +56,11 @@ pub async fn main() -> RocketMQResult<()> {
     println!("===============waiting================");
     let _ = rx.recv().await;
     producer.shutdown().await;
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-client/examples/rpc/request_producer.rs
+++ b/rocketmq-client/examples/rpc/request_producer.rs
@@ -23,12 +23,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "RequestTopic";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = DefaultMQProducer::builder();
 
@@ -51,6 +50,11 @@ pub async fn main() -> RocketMQResult<()> {
         .await?;
     println!("send result: {:?}", message);
     producer.shutdown().await;
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-client/examples/transaction/transaction_producer.rs
+++ b/rocketmq-client/examples/transaction/transaction_producer.rs
@@ -34,12 +34,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let builder = TransactionMQProducer::builder();
 
@@ -63,6 +62,11 @@ pub async fn main() -> RocketMQResult<()> {
     }
     let _ = tokio::signal::ctrl_c().await;
     producer.shutdown().await;
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-controller/examples/controller_manager_basic.rs
+++ b/rocketmq-controller/examples/controller_manager_basic.rs
@@ -34,13 +34,12 @@ use rocketmq_controller::manager::ControllerManager;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
-use tracing_subscriber::fmt;
-use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize logging
-    tracing_subscriber::registry().with(fmt::layer()).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
 
     info!("Starting ControllerManager example");
 
@@ -86,6 +85,11 @@ async fn main() -> Result<()> {
     info!("Shutting down ControllerManager...");
     manager.shutdown().await?;
     info!(" Controller shut down successfully");
+
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-controller/examples/controller_manager_cluster.rs
+++ b/rocketmq-controller/examples/controller_manager_cluster.rs
@@ -36,13 +36,12 @@ use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
-use tracing_subscriber::fmt;
-use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize logging
-    tracing_subscriber::registry().with(fmt::layer()).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
 
     info!("Starting 3-node ControllerManager cluster example");
 
@@ -65,6 +64,11 @@ async fn main() -> Result<()> {
     shutdown_cluster(managers).await?;
 
     info!("Cluster shutdown complete");
+    telemetry_guard
+        .shutdown()
+        .into_result()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-controller/examples/three_node_cluster.rs
+++ b/rocketmq-controller/examples/three_node_cluster.rs
@@ -38,7 +38,8 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())?;
 
     let peers = vec![
         RaftPeer {
@@ -129,5 +130,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::signal::ctrl_c().await?;
 
     node.shutdown().await?;
+    telemetry_guard.shutdown().into_result()?;
     Ok(())
 }

--- a/rocketmq/Cargo.toml
+++ b/rocketmq/Cargo.toml
@@ -44,9 +44,9 @@ cron   = "0.17"
 
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
-criterion          = { version = "0.8.2", features = ["async_tokio"] }
-serde_json         = { workspace = true }
+rocketmq-observability = { workspace = true }
+criterion              = { version = "0.8.2", features = ["async_tokio"] }
+serde_json             = { workspace = true }
 
 [[bench]]
 name    = "service_manager_lifecycle_bench"

--- a/rocketmq/examples/advanced_usage.rs
+++ b/rocketmq/examples/advanced_usage.rs
@@ -27,12 +27,11 @@ use rocketmq_rust::TaskScheduler;
 use tokio::time::sleep;
 use tracing::error;
 use tracing::info;
-use tracing::Level;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
-    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())?;
 
     // Create custom scheduler configuration
     let config = SchedulerConfig {
@@ -222,5 +221,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Final counter value: {}", counter.load(Ordering::Relaxed));
 
+    telemetry_guard.shutdown().into_result()?;
     Ok(())
 }

--- a/rocketmq/examples/basic_usage.rs
+++ b/rocketmq/examples/basic_usage.rs
@@ -23,12 +23,11 @@ use rocketmq_rust::TaskResult;
 use rocketmq_rust::TaskScheduler;
 use tokio::time::sleep;
 use tracing::info;
-use tracing::Level;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
-    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())?;
 
     // Create scheduler
     let scheduler = TaskScheduler::default();
@@ -73,5 +72,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Stop the scheduler
     scheduler.stop().await?;
 
+    telemetry_guard.shutdown().into_result()?;
     Ok(())
 }

--- a/rocketmq/examples/basic_usage_more.rs
+++ b/rocketmq/examples/basic_usage_more.rs
@@ -25,12 +25,11 @@ use rocketmq_rust::TaskResult;
 use rocketmq_rust::TaskScheduler;
 use tokio::time::sleep;
 use tracing::info;
-use tracing::Level;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
-    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())?;
 
     // Create scheduler with custom config
     let config = SchedulerConfig {
@@ -205,5 +204,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Stop the scheduler
     scheduler.stop().await?;
 
+    telemetry_guard.shutdown().into_result()?;
     Ok(())
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8096

### Brief Description

This PR removes legacy logger bootstrap patterns from root workspace examples and routes them through the unified telemetry bootstrap.

Changes include:

- Replace `rocketmq_common::log::init_logger` in root workspace client examples with `rocketmq_observability::install_global`.
- Replace direct `tracing_subscriber` setup in controller and scheduler examples with the unified bootstrap.
- Keep a telemetry runtime guard alive until normal example completion and explicitly shut it down.
- Switch the `rocketmq-rust` example dev dependency from `tracing-subscriber` to `rocketmq-observability`.
- Keep standalone `rocketmq-example` untouched because it is a separate project with its own validation boundary.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-rust --examples --all-features` passed.
- `cargo test -p rocketmq-client-rust --examples --all-features` passed.
- `cargo test -p rocketmq-controller --examples --all-features` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
