### PR TITLE
[ISSUE #8149]🚀Reserve controlled change guardrails

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -24,7 +24,7 @@ Optional features:
 
 - `streamable-http`: enables the Streamable HTTP transport.
 - `observability`: reserves integration with the repository observability crate.
-- `dangerous-tools`: reserved for future controlled change tools and still requires runtime policy.
+- `dangerous-tools`: registers future controlled change tools as dry-run plan generators and still requires runtime policy.
 
 ## Safety Boundary
 
@@ -38,6 +38,8 @@ The default profile is diagnostics-oriented and read-only:
 - `server.stdio.log_to_stderr = true` keeps stdout reserved for MCP protocol frames.
 
 For HTTP deployments, keep `server.http.bind` on loopback unless there is a reviewed network boundary. When `server.http.require_auth = true`, the process requires `ROCKETMQ_MCP_HTTP_TOKEN` and clients must send `Authorization: Bearer <token>`.
+
+When `dangerous-tools` is compiled, change tools are still controlled by runtime policy. Dry-run requests return a change plan, impact analysis, rollback suggestions, and a confirmation challenge. Apply requests require `confirm_token` and are rejected by the current implementation; no mutation API is called.
 
 ## Build
 
@@ -200,6 +202,14 @@ For HTTP-capable clients, use the Streamable HTTP URL `http://127.0.0.1:8089/mcp
 - `mq_query_consumer_lag`: query consumer progress and lag.
 - `mq_describe_broker`: describe broker runtime information.
 - `mq_diagnose_consumer_lag`: aggregate read-only evidence and return a diagnosis report.
+
+Feature-gated controlled change tools, available only with `dangerous-tools`, are dry-run plan generators:
+
+- `mq_create_topic`: plan future topic creation.
+- `mq_update_topic_config`: plan future topic configuration updates.
+- `mq_update_topic_perm`: plan future topic permission updates.
+- `mq_update_broker_config`: plan future broker configuration updates.
+- `mq_reset_consumer_offset`: plan future consumer offset resets with impact analysis.
 
 ## Resources
 

--- a/rocketmq-tools/rocketmq-mcp/src/guard/confirmation.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/confirmation.rs
@@ -24,11 +24,19 @@ pub(crate) fn check_confirmation(
     risk_level: RiskLevel,
     arguments: &JsonObject,
 ) -> Result<(), GuardError> {
-    if !security.require_confirmation || !matches!(risk_level, RiskLevel::Change) {
+    if !matches!(risk_level, RiskLevel::Change) {
+        return Ok(());
+    }
+
+    if is_dry_run_change(arguments) {
         return Ok(());
     }
 
     if has_non_empty_string(arguments, "confirm_token") {
+        return Ok(());
+    }
+
+    if !security.require_confirmation && !is_apply_change(arguments) {
         return Ok(());
     }
 
@@ -42,4 +50,78 @@ fn has_non_empty_string(arguments: &JsonObject, key: &str) -> bool {
         .get(key)
         .and_then(Value::as_str)
         .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn is_dry_run_change(arguments: &JsonObject) -> bool {
+    arguments
+        .get("mode")
+        .and_then(Value::as_str)
+        .map(|value| value.trim().to_ascii_lowercase())
+        .is_some_and(|value| matches!(value.as_str(), "dry_run" | "dry-run" | "dryrun"))
+}
+
+fn is_apply_change(arguments: &JsonObject) -> bool {
+    arguments
+        .get("mode")
+        .and_then(Value::as_str)
+        .map(|value| value.trim().to_ascii_lowercase())
+        .is_some_and(|value| value == "apply")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_dry_run_does_not_require_confirm_token() {
+        let arguments = serde_json::json!({
+            "cluster": "local-dev",
+            "mode": "dry_run",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        check_confirmation(&security(true), RiskLevel::Change, &arguments).unwrap();
+    }
+
+    #[test]
+    fn change_apply_requires_confirm_token() {
+        let arguments = serde_json::json!({
+            "cluster": "local-dev",
+            "mode": "apply",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let err = check_confirmation(&security(true), RiskLevel::Change, &arguments).unwrap_err();
+
+        assert!(err.to_string().contains("confirm_token"));
+    }
+
+    #[test]
+    fn change_apply_requires_confirm_token_even_when_confirmation_is_disabled() {
+        let arguments = serde_json::json!({
+            "cluster": "local-dev",
+            "mode": "apply",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let err = check_confirmation(&security(false), RiskLevel::Change, &arguments).unwrap_err();
+
+        assert!(err.to_string().contains("confirm_token"));
+    }
+
+    fn security(require_confirmation: bool) -> SecurityConfig {
+        SecurityConfig {
+            profile: "operator".to_string(),
+            allow_dangerous_tools: true,
+            require_confirmation,
+            sanitize_output: true,
+            rate_limit_per_minute: 60,
+        }
+    }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -202,15 +202,18 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        insta::assert_json_snapshot!(
-            "mcp_protocol_surface",
-            json!({
-                "tools": tools,
-                "resources": resources,
-                "resource_templates": resource_templates,
-                "prompts": prompts,
-            })
-        );
+        let surface = json!({
+            "tools": tools,
+            "resources": resources,
+            "resource_templates": resource_templates,
+            "prompts": prompts,
+        });
+
+        #[cfg(not(feature = "dangerous-tools"))]
+        insta::assert_json_snapshot!("mcp_protocol_surface", surface);
+
+        #[cfg(feature = "dangerous-tools")]
+        insta::assert_json_snapshot!("mcp_protocol_surface_with_dangerous_tools", surface);
     }
 
     fn example_config_path() -> std::path::PathBuf {

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_dangerous_tools.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_dangerous_tools.snap
@@ -1,0 +1,132 @@
+---
+source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+expression: surface
+---
+{
+  "prompts": [
+    {
+      "argument_count": 4,
+      "name": "diagnose_consumer_lag"
+    },
+    {
+      "argument_count": 3,
+      "name": "broker_health_check"
+    }
+  ],
+  "resource_templates": [],
+  "resources": [
+    {
+      "mime_type": "application/json",
+      "name": "cluster_overview",
+      "uri": "rocketmq://cluster/overview"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "topics",
+      "uri": "rocketmq://topics"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "brokers",
+      "uri": "rocketmq://brokers"
+    },
+    {
+      "mime_type": "application/json",
+      "name": "consumer_groups",
+      "uri": "rocketmq://consumer-groups"
+    }
+  ],
+  "tools": [
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_cluster_overview",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_list_topics",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_describe_topic",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_query_topic_route",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_list_consumer_groups",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_query_consumer_lag",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_describe_broker",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_diagnose_consumer_lag",
+      "read_only": true
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_create_topic",
+      "read_only": false
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_update_topic_config",
+      "read_only": false
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_update_topic_perm",
+      "read_only": false
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_update_broker_config",
+      "read_only": false
+    },
+    {
+      "destructive": false,
+      "has_input_schema": true,
+      "has_output_schema": true,
+      "name": "mq_reset_consumer_offset",
+      "read_only": false
+    }
+  ]
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/change_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/change_tools.rs
@@ -1,0 +1,340 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const CREATE_TOPIC_TOOL: &str = "mq_create_topic";
+pub const UPDATE_TOPIC_CONFIG_TOOL: &str = "mq_update_topic_config";
+pub const UPDATE_TOPIC_PERM_TOOL: &str = "mq_update_topic_perm";
+pub const UPDATE_BROKER_CONFIG_TOOL: &str = "mq_update_broker_config";
+pub const RESET_CONSUMER_OFFSET_TOOL: &str = "mq_reset_consumer_offset";
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ChangeRequest<T> {
+    pub cluster: String,
+    pub mode: ChangeMode,
+    pub operator: String,
+    pub reason: String,
+    #[serde(default)]
+    pub confirm_token: Option<String>,
+    pub payload: T,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeMode {
+    #[serde(alias = "dry-run", alias = "dryrun")]
+    DryRun,
+    Apply,
+}
+
+impl ChangeMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DryRun => "dry_run",
+            Self::Apply => "apply",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct CreateTopicPayload {
+    pub topic: String,
+    #[serde(default)]
+    pub read_queue_nums: Option<u32>,
+    #[serde(default)]
+    pub write_queue_nums: Option<u32>,
+    #[serde(default)]
+    pub perm: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct UpdateTopicConfigPayload {
+    pub topic: String,
+    pub config_key: String,
+    pub config_value: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct UpdateTopicPermPayload {
+    pub topic: String,
+    pub perm: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct UpdateBrokerConfigPayload {
+    pub broker_name: String,
+    pub config_key: String,
+    pub config_value: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ResetConsumerOffsetPayload {
+    pub topic: String,
+    pub consumer_group: String,
+    #[serde(default)]
+    pub target_offset: Option<i64>,
+    #[serde(default)]
+    pub timestamp_millis: Option<i64>,
+}
+
+pub type CreateTopicArgs = ChangeRequest<CreateTopicPayload>;
+pub type UpdateTopicConfigArgs = ChangeRequest<UpdateTopicConfigPayload>;
+pub type UpdateTopicPermArgs = ChangeRequest<UpdateTopicPermPayload>;
+pub type UpdateBrokerConfigArgs = ChangeRequest<UpdateBrokerConfigPayload>;
+pub type ResetConsumerOffsetArgs = ChangeRequest<ResetConsumerOffsetPayload>;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ChangePlan {
+    pub tool: String,
+    pub cluster: String,
+    pub mode: ChangeMode,
+    pub operator: String,
+    pub reason: String,
+    pub summary: String,
+    pub planned_changes: Vec<String>,
+    pub impact_analysis: Vec<String>,
+    pub rollback_suggestions: Vec<String>,
+    pub confirm_challenge: Option<ConfirmChallenge>,
+    pub applied: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ConfirmChallenge {
+    pub challenge_id: String,
+    pub instruction: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChangeToolError {
+    #[error("{0} apply mode is reserved; no mutation was executed")]
+    ApplyReserved(&'static str),
+}
+
+pub fn plan_create_topic(request: CreateTopicArgs) -> Result<ChangePlan, ChangeToolError> {
+    planned_change(
+        CREATE_TOPIC_TOOL,
+        request,
+        |payload| {
+            vec![format!(
+                "Create topic `{}` with read_queue_nums={:?}, write_queue_nums={:?}, perm={:?}.",
+                payload.topic, payload.read_queue_nums, payload.write_queue_nums, payload.perm
+            )]
+        },
+        |payload| {
+            vec![
+                format!(
+                    "Namesrv and brokers would expose a new topic named `{}`.",
+                    payload.topic
+                ),
+                "No messages are produced, consumed, or moved during dry-run.".to_string(),
+            ]
+        },
+        |payload| {
+            vec![format!(
+                "If applied later and validation fails, delete or disable topic `{}` through reviewed operator \
+                 tooling.",
+                payload.topic
+            )]
+        },
+    )
+}
+
+pub fn plan_update_topic_config(request: UpdateTopicConfigArgs) -> Result<ChangePlan, ChangeToolError> {
+    planned_change(
+        UPDATE_TOPIC_CONFIG_TOOL,
+        request,
+        |payload| {
+            vec![format!(
+                "Update topic `{}` config `{}` to `{}`.",
+                payload.topic, payload.config_key, payload.config_value
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Producers and consumers using topic `{}` may observe the new `{}` value after apply.",
+                payload.topic, payload.config_key
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Record the previous `{}` value before apply and restore it if validation fails.",
+                payload.config_key
+            )]
+        },
+    )
+}
+
+pub fn plan_update_topic_perm(request: UpdateTopicPermArgs) -> Result<ChangePlan, ChangeToolError> {
+    planned_change(
+        UPDATE_TOPIC_PERM_TOOL,
+        request,
+        |payload| {
+            vec![format!(
+                "Update topic `{}` permission to `{}`.",
+                payload.topic, payload.perm
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Topic `{}` clients may gain or lose read/write access after apply.",
+                payload.topic
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Record the current permission for topic `{}` and restore it if client validation fails.",
+                payload.topic
+            )]
+        },
+    )
+}
+
+pub fn plan_update_broker_config(request: UpdateBrokerConfigArgs) -> Result<ChangePlan, ChangeToolError> {
+    planned_change(
+        UPDATE_BROKER_CONFIG_TOOL,
+        request,
+        |payload| {
+            vec![format!(
+                "Update broker `{}` config `{}` to `{}`.",
+                payload.broker_name, payload.config_key, payload.config_value
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Broker `{}` behavior may change after `{}` is applied.",
+                payload.broker_name, payload.config_key
+            )]
+        },
+        |payload| {
+            vec![format!(
+                "Record the previous broker `{}` value and restore it if broker health checks fail.",
+                payload.config_key
+            )]
+        },
+    )
+}
+
+pub fn plan_reset_consumer_offset(request: ResetConsumerOffsetArgs) -> Result<ChangePlan, ChangeToolError> {
+    planned_change(
+        RESET_CONSUMER_OFFSET_TOOL,
+        request,
+        |payload| {
+            vec![format!(
+                "Reset consumer group `{}` offset for topic `{}` to offset {:?} or timestamp {:?}.",
+                payload.consumer_group, payload.topic, payload.target_offset, payload.timestamp_millis
+            )]
+        },
+        |payload| {
+            vec![
+                format!(
+                    "Consumer group `{}` may reconsume or skip messages on topic `{}` after apply.",
+                    payload.consumer_group, payload.topic
+                ),
+                "Run dry-run evidence review with lag, queue offsets, and consumer ownership before any future apply."
+                    .to_string(),
+            ]
+        },
+        |payload| {
+            vec![format!(
+                "Capture current offsets for `{}` on `{}` before apply so they can be restored.",
+                payload.consumer_group, payload.topic
+            )]
+        },
+    )
+}
+
+fn planned_change<T, P, I, R>(
+    tool: &'static str,
+    request: ChangeRequest<T>,
+    planned_changes: P,
+    impact_analysis: I,
+    rollback_suggestions: R,
+) -> Result<ChangePlan, ChangeToolError>
+where
+    P: FnOnce(&T) -> Vec<String>,
+    I: FnOnce(&T) -> Vec<String>,
+    R: FnOnce(&T) -> Vec<String>,
+{
+    if matches!(request.mode, ChangeMode::Apply) {
+        return Err(ChangeToolError::ApplyReserved(tool));
+    }
+
+    Ok(ChangePlan {
+        tool: tool.to_string(),
+        cluster: request.cluster.clone(),
+        mode: request.mode,
+        operator: request.operator.clone(),
+        reason: request.reason.clone(),
+        summary: format!("{tool} {} generated a dry-run change plan.", request.mode.as_str()),
+        planned_changes: planned_changes(&request.payload),
+        impact_analysis: impact_analysis(&request.payload),
+        rollback_suggestions: rollback_suggestions(&request.payload),
+        confirm_challenge: Some(ConfirmChallenge {
+            challenge_id: format!("dry-run:{tool}:{}:{}", request.cluster, request.operator),
+            instruction: "Future apply support must submit mode=apply with a reviewed confirm_token.".to_string(),
+        }),
+        applied: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dry_run_create_topic_returns_change_plan() {
+        let plan = plan_create_topic(ChangeRequest {
+            cluster: "local-dev".to_string(),
+            mode: ChangeMode::DryRun,
+            operator: "sre".to_string(),
+            reason: "capacity preparation".to_string(),
+            confirm_token: None,
+            payload: CreateTopicPayload {
+                topic: "orders".to_string(),
+                read_queue_nums: Some(8),
+                write_queue_nums: Some(8),
+                perm: Some("read_write".to_string()),
+            },
+        })
+        .unwrap();
+
+        assert_eq!(plan.tool, CREATE_TOPIC_TOOL);
+        assert!(!plan.applied);
+        assert!(plan.confirm_challenge.is_some());
+        assert!(plan.planned_changes[0].contains("orders"));
+    }
+
+    #[test]
+    fn apply_mode_is_reserved() {
+        let err = plan_reset_consumer_offset(ChangeRequest {
+            cluster: "local-dev".to_string(),
+            mode: ChangeMode::Apply,
+            operator: "sre".to_string(),
+            reason: "lag mitigation".to_string(),
+            confirm_token: Some("reviewed".to_string()),
+            payload: ResetConsumerOffsetPayload {
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                target_offset: Some(10),
+                timestamp_millis: None,
+            },
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("reserved"));
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -28,6 +28,8 @@ use crate::guard::Guard;
 use crate::guard::GuardError;
 use crate::service::diagnosis_service;
 use crate::tools::broker_tools;
+#[cfg(feature = "dangerous-tools")]
+use crate::tools::change_tools;
 use crate::tools::cluster_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
@@ -209,6 +211,96 @@ where
                     .map(|output| success_result(output.summary.clone(), &output))
                     .unwrap_or_else(|error| Ok(error_result(diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL, error)))
             }
+            #[cfg(feature = "dangerous-tools")]
+            change_tools::CREATE_TOPIC_TOOL => {
+                let args = match decode_args::<change_tools::CreateTopicArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
+                change_tools::plan_create_topic(args)
+                    .map(|output| success_result(summary_change_plan(&output), &output))
+                    .unwrap_or_else(|error| {
+                        Ok(error_result(
+                            change_tools::CREATE_TOPIC_TOOL,
+                            ToolExecutionError::DangerousToolDisabled(error.to_string()),
+                        ))
+                    })
+            }
+            #[cfg(feature = "dangerous-tools")]
+            change_tools::UPDATE_TOPIC_CONFIG_TOOL => {
+                let args = match decode_args::<change_tools::UpdateTopicConfigArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
+                change_tools::plan_update_topic_config(args)
+                    .map(|output| success_result(summary_change_plan(&output), &output))
+                    .unwrap_or_else(|error| {
+                        Ok(error_result(
+                            change_tools::UPDATE_TOPIC_CONFIG_TOOL,
+                            ToolExecutionError::DangerousToolDisabled(error.to_string()),
+                        ))
+                    })
+            }
+            #[cfg(feature = "dangerous-tools")]
+            change_tools::UPDATE_TOPIC_PERM_TOOL => {
+                let args = match decode_args::<change_tools::UpdateTopicPermArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
+                change_tools::plan_update_topic_perm(args)
+                    .map(|output| success_result(summary_change_plan(&output), &output))
+                    .unwrap_or_else(|error| {
+                        Ok(error_result(
+                            change_tools::UPDATE_TOPIC_PERM_TOOL,
+                            ToolExecutionError::DangerousToolDisabled(error.to_string()),
+                        ))
+                    })
+            }
+            #[cfg(feature = "dangerous-tools")]
+            change_tools::UPDATE_BROKER_CONFIG_TOOL => {
+                let args = match decode_args::<change_tools::UpdateBrokerConfigArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
+                change_tools::plan_update_broker_config(args)
+                    .map(|output| success_result(summary_change_plan(&output), &output))
+                    .unwrap_or_else(|error| {
+                        Ok(error_result(
+                            change_tools::UPDATE_BROKER_CONFIG_TOOL,
+                            ToolExecutionError::DangerousToolDisabled(error.to_string()),
+                        ))
+                    })
+            }
+            #[cfg(feature = "dangerous-tools")]
+            change_tools::RESET_CONSUMER_OFFSET_TOOL => {
+                let args = match decode_args::<change_tools::ResetConsumerOffsetArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        guarded_call.record_protocol_error(error.message.to_string());
+                        return Err(error);
+                    }
+                };
+                change_tools::plan_reset_consumer_offset(args)
+                    .map(|output| success_result(summary_change_plan(&output), &output))
+                    .unwrap_or_else(|error| {
+                        Ok(error_result(
+                            change_tools::RESET_CONSUMER_OFFSET_TOOL,
+                            ToolExecutionError::DangerousToolDisabled(error.to_string()),
+                        ))
+                    })
+            }
             _ => unreachable!("unknown tool was rejected before dispatch"),
         }?;
 
@@ -300,6 +392,16 @@ fn summary_describe_broker(output: &broker_tools::DescribeBrokerOutput) -> Strin
         output.broker_name,
         output.cluster,
         output.brokers.len()
+    )
+}
+
+#[cfg(feature = "dangerous-tools")]
+fn summary_change_plan(output: &change_tools::ChangePlan) -> String {
+    format!(
+        "{} generated {} planned changes for cluster {}; no mutation was applied.",
+        output.tool,
+        output.planned_changes.len(),
+        output.cluster
     )
 }
 
@@ -478,6 +580,141 @@ mod tests {
         assert_eq!(records[0].status, AuditStatus::Failure);
     }
 
+    #[cfg(feature = "dangerous-tools")]
+    #[tokio::test]
+    async fn runtime_policy_denies_reserved_change_tool_by_default() {
+        let guard = test_guard_with_policy("operator", false);
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
+            .call(
+                CallToolRequestParams::new(change_tools::CREATE_TOPIC_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "mode": "dry_run",
+                        "operator": "sre",
+                        "reason": "capacity preparation",
+                        "payload": {
+                            "topic": "orders"
+                        }
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(content_text(&result).contains("dangerous tool disabled"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    #[cfg(feature = "dangerous-tools")]
+    #[tokio::test]
+    async fn dry_run_change_plan_is_audited_without_confirm_token() {
+        let guard = test_guard_with_policy("operator", true);
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
+            .call(
+                CallToolRequestParams::new(change_tools::CREATE_TOPIC_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "mode": "dry_run",
+                        "operator": "sre",
+                        "reason": "capacity preparation",
+                        "payload": {
+                            "topic": "orders",
+                            "read_queue_nums": 8,
+                            "write_queue_nums": 8,
+                            "perm": "read_write"
+                        }
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        let structured = result.structured_content.as_ref().unwrap();
+        assert_eq!(structured["tool"], change_tools::CREATE_TOPIC_TOOL);
+        assert_eq!(structured["applied"], false);
+        assert!(structured["confirm_challenge"].is_object());
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Success);
+    }
+
+    #[cfg(feature = "dangerous-tools")]
+    #[tokio::test]
+    async fn apply_change_without_confirm_token_is_denied() {
+        let guard = test_guard_with_policy("operator", true);
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
+            .call(
+                CallToolRequestParams::new(change_tools::RESET_CONSUMER_OFFSET_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "mode": "apply",
+                        "operator": "sre",
+                        "reason": "lag mitigation",
+                        "payload": {
+                            "topic": "orders",
+                            "consumer_group": "order-service",
+                            "target_offset": 10
+                        }
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(content_text(&result).contains("confirm_token"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    #[cfg(feature = "dangerous-tools")]
+    #[tokio::test]
+    async fn apply_change_with_confirm_token_is_reserved() {
+        let guard = test_guard_with_policy("operator", true);
+        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
+            .call(
+                CallToolRequestParams::new(change_tools::RESET_CONSUMER_OFFSET_TOOL).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "mode": "apply",
+                        "operator": "sre",
+                        "reason": "lag mitigation",
+                        "confirm_token": "reviewed",
+                        "payload": {
+                            "topic": "orders",
+                            "consumer_group": "order-service",
+                            "target_offset": 10
+                        }
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(content_text(&result).contains("no mutation was executed"));
+        let records = guard.audit_log().records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
     fn content_text(result: &CallToolResult) -> String {
         result
             .content
@@ -491,10 +728,14 @@ mod tests {
     }
 
     fn test_guard(profile: &str) -> Guard {
+        test_guard_with_policy(profile, false)
+    }
+
+    fn test_guard_with_policy(profile: &str, allow_dangerous_tools: bool) -> Guard {
         Guard::new(
             SecurityConfig {
                 profile: profile.to_string(),
-                allow_dangerous_tools: false,
+                allow_dangerous_tools,
                 require_confirmation: true,
                 sanitize_output: true,
                 rate_limit_per_minute: 60,

--- a/rocketmq-tools/rocketmq-mcp/src/tools/mod.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/mod.rs
@@ -15,6 +15,8 @@
 //! Read-only MCP tools exposed by the RocketMQ MCP server.
 
 pub mod broker_tools;
+#[cfg(feature = "dangerous-tools")]
+pub mod change_tools;
 pub mod cluster_tools;
 pub mod consumer_tools;
 pub mod diagnosis_tools;

--- a/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
@@ -20,6 +20,8 @@ use rmcp::model::ToolAnnotations;
 
 use crate::guard::RiskLevel;
 use crate::tools::broker_tools;
+#[cfg(feature = "dangerous-tools")]
+use crate::tools::change_tools;
 use crate::tools::cluster_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
@@ -43,12 +45,18 @@ pub fn tool_risk_level(name: &str) -> Option<RiskLevel> {
         | consumer_tools::QUERY_CONSUMER_LAG_TOOL
         | broker_tools::DESCRIBE_BROKER_TOOL => Some(RiskLevel::ReadOnly),
         diagnosis_tools::DIAGNOSE_CONSUMER_LAG_TOOL => Some(RiskLevel::Diagnose),
+        #[cfg(feature = "dangerous-tools")]
+        change_tools::CREATE_TOPIC_TOOL
+        | change_tools::UPDATE_TOPIC_CONFIG_TOOL
+        | change_tools::UPDATE_TOPIC_PERM_TOOL
+        | change_tools::UPDATE_BROKER_CONFIG_TOOL
+        | change_tools::RESET_CONSUMER_OFFSET_TOOL => Some(RiskLevel::Change),
         _ => None,
     }
 }
 
 pub fn tool_definitions() -> Vec<Tool> {
-    vec![
+    let tools = vec![
         read_only_tool::<cluster_tools::ClusterOverviewArgs, cluster_tools::ClusterOverviewOutput>(
             cluster_tools::CLUSTER_OVERVIEW_TOOL,
             "RocketMQ cluster overview",
@@ -89,7 +97,45 @@ pub fn tool_definitions() -> Vec<Tool> {
             "RocketMQ consumer lag diagnosis",
             "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
         ),
-    ]
+    ];
+
+    #[cfg(feature = "dangerous-tools")]
+    {
+        let mut tools = tools;
+        tools.extend([
+            change_tool::<change_tools::CreateTopicArgs, change_tools::ChangePlan>(
+                change_tools::CREATE_TOPIC_TOOL,
+                "RocketMQ create topic plan",
+                "Generate a dry-run change plan for future topic creation support.",
+            ),
+            change_tool::<change_tools::UpdateTopicConfigArgs, change_tools::ChangePlan>(
+                change_tools::UPDATE_TOPIC_CONFIG_TOOL,
+                "RocketMQ update topic config plan",
+                "Generate a dry-run change plan for future topic config updates.",
+            ),
+            change_tool::<change_tools::UpdateTopicPermArgs, change_tools::ChangePlan>(
+                change_tools::UPDATE_TOPIC_PERM_TOOL,
+                "RocketMQ update topic permission plan",
+                "Generate a dry-run change plan for future topic permission updates.",
+            ),
+            change_tool::<change_tools::UpdateBrokerConfigArgs, change_tools::ChangePlan>(
+                change_tools::UPDATE_BROKER_CONFIG_TOOL,
+                "RocketMQ update broker config plan",
+                "Generate a dry-run change plan for future broker config updates.",
+            ),
+            change_tool::<change_tools::ResetConsumerOffsetArgs, change_tools::ChangePlan>(
+                change_tools::RESET_CONSUMER_OFFSET_TOOL,
+                "RocketMQ reset consumer offset plan",
+                "Generate a dry-run impact plan for future consumer offset resets.",
+            ),
+        ]);
+        tools
+    }
+
+    #[cfg(not(feature = "dangerous-tools"))]
+    {
+        tools
+    }
 }
 
 fn read_only_tool<I, O>(name: &'static str, title: &'static str, description: &'static str) -> Tool
@@ -110,6 +156,25 @@ where
         )
 }
 
+#[cfg(feature = "dangerous-tools")]
+fn change_tool<I, O>(name: &'static str, title: &'static str, description: &'static str) -> Tool
+where
+    I: JsonSchema + 'static,
+    O: JsonSchema + 'static,
+{
+    Tool::new(name, description, std::sync::Arc::new(Default::default()))
+        .with_title(title)
+        .with_input_schema::<I>()
+        .with_output_schema::<O>()
+        .with_annotations(
+            ToolAnnotations::with_title(title)
+                .read_only(false)
+                .destructive(false)
+                .idempotent(false)
+                .open_world(true),
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,24 +184,16 @@ mod tests {
         let result = list_tools();
         let names = result.tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>();
 
-        assert_eq!(
-            names,
-            [
-                "mq_cluster_overview",
-                "mq_list_topics",
-                "mq_describe_topic",
-                "mq_query_topic_route",
-                "mq_list_consumer_groups",
-                "mq_query_consumer_lag",
-                "mq_describe_broker",
-                "mq_diagnose_consumer_lag",
-            ]
-        );
+        assert!(names.starts_with(&mvp_tool_names()));
+        #[cfg(not(feature = "dangerous-tools"))]
+        assert_eq!(names, mvp_tool_names());
+        #[cfg(feature = "dangerous-tools")]
+        assert_eq!(names, all_tool_names());
         assert!(result.next_cursor.is_none());
     }
 
     #[test]
-    fn each_tool_has_input_schema_and_read_only_annotation() {
+    fn each_tool_has_input_schema_and_expected_annotation() {
         for tool in tool_definitions() {
             assert_eq!(
                 tool.input_schema.get("type").and_then(|value| value.as_str()),
@@ -144,8 +201,14 @@ mod tests {
             );
             assert!(tool.output_schema.is_some());
             let annotations = tool.annotations.as_ref().expect("tool annotations");
-            assert_eq!(annotations.read_only_hint, Some(true));
             assert_eq!(annotations.destructive_hint, Some(false));
+            if is_mvp_tool(tool.name.as_ref()) {
+                assert_eq!(annotations.read_only_hint, Some(true));
+                assert_eq!(annotations.idempotent_hint, Some(true));
+            } else {
+                assert_eq!(annotations.read_only_hint, Some(false));
+                assert_eq!(annotations.idempotent_hint, Some(false));
+            }
         }
     }
 
@@ -180,6 +243,40 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        #[cfg(not(feature = "dangerous-tools"))]
         insta::assert_json_snapshot!("tool_contract_schema_metadata", contracts);
+
+        #[cfg(feature = "dangerous-tools")]
+        insta::assert_json_snapshot!("tool_contract_schema_metadata_with_dangerous_tools", contracts);
+    }
+
+    fn mvp_tool_names() -> Vec<&'static str> {
+        vec![
+            "mq_cluster_overview",
+            "mq_list_topics",
+            "mq_describe_topic",
+            "mq_query_topic_route",
+            "mq_list_consumer_groups",
+            "mq_query_consumer_lag",
+            "mq_describe_broker",
+            "mq_diagnose_consumer_lag",
+        ]
+    }
+
+    #[cfg(feature = "dangerous-tools")]
+    fn all_tool_names() -> Vec<&'static str> {
+        let mut names = mvp_tool_names();
+        names.extend([
+            "mq_create_topic",
+            "mq_update_topic_config",
+            "mq_update_topic_perm",
+            "mq_update_broker_config",
+            "mq_reset_consumer_offset",
+        ]);
+        names
+    }
+
+    fn is_mvp_tool(name: &str) -> bool {
+        mvp_tool_names().contains(&name)
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata_with_dangerous_tools.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata_with_dangerous_tools.snap
@@ -1,0 +1,185 @@
+---
+source: rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+expression: contracts
+---
+[
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster"
+    ],
+    "input_type": "object",
+    "name": "mq_cluster_overview",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": null,
+    "input_type": "object",
+    "name": "mq_list_topics",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic"
+    ],
+    "input_type": "object",
+    "name": "mq_describe_topic",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic"
+    ],
+    "input_type": "object",
+    "name": "mq_query_topic_route",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": null,
+    "input_type": "object",
+    "name": "mq_list_consumer_groups",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic",
+      "consumer_group"
+    ],
+    "input_type": "object",
+    "name": "mq_query_consumer_lag",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "broker_name"
+    ],
+    "input_type": "object",
+    "name": "mq_describe_broker",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": true,
+    "input_required": [
+      "cluster",
+      "topic",
+      "consumer_group"
+    ],
+    "input_type": "object",
+    "name": "mq_diagnose_consumer_lag",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": true
+  },
+  {
+    "destructive": false,
+    "idempotent": false,
+    "input_required": [
+      "cluster",
+      "mode",
+      "operator",
+      "reason",
+      "payload"
+    ],
+    "input_type": "object",
+    "name": "mq_create_topic",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": false
+  },
+  {
+    "destructive": false,
+    "idempotent": false,
+    "input_required": [
+      "cluster",
+      "mode",
+      "operator",
+      "reason",
+      "payload"
+    ],
+    "input_type": "object",
+    "name": "mq_update_topic_config",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": false
+  },
+  {
+    "destructive": false,
+    "idempotent": false,
+    "input_required": [
+      "cluster",
+      "mode",
+      "operator",
+      "reason",
+      "payload"
+    ],
+    "input_type": "object",
+    "name": "mq_update_topic_perm",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": false
+  },
+  {
+    "destructive": false,
+    "idempotent": false,
+    "input_required": [
+      "cluster",
+      "mode",
+      "operator",
+      "reason",
+      "payload"
+    ],
+    "input_type": "object",
+    "name": "mq_update_broker_config",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": false
+  },
+  {
+    "destructive": false,
+    "idempotent": false,
+    "input_required": [
+      "cluster",
+      "mode",
+      "operator",
+      "reason",
+      "payload"
+    ],
+    "input_type": "object",
+    "name": "mq_reset_consumer_offset",
+    "open_world": true,
+    "output_type": "object",
+    "read_only": false
+  }
+]


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #8149

### Brief Description

Reserve controlled change guardrails for rocketmq-mcp behind the dangerous-tools feature. The change adds schemas and dry-run plan outputs for future topic creation, topic config updates, topic permission updates, broker config updates, and consumer offset resets.

The default MCP surface remains read-only and diagnostic. When dangerous-tools is compiled, runtime policy still blocks these tools unless operator policy opts in. Dry-run requests return a plan, impact analysis, rollback suggestions, and confirmation challenge metadata. Apply requests require confirm_token and are still rejected without executing any mutation API.

### How Did You Test This Change?

- `INSTA_UPDATE=always cargo test -p rocketmq-mcp --features dangerous-tools`
- `cargo test -p rocketmq-mcp`
- `cargo test -p rocketmq-mcp --features dangerous-tools`
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http,dangerous-tools -- -D warnings`
- `cargo test -p rocketmq-mcp --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature-gated change planning tools for topic, broker, and consumer offset operations.
  * Improved tool visibility and risk labeling so supported actions are clearly separated from read-only tools.

* **Bug Fixes**
  * Tightened confirmation handling for change requests, including dry-run vs. apply behavior.
  * Ensured apply-style requests require stronger confirmation safeguards.

* **Documentation**
  * Clarified how controlled change tools behave, including dry-run planning, impact details, and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->