### PR TITLE
[ISSUE #8100]♻️Preserve broker auth error boundaries

### DIFF
--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -322,7 +322,10 @@ impl AuthAdminService {
 }
 
 fn map_authz_error(error: AuthorizationError) -> RocketMQError {
-    RocketMQError::from(error)
+    match error {
+        AuthorizationError::PermissionDenied { .. } => permission_denied(error.to_string()),
+        other => RocketMQError::from(other),
+    }
 }
 
 fn permission_denied(message: impl Into<String>) -> RocketMQError {

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -307,7 +307,11 @@ where
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if let Some(auth_runtime) = &self.auth_runtime {
             if let Err(error) = auth_runtime.check_remoting(&ctx, request).await {
-                let response = error_response::command_from_error_with_opaque(&error, request.opaque());
+                let response = error_response::command_from_error_with_remark_and_opaque(
+                    &error,
+                    error.to_string(),
+                    request.opaque(),
+                );
                 return Ok(Some(response));
             }
         }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)
- Fixes #8100

### Brief Description
- Preserves broker admin authorization denials as `BrokerPermissionDenied` at the `AuthAdminService` boundary.
- Keeps concrete auth rejection remarks when `BrokerRequestProcessor` rejects remoting requests before dispatch.

### How Did You Test This Change?
- `cargo fmt --all`
- `cargo test -p rocketmq-broker auth::auth_admin_service::tests::map_authz_error_preserves_admin_error_category --all-features -- --exact --nocapture`
- `cargo test -p rocketmq-broker processor::tests::broker_request_processor_checks_auth_before_dispatch --all-features -- --exact --nocapture`
- `cargo test -p rocketmq-broker --all-features`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` with a temporary Cargo target directory outside the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker permission-denied handling so authorization failures now return a clearer, specific error.
  * Authentication failures during request processing now include the error message in the response, making issues easier to diagnose.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->