### PR TITLE
[ISSUE #8139]🚀Add rocketmq-mcp runbook prompts

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/prompts/broker_health_check.md
+++ b/rocketmq-tools/rocketmq-mcp/prompts/broker_health_check.md
@@ -1,0 +1,47 @@
+---
+name: broker_health_check
+title: Broker Health Check
+description: Check RocketMQ broker health from read-only broker, cluster, and topic evidence.
+arguments:
+  - name: cluster
+    required: true
+    description: RocketMQ cluster name or configured connection name.
+  - name: broker_name
+    required: false
+    description: Optional broker name. When omitted, inspect all brokers in the cluster.
+  - name: check_level
+    required: false
+    description: "Optional check level: quick, standard, or deep."
+---
+# Broker Health Check Task
+
+You are the rocketmq-rust AI SRE. Check broker health for cluster `{{cluster}}`.
+
+Broker filter: `{{broker_name}}`
+Check level: `{{check_level}}`
+
+## Required Tools
+
+1. `mq_cluster_overview`
+2. `mq_describe_broker`
+3. `mq_list_topics`
+
+If `mq_query_broker_metrics` is registered in this server, you may use it as extra read-only evidence. It is not required for the MVP runbook.
+
+## Forbidden Actions
+
+- Do not call mutation tools.
+- Do not clean topics, delete commit logs, switch timer engines, or update broker config.
+- Do not infer disk, thread pool, or runtime pressure without evidence.
+
+## Final Markdown Report
+
+# Broker Health Check Report
+
+## 1. Health Level
+## 2. Overall Conclusion
+## 3. Broker Status
+## 4. Abnormal Findings
+## 5. Risk Analysis
+## 6. Recommendations
+## 7. Follow-up Metrics

--- a/rocketmq-tools/rocketmq-mcp/prompts/diagnose_consumer_lag.md
+++ b/rocketmq-tools/rocketmq-mcp/prompts/diagnose_consumer_lag.md
@@ -1,0 +1,53 @@
+---
+name: diagnose_consumer_lag
+title: Diagnose Consumer Lag
+description: Diagnose consumer lag for a RocketMQ topic and consumer group.
+arguments:
+  - name: cluster
+    required: true
+    description: RocketMQ cluster name or configured connection name.
+  - name: topic
+    required: true
+    description: Topic name.
+  - name: consumer_group
+    required: true
+    description: Consumer group name.
+  - name: time_range
+    required: false
+    description: Optional investigation time range.
+---
+# Consumer Lag Diagnosis Task
+
+You are the rocketmq-rust AI SRE. Diagnose consumer lag for topic `{{topic}}` in consumer group `{{consumer_group}}` on cluster `{{cluster}}`.
+
+## Required Tools
+
+1. `mq_diagnose_consumer_lag`
+2. `mq_query_consumer_lag`
+3. `mq_describe_topic`
+4. `mq_query_topic_route`
+5. `mq_describe_broker`
+
+## Optional Context
+
+- Time range: `{{time_range}}`
+- Use `rocketmq://consumer-groups` and `rocketmq://topics` only as read-only context if useful.
+
+## Forbidden Actions
+
+- Do not call mutation tools.
+- Do not reset offsets automatically.
+- Do not delete or update topics.
+- Do not modify broker or consumer group configuration.
+
+## Final Markdown Report
+
+# Consumer Lag Diagnosis Report
+
+## 1. Diagnosis Conclusion
+## 2. Impact Scope
+## 3. Key Evidence
+## 4. Root Cause Analysis
+## 5. Recommendations
+## 6. Risks
+## 7. Follow-up Metrics

--- a/rocketmq-tools/rocketmq-mcp/src/prompts/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/prompts/mod.rs
@@ -12,18 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
+//! Runbook prompt templates exposed by the RocketMQ MCP server.
 
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod adapter;
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod model;
-pub mod prompts;
-pub mod protocol;
-pub mod resources;
-pub mod service;
-pub mod tools;
-pub mod transport;
+pub mod registry;
+pub mod renderer;
+pub mod template;

--- a/rocketmq-tools/rocketmq-mcp/src/prompts/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/prompts/registry.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::ListPromptsResult;
+use rmcp::model::Prompt;
+use rmcp::model::PromptArgument;
+
+use crate::prompts::template::PromptTemplate;
+use crate::prompts::template::PromptTemplateError;
+
+const PROMPT_SOURCES: &[&str] = &[
+    include_str!("../../prompts/diagnose_consumer_lag.md"),
+    include_str!("../../prompts/broker_health_check.md"),
+];
+
+pub fn list_prompts() -> Result<ListPromptsResult, PromptTemplateError> {
+    Ok(ListPromptsResult::with_all_items(
+        prompt_templates()?.into_iter().map(to_prompt).collect(),
+    ))
+}
+
+pub fn get_template(name: &str) -> Result<Option<PromptTemplate>, PromptTemplateError> {
+    Ok(prompt_templates()?
+        .into_iter()
+        .find(|template| template.front_matter.name == name))
+}
+
+pub fn prompt_templates() -> Result<Vec<PromptTemplate>, PromptTemplateError> {
+    PROMPT_SOURCES
+        .iter()
+        .map(|source| PromptTemplate::parse(source))
+        .collect()
+}
+
+fn to_prompt(template: PromptTemplate) -> Prompt {
+    let arguments = template
+        .front_matter
+        .arguments
+        .iter()
+        .map(|argument| {
+            let mut prompt_argument = PromptArgument::new(argument.name.clone()).with_required(argument.required);
+            if let Some(description) = &argument.description {
+                prompt_argument = prompt_argument.with_description(description.clone());
+            }
+            prompt_argument
+        })
+        .collect::<Vec<_>>();
+
+    Prompt::new(
+        template.front_matter.name,
+        Some(template.front_matter.description),
+        Some(arguments),
+    )
+    .with_title(template.front_matter.title)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_prompts_returns_mvp_runbooks() {
+        let result = list_prompts().unwrap();
+        let names = result
+            .prompts
+            .iter()
+            .map(|prompt| prompt.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["diagnose_consumer_lag", "broker_health_check"]);
+        assert!(result.prompts.iter().all(|prompt| prompt.arguments.is_some()));
+    }
+
+    #[test]
+    fn get_template_finds_known_prompt() {
+        let template = get_template("diagnose_consumer_lag").unwrap().unwrap();
+
+        assert_eq!(template.front_matter.title, "Diagnose Consumer Lag");
+        assert!(template.body.contains("mq_diagnose_consumer_lag"));
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/prompts/renderer.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/prompts/renderer.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::GetPromptRequestParams;
+use rmcp::model::GetPromptResult;
+use rmcp::model::JsonObject;
+use rmcp::model::PromptMessage;
+use rmcp::model::Role;
+use rmcp::ErrorData;
+use serde_json::Value;
+
+use crate::prompts::registry;
+use crate::prompts::template::PromptTemplate;
+use crate::prompts::template::PromptTemplateArgument;
+use crate::prompts::template::PromptTemplateError;
+
+pub fn get_prompt(request: GetPromptRequestParams) -> Result<GetPromptResult, ErrorData> {
+    let template = registry::get_template(&request.name)
+        .map_err(template_error)?
+        .ok_or_else(|| ErrorData::invalid_params(format!("unknown prompt: {}", request.name), None))?;
+    let arguments = request.arguments.unwrap_or_default();
+    validate_required_arguments(&template, &arguments)?;
+    let text = render_template(&template, &arguments);
+
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(Role::User, text)])
+        .with_description(template.front_matter.description))
+}
+
+fn validate_required_arguments(template: &PromptTemplate, arguments: &JsonObject) -> Result<(), ErrorData> {
+    for argument in template
+        .front_matter
+        .arguments
+        .iter()
+        .filter(|argument| argument.required)
+    {
+        if !argument_present(argument, arguments) {
+            return Err(ErrorData::invalid_params(
+                format!("missing required prompt argument: {}", argument.name),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn argument_present(argument: &PromptTemplateArgument, arguments: &JsonObject) -> bool {
+    arguments
+        .get(&argument.name)
+        .is_some_and(|value| !value.is_null() && value.as_str().is_none_or(|value| !value.trim().is_empty()))
+}
+
+fn render_template(template: &PromptTemplate, arguments: &JsonObject) -> String {
+    let mut rendered = template.body.clone();
+    for argument in &template.front_matter.arguments {
+        let value = arguments.get(&argument.name).map(render_value).unwrap_or_default();
+        rendered = rendered.replace(&format!("{{{{{}}}}}", argument.name), &value);
+    }
+    rendered
+}
+
+fn render_value(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn template_error(error: PromptTemplateError) -> ErrorData {
+    ErrorData::internal_error(error.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::ContentBlock;
+
+    use super::*;
+
+    #[test]
+    fn renders_prompt_arguments() {
+        let result = get_prompt(
+            GetPromptRequestParams::new("diagnose_consumer_lag").with_arguments(
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "topic": "orders",
+                    "consumer_group": "order-service",
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .unwrap();
+        let text = prompt_text(&result);
+
+        assert!(text.contains("orders"));
+        assert!(text.contains("order-service"));
+        assert!(text.contains("mq_diagnose_consumer_lag"));
+        assert!(text.contains("Do not call mutation tools"));
+    }
+
+    #[test]
+    fn missing_required_argument_returns_protocol_error() {
+        let err = get_prompt(
+            GetPromptRequestParams::new("diagnose_consumer_lag").with_arguments(
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "topic": "orders",
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("consumer_group"));
+    }
+
+    fn prompt_text(result: &GetPromptResult) -> &str {
+        match &result.messages[0].content {
+            ContentBlock::Text(text) => &text.text,
+            _ => panic!("prompt should render text"),
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/prompts/template.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/prompts/template.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptTemplate {
+    pub front_matter: PromptFrontMatter,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PromptFrontMatter {
+    pub name: String,
+    pub title: String,
+    pub description: String,
+    #[serde(default)]
+    pub arguments: Vec<PromptTemplateArgument>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PromptTemplateArgument {
+    pub name: String,
+    #[serde(default)]
+    pub required: bool,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PromptTemplateError {
+    #[error("prompt template must start with YAML front matter")]
+    MissingFrontMatter,
+
+    #[error("prompt template front matter is not terminated")]
+    UnterminatedFrontMatter,
+
+    #[error("invalid prompt template front matter: {0}")]
+    InvalidFrontMatter(#[from] serde_yaml::Error),
+}
+
+impl PromptTemplate {
+    pub fn parse(source: &str) -> Result<Self, PromptTemplateError> {
+        let source = source
+            .strip_prefix("---\n")
+            .ok_or(PromptTemplateError::MissingFrontMatter)?;
+        let (front_matter, body) = source
+            .split_once("\n---\n")
+            .ok_or(PromptTemplateError::UnterminatedFrontMatter)?;
+        Ok(Self {
+            front_matter: serde_yaml::from_str(front_matter)?,
+            body: body.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_front_matter_and_body() {
+        let template = PromptTemplate::parse(
+            r#"---
+name: test_prompt
+title: Test Prompt
+description: Test description.
+arguments:
+  - name: cluster
+    required: true
+    description: Cluster name.
+---
+# Body
+
+Use {{cluster}}.
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(template.front_matter.name, "test_prompt");
+        assert_eq!(template.front_matter.arguments[0].name, "cluster");
+        assert!(template.front_matter.arguments[0].required);
+        assert!(template.body.contains("{{cluster}}"));
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -14,7 +14,10 @@
 
 use rmcp::model::CallToolRequestParams;
 use rmcp::model::CallToolResult;
+use rmcp::model::GetPromptRequestParams;
+use rmcp::model::GetPromptResult;
 use rmcp::model::Implementation;
+use rmcp::model::ListPromptsResult;
 use rmcp::model::ListResourceTemplatesResult;
 use rmcp::model::ListResourcesResult;
 use rmcp::model::ListToolsResult;
@@ -31,6 +34,7 @@ use rmcp::ServerHandler;
 
 use crate::adapter::admin_core_adapter::AdminCoreAdapter;
 use crate::app::McpApp;
+use crate::prompts;
 use crate::resources;
 use crate::tools;
 use crate::tools::executor::ToolExecutor;
@@ -88,6 +92,22 @@ impl ServerHandler for RocketmqMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
         resources::reader::read_resource(self.app.config(), &request.uri)
+    }
+
+    async fn list_prompts(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, ErrorData> {
+        prompts::registry::list_prompts().map_err(|error| ErrorData::internal_error(error.to_string(), None))
+    }
+
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, ErrorData> {
+        prompts::renderer::get_prompt(request)
     }
 
     async fn list_tools(


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8139

### Brief Description

Adds the MVP runbook prompt system for rocketmq-mcp.
The server now lists and renders diagnose_consumer_lag and broker_health_check prompts, validates required arguments, and returns MCP prompt messages.

### How Did You Test This Change?

- cargo fmt --all
- cargo check -p rocketmq-mcp
- cargo test -p rocketmq-mcp prompt
- cargo test -p rocketmq-mcp
- cargo clippy --all-targets -p rocketmq-mcp -- -D warnings
- cargo run -p rocketmq-mcp -- --config rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml --transport stdio
- git diff --check
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
