### PR TITLE
[ISSUE #8109]🐛Fix rocketmq-example telemetry shutdown handling

### DIFF
--- a/rocketmq-example/examples/consumer/broadcast_consumer.rs
+++ b/rocketmq-example/examples/consumer/broadcast_consumer.rs
@@ -63,6 +63,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/consumer_cluster.rs
+++ b/rocketmq-example/examples/consumer/consumer_cluster.rs
@@ -132,6 +132,7 @@ pub async fn main() -> RocketMQResult<()> {
 
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/lite_pull_consumer.rs
+++ b/rocketmq-example/examples/consumer/lite_pull_consumer.rs
@@ -78,6 +78,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/orderly_consumer.rs
+++ b/rocketmq-example/examples/consumer/orderly_consumer.rs
@@ -57,6 +57,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -58,6 +58,7 @@ pub async fn main() -> RocketMQResult<()> {
     let _ = wait_for_signal().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/request_reply_responder.rs
+++ b/rocketmq-example/examples/consumer/request_reply_responder.rs
@@ -74,6 +74,7 @@ pub async fn main() -> RocketMQResult<()> {
     reply_producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/sql_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/sql_filter_consumer.rs
@@ -63,6 +63,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/consumer/tag_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/tag_filter_consumer.rs
@@ -63,6 +63,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/interop/request_code_smoke.rs
+++ b/rocketmq-example/examples/interop/request_code_smoke.rs
@@ -86,6 +86,7 @@ pub async fn main() -> RocketMQResult<()> {
     let result = run_smoke(config).await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
     result
 }

--- a/rocketmq-example/examples/producer/basic_send.rs
+++ b/rocketmq-example/examples/producer/basic_send.rs
@@ -67,6 +67,7 @@ pub async fn main() -> RocketMQResult<()> {
     println!("\n========== All examples completed ==========");
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/batch_send.rs
+++ b/rocketmq-example/examples/producer/batch_send.rs
@@ -93,6 +93,7 @@ pub async fn main() -> RocketMQResult<()> {
     println!("\n========== All examples completed ==========");
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/delay_send.rs
+++ b/rocketmq-example/examples/producer/delay_send.rs
@@ -48,6 +48,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/order_send.rs
+++ b/rocketmq-example/examples/producer/order_send.rs
@@ -63,6 +63,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/producer_simple.rs
+++ b/rocketmq-example/examples/producer/producer_simple.rs
@@ -48,6 +48,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/producer_with_timeout.rs
+++ b/rocketmq-example/examples/producer/producer_with_timeout.rs
@@ -87,6 +87,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/request_callback_send.rs
+++ b/rocketmq-example/examples/producer/request_callback_send.rs
@@ -95,6 +95,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/request_send.rs
+++ b/rocketmq-example/examples/producer/request_send.rs
@@ -54,6 +54,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/send_to_queue.rs
+++ b/rocketmq-example/examples/producer/send_to_queue.rs
@@ -78,6 +78,7 @@ pub async fn main() -> RocketMQResult<()> {
     println!("\n========== All examples completed ==========");
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/send_with_selector.rs
+++ b/rocketmq-example/examples/producer/send_with_selector.rs
@@ -71,6 +71,7 @@ pub async fn main() -> RocketMQResult<()> {
     println!("\n========== All examples completed ==========");
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/send_with_selector_advanced.rs
+++ b/rocketmq-example/examples/producer/send_with_selector_advanced.rs
@@ -89,6 +89,7 @@ pub async fn main() -> RocketMQResult<()> {
 
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())

--- a/rocketmq-example/examples/producer/transaction_send.rs
+++ b/rocketmq-example/examples/producer/transaction_send.rs
@@ -65,6 +65,7 @@ pub async fn main() -> RocketMQResult<()> {
     producer.shutdown().await;
     telemetry_guard
         .shutdown()
+        .into_result()
         .expect("telemetry logging shutdown should succeed");
 
     Ok(())


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8109

### Brief Description

Updates all standalone `rocketmq-example/examples` telemetry shutdown call sites to call `TelemetryShutdownReport::into_result()` before `expect(...)`. This matches the `TelemetryRuntimeGuard::shutdown()` API and keeps shutdown failure handling explicit across consumer, producer, and interop examples.

### How Did You Test This Change?

- `cargo clean -p rocketmq-observability`
- `cargo check --example consumer-broadcast`
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated shutdown handling across the example producer and consumer apps so telemetry shutdown results are converted consistently before being checked.
  * This improves end-of-run error handling and makes shutdown behavior more reliable across the examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->