### PR TITLE
[ISSUE #8124]♻️Unify observability errors in error crate

### DIFF
--- a/rocketmq-error/README-zh_cn.md
+++ b/rocketmq-error/README-zh_cn.md
@@ -13,6 +13,7 @@
 - `RocketMQError`：RocketMQ Rust 各 crate 使用的主错误枚举。
 - `RocketMQResult<T>`：标准 result 类型别名。
 - 领域专用的嵌套错误，例如 `NetworkError`、`SerializationError`、`ProtocolError`、`RpcClientError`、`AuthError`、`ControllerError`、`ToolsError`、`FilterError` 和 `UnifiedServiceError`。
+- `ObservabilityError`：telemetry、logging、exporter 初始化、subscriber 安装和 provider 关闭错误。
 - 稳定分类体系：`ErrorKind`、`ErrorCode`、`ErrorScope` 和 `ErrorCategory`。
 - 静态元数据注册表：`ErrorSpec` 和 `ALL_ERROR_SPECS`。
 - 面向 remoting、gRPC、HTTP 和 CLI 适配器的边界映射。
@@ -44,7 +45,7 @@ fn validate_broker_addr(addr: &str) -> RocketMQResult<()> {
 }
 ```
 
-`std::io::Error`、`std::str::Utf8Error`，以及 `NetworkError`、`SerializationError`、`ProtocolError`、`RpcClientError`、`AuthError`、`ControllerError`、`ToolsError`、`FilterError` 和 `UnifiedServiceError` 等被包裹的嵌套错误，都可以通过 `From` 转换为 `RocketMQError`，因此常规代码路径可以使用 `?` 运算符。
+`std::io::Error`、`std::str::Utf8Error`，以及 `NetworkError`、`SerializationError`、`ProtocolError`、`RpcClientError`、`AuthError`、`ControllerError`、`ToolsError`、`FilterError`、`ObservabilityError` 和 `UnifiedServiceError` 等被包裹的嵌套错误，都可以通过 `From` 转换为 `RocketMQError`，因此常规代码路径可以使用 `?` 运算符。
 
 ## 架构
 
@@ -66,7 +67,7 @@ flowchart TB
         result["RocketMQResult&lt;T&gt;"]
         root["RocketMQError"]
         wrapped["NetworkError / SerializationError / ProtocolError / RpcClientError"]
-        domain["AuthError / ControllerError / ToolsError / FilterError / UnifiedServiceError"]
+        domain["AuthError / ControllerError / ToolsError / FilterError / ObservabilityError / UnifiedServiceError"]
         direct["Broker / Route / Client / Storage / Configuration / System variants"]
         result --> root
         wrapped --> root
@@ -119,6 +120,7 @@ flowchart TB
 | `RocketMQError::Controller` | `ControllerError` | controller 和 Raft 工作流 |
 | `RocketMQError::Tools` | `ToolsError` | admin tools 和 CLI 操作 |
 | `RocketMQError::Filter` | `FilterError` | Bloom Filter 和 bit-array 工具 |
+| `RocketMQError::Observability` | `ObservabilityError` | telemetry bootstrap、exporter、subscriber 安装、provider 关闭 |
 
 重要的直接变体族：
 

--- a/rocketmq-error/README.md
+++ b/rocketmq-error/README.md
@@ -18,6 +18,8 @@ remoting, gRPC, HTTP, CLI, logs, or metrics.
 - Domain-specific nested errors such as `NetworkError`, `SerializationError`,
   `ProtocolError`, `RpcClientError`, `AuthError`, `ControllerError`,
   `ToolsError`, `FilterError`, and `UnifiedServiceError`.
+- `ObservabilityError`: telemetry, logging, exporter initialization,
+  subscriber installation, and provider shutdown errors.
 - Stable taxonomy: `ErrorKind`, `ErrorCode`, `ErrorScope`, and
   `ErrorCategory`.
 - Static metadata registry: `ErrorSpec` and `ALL_ERROR_SPECS`.
@@ -57,9 +59,9 @@ fn validate_broker_addr(addr: &str) -> RocketMQResult<()> {
 
 `std::io::Error`, `std::str::Utf8Error`, and wrapped nested errors such as
 `NetworkError`, `SerializationError`, `ProtocolError`, `RpcClientError`,
-`AuthError`, `ControllerError`, `ToolsError`, `FilterError`, and
-`UnifiedServiceError` convert into `RocketMQError` through `From`, so the `?`
-operator can be used in normal code paths.
+`AuthError`, `ControllerError`, `ToolsError`, `FilterError`,
+`ObservabilityError`, and `UnifiedServiceError` convert into `RocketMQError`
+through `From`, so the `?` operator can be used in normal code paths.
 
 ## Architecture
 
@@ -82,7 +84,7 @@ flowchart TB
         result["RocketMQResult&lt;T&gt;"]
         root["RocketMQError"]
         wrapped["NetworkError / SerializationError / ProtocolError / RpcClientError"]
-        domain["AuthError / ControllerError / ToolsError / FilterError / UnifiedServiceError"]
+        domain["AuthError / ControllerError / ToolsError / FilterError / ObservabilityError / UnifiedServiceError"]
         direct["Broker / Route / Client / Storage / Configuration / System variants"]
         result --> root
         wrapped --> root
@@ -138,6 +140,7 @@ Important wrapped families:
 | `RocketMQError::Controller` | `ControllerError` | controller and Raft workflows |
 | `RocketMQError::Tools` | `ToolsError` | admin tools and CLI operations |
 | `RocketMQError::Filter` | `FilterError` | bloom filter and bit-array utilities |
+| `RocketMQError::Observability` | `ObservabilityError` | telemetry bootstrap, exporters, subscriber install, provider shutdown |
 
 Important direct families:
 

--- a/rocketmq-error/src/boundary.rs
+++ b/rocketmq-error/src/boundary.rs
@@ -207,6 +207,9 @@ impl RemotingSpec {
             | ErrorKind::ConfigMissing
             | ErrorKind::ConfigInvalidValue
             | ErrorKind::AuthConfigInvalid
+            | ErrorKind::ObservabilityFeatureDisabled
+            | ErrorKind::ObservabilityConfigInvalid
+            | ErrorKind::ObservabilityLogFilterInvalid
             | ErrorKind::MissingRequiredMessageProperty => RemotingResponseCode::InvalidParameter,
             ErrorKind::Protocol | ErrorKind::InvalidVersionOrdinal => RemotingResponseCode::RequestCodeNotSupported,
             ErrorKind::Network | ErrorKind::Timeout | ErrorKind::RetryLimitExceeded => RemotingResponseCode::SystemBusy,
@@ -300,6 +303,9 @@ impl GrpcSpec {
             | ErrorKind::ConfigMissing
             | ErrorKind::ConfigInvalidValue
             | ErrorKind::AuthConfigInvalid
+            | ErrorKind::ObservabilityFeatureDisabled
+            | ErrorKind::ObservabilityConfigInvalid
+            | ErrorKind::ObservabilityLogFilterInvalid
             | ErrorKind::MissingRequiredMessageProperty => {
                 Self::new(GrpcPayloadCode::BadRequest, GrpcStatusCode::InvalidArgument)
             }
@@ -387,6 +393,9 @@ impl HttpSpec {
             | ErrorKind::ConfigMissing
             | ErrorKind::ConfigInvalidValue
             | ErrorKind::AuthConfigInvalid
+            | ErrorKind::ObservabilityFeatureDisabled
+            | ErrorKind::ObservabilityConfigInvalid
+            | ErrorKind::ObservabilityLogFilterInvalid
             | ErrorKind::MissingRequiredMessageProperty
             | ErrorKind::Protocol
             | ErrorKind::InvalidVersionOrdinal => HttpStatusCode::BAD_REQUEST,
@@ -461,7 +470,10 @@ impl CliSpec {
             ErrorKind::ConfigParseFailed
             | ErrorKind::ConfigMissing
             | ErrorKind::ConfigInvalidValue
-            | ErrorKind::AuthConfigInvalid => CliExitCode::CONFIG,
+            | ErrorKind::AuthConfigInvalid
+            | ErrorKind::ObservabilityFeatureDisabled
+            | ErrorKind::ObservabilityConfigInvalid
+            | ErrorKind::ObservabilityLogFilterInvalid => CliExitCode::CONFIG,
             ErrorKind::Network | ErrorKind::Timeout | ErrorKind::RetryLimitExceeded => CliExitCode::TEMPORARY_FAILURE,
             ErrorKind::StorageCorrupted | ErrorKind::StorageOutOfSpace => CliExitCode::DATA,
             ErrorKind::Tools => CliExitCode::UNAVAILABLE,

--- a/rocketmq-error/src/context.rs
+++ b/rocketmq-error/src/context.rs
@@ -110,6 +110,15 @@ impl RedactionPolicy {
             | ErrorKind::ConfigInvalidValue
             | ErrorKind::AuthConfigInvalid
             | ErrorKind::AuthHotReloadFailed
+            | ErrorKind::ObservabilityConfigInvalid
+            | ErrorKind::ObservabilityMetricsInitFailed
+            | ErrorKind::ObservabilityTracesInitFailed
+            | ErrorKind::ObservabilityLogsInitFailed
+            | ErrorKind::ObservabilityLoggingInitFailed
+            | ErrorKind::ObservabilityLogFilterInvalid
+            | ErrorKind::ObservabilityMetricsShutdownFailed
+            | ErrorKind::ObservabilityTracesShutdownFailed
+            | ErrorKind::ObservabilityLogsShutdownFailed
             | ErrorKind::Controller
             | ErrorKind::ControllerRaftError
             | ErrorKind::ControllerConsensusTimeout

--- a/rocketmq-error/src/kind.rs
+++ b/rocketmq-error/src/kind.rs
@@ -57,6 +57,7 @@ pub enum ErrorScope {
     Client,
     Tools,
     Filter,
+    Observability,
     Storage,
     Configuration,
     System,
@@ -81,6 +82,7 @@ pub enum ErrorCategory {
     Client,
     Tools,
     Filter,
+    Observability,
     Storage,
     Configuration,
     System,
@@ -103,6 +105,7 @@ impl ErrorCategory {
             Self::Client => "client",
             Self::Tools => "tools",
             Self::Filter => "filter",
+            Self::Observability => "observability",
             Self::Storage => "storage",
             Self::Configuration => "configuration",
             Self::System => "system",
@@ -160,6 +163,17 @@ pub enum ErrorKind {
     ConsumerNotAvailable,
     Tools,
     Filter,
+    ObservabilityFeatureDisabled,
+    ObservabilityConfigInvalid,
+    ObservabilityMetricsInitFailed,
+    ObservabilityTracesInitFailed,
+    ObservabilityLogsInitFailed,
+    ObservabilityLoggingInitFailed,
+    ObservabilityLogFilterInvalid,
+    ObservabilitySubscriberInstallFailed,
+    ObservabilityMetricsShutdownFailed,
+    ObservabilityTracesShutdownFailed,
+    ObservabilityLogsShutdownFailed,
     StorageReadFailed,
     StorageWriteFailed,
     StorageCorrupted,
@@ -227,6 +241,17 @@ impl ErrorKind {
         Self::ConsumerNotAvailable,
         Self::Tools,
         Self::Filter,
+        Self::ObservabilityFeatureDisabled,
+        Self::ObservabilityConfigInvalid,
+        Self::ObservabilityMetricsInitFailed,
+        Self::ObservabilityTracesInitFailed,
+        Self::ObservabilityLogsInitFailed,
+        Self::ObservabilityLoggingInitFailed,
+        Self::ObservabilityLogFilterInvalid,
+        Self::ObservabilitySubscriberInstallFailed,
+        Self::ObservabilityMetricsShutdownFailed,
+        Self::ObservabilityTracesShutdownFailed,
+        Self::ObservabilityLogsShutdownFailed,
         Self::StorageReadFailed,
         Self::StorageWriteFailed,
         Self::StorageCorrupted,
@@ -295,6 +320,17 @@ impl ErrorKind {
             Self::ConsumerNotAvailable => "CONSUMER_NOT_AVAILABLE",
             Self::Tools => "TOOLS_ERROR",
             Self::Filter => "FILTER_ERROR",
+            Self::ObservabilityFeatureDisabled => "OBSERVABILITY_FEATURE_DISABLED",
+            Self::ObservabilityConfigInvalid => "OBSERVABILITY_CONFIG_INVALID",
+            Self::ObservabilityMetricsInitFailed => "OBSERVABILITY_METRICS_INIT_FAILED",
+            Self::ObservabilityTracesInitFailed => "OBSERVABILITY_TRACES_INIT_FAILED",
+            Self::ObservabilityLogsInitFailed => "OBSERVABILITY_LOGS_INIT_FAILED",
+            Self::ObservabilityLoggingInitFailed => "OBSERVABILITY_LOGGING_INIT_FAILED",
+            Self::ObservabilityLogFilterInvalid => "OBSERVABILITY_LOG_FILTER_INVALID",
+            Self::ObservabilitySubscriberInstallFailed => "OBSERVABILITY_SUBSCRIBER_INSTALL_FAILED",
+            Self::ObservabilityMetricsShutdownFailed => "OBSERVABILITY_METRICS_SHUTDOWN_FAILED",
+            Self::ObservabilityTracesShutdownFailed => "OBSERVABILITY_TRACES_SHUTDOWN_FAILED",
+            Self::ObservabilityLogsShutdownFailed => "OBSERVABILITY_LOGS_SHUTDOWN_FAILED",
             Self::StorageReadFailed => "STORAGE_READ_FAILED",
             Self::StorageWriteFailed => "STORAGE_WRITE_FAILED",
             Self::StorageCorrupted => "STORAGE_CORRUPTED",
@@ -366,6 +402,17 @@ impl ErrorKind {
             | Self::ConsumerNotAvailable => ErrorScope::Client,
             Self::Tools => ErrorScope::Tools,
             Self::Filter => ErrorScope::Filter,
+            Self::ObservabilityFeatureDisabled
+            | Self::ObservabilityConfigInvalid
+            | Self::ObservabilityMetricsInitFailed
+            | Self::ObservabilityTracesInitFailed
+            | Self::ObservabilityLogsInitFailed
+            | Self::ObservabilityLoggingInitFailed
+            | Self::ObservabilityLogFilterInvalid
+            | Self::ObservabilitySubscriberInstallFailed
+            | Self::ObservabilityMetricsShutdownFailed
+            | Self::ObservabilityTracesShutdownFailed
+            | Self::ObservabilityLogsShutdownFailed => ErrorScope::Observability,
             Self::StorageReadFailed
             | Self::StorageWriteFailed
             | Self::StorageCorrupted
@@ -436,6 +483,17 @@ impl ErrorKind {
             | Self::ConsumerNotAvailable => ErrorCategory::Client,
             Self::Tools => ErrorCategory::Tools,
             Self::Filter => ErrorCategory::Filter,
+            Self::ObservabilityFeatureDisabled
+            | Self::ObservabilityConfigInvalid
+            | Self::ObservabilityMetricsInitFailed
+            | Self::ObservabilityTracesInitFailed
+            | Self::ObservabilityLogsInitFailed
+            | Self::ObservabilityLoggingInitFailed
+            | Self::ObservabilityLogFilterInvalid
+            | Self::ObservabilitySubscriberInstallFailed
+            | Self::ObservabilityMetricsShutdownFailed
+            | Self::ObservabilityTracesShutdownFailed
+            | Self::ObservabilityLogsShutdownFailed => ErrorCategory::Observability,
             Self::StorageReadFailed
             | Self::StorageWriteFailed
             | Self::StorageCorrupted

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -69,6 +69,9 @@ pub mod controller_error;
 // Filter error module
 pub mod filter_error;
 
+// Observability error module
+pub mod observability_error;
+
 // Client error module
 pub mod client_error;
 
@@ -101,6 +104,7 @@ pub use kind::ErrorCategory;
 pub use kind::ErrorCode;
 pub use kind::ErrorKind;
 pub use kind::ErrorScope;
+pub use observability_error::ObservabilityError;
 pub use policy::ErrorSeverity;
 pub use policy::ObserveSpec;
 pub use policy::RecoverySpec;

--- a/rocketmq-error/src/observability_error.rs
+++ b/rocketmq-error/src/observability_error.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::context::ErrorContext;
+use crate::context::Sensitive;
+use crate::kind::ErrorKind;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -51,6 +54,44 @@ pub enum ObservabilityError {
 }
 
 impl ObservabilityError {
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::FeatureDisabled(_) => ErrorKind::ObservabilityFeatureDisabled,
+            Self::InvalidConfig(_) => ErrorKind::ObservabilityConfigInvalid,
+            Self::MetricsInit(_) => ErrorKind::ObservabilityMetricsInitFailed,
+            Self::TracesInit(_) => ErrorKind::ObservabilityTracesInitFailed,
+            Self::LogsInit(_) => ErrorKind::ObservabilityLogsInitFailed,
+            Self::LoggingInit(_) => ErrorKind::ObservabilityLoggingInitFailed,
+            Self::InvalidLogFilter { .. } => ErrorKind::ObservabilityLogFilterInvalid,
+            Self::SubscriberInstallFailed { .. } => ErrorKind::ObservabilitySubscriberInstallFailed,
+            Self::MetricsShutdown(_) => ErrorKind::ObservabilityMetricsShutdownFailed,
+            Self::TracesShutdown(_) => ErrorKind::ObservabilityTracesShutdownFailed,
+            Self::LogsShutdown(_) => ErrorKind::ObservabilityLogsShutdownFailed,
+        }
+    }
+
+    pub fn context(&self) -> ErrorContext {
+        match self {
+            Self::FeatureDisabled(feature) => ErrorContext::new().with_field("feature", *feature),
+            Self::InvalidConfig(reason)
+            | Self::MetricsInit(reason)
+            | Self::TracesInit(reason)
+            | Self::LogsInit(reason)
+            | Self::LoggingInit(reason)
+            | Self::MetricsShutdown(reason)
+            | Self::TracesShutdown(reason)
+            | Self::LogsShutdown(reason) => {
+                ErrorContext::new().with_sensitive("reason", Sensitive::new(reason.clone()))
+            }
+            Self::InvalidLogFilter { filter, error } => ErrorContext::new()
+                .with_sensitive("filter", Sensitive::new(filter.clone()))
+                .with_sensitive("error", Sensitive::new(error.clone())),
+            Self::SubscriberInstallFailed { attempted, installed } => ErrorContext::new()
+                .with_field("attempted", attempted.to_string())
+                .with_field("installed", installed.to_string()),
+        }
+    }
+
     pub fn invalid_config(message: impl Into<String>) -> Self {
         Self::InvalidConfig(message.into())
     }

--- a/rocketmq-error/src/observability_error.rs
+++ b/rocketmq-error/src/observability_error.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ObservabilityError {
+    #[error("observability feature '{0}' is not enabled")]
+    FeatureDisabled(&'static str),
+
+    #[error("invalid observability config: {0}")]
+    InvalidConfig(String),
+
+    #[error("metrics initialization failed: {0}")]
+    MetricsInit(String),
+
+    #[error("traces initialization failed: {0}")]
+    TracesInit(String),
+
+    #[error("logs initialization failed: {0}")]
+    LogsInit(String),
+
+    #[error("logging initialization failed: {0}")]
+    LoggingInit(String),
+
+    #[error("invalid log filter '{filter}': {error}")]
+    InvalidLogFilter { filter: String, error: String },
+
+    #[error("tracing subscriber installation failed: attempted={attempted}, installed={installed}")]
+    SubscriberInstallFailed { attempted: bool, installed: bool },
+
+    #[error("metrics shutdown failed: {0}")]
+    MetricsShutdown(String),
+
+    #[error("traces shutdown failed: {0}")]
+    TracesShutdown(String),
+
+    #[error("logs shutdown failed: {0}")]
+    LogsShutdown(String),
+}
+
+impl ObservabilityError {
+    pub fn invalid_config(message: impl Into<String>) -> Self {
+        Self::InvalidConfig(message.into())
+    }
+
+    pub fn metrics_init(error: impl ToString) -> Self {
+        Self::MetricsInit(error.to_string())
+    }
+
+    pub fn traces_init(error: impl ToString) -> Self {
+        Self::TracesInit(error.to_string())
+    }
+
+    pub fn logs_init(error: impl ToString) -> Self {
+        Self::LogsInit(error.to_string())
+    }
+
+    pub fn logging_init(error: impl ToString) -> Self {
+        Self::LoggingInit(error.to_string())
+    }
+
+    pub fn invalid_log_filter(filter: impl Into<String>, error: impl ToString) -> Self {
+        Self::InvalidLogFilter {
+            filter: filter.into(),
+            error: error.to_string(),
+        }
+    }
+
+    pub fn subscriber_install_failed(attempted: bool, installed: bool) -> Self {
+        Self::SubscriberInstallFailed { attempted, installed }
+    }
+
+    pub fn metrics_shutdown(error: impl ToString) -> Self {
+        Self::MetricsShutdown(error.to_string())
+    }
+
+    pub fn traces_shutdown(error: impl ToString) -> Self {
+        Self::TracesShutdown(error.to_string())
+    }
+
+    pub fn logs_shutdown(error: impl ToString) -> Self {
+        Self::LogsShutdown(error.to_string())
+    }
+}

--- a/rocketmq-error/src/policy.rs
+++ b/rocketmq-error/src/policy.rs
@@ -55,7 +55,14 @@ impl RecoverySpec {
             | ErrorKind::Timeout
             | ErrorKind::RetryLimitExceeded
             | ErrorKind::StorageLockFailed
-            | ErrorKind::Tools => RetryClass::AfterBackoff,
+            | ErrorKind::Tools
+            | ErrorKind::ObservabilityMetricsInitFailed
+            | ErrorKind::ObservabilityTracesInitFailed
+            | ErrorKind::ObservabilityLogsInitFailed
+            | ErrorKind::ObservabilityLoggingInitFailed
+            | ErrorKind::ObservabilityMetricsShutdownFailed
+            | ErrorKind::ObservabilityTracesShutdownFailed
+            | ErrorKind::ObservabilityLogsShutdownFailed => RetryClass::AfterBackoff,
             ErrorKind::MessageLookupFailed | ErrorKind::QueryNotFound | ErrorKind::SubscriptionGroupNotExist => {
                 RetryClass::Immediate
             }
@@ -102,6 +109,9 @@ const fn observe_severity(kind: ErrorKind) -> ErrorSeverity {
         | ErrorKind::ResponseProcessFailed
         | ErrorKind::ConfigMissing
         | ErrorKind::ConfigInvalidValue
+        | ErrorKind::ObservabilityFeatureDisabled
+        | ErrorKind::ObservabilityConfigInvalid
+        | ErrorKind::ObservabilityLogFilterInvalid
         | ErrorKind::MissingRequiredMessageProperty => ErrorSeverity::Info,
         ErrorKind::RouteNotFound
         | ErrorKind::TopicNotExist

--- a/rocketmq-error/src/spec.rs
+++ b/rocketmq-error/src/spec.rs
@@ -113,6 +113,35 @@ pub const ALL_ERROR_SPECS: &[ErrorSpec] = &[
     spec!(ConsumerNotAvailable, "Consumer is not available"),
     spec!(Tools, "Tools operation failed"),
     spec!(Filter, "Filter operation failed"),
+    spec!(ObservabilityFeatureDisabled, "Observability feature is disabled"),
+    spec!(ObservabilityConfigInvalid, "Observability configuration is invalid"),
+    spec!(
+        ObservabilityMetricsInitFailed,
+        "Observability metrics initialization failed"
+    ),
+    spec!(
+        ObservabilityTracesInitFailed,
+        "Observability traces initialization failed"
+    ),
+    spec!(ObservabilityLogsInitFailed, "Observability logs initialization failed"),
+    spec!(
+        ObservabilityLoggingInitFailed,
+        "Observability logging initialization failed"
+    ),
+    spec!(ObservabilityLogFilterInvalid, "Observability log filter is invalid"),
+    spec!(
+        ObservabilitySubscriberInstallFailed,
+        "Observability subscriber installation failed"
+    ),
+    spec!(
+        ObservabilityMetricsShutdownFailed,
+        "Observability metrics shutdown failed"
+    ),
+    spec!(
+        ObservabilityTracesShutdownFailed,
+        "Observability traces shutdown failed"
+    ),
+    spec!(ObservabilityLogsShutdownFailed, "Observability logs shutdown failed"),
     spec!(StorageReadFailed, "Storage read failed"),
     spec!(StorageWriteFailed, "Storage write failed"),
     spec!(StorageCorrupted, "Storage data is corrupted"),

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -457,7 +457,7 @@ impl RocketMQError {
             Self::ConsumerNotAvailable => ErrorKind::ConsumerNotAvailable,
             Self::Tools(error) => error.kind(),
             Self::Filter(_) => ErrorKind::Filter,
-            Self::Observability(_) => ErrorKind::Internal,
+            Self::Observability(error) => error.kind(),
             Self::StorageReadFailed { .. } => ErrorKind::StorageReadFailed,
             Self::StorageWriteFailed { .. } => ErrorKind::StorageWriteFailed,
             Self::StorageCorrupted { .. } => ErrorKind::StorageCorrupted,
@@ -592,7 +592,7 @@ impl RocketMQError {
                 .with_field("actual", actual.as_str()),
             Self::Tools(error) => error.context(),
             Self::Filter(error) => ErrorContext::new().with_field("filter_error", error.to_string()),
-            Self::Observability(error) => redacted_context("observability_error", error.to_string()),
+            Self::Observability(error) => error.context(),
             Self::StorageReadFailed { path, reason } | Self::StorageWriteFailed { path, reason } => ErrorContext::new()
                 .with_sensitive("path", Sensitive::new(path.clone()))
                 .with_sensitive("reason", Sensitive::new(reason.clone())),

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -28,6 +28,7 @@ use std::io;
 
 // Re-export filter error
 pub use crate::filter_error::FilterError;
+pub use crate::observability_error::ObservabilityError;
 
 use crate::boundary::BoundaryErrorView;
 use crate::context::ErrorContext;
@@ -295,6 +296,13 @@ pub enum RocketMQError {
     Filter(#[from] FilterError),
 
     // ============================================================================
+    // Observability Errors
+    // ============================================================================
+    /// Telemetry, logging, exporter, and provider lifecycle errors.
+    #[error(transparent)]
+    Observability(#[from] ObservabilityError),
+
+    // ============================================================================
     // Storage Errors
     // ============================================================================
     /// Storage read failed
@@ -449,6 +457,7 @@ impl RocketMQError {
             Self::ConsumerNotAvailable => ErrorKind::ConsumerNotAvailable,
             Self::Tools(error) => error.kind(),
             Self::Filter(_) => ErrorKind::Filter,
+            Self::Observability(_) => ErrorKind::Internal,
             Self::StorageReadFailed { .. } => ErrorKind::StorageReadFailed,
             Self::StorageWriteFailed { .. } => ErrorKind::StorageWriteFailed,
             Self::StorageCorrupted { .. } => ErrorKind::StorageCorrupted,
@@ -583,6 +592,7 @@ impl RocketMQError {
                 .with_field("actual", actual.as_str()),
             Self::Tools(error) => error.context(),
             Self::Filter(error) => ErrorContext::new().with_field("filter_error", error.to_string()),
+            Self::Observability(error) => redacted_context("observability_error", error.to_string()),
             Self::StorageReadFailed { path, reason } | Self::StorageWriteFailed { path, reason } => ErrorContext::new()
                 .with_sensitive("path", Sensitive::new(path.clone()))
                 .with_sensitive("reason", Sensitive::new(reason.clone())),

--- a/rocketmq-error/tests/error_context_redaction.rs
+++ b/rocketmq-error/tests/error_context_redaction.rs
@@ -1,4 +1,6 @@
 use rocketmq_error::ErrorContext;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::ObservabilityError;
 use rocketmq_error::RedactionKind;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::Sensitive;
@@ -65,4 +67,33 @@ fn boundary_view_exposes_public_message_and_redacted_context() {
     assert_eq!(view.context().to_string(), "internal_error=<redacted>");
     assert!(!view.context().to_string().contains("plain-text"));
     assert!(!view.is_retryable());
+}
+
+#[test]
+fn observability_error_context_redacts_sensitive_details() {
+    let init = RocketMQError::from(ObservabilityError::metrics_init(
+        "endpoint=http://127.0.0.1:4317?token=secret",
+    ));
+
+    assert_eq!(init.kind(), ErrorKind::ObservabilityMetricsInitFailed);
+    let context = init.context();
+    assert_eq!(context.fields()[0].key, "reason");
+    assert_eq!(context.fields()[0].redaction, RedactionKind::Sensitive);
+    assert_eq!(context.to_string(), "reason=<redacted>");
+    assert!(!context.to_string().contains("secret"));
+
+    let filter = RocketMQError::from(ObservabilityError::invalid_log_filter(
+        "rocketmq_store=trace",
+        "invalid directive",
+    ));
+    let context = filter.context();
+
+    assert_eq!(filter.kind(), ErrorKind::ObservabilityLogFilterInvalid);
+    assert_eq!(context.len(), 2);
+    assert_eq!(context.fields()[0].key, "filter");
+    assert_eq!(context.fields()[0].redaction, RedactionKind::Sensitive);
+    assert_eq!(context.fields()[1].key, "error");
+    assert_eq!(context.fields()[1].redaction, RedactionKind::Sensitive);
+    assert!(!context.to_string().contains("rocketmq_store=trace"));
+    assert!(!context.to_string().contains("invalid directive"));
 }

--- a/rocketmq-error/tests/error_kind_contract.rs
+++ b/rocketmq-error/tests/error_kind_contract.rs
@@ -58,6 +58,28 @@ fn error_kind_exposes_code_scope_and_category() {
 }
 
 #[test]
+fn observability_kinds_have_observability_scope_and_category() {
+    let cases = [
+        ErrorKind::ObservabilityFeatureDisabled,
+        ErrorKind::ObservabilityConfigInvalid,
+        ErrorKind::ObservabilityMetricsInitFailed,
+        ErrorKind::ObservabilityTracesInitFailed,
+        ErrorKind::ObservabilityLogsInitFailed,
+        ErrorKind::ObservabilityLoggingInitFailed,
+        ErrorKind::ObservabilityLogFilterInvalid,
+        ErrorKind::ObservabilitySubscriberInstallFailed,
+        ErrorKind::ObservabilityMetricsShutdownFailed,
+        ErrorKind::ObservabilityTracesShutdownFailed,
+        ErrorKind::ObservabilityLogsShutdownFailed,
+    ];
+
+    for kind in cases {
+        assert_eq!(kind.scope(), ErrorScope::Observability);
+        assert_eq!(kind.category(), ErrorCategory::Observability);
+    }
+}
+
+#[test]
 fn all_error_kinds_have_unique_codes() {
     let mut codes = HashSet::new();
 

--- a/rocketmq-error/tests/error_policy_specs.rs
+++ b/rocketmq-error/tests/error_policy_specs.rs
@@ -32,6 +32,18 @@ fn selected_error_kinds_have_observability_policy() {
 }
 
 #[test]
+fn observability_errors_have_expected_policy() {
+    assert_eq!(
+        ErrorKind::ObservabilityConfigInvalid.spec().recovery.retry,
+        RetryClass::Never
+    );
+    assert_eq!(
+        ErrorKind::ObservabilityMetricsInitFailed.spec().observe.severity,
+        ErrorSeverity::Error
+    );
+}
+
+#[test]
 fn every_error_spec_has_low_cardinality_observability_labels() {
     for spec in ALL_ERROR_SPECS {
         assert_eq!(spec.observe.metric_label, spec.code.as_str());

--- a/rocketmq-error/tests/error_protocol_specs.rs
+++ b/rocketmq-error/tests/error_protocol_specs.rs
@@ -29,6 +29,23 @@ fn selected_error_kinds_have_protocol_primitives() {
 }
 
 #[test]
+fn observability_errors_have_conservative_boundary_primitives() {
+    let config = ErrorKind::ObservabilityConfigInvalid.spec();
+    assert_eq!(config.remoting.code, RemotingResponseCode::InvalidParameter);
+    assert_eq!(config.grpc.payload, GrpcPayloadCode::BadRequest);
+    assert_eq!(config.grpc.status, GrpcStatusCode::InvalidArgument);
+    assert_eq!(config.http.status, HttpStatusCode::BAD_REQUEST);
+    assert_eq!(config.cli.exit_code, CliExitCode::CONFIG);
+
+    let init = ErrorKind::ObservabilityMetricsInitFailed.spec();
+    assert_eq!(init.remoting.code, RemotingResponseCode::SystemError);
+    assert_eq!(init.grpc.payload, GrpcPayloadCode::InternalError);
+    assert_eq!(init.grpc.status, GrpcStatusCode::Internal);
+    assert_eq!(init.http.status, HttpStatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(init.cli.exit_code, CliExitCode::SOFTWARE);
+}
+
+#[test]
 fn protocol_primitives_are_complete_for_all_specs() {
     for spec in ALL_ERROR_SPECS {
         assert_ne!(spec.remoting.code.as_i32(), 0, "{:?}", spec.kind);

--- a/rocketmq-error/tests/error_spec_registry.rs
+++ b/rocketmq-error/tests/error_spec_registry.rs
@@ -48,6 +48,22 @@ fn rocketmq_error_reports_spec() {
 }
 
 #[test]
+fn observability_error_specs_are_registered() {
+    assert_eq!(
+        ErrorKind::ObservabilityFeatureDisabled.code().as_str(),
+        "OBSERVABILITY_FEATURE_DISABLED"
+    );
+    assert_eq!(
+        ErrorKind::from_code("OBSERVABILITY_SUBSCRIBER_INSTALL_FAILED"),
+        Some(ErrorKind::ObservabilitySubscriberInstallFailed)
+    );
+    assert!(ErrorKind::ObservabilityConfigInvalid
+        .spec()
+        .public_message
+        .contains("Observability"));
+}
+
+#[test]
 fn sensitive_error_specs_require_redaction() {
     assert_eq!(
         ErrorKind::Authentication.spec().redact,

--- a/rocketmq-error/tests/observability_error_contract.rs
+++ b/rocketmq-error/tests/observability_error_contract.rs
@@ -1,0 +1,33 @@
+use rocketmq_error::ObservabilityError;
+use rocketmq_error::RocketMQError;
+
+#[test]
+fn observability_error_preserves_existing_variants() {
+    let error = ObservabilityError::invalid_log_filter("rocketmq_store==debug", "invalid directive");
+
+    assert!(matches!(
+        error,
+        ObservabilityError::InvalidLogFilter { filter, error }
+            if filter == "rocketmq_store==debug" && error == "invalid directive"
+    ));
+}
+
+#[test]
+fn observability_subscriber_install_failure_uses_primitive_status() {
+    let error = ObservabilityError::subscriber_install_failed(true, false);
+
+    assert!(matches!(
+        error,
+        ObservabilityError::SubscriberInstallFailed {
+            attempted: true,
+            installed: false
+        }
+    ));
+}
+
+#[test]
+fn observability_error_converts_to_rocketmq_error() {
+    let error = RocketMQError::from(ObservabilityError::metrics_init("exporter failed"));
+
+    assert!(matches!(error, RocketMQError::Observability(_)));
+}

--- a/rocketmq-observability/README-zh_cn.md
+++ b/rocketmq-observability/README-zh_cn.md
@@ -101,6 +101,7 @@ fn main() -> Result<(), rocketmq_observability::ObservabilityError> {
 | `stdout` | 兼容性 feature。运行时日志输出由 `MetricsExporter::Log`、`TraceExporter::Log` 或 `LogsExporter::Log` 选择。 |
 
 如果运行时配置请求了未启用 feature 的 exporter，`init_observability` 会返回 `ObservabilityError::FeatureDisabled`。
+`ObservabilityError` 由 `rocketmq-error` 托管，并由 `rocketmq-observability` 重新导出以保持兼容。
 
 ## 模块职责
 

--- a/rocketmq-observability/README.md
+++ b/rocketmq-observability/README.md
@@ -124,6 +124,8 @@ The default feature set is empty.
 
 If runtime config requests an exporter whose feature is not enabled,
 `init_observability` returns `ObservabilityError::FeatureDisabled`.
+`ObservabilityError` is owned by `rocketmq-error` and re-exported by
+`rocketmq-observability` for compatibility.
 
 ## Module Map
 

--- a/rocketmq-observability/src/init.rs
+++ b/rocketmq-observability/src/init.rs
@@ -262,7 +262,10 @@ pub(crate) fn enforce_subscriber_install_policy(
     }
 
     match config.subscriber_install_policy {
-        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(status)),
+        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(
+            status.attempted,
+            status.installed,
+        )),
         SubscriberInstallPolicy::BestEffort => {
             if status.attempted {
                 tracing::warn!(

--- a/rocketmq-observability/src/logging.rs
+++ b/rocketmq-observability/src/logging.rs
@@ -201,7 +201,10 @@ fn enforce_bootstrap_subscriber_policy(
     }
 
     match config.observability.subscriber_install_policy {
-        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(status)),
+        SubscriberInstallPolicy::Required => Err(ObservabilityError::subscriber_install_failed(
+            status.attempted,
+            status.installed,
+        )),
         SubscriberInstallPolicy::BestEffort => {
             tracing::warn!(
                 target: "rocketmq_observability",

--- a/rocketmq-observability/tests/error_compat.rs
+++ b/rocketmq-observability/tests/error_compat.rs
@@ -12,4 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use rocketmq_error::ObservabilityError;
+use rocketmq_error::RocketMQError;
+
+#[test]
+fn observability_error_public_path_is_preserved() {
+    let error = rocketmq_observability::ObservabilityError::invalid_config("bad config");
+
+    assert!(matches!(
+        error,
+        rocketmq_observability::ObservabilityError::InvalidConfig(message)
+            if message == "bad config"
+    ));
+}
+
+#[test]
+fn observability_error_public_path_converts_to_rocketmq_error() {
+    let error = RocketMQError::from(rocketmq_observability::ObservabilityError::invalid_config("bad config"));
+
+    assert!(matches!(error, RocketMQError::Observability(_)));
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8124

### Brief Description

Moves `ObservabilityError` ownership into `rocketmq-error`, registers observability failures in the unified error kernel, and keeps `rocketmq-observability` re-export compatibility. The migration preserves observability-specific `Result<T, ObservabilityError>` APIs while enabling conversion into `RocketMQError`.

### How Did You Test This Change?

All commands below passed.

- `cargo fmt --all`
- `cargo test -p rocketmq-error`
- `cargo test -p rocketmq-observability`
- `cargo test -p rocketmq-observability --features observability`
- `cargo test -p rocketmq-observability --features prometheus`
- `cargo test -p rocketmq-observability --features otel-logs`
- `cargo test -p rocketmq-observability --features otlp-metrics,otlp-traces,otlp-logs`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cd rocketmq-example && cargo fmt --all`
- `cd rocketmq-example && cargo clippy --all-targets -- -D warnings`
- `cd rocketmq-dashboard/rocketmq-dashboard-web/backend && cargo fmt --all`
- `cd rocketmq-dashboard/rocketmq-dashboard-web/backend && cargo clippy --all-targets --all-features -- -D warnings`
- `cd rocketmq-dashboard/rocketmq-dashboard-web/backend && cargo build --all-targets --all-features`
- `cd rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri && cargo fmt --all`
- `cd rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- `cargo tree -p rocketmq-error`
- `git diff --check main...HEAD`

Note: Several Rust commands emitted Windows linker stdout warnings, but all listed commands exited successfully. The `rocketmq-error` dependency tree contains only `anyhow` and `thiserror` plus their proc-macro dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new observability error family with clearer, typed failures for config issues, initialization/shutdown problems, log filtering, and subscriber installation.
  * Observability errors are now available through the shared error API and are compatible across related packages.

* **Bug Fixes**
  * Improved how observability-related errors are classified, reported, and redacted so sensitive details are less likely to appear in messages.
  * Updated boundary behavior so these errors map more consistently to user-facing responses and retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->