### PR TITLE
[ISSUE #8145]🧪Add rocketmq-mcp protocol contract tests

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/guard/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/mod.rs
@@ -376,6 +376,24 @@ mod tests {
         assert_eq!(records[0].status, AuditStatus::Failure);
     }
 
+    #[test]
+    fn security_policy_denies_destructive_tools_even_for_operator() {
+        let guard = test_guard("operator", true, 60);
+        let arguments = serde_json::json!({ "cluster": "local-dev", "confirm_token": "yes" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let err = guard
+            .begin_tool_call("mq_delete_topic", RiskLevel::Destructive, &arguments)
+            .unwrap_err();
+
+        assert!(err.to_string().to_ascii_lowercase().contains("destructive"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
     fn test_guard(profile: &str, allow_dangerous_tools: bool, rate_limit_per_minute: u32) -> Guard {
         Guard::new(
             SecurityConfig {

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -139,10 +139,14 @@ impl ServerHandler for RocketmqMcpServer {
 #[cfg(test)]
 mod tests {
     use rmcp::ServerHandler;
+    use serde_json::json;
 
     use super::*;
     use crate::app::McpApp;
     use crate::config::McpConfig;
+    use crate::prompts;
+    use crate::resources;
+    use crate::tools;
 
     #[test]
     fn server_info_declares_mvp_capabilities() {
@@ -156,6 +160,57 @@ mod tests {
         assert!(info.capabilities.tools.is_some());
         assert!(info.capabilities.resources.is_some());
         assert!(info.capabilities.prompts.is_some());
+    }
+
+    #[test]
+    fn mcp_protocol_surface_snapshot() {
+        let tools = tools::registry::list_tools()
+            .tools
+            .into_iter()
+            .map(|tool| {
+                let annotations = tool.annotations.expect("tool annotations");
+                json!({
+                    "name": tool.name.as_ref(),
+                    "has_input_schema": tool.input_schema.get("type").is_some(),
+                    "has_output_schema": tool.output_schema.is_some(),
+                    "read_only": annotations.read_only_hint,
+                    "destructive": annotations.destructive_hint,
+                })
+            })
+            .collect::<Vec<_>>();
+        let resources = resources::registry::list_resources()
+            .resources
+            .into_iter()
+            .map(|resource| {
+                json!({
+                    "uri": resource.uri,
+                    "name": resource.name,
+                    "mime_type": resource.mime_type,
+                })
+            })
+            .collect::<Vec<_>>();
+        let resource_templates = resources::registry::list_resource_templates().resource_templates;
+        let prompts = prompts::registry::list_prompts()
+            .unwrap()
+            .prompts
+            .into_iter()
+            .map(|prompt| {
+                json!({
+                    "name": prompt.name,
+                    "argument_count": prompt.arguments.as_ref().map(Vec::len).unwrap_or_default(),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        insta::assert_json_snapshot!(
+            "mcp_protocol_surface",
+            json!({
+                "tools": tools,
+                "resources": resources,
+                "resource_templates": resource_templates,
+                "prompts": prompts,
+            })
+        );
     }
 
     fn example_config_path() -> std::path::PathBuf {

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -1,0 +1,97 @@
+---
+source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+expression: "json!({\n    \"tools\": tools, \"resources\": resources, \"resource_templates\":\n    resource_templates, \"prompts\": prompts,\n})"
+---
+{
+  "prompts": [
+    {
+      "argument_count": 4,
+      "name": "diagnose_consumer_lag"
+    },
+    {
+      "argument_count": 3,
+      "name": "broker_health_check"
+    }
+  ],
+  "resource_templates": [],
+  "resources": [
+    {
+      "mime_type": "application/json",
+      "name": "cluster_overview",
+      "uri": "rocketmq://cluster/overview"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "topics",
+      "uri": "rocketmq://topics"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "brokers",
+      "uri": "rocketmq://brokers"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "consumer_groups",
+      "uri": "rocketmq://consumer-groups"
+    }
+  ],
+  "tools": [
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_cluster_overview",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_list_topics",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_describe_topic",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_query_topic_route",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_list_consumer_groups",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_query_consumer_lag",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_describe_broker",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_diagnose_consumer_lag",
+      "read_only": true
+    }
+  ]
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
@@ -159,4 +159,27 @@ mod tests {
             Some(RiskLevel::Diagnose)
         );
     }
+
+    #[test]
+    fn tool_contract_schema_metadata_snapshot() {
+        let contracts = tool_definitions()
+            .into_iter()
+            .map(|tool| {
+                let annotations = tool.annotations.expect("tool annotations");
+                let output_schema = tool.output_schema.expect("output schema");
+                serde_json::json!({
+                    "name": tool.name.as_ref(),
+                    "input_type": tool.input_schema.get("type"),
+                    "input_required": tool.input_schema.get("required"),
+                    "output_type": output_schema.get("type"),
+                    "read_only": annotations.read_only_hint,
+                    "destructive": annotations.destructive_hint,
+                    "idempotent": annotations.idempotent_hint,
+                    "open_world": annotations.open_world_hint,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        insta::assert_json_snapshot!("tool_contract_schema_metadata", contracts);
+    }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata.snap
@@ -1,0 +1,105 @@
+---
+source: rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+expression: contracts
+---
+[
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster"
+    ],
+    "input_type": "object",
+    "name": "mq_cluster_overview",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": null,
+    "input_type": "object",
+    "name": "mq_list_topics",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic"
+    ],
+    "input_type": "object",
+    "name": "mq_describe_topic",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic"
+    ],
+    "input_type": "object",
+    "name": "mq_query_topic_route",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": null,
+    "input_type": "object",
+    "name": "mq_list_consumer_groups",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic",
+      "consumer_group"
+    ],
+    "input_type": "object",
+    "name": "mq_query_consumer_lag",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "broker_name"
+    ],
+    "input_type": "object",
+    "name": "mq_describe_broker",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic",
+      "consumer_group"
+    ],
+    "input_type": "object",
+    "name": "mq_diagnose_consumer_lag",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  }
+]

--- a/rocketmq-tools/rocketmq-mcp/tests/integration.rs
+++ b/rocketmq-tools/rocketmq-mcp/tests/integration.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::process::Command;
+use std::process::Stdio;
+
+use serde_json::Value;
+
+#[test]
+fn mcp_inspector_stdio_surface_integration() {
+    let output = run_stdio_server(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"integration-inspector","version":"1.0.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"resources/list","params":{}}
+{"jsonrpc":"2.0","id":4,"method":"resources/templates/list","params":{}}
+{"jsonrpc":"2.0","id":5,"method":"prompts/list","params":{}}
+{"jsonrpc":"2.0","id":6,"method":"resources/read","params":{"uri":"rocketmq://cluster/overview"}}
+{"jsonrpc":"2.0","id":7,"method":"prompts/get","params":{"name":"broker_health_check","arguments":{"cluster":"local-dev"}}}
+{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"mq_cluster_overview","arguments":{"cluster":"missing-cluster"}}}
+"#,
+    );
+
+    assert!(output.status.success(), "server failed: {}", output.stderr);
+    let responses = parse_stdout_json(&output.stdout);
+
+    assert!(responses[&1]["result"]["capabilities"]["tools"].is_object());
+    assert!(responses[&1]["result"]["capabilities"]["resources"].is_object());
+    assert!(responses[&1]["result"]["capabilities"]["prompts"].is_object());
+    assert_json_array_contains_field_value(&responses[&2]["result"]["tools"], "name", "mq_cluster_overview");
+    assert_json_array_contains_field_value(
+        &responses[&3]["result"]["resources"],
+        "uri",
+        "rocketmq://cluster/overview",
+    );
+    assert!(responses[&4]["result"]["resourceTemplates"].is_array());
+    assert_json_array_contains_field_value(&responses[&5]["result"]["prompts"], "name", "diagnose_consumer_lag");
+    assert!(responses[&6]["result"]["contents"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("local-dev"));
+    assert!(responses[&7]["result"]["messages"][0]["content"]["text"]
+        .as_str()
+        .unwrap()
+        .contains("Broker Health Check Task"));
+    assert_eq!(responses[&8]["result"]["isError"], true);
+    assert!(responses[&8]["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("missing-cluster"));
+}
+
+struct StdioOutput {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_stdio_server(input: &str) -> StdioOutput {
+    let binary = env!("CARGO_BIN_EXE_rocketmq-mcp");
+    let config = temporary_memory_audit_config();
+    let mut child = Command::new(binary)
+        .arg("--config")
+        .arg(&config)
+        .arg("--transport")
+        .arg("stdio")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rocketmq-mcp");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write json-rpc input");
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().expect("wait for rocketmq-mcp");
+    let _ = std::fs::remove_file(config);
+    StdioOutput {
+        status: output.status,
+        stdout: String::from_utf8(output.stdout).expect("stdout utf8"),
+        stderr: String::from_utf8(output.stderr).expect("stderr utf8"),
+    }
+}
+
+fn temporary_memory_audit_config() -> std::path::PathBuf {
+    let example = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("conf")
+        .join("mcp.example.toml");
+    let config = std::fs::read_to_string(example).expect("read example config");
+    let config = config
+        .replace("sink = \"file\"", "sink = \"memory\"")
+        .replace("path = \"./logs/rocketmq-mcp-audit.log\"", "path = \"\"");
+    let path = std::env::temp_dir().join(format!("rocketmq-mcp-integration-{}.toml", std::process::id()));
+    std::fs::write(&path, config).expect("write temp config");
+    path
+}
+
+fn parse_stdout_json(stdout: &str) -> HashMap<i64, Value> {
+    let mut responses = HashMap::new();
+    for (line_number, line) in stdout.lines().enumerate() {
+        let value = serde_json::from_str::<Value>(line)
+            .unwrap_or_else(|error| panic!("stdout line {} was not JSON: {error}: {line}", line_number + 1));
+        if let Some(id) = value.get("id").and_then(Value::as_i64) {
+            responses.insert(id, value);
+        }
+    }
+    responses
+}
+
+fn assert_json_array_contains_field_value(array: &Value, field: &str, expected: &str) {
+    let values = array.as_array().expect("json array");
+    assert!(
+        values
+            .iter()
+            .any(|value| value.get(field).and_then(Value::as_str) == Some(expected)),
+        "expected {field}={expected} in {values:?}",
+    );
+}


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8145

### Brief Description

Adds rocketmq-mcp protocol, tool contract, security, snapshot, and stdio integration coverage.
The new tests snapshot the MCP discovery surface and tool schema metadata, add a security denial test, and drive the rocketmq-mcp binary over stdio to verify tools, resources, prompts, error results, and stdout JSON cleanliness.

### How Did You Test This Change?

- cargo fmt --all
- INSTA_UPDATE=always cargo test -p rocketmq-mcp mcp_protocol
- INSTA_UPDATE=always cargo test -p rocketmq-mcp tool_contract
- cargo test -p rocketmq-mcp mcp_protocol
- cargo test -p rocketmq-mcp tool_contract
- cargo test -p rocketmq-mcp security
- cargo test -p rocketmq-mcp --test integration
- cargo test -p rocketmq-mcp
- cargo test -p rocketmq-mcp --features streamable-http http
- cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings
- git diff --check
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for the MCP interface and tool behavior.
  * Added checks for the exposed tool, resource, template, and prompt surface to keep responses consistent.
  * Added coverage for audit logging and destructive action blocking, including operator scenarios.
  * Added an end-to-end startup and request flow test over standard input/output to verify initialization, listings, resource reads, prompts, and tool error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->