### PR TITLE
[ISSUE #8141]🚀Add rocketmq-mcp security guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,6 +4432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -58,6 +58,7 @@ schemars           = "1.1"
 serde              = { workspace = true }
 serde_json         = { workspace = true }
 serde_yaml         = { workspace = true }
+sha2               = "0.11"
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
 tokio-util         = { workspace = true }

--- a/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
@@ -20,7 +20,7 @@ namesrv_addr = "127.0.0.1:9876"
 default = true
 
 [security]
-profile = "read_only"
+profile = "diagnose"
 allow_dangerous_tools = false
 require_confirmation = true
 sanitize_output = true

--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -15,15 +15,18 @@
 use crate::config::Args;
 use crate::config::McpConfig;
 use crate::config::TransportKind;
+use crate::guard::Guard;
 
 #[derive(Debug, Clone)]
 pub struct McpApp {
     config: McpConfig,
+    guard: Guard,
 }
 
 impl McpApp {
     pub fn new(config: McpConfig) -> Self {
-        Self { config }
+        let guard = Guard::new(config.security.clone(), config.audit.clone(), &config.clusters);
+        Self { config, guard }
     }
 
     pub async fn bootstrap(args: Args) -> anyhow::Result<Self> {
@@ -34,6 +37,10 @@ impl McpApp {
 
     pub fn config(&self) -> &McpConfig {
         &self.config
+    }
+
+    pub fn guard(&self) -> &Guard {
+        &self.guard
     }
 
     pub fn transport(&self) -> TransportKind {

--- a/rocketmq-tools/rocketmq-mcp/src/config.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/config.rs
@@ -120,6 +120,18 @@ impl McpConfig {
             ));
         }
 
+        validate_security_profile(&self.security.profile)?;
+        if self.security.rate_limit_per_minute == 0 {
+            return Err(McpError::InvalidConfig(
+                "security.rate_limit_per_minute must be greater than zero".to_string(),
+            ));
+        }
+
+        validate_audit_sink(&self.audit.sink)?;
+        if self.audit.enabled && self.audit.sink == "file" {
+            validate_non_empty("audit.path", &self.audit.path)?;
+        }
+
         Ok(())
     }
 }
@@ -225,6 +237,22 @@ fn validate_non_empty(field: &str, value: &str) -> Result<(), McpError> {
         return Err(McpError::InvalidConfig(format!("{field} must not be empty")));
     }
     Ok(())
+}
+
+fn validate_security_profile(profile: &str) -> Result<(), McpError> {
+    match profile.trim().to_ascii_lowercase().as_str() {
+        "read_only" | "readonly" | "read-only" | "diagnose" | "diagnostic" | "operator" => Ok(()),
+        other => Err(McpError::InvalidConfig(format!(
+            "unsupported security.profile `{other}`"
+        ))),
+    }
+}
+
+fn validate_audit_sink(sink: &str) -> Result<(), McpError> {
+    match sink.trim().to_ascii_lowercase().as_str() {
+        "memory" | "file" | "tracing" => Ok(()),
+        other => Err(McpError::InvalidConfig(format!("unsupported audit.sink `{other}`"))),
+    }
 }
 
 fn trimmed_override(field: &str, value: Option<&str>) -> Result<Option<String>, McpError> {

--- a/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+
+use crate::config::AuditConfig;
+use crate::guard::RiskLevel;
+
+const MAX_AUDIT_RECORDS: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditStatus {
+    Success,
+    Failure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuditRecord {
+    pub timestamp_unix_ms: u128,
+    pub request_id: String,
+    pub operator: String,
+    pub client: Option<String>,
+    pub cluster: Option<String>,
+    pub tool: String,
+    pub arguments_hash: String,
+    pub risk_level: RiskLevel,
+    pub status: AuditStatus,
+    pub duration_ms: u128,
+    pub error: Option<String>,
+}
+
+impl AuditRecord {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        request_id: String,
+        operator: String,
+        client: Option<String>,
+        cluster: Option<String>,
+        tool: String,
+        arguments_hash: String,
+        risk_level: RiskLevel,
+        status: AuditStatus,
+        duration_ms: u128,
+        error: Option<String>,
+    ) -> Self {
+        Self {
+            timestamp_unix_ms: now_unix_ms(),
+            request_id,
+            operator,
+            client,
+            cluster,
+            tool,
+            arguments_hash,
+            risk_level,
+            status,
+            duration_ms,
+            error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AuditLog {
+    records: Arc<Mutex<VecDeque<AuditRecord>>>,
+}
+
+impl AuditLog {
+    pub fn record(&self, config: &AuditConfig, record: AuditRecord) {
+        self.push(record.clone());
+
+        match config.sink.as_str() {
+            "memory" => {}
+            "file" => write_file_record(config, &record),
+            "tracing" => {
+                tracing::info!(
+                    request_id = %record.request_id,
+                    tool = %record.tool,
+                    risk_level = ?record.risk_level,
+                    status = ?record.status,
+                    duration_ms = record.duration_ms,
+                    "rocketmq-mcp audit record"
+                );
+            }
+            sink => tracing::warn!(sink, "unknown rocketmq-mcp audit sink"),
+        }
+    }
+
+    pub fn records(&self) -> Vec<AuditRecord> {
+        self.records
+            .lock()
+            .map(|records| records.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn push(&self, record: AuditRecord) {
+        let Ok(mut records) = self.records.lock() else {
+            return;
+        };
+
+        if records.len() == MAX_AUDIT_RECORDS {
+            records.pop_front();
+        }
+        records.push_back(record);
+    }
+}
+
+fn write_file_record(config: &AuditConfig, record: &AuditRecord) {
+    if config.path.trim().is_empty() {
+        tracing::warn!("rocketmq-mcp audit file sink has an empty path");
+        return;
+    }
+
+    let path = Path::new(&config.path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                tracing::warn!(?error, path = %config.path, "failed to create rocketmq-mcp audit directory");
+                return;
+            }
+        }
+    }
+
+    let line = match serde_json::to_string(record) {
+        Ok(line) => line,
+        Err(error) => {
+            tracing::warn!(?error, "failed to serialize rocketmq-mcp audit record");
+            return;
+        }
+    };
+
+    match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(mut file) => {
+            if let Err(error) = writeln!(file, "{line}") {
+                tracing::warn!(?error, path = %config.path, "failed to write rocketmq-mcp audit record");
+            }
+        }
+        Err(error) => {
+            tracing::warn!(?error, path = %config.path, "failed to open rocketmq-mcp audit file");
+        }
+    }
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/confirmation.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/confirmation.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::JsonObject;
+use serde_json::Value;
+
+use crate::config::SecurityConfig;
+use crate::guard::GuardError;
+use crate::guard::RiskLevel;
+
+pub(crate) fn check_confirmation(
+    security: &SecurityConfig,
+    risk_level: RiskLevel,
+    arguments: &JsonObject,
+) -> Result<(), GuardError> {
+    if !security.require_confirmation || !matches!(risk_level, RiskLevel::Change) {
+        return Ok(());
+    }
+
+    if has_non_empty_string(arguments, "confirm_token") {
+        return Ok(());
+    }
+
+    Err(GuardError::ConfirmationRequired(
+        "change tools require a non-empty confirm_token".to_string(),
+    ))
+}
+
+fn has_non_empty_string(arguments: &JsonObject, key: &str) -> bool {
+    arguments
+        .get(key)
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/mod.rs
@@ -1,0 +1,371 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod audit;
+pub mod confirmation;
+pub mod rate_limit;
+pub mod rbac;
+pub mod sanitizer;
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Instant;
+
+use rmcp::model::CallToolResult;
+use rmcp::model::JsonObject;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::Digest;
+use sha2::Sha256;
+
+use crate::config::AuditConfig;
+use crate::config::ClusterConfig;
+use crate::config::SecurityConfig;
+use crate::guard::audit::AuditLog;
+use crate::guard::audit::AuditRecord;
+use crate::guard::audit::AuditStatus;
+use crate::guard::rate_limit::RateLimiter;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskLevel {
+    ReadOnly,
+    Diagnose,
+    Change,
+    Destructive,
+}
+
+impl RiskLevel {
+    pub fn is_dangerous(self) -> bool {
+        matches!(self, Self::Change | Self::Destructive)
+    }
+}
+
+impl std::fmt::Display for RiskLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadOnly => f.write_str("ReadOnly"),
+            Self::Diagnose => f.write_str("Diagnose"),
+            Self::Change => f.write_str("Change"),
+            Self::Destructive => f.write_str("Destructive"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GuardError {
+    #[error("invalid guard argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
+    #[error("rate limit exceeded: {0}")]
+    RateLimited(String),
+
+    #[error("dangerous tool disabled: {0}")]
+    DangerousToolDisabled(String),
+
+    #[error("confirmation required: {0}")]
+    ConfirmationRequired(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Guard {
+    security: SecurityConfig,
+    audit_config: AuditConfig,
+    allowed_clusters: Arc<[String]>,
+    audit_log: AuditLog,
+    rate_limiter: RateLimiter,
+    next_request_id: Arc<AtomicU64>,
+}
+
+impl Guard {
+    pub fn new(security: SecurityConfig, audit_config: AuditConfig, clusters: &[ClusterConfig]) -> Self {
+        let allowed_clusters = clusters
+            .iter()
+            .map(|cluster| cluster.name.clone())
+            .collect::<Vec<_>>()
+            .into();
+        Self {
+            security,
+            audit_config,
+            allowed_clusters,
+            audit_log: AuditLog::default(),
+            rate_limiter: RateLimiter::default(),
+            next_request_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    pub fn audit_log(&self) -> AuditLog {
+        self.audit_log.clone()
+    }
+
+    pub fn begin_tool_call(
+        &self,
+        tool_name: &str,
+        risk_level: RiskLevel,
+        arguments: &JsonObject,
+    ) -> Result<GuardedToolCall, GuardError> {
+        let guarded = GuardedToolCall {
+            guard: self.clone(),
+            request_id: self.allocate_request_id(),
+            tool_name: tool_name.to_string(),
+            risk_level,
+            cluster: extract_cluster(arguments),
+            arguments_hash: hash_arguments(arguments),
+            started_at: Instant::now(),
+        };
+
+        if let Err(error) = self.validate_cluster(arguments) {
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
+        if let Err(error) = rbac::check_rbac(&self.security, risk_level) {
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
+        if let Err(error) = self.check_dangerous_tool(tool_name, risk_level) {
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
+        if let Err(error) = confirmation::check_confirmation(&self.security, risk_level, arguments) {
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
+        if let Err(error) = self.rate_limiter.check(tool_name, self.security.rate_limit_per_minute) {
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
+        Ok(guarded)
+    }
+
+    fn allocate_request_id(&self) -> String {
+        let id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        format!("mcp-{id}")
+    }
+
+    fn validate_cluster(&self, arguments: &JsonObject) -> Result<(), GuardError> {
+        let Some(cluster) = extract_cluster(arguments) else {
+            return Ok(());
+        };
+
+        if self.allowed_clusters.iter().any(|allowed| allowed == &cluster) {
+            return Ok(());
+        }
+
+        Err(GuardError::InvalidArgument(format!(
+            "cluster `{cluster}` is not configured"
+        )))
+    }
+
+    fn check_dangerous_tool(&self, tool_name: &str, risk_level: RiskLevel) -> Result<(), GuardError> {
+        if matches!(risk_level, RiskLevel::Destructive) {
+            return Err(GuardError::DangerousToolDisabled(format!(
+                "{tool_name} is destructive and is not implemented"
+            )));
+        }
+
+        if risk_level.is_dangerous() && !self.security.allow_dangerous_tools {
+            return Err(GuardError::DangerousToolDisabled(format!(
+                "{tool_name} requires the dangerous-tools feature and runtime opt-in"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GuardedToolCall {
+    guard: Guard,
+    request_id: String,
+    tool_name: String,
+    risk_level: RiskLevel,
+    cluster: Option<String>,
+    arguments_hash: String,
+    started_at: Instant,
+}
+
+impl GuardedToolCall {
+    pub fn finish_result(&self, result: CallToolResult) -> CallToolResult {
+        let result = if self.guard.security.sanitize_output {
+            sanitizer::sanitize_call_tool_result(result)
+        } else {
+            result
+        };
+
+        let is_error = result.is_error.unwrap_or(false);
+        if is_error {
+            self.record_failure("tool returned an error result");
+        } else {
+            self.record_success();
+        }
+
+        result
+    }
+
+    pub fn record_protocol_error(&self, error: impl Into<String>) {
+        self.record_failure(error.into());
+    }
+
+    fn record_success(&self) {
+        self.record(AuditStatus::Success, None);
+    }
+
+    fn record_failure(&self, error: impl Into<String>) {
+        self.record(AuditStatus::Failure, Some(error.into()));
+    }
+
+    fn record(&self, status: AuditStatus, error: Option<String>) {
+        if !self.guard.audit_config.enabled {
+            return;
+        }
+
+        let record = AuditRecord::new(
+            self.request_id.clone(),
+            "ai-agent".to_string(),
+            None,
+            self.cluster.clone(),
+            self.tool_name.clone(),
+            self.arguments_hash.clone(),
+            self.risk_level,
+            status,
+            self.started_at.elapsed().as_millis(),
+            error,
+        );
+        self.guard.audit_log.record(&self.guard.audit_config, record);
+    }
+}
+
+fn extract_cluster(arguments: &JsonObject) -> Option<String> {
+    arguments
+        .get("cluster")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn hash_arguments(arguments: &JsonObject) -> String {
+    let bytes = serde_json::to_vec(arguments).unwrap_or_default();
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AuditConfig;
+    use crate::config::ClusterConfig;
+    use crate::config::SecurityConfig;
+
+    #[test]
+    fn read_only_profile_denies_diagnose_tool() {
+        let guard = test_guard("read_only", false, 60);
+        let arguments = serde_json::json!({ "cluster": "local-dev" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let err = guard
+            .begin_tool_call("mq_diagnose_consumer_lag", RiskLevel::Diagnose, &arguments)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("permission denied"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    #[test]
+    fn diagnose_profile_allows_read_only_and_diagnose_tools() {
+        let guard = test_guard("diagnose", false, 60);
+        let arguments = serde_json::json!({ "cluster": "local-dev" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        guard
+            .begin_tool_call("mq_cluster_overview", RiskLevel::ReadOnly, &arguments)
+            .unwrap();
+        guard
+            .begin_tool_call("mq_diagnose_consumer_lag", RiskLevel::Diagnose, &arguments)
+            .unwrap();
+    }
+
+    #[test]
+    fn dangerous_tools_are_disabled_without_runtime_opt_in() {
+        let guard = test_guard("operator", false, 60);
+        let arguments = serde_json::json!({ "cluster": "local-dev", "confirm_token": "yes" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let err = guard
+            .begin_tool_call("mq_reset_consumer_offset", RiskLevel::Change, &arguments)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("dangerous tool disabled"));
+    }
+
+    #[test]
+    fn rate_limit_denial_is_audited() {
+        let guard = test_guard("diagnose", false, 1);
+        let arguments = serde_json::json!({ "cluster": "local-dev" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        guard
+            .begin_tool_call("mq_cluster_overview", RiskLevel::ReadOnly, &arguments)
+            .unwrap();
+        let err = guard
+            .begin_tool_call("mq_cluster_overview", RiskLevel::ReadOnly, &arguments)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("rate limit exceeded"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    fn test_guard(profile: &str, allow_dangerous_tools: bool, rate_limit_per_minute: u32) -> Guard {
+        Guard::new(
+            SecurityConfig {
+                profile: profile.to_string(),
+                allow_dangerous_tools,
+                require_confirmation: true,
+                sanitize_output: true,
+                rate_limit_per_minute,
+            },
+            AuditConfig {
+                enabled: true,
+                sink: "memory".to_string(),
+                path: String::new(),
+            },
+            &[ClusterConfig {
+                name: "local-dev".to_string(),
+                namesrv_addr: "127.0.0.1:9876".to_string(),
+                default: Some(true),
+            }],
+        )
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/rate_limit.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/rate_limit.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::guard::GuardError;
+
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RateLimiter {
+    calls: Arc<Mutex<HashMap<String, VecDeque<Instant>>>>,
+}
+
+impl RateLimiter {
+    pub(crate) fn check(&self, tool_name: &str, limit_per_minute: u32) -> Result<(), GuardError> {
+        if limit_per_minute == 0 {
+            return Err(GuardError::RateLimited(format!(
+                "{tool_name} is disabled by zero rate limit"
+            )));
+        }
+
+        let Ok(mut calls) = self.calls.lock() else {
+            return Err(GuardError::RateLimited("rate limiter state is unavailable".to_string()));
+        };
+        let now = Instant::now();
+        let entries = calls.entry(tool_name.to_string()).or_default();
+
+        while entries
+            .front()
+            .is_some_and(|first_call| now.duration_since(*first_call) >= RATE_LIMIT_WINDOW)
+        {
+            entries.pop_front();
+        }
+
+        if entries.len() >= limit_per_minute as usize {
+            return Err(GuardError::RateLimited(format!(
+                "{tool_name} exceeded {limit_per_minute} calls per minute"
+            )));
+        }
+
+        entries.push_back(now);
+        Ok(())
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/rbac.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/rbac.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::SecurityConfig;
+use crate::guard::GuardError;
+use crate::guard::RiskLevel;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SecurityRole {
+    ReadOnly,
+    Diagnose,
+    Operator,
+}
+
+impl SecurityRole {
+    pub(crate) fn from_profile(profile: &str) -> Result<Self, GuardError> {
+        match profile.trim().to_ascii_lowercase().as_str() {
+            "read_only" | "readonly" | "read-only" => Ok(Self::ReadOnly),
+            "diagnose" | "diagnostic" => Ok(Self::Diagnose),
+            "operator" => Ok(Self::Operator),
+            other => Err(GuardError::InvalidArgument(format!(
+                "unknown security profile `{other}`"
+            ))),
+        }
+    }
+
+    fn allows(self, risk_level: RiskLevel) -> bool {
+        match self {
+            Self::ReadOnly => matches!(risk_level, RiskLevel::ReadOnly),
+            Self::Diagnose => matches!(risk_level, RiskLevel::ReadOnly | RiskLevel::Diagnose),
+            Self::Operator => matches!(
+                risk_level,
+                RiskLevel::ReadOnly | RiskLevel::Diagnose | RiskLevel::Change
+            ),
+        }
+    }
+}
+
+pub(crate) fn check_rbac(security: &SecurityConfig, risk_level: RiskLevel) -> Result<(), GuardError> {
+    let role = SecurityRole::from_profile(&security.profile)?;
+    if role.allows(risk_level) {
+        return Ok(());
+    }
+
+    Err(GuardError::PermissionDenied(format!(
+        "profile `{}` cannot call {risk_level} tools",
+        security.profile
+    )))
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/sanitizer.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/sanitizer.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rmcp::model::CallToolResult;
+use rmcp::model::ContentBlock;
+use serde_json::Value;
+
+const REDACTED: &str = "[REDACTED]";
+
+static SENSITIVE_ASSIGNMENT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)(access[_-]?key|secret[_-]?key|token|password)(["'\s:=]+)([^,\s"'}]+)"#).unwrap());
+
+pub fn sanitize_call_tool_result(mut result: CallToolResult) -> CallToolResult {
+    for content in &mut result.content {
+        if let ContentBlock::Text(text) = content {
+            text.text = sanitize_text(&text.text);
+        }
+    }
+
+    if let Some(structured_content) = result.structured_content.as_mut() {
+        sanitize_value(structured_content);
+    }
+
+    result
+}
+
+pub fn sanitize_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if is_sensitive_key(key) {
+                    *value = Value::String(REDACTED.to_string());
+                } else {
+                    sanitize_value(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                sanitize_value(value);
+            }
+        }
+        Value::String(value) => {
+            *value = sanitize_text(value);
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+pub fn sanitize_text(value: &str) -> String {
+    SENSITIVE_ASSIGNMENT
+        .replace_all(value, |captures: &regex::Captures<'_>| {
+            format!("{}{}{}", &captures[1], &captures[2], REDACTED)
+        })
+        .into_owned()
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key
+        .chars()
+        .filter(|ch| !matches!(ch, '_' | '-' | '.'))
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+
+    normalized.contains("accesskey")
+        || normalized.contains("secretkey")
+        || normalized.contains("token")
+        || normalized.contains("password")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_sensitive_json_fields_recursively() {
+        let mut value = serde_json::json!({
+            "access_key": "ak",
+            "nested": {
+                "secretKey": "sk",
+                "token": "token-value",
+                "broker_name": "broker-a"
+            }
+        });
+
+        sanitize_value(&mut value);
+
+        assert_eq!(value["access_key"], REDACTED);
+        assert_eq!(value["nested"]["secretKey"], REDACTED);
+        assert_eq!(value["nested"]["token"], REDACTED);
+        assert_eq!(value["nested"]["broker_name"], "broker-a");
+    }
+
+    #[test]
+    fn sanitizes_sensitive_text_assignments() {
+        let value = sanitize_text("access_key=ak secret-key:sk token=bearer password=pw");
+
+        assert!(!value.contains("ak"));
+        assert!(!value.contains("sk"));
+        assert!(!value.contains("bearer"));
+        assert!(!value.contains("pw"));
+        assert!(value.contains(REDACTED));
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/lib.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/lib.rs
@@ -20,6 +20,7 @@ pub mod adapter;
 pub mod app;
 pub mod config;
 pub mod error;
+pub mod guard;
 pub mod model;
 pub mod prompts;
 pub mod protocol;

--- a/rocketmq-tools/rocketmq-mcp/src/prompts/template.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/prompts/template.rs
@@ -51,6 +51,8 @@ pub enum PromptTemplateError {
 
 impl PromptTemplate {
     pub fn parse(source: &str) -> Result<Self, PromptTemplateError> {
+        let source = source.strip_prefix('\u{feff}').unwrap_or(source);
+        let source = source.replace("\r\n", "\n").replace('\r', "\n");
         let source = source
             .strip_prefix("---\n")
             .ok_or(PromptTemplateError::MissingFrontMatter)?;
@@ -91,5 +93,16 @@ Use {{cluster}}.
         assert_eq!(template.front_matter.arguments[0].name, "cluster");
         assert!(template.front_matter.arguments[0].required);
         assert!(template.body.contains("{{cluster}}"));
+    }
+
+    #[test]
+    fn parses_crlf_front_matter() {
+        let template = PromptTemplate::parse(
+            "---\r\nname: test_prompt\r\ntitle: Test Prompt\r\ndescription: Test description.\r\n---\r\nBody\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(template.front_matter.name, "test_prompt");
+        assert_eq!(template.body, "Body\n");
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -123,9 +123,12 @@ impl ServerHandler for RocketmqMcpServer {
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        ToolExecutor::new(AdminCoreAdapter::new(self.app.config().clone()))
-            .call(request)
-            .await
+        ToolExecutor::new(
+            AdminCoreAdapter::new(self.app.config().clone()),
+            self.app.guard().clone(),
+        )
+        .call(request)
+        .await
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -24,11 +24,14 @@ use rmcp::model::JsonObject;
 use rmcp::ErrorData;
 
 use crate::adapter::admin_core_adapter::ReadOnlyAdminAdapter;
+use crate::guard::Guard;
+use crate::guard::GuardError;
 use crate::service::diagnosis_service;
 use crate::tools::broker_tools;
 use crate::tools::cluster_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
+use crate::tools::registry;
 use crate::tools::topic_tools;
 
 #[derive(Debug, thiserror::Error)]
@@ -38,6 +41,18 @@ pub(crate) enum ToolExecutionError {
 
     #[error("backend error: {0}")]
     Backend(String),
+
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
+    #[error("rate limit exceeded: {0}")]
+    RateLimited(String),
+
+    #[error("dangerous tool disabled: {0}")]
+    DangerousToolDisabled(String),
+
+    #[error("confirmation required: {0}")]
+    ConfirmationRequired(String),
 }
 
 impl ToolExecutionError {
@@ -46,23 +61,51 @@ impl ToolExecutionError {
     }
 }
 
+impl From<GuardError> for ToolExecutionError {
+    fn from(error: GuardError) -> Self {
+        match error {
+            GuardError::InvalidArgument(message) => Self::InvalidArguments(message),
+            GuardError::PermissionDenied(message) => Self::PermissionDenied(message),
+            GuardError::RateLimited(message) => Self::RateLimited(message),
+            GuardError::DangerousToolDisabled(message) => Self::DangerousToolDisabled(message),
+            GuardError::ConfirmationRequired(message) => Self::ConfirmationRequired(message),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ToolExecutor<A> {
     adapter: A,
+    guard: Guard,
 }
 
 impl<A> ToolExecutor<A>
 where
     A: ReadOnlyAdminAdapter,
 {
-    pub(crate) fn new(adapter: A) -> Self {
-        Self { adapter }
+    pub(crate) fn new(adapter: A, guard: Guard) -> Self {
+        Self { adapter, guard }
     }
 
     pub(crate) async fn call(&self, request: CallToolRequestParams) -> Result<CallToolResult, ErrorData> {
-        match request.name.as_ref() {
+        let tool_name = request.name.to_string();
+        let risk_level = registry::tool_risk_level(&tool_name)
+            .ok_or_else(|| ErrorData::invalid_params(format!("unknown tool: {tool_name}"), None))?;
+        let arguments = request.arguments.unwrap_or_default();
+        let guarded_call = match self.guard.begin_tool_call(&tool_name, risk_level, &arguments) {
+            Ok(guarded_call) => guarded_call,
+            Err(error) => return Ok(error_result(&tool_name, error.into())),
+        };
+
+        let result = match tool_name.as_str() {
             cluster_tools::CLUSTER_OVERVIEW_TOOL => {
-                let args = decode_args::<cluster_tools::ClusterOverviewArgs>(request.arguments)?;
+                let args = match decode_args::<cluster_tools::ClusterOverviewArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .cluster_overview(args)
                     .await
@@ -70,7 +113,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(cluster_tools::CLUSTER_OVERVIEW_TOOL, error)))
             }
             topic_tools::LIST_TOPICS_TOOL => {
-                let args = decode_args::<topic_tools::ListTopicsArgs>(request.arguments)?;
+                let args = match decode_args::<topic_tools::ListTopicsArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .list_topics(args)
                     .await
@@ -78,7 +127,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(topic_tools::LIST_TOPICS_TOOL, error)))
             }
             topic_tools::DESCRIBE_TOPIC_TOOL => {
-                let args = decode_args::<topic_tools::DescribeTopicArgs>(request.arguments)?;
+                let args = match decode_args::<topic_tools::DescribeTopicArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .describe_topic(args)
                     .await
@@ -86,7 +141,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(topic_tools::DESCRIBE_TOPIC_TOOL, error)))
             }
             topic_tools::QUERY_TOPIC_ROUTE_TOOL => {
-                let args = decode_args::<topic_tools::QueryTopicRouteArgs>(request.arguments)?;
+                let args = match decode_args::<topic_tools::QueryTopicRouteArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .query_topic_route(args)
                     .await
@@ -94,7 +155,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(topic_tools::QUERY_TOPIC_ROUTE_TOOL, error)))
             }
             consumer_tools::LIST_CONSUMER_GROUPS_TOOL => {
-                let args = decode_args::<consumer_tools::ListConsumerGroupsArgs>(request.arguments)?;
+                let args = match decode_args::<consumer_tools::ListConsumerGroupsArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .list_consumer_groups(args)
                     .await
@@ -102,7 +169,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(consumer_tools::LIST_CONSUMER_GROUPS_TOOL, error)))
             }
             consumer_tools::QUERY_CONSUMER_LAG_TOOL => {
-                let args = decode_args::<consumer_tools::QueryConsumerLagArgs>(request.arguments)?;
+                let args = match decode_args::<consumer_tools::QueryConsumerLagArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .query_consumer_lag(args)
                     .await
@@ -110,7 +183,13 @@ where
                     .unwrap_or_else(|error| Ok(error_result(consumer_tools::QUERY_CONSUMER_LAG_TOOL, error)))
             }
             broker_tools::DESCRIBE_BROKER_TOOL => {
-                let args = decode_args::<broker_tools::DescribeBrokerArgs>(request.arguments)?;
+                let args = match decode_args::<broker_tools::DescribeBrokerArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 self.adapter
                     .describe_broker(args)
                     .await
@@ -118,22 +197,30 @@ where
                     .unwrap_or_else(|error| Ok(error_result(broker_tools::DESCRIBE_BROKER_TOOL, error)))
             }
             diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL => {
-                let args = decode_args::<diagnosis_tools::DiagnoseConsumerLagArgs>(request.arguments)?;
+                let args = match decode_args::<diagnosis_tools::DiagnoseConsumerLagArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
                 diagnosis_service::diagnose_consumer_lag(&self.adapter, args)
                     .await
                     .map(|output| success_result(output.summary.clone(), &output))
                     .unwrap_or_else(|error| Ok(error_result(diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL, error)))
             }
-            tool_name => Err(ErrorData::invalid_params(format!("unknown tool: {tool_name}"), None)),
-        }
+            _ => unreachable!("unknown tool was rejected before dispatch"),
+        }?;
+
+        Ok(guarded_call.finish_result(result))
     }
 }
 
-fn decode_args<T>(arguments: Option<JsonObject>) -> Result<T, ErrorData>
+fn decode_args<T>(arguments: JsonObject) -> Result<T, ErrorData>
 where
     T: DeserializeOwned,
 {
-    serde_json::from_value(Value::Object(arguments.unwrap_or_default()))
+    serde_json::from_value(Value::Object(arguments))
         .map_err(|error| ErrorData::invalid_params(format!("invalid tool arguments: {error}"), None))
 }
 
@@ -218,6 +305,12 @@ fn summary_describe_broker(output: &broker_tools::DescribeBrokerOutput) -> Strin
 
 #[cfg(test)]
 mod tests {
+    use crate::config::AuditConfig;
+    use crate::config::ClusterConfig;
+    use crate::config::SecurityConfig;
+    use crate::guard::audit::AuditStatus;
+    use crate::guard::Guard;
+
     use super::*;
 
     #[derive(Clone)]
@@ -231,7 +324,9 @@ mod tests {
             args: cluster_tools::ClusterOverviewArgs,
         ) -> Result<cluster_tools::ClusterOverviewOutput, ToolExecutionError> {
             if self.fail {
-                return Err(ToolExecutionError::backend("nameserver unavailable"));
+                return Err(ToolExecutionError::backend(
+                    "nameserver unavailable secret_key=super-secret",
+                ));
             }
             Ok(cluster_tools::ClusterOverviewOutput {
                 cluster: args.cluster,
@@ -288,7 +383,8 @@ mod tests {
 
     #[tokio::test]
     async fn call_returns_summary_and_structured_content() {
-        let result = ToolExecutor::new(FakeAdapter { fail: false })
+        let guard = test_guard("diagnose");
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
             .call(
                 CallToolRequestParams::new(cluster_tools::CLUSTER_OVERVIEW_TOOL).with_arguments(
                     serde_json::json!({
@@ -305,11 +401,17 @@ mod tests {
         assert_eq!(result.is_error, Some(false));
         assert_eq!(result.structured_content.as_ref().unwrap()["cluster"], "local-dev");
         assert!(!result.content.is_empty());
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].tool, cluster_tools::CLUSTER_OVERVIEW_TOOL);
+        assert_eq!(records[0].cluster.as_deref(), Some("local-dev"));
+        assert_eq!(records[0].status, AuditStatus::Success);
     }
 
     #[tokio::test]
     async fn backend_error_is_returned_as_tool_error() {
-        let result = ToolExecutor::new(FakeAdapter { fail: true })
+        let guard = test_guard("diagnose");
+        let result = ToolExecutor::new(FakeAdapter { fail: true }, guard.clone())
             .call(
                 CallToolRequestParams::new(cluster_tools::CLUSTER_OVERVIEW_TOOL).with_arguments(
                     serde_json::json!({
@@ -328,16 +430,86 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("nameserver unavailable"));
+        assert!(!result
+            .structured_content
+            .as_ref()
+            .unwrap()
+            .to_string()
+            .contains("super-secret"));
+        assert!(!content_text(&result).contains("super-secret"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
     }
 
     #[tokio::test]
     async fn unknown_tool_returns_protocol_error() {
-        let err = ToolExecutor::new(FakeAdapter { fail: false })
+        let err = ToolExecutor::new(FakeAdapter { fail: false }, test_guard("diagnose"))
             .call(CallToolRequestParams::new("unknown_tool"))
             .await
             .unwrap_err();
 
         assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn read_only_guard_denies_diagnosis_tool() {
+        let guard = test_guard("read_only");
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
+            .call(
+                CallToolRequestParams::new(diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "topic": "orders",
+                        "consumer_group": "order-service",
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(content_text(&result).contains("permission denied"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    fn content_text(result: &CallToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter_map(|content| match content {
+                ContentBlock::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn test_guard(profile: &str) -> Guard {
+        Guard::new(
+            SecurityConfig {
+                profile: profile.to_string(),
+                allow_dangerous_tools: false,
+                require_confirmation: true,
+                sanitize_output: true,
+                rate_limit_per_minute: 60,
+            },
+            AuditConfig {
+                enabled: true,
+                sink: "memory".to_string(),
+                path: String::new(),
+            },
+            &[ClusterConfig {
+                name: "local-dev".to_string(),
+                namesrv_addr: "127.0.0.1:9876".to_string(),
+                default: Some(true),
+            }],
+        )
     }
 
     fn broker_summary() -> cluster_tools::BrokerSummary {

--- a/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
@@ -18,6 +18,7 @@ use rmcp::model::ListToolsResult;
 use rmcp::model::Tool;
 use rmcp::model::ToolAnnotations;
 
+use crate::guard::RiskLevel;
 use crate::tools::broker_tools;
 use crate::tools::cluster_tools;
 use crate::tools::consumer_tools;
@@ -30,6 +31,20 @@ pub fn list_tools() -> ListToolsResult {
 
 pub fn get_tool(name: &str) -> Option<Tool> {
     tool_definitions().into_iter().find(|tool| tool.name.as_ref() == name)
+}
+
+pub fn tool_risk_level(name: &str) -> Option<RiskLevel> {
+    match name {
+        cluster_tools::CLUSTER_OVERVIEW_TOOL
+        | topic_tools::LIST_TOPICS_TOOL
+        | topic_tools::DESCRIBE_TOPIC_TOOL
+        | topic_tools::QUERY_TOPIC_ROUTE_TOOL
+        | consumer_tools::LIST_CONSUMER_GROUPS_TOOL
+        | consumer_tools::QUERY_CONSUMER_LAG_TOOL
+        | broker_tools::DESCRIBE_BROKER_TOOL => Some(RiskLevel::ReadOnly),
+        diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL => Some(RiskLevel::Diagnose),
+        _ => None,
+    }
 }
 
 pub fn tool_definitions() -> Vec<Tool> {
@@ -132,5 +147,16 @@ mod tests {
             assert_eq!(annotations.read_only_hint, Some(true));
             assert_eq!(annotations.destructive_hint, Some(false));
         }
+    }
+
+    #[test]
+    fn each_registered_tool_has_a_guard_risk_level() {
+        for tool in tool_definitions() {
+            assert!(tool_risk_level(tool.name.as_ref()).is_some());
+        }
+        assert_eq!(
+            tool_risk_level(diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL),
+            Some(RiskLevel::Diagnose)
+        );
     }
 }


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8141

### Brief Description

Adds the rocketmq-mcp guard pipeline for tool execution.
Tool calls now pass through cluster validation, RBAC, dangerous-tool checks, confirmation checks, rate limiting, output sanitization, and audit recording. The change also makes prompt template parsing tolerant of CRLF front matter so Windows checkouts keep prompt tests stable.

### How Did You Test This Change?

- cargo fmt --all
- cargo check -p rocketmq-mcp
- cargo test -p rocketmq-mcp guard
- cargo test -p rocketmq-mcp prompt
- cargo test -p rocketmq-mcp
- cargo clippy --all-targets -p rocketmq-mcp -- -D warnings
- cargo run -p rocketmq-mcp -- --config <temporary memory-audit config> --transport stdio
- .\scripts\check-agents-routing.ps1
- git diff --check
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
