### PR TITLE
[ISSUE #8117]✨Harden AGENTS routing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,103 @@
 # AGENTS.md
 
 ## Scope and precedence
+
 - This file applies to the whole repository unless a deeper `AGENTS.md` overrides it.
 - Follow the nearest `AGENTS.md` for files under standalone projects and dashboard subdirectories.
 - Direct user instructions in the current conversation take precedence over this file.
 - If repository instructions conflict with each other, choose the more specific instruction and mention the conflict in the final response.
 
-## Repository shape
-- The repository root is the main Cargo workspace for the core RocketMQ Rust crates.
+## Repository routing model
+
+- The repository root is the main Cargo workspace. Its source of truth is the root `Cargo.toml` `[workspace].members` list.
+- `rocketmq-dashboard/rocketmq-dashboard-common/` is a root workspace member and shared dashboard crate.
 - `rocketmq-example/` is a standalone Cargo project.
 - `rocketmq-dashboard/rocketmq-dashboard-gpui/` is a standalone Cargo project.
-- `rocketmq-dashboard/rocketmq-dashboard-tauri/` is the Tauri app root, not a Cargo workspace root.
+- `rocketmq-dashboard/rocketmq-dashboard-tauri/` is the Tauri app root and a standalone Node/Vite frontend project.
 - `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` is the standalone Rust backend for the Tauri app.
 - `rocketmq-dashboard/rocketmq-dashboard-web/` is the Web Dashboard root, not a Cargo workspace root.
 - `rocketmq-dashboard/rocketmq-dashboard-web/backend/` is the standalone Rust backend for the Web Dashboard.
 - `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` is the standalone React + TypeScript + Vite frontend for the Web Dashboard.
-- Root workspace validation does not validate standalone projects or Node/Vite frontend projects.
+- `rocketmq-website/` is the standalone Docusaurus website project.
+- Root workspace validation does not validate standalone Cargo projects or Node/Vite/Docusaurus projects.
 
-## Codex workflow
+## Workflow
+
 - Before editing, inspect the relevant files and check the worktree state with `git status --short`.
 - Treat existing uncommitted changes as user work. Do not overwrite, revert, or reformat unrelated changes.
 - Keep changes tightly scoped to the request. Avoid unrelated refactors, dependency updates, and configuration churn.
 - Prefer `rg` or `rg --files` for search. If unavailable, use the fastest local equivalent.
+- If a required local validation command is missing, use the repository's documented installation or CI-equivalent path when one exists; do not change project
+  dependencies or configuration just to work around local tool availability.
 - Follow existing module structure, naming, error handling, and test style before introducing new patterns.
 - Use patch-style edits for manual changes when tool support is available. Generated files and formatter output may be produced by their normal tools.
 - For behavior changes, add or update focused tests that would fail without the change.
 - Do not create commits, branches, or pull requests unless the user asks.
 
 ## Rust toolchain and style
+
 - Use the repository Rust toolchain. Do not change `rust-toolchain.toml` unless explicitly required.
 - Respect `rustfmt.toml` and `.clippy.toml`.
 - Do not relax lint, formatting, feature, or CI configuration to make a change pass unless the task specifically requires it.
 - Prefer clear, idiomatic Rust over clever abstractions.
 - Be mindful of allocations, blocking calls, and lock scope in hot paths and async code.
+- New Rust source files should keep the RocketMQ Rust Apache 2.0 copyright header style already used in the repository.
+- Do not normalize editions across projects. The root workspace is mostly Rust 2021, while several tools and standalone dashboard projects are Rust 2024.
+
+## Rust API and implementation guardrails
+
+- When touching Rust code, prefer Clippy-friendly forms such as collapsed `if`/`if let`, method references over redundant closures, and inline named variables
+  in `format!`, logging, and assertion macros when it reads naturally.
+- When code is complex, add concise comments or examples that explain invariants, ordering, error handling, or concurrency assumptions. Avoid comments that only
+  restate what the code already says.
+- Avoid introducing public APIs with positional `bool`, ambiguous `Option`, or numeric mode arguments that make callsites hard to read. Prefer enums, named
+  methods, builders, or small newtypes when they keep the callsite self-documenting.
+- When an existing positional API must be called with an opaque `None`, boolean, or numeric literal, consider an exact `/*param_name*/` comment before the
+  literal. Do not add these comments for string or char literals unless they add real clarity.
+- Prefer exhaustive `match` arms for project-owned enums and public behavior. Use wildcard arms only when grouping future or irrelevant cases is intentional and
+  clear from context.
+- Keep modules private by default and expose intentional public API through narrow visibility or explicit re-exports.
+- Newly added public traits should include doc comments that explain the trait role and what implementations are expected to provide.
+- Avoid adding small helper methods that are referenced only once unless they name a non-trivial invariant, isolate unsafe or locking behavior, or match an
+  established local pattern.
+- For tracing async work, prefer instrumenting the function or method definition with `#[tracing::instrument(...)]` after checking whether the callee or
+  immediate delegate is already instrumented. Use call-site `.instrument(...)` when intentionally binding an explicit observation/request span to a future.
+- Avoid growing large, high-touch modules. Prefer adding focused modules for new functionality; target Rust modules under roughly 500 lines excluding tests, and
+  avoid extending files above roughly 800 lines unless there is a strong local reason.
+- When extracting code from a large module, move the related tests and module/type docs toward the new implementation so invariants stay close to the code that
+  owns them.
+
+## Validation router
+
+| Area changed                                                                      | Work directory                                           | Required final / pre-PR validation                                                                                      | Escalate when                                                                                                                           |
+|-----------------------------------------------------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| Root workspace Rust crates and `rocketmq-dashboard/rocketmq-dashboard-common/`    | repository root                                          | `cargo fmt --all`; `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`                     | Cross-crate API, feature flags, build config, runtime ownership, typed errors, observability, RocksDB, or shared dashboard code changes |
+| `rocketmq-example/`                                                               | `rocketmq-example/`                                      | Follow `rocketmq-example/AGENTS.md`                                                                                     | Shared client/common/remoting/error/observability/admin dependencies changed                                                            |
+| `rocketmq-dashboard/rocketmq-dashboard-gpui/`                                     | `rocketmq-dashboard/rocketmq-dashboard-gpui/`            | Follow its `AGENTS.md`                                                                                                  | `rocketmq-dashboard-common/` or dashboard shared behavior changed                                                                       |
+| `rocketmq-dashboard/rocketmq-dashboard-tauri/` frontend                           | `rocketmq-dashboard/rocketmq-dashboard-tauri/`           | Follow its `AGENTS.md`; CI uses `npm ci` and `npm run build`                                                            | Shared frontend config, Tauri shell behavior, or package metadata changed                                                               |
+| `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`                          | `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` | Follow its `AGENTS.md`                                                                                                  | Shared root crates used by the Tauri backend changed                                                                                    |
+| `rocketmq-dashboard/rocketmq-dashboard-web/backend/`                              | `rocketmq-dashboard/rocketmq-dashboard-web/backend/`     | Follow its `AGENTS.md`                                                                                                  | `rocketmq-dashboard-common/`, admin core, client/common/remoting/error, or API contracts changed                                        |
+| `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`                             | `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`    | Follow its `AGENTS.md`; CI uses `npm ci` and `npm run build`                                                            | API contract, routing, shared UI patterns, or package metadata changed                                                                  |
+| `rocketmq-website/`                                                               | `rocketmq-website/`                                      | Follow `rocketmq-website/AGENTS.md`; CI uses `npm ci` and `npm run build`                                               | Docusaurus config, package metadata, generated docs commands, or navigation changed                                                     |
+| `AGENTS.md`, `**/AGENTS.md`, `Cargo.toml`, `package.json`, `.github/workflows/**` | repository root                                          | `.\scripts\check-agents-routing.ps1` on Windows or `bash ./scripts/check-agents-routing.sh` on Unix; `git diff --check` | Any project boundary, validation command, workflow path filter, or standalone project changes                                           |
 
 ## Mandatory Rust validation
-After every Rust code change, finish with a successful format pass and clippy pass for each affected Cargo project.
+
+Before submitting a PR or handing off completed Rust code work, finish with a successful format pass and clippy pass for each affected Cargo project. These full
+validation commands are not required after every small edit while iterating.
 
 Do not finish with unformatted Rust code.
-Do not finish without a relevant clippy pass.
+Do not finish PR-ready or final Rust code work without a relevant clippy pass.
 Do not claim validation passed unless the command completed successfully.
+Rust validation can be slow because of workspace locks and native dependencies; let relevant commands complete unless they clearly fail or exceed the chosen
+timeout, and do not kill unrelated Cargo or rustc processes.
 
-Documentation-only changes do not require Cargo validation unless they affect generated Rust, build configuration, examples, or documented commands that need verification.
+Documentation-only changes do not require Cargo validation unless they affect generated Rust, build configuration, examples, documented commands that need
+verification, or routing/validation instructions.
 
 ## Root workspace validation
-For Rust changes inside the root workspace, run from the repository root:
+
+For Rust changes inside the root workspace, run from the repository root before PR submission or final handoff:
 
 ```bash
 cargo fmt --all
@@ -54,13 +107,14 @@ cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
 Package-level clippy may be useful while iterating, but the final required pass for root workspace Rust changes is the workspace command above.
 
 ## Standalone project validation
-Root workspace commands do not cover standalone projects. If changes affect one of these projects, validate it in its own directory and follow any deeper `AGENTS.md` there:
+
+Root workspace commands do not cover standalone projects. If changes affect one of these projects, validate it before PR submission or final handoff in its own
+directory and follow any deeper `AGENTS.md` there:
 
 - `rocketmq-example/`
 - `rocketmq-dashboard/rocketmq-dashboard-gpui/`
 - `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`
 - `rocketmq-dashboard/rocketmq-dashboard-web/backend/`
-- `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`
 
 When no deeper instruction gives a different command, use:
 
@@ -70,35 +124,124 @@ cargo clippy --all-targets --all-features -- -D warnings
 ```
 
 For `rocketmq-dashboard/rocketmq-dashboard-tauri/` frontend changes, follow the dashboard `AGENTS.md` in that directory.
-For `rocketmq-dashboard/rocketmq-dashboard-web/` changes, follow the nearest Web Dashboard `AGENTS.md`; backend validation runs from `backend/`, and frontend validation runs from `frontend/`.
+For `rocketmq-dashboard/rocketmq-dashboard-web/` changes, follow the nearest Web Dashboard `AGENTS.md`; backend validation runs from `backend/`, and frontend
+validation runs from `frontend/`.
+For `rocketmq-website/` changes, follow `rocketmq-website/AGENTS.md`.
+
+## Specialized guardrails
+
+- Runtime ownership and blocking: if production changes touch `tokio::spawn`, `JoinSet`, `std::thread`, runtime creation, `block_on`, `spawn_blocking`,
+  scheduler loops, shutdown paths, `TaskGroup`, `ScheduledTaskGroup`, `RuntimeOwner`, or `ServiceContext`, run:
+
+```powershell
+.\scripts\runtime-audit.ps1 -SkipBaseline
+```
+
+- Runtime baseline changes: if the accepted runtime boundary baseline changes, run:
+
+```powershell
+.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline
+```
+
+- Typed error architecture: if changes touch `rocketmq-error`, public error mapping, remoting/gRPC/HTTP/CLI error exits, retry/severity/redaction/observability
+  error metadata, or sensitive debug fields, run one of:
+
+```powershell
+.\scripts\check-error-hygiene.ps1
+```
+
+```bash
+python scripts/error_architecture_guard.py
+```
+
+- Observability feature matrix: if changes touch `rocketmq-observability`, telemetry feature flags, broker observability wiring, or `Cargo.toml` feature
+  definitions, run the relevant local subset of the CI matrix from `.github/workflows/rocketmq-rust-ci.yaml`, including `cargo check`, `cargo clippy`, and
+  `cargo test -p rocketmq-observability` for affected features such as `observability`, `otlp-metrics`, `otel-metrics,prometheus`, `otlp-traces`, `otlp-logs`,
+  and combined OTLP/prometheus features.
+- RocksDB store feature: if changes touch `rocksdb_store` behavior in `rocketmq-store` or `rocketmq-broker`, run the relevant CI-equivalent checks:
+
+```bash
+cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings
+cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings
+cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests
+cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests
+cargo test -p rocketmq-broker --features rocksdb_store rocksdb
+cargo test -p rocketmq-broker --features rocksdb_store pop_consumer
+```
 
 ## Testing policy
+
 - Run tests only for the modified area by default.
 - Prefer the smallest effective scope: named test, module test, package test, then broader integration tests.
 - Run broader tests only when the change affects shared infrastructure, feature flags, public cross-crate APIs, or multiple crates.
 - For bug fixes, add or update a regression test when practical.
 - For new behavior, add or update tests that cover the externally visible behavior.
+- Prefer comparing whole values or DTOs when they implement meaningful equality instead of asserting field-by-field copies of the same object.
+- Do not add tests that only restate statically defined constants, and do not add negative tests for behavior that was removed.
 
 Examples:
 
 ```bash
 cargo test -p rocketmq-common
-cargo test -p rocketmq-client --lib
+cargo test -p rocketmq-client-rust --lib
 cargo test -p rocketmq-remoting some_test_name
 ```
 
 ## Shared code rule
-If a shared crate is modified and that change can affect standalone projects, validate the affected standalone projects as well.
 
-Common shared crates include:
+If a shared crate is modified and that change can affect standalone projects, validate the affected standalone projects as well. Check the standalone
+`Cargo.toml` files for actual path dependencies before deciding the final scope.
+
+Common shared crates and paths include:
+
+- `rocketmq`
 - `rocketmq-common`
 - `rocketmq-runtime`
 - `rocketmq-client`
 - `rocketmq-remoting`
 - `rocketmq-macros`
 - `rocketmq-error`
+- `rocketmq-observability`
+- `rocketmq-dashboard/rocketmq-dashboard-common`
+- `rocketmq-tools/rocketmq-admin/rocketmq-admin-core`
+
+## Documentation, website, and generated artifacts
+
+- Documentation-only changes outside executable docs do not require Cargo validation.
+- Changes under `rocketmq-website/` are website changes, not plain Markdown-only changes; run the website validation from `rocketmq-website/AGENTS.md`.
+- Do not commit generated build output, local logs, runtime audit artifacts under `target/`, or Node build directories.
+- For paired Markdown/HTML reports, verify both outputs stay aligned with the source data or script that generated them.
+
+## AGENTS routing drift control
+
+Run the routing drift check when changing project boundaries, validation commands, workflow path filters, package manifests, or any `AGENTS.md`:
+
+Windows PowerShell:
+
+```powershell
+.\scripts\check-agents-routing.ps1
+```
+
+Unix Bash:
+
+```bash
+bash ./scripts/check-agents-routing.sh
+```
+
+The PowerShell and Bash scripts are equivalent checks and must be kept in sync. They check that root routing mentions all standalone Cargo projects,
+Node/Docusaurus projects, critical workflow routes, and specialized guard commands. The architecture decision is documented in
+`rocketmq-doc/en/agents-routing-validation-adr.md`.
+
+## Project-local agent assets
+
+- Use `.agents/skills/rocketmq-rust-issue-generator/` when drafting or publishing GitHub issues for this repository.
+- Use `.agents/skills/rocketmq-rust-pr-submitter/` when preparing or publishing PR titles, commit messages, and PR bodies for this repository.
+- Use `.agents/skills/rust-doc-comment-generator/` for substantial Rustdoc/comment generation.
+- Use `.agents/skills/translate-it-doc-en-zh/` for English-to-Chinese technical documentation translation.
+- Keep `.agents/skills/**` and `.claude/skills/**` copies aligned when changing duplicated project-local skills.
 
 ## Final response expectations
+
 - Summarize the files changed and the intent of the change.
 - List validation commands run and their result.
 - If required validation was skipped or could not run, explain why and identify the remaining risk.

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md
@@ -8,7 +8,7 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-gpui/`.
 - Do not rely on root workspace validation for this directory.
 
 ## Mandatory validation
-Run from `rocketmq-dashboard/rocketmq-dashboard-gpui/` after every Rust code change:
+Run from `rocketmq-dashboard/rocketmq-dashboard-gpui/` before PR submission or final handoff for Rust code changes:
 
 ```bash
 cargo fmt --all

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md
@@ -9,7 +9,7 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-tauri/`.
 - Rust backend code is validated in `src-tauri/`.
 
 ## Frontend validation
-When changing frontend code, run from this directory:
+Before PR submission or final handoff for frontend changes, run from this directory:
 
 ```bash
 npm ci

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md
@@ -8,7 +8,7 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`.
 - Do not rely on root workspace validation for this directory.
 
 ## Mandatory validation
-Run from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` after every Rust code change:
+Run from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` before PR submission or final handoff for Rust code changes:
 
 ```bash
 cargo fmt --all

--- a/rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md
@@ -26,7 +26,7 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-web/`.
 - Avoid `async-trait` unless there is no reasonable alternative.
 
 ## Backend validation
-Run from `rocketmq-dashboard/rocketmq-dashboard-web/backend/` after every Rust code change:
+Run from `rocketmq-dashboard/rocketmq-dashboard-web/backend/` before PR submission or final handoff for Rust code changes:
 
 ```bash
 cargo fmt --all
@@ -48,7 +48,7 @@ cargo build --all-targets --all-features
 - Message and detail inspection should use drawers or focused dialogs, not full page rewrites unless routing requires it.
 
 ## Frontend validation
-Run from `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` after frontend changes:
+Run from `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` before PR submission or final handoff for frontend changes:
 
 ```bash
 npm ci

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md
@@ -35,7 +35,7 @@ It overrides the Web Dashboard root instructions for backend files.
 - Prefer explicit error mapping through the local dashboard error and API response model.
 
 ## Validation
-Run from this directory after every Rust code change:
+Run from this directory before PR submission or final handoff for Rust code changes:
 
 ```bash
 cargo fmt --all

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
@@ -46,7 +46,7 @@ D:\Github\Java\rocketmq-dashboard\frontend-new
 - Do not copy the old Java visual style directly.
 
 ## Validation
-Run from this directory after frontend changes:
+Run from this directory before PR submission or final handoff for frontend changes:
 
 ```bash
 npm ci

--- a/rocketmq-doc/en/agents-routing-validation-adr.md
+++ b/rocketmq-doc/en/agents-routing-validation-adr.md
@@ -1,0 +1,80 @@
+# ADR: AGENTS Routing Validation
+
+## Status
+Accepted
+
+## Context
+The RocketMQ Rust repository is broader than the root Cargo workspace. The root `Cargo.toml` owns the main workspace members, while several projects are intentionally standalone:
+
+- `rocketmq-example/`
+- `rocketmq-dashboard/rocketmq-dashboard-gpui/`
+- `rocketmq-dashboard/rocketmq-dashboard-tauri/`
+- `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`
+- `rocketmq-dashboard/rocketmq-dashboard-web/`
+- `rocketmq-dashboard/rocketmq-dashboard-web/backend/`
+- `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`
+- `rocketmq-website/`
+
+Root workspace commands such as `cargo fmt --all` and `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` do not validate all standalone Rust, Node/Vite, or Docusaurus projects. The repository also has specialized quality gates for runtime ownership, typed error architecture, observability feature combinations, and RocksDB store behavior.
+
+Without an explicit routing model, agents can incorrectly treat the root Cargo workspace as the whole repository or skip project-specific validation after touching shared crates.
+
+## Decision
+Use root `AGENTS.md` as the repository-level validation router.
+
+The root file must:
+
+- Identify the root workspace source of truth as the root `Cargo.toml`.
+- Route standalone Cargo, Node/Vite, Web Dashboard, Tauri, and Docusaurus work to the nearest project `AGENTS.md`.
+- List the local validation commands for root workspace changes and the routing rules for standalone projects.
+- Define when to run specialized guards such as `scripts/runtime-audit.ps1`, `scripts/check-error-hygiene.ps1`, `scripts/error_architecture_guard.py`, observability feature checks, and RocksDB feature checks.
+- Require `scripts/check-agents-routing.ps1` on Windows or `scripts/check-agents-routing.sh` on Unix when project boundaries, manifests, workflow path filters, or `AGENTS.md` files change.
+
+Add `rocketmq-website/AGENTS.md` so the Docusaurus website has a local validation contract.
+
+Add `scripts/check-agents-routing.ps1` and `scripts/check-agents-routing.sh` as lightweight drift checks. The scripts validate that:
+
+- Root `AGENTS.md` mentions all required standalone routes.
+- Every standalone Cargo project with its own `[workspace]` has a same-directory `AGENTS.md`.
+- Every discovered `package.json` project has a same-directory `AGENTS.md`.
+- Key workflow routes are represented in root `AGENTS.md`.
+- The shared-code list and specialized guard commands remain discoverable.
+
+## Alternatives
+### Only Expand Root AGENTS.md
+This is simpler, but it leaves no automated signal when a new standalone project, `package.json`, workflow path, or shared validation route is added.
+
+### Rely Only on GitHub Actions
+CI validates pull requests but does not help agents choose the right local command before finishing work. It also does not explain routing intent or standalone project boundaries.
+
+### Duplicate Full Instructions Everywhere
+Copying root validation details into every subproject increases drift risk. The chosen model keeps root routing centralized and leaves project-specific details in nearest `AGENTS.md` files.
+
+## Consequences
+Benefits:
+
+- Agents can determine validation scope from path ownership instead of guessing.
+- Standalone project coverage becomes visible and checkable.
+- New project boundaries require an explicit AGENTS update.
+- Runtime, typed error, observability, and RocksDB guardrails are discoverable from the root workflow.
+
+Costs:
+
+- `scripts/check-agents-routing.ps1` and `scripts/check-agents-routing.sh` must be updated together when intentional validation topology changes.
+- The check is structural. It cannot prove every command is sufficient for every code change.
+- CI remains the final cross-platform authority for Linux, macOS, Windows, and Node version behavior.
+
+## Validation
+Run from the repository root before PR submission or final handoff when changes touch `AGENTS.md`, nested `AGENTS.md` files, `Cargo.toml`, `package.json`, or `.github/workflows/**`:
+
+```powershell
+.\scripts\check-agents-routing.ps1
+git diff --check
+```
+
+```bash
+bash ./scripts/check-agents-routing.sh
+git diff --check
+```
+
+Rust or Node validation is still required when the changed files affect Rust code, generated Rust, build configuration, examples, frontend behavior, website behavior, or documented commands that need verification.

--- a/rocketmq-example/AGENTS.md
+++ b/rocketmq-example/AGENTS.md
@@ -8,7 +8,7 @@ This file applies to `rocketmq-example/`.
 - Do not rely on root workspace validation for this directory.
 
 ## Mandatory validation
-Run from `rocketmq-example/` after every Rust code change:
+Run from `rocketmq-example/` before PR submission or final handoff for Rust code changes:
 
 ```bash
 cargo fmt --all

--- a/rocketmq-website/AGENTS.md
+++ b/rocketmq-website/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Scope
+This file applies to `rocketmq-website/`.
+
+## Project role
+- This directory is the standalone Docusaurus website for RocketMQ Rust.
+- It is a Node project, not a Cargo project and not part of the root Rust workspace.
+- Root Cargo validation does not validate this website.
+
+## Repository boundaries
+- Keep website changes scoped to `rocketmq-website/` unless the user explicitly asks to update source docs, workflows, or shared repository instructions.
+- Do not commit generated Docusaurus build output.
+- Do not introduce unrelated dependency updates.
+
+## Codex workflow
+- Check `git status --short` before editing.
+- Treat existing uncommitted changes as user work.
+- Use `rg` or `rg --files` for searching.
+- Use patch-style edits for manual changes.
+- Do not create commits, branches, or pull requests unless the user asks.
+
+## Validation
+Run from `rocketmq-website/` before PR submission or final handoff for website changes:
+
+```bash
+npm ci
+npm run build
+```
+
+For iteration when dependencies are already installed:
+
+```bash
+npm run build
+```
+
+Documentation-only changes outside this directory do not require website validation. Changes inside this directory should be treated as website changes because Docusaurus routing, navigation, MDX rendering, and build configuration can fail independently of Cargo.
+
+## Final response expectations
+- Summarize website files changed and why.
+- List validation commands and results.
+- If validation was skipped because the change is outside website behavior or because only repository instructions changed, say so explicitly.

--- a/scripts/check-agents-routing.ps1
+++ b/scripts/check-agents-routing.ps1
@@ -1,0 +1,245 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+$script:Failures = New-Object System.Collections.Generic.List[string]
+$script:SkipDirectoryNames = @(".git", ".idea", "target", "node_modules", "build", "dist")
+
+function Add-Failure {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    $script:Failures.Add($Message) | Out-Null
+}
+
+function Convert-ToRepoRelativePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $resolved = (Resolve-Path -LiteralPath $Path).Path
+    $rootPrefix = $script:RepoRoot.TrimEnd([char[]]@("\", "/"))
+    if ($resolved.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $resolved.Substring($rootPrefix.Length).TrimStart([char[]]@("\", "/")) -replace "\\", "/"
+    }
+    return $resolved -replace "\\", "/"
+}
+
+function Read-RepositoryText {
+    param([Parameter(Mandatory = $true)][string]$RelativePath)
+
+    $path = Join-Path $script:RepoRoot $RelativePath
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure "Missing required file: $RelativePath"
+        return ""
+    }
+    return Get-Content -LiteralPath $path -Raw -Encoding UTF8
+}
+
+function Test-TextContains {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Needle
+    )
+
+    return $Text.IndexOf($Needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+}
+
+function Assert-TextContains {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Needle,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+
+    if (-not (Test-TextContains -Text $Text -Needle $Needle)) {
+        Add-Failure "$Context does not mention '$Needle'"
+    }
+}
+
+function Get-FilesByName {
+    param([Parameter(Mandatory = $true)][string]$FileName)
+
+    $stack = New-Object System.Collections.Generic.Stack[System.IO.DirectoryInfo]
+    $stack.Push((Get-Item -LiteralPath $script:RepoRoot))
+
+    while ($stack.Count -gt 0) {
+        $directory = $stack.Pop()
+        foreach ($file in Get-ChildItem -LiteralPath $directory.FullName -File -Filter $FileName -ErrorAction SilentlyContinue) {
+            $file
+        }
+
+        foreach ($child in Get-ChildItem -LiteralPath $directory.FullName -Directory -Force -ErrorAction SilentlyContinue) {
+            if ($script:SkipDirectoryNames -contains $child.Name) {
+                continue
+            }
+            $stack.Push($child)
+        }
+    }
+}
+
+function Assert-SameDirectoryAgents {
+    param(
+        [Parameter(Mandatory = $true)][string]$Directory,
+        [Parameter(Mandatory = $true)][string]$Reason
+    )
+
+    $agentsPath = Join-Path $Directory "AGENTS.md"
+    if (-not (Test-Path -LiteralPath $agentsPath)) {
+        $relative = Convert-ToRepoRelativePath -Path $Directory
+        Add-Failure "$Reason at '$relative' has no same-directory AGENTS.md"
+    }
+}
+
+$rootAgentsText = Read-RepositoryText -RelativePath "AGENTS.md"
+
+$requiredRoutePaths = @(
+    "rocketmq-example/",
+    "rocketmq-dashboard/rocketmq-dashboard-gpui/",
+    "rocketmq-dashboard/rocketmq-dashboard-tauri/",
+    "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/",
+    "rocketmq-dashboard/rocketmq-dashboard-web/",
+    "rocketmq-dashboard/rocketmq-dashboard-web/backend/",
+    "rocketmq-dashboard/rocketmq-dashboard-web/frontend/",
+    "rocketmq-website/"
+)
+
+foreach ($routePath in $requiredRoutePaths) {
+    Assert-TextContains -Text $rootAgentsText -Needle $routePath -Context "Root AGENTS.md"
+}
+
+$requiredRootTerms = @(
+    'root `Cargo.toml`',
+    "cargo fmt --all",
+    "cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings",
+    "cargo clippy --all-targets --all-features -- -D warnings",
+    "npm ci",
+    "npm run build",
+    ".\scripts\check-agents-routing.ps1",
+    "./scripts/check-agents-routing.sh",
+    ".\scripts\runtime-audit.ps1 -SkipBaseline",
+    ".\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline",
+    ".\scripts\check-error-hygiene.ps1",
+    "python scripts/error_architecture_guard.py",
+    "rocksdb_store",
+    "otlp-metrics",
+    "rocketmq-doc/en/agents-routing-validation-adr.md"
+)
+
+foreach ($term in $requiredRootTerms) {
+    Assert-TextContains -Text $rootAgentsText -Needle $term -Context "Root AGENTS.md"
+}
+
+$requiredSharedPaths = @(
+    "rocketmq",
+    "rocketmq-common",
+    "rocketmq-runtime",
+    "rocketmq-client",
+    "rocketmq-remoting",
+    "rocketmq-macros",
+    "rocketmq-error",
+    "rocketmq-observability",
+    "rocketmq-dashboard/rocketmq-dashboard-common",
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core"
+)
+
+foreach ($sharedPath in $requiredSharedPaths) {
+    Assert-TextContains -Text $rootAgentsText -Needle $sharedPath -Context "Root AGENTS.md shared code rule"
+}
+
+$expectedProjectAgents = @(
+    "rocketmq-example/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md",
+    "rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md",
+    "rocketmq-website/AGENTS.md"
+)
+
+foreach ($agentsFile in $expectedProjectAgents) {
+    $path = Join-Path $script:RepoRoot $agentsFile
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure "Missing project AGENTS file: $agentsFile"
+    }
+}
+
+$standaloneCargoCount = 0
+foreach ($manifest in Get-FilesByName -FileName "Cargo.toml") {
+    $relativeManifest = Convert-ToRepoRelativePath -Path $manifest.FullName
+    if ($relativeManifest -eq "Cargo.toml") {
+        continue
+    }
+
+    $manifestText = Get-Content -LiteralPath $manifest.FullName -Raw -Encoding UTF8
+    if ($manifestText -match "(?m)^\s*\[workspace\]\s*$") {
+        $standaloneCargoCount++
+        $manifestDirectory = Split-Path -Parent $manifest.FullName
+        $relativeDirectory = (Convert-ToRepoRelativePath -Path $manifestDirectory).TrimEnd("/") + "/"
+        Assert-SameDirectoryAgents -Directory $manifestDirectory -Reason "Standalone Cargo project"
+        Assert-TextContains -Text $rootAgentsText -Needle $relativeDirectory -Context "Root AGENTS.md standalone Cargo routing"
+    }
+}
+
+$nodeProjectCount = 0
+foreach ($packageJson in Get-FilesByName -FileName "package.json") {
+    $packageDirectory = Split-Path -Parent $packageJson.FullName
+    $relativeDirectory = (Convert-ToRepoRelativePath -Path $packageDirectory).TrimEnd("/") + "/"
+    $nodeProjectCount++
+    Assert-SameDirectoryAgents -Directory $packageDirectory -Reason "Node project"
+    Assert-TextContains -Text $rootAgentsText -Needle $relativeDirectory -Context "Root AGENTS.md Node project routing"
+}
+
+$workflowRoutes = [ordered]@{
+    ".github/workflows/rocketmq-rust-ci.yaml" = "Root workspace validation"
+    ".github/workflows/rocketmq-example-ci.yaml" = "rocketmq-example/"
+    ".github/workflows/dashboard-web-ci.yml" = "rocketmq-dashboard/rocketmq-dashboard-web/"
+    ".github/workflows/dashboard-tauri-ci.yml" = "rocketmq-dashboard/rocketmq-dashboard-tauri/"
+    ".github/workflows/website-check.yml" = "rocketmq-website/"
+    ".github/workflows/deploy.yml" = "rocketmq-website/"
+}
+
+foreach ($entry in $workflowRoutes.GetEnumerator()) {
+    $workflowPath = Join-Path $script:RepoRoot $entry.Key
+    if (Test-Path -LiteralPath $workflowPath) {
+        Assert-TextContains -Text $rootAgentsText -Needle $entry.Value -Context "Root AGENTS.md workflow routing for $($entry.Key)"
+    }
+}
+
+$adrPath = Join-Path $script:RepoRoot "rocketmq-doc/en/agents-routing-validation-adr.md"
+if (Test-Path -LiteralPath $adrPath) {
+    $adrText = Get-Content -LiteralPath $adrPath -Raw -Encoding UTF8
+    foreach ($term in @("AGENTS.md", "check-agents-routing.ps1", "check-agents-routing.sh", 'root `Cargo.toml`', "standalone")) {
+        Assert-TextContains -Text $adrText -Needle $term -Context "AGENTS routing ADR"
+    }
+}
+else {
+    Add-Failure "Missing AGENTS routing ADR: rocketmq-doc/en/agents-routing-validation-adr.md"
+}
+
+if ($script:Failures.Count -gt 0) {
+    Write-Output "AGENTS routing check failed with $($script:Failures.Count) issue(s):"
+    foreach ($failure in $script:Failures) {
+        Write-Output " - $failure"
+    }
+    exit 1
+}
+
+Write-Output "AGENTS_ROUTING_CHECK_OK standalone_cargo=$standaloneCargoCount node_projects=$nodeProjectCount routes=$($requiredRoutePaths.Count)"

--- a/scripts/check-agents-routing.sh
+++ b/scripts/check-agents-routing.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ROOT="$(cd "$ROOT" && pwd)"
+
+FAILURES=()
+
+add_failure() {
+  FAILURES+=("$1")
+}
+
+repo_relative_path() {
+  local path="$1"
+  local absolute
+  absolute="$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
+  local relative="${absolute#"$ROOT"/}"
+  printf '%s\n' "${relative//\\//}"
+}
+
+read_repository_text() {
+  local relative_path="$1"
+  local path="$ROOT/$relative_path"
+
+  if [[ ! -f "$path" ]]; then
+    add_failure "Missing required file: $relative_path"
+    printf '\n'
+    return
+  fi
+
+  cat "$path"
+}
+
+text_contains() {
+  local text="$1"
+  local needle="$2"
+  grep -Fqi -- "$needle" <<<"$text"
+}
+
+assert_text_contains() {
+  local text="$1"
+  local needle="$2"
+  local context="$3"
+
+  if ! text_contains "$text" "$needle"; then
+    add_failure "$context does not mention '$needle'"
+  fi
+}
+
+find_files_by_name() {
+  local file_name="$1"
+
+  find "$ROOT" \
+    \( -name .git -o -name .idea -o -name target -o -name node_modules -o -name build -o -name dist \) -prune -o \
+    -type f -name "$file_name" -print
+}
+
+assert_same_directory_agents() {
+  local directory="$1"
+  local reason="$2"
+
+  if [[ ! -f "$directory/AGENTS.md" ]]; then
+    local relative
+    relative="$(repo_relative_path "$directory")"
+    add_failure "$reason at '$relative' has no same-directory AGENTS.md"
+  fi
+}
+
+ROOT_AGENTS_TEXT="$(read_repository_text "AGENTS.md")"
+
+REQUIRED_ROUTE_PATHS=(
+  "rocketmq-example/"
+  "rocketmq-dashboard/rocketmq-dashboard-gpui/"
+  "rocketmq-dashboard/rocketmq-dashboard-tauri/"
+  "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/"
+  "rocketmq-dashboard/rocketmq-dashboard-web/"
+  "rocketmq-dashboard/rocketmq-dashboard-web/backend/"
+  "rocketmq-dashboard/rocketmq-dashboard-web/frontend/"
+  "rocketmq-website/"
+)
+
+for route_path in "${REQUIRED_ROUTE_PATHS[@]}"; do
+  assert_text_contains "$ROOT_AGENTS_TEXT" "$route_path" "Root AGENTS.md"
+done
+
+REQUIRED_ROOT_TERMS=(
+  'root `Cargo.toml`'
+  "cargo fmt --all"
+  "cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings"
+  "cargo clippy --all-targets --all-features -- -D warnings"
+  "npm ci"
+  "npm run build"
+  ".\\scripts\\check-agents-routing.ps1"
+  "./scripts/check-agents-routing.sh"
+  ".\\scripts\\runtime-audit.ps1 -SkipBaseline"
+  ".\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline"
+  ".\\scripts\\check-error-hygiene.ps1"
+  "python scripts/error_architecture_guard.py"
+  "rocksdb_store"
+  "otlp-metrics"
+  "rocketmq-doc/en/agents-routing-validation-adr.md"
+)
+
+for term in "${REQUIRED_ROOT_TERMS[@]}"; do
+  assert_text_contains "$ROOT_AGENTS_TEXT" "$term" "Root AGENTS.md"
+done
+
+REQUIRED_SHARED_PATHS=(
+  "rocketmq"
+  "rocketmq-common"
+  "rocketmq-runtime"
+  "rocketmq-client"
+  "rocketmq-remoting"
+  "rocketmq-macros"
+  "rocketmq-error"
+  "rocketmq-observability"
+  "rocketmq-dashboard/rocketmq-dashboard-common"
+  "rocketmq-tools/rocketmq-admin/rocketmq-admin-core"
+)
+
+for shared_path in "${REQUIRED_SHARED_PATHS[@]}"; do
+  assert_text_contains "$ROOT_AGENTS_TEXT" "$shared_path" "Root AGENTS.md shared code rule"
+done
+
+EXPECTED_PROJECT_AGENTS=(
+  "rocketmq-example/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md"
+  "rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md"
+  "rocketmq-website/AGENTS.md"
+)
+
+for agents_file in "${EXPECTED_PROJECT_AGENTS[@]}"; do
+  if [[ ! -f "$ROOT/$agents_file" ]]; then
+    add_failure "Missing project AGENTS file: $agents_file"
+  fi
+done
+
+standalone_cargo_count=0
+while IFS= read -r manifest; do
+  relative_manifest="$(repo_relative_path "$manifest")"
+  if [[ "$relative_manifest" == "Cargo.toml" ]]; then
+    continue
+  fi
+
+  if grep -Eq '^[[:space:]]*\[workspace\][[:space:]]*$' "$manifest"; then
+    standalone_cargo_count=$((standalone_cargo_count + 1))
+    manifest_directory="$(dirname "$manifest")"
+    relative_directory="$(repo_relative_path "$manifest_directory")/"
+    assert_same_directory_agents "$manifest_directory" "Standalone Cargo project"
+    assert_text_contains "$ROOT_AGENTS_TEXT" "$relative_directory" "Root AGENTS.md standalone Cargo routing"
+  fi
+done < <(find_files_by_name "Cargo.toml")
+
+node_project_count=0
+while IFS= read -r package_json; do
+  package_directory="$(dirname "$package_json")"
+  relative_directory="$(repo_relative_path "$package_directory")/"
+  node_project_count=$((node_project_count + 1))
+  assert_same_directory_agents "$package_directory" "Node project"
+  assert_text_contains "$ROOT_AGENTS_TEXT" "$relative_directory" "Root AGENTS.md Node project routing"
+done < <(find_files_by_name "package.json")
+
+WORKFLOW_PATHS=(
+  ".github/workflows/rocketmq-rust-ci.yaml|Root workspace validation"
+  ".github/workflows/rocketmq-example-ci.yaml|rocketmq-example/"
+  ".github/workflows/dashboard-web-ci.yml|rocketmq-dashboard/rocketmq-dashboard-web/"
+  ".github/workflows/dashboard-tauri-ci.yml|rocketmq-dashboard/rocketmq-dashboard-tauri/"
+  ".github/workflows/website-check.yml|rocketmq-website/"
+  ".github/workflows/deploy.yml|rocketmq-website/"
+)
+
+for workflow_entry in "${WORKFLOW_PATHS[@]}"; do
+  workflow_path="${workflow_entry%%|*}"
+  route="${workflow_entry#*|}"
+  if [[ -f "$ROOT/$workflow_path" ]]; then
+    assert_text_contains "$ROOT_AGENTS_TEXT" "$route" "Root AGENTS.md workflow routing for $workflow_path"
+  fi
+done
+
+ADR_PATH="$ROOT/rocketmq-doc/en/agents-routing-validation-adr.md"
+if [[ -f "$ADR_PATH" ]]; then
+  ADR_TEXT="$(cat "$ADR_PATH")"
+  for term in "AGENTS.md" "check-agents-routing.ps1" "check-agents-routing.sh" 'root `Cargo.toml`' "standalone"; do
+    assert_text_contains "$ADR_TEXT" "$term" "AGENTS routing ADR"
+  done
+else
+  add_failure "Missing AGENTS routing ADR: rocketmq-doc/en/agents-routing-validation-adr.md"
+fi
+
+if (( ${#FAILURES[@]} > 0 )); then
+  printf 'AGENTS routing check failed with %d issue(s):\n' "${#FAILURES[@]}"
+  for failure in "${FAILURES[@]}"; do
+    printf ' - %s\n' "$failure"
+  done
+  exit 1
+fi
+
+printf 'AGENTS_ROUTING_CHECK_OK standalone_cargo=%d node_projects=%d routes=%d\n' \
+  "$standalone_cargo_count" "$node_project_count" "${#REQUIRED_ROUTE_PATHS[@]}"


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8117

### Brief Description

This PR hardens the repository agent guidance and validation routing:

- Expands the root `AGENTS.md` routing model for the root Cargo workspace, standalone Cargo projects, dashboard projects, and the Docusaurus website.
- Adds `rocketmq-website/AGENTS.md` so website changes have a local validation contract.
- Adds PowerShell and Bash routing drift checks for AGENTS, manifests, workflow routes, and specialized validation guards.
- Documents the routing decision in `rocketmq-doc/en/agents-routing-validation-adr.md`.
- Aligns nested AGENTS validation language around final handoff and PR submission.
- Adds Rust API, implementation, testing, and complex-code comment guardrails that fit the current repository.

### How Did You Test This Change?

- `./scripts/check-agents-routing.ps1` passed with `AGENTS_ROUTING_CHECK_OK standalone_cargo=4 node_projects=3 routes=8`.
- `git diff --check` passed; Git emitted only an LF/CRLF working-copy warning for `AGENTS.md`.
- Cargo and npm validation were not run because this change only updates repository instructions, routing checks, and documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and expanded repository guidance for how changes should be routed and validated across the project.
  * Introduced clearer validation instructions for standalone subprojects and the website.

* **Chores**
  * Added automated checks to help keep routing and validation guidance consistent.
  * Updated several project-specific instructions to standardize when validation should run before final submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->