### PR TITLE
[ISSUE #7617]🧪Add snapshot and append coverage for ClusterAddrTable

### DIFF
--- a/rocketmq-namesrv/src/route/tables/cluster_table.rs
+++ b/rocketmq-namesrv/src/route/tables/cluster_table.rs
@@ -296,6 +296,7 @@ mod tests {
 
         // Remove cluster
         assert!(table.remove_cluster("DefaultCluster"));
+        assert!(!table.remove_cluster("UnknownCluster"));
         assert!(!table.contains_cluster("DefaultCluster"));
     }
 
@@ -365,6 +366,50 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(!table.contains_cluster("EmptyCluster"));
         assert!(table.contains_cluster("NonEmptyCluster"));
+        assert!(table.contains_broker("NonEmptyCluster", "broker-b"));
+        assert_eq!(table.cleanup_empty_clusters(), 0);
+    }
+
+    #[test]
+    fn test_snapshot_returns_owned_public_names() {
+        let table = ClusterAddrTable::new();
+        let cluster: ClusterName = CheetahString::from_string("ClusterA".to_string());
+        let broker_a: BrokerName = CheetahString::from_string("broker-a".to_string());
+        let broker_b: BrokerName = CheetahString::from_string("broker-b".to_string());
+
+        table.add_broker(cluster.clone(), broker_a.clone());
+
+        let snapshot = table.snapshot();
+        let brokers = snapshot.get(&cluster).unwrap();
+        assert_eq!(brokers.len(), 1);
+        assert!(brokers.contains(&broker_a));
+
+        table.add_broker(cluster.clone(), broker_b.clone());
+
+        let brokers = snapshot.get(&cluster).unwrap();
+        assert_eq!(brokers.len(), 1);
+        assert!(brokers.contains(&broker_a));
+        assert!(!brokers.contains(&broker_b));
+    }
+
+    #[test]
+    fn test_append_cluster_and_broker_names_appends_to_existing_topic_list() {
+        let table = ClusterAddrTable::new();
+        let existing_topic = CheetahString::from_string("ExistingTopic".to_string());
+        let mut topic_list = vec![existing_topic.clone()];
+        let cluster: ClusterName = CheetahString::from_string("DefaultCluster".to_string());
+        let broker_a: BrokerName = CheetahString::from_string("broker-a".to_string());
+        let broker_b: BrokerName = CheetahString::from_string("broker-b".to_string());
+
+        table.add_broker(cluster.clone(), broker_a.clone());
+        table.add_broker(cluster.clone(), broker_b.clone());
+        table.append_cluster_and_broker_names(&mut topic_list);
+
+        assert_eq!(topic_list.len(), 4);
+        assert_eq!(topic_list[0], existing_topic);
+        assert!(topic_list.contains(&cluster));
+        assert!(topic_list.contains(&broker_a));
+        assert!(topic_list.contains(&broker_b));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7617

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for removing an unknown cluster, confirming it returns `false`.
  * Added tests to ensure snapshot results stay stable when the table changes.
  * Added tests verifying cluster and broker names are appended to existing topic lists without removing current entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->