### PR TITLE
[ISSUE #8127]🚀Add rocketmq-mcp crate skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,10 +267,13 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -278,10 +281,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -300,6 +308,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1266,6 +1275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -3143,6 +3171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3442,16 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4023,6 +4067,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "rocketmq-admin-cli"
 version = "1.0.0"
 dependencies = [
@@ -4316,6 +4404,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "rocketmq-mcp"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "config",
+ "insta",
+ "mockall",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "rmcp",
+ "rocketmq-admin-core",
+ "rocketmq-auth",
+ "rocketmq-client-rust",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-observability",
+ "rocketmq-remoting",
+ "rocketmq-runtime",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "validator",
 ]
 
 [[package]]
@@ -4778,10 +4901,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4868,6 +5005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4891,12 +5039,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5034,6 +5205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5255,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5711,6 +5901,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -5732,6 +5923,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5963,6 +6155,36 @@ dependencies = [
  "js-sys",
  "rand 0.10.2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6709,6 +6931,12 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli",
   "rocketmq-tools/rocketmq-admin/rocketmq-admin-core",
   "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui",
+  "rocketmq-tools/rocketmq-mcp",
   "rocketmq-tools/rocketmq-store-inspect",
   "rocketmq-dashboard/rocketmq-dashboard-common",
 ]

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -1,0 +1,76 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+[package]
+name                   = "rocketmq-mcp"
+version.workspace      = true
+authors.workspace      = true
+edition.workspace      = true
+homepage.workspace     = true
+repository.workspace   = true
+license.workspace      = true
+keywords               = ["rocketmq", "mcp", "ai", "sre", "agent"]
+categories             = ["development-tools", "command-line-utilities"]
+readme                 = "README.md"
+description            = "Model Context Protocol server for RocketMQ-Rust AI SRE and diagnostics"
+rust-version.workspace = true
+
+[features]
+default         = ["read-only", "diagnose", "stdio"]
+read-only       = []
+diagnose        = ["read-only"]
+stdio           = ["rmcp/transport-io"]
+observability   = ["dep:rocketmq-observability"]
+auth            = ["dep:rocketmq-auth"]
+streamable-http = ["rmcp/transport-streamable-http-server", "dep:axum", "dep:tower-http", "auth"]
+dangerous-tools = ["auth"]
+
+[dependencies]
+rocketmq-admin-core   = { version = "1.0.0", path = "../rocketmq-admin/rocketmq-admin-core" }
+rocketmq-auth         = { workspace = true, optional = true }
+rocketmq-client-rust  = { workspace = true }
+rocketmq-common       = { workspace = true }
+rocketmq-error        = { workspace = true }
+rocketmq-observability = { workspace = true, optional = true }
+rocketmq-remoting     = { workspace = true }
+rocketmq-runtime      = { workspace = true }
+
+anyhow             = { workspace = true }
+axum               = { version = "0.8", optional = true }
+clap               = { version = "4.6.1", features = ["derive"] }
+config             = { workspace = true }
+once_cell          = "1.21"
+regex              = "1.12.4"
+rmcp               = { version = "2.2", features = ["server", "macros", "schemars"] }
+schemars           = "1.1"
+serde              = { workspace = true }
+serde_json         = { workspace = true }
+serde_yaml         = { workspace = true }
+thiserror          = { workspace = true }
+tokio              = { workspace = true }
+tokio-util         = { workspace = true }
+tower-http         = { version = "0.6", features = ["cors", "trace"], optional = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+validator          = { version = "0.20", features = ["derive"] }
+
+[dev-dependencies]
+insta             = { version = "1.43", features = ["json"] }
+mockall           = { workspace = true }
+pretty_assertions = "1.4"
+
+[[bin]]
+name = "rocketmq-mcp"
+path = "src/main.rs"

--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -1,0 +1,17 @@
+# RocketMQ MCP
+
+`rocketmq-mcp` is the Model Context Protocol server for RocketMQ-Rust AI SRE and diagnostics workflows.
+
+The initial crate only defines the package boundary, feature flags, configuration examples, and binary entry point. Later staged changes add stdio transport, read-only tools, resources, prompts, guard logic, and optional HTTP transport.
+
+## Scope
+
+- Default mode is read-only diagnostics over stdio.
+- Change tools are disabled unless both compile-time features and runtime configuration allow them.
+- The server runs as an independent tool process and does not enter the broker, namesrv, or store runtime path.
+
+## Build
+
+```bash
+cargo check -p rocketmq-mcp
+```

--- a/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
@@ -1,0 +1,38 @@
+[server]
+name = "rocketmq-mcp"
+version = "1.0.0"
+transport = "stdio"
+log_level = "info"
+
+[server.stdio]
+log_to_stderr = true
+
+[server.http]
+bind = "127.0.0.1:8089"
+endpoint = "/mcp"
+validate_origin = true
+allowed_origins = ["http://127.0.0.1", "http://localhost"]
+require_auth = true
+
+[[clusters]]
+name = "local-dev"
+namesrv_addr = "127.0.0.1:9876"
+default = true
+
+[security]
+profile = "read_only"
+allow_dangerous_tools = false
+require_confirmation = true
+sanitize_output = true
+rate_limit_per_minute = 60
+
+[audit]
+enabled = true
+sink = "file"
+path = "./logs/rocketmq-mcp-audit.log"
+
+[cache]
+cluster_overview_ttl_ms = 3000
+topic_list_ttl_ms = 5000
+broker_metrics_ttl_ms = 2000
+consumer_lag_ttl_ms = 1000

--- a/rocketmq-tools/rocketmq-mcp/conf/permissions.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/permissions.example.toml
@@ -1,0 +1,23 @@
+[roles.read_only]
+allow_tools = [
+  "mq_cluster_overview",
+  "mq_list_topics",
+  "mq_describe_topic",
+  "mq_query_topic_route",
+  "mq_list_consumer_groups",
+  "mq_query_consumer_lag",
+  "mq_describe_broker",
+]
+deny_tools = ["*"]
+
+[roles.diagnose]
+include = ["read_only"]
+allow_tools = [
+  "mq_diagnose_consumer_lag",
+]
+
+[roles.operator]
+include = ["diagnose"]
+allow_tools = []
+require_confirmation = true
+require_dry_run_first = true

--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::Args;
+use crate::config::McpConfig;
+
+#[derive(Debug, Clone)]
+pub struct McpApp {
+    config: McpConfig,
+}
+
+impl McpApp {
+    pub async fn bootstrap(args: Args) -> anyhow::Result<Self> {
+        let config = McpConfig::load(&args.config)?;
+        Ok(Self { config })
+    }
+
+    pub fn config(&self) -> &McpConfig {
+        &self.config
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/config.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/config.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use clap::Parser;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Parser)]
+pub struct Args {
+    #[arg(long, default_value = "rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml")]
+    pub config: String,
+
+    #[arg(long, default_value = "stdio")]
+    pub transport: String,
+
+    #[arg(long)]
+    pub bind: Option<String>,
+
+    #[arg(long)]
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpConfig {
+    pub server: ServerConfig,
+    pub clusters: Vec<ClusterConfig>,
+    pub security: SecurityConfig,
+    pub audit: AuditConfig,
+    pub cache: CacheConfig,
+}
+
+impl McpConfig {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let config = config::Config::builder()
+            .add_source(config::File::from(path.as_ref()))
+            .build()?;
+        Ok(config.try_deserialize()?)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    pub name: String,
+    pub version: String,
+    pub transport: String,
+    pub log_level: String,
+    pub stdio: StdioConfig,
+    pub http: HttpConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StdioConfig {
+    pub log_to_stderr: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpConfig {
+    pub bind: String,
+    pub endpoint: String,
+    pub validate_origin: bool,
+    pub allowed_origins: Vec<String>,
+    pub require_auth: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClusterConfig {
+    pub name: String,
+    pub namesrv_addr: String,
+    pub default: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SecurityConfig {
+    pub profile: String,
+    pub allow_dangerous_tools: bool,
+    pub require_confirmation: bool,
+    pub sanitize_output: bool,
+    pub rate_limit_per_minute: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuditConfig {
+    pub enabled: bool,
+    pub sink: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheConfig {
+    pub cluster_overview_ttl_ms: u64,
+    pub topic_list_ttl_ms: u64,
+    pub broker_metrics_ttl_ms: u64,
+    pub consumer_lag_ttl_ms: u64,
+}

--- a/rocketmq-tools/rocketmq-mcp/src/error.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/error.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    #[error("unsupported transport: {0}")]
+    UnsupportedTransport(String),
+}

--- a/rocketmq-tools/rocketmq-mcp/src/lib.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Model Context Protocol server for RocketMQ-Rust diagnostics.
+
+pub mod app;
+pub mod config;
+pub mod error;

--- a/rocketmq-tools/rocketmq-mcp/src/main.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/main.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Parser;
+use rocketmq_mcp::app::McpApp;
+use rocketmq_mcp::config::Args;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let app = McpApp::bootstrap(args).await?;
+
+    eprintln!(
+        "{} skeleton initialized with {} cluster(s)",
+        app.config().server.name,
+        app.config().clusters.len()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8127

### Brief Description

Adds the initial `rocketmq-mcp` workspace crate under `rocketmq-tools/rocketmq-mcp` with the package manifest, feature gates, README, example configuration files, and minimal binary/library skeleton. The new crate follows the workspace edition and keeps MCP transport and operational tools for later staged pull requests.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo check -p rocketmq-mcp` passed.
- `cargo test -p rocketmq-mcp` passed.
- `.\scripts\check-agents-routing.ps1` passed.
- `git diff --check` passed with only LF/CRLF conversion warnings from the local Windows checkout.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new RocketMQ MCP server crate to the workspace.
  * Introduced command-line startup, configuration loading, and error handling for the new server.
  * Added example configuration and permission files for stdio and HTTP usage, with read-only and diagnostic modes.

* **Documentation**
  * Added a README with setup guidance, default behavior, and build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->