### PR TITLE
[ISSUE #8098]♻️Use telemetry bootstrap in standalone examples

### DIFF
--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2322,6 +2322,7 @@ dependencies = [
  "rocketmq-client-rust",
  "rocketmq-common",
  "rocketmq-error",
+ "rocketmq-observability",
  "rocketmq-remoting",
  "rocketmq-rust",
  "tokio",

--- a/rocketmq-example/Cargo.toml
+++ b/rocketmq-example/Cargo.toml
@@ -44,6 +44,7 @@ rand                 = "0.8"
 rocketmq-client-rust = { path = "../rocketmq-client" }
 rocketmq-common      = { path = "../rocketmq-common" }
 rocketmq-error       = { path = "../rocketmq-error" }
+rocketmq-observability = { path = "../rocketmq-observability" }
 rocketmq-remoting    = { path = "../rocketmq-remoting" }
 rocketmq-rust        = { path = "../rocketmq" }
 rocketmq-tools       = { path = "../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", package = "rocketmq-admin-core" }

--- a/rocketmq-example/examples/consumer/broadcast_consumer.rs
+++ b/rocketmq-example/examples/consumer/broadcast_consumer.rs
@@ -39,11 +39,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "BroadcastConsumerTestTopic";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let client_config = broadcast_client_config()?;
 
     let mut consumer = DefaultMQPushConsumer::builder()
@@ -61,6 +61,10 @@ pub async fn main() -> RocketMQResult<()> {
     info!("broadcast consumer started. group={}, topic={}", CONSUMER_GROUP, TOPIC);
     let _ = wait_for_signal().await;
     consumer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/consumer_cluster.rs
+++ b/rocketmq-example/examples/consumer/consumer_cluster.rs
@@ -59,12 +59,12 @@ const USE_CLOSURE: bool = false;
 /// 1. Start multiple instances of this consumer (with the same consumer group)
 /// 2. Send messages to the topic using a producer
 /// 3. Observe that messages are distributed among the consumer instances
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
     // Initialize logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // Create a push consumer with cluster mode
     let builder = DefaultMQPushConsumer::builder();
 
@@ -129,6 +129,10 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
 
     info!("Cluster consumer shutdown completed.");
+
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-example/examples/consumer/lite_pull_consumer.rs
+++ b/rocketmq-example/examples/consumer/lite_pull_consumer.rs
@@ -31,11 +31,11 @@ pub const TOPIC: &str = "LitePullConsumerTestTopic";
 pub const TAG_EXPRESSION: &str = "LitePullTag";
 pub const POLL_TIMEOUT_MS: u64 = 1000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let consumer = DefaultLitePullConsumer::builder()
         .consumer_group(CONSUMER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -76,6 +76,10 @@ pub async fn main() -> RocketMQResult<()> {
     }
 
     consumer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/orderly_consumer.rs
+++ b/rocketmq-example/examples/consumer/orderly_consumer.rs
@@ -35,11 +35,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "OrderSendTestTopic";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut consumer = DefaultMQPushConsumer::builder()
         .consumer_group(CONSUMER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -55,6 +55,10 @@ pub async fn main() -> RocketMQResult<()> {
     info!("orderly consumer started. group={}, topic={}", CONSUMER_GROUP, TOPIC);
     let _ = wait_for_signal().await;
     consumer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -36,12 +36,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
 pub const TAG: &str = "*";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     switch_pop_consumer().await?;
 
     // create a producer builder with default configuration
@@ -57,6 +56,10 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = wait_for_signal().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/request_reply_responder.rs
+++ b/rocketmq-example/examples/consumer/request_reply_responder.rs
@@ -39,11 +39,11 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "*";
 pub const REPLY_TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut reply_producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -72,6 +72,10 @@ pub async fn main() -> RocketMQResult<()> {
 
     consumer.shutdown().await;
     reply_producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/sql_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/sql_filter_consumer.rs
@@ -36,11 +36,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "SqlFilterConsumerTestTopic";
 pub const SQL_EXPRESSION: &str = "region = 'cn' AND priority >= 3";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut consumer = DefaultMQPushConsumer::builder()
         .consumer_group(CONSUMER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -61,6 +61,10 @@ pub async fn main() -> RocketMQResult<()> {
     );
     let _ = wait_for_signal().await;
     consumer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/consumer/tag_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/tag_filter_consumer.rs
@@ -36,11 +36,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TagFilterConsumerTestTopic";
 pub const TAG_EXPRESSION: &str = "TagA || TagB";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut consumer = DefaultMQPushConsumer::builder()
         .consumer_group(CONSUMER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -61,6 +61,10 @@ pub async fn main() -> RocketMQResult<()> {
     );
     let _ = wait_for_signal().await;
     consumer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/interop/request_code_smoke.rs
+++ b/rocketmq-example/examples/interop/request_code_smoke.rs
@@ -77,13 +77,17 @@ impl SmokeConfig {
     }
 }
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let config = SmokeConfig::from_env()?;
-    run_smoke(config).await
+    let result = run_smoke(config).await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+    result
 }
 
 async fn run_smoke(config: SmokeConfig) -> RocketMQResult<()> {

--- a/rocketmq-example/examples/producer/basic_send.rs
+++ b/rocketmq-example/examples/producer/basic_send.rs
@@ -34,11 +34,11 @@ pub const TOPIC: &str = "BasicSendTestTopic";
 pub const TAG: &str = "BasicTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -65,6 +65,10 @@ pub async fn main() -> RocketMQResult<()> {
 
     producer.shutdown().await;
     println!("\n========== All examples completed ==========");
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/producer/batch_send.rs
+++ b/rocketmq-example/examples/producer/batch_send.rs
@@ -39,11 +39,11 @@ pub const TOPIC: &str = "BatchSendTestTopic";
 pub const TAG: &str = "BatchTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -91,6 +91,10 @@ pub async fn main() -> RocketMQResult<()> {
 
     producer.shutdown().await;
     println!("\n========== All examples completed ==========");
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/producer/delay_send.rs
+++ b/rocketmq-example/examples/producer/delay_send.rs
@@ -28,11 +28,11 @@ pub const TOPIC: &str = "DelaySendTestTopic";
 pub const TAG: &str = "DelayTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -46,6 +46,10 @@ pub async fn main() -> RocketMQResult<()> {
     send_deliver_time(&mut producer).await?;
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/producer/order_send.rs
+++ b/rocketmq-example/examples/producer/order_send.rs
@@ -24,11 +24,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "OrderSendTestTopic";
 pub const TAG: &str = "OrderTag";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -61,5 +61,9 @@ pub async fn main() -> RocketMQResult<()> {
     }
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-example/examples/producer/producer_simple.rs
+++ b/rocketmq-example/examples/producer/producer_simple.rs
@@ -23,12 +23,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "ProducerSimpleTest";
 pub const TAG: &str = "TagA";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    //init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
@@ -47,5 +46,9 @@ pub async fn main() -> RocketMQResult<()> {
         println!("send result: {:?}", send_result);
     }
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-example/examples/producer/producer_with_timeout.rs
+++ b/rocketmq-example/examples/producer/producer_with_timeout.rs
@@ -26,12 +26,11 @@ pub const TAG: &str = "TagA";
 // Send timeout in milliseconds
 pub const SEND_TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    // init logger
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     // create a producer builder with default configuration
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
@@ -86,5 +85,9 @@ pub async fn main() -> RocketMQResult<()> {
     println!("send result with deliver time: {:?}", send_result);
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-example/examples/producer/request_callback_send.rs
+++ b/rocketmq-example/examples/producer/request_callback_send.rs
@@ -29,11 +29,11 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "RequestTag";
 pub const REQUEST_TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -93,5 +93,9 @@ pub async fn main() -> RocketMQResult<()> {
     }
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-example/examples/producer/request_send.rs
+++ b/rocketmq-example/examples/producer/request_send.rs
@@ -25,11 +25,11 @@ pub const TOPIC: &str = "RequestSendTestTopic";
 pub const TAG: &str = "RequestTag";
 pub const REQUEST_TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -52,5 +52,9 @@ pub async fn main() -> RocketMQResult<()> {
     println!("request response: topic={}, body={}", response.topic(), body);
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }

--- a/rocketmq-example/examples/producer/send_to_queue.rs
+++ b/rocketmq-example/examples/producer/send_to_queue.rs
@@ -35,11 +35,11 @@ pub const TOPIC: &str = "SendToQueueTestTopic";
 pub const TAG: &str = "QueueTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -76,6 +76,10 @@ pub async fn main() -> RocketMQResult<()> {
 
     producer.shutdown().await;
     println!("\n========== All examples completed ==========");
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/producer/send_with_selector.rs
+++ b/rocketmq-example/examples/producer/send_with_selector.rs
@@ -38,11 +38,11 @@ pub const TOPIC: &str = "SendWithSelectorTestTopic";
 pub const TAG: &str = "SelectorTag";
 pub const TIMEOUT_MS: u64 = 3000;
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -69,6 +69,10 @@ pub async fn main() -> RocketMQResult<()> {
 
     producer.shutdown().await;
     println!("\n========== All examples completed ==========");
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 

--- a/rocketmq-example/examples/producer/send_with_selector_advanced.rs
+++ b/rocketmq-example/examples/producer/send_with_selector_advanced.rs
@@ -46,11 +46,11 @@ pub const PRODUCER_GROUP: &str = "producer_advanced_selector";
 pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "AdvancedSelectorTestTopic";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = DefaultMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -86,6 +86,10 @@ pub async fn main() -> RocketMQResult<()> {
     println!("  - Type safety: No runtime type casting required");
     println!("  - Performance: ~8-13ns improvement per selector call");
     println!("  - Clean API: Direct closure passing without Arc wrapping");
+
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
 
     Ok(())
 }

--- a/rocketmq-example/examples/producer/transaction_send.rs
+++ b/rocketmq-example/examples/producer/transaction_send.rs
@@ -36,11 +36,11 @@ pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TransactionSendTestTopic";
 pub const TAG: &str = "TransactionTag";
 
-#[allow(deprecated)]
 #[rocketmq::main]
 pub async fn main() -> RocketMQResult<()> {
-    rocketmq_common::log::init_logger()?;
-
+    let telemetry_guard =
+        rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+            .expect("telemetry logging bootstrap should initialize");
     let mut producer = TransactionMQProducer::builder()
         .producer_group(PRODUCER_GROUP)
         .name_server_addr(DEFAULT_NAMESRVADDR)
@@ -63,6 +63,10 @@ pub async fn main() -> RocketMQResult<()> {
     }
 
     producer.shutdown().await;
+    telemetry_guard
+        .shutdown()
+        .expect("telemetry logging shutdown should succeed");
+
     Ok(())
 }
 


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8098

### Brief Description

This PR migrates the standalone example project away from the compatibility logger and into the unified telemetry bootstrap.

Changes include:

- Add `rocketmq-observability` as a dev dependency for the standalone example project.
- Replace `rocketmq_common::log::init_logger` in standalone consumer, producer, and interop examples.
- Keep a telemetry guard alive until normal example completion.
- Explicitly shut down the telemetry guard before returning from migrated examples.
- Keep root documentation files untouched.

### How Did You Test This Change?

- `cargo fmt --all` passed from `rocketmq-example`.
- `cargo clippy --all-targets -- -D warnings` passed from `rocketmq-example`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example producer and consumer apps now start with unified observability telemetry and cleanly shut it down on exit.
  * Added telemetry support to the example project’s development dependencies so the examples can run with observability enabled.

* **Chores**
  * Removed outdated startup logging setup from the examples to align them with the new telemetry-based runtime flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->