### PR TITLE
[ISSUE #8131]🚀Add rocketmq-mcp stdio server bootstrap

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -22,10 +22,14 @@ pub struct McpApp {
 }
 
 impl McpApp {
+    pub fn new(config: McpConfig) -> Self {
+        Self { config }
+    }
+
     pub async fn bootstrap(args: Args) -> anyhow::Result<Self> {
         let config = McpConfig::load_with_overrides(&args)?;
         init_tracing(&config)?;
-        Ok(Self { config })
+        Ok(Self::new(config))
     }
 
     pub fn config(&self) -> &McpConfig {

--- a/rocketmq-tools/rocketmq-mcp/src/main.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/main.rs
@@ -15,6 +15,8 @@
 use clap::Parser;
 use rocketmq_mcp::app::McpApp;
 use rocketmq_mcp::config::Args;
+use rocketmq_mcp::config::TransportKind;
+use rocketmq_mcp::transport;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -28,6 +30,11 @@ async fn main() -> anyhow::Result<()> {
         "{} startup initialized",
         app.config().server.name,
     );
+
+    match app.transport() {
+        TransportKind::Stdio => transport::stdio::serve(app).await?,
+        TransportKind::StreamableHttp => anyhow::bail!("streamable-http transport is not implemented yet"),
+    }
 
     Ok(())
 }

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/mod.rs
@@ -12,10 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod transport;
+pub mod server;

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::Implementation;
+use rmcp::model::ServerCapabilities;
+use rmcp::model::ServerInfo;
+use rmcp::ServerHandler;
+
+use crate::app::McpApp;
+
+#[derive(Debug, Clone)]
+pub struct RocketmqMcpServer {
+    app: McpApp,
+}
+
+impl RocketmqMcpServer {
+    pub fn new(app: McpApp) -> Self {
+        Self { app }
+    }
+
+    pub fn app(&self) -> &McpApp {
+        &self.app
+    }
+}
+
+impl ServerHandler for RocketmqMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .enable_prompts()
+                .build(),
+        )
+        .with_server_info(Implementation::new(
+            self.app.config().server.name.clone(),
+            self.app.config().server.version.clone(),
+        ))
+        .with_instructions("RocketMQ-Rust MCP server for read-only context, diagnostics, and SRE runbooks.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::ServerHandler;
+
+    use super::*;
+    use crate::app::McpApp;
+    use crate::config::McpConfig;
+
+    #[test]
+    fn server_info_declares_mvp_capabilities() {
+        let app = McpApp::new(McpConfig::load(example_config_path()).unwrap());
+        let server = RocketmqMcpServer::new(app);
+
+        let info = server.get_info();
+
+        assert_eq!(info.server_info.name, "rocketmq-mcp");
+        assert_eq!(info.server_info.version, "1.0.0");
+        assert!(info.capabilities.tools.is_some());
+        assert!(info.capabilities.resources.is_some());
+        assert!(info.capabilities.prompts.is_some());
+    }
+
+    fn example_config_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("conf")
+            .join("mcp.example.toml")
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/transport/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/mod.rs
@@ -12,10 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod transport;
+pub mod stdio;

--- a/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
+use rmcp::ServiceExt;
 
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod transport;
+use crate::app::McpApp;
+use crate::protocol::server::RocketmqMcpServer;
+
+pub async fn serve(app: McpApp) -> anyhow::Result<()> {
+    let server = RocketmqMcpServer::new(app);
+    let service = server.serve(rmcp::transport::stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8131

### Brief Description

Adds the minimal MCP server bootstrap for `rocketmq-mcp`. The new server declares tools, resources, and prompts capabilities through `rmcp::ServerHandler`, starts over stdio transport, and keeps list handlers empty for the upcoming resource, tool, and prompt phases.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-mcp protocol` passed.
- Direct stdio JSON-RPC smoke passed for `initialize`, `tools/list`, `resources/list`, and `prompts/list`.
- `cargo check -p rocketmq-mcp` passed.
- `cargo test -p rocketmq-mcp` passed.
- `git diff --check` passed with only LF/CRLF conversion warnings from the local Windows checkout.
- `cargo clippy --all-targets -p rocketmq-mcp -- -D warnings` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for starting the MCP app over standard input/output.
  * Introduced server-side metadata and capability reporting for tools, resources, and prompts.
  * Expanded the crate’s public API to include protocol and transport modules.

* **Bug Fixes**
  * Startup now clearly handles unsupported transport modes by returning an error instead of continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->