### PR TITLE
[ISSUE #8135]🚀Add rocketmq-mcp read-only tools

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs
@@ -1,0 +1,450 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use rocketmq_admin_core::core::broker::BrokerRuntimeStatsQueryRequest;
+use rocketmq_admin_core::core::broker::BrokerService;
+use rocketmq_admin_core::core::cluster::ClusterBaseInfoRow;
+use rocketmq_admin_core::core::cluster::ClusterListQueryRequest;
+use rocketmq_admin_core::core::cluster::ClusterService;
+use rocketmq_admin_core::core::consumer::ConsumerProgressRequest;
+use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
+use rocketmq_admin_core::core::consumer::ConsumerService;
+use rocketmq_admin_core::core::topic::TopicListQueryRequest;
+use rocketmq_admin_core::core::topic::TopicRouteQueryRequest;
+use rocketmq_admin_core::core::topic::TopicService;
+use rocketmq_admin_core::core::RocketMQError;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::config::ClusterConfig;
+use crate::config::McpConfig;
+use crate::tools::broker_tools;
+use crate::tools::cluster_tools;
+use crate::tools::consumer_tools;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools;
+
+pub(crate) trait ReadOnlyAdminAdapter: Clone + Send + Sync + 'static {
+    async fn cluster_overview(
+        &self,
+        args: cluster_tools::ClusterOverviewArgs,
+    ) -> Result<cluster_tools::ClusterOverviewOutput, ToolExecutionError>;
+
+    async fn list_topics(
+        &self,
+        args: topic_tools::ListTopicsArgs,
+    ) -> Result<topic_tools::ListTopicsOutput, ToolExecutionError>;
+
+    async fn describe_topic(
+        &self,
+        args: topic_tools::DescribeTopicArgs,
+    ) -> Result<topic_tools::DescribeTopicOutput, ToolExecutionError>;
+
+    async fn query_topic_route(
+        &self,
+        args: topic_tools::QueryTopicRouteArgs,
+    ) -> Result<topic_tools::QueryTopicRouteOutput, ToolExecutionError>;
+
+    async fn list_consumer_groups(
+        &self,
+        args: consumer_tools::ListConsumerGroupsArgs,
+    ) -> Result<consumer_tools::ListConsumerGroupsOutput, ToolExecutionError>;
+
+    async fn query_consumer_lag(
+        &self,
+        args: consumer_tools::QueryConsumerLagArgs,
+    ) -> Result<consumer_tools::QueryConsumerLagOutput, ToolExecutionError>;
+
+    async fn describe_broker(
+        &self,
+        args: broker_tools::DescribeBrokerArgs,
+    ) -> Result<broker_tools::DescribeBrokerOutput, ToolExecutionError>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AdminCoreAdapter {
+    config: McpConfig,
+}
+
+impl AdminCoreAdapter {
+    pub(crate) fn new(config: McpConfig) -> Self {
+        Self { config }
+    }
+
+    fn resolve_cluster(&self, cluster: Option<&str>) -> Result<ResolvedCluster, ToolExecutionError> {
+        let cluster = cluster.map(str::trim).filter(|cluster| !cluster.is_empty());
+        let config = match cluster {
+            Some(name) => self
+                .config
+                .clusters
+                .iter()
+                .find(|candidate| candidate.name == name)
+                .ok_or_else(|| ToolExecutionError::InvalidArguments(format!("unknown cluster: {name}")))?,
+            None => default_cluster(&self.config.clusters)?,
+        };
+
+        Ok(ResolvedCluster {
+            name: config.name.clone(),
+            namesrv_addr: config.namesrv_addr.clone(),
+        })
+    }
+}
+
+impl ReadOnlyAdminAdapter for AdminCoreAdapter {
+    async fn cluster_overview(
+        &self,
+        args: cluster_tools::ClusterOverviewArgs,
+    ) -> Result<cluster_tools::ClusterOverviewOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(Some(&args.cluster))?;
+        let cluster_result = ClusterService::query_cluster_list_by_request_with_rpc_hook(
+            ClusterListQueryRequest::new(false, Some(cluster.name.clone()))
+                .with_optional_namesrv_addr(Some(cluster.namesrv_addr.clone())),
+            None,
+        )
+        .await
+        .map_err(admin_error)?;
+        let topics = self
+            .list_topics(topic_tools::ListTopicsArgs {
+                cluster: Some(cluster.name.clone()),
+            })
+            .await?;
+        let consumer_groups = self
+            .list_consumer_groups(consumer_tools::ListConsumerGroupsArgs {
+                cluster: Some(cluster.name.clone()),
+            })
+            .await?;
+
+        Ok(cluster_tools::ClusterOverviewOutput {
+            cluster: cluster.name,
+            namesrv_addr: cluster.namesrv_addr,
+            brokers: cluster_result.base_rows.iter().map(map_broker_summary).collect(),
+            topic_count: topics.topic_count,
+            consumer_group_count: consumer_groups.consumer_group_count,
+            generated_at: generated_at(),
+        })
+    }
+
+    async fn list_topics(
+        &self,
+        args: topic_tools::ListTopicsArgs,
+    ) -> Result<topic_tools::ListTopicsOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(args.cluster.as_deref())?;
+        let result = TopicService::query_topic_list(
+            TopicListQueryRequest::new()
+                .with_optional_namesrv_addr(Some(cluster.namesrv_addr.clone()))
+                .with_optional_cluster_name(Some(cluster.name.clone())),
+        )
+        .await
+        .map_err(admin_error)?;
+        let mut topics = result
+            .topics
+            .iter()
+            .map(|item| topic_tools::TopicListEntry {
+                topic: item.topic.to_string(),
+                cluster: item.cluster.as_ref().map(ToString::to_string),
+                consumer_group: item.consumer_group.as_ref().map(ToString::to_string),
+            })
+            .collect::<Vec<_>>();
+        topics.sort_by(|left, right| left.topic.cmp(&right.topic));
+
+        Ok(topic_tools::ListTopicsOutput {
+            cluster: cluster.name,
+            namesrv_addr: cluster.namesrv_addr,
+            topic_count: topics.len(),
+            topics,
+            generated_at: generated_at(),
+        })
+    }
+
+    async fn describe_topic(
+        &self,
+        args: topic_tools::DescribeTopicArgs,
+    ) -> Result<topic_tools::DescribeTopicOutput, ToolExecutionError> {
+        let route = self
+            .query_topic_route(topic_tools::QueryTopicRouteArgs {
+                cluster: args.cluster,
+                topic: args.topic,
+            })
+            .await?;
+        let mut broker_names = route
+            .brokers
+            .iter()
+            .map(|broker| broker.broker_name.clone())
+            .collect::<Vec<_>>();
+        broker_names.sort();
+        broker_names.dedup();
+
+        Ok(topic_tools::DescribeTopicOutput {
+            cluster: route.cluster,
+            namesrv_addr: route.namesrv_addr,
+            topic: route.topic,
+            read_queue_count: route.queues.iter().map(|queue| queue.read_queue_nums).sum(),
+            write_queue_count: route.queues.iter().map(|queue| queue.write_queue_nums).sum(),
+            broker_names,
+            brokers: route.brokers,
+            queues: route.queues,
+            generated_at: route.generated_at,
+        })
+    }
+
+    async fn query_topic_route(
+        &self,
+        args: topic_tools::QueryTopicRouteArgs,
+    ) -> Result<topic_tools::QueryTopicRouteOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(Some(&args.cluster))?;
+        let route = TopicService::query_topic_route(
+            TopicRouteQueryRequest::try_new(args.topic.clone())
+                .map_err(admin_error)?
+                .with_optional_namesrv_addr(Some(cluster.namesrv_addr.clone())),
+        )
+        .await
+        .map_err(admin_error)?
+        .ok_or_else(|| ToolExecutionError::Backend(format!("topic route not found: {}", args.topic)))?;
+
+        Ok(map_topic_route(cluster, args.topic, route))
+    }
+
+    async fn list_consumer_groups(
+        &self,
+        args: consumer_tools::ListConsumerGroupsArgs,
+    ) -> Result<consumer_tools::ListConsumerGroupsOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(args.cluster.as_deref())?;
+        let result = ConsumerService::query_consumer_progress_by_request_with_rpc_hook(
+            ConsumerProgressRequest::try_new(
+                None,
+                None,
+                false,
+                Some(cluster.name.clone()),
+                Some(cluster.namesrv_addr.clone()),
+            )
+            .map_err(admin_error)?,
+            None,
+        )
+        .await
+        .map_err(admin_error)?;
+        let groups = match result {
+            ConsumerProgressResult::All(groups) => groups
+                .into_iter()
+                .map(|group| consumer_tools::ConsumerGroupSummary {
+                    group: group.group,
+                    version: group.version,
+                    client_count: group.count,
+                    consume_type: format!("{:?}", group.consume_type),
+                    message_model: format!("{:?}", group.message_model),
+                    consume_tps: group.consume_tps,
+                    diff_total: group.diff_total,
+                })
+                .collect::<Vec<_>>(),
+            ConsumerProgressResult::Group(_) => Vec::new(),
+        };
+
+        Ok(consumer_tools::ListConsumerGroupsOutput {
+            cluster: cluster.name,
+            namesrv_addr: cluster.namesrv_addr,
+            consumer_group_count: groups.len(),
+            groups,
+            generated_at: generated_at(),
+        })
+    }
+
+    async fn query_consumer_lag(
+        &self,
+        args: consumer_tools::QueryConsumerLagArgs,
+    ) -> Result<consumer_tools::QueryConsumerLagOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(Some(&args.cluster))?;
+        let result = ConsumerService::query_consumer_progress_by_request_with_rpc_hook(
+            ConsumerProgressRequest::try_new(
+                Some(args.consumer_group.clone()),
+                Some(args.topic.clone()),
+                true,
+                Some(cluster.name.clone()),
+                Some(cluster.namesrv_addr.clone()),
+            )
+            .map_err(admin_error)?,
+            None,
+        )
+        .await
+        .map_err(admin_error)?;
+
+        let ConsumerProgressResult::Group(progress) = result else {
+            return Err(ToolExecutionError::Backend(
+                "consumer progress query did not return group result".to_string(),
+            ));
+        };
+
+        let queues = progress
+            .rows
+            .iter()
+            .map(|row| consumer_tools::QueueLag {
+                topic: row.topic.to_string(),
+                broker_name: row.broker_name.to_string(),
+                queue_id: row.queue_id,
+                broker_offset: row.broker_offset,
+                consumer_offset: row.consumer_offset,
+                lag: row.diff,
+                inflight: row.inflight,
+                last_timestamp: row.last_timestamp,
+                client_ip: row.client_ip.clone(),
+            })
+            .collect::<Vec<_>>();
+        let max_queue_lag = queues.iter().map(|queue| queue.lag).max().unwrap_or_default();
+
+        Ok(consumer_tools::QueryConsumerLagOutput {
+            cluster: cluster.name,
+            namesrv_addr: cluster.namesrv_addr,
+            topic: args.topic,
+            consumer_group: args.consumer_group,
+            total_lag: progress.diff_total,
+            max_queue_lag,
+            queue_count: queues.len(),
+            consume_tps: progress.consume_tps,
+            inflight_total: progress.inflight_total,
+            queues,
+            generated_at: generated_at(),
+        })
+    }
+
+    async fn describe_broker(
+        &self,
+        args: broker_tools::DescribeBrokerArgs,
+    ) -> Result<broker_tools::DescribeBrokerOutput, ToolExecutionError> {
+        let cluster = self.resolve_cluster(Some(&args.cluster))?;
+        let cluster_result = ClusterService::query_cluster_list_by_request_with_rpc_hook(
+            ClusterListQueryRequest::new(false, Some(cluster.name.clone()))
+                .with_optional_namesrv_addr(Some(cluster.namesrv_addr.clone())),
+            None,
+        )
+        .await
+        .map_err(admin_error)?;
+        let brokers = cluster_result
+            .base_rows
+            .iter()
+            .filter(|row| row.broker_name == args.broker_name)
+            .map(map_broker_summary)
+            .collect::<Vec<_>>();
+
+        if brokers.is_empty() {
+            let _ = BrokerService::query_broker_runtime_stats_by_request_with_rpc_hook(
+                BrokerRuntimeStatsQueryRequest::try_new(None, Some(cluster.name.clone())).map_err(admin_error)?,
+                None,
+            )
+            .await;
+            return Err(ToolExecutionError::Backend(format!(
+                "broker not found in cluster {}: {}",
+                cluster.name, args.broker_name
+            )));
+        }
+
+        Ok(broker_tools::DescribeBrokerOutput {
+            cluster: cluster.name,
+            namesrv_addr: cluster.namesrv_addr,
+            broker_name: args.broker_name,
+            brokers,
+            generated_at: generated_at(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedCluster {
+    name: String,
+    namesrv_addr: String,
+}
+
+fn default_cluster(clusters: &[ClusterConfig]) -> Result<&ClusterConfig, ToolExecutionError> {
+    clusters
+        .iter()
+        .find(|cluster| cluster.default.unwrap_or(false))
+        .or_else(|| (clusters.len() == 1).then(|| &clusters[0]))
+        .ok_or_else(|| ToolExecutionError::InvalidArguments("cluster must be provided".to_string()))
+}
+
+fn admin_error(error: RocketMQError) -> ToolExecutionError {
+    ToolExecutionError::backend(error)
+}
+
+fn generated_at() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+fn map_broker_summary(row: &ClusterBaseInfoRow) -> cluster_tools::BrokerSummary {
+    cluster_tools::BrokerSummary {
+        cluster: row.cluster_name.clone(),
+        broker_name: row.broker_name.clone(),
+        broker_id: row.broker_id,
+        broker_addr: row.broker_addr.to_string(),
+        version: row.version.clone(),
+        in_tps: row.in_tps.clone(),
+        out_tps: row.out_tps.clone(),
+        timer_progress: row.timer_progress.clone(),
+        page_cache_lock_time_millis: row.page_cache_lock_time_millis.clone(),
+        hour: row.hour.clone(),
+        space: row.space.clone(),
+        broker_active: row.broker_active,
+    }
+}
+
+fn map_topic_route(
+    cluster: ResolvedCluster,
+    topic: String,
+    route: TopicRouteData,
+) -> topic_tools::QueryTopicRouteOutput {
+    let mut brokers = route
+        .broker_datas
+        .iter()
+        .map(|broker| {
+            let broker_addrs = broker
+                .broker_addrs()
+                .iter()
+                .map(|(broker_id, broker_addr)| (broker_id.to_string(), broker_addr.to_string()))
+                .collect::<BTreeMap<_, _>>();
+            topic_tools::TopicRouteBroker {
+                cluster: broker.cluster().to_string(),
+                broker_name: broker.broker_name().to_string(),
+                broker_addrs,
+                zone_name: broker.zone_name().map(ToString::to_string),
+                enable_acting_master: broker.enable_acting_master(),
+            }
+        })
+        .collect::<Vec<_>>();
+    brokers.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+
+    let mut queues = route
+        .queue_datas
+        .iter()
+        .map(|queue| topic_tools::TopicRouteQueue {
+            broker_name: queue.broker_name().to_string(),
+            read_queue_nums: queue.read_queue_nums(),
+            write_queue_nums: queue.write_queue_nums(),
+            perm: queue.perm(),
+            topic_sys_flag: queue.topic_sys_flag(),
+        })
+        .collect::<Vec<_>>();
+    queues.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+
+    topic_tools::QueryTopicRouteOutput {
+        cluster: cluster.name,
+        namesrv_addr: cluster.namesrv_addr,
+        topic,
+        brokers,
+        queues,
+        generated_at: generated_at(),
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/adapter/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/mod.rs
@@ -12,15 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
+//! Adapters from MCP tool contracts to existing RocketMQ Rust admin services.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod adapter;
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod resources;
-pub mod tools;
-pub mod transport;
+pub mod admin_core_adapter;

--- a/rocketmq-tools/rocketmq-mcp/src/main.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 // Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -12,21 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rmcp::model::CallToolRequestParams;
+use rmcp::model::CallToolResult;
 use rmcp::model::Implementation;
 use rmcp::model::ListResourceTemplatesResult;
 use rmcp::model::ListResourcesResult;
+use rmcp::model::ListToolsResult;
 use rmcp::model::PaginatedRequestParams;
 use rmcp::model::ReadResourceRequestParams;
 use rmcp::model::ReadResourceResult;
 use rmcp::model::ServerCapabilities;
 use rmcp::model::ServerInfo;
+use rmcp::model::Tool;
 use rmcp::service::RequestContext;
 use rmcp::ErrorData;
 use rmcp::RoleServer;
 use rmcp::ServerHandler;
 
+use crate::adapter::admin_core_adapter::AdminCoreAdapter;
 use crate::app::McpApp;
 use crate::resources;
+use crate::tools;
+use crate::tools::executor::ToolExecutor;
 
 #[derive(Debug, Clone)]
 pub struct RocketmqMcpServer {
@@ -81,6 +88,28 @@ impl ServerHandler for RocketmqMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
         resources::reader::read_resource(self.app.config(), &request.uri)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        Ok(tools::registry::list_tools())
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        ToolExecutor::new(AdminCoreAdapter::new(self.app.config().clone()))
+            .call(request)
+            .await
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        tools::registry::get_tool(name)
     }
 }
 

--- a/rocketmq-tools/rocketmq-mcp/src/tools/broker_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/broker_tools.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::tools::cluster_tools::BrokerSummary;
+
+pub const DESCRIBE_BROKER_TOOL: &str = "mq_describe_broker";
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct DescribeBrokerArgs {
+    pub cluster: String,
+    pub broker_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct DescribeBrokerOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub broker_name: String,
+    pub brokers: Vec<BrokerSummary>,
+    pub generated_at: String,
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/cluster_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/cluster_tools.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const CLUSTER_OVERVIEW_TOOL: &str = "mq_cluster_overview";
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ClusterOverviewArgs {
+    pub cluster: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerSummary {
+    pub cluster: String,
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub broker_addr: String,
+    pub version: String,
+    pub in_tps: String,
+    pub out_tps: String,
+    pub timer_progress: String,
+    pub page_cache_lock_time_millis: String,
+    pub hour: String,
+    pub space: String,
+    pub broker_active: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ClusterOverviewOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub brokers: Vec<BrokerSummary>,
+    pub topic_count: usize,
+    pub consumer_group_count: usize,
+    pub generated_at: String,
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/consumer_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/consumer_tools.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const LIST_CONSUMER_GROUPS_TOOL: &str = "mq_list_consumer_groups";
+pub const QUERY_CONSUMER_LAG_TOOL: &str = "mq_query_consumer_lag";
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ListConsumerGroupsArgs {
+    #[serde(default)]
+    pub cluster: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct ConsumerGroupSummary {
+    pub group: String,
+    pub version: i32,
+    pub client_count: i32,
+    pub consume_type: String,
+    pub message_model: String,
+    pub consume_tps: f64,
+    pub diff_total: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct ListConsumerGroupsOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub consumer_group_count: usize,
+    pub groups: Vec<ConsumerGroupSummary>,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct QueryConsumerLagArgs {
+    pub cluster: String,
+    pub topic: String,
+    pub consumer_group: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct QueueLag {
+    pub topic: String,
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub broker_offset: i64,
+    pub consumer_offset: i64,
+    pub lag: i64,
+    pub inflight: i64,
+    pub last_timestamp: i64,
+    pub client_ip: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct QueryConsumerLagOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub topic: String,
+    pub consumer_group: String,
+    pub total_lag: i64,
+    pub max_queue_lag: i64,
+    pub queue_count: usize,
+    pub consume_tps: f64,
+    pub inflight_total: i64,
+    pub queues: Vec<QueueLag>,
+    pub generated_at: String,
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -1,0 +1,350 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::json;
+use serde_json::Value;
+
+use rmcp::model::CallToolRequestParams;
+use rmcp::model::CallToolResult;
+use rmcp::model::ContentBlock;
+use rmcp::model::JsonObject;
+use rmcp::ErrorData;
+
+use crate::adapter::admin_core_adapter::ReadOnlyAdminAdapter;
+use crate::tools::broker_tools;
+use crate::tools::cluster_tools;
+use crate::tools::consumer_tools;
+use crate::tools::topic_tools;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ToolExecutionError {
+    #[error("invalid arguments: {0}")]
+    InvalidArguments(String),
+
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+impl ToolExecutionError {
+    pub(crate) fn backend(error: impl ToString) -> Self {
+        Self::Backend(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ToolExecutor<A> {
+    adapter: A,
+}
+
+impl<A> ToolExecutor<A>
+where
+    A: ReadOnlyAdminAdapter,
+{
+    pub(crate) fn new(adapter: A) -> Self {
+        Self { adapter }
+    }
+
+    pub(crate) async fn call(&self, request: CallToolRequestParams) -> Result<CallToolResult, ErrorData> {
+        match request.name.as_ref() {
+            cluster_tools::CLUSTER_OVERVIEW_TOOL => {
+                let args = decode_args::<cluster_tools::ClusterOverviewArgs>(request.arguments)?;
+                self.adapter
+                    .cluster_overview(args)
+                    .await
+                    .map(|output| success_result(summary_cluster_overview(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(cluster_tools::CLUSTER_OVERVIEW_TOOL, error)))
+            }
+            topic_tools::LIST_TOPICS_TOOL => {
+                let args = decode_args::<topic_tools::ListTopicsArgs>(request.arguments)?;
+                self.adapter
+                    .list_topics(args)
+                    .await
+                    .map(|output| success_result(summary_list_topics(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(topic_tools::LIST_TOPICS_TOOL, error)))
+            }
+            topic_tools::DESCRIBE_TOPIC_TOOL => {
+                let args = decode_args::<topic_tools::DescribeTopicArgs>(request.arguments)?;
+                self.adapter
+                    .describe_topic(args)
+                    .await
+                    .map(|output| success_result(summary_describe_topic(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(topic_tools::DESCRIBE_TOPIC_TOOL, error)))
+            }
+            topic_tools::QUERY_TOPIC_ROUTE_TOOL => {
+                let args = decode_args::<topic_tools::QueryTopicRouteArgs>(request.arguments)?;
+                self.adapter
+                    .query_topic_route(args)
+                    .await
+                    .map(|output| success_result(summary_topic_route(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(topic_tools::QUERY_TOPIC_ROUTE_TOOL, error)))
+            }
+            consumer_tools::LIST_CONSUMER_GROUPS_TOOL => {
+                let args = decode_args::<consumer_tools::ListConsumerGroupsArgs>(request.arguments)?;
+                self.adapter
+                    .list_consumer_groups(args)
+                    .await
+                    .map(|output| success_result(summary_consumer_groups(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(consumer_tools::LIST_CONSUMER_GROUPS_TOOL, error)))
+            }
+            consumer_tools::QUERY_CONSUMER_LAG_TOOL => {
+                let args = decode_args::<consumer_tools::QueryConsumerLagArgs>(request.arguments)?;
+                self.adapter
+                    .query_consumer_lag(args)
+                    .await
+                    .map(|output| success_result(summary_consumer_lag(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(consumer_tools::QUERY_CONSUMER_LAG_TOOL, error)))
+            }
+            broker_tools::DESCRIBE_BROKER_TOOL => {
+                let args = decode_args::<broker_tools::DescribeBrokerArgs>(request.arguments)?;
+                self.adapter
+                    .describe_broker(args)
+                    .await
+                    .map(|output| success_result(summary_describe_broker(&output), &output))
+                    .unwrap_or_else(|error| Ok(error_result(broker_tools::DESCRIBE_BROKER_TOOL, error)))
+            }
+            tool_name => Err(ErrorData::invalid_params(format!("unknown tool: {tool_name}"), None)),
+        }
+    }
+}
+
+fn decode_args<T>(arguments: Option<JsonObject>) -> Result<T, ErrorData>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(Value::Object(arguments.unwrap_or_default()))
+        .map_err(|error| ErrorData::invalid_params(format!("invalid tool arguments: {error}"), None))
+}
+
+fn success_result<T>(summary: String, output: &T) -> Result<CallToolResult, ErrorData>
+where
+    T: Serialize,
+{
+    let structured = serde_json::to_value(output)
+        .map_err(|error| ErrorData::internal_error(format!("failed to serialize tool output: {error}"), None))?;
+    let mut result = CallToolResult::success(vec![ContentBlock::text(summary)]);
+    result.structured_content = Some(structured);
+    Ok(result)
+}
+
+fn error_result(tool_name: &str, error: ToolExecutionError) -> CallToolResult {
+    let message = format!("{tool_name} failed: {error}");
+    let mut result = CallToolResult::error(vec![ContentBlock::text(message)]);
+    result.structured_content = Some(json!({
+        "tool": tool_name,
+        "error": error.to_string(),
+    }));
+    result
+}
+
+fn summary_cluster_overview(output: &cluster_tools::ClusterOverviewOutput) -> String {
+    format!(
+        "Cluster {} has {} broker rows, {} topics, and {} consumer groups.",
+        output.cluster,
+        output.brokers.len(),
+        output.topic_count,
+        output.consumer_group_count
+    )
+}
+
+fn summary_list_topics(output: &topic_tools::ListTopicsOutput) -> String {
+    format!("Cluster {} has {} topics.", output.cluster, output.topic_count)
+}
+
+fn summary_describe_topic(output: &topic_tools::DescribeTopicOutput) -> String {
+    format!(
+        "Topic {} on cluster {} has {} brokers, {} read queues, and {} write queues.",
+        output.topic,
+        output.cluster,
+        output.broker_names.len(),
+        output.read_queue_count,
+        output.write_queue_count
+    )
+}
+
+fn summary_topic_route(output: &topic_tools::QueryTopicRouteOutput) -> String {
+    format!(
+        "Topic {} route on cluster {} has {} brokers and {} queue entries.",
+        output.topic,
+        output.cluster,
+        output.brokers.len(),
+        output.queues.len()
+    )
+}
+
+fn summary_consumer_groups(output: &consumer_tools::ListConsumerGroupsOutput) -> String {
+    format!(
+        "Cluster {} has {} consumer groups.",
+        output.cluster, output.consumer_group_count
+    )
+}
+
+fn summary_consumer_lag(output: &consumer_tools::QueryConsumerLagOutput) -> String {
+    format!(
+        "Consumer group {} has total lag {} on topic {} across {} queues.",
+        output.consumer_group, output.total_lag, output.topic, output.queue_count
+    )
+}
+
+fn summary_describe_broker(output: &broker_tools::DescribeBrokerOutput) -> String {
+    format!(
+        "Broker {} on cluster {} has {} broker rows.",
+        output.broker_name,
+        output.cluster,
+        output.brokers.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeAdapter {
+        fail: bool,
+    }
+
+    impl ReadOnlyAdminAdapter for FakeAdapter {
+        async fn cluster_overview(
+            &self,
+            args: cluster_tools::ClusterOverviewArgs,
+        ) -> Result<cluster_tools::ClusterOverviewOutput, ToolExecutionError> {
+            if self.fail {
+                return Err(ToolExecutionError::backend("nameserver unavailable"));
+            }
+            Ok(cluster_tools::ClusterOverviewOutput {
+                cluster: args.cluster,
+                namesrv_addr: "127.0.0.1:9876".to_string(),
+                brokers: vec![broker_summary()],
+                topic_count: 2,
+                consumer_group_count: 1,
+                generated_at: "1".to_string(),
+            })
+        }
+
+        async fn list_topics(
+            &self,
+            _args: topic_tools::ListTopicsArgs,
+        ) -> Result<topic_tools::ListTopicsOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+
+        async fn describe_topic(
+            &self,
+            _args: topic_tools::DescribeTopicArgs,
+        ) -> Result<topic_tools::DescribeTopicOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+
+        async fn query_topic_route(
+            &self,
+            _args: topic_tools::QueryTopicRouteArgs,
+        ) -> Result<topic_tools::QueryTopicRouteOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+
+        async fn list_consumer_groups(
+            &self,
+            _args: consumer_tools::ListConsumerGroupsArgs,
+        ) -> Result<consumer_tools::ListConsumerGroupsOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+
+        async fn query_consumer_lag(
+            &self,
+            _args: consumer_tools::QueryConsumerLagArgs,
+        ) -> Result<consumer_tools::QueryConsumerLagOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+
+        async fn describe_broker(
+            &self,
+            _args: broker_tools::DescribeBrokerArgs,
+        ) -> Result<broker_tools::DescribeBrokerOutput, ToolExecutionError> {
+            unimplemented!("not needed by this test")
+        }
+    }
+
+    #[tokio::test]
+    async fn call_returns_summary_and_structured_content() {
+        let result = ToolExecutor::new(FakeAdapter { fail: false })
+            .call(
+                CallToolRequestParams::new(cluster_tools::CLUSTER_OVERVIEW_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(result.structured_content.as_ref().unwrap()["cluster"], "local-dev");
+        assert!(!result.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn backend_error_is_returned_as_tool_error() {
+        let result = ToolExecutor::new(FakeAdapter { fail: true })
+            .call(
+                CallToolRequestParams::new(cluster_tools::CLUSTER_OVERVIEW_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.structured_content.as_ref().unwrap()["error"]
+            .as_str()
+            .unwrap()
+            .contains("nameserver unavailable"));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_returns_protocol_error() {
+        let err = ToolExecutor::new(FakeAdapter { fail: false })
+            .call(CallToolRequestParams::new("unknown_tool"))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    fn broker_summary() -> cluster_tools::BrokerSummary {
+        cluster_tools::BrokerSummary {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+            broker_id: 0,
+            broker_addr: "127.0.0.1:10911".to_string(),
+            version: "5.3.0".to_string(),
+            in_tps: "1.0".to_string(),
+            out_tps: "1.0".to_string(),
+            timer_progress: "0".to_string(),
+            page_cache_lock_time_millis: "0".to_string(),
+            hour: "0".to_string(),
+            space: "0".to_string(),
+            broker_active: true,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/mod.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
+//! Read-only MCP tools exposed by the RocketMQ MCP server.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod adapter;
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod protocol;
-pub mod resources;
-pub mod tools;
-pub mod transport;
+pub mod broker_tools;
+pub mod cluster_tools;
+pub mod consumer_tools;
+pub mod executor;
+pub mod registry;
+pub mod topic_tools;

--- a/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+
+use rmcp::model::ListToolsResult;
+use rmcp::model::Tool;
+use rmcp::model::ToolAnnotations;
+
+use crate::tools::broker_tools;
+use crate::tools::cluster_tools;
+use crate::tools::consumer_tools;
+use crate::tools::topic_tools;
+
+pub fn list_tools() -> ListToolsResult {
+    ListToolsResult::with_all_items(tool_definitions())
+}
+
+pub fn get_tool(name: &str) -> Option<Tool> {
+    tool_definitions().into_iter().find(|tool| tool.name.as_ref() == name)
+}
+
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        read_only_tool::<cluster_tools::ClusterOverviewArgs, cluster_tools::ClusterOverviewOutput>(
+            cluster_tools::CLUSTER_OVERVIEW_TOOL,
+            "RocketMQ cluster overview",
+            "Summarize configured cluster brokers, topic count, and consumer group count.",
+        ),
+        read_only_tool::<topic_tools::ListTopicsArgs, topic_tools::ListTopicsOutput>(
+            topic_tools::LIST_TOPICS_TOOL,
+            "RocketMQ topic list",
+            "List topics visible from the selected RocketMQ cluster.",
+        ),
+        read_only_tool::<topic_tools::DescribeTopicArgs, topic_tools::DescribeTopicOutput>(
+            topic_tools::DESCRIBE_TOPIC_TOOL,
+            "RocketMQ topic description",
+            "Describe a topic with broker and queue route information.",
+        ),
+        read_only_tool::<topic_tools::QueryTopicRouteArgs, topic_tools::QueryTopicRouteOutput>(
+            topic_tools::QUERY_TOPIC_ROUTE_TOOL,
+            "RocketMQ topic route",
+            "Query topic route data including broker addresses and queue distribution.",
+        ),
+        read_only_tool::<consumer_tools::ListConsumerGroupsArgs, consumer_tools::ListConsumerGroupsOutput>(
+            consumer_tools::LIST_CONSUMER_GROUPS_TOOL,
+            "RocketMQ consumer groups",
+            "List consumer groups and current consumption summary.",
+        ),
+        read_only_tool::<consumer_tools::QueryConsumerLagArgs, consumer_tools::QueryConsumerLagOutput>(
+            consumer_tools::QUERY_CONSUMER_LAG_TOOL,
+            "RocketMQ consumer lag",
+            "Query per-queue consumer lag for a topic and consumer group.",
+        ),
+        read_only_tool::<broker_tools::DescribeBrokerArgs, broker_tools::DescribeBrokerOutput>(
+            broker_tools::DESCRIBE_BROKER_TOOL,
+            "RocketMQ broker description",
+            "Describe broker rows for a broker name in the selected cluster.",
+        ),
+    ]
+}
+
+fn read_only_tool<I, O>(name: &'static str, title: &'static str, description: &'static str) -> Tool
+where
+    I: JsonSchema + 'static,
+    O: JsonSchema + 'static,
+{
+    Tool::new(name, description, std::sync::Arc::new(Default::default()))
+        .with_title(title)
+        .with_input_schema::<I>()
+        .with_output_schema::<O>()
+        .with_annotations(
+            ToolAnnotations::with_title(title)
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true)
+                .open_world(true),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_tools_returns_all_read_only_mvp_tools() {
+        let result = list_tools();
+        let names = result.tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            [
+                "mq_cluster_overview",
+                "mq_list_topics",
+                "mq_describe_topic",
+                "mq_query_topic_route",
+                "mq_list_consumer_groups",
+                "mq_query_consumer_lag",
+                "mq_describe_broker",
+            ]
+        );
+        assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn each_tool_has_input_schema_and_read_only_annotation() {
+        for tool in tool_definitions() {
+            assert_eq!(
+                tool.input_schema.get("type").and_then(|value| value.as_str()),
+                Some("object")
+            );
+            assert!(tool.output_schema.is_some());
+            let annotations = tool.annotations.as_ref().expect("tool annotations");
+            assert_eq!(annotations.read_only_hint, Some(true));
+            assert_eq!(annotations.destructive_hint, Some(false));
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/topic_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/topic_tools.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const LIST_TOPICS_TOOL: &str = "mq_list_topics";
+pub const DESCRIBE_TOPIC_TOOL: &str = "mq_describe_topic";
+pub const QUERY_TOPIC_ROUTE_TOOL: &str = "mq_query_topic_route";
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ListTopicsArgs {
+    #[serde(default)]
+    pub cluster: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TopicListEntry {
+    pub topic: String,
+    pub cluster: Option<String>,
+    pub consumer_group: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ListTopicsOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub topic_count: usize,
+    pub topics: Vec<TopicListEntry>,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct DescribeTopicArgs {
+    pub cluster: String,
+    pub topic: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct QueryTopicRouteArgs {
+    pub cluster: String,
+    pub topic: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TopicRouteBroker {
+    pub cluster: String,
+    pub broker_name: String,
+    pub broker_addrs: BTreeMap<String, String>,
+    pub zone_name: Option<String>,
+    pub enable_acting_master: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TopicRouteQueue {
+    pub broker_name: String,
+    pub read_queue_nums: u32,
+    pub write_queue_nums: u32,
+    pub perm: u32,
+    pub topic_sys_flag: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct QueryTopicRouteOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub topic: String,
+    pub brokers: Vec<TopicRouteBroker>,
+    pub queues: Vec<TopicRouteQueue>,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct DescribeTopicOutput {
+    pub cluster: String,
+    pub namesrv_addr: String,
+    pub topic: String,
+    pub broker_names: Vec<String>,
+    pub read_queue_count: u32,
+    pub write_queue_count: u32,
+    pub brokers: Vec<TopicRouteBroker>,
+    pub queues: Vec<TopicRouteQueue>,
+    pub generated_at: String,
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8135

### Brief Description

Adds the read-only MCP tool layer for rocketmq-mcp.
The server now lists and routes seven RocketMQ query tools, exposes typed input and output schemas, returns structuredContent, and maps backend failures to caller-visible tool errors.

### How Did You Test This Change?

- cargo fmt --all
- cargo check -p rocketmq-mcp
- cargo test -p rocketmq-mcp tool
- cargo test -p rocketmq-mcp
- cargo clippy --all-targets -p rocketmq-mcp -- -D warnings
- cargo run -p rocketmq-mcp -- --config rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml --transport stdio
- git diff --check
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
