### PR TITLE
[ISSUE #8114]🐛Stabilize tieredstore read fallback query test

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -6232,6 +6232,7 @@ mod tests {
                     storage_level: TieredStorageLevel::Force,
                     backend_provider: "memory".to_string(),
                     store_path_root_dir: temp_dir.path().join("tieredstore"),
+                    delete_file_enable: false,
                     max_pending_tasks: 16,
                     ..TieredStoreConfig::default()
                 }),


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8114

### Brief Description

Disables tiered file deletion for the `tieredstore_read_path_falls_back_when_local_queue_is_missing` test. The test uses a synthetic old store timestamp and verifies read/query fallback behavior, not cleanup; keeping cleanup enabled let the zero-delay cleanup scheduler remove the tiered index before query fallback assertions on busy runners.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --lib message_store::local_file_message_store::tests::tieredstore_read_path_falls_back_when_local_queue_is_missing --all-features -- --nocapture` - passed.
- `cargo fmt --all` - passed.
- `cargo test -p rocketmq-store --lib --all-features` - passed, 623 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a storage fallback test setup to better reflect scenarios where local data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->