### PR TITLE
[ISSUE #8133]🚀Add rocketmq-mcp MVP resources

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -13,11 +13,20 @@
 // limitations under the License.
 
 use rmcp::model::Implementation;
+use rmcp::model::ListResourceTemplatesResult;
+use rmcp::model::ListResourcesResult;
+use rmcp::model::PaginatedRequestParams;
+use rmcp::model::ReadResourceRequestParams;
+use rmcp::model::ReadResourceResult;
 use rmcp::model::ServerCapabilities;
 use rmcp::model::ServerInfo;
+use rmcp::service::RequestContext;
+use rmcp::ErrorData;
+use rmcp::RoleServer;
 use rmcp::ServerHandler;
 
 use crate::app::McpApp;
+use crate::resources;
 
 #[derive(Debug, Clone)]
 pub struct RocketmqMcpServer {
@@ -48,6 +57,30 @@ impl ServerHandler for RocketmqMcpServer {
             self.app.config().server.version.clone(),
         ))
         .with_instructions("RocketMQ-Rust MCP server for read-only context, diagnostics, and SRE runbooks.")
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        Ok(resources::registry::list_resources())
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        Ok(resources::registry::list_resource_templates())
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        resources::reader::read_resource(self.app.config(), &request.uri)
     }
 }
 

--- a/rocketmq-tools/rocketmq-mcp/src/resources/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/mod.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
+//! Static MCP resources exposed by the RocketMQ MCP server.
 
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod resources;
-pub mod transport;
+pub mod reader;
+pub mod registry;
+pub mod uri;

--- a/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
@@ -1,0 +1,148 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::ReadResourceResult;
+use rmcp::model::ResourceContents;
+use rmcp::ErrorData;
+use serde_json::json;
+use serde_json::Map;
+use serde_json::Value;
+
+use crate::config::McpConfig;
+use crate::resources::uri::RocketmqResourceUri;
+use crate::resources::uri::JSON_MIME_TYPE;
+
+pub fn read_resource(config: &McpConfig, uri: &str) -> Result<ReadResourceResult, ErrorData> {
+    let resource_uri = RocketmqResourceUri::parse(uri)
+        .ok_or_else(|| ErrorData::resource_not_found(format!("resource not found: {uri}"), None))?;
+    let payload = resource_payload(config, resource_uri);
+    let text = serde_json::to_string_pretty(&payload)
+        .map_err(|err| ErrorData::internal_error(format!("failed to serialize resource {uri}: {err}"), None))?;
+
+    Ok(ReadResourceResult::new(vec![ResourceContents::text(
+        text,
+        resource_uri.as_str(),
+    )
+    .with_mime_type(JSON_MIME_TYPE)]))
+}
+
+fn resource_payload(config: &McpConfig, uri: RocketmqResourceUri) -> Value {
+    match uri {
+        RocketmqResourceUri::ClusterOverview => cluster_overview_payload(config),
+        RocketmqResourceUri::Topics => inventory_payload(uri, "topics"),
+        RocketmqResourceUri::Brokers => inventory_payload(uri, "brokers"),
+        RocketmqResourceUri::ConsumerGroups => inventory_payload(uri, "consumer_groups"),
+    }
+}
+
+fn cluster_overview_payload(config: &McpConfig) -> Value {
+    let clusters = config
+        .clusters
+        .iter()
+        .map(|cluster| {
+            json!({
+                "name": cluster.name,
+                "namesrv_addr": cluster.namesrv_addr,
+                "default": cluster.default.unwrap_or(false),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "schema_version": "mvp.v1",
+        "resource": RocketmqResourceUri::ClusterOverview.as_str(),
+        "source": "configuration",
+        "cluster_count": clusters.len(),
+        "clusters": clusters,
+        "cache_ttl_ms": config.cache.cluster_overview_ttl_ms,
+    })
+}
+
+fn inventory_payload(uri: RocketmqResourceUri, field: &str) -> Value {
+    let mut payload = Map::new();
+    payload.insert("schema_version".to_string(), json!("mvp.v1"));
+    payload.insert("resource".to_string(), json!(uri.as_str()));
+    payload.insert("source".to_string(), json!("mvp-static"));
+    payload.insert(field.to_string(), json!([]));
+    Value::Object(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::ResourceContents;
+
+    use super::*;
+    use crate::config::McpConfig;
+
+    #[test]
+    fn read_cluster_overview_uses_configured_clusters() {
+        let result = read_resource(
+            &McpConfig::load(example_config_path()).unwrap(),
+            "rocketmq://cluster/overview",
+        )
+        .unwrap();
+        let payload = read_json_payload(&result);
+
+        assert_eq!(payload["resource"], "rocketmq://cluster/overview");
+        assert_eq!(payload["source"], "configuration");
+        assert_eq!(payload["cluster_count"], 1);
+        assert_eq!(payload["clusters"][0]["name"], "local-dev");
+        assert_eq!(payload["clusters"][0]["namesrv_addr"], "127.0.0.1:9876");
+        assert_eq!(payload["clusters"][0]["default"], true);
+        assert_eq!(payload["cache_ttl_ms"], 3000);
+    }
+
+    #[test]
+    fn read_inventory_resource_returns_stable_json_shape() {
+        let result = read_resource(
+            &McpConfig::load(example_config_path()).unwrap(),
+            "rocketmq://consumer-groups",
+        )
+        .unwrap();
+        let payload = read_json_payload(&result);
+
+        assert_eq!(payload["schema_version"], "mvp.v1");
+        assert_eq!(payload["resource"], "rocketmq://consumer-groups");
+        assert_eq!(payload["source"], "mvp-static");
+        assert_eq!(payload["consumer_groups"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn read_unknown_resource_returns_protocol_not_found() {
+        let err = read_resource(&McpConfig::load(example_config_path()).unwrap(), "rocketmq://unknown").unwrap_err();
+
+        assert_eq!(err.code, rmcp::model::ErrorCode::RESOURCE_NOT_FOUND);
+        assert!(err.message.contains("resource not found"));
+    }
+
+    fn read_json_payload(result: &ReadResourceResult) -> Value {
+        assert_eq!(result.contents.len(), 1);
+        match &result.contents[0] {
+            ResourceContents::TextResourceContents { mime_type, text, .. } => {
+                assert_eq!(mime_type.as_deref(), Some(JSON_MIME_TYPE));
+                serde_json::from_str(text).unwrap()
+            }
+            ResourceContents::BlobResourceContents { .. } => {
+                panic!("resource should be returned as text")
+            }
+            _ => panic!("unsupported resource content variant"),
+        }
+    }
+
+    fn example_config_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("conf")
+            .join("mcp.example.toml")
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::ListResourceTemplatesResult;
+use rmcp::model::ListResourcesResult;
+use rmcp::model::Resource;
+
+use crate::resources::uri::RocketmqResourceUri;
+use crate::resources::uri::JSON_MIME_TYPE;
+
+pub fn list_resources() -> ListResourcesResult {
+    ListResourcesResult::with_all_items(RocketmqResourceUri::ALL.into_iter().map(resource_descriptor).collect())
+}
+
+pub fn list_resource_templates() -> ListResourceTemplatesResult {
+    ListResourceTemplatesResult::default()
+}
+
+fn resource_descriptor(uri: RocketmqResourceUri) -> Resource {
+    Resource::new(uri.as_str(), uri.name())
+        .with_title(uri.title())
+        .with_description(uri.description())
+        .with_mime_type(JSON_MIME_TYPE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mvp_registry_lists_static_resources() {
+        let result = list_resources();
+        let uris = result
+            .resources
+            .iter()
+            .map(|resource| resource.uri.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            uris,
+            [
+                "rocketmq://cluster/overview",
+                "rocketmq://topics",
+                "rocketmq://brokers",
+                "rocketmq://consumer-groups",
+            ]
+        );
+        assert!(result.next_cursor.is_none());
+        assert!(result.resources.iter().all(|resource| {
+            resource.mime_type.as_deref() == Some(JSON_MIME_TYPE)
+                && resource.title.is_some()
+                && resource.description.is_some()
+        }));
+    }
+
+    #[test]
+    fn mvp_registry_has_no_resource_templates() {
+        let result = list_resource_templates();
+
+        assert!(result.resource_templates.is_empty());
+        assert!(result.next_cursor.is_none());
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/resources/uri.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/uri.rs
@@ -1,0 +1,115 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const JSON_MIME_TYPE: &str = "application/json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RocketmqResourceUri {
+    ClusterOverview,
+    Topics,
+    Brokers,
+    ConsumerGroups,
+}
+
+impl RocketmqResourceUri {
+    pub const ALL: [Self; 4] = [Self::ClusterOverview, Self::Topics, Self::Brokers, Self::ConsumerGroups];
+
+    pub fn parse(uri: &str) -> Option<Self> {
+        match uri {
+            "rocketmq://cluster/overview" => Some(Self::ClusterOverview),
+            "rocketmq://topics" => Some(Self::Topics),
+            "rocketmq://brokers" => Some(Self::Brokers),
+            "rocketmq://consumer-groups" => Some(Self::ConsumerGroups),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ClusterOverview => "rocketmq://cluster/overview",
+            Self::Topics => "rocketmq://topics",
+            Self::Brokers => "rocketmq://brokers",
+            Self::ConsumerGroups => "rocketmq://consumer-groups",
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::ClusterOverview => "cluster_overview",
+            Self::Topics => "topics",
+            Self::Brokers => "brokers",
+            Self::ConsumerGroups => "consumer_groups",
+        }
+    }
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::ClusterOverview => "RocketMQ cluster overview",
+            Self::Topics => "RocketMQ topics",
+            Self::Brokers => "RocketMQ brokers",
+            Self::ConsumerGroups => "RocketMQ consumer groups",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::ClusterOverview => "Configured RocketMQ clusters and nameserver endpoints.",
+            Self::Topics => "RocketMQ topic inventory resource.",
+            Self::Brokers => "RocketMQ broker inventory resource.",
+            Self::ConsumerGroups => "RocketMQ consumer group inventory resource.",
+        }
+    }
+}
+
+impl TryFrom<&str> for RocketmqResourceUri {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value).ok_or(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_resources_have_stable_uris() {
+        let uris = RocketmqResourceUri::ALL.map(RocketmqResourceUri::as_str);
+
+        assert_eq!(
+            uris,
+            [
+                "rocketmq://cluster/overview",
+                "rocketmq://topics",
+                "rocketmq://brokers",
+                "rocketmq://consumer-groups",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_accepts_only_mvp_resource_uris() {
+        assert_eq!(
+            RocketmqResourceUri::parse("rocketmq://cluster/overview"),
+            Some(RocketmqResourceUri::ClusterOverview)
+        );
+        assert_eq!(
+            RocketmqResourceUri::parse("rocketmq://consumer-groups"),
+            Some(RocketmqResourceUri::ConsumerGroups)
+        );
+        assert_eq!(RocketmqResourceUri::parse("rocketmq://topics/foo"), None);
+        assert_eq!(RocketmqResourceUri::parse("file:///etc/passwd"), None);
+    }
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8133

### Brief Description

Adds the static RocketMQ MCP resource registry and read handler for the MVP resources.
The server now advertises the four resource URIs and returns JSON text content for cluster overview, topics, brokers, and consumer groups.

### How Did You Test This Change?

- cargo fmt --all
- cargo check -p rocketmq-mcp
- cargo test -p rocketmq-mcp resources
- cargo test -p rocketmq-mcp
- cargo clippy --all-targets -p rocketmq-mcp -- -D warnings
- cargo run -p rocketmq-mcp -- --config rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml --transport stdio
- git diff --check
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for browsing RocketMQ resources and resource templates in the MCP server.
  * Added readable resource details for cluster overview, topics, brokers, and consumer groups.
  * Introduced stable resource URIs with consistent names, titles, and descriptions.

* **Bug Fixes**
  * Unknown or unsupported resource requests now return a clear “resource not found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->