### PR TITLE
[ISSUE #8159]✨Define rocketmq-mcp architecture and measurable baselines

### DIFF
--- a/rocketmq-doc/README.md
+++ b/rocketmq-doc/README.md
@@ -52,6 +52,8 @@ rocketmq-doc/
 - Broker Naming Conventions
 - Error Architecture Redesign ADR
 - Error Architecture Inventory
+- [RocketMQ MCP Architecture ADR](en/07-rocketmq-mcp-architecture-adr.md)
+- [RocketMQ MCP Baseline Report](en/07-rocketmq-mcp-baseline-report.md)
 - Protocol Design
 - Storage Design
 - Network Architecture

--- a/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
@@ -1,0 +1,104 @@
+---
+title: "RocketMQ MCP Architecture ADR"
+permalink: /docs/rocketmq-mcp-architecture-adr/
+excerpt: "Accepted clean-break architecture and public contract for the RocketMQ MCP server refactor."
+last_modified_at: 2026-07-10T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# RocketMQ MCP Architecture ADR
+
+## Status
+
+Accepted for the unreleased `rocketmq-mcp` refactor.
+
+## Context
+
+The current MCP server is unused and has no compatibility commitment. Its
+read-only tools, resources, prompts, configuration, protocol integration, and
+admin-client lifecycle are therefore a clean-break migration surface. The
+future implementation must be coherent for both stdio and Streamable HTTP,
+preserve the deny-by-default safety boundary, and make workflow-level
+diagnosis efficient without creating a global connection pool prematurely.
+
+## Decisions
+
+| ADR | Decision |
+| --- | --- |
+| ADR-001 | Use a single-process modular architecture. The server process owns protocol handling, authorization, query workflows, planning, and evidence generation through explicit module boundaries. |
+| ADR-002 | Introduce a workflow-scoped `AdminSession` before considering any global admin-client pool. A workflow creates, owns, shuts down, and awaits its session. |
+| ADR-003 | Route Tools, Resources, and Diagnosis through a shared `QueryFacade`; protocol handlers do not each assemble their own admin calls. |
+| ADR-004 | Use cluster-scoped resource URIs in the form `rocketmq://clusters/{cluster}/...`. Resources are not implicitly bound to a default cluster. |
+| ADR-005 | Derive identity and authorization from `RequestContext`, not Tool arguments, resource URI components, prompt arguments, or process-global mutable state. |
+| ADR-006 | Separate Plan from Apply. A Plan is a reviewable, versioned representation of an intended change; Apply is a distinct, explicitly authorized operation. |
+| ADR-007 | Version Evidence and Rules independently. Diagnosis output identifies the evidence and rule versions that produced it. |
+| ADR-008 | Target MCP `2025-11-25` only. The refactor does not promise a dual-version protocol bridge with MCP `2025-06-18`. |
+| ADR-009 | Replace the current implementation with a clean break because it is unused. Do not retain legacy Tool, URI, schema, configuration, or feature aliases. |
+
+## Frozen Public Contract
+
+The following names are the final public Tool contract for the refactor. They
+are intentionally different from the current `mq_*` names and are introduced
+without aliases.
+
+### Query and Diagnosis Tools
+
+| Tool |
+| --- |
+| `rocketmq_get_cluster_overview` |
+| `rocketmq_list_topics` |
+| `rocketmq_describe_topic` |
+| `rocketmq_get_topic_route` |
+| `rocketmq_list_consumer_groups` |
+| `rocketmq_get_consumer_lag` |
+| `rocketmq_describe_broker` |
+| `rocketmq_diagnose_consumer_lag` |
+
+### Plan Tools
+
+| Tool |
+| --- |
+| `rocketmq_plan_create_topic` |
+| `rocketmq_plan_update_topic_config` |
+| `rocketmq_plan_update_topic_permissions` |
+| `rocketmq_plan_update_broker_config` |
+| `rocketmq_plan_reset_consumer_offset` |
+
+The planning capability is gated by the `change-planning` feature. Plan Tools
+must not apply a change. A later Apply capability requires a separate public
+contract and authorization decision.
+
+The refactor uses Rust 2021 or later and, after P1, uses one source file per
+module under `rocketmq-tools/rocketmq-mcp/src` without `mod.rs`. No legacy
+Tool, URI, schema, configuration, or feature alias is allowed.
+
+## Module Direction
+
+```text
+transport and protocol
+        -> RequestContext identity and authorization
+        -> Tool, Resource, and Prompt handlers
+        -> QueryFacade / planning workflows / diagnosis rules
+        -> workflow-scoped AdminSession
+        -> rocketmq-admin-core
+```
+
+`QueryFacade` owns cluster selection, request-scoped query composition,
+normalization, and read-model construction. Resources and Tools are different
+MCP presentations of the same query results. Diagnosis consumes the same
+facade, adds versioned evidence, and evaluates versioned rules.
+
+## Consequences
+
+P0 records the baseline and freezes the destination contract. It deliberately
+does not change the production Tool names, resource URIs, protocol version,
+feature flags, or admin lifecycle. P1 introduces the clean-break module and
+protocol contract. P2 introduces `QueryFacade`, `AdminSession`, and measurable
+workflow lifecycle counters. Subsequent work may add planning and Apply only
+through the Plan/Apply boundary defined here.
+
+The migration cost is intentional: existing integrations must move directly to
+the new MCP `2025-11-25` contract. The benefit is one stable architecture with
+clear authorization ownership, cluster isolation, reusable query workflows,
+and auditable diagnosis and change behavior.

--- a/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
@@ -1,0 +1,166 @@
+---
+title: "RocketMQ MCP Baseline Report"
+permalink: /docs/rocketmq-mcp-baseline-report/
+excerpt: "Reproducible P0 baseline evidence for the RocketMQ MCP refactor."
+last_modified_at: 2026-07-10T00:00:00+08:00
+toc: true
+classes: wide
+---
+
+# RocketMQ MCP Baseline Report
+
+## Scope and Method
+
+This P0 baseline is anchored to base commit `c79d7b0e`. It records source-level
+and test-level evidence so later refactor work can compare a known starting
+point without implying that the current implementation is the target public
+contract. Static call-graph evidence is explicitly distinguished from runtime
+measurement; this report does not fabricate live-cluster latency or counters.
+
+## Current MCP Surface
+
+At `c79d7b0e`, the default feature surface has 8 Tools, 4 Resources, 0
+Resource templates, and 2 Prompts.
+
+| Kind | Current entries |
+| --- | --- |
+| Tools | `mq_cluster_overview`, `mq_list_topics`, `mq_describe_topic`, `mq_query_topic_route`, `mq_list_consumer_groups`, `mq_query_consumer_lag`, `mq_describe_broker`, `mq_diagnose_consumer_lag` |
+| Resources | `rocketmq://cluster/overview`, `rocketmq://topics`, `rocketmq://brokers`, `rocketmq://consumer-groups` |
+| Resource templates | None |
+| Prompts | `diagnose_consumer_lag`, `broker_health_check` |
+
+The optional `dangerous-tools` feature exposes 5 additional planning entries:
+`mq_create_topic`, `mq_update_topic_config`, `mq_update_topic_perm`,
+`mq_update_broker_config`, and `mq_reset_consumer_offset`.
+
+The current stdio integration request in
+`rocketmq-tools/rocketmq-mcp/tests/integration.rs` requests MCP `2025-06-18`.
+P1 replaces that integration with MCP `2025-11-25`; no dual-version promise is
+made.
+
+## Existing Snapshot Coverage Before P0
+
+Before this PR, the Tool contract snapshots in
+`rocketmq-tools/rocketmq-mcp/src/tools/snapshots/` covered the Tool name,
+input schema type and required-field summary, output schema type, and the four
+annotation hints. They did not freeze complete input or output schemas.
+
+Before this PR, the protocol surface snapshots in
+`rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/` covered abbreviated Tool
+schema presence and two annotations, Resource URI/name/MIME type, an empty
+resource-template list, and Prompt name plus argument count. They did not
+freeze complete Tool schemas and annotations, complete Resource descriptors,
+Resource templates, or Prompt descriptors and arguments.
+
+P0 expands both existing snapshot projections to serialize the complete MCP
+descriptors. The default and `dangerous-tools` snapshot files remain separate,
+so optional surface changes cannot silently escape the default contract test.
+
+## Static Admin Lifecycle Call Graph
+
+The following counts are source-call-graph counts, not measured runtime
+counters or latency measurements. Each named `rocketmq-admin-core` entry point
+constructs, starts, and shuts down an admin client for that operation.
+
+### Cluster Overview: Three Complete Lifecycles
+
+`AdminCoreAdapter::cluster_overview` in
+`rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs` invokes these
+three operations:
+
+1. `ClusterService::query_cluster_list_by_request_with_rpc_hook`, whose
+   lifecycle is implemented in
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/cluster.rs`.
+2. `TopicService::query_topic_list`, whose lifecycle is implemented in
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic/operations.rs`.
+3. `ConsumerService::query_consumer_progress_by_request_with_rpc_hook`, whose
+   lifecycle is implemented in
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs`.
+
+Therefore one successful current cluster-overview call opens three complete
+admin lifecycles.
+
+### Normal No-Fallback High-Lag Diagnosis: Four Complete Lifecycles
+
+`diagnose_consumer_lag` in
+`rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs` runs the
+following adapter operations in sequence. In the normal no-fallback path, a
+high-lag result selects a top-lag broker and that broker is present in the
+cluster listing, so all four occur:
+
+1. `query_consumer_lag`, which calls
+   `ConsumerService::query_consumer_progress_by_request_with_rpc_hook` in
+   `rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs` and
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs`.
+2. `describe_topic`, which delegates to `query_topic_route`, then calls
+   `TopicService::query_topic_route` in
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic/operations.rs`.
+3. `query_topic_route`, which makes a second independent
+   `TopicService::query_topic_route` lifecycle through the same source paths.
+4. `describe_broker`, which calls
+   `ClusterService::query_cluster_list_by_request_with_rpc_hook` through
+   `rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs` and
+   `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/cluster.rs`.
+
+Thus the normal no-fallback high-lag diagnosis path statically opens four
+complete admin lifecycles.
+
+If `describe_broker` does not find the selected broker in the cluster listing,
+`AdminCoreAdapter::describe_broker` additionally calls
+`BrokerService::query_broker_runtime_stats_by_request_with_rpc_hook` in
+`rocketmq-tools/rocketmq-mcp/src/adapter/admin_core_adapter.rs` and
+`rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker/operations.rs`.
+That fallback opens a fifth complete admin lifecycle. `diagnose_consumer_lag`
+still returns its report with partial/error broker evidence because the
+adapter error is recorded as diagnosis evidence rather than propagated as the
+workflow result.
+
+The existing `ReadOnlyAdminAdapter` fake seam in `admin_core_adapter.rs`
+supports deterministic workflow tests, but P0 adds no counter seam and no
+production lifecycle refactor.
+
+## Observed Baseline Validation
+
+At the baseline, the following results were observed:
+
+| Command | Result |
+| --- | --- |
+| `cargo check -p rocketmq-mcp` | Passed |
+| `cargo test -p rocketmq-mcp` | Passed: 40 unit tests and 1 stdio integration test |
+
+These results establish build and test health only. They do not measure a live
+RocketMQ cluster, connection setup, request latency, throughput, or lifecycle
+counter values.
+
+## Measurable Exit Targets
+
+### P1 Contract Replacement
+
+P1 is complete only when the following evidence is updated together:
+
+| Target | Evidence and command |
+| --- | --- |
+| MCP target version | The stdio integration initializes with `2025-11-25`; run `cargo test -p rocketmq-mcp --test integration`. |
+| Public Tool and resource contract | Default and `change-planning` contract snapshots contain only the frozen names and cluster-scoped `rocketmq://clusters/{cluster}/...` URIs; run `cargo test -p rocketmq-mcp snapshot` and `cargo test -p rocketmq-mcp --features change-planning snapshot`. |
+| Clean break | Source review and focused `rg` evidence show no legacy Tool, URI, schema, configuration, or feature aliases in the P1 module tree. |
+| Module layout | Source review confirms Rust 2021+ modules have no `mod.rs` under `rocketmq-tools/rocketmq-mcp/src`. |
+
+### P2 Query and Lifecycle Replacement
+
+P2 is complete only when deterministic tests at the injected admin-session
+seam prove the following targets for a selected cluster, including the
+session-start and session-shutdown counters:
+
+| Target | Evidence and command |
+| --- | --- |
+| Shared query path | Tool, Resource, and Diagnosis tests execute through `QueryFacade`, not duplicate adapter composition. |
+| Lifecycle ownership | A cluster overview and each high-lag diagnosis path, including the selected-broker-missing fallback, each start and shut down exactly one workflow-scoped `AdminSession`; no global pool is introduced. |
+| Diagnosis provenance | Output tests assert explicit Evidence and Rules version fields. |
+
+The P2 evidence command must run the focused counter tests, for example
+`cargo test -p rocketmq-mcp query_facade` and
+`cargo test -p rocketmq-mcp admin_session`, followed by the full
+`cargo test -p rocketmq-mcp`. The baseline report should then record the test
+names, counter values, and source paths. It must still avoid claiming
+live-cluster latency unless a separately documented controlled measurement
+produces it.

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -167,39 +167,21 @@ mod tests {
         let tools = tools::registry::list_tools()
             .tools
             .into_iter()
-            .map(|tool| {
-                let annotations = tool.annotations.expect("tool annotations");
-                json!({
-                    "name": tool.name.as_ref(),
-                    "has_input_schema": tool.input_schema.get("type").is_some(),
-                    "has_output_schema": tool.output_schema.is_some(),
-                    "read_only": annotations.read_only_hint,
-                    "destructive": annotations.destructive_hint,
-                })
-            })
+            .map(|tool| serde_json::to_value(tool).expect("tool descriptor serializes"))
             .collect::<Vec<_>>();
         let resources = resources::registry::list_resources()
             .resources
             .into_iter()
-            .map(|resource| {
-                json!({
-                    "uri": resource.uri,
-                    "name": resource.name,
-                    "mime_type": resource.mime_type,
-                })
-            })
+            .map(|resource| serde_json::to_value(resource).expect("resource descriptor serializes"))
             .collect::<Vec<_>>();
-        let resource_templates = resources::registry::list_resource_templates().resource_templates;
+        let resource_templates =
+            serde_json::to_value(resources::registry::list_resource_templates().resource_templates)
+                .expect("resource templates serialize");
         let prompts = prompts::registry::list_prompts()
             .unwrap()
             .prompts
             .into_iter()
-            .map(|prompt| {
-                json!({
-                    "name": prompt.name,
-                    "argument_count": prompt.arguments.as_ref().map(Vec::len).unwrap_or_default(),
-                })
-            })
+            .map(|prompt| serde_json::to_value(prompt).expect("prompt descriptor serializes"))
             .collect::<Vec<_>>();
 
         let surface = json!({

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -1,97 +1,1205 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
-expression: "json!({\n    \"tools\": tools, \"resources\": resources, \"resource_templates\":\n    resource_templates, \"prompts\": prompts,\n})"
+expression: surface
 ---
 {
   "prompts": [
     {
-      "argument_count": 4,
-      "name": "diagnose_consumer_lag"
+      "arguments": [
+        {
+          "description": "RocketMQ cluster name or configured connection name.",
+          "name": "cluster",
+          "required": true
+        },
+        {
+          "description": "Topic name.",
+          "name": "topic",
+          "required": true
+        },
+        {
+          "description": "Consumer group name.",
+          "name": "consumer_group",
+          "required": true
+        },
+        {
+          "description": "Optional investigation time range.",
+          "name": "time_range",
+          "required": false
+        }
+      ],
+      "description": "Diagnose consumer lag for a RocketMQ topic and consumer group.",
+      "name": "diagnose_consumer_lag",
+      "title": "Diagnose Consumer Lag"
     },
     {
-      "argument_count": 3,
-      "name": "broker_health_check"
+      "arguments": [
+        {
+          "description": "RocketMQ cluster name or configured connection name.",
+          "name": "cluster",
+          "required": true
+        },
+        {
+          "description": "Optional broker name. When omitted, inspect all brokers in the cluster.",
+          "name": "broker_name",
+          "required": false
+        },
+        {
+          "description": "Optional check level: quick, standard, or deep.",
+          "name": "check_level",
+          "required": false
+        }
+      ],
+      "description": "Check RocketMQ broker health from read-only broker, cluster, and topic evidence.",
+      "name": "broker_health_check",
+      "title": "Broker Health Check"
     }
   ],
   "resource_templates": [],
   "resources": [
     {
-      "mime_type": "application/json",
+      "description": "Configured RocketMQ clusters and nameserver endpoints.",
+      "mimeType": "application/json",
       "name": "cluster_overview",
+      "title": "RocketMQ cluster overview",
       "uri": "rocketmq://cluster/overview"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ topic inventory resource.",
+      "mimeType": "application/json",
       "name": "topics",
+      "title": "RocketMQ topics",
       "uri": "rocketmq://topics"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ broker inventory resource.",
+      "mimeType": "application/json",
       "name": "brokers",
+      "title": "RocketMQ brokers",
       "uri": "rocketmq://brokers"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ consumer group inventory resource.",
+      "mimeType": "application/json",
       "name": "consumer_groups",
+      "title": "RocketMQ consumer groups",
       "uri": "rocketmq://consumer-groups"
     }
   ],
   "tools": [
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ cluster overview"
+      },
+      "description": "Summarize configured cluster brokers, topic count, and consumer group count.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
       "name": "mq_cluster_overview",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "BrokerSummary": {
+            "properties": {
+              "broker_active": {
+                "type": "boolean"
+              },
+              "broker_addr": {
+                "type": "string"
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "hour": {
+                "type": "string"
+              },
+              "in_tps": {
+                "type": "string"
+              },
+              "out_tps": {
+                "type": "string"
+              },
+              "page_cache_lock_time_millis": {
+                "type": "string"
+              },
+              "space": {
+                "type": "string"
+              },
+              "timer_progress": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_id",
+              "broker_addr",
+              "version",
+              "in_tps",
+              "out_tps",
+              "timer_progress",
+              "page_cache_lock_time_millis",
+              "hour",
+              "space",
+              "broker_active"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/BrokerSummary"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "topic_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "brokers",
+          "topic_count",
+          "consumer_group_count",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ cluster overview"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic list"
+      },
+      "description": "List topics visible from the selected RocketMQ cluster.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "name": "mq_list_topics",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicListEntry": {
+            "properties": {
+              "cluster": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "consumer_group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "topic_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "topics": {
+            "items": {
+              "$ref": "#/$defs/TopicListEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic_count",
+          "topics",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic list"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic description"
+      },
+      "description": "Describe a topic with broker and queue route information.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
       "name": "mq_describe_topic",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicRouteBroker": {
+            "properties": {
+              "broker_addrs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "enable_acting_master": {
+                "type": "boolean"
+              },
+              "zone_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_addrs",
+              "enable_acting_master"
+            ],
+            "type": "object"
+          },
+          "TopicRouteQueue": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic_sys_flag": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "topic_sys_flag"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteBroker"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteQueue"
+            },
+            "type": "array"
+          },
+          "read_queue_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "write_queue_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "broker_names",
+          "read_queue_count",
+          "write_queue_count",
+          "brokers",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic description"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic route"
+      },
+      "description": "Query topic route data including broker addresses and queue distribution.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
       "name": "mq_query_topic_route",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicRouteBroker": {
+            "properties": {
+              "broker_addrs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "enable_acting_master": {
+                "type": "boolean"
+              },
+              "zone_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_addrs",
+              "enable_acting_master"
+            ],
+            "type": "object"
+          },
+          "TopicRouteQueue": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic_sys_flag": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "topic_sys_flag"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteBroker"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteQueue"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "brokers",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic route"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer groups"
+      },
+      "description": "List consumer groups and current consumption summary.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "name": "mq_list_consumer_groups",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "ConsumerGroupSummary": {
+            "properties": {
+              "client_count": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "consume_tps": {
+                "format": "double",
+                "type": "number"
+              },
+              "consume_type": {
+                "type": "string"
+              },
+              "diff_total": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "group": {
+                "type": "string"
+              },
+              "message_model": {
+                "type": "string"
+              },
+              "version": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "group",
+              "version",
+              "client_count",
+              "consume_type",
+              "message_model",
+              "consume_tps",
+              "diff_total"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/$defs/ConsumerGroupSummary"
+            },
+            "type": "array"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "consumer_group_count",
+          "groups",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer groups"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer lag"
+      },
+      "description": "Query per-queue consumer lag for a topic and consumer group.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
       "name": "mq_query_consumer_lag",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "QueueLag": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "broker_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "client_ip": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "consumer_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "inflight": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "lag": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "last_timestamp": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "broker_name",
+              "queue_id",
+              "broker_offset",
+              "consumer_offset",
+              "lag",
+              "inflight",
+              "last_timestamp"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consume_tps": {
+            "format": "double",
+            "type": "number"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "inflight_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "max_queue_lag": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queue_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/QueueLag"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "total_lag": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "consumer_group",
+          "total_lag",
+          "max_queue_lag",
+          "queue_count",
+          "consume_tps",
+          "inflight_total",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer lag"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker description"
+      },
+      "description": "Describe broker rows for a broker name in the selected cluster.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
       "name": "mq_describe_broker",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "BrokerSummary": {
+            "properties": {
+              "broker_active": {
+                "type": "boolean"
+              },
+              "broker_addr": {
+                "type": "string"
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "hour": {
+                "type": "string"
+              },
+              "in_tps": {
+                "type": "string"
+              },
+              "out_tps": {
+                "type": "string"
+              },
+              "page_cache_lock_time_millis": {
+                "type": "string"
+              },
+              "space": {
+                "type": "string"
+              },
+              "timer_progress": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_id",
+              "broker_addr",
+              "version",
+              "in_tps",
+              "out_tps",
+              "timer_progress",
+              "page_cache_lock_time_millis",
+              "hour",
+              "space",
+              "broker_active"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/BrokerSummary"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "broker_name",
+          "brokers",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker description"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer lag diagnosis"
+      },
+      "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "lag_threshold": {
+            "default": null,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "time_range": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
       "name": "mq_diagnose_consumer_lag",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "Evidence": {
+            "properties": {
+              "data": true,
+              "id": {
+                "type": "string"
+              },
+              "source_tool": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/$defs/EvidenceStatus"
+              },
+              "summary": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "source_tool",
+              "status",
+              "summary",
+              "data"
+            ],
+            "type": "object"
+          },
+          "EvidenceStatus": {
+            "enum": [
+              "Present",
+              "Missing",
+              "Error"
+            ],
+            "type": "string"
+          },
+          "ImpactItem": {
+            "properties": {
+              "area": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "severity": {
+                "$ref": "#/$defs/Severity"
+              }
+            },
+            "required": [
+              "area",
+              "description",
+              "severity"
+            ],
+            "type": "object"
+          },
+          "MetricWatchItem": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "target",
+              "reason"
+            ],
+            "type": "object"
+          },
+          "Recommendation": {
+            "properties": {
+              "action": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string"
+              },
+              "rationale": {
+                "type": "string"
+              },
+              "risk": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "action",
+              "priority",
+              "rationale",
+              "risk"
+            ],
+            "type": "object"
+          },
+          "RootCauseCandidate": {
+            "properties": {
+              "cause": {
+                "type": "string"
+              },
+              "confidence": {
+                "format": "float",
+                "type": "number"
+              },
+              "evidence_refs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "reasoning": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cause",
+              "confidence",
+              "evidence_refs",
+              "reasoning"
+            ],
+            "type": "object"
+          },
+          "Severity": {
+            "enum": [
+              "Healthy",
+              "Low",
+              "Medium",
+              "High",
+              "Critical",
+              "Unknown"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confidence": {
+            "format": "float",
+            "type": "number"
+          },
+          "evidences": {
+            "items": {
+              "$ref": "#/$defs/Evidence"
+            },
+            "type": "array"
+          },
+          "follow_up_metrics": {
+            "items": {
+              "$ref": "#/$defs/MetricWatchItem"
+            },
+            "type": "array"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "impacts": {
+            "items": {
+              "$ref": "#/$defs/ImpactItem"
+            },
+            "type": "array"
+          },
+          "recommendations": {
+            "items": {
+              "$ref": "#/$defs/Recommendation"
+            },
+            "type": "array"
+          },
+          "report_type": {
+            "type": "string"
+          },
+          "risks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "root_causes": {
+            "items": {
+              "$ref": "#/$defs/RootCauseCandidate"
+            },
+            "type": "array"
+          },
+          "severity": {
+            "$ref": "#/$defs/Severity"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "target": true
+        },
+        "required": [
+          "report_type",
+          "cluster",
+          "target",
+          "severity",
+          "confidence",
+          "summary",
+          "impacts",
+          "evidences",
+          "root_causes",
+          "recommendations",
+          "risks",
+          "follow_up_metrics",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer lag diagnosis"
     }
   ]
 }

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_dangerous_tools.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_dangerous_tools.snap
@@ -5,128 +5,2056 @@ expression: surface
 {
   "prompts": [
     {
-      "argument_count": 4,
-      "name": "diagnose_consumer_lag"
+      "arguments": [
+        {
+          "description": "RocketMQ cluster name or configured connection name.",
+          "name": "cluster",
+          "required": true
+        },
+        {
+          "description": "Topic name.",
+          "name": "topic",
+          "required": true
+        },
+        {
+          "description": "Consumer group name.",
+          "name": "consumer_group",
+          "required": true
+        },
+        {
+          "description": "Optional investigation time range.",
+          "name": "time_range",
+          "required": false
+        }
+      ],
+      "description": "Diagnose consumer lag for a RocketMQ topic and consumer group.",
+      "name": "diagnose_consumer_lag",
+      "title": "Diagnose Consumer Lag"
     },
     {
-      "argument_count": 3,
-      "name": "broker_health_check"
+      "arguments": [
+        {
+          "description": "RocketMQ cluster name or configured connection name.",
+          "name": "cluster",
+          "required": true
+        },
+        {
+          "description": "Optional broker name. When omitted, inspect all brokers in the cluster.",
+          "name": "broker_name",
+          "required": false
+        },
+        {
+          "description": "Optional check level: quick, standard, or deep.",
+          "name": "check_level",
+          "required": false
+        }
+      ],
+      "description": "Check RocketMQ broker health from read-only broker, cluster, and topic evidence.",
+      "name": "broker_health_check",
+      "title": "Broker Health Check"
     }
   ],
   "resource_templates": [],
   "resources": [
     {
-      "mime_type": "application/json",
+      "description": "Configured RocketMQ clusters and nameserver endpoints.",
+      "mimeType": "application/json",
       "name": "cluster_overview",
+      "title": "RocketMQ cluster overview",
       "uri": "rocketmq://cluster/overview"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ topic inventory resource.",
+      "mimeType": "application/json",
       "name": "topics",
+      "title": "RocketMQ topics",
       "uri": "rocketmq://topics"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ broker inventory resource.",
+      "mimeType": "application/json",
       "name": "brokers",
+      "title": "RocketMQ brokers",
       "uri": "rocketmq://brokers"
     },
     {
-      "mime_type": "application/json",
+      "description": "RocketMQ consumer group inventory resource.",
+      "mimeType": "application/json",
       "name": "consumer_groups",
+      "title": "RocketMQ consumer groups",
       "uri": "rocketmq://consumer-groups"
     }
   ],
   "tools": [
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ cluster overview"
+      },
+      "description": "Summarize configured cluster brokers, topic count, and consumer group count.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
       "name": "mq_cluster_overview",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "BrokerSummary": {
+            "properties": {
+              "broker_active": {
+                "type": "boolean"
+              },
+              "broker_addr": {
+                "type": "string"
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "hour": {
+                "type": "string"
+              },
+              "in_tps": {
+                "type": "string"
+              },
+              "out_tps": {
+                "type": "string"
+              },
+              "page_cache_lock_time_millis": {
+                "type": "string"
+              },
+              "space": {
+                "type": "string"
+              },
+              "timer_progress": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_id",
+              "broker_addr",
+              "version",
+              "in_tps",
+              "out_tps",
+              "timer_progress",
+              "page_cache_lock_time_millis",
+              "hour",
+              "space",
+              "broker_active"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/BrokerSummary"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "topic_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "brokers",
+          "topic_count",
+          "consumer_group_count",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ cluster overview"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic list"
+      },
+      "description": "List topics visible from the selected RocketMQ cluster.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "name": "mq_list_topics",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicListEntry": {
+            "properties": {
+              "cluster": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "consumer_group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "topic_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "topics": {
+            "items": {
+              "$ref": "#/$defs/TopicListEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic_count",
+          "topics",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic list"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic description"
+      },
+      "description": "Describe a topic with broker and queue route information.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
       "name": "mq_describe_topic",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicRouteBroker": {
+            "properties": {
+              "broker_addrs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "enable_acting_master": {
+                "type": "boolean"
+              },
+              "zone_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_addrs",
+              "enable_acting_master"
+            ],
+            "type": "object"
+          },
+          "TopicRouteQueue": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic_sys_flag": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "topic_sys_flag"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteBroker"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteQueue"
+            },
+            "type": "array"
+          },
+          "read_queue_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "write_queue_count": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "broker_names",
+          "read_queue_count",
+          "write_queue_count",
+          "brokers",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic description"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ topic route"
+      },
+      "description": "Query topic route data including broker addresses and queue distribution.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
       "name": "mq_query_topic_route",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "TopicRouteBroker": {
+            "properties": {
+              "broker_addrs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "enable_acting_master": {
+                "type": "boolean"
+              },
+              "zone_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_addrs",
+              "enable_acting_master"
+            ],
+            "type": "object"
+          },
+          "TopicRouteQueue": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic_sys_flag": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "topic_sys_flag"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteBroker"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/TopicRouteQueue"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "brokers",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ topic route"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer groups"
+      },
+      "description": "List consumer groups and current consumption summary.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "name": "mq_list_consumer_groups",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "ConsumerGroupSummary": {
+            "properties": {
+              "client_count": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "consume_tps": {
+                "format": "double",
+                "type": "number"
+              },
+              "consume_type": {
+                "type": "string"
+              },
+              "diff_total": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "group": {
+                "type": "string"
+              },
+              "message_model": {
+                "type": "string"
+              },
+              "version": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "group",
+              "version",
+              "client_count",
+              "consume_type",
+              "message_model",
+              "consume_tps",
+              "diff_total"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/$defs/ConsumerGroupSummary"
+            },
+            "type": "array"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "consumer_group_count",
+          "groups",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer groups"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer lag"
+      },
+      "description": "Query per-queue consumer lag for a topic and consumer group.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
       "name": "mq_query_consumer_lag",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "QueueLag": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "broker_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "client_ip": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "consumer_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "inflight": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "lag": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "last_timestamp": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "broker_name",
+              "queue_id",
+              "broker_offset",
+              "consumer_offset",
+              "lag",
+              "inflight",
+              "last_timestamp"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consume_tps": {
+            "format": "double",
+            "type": "number"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "inflight_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "max_queue_lag": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          },
+          "queue_count": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "queues": {
+            "items": {
+              "$ref": "#/$defs/QueueLag"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "type": "string"
+          },
+          "total_lag": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "topic",
+          "consumer_group",
+          "total_lag",
+          "max_queue_lag",
+          "queue_count",
+          "consume_tps",
+          "inflight_total",
+          "queues",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer lag"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker description"
+      },
+      "description": "Describe broker rows for a broker name in the selected cluster.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
       "name": "mq_describe_broker",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "BrokerSummary": {
+            "properties": {
+              "broker_active": {
+                "type": "boolean"
+              },
+              "broker_addr": {
+                "type": "string"
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "hour": {
+                "type": "string"
+              },
+              "in_tps": {
+                "type": "string"
+              },
+              "out_tps": {
+                "type": "string"
+              },
+              "page_cache_lock_time_millis": {
+                "type": "string"
+              },
+              "space": {
+                "type": "string"
+              },
+              "timer_progress": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "broker_id",
+              "broker_addr",
+              "version",
+              "in_tps",
+              "out_tps",
+              "timer_progress",
+              "page_cache_lock_time_millis",
+              "hour",
+              "space",
+              "broker_active"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "brokers": {
+            "items": {
+              "$ref": "#/$defs/BrokerSummary"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "namesrv_addr": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "namesrv_addr",
+          "broker_name",
+          "brokers",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker description"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer lag diagnosis"
+      },
+      "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "lag_threshold": {
+            "default": null,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "time_range": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
       "name": "mq_diagnose_consumer_lag",
-      "read_only": true
+      "outputSchema": {
+        "$defs": {
+          "Evidence": {
+            "properties": {
+              "data": true,
+              "id": {
+                "type": "string"
+              },
+              "source_tool": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/$defs/EvidenceStatus"
+              },
+              "summary": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "source_tool",
+              "status",
+              "summary",
+              "data"
+            ],
+            "type": "object"
+          },
+          "EvidenceStatus": {
+            "enum": [
+              "Present",
+              "Missing",
+              "Error"
+            ],
+            "type": "string"
+          },
+          "ImpactItem": {
+            "properties": {
+              "area": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "severity": {
+                "$ref": "#/$defs/Severity"
+              }
+            },
+            "required": [
+              "area",
+              "description",
+              "severity"
+            ],
+            "type": "object"
+          },
+          "MetricWatchItem": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "target",
+              "reason"
+            ],
+            "type": "object"
+          },
+          "Recommendation": {
+            "properties": {
+              "action": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string"
+              },
+              "rationale": {
+                "type": "string"
+              },
+              "risk": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "action",
+              "priority",
+              "rationale",
+              "risk"
+            ],
+            "type": "object"
+          },
+          "RootCauseCandidate": {
+            "properties": {
+              "cause": {
+                "type": "string"
+              },
+              "confidence": {
+                "format": "float",
+                "type": "number"
+              },
+              "evidence_refs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "reasoning": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cause",
+              "confidence",
+              "evidence_refs",
+              "reasoning"
+            ],
+            "type": "object"
+          },
+          "Severity": {
+            "enum": [
+              "Healthy",
+              "Low",
+              "Medium",
+              "High",
+              "Critical",
+              "Unknown"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confidence": {
+            "format": "float",
+            "type": "number"
+          },
+          "evidences": {
+            "items": {
+              "$ref": "#/$defs/Evidence"
+            },
+            "type": "array"
+          },
+          "follow_up_metrics": {
+            "items": {
+              "$ref": "#/$defs/MetricWatchItem"
+            },
+            "type": "array"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "impacts": {
+            "items": {
+              "$ref": "#/$defs/ImpactItem"
+            },
+            "type": "array"
+          },
+          "recommendations": {
+            "items": {
+              "$ref": "#/$defs/Recommendation"
+            },
+            "type": "array"
+          },
+          "report_type": {
+            "type": "string"
+          },
+          "risks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "root_causes": {
+            "items": {
+              "$ref": "#/$defs/RootCauseCandidate"
+            },
+            "type": "array"
+          },
+          "severity": {
+            "$ref": "#/$defs/Severity"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "target": true
+        },
+        "required": [
+          "report_type",
+          "cluster",
+          "target",
+          "severity",
+          "confidence",
+          "summary",
+          "impacts",
+          "evidences",
+          "root_causes",
+          "recommendations",
+          "risks",
+          "follow_up_metrics",
+          "generated_at"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer lag diagnosis"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true,
+        "readOnlyHint": false,
+        "title": "RocketMQ create topic plan"
+      },
+      "description": "Generate a dry-run change plan for future topic creation support.",
+      "inputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "CreateTopicPayload": {
+            "properties": {
+              "perm": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "read_queue_nums": {
+                "default": null,
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "topic": {
+                "type": "string"
+              },
+              "write_queue_nums": {
+                "default": null,
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "topic"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_token": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/CreateTopicPayload"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "payload"
+        ],
+        "type": "object"
+      },
       "name": "mq_create_topic",
-      "read_only": false
+      "outputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ConfirmChallenge": {
+            "properties": {
+              "challenge_id": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "challenge_id",
+              "instruction"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "applied": {
+            "type": "boolean"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_challenge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ConfirmChallenge"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "impact_analysis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "planned_changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "rollback_suggestions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "summary",
+          "planned_changes",
+          "impact_analysis",
+          "rollback_suggestions",
+          "applied"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ create topic plan"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true,
+        "readOnlyHint": false,
+        "title": "RocketMQ update topic config plan"
+      },
+      "description": "Generate a dry-run change plan for future topic config updates.",
+      "inputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "UpdateTopicConfigPayload": {
+            "properties": {
+              "config_key": {
+                "type": "string"
+              },
+              "config_value": {
+                "type": "string"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "config_key",
+              "config_value"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_token": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/UpdateTopicConfigPayload"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "payload"
+        ],
+        "type": "object"
+      },
       "name": "mq_update_topic_config",
-      "read_only": false
+      "outputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ConfirmChallenge": {
+            "properties": {
+              "challenge_id": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "challenge_id",
+              "instruction"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "applied": {
+            "type": "boolean"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_challenge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ConfirmChallenge"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "impact_analysis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "planned_changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "rollback_suggestions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "summary",
+          "planned_changes",
+          "impact_analysis",
+          "rollback_suggestions",
+          "applied"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ update topic config plan"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true,
+        "readOnlyHint": false,
+        "title": "RocketMQ update topic permission plan"
+      },
+      "description": "Generate a dry-run change plan for future topic permission updates.",
+      "inputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "UpdateTopicPermPayload": {
+            "properties": {
+              "perm": {
+                "type": "string"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "perm"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_token": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/UpdateTopicPermPayload"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "payload"
+        ],
+        "type": "object"
+      },
       "name": "mq_update_topic_perm",
-      "read_only": false
+      "outputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ConfirmChallenge": {
+            "properties": {
+              "challenge_id": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "challenge_id",
+              "instruction"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "applied": {
+            "type": "boolean"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_challenge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ConfirmChallenge"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "impact_analysis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "planned_changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "rollback_suggestions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "summary",
+          "planned_changes",
+          "impact_analysis",
+          "rollback_suggestions",
+          "applied"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ update topic permission plan"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true,
+        "readOnlyHint": false,
+        "title": "RocketMQ update broker config plan"
+      },
+      "description": "Generate a dry-run change plan for future broker config updates.",
+      "inputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "UpdateBrokerConfigPayload": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "config_key": {
+                "type": "string"
+              },
+              "config_value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "broker_name",
+              "config_key",
+              "config_value"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_token": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/UpdateBrokerConfigPayload"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "payload"
+        ],
+        "type": "object"
+      },
       "name": "mq_update_broker_config",
-      "read_only": false
+      "outputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ConfirmChallenge": {
+            "properties": {
+              "challenge_id": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "challenge_id",
+              "instruction"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "applied": {
+            "type": "boolean"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_challenge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ConfirmChallenge"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "impact_analysis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "planned_changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "rollback_suggestions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "summary",
+          "planned_changes",
+          "impact_analysis",
+          "rollback_suggestions",
+          "applied"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ update broker config plan"
     },
     {
-      "destructive": false,
-      "has_input_schema": true,
-      "has_output_schema": true,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true,
+        "readOnlyHint": false,
+        "title": "RocketMQ reset consumer offset plan"
+      },
+      "description": "Generate a dry-run impact plan for future consumer offset resets.",
+      "inputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ResetConsumerOffsetPayload": {
+            "properties": {
+              "consumer_group": {
+                "type": "string"
+              },
+              "target_offset": {
+                "default": null,
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "timestamp_millis": {
+                "default": null,
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "consumer_group"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_token": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/ResetConsumerOffsetPayload"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "payload"
+        ],
+        "type": "object"
+      },
       "name": "mq_reset_consumer_offset",
-      "read_only": false
+      "outputSchema": {
+        "$defs": {
+          "ChangeMode": {
+            "enum": [
+              "dry_run",
+              "apply"
+            ],
+            "type": "string"
+          },
+          "ConfirmChallenge": {
+            "properties": {
+              "challenge_id": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "challenge_id",
+              "instruction"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "applied": {
+            "type": "boolean"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "confirm_challenge": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ConfirmChallenge"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "impact_analysis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "$ref": "#/$defs/ChangeMode"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "planned_changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "rollback_suggestions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "cluster",
+          "mode",
+          "operator",
+          "reason",
+          "summary",
+          "planned_changes",
+          "impact_analysis",
+          "rollback_suggestions",
+          "applied"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ reset consumer offset plan"
     }
   ]
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/registry.rs
@@ -227,20 +227,7 @@ mod tests {
     fn tool_contract_schema_metadata_snapshot() {
         let contracts = tool_definitions()
             .into_iter()
-            .map(|tool| {
-                let annotations = tool.annotations.expect("tool annotations");
-                let output_schema = tool.output_schema.expect("output schema");
-                serde_json::json!({
-                    "name": tool.name.as_ref(),
-                    "input_type": tool.input_schema.get("type"),
-                    "input_required": tool.input_schema.get("required"),
-                    "output_type": output_schema.get("type"),
-                    "read_only": annotations.read_only_hint,
-                    "destructive": annotations.destructive_hint,
-                    "idempotent": annotations.idempotent_hint,
-                    "open_world": annotations.open_world_hint,
-                })
-            })
+            .map(|tool| serde_json::to_value(tool).expect("tool contract serializes"))
             .collect::<Vec<_>>();
 
         #[cfg(not(feature = "dangerous-tools"))]

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata.snap
@@ -4,102 +4,1118 @@ expression: contracts
 ---
 [
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ cluster overview"
+    },
+    "description": "Summarize configured cluster brokers, topic count, and consumer group count.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
     "name": "mq_cluster_overview",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "BrokerSummary": {
+          "properties": {
+            "broker_active": {
+              "type": "boolean"
+            },
+            "broker_addr": {
+              "type": "string"
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "hour": {
+              "type": "string"
+            },
+            "in_tps": {
+              "type": "string"
+            },
+            "out_tps": {
+              "type": "string"
+            },
+            "page_cache_lock_time_millis": {
+              "type": "string"
+            },
+            "space": {
+              "type": "string"
+            },
+            "timer_progress": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_id",
+            "broker_addr",
+            "version",
+            "in_tps",
+            "out_tps",
+            "timer_progress",
+            "page_cache_lock_time_millis",
+            "hour",
+            "space",
+            "broker_active"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/BrokerSummary"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "topic_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "brokers",
+        "topic_count",
+        "consumer_group_count",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ cluster overview"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": null,
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic list"
+    },
+    "description": "List topics visible from the selected RocketMQ cluster.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "name": "mq_list_topics",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicListEntry": {
+          "properties": {
+            "cluster": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "consumer_group": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "topic_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "topics": {
+          "items": {
+            "$ref": "#/$defs/TopicListEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic_count",
+        "topics",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic list"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic description"
+    },
+    "description": "Describe a topic with broker and queue route information.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
     "name": "mq_describe_topic",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicRouteBroker": {
+          "properties": {
+            "broker_addrs": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "enable_acting_master": {
+              "type": "boolean"
+            },
+            "zone_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_addrs",
+            "enable_acting_master"
+          ],
+          "type": "object"
+        },
+        "TopicRouteQueue": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic_sys_flag": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "topic_sys_flag"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteBroker"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteQueue"
+          },
+          "type": "array"
+        },
+        "read_queue_count": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "write_queue_count": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "broker_names",
+        "read_queue_count",
+        "write_queue_count",
+        "brokers",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic description"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic route"
+    },
+    "description": "Query topic route data including broker addresses and queue distribution.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
     "name": "mq_query_topic_route",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicRouteBroker": {
+          "properties": {
+            "broker_addrs": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "enable_acting_master": {
+              "type": "boolean"
+            },
+            "zone_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_addrs",
+            "enable_acting_master"
+          ],
+          "type": "object"
+        },
+        "TopicRouteQueue": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic_sys_flag": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "topic_sys_flag"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteBroker"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteQueue"
+          },
+          "type": "array"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "brokers",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic route"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": null,
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer groups"
+    },
+    "description": "List consumer groups and current consumption summary.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "name": "mq_list_consumer_groups",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "ConsumerGroupSummary": {
+          "properties": {
+            "client_count": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "consume_tps": {
+              "format": "double",
+              "type": "number"
+            },
+            "consume_type": {
+              "type": "string"
+            },
+            "diff_total": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "group": {
+              "type": "string"
+            },
+            "message_model": {
+              "type": "string"
+            },
+            "version": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "group",
+            "version",
+            "client_count",
+            "consume_type",
+            "message_model",
+            "consume_tps",
+            "diff_total"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "groups": {
+          "items": {
+            "$ref": "#/$defs/ConsumerGroupSummary"
+          },
+          "type": "array"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "consumer_group_count",
+        "groups",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer groups"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic",
-      "consumer_group"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer lag"
+    },
+    "description": "Query per-queue consumer lag for a topic and consumer group.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
     "name": "mq_query_consumer_lag",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "QueueLag": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "broker_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "client_ip": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "consumer_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "inflight": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "lag": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "last_timestamp": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "broker_name",
+            "queue_id",
+            "broker_offset",
+            "consumer_offset",
+            "lag",
+            "inflight",
+            "last_timestamp"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consume_tps": {
+          "format": "double",
+          "type": "number"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "inflight_total": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "max_queue_lag": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queue_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/QueueLag"
+          },
+          "type": "array"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "total_lag": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "consumer_group",
+        "total_lag",
+        "max_queue_lag",
+        "queue_count",
+        "consume_tps",
+        "inflight_total",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer lag"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "broker_name"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker description"
+    },
+    "description": "Describe broker rows for a broker name in the selected cluster.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
     "name": "mq_describe_broker",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "BrokerSummary": {
+          "properties": {
+            "broker_active": {
+              "type": "boolean"
+            },
+            "broker_addr": {
+              "type": "string"
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "hour": {
+              "type": "string"
+            },
+            "in_tps": {
+              "type": "string"
+            },
+            "out_tps": {
+              "type": "string"
+            },
+            "page_cache_lock_time_millis": {
+              "type": "string"
+            },
+            "space": {
+              "type": "string"
+            },
+            "timer_progress": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_id",
+            "broker_addr",
+            "version",
+            "in_tps",
+            "out_tps",
+            "timer_progress",
+            "page_cache_lock_time_millis",
+            "hour",
+            "space",
+            "broker_active"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/BrokerSummary"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "broker_name",
+        "brokers",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker description"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic",
-      "consumer_group"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer lag diagnosis"
+    },
+    "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "lag_threshold": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "time_range": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
     "name": "mq_diagnose_consumer_lag",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "Evidence": {
+          "properties": {
+            "data": true,
+            "id": {
+              "type": "string"
+            },
+            "source_tool": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/$defs/EvidenceStatus"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "source_tool",
+            "status",
+            "summary",
+            "data"
+          ],
+          "type": "object"
+        },
+        "EvidenceStatus": {
+          "enum": [
+            "Present",
+            "Missing",
+            "Error"
+          ],
+          "type": "string"
+        },
+        "ImpactItem": {
+          "properties": {
+            "area": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "severity": {
+              "$ref": "#/$defs/Severity"
+            }
+          },
+          "required": [
+            "area",
+            "description",
+            "severity"
+          ],
+          "type": "object"
+        },
+        "MetricWatchItem": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "target",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "Recommendation": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string"
+            },
+            "rationale": {
+              "type": "string"
+            },
+            "risk": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "priority",
+            "rationale",
+            "risk"
+          ],
+          "type": "object"
+        },
+        "RootCauseCandidate": {
+          "properties": {
+            "cause": {
+              "type": "string"
+            },
+            "confidence": {
+              "format": "float",
+              "type": "number"
+            },
+            "evidence_refs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reasoning": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cause",
+            "confidence",
+            "evidence_refs",
+            "reasoning"
+          ],
+          "type": "object"
+        },
+        "Severity": {
+          "enum": [
+            "Healthy",
+            "Low",
+            "Medium",
+            "High",
+            "Critical",
+            "Unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confidence": {
+          "format": "float",
+          "type": "number"
+        },
+        "evidences": {
+          "items": {
+            "$ref": "#/$defs/Evidence"
+          },
+          "type": "array"
+        },
+        "follow_up_metrics": {
+          "items": {
+            "$ref": "#/$defs/MetricWatchItem"
+          },
+          "type": "array"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "impacts": {
+          "items": {
+            "$ref": "#/$defs/ImpactItem"
+          },
+          "type": "array"
+        },
+        "recommendations": {
+          "items": {
+            "$ref": "#/$defs/Recommendation"
+          },
+          "type": "array"
+        },
+        "report_type": {
+          "type": "string"
+        },
+        "risks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "root_causes": {
+          "items": {
+            "$ref": "#/$defs/RootCauseCandidate"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "target": true
+      },
+      "required": [
+        "report_type",
+        "cluster",
+        "target",
+        "severity",
+        "confidence",
+        "summary",
+        "impacts",
+        "evidences",
+        "root_causes",
+        "recommendations",
+        "risks",
+        "follow_up_metrics",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer lag diagnosis"
   }
 ]

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata_with_dangerous_tools.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__registry__tests__tool_contract_schema_metadata_with_dangerous_tools.snap
@@ -4,182 +4,1973 @@ expression: contracts
 ---
 [
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ cluster overview"
+    },
+    "description": "Summarize configured cluster brokers, topic count, and consumer group count.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
     "name": "mq_cluster_overview",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "BrokerSummary": {
+          "properties": {
+            "broker_active": {
+              "type": "boolean"
+            },
+            "broker_addr": {
+              "type": "string"
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "hour": {
+              "type": "string"
+            },
+            "in_tps": {
+              "type": "string"
+            },
+            "out_tps": {
+              "type": "string"
+            },
+            "page_cache_lock_time_millis": {
+              "type": "string"
+            },
+            "space": {
+              "type": "string"
+            },
+            "timer_progress": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_id",
+            "broker_addr",
+            "version",
+            "in_tps",
+            "out_tps",
+            "timer_progress",
+            "page_cache_lock_time_millis",
+            "hour",
+            "space",
+            "broker_active"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/BrokerSummary"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "topic_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "brokers",
+        "topic_count",
+        "consumer_group_count",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ cluster overview"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": null,
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic list"
+    },
+    "description": "List topics visible from the selected RocketMQ cluster.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "name": "mq_list_topics",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicListEntry": {
+          "properties": {
+            "cluster": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "consumer_group": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "topic_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "topics": {
+          "items": {
+            "$ref": "#/$defs/TopicListEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic_count",
+        "topics",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic list"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic description"
+    },
+    "description": "Describe a topic with broker and queue route information.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
     "name": "mq_describe_topic",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicRouteBroker": {
+          "properties": {
+            "broker_addrs": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "enable_acting_master": {
+              "type": "boolean"
+            },
+            "zone_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_addrs",
+            "enable_acting_master"
+          ],
+          "type": "object"
+        },
+        "TopicRouteQueue": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic_sys_flag": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "topic_sys_flag"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteBroker"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteQueue"
+          },
+          "type": "array"
+        },
+        "read_queue_count": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "write_queue_count": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "broker_names",
+        "read_queue_count",
+        "write_queue_count",
+        "brokers",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic description"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ topic route"
+    },
+    "description": "Query topic route data including broker addresses and queue distribution.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
     "name": "mq_query_topic_route",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "TopicRouteBroker": {
+          "properties": {
+            "broker_addrs": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "enable_acting_master": {
+              "type": "boolean"
+            },
+            "zone_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_addrs",
+            "enable_acting_master"
+          ],
+          "type": "object"
+        },
+        "TopicRouteQueue": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic_sys_flag": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "topic_sys_flag"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteBroker"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/TopicRouteQueue"
+          },
+          "type": "array"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "brokers",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ topic route"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": null,
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer groups"
+    },
+    "description": "List consumer groups and current consumption summary.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "name": "mq_list_consumer_groups",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "ConsumerGroupSummary": {
+          "properties": {
+            "client_count": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "consume_tps": {
+              "format": "double",
+              "type": "number"
+            },
+            "consume_type": {
+              "type": "string"
+            },
+            "diff_total": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "group": {
+              "type": "string"
+            },
+            "message_model": {
+              "type": "string"
+            },
+            "version": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "group",
+            "version",
+            "client_count",
+            "consume_type",
+            "message_model",
+            "consume_tps",
+            "diff_total"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "groups": {
+          "items": {
+            "$ref": "#/$defs/ConsumerGroupSummary"
+          },
+          "type": "array"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "consumer_group_count",
+        "groups",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer groups"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic",
-      "consumer_group"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer lag"
+    },
+    "description": "Query per-queue consumer lag for a topic and consumer group.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
     "name": "mq_query_consumer_lag",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "QueueLag": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "broker_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "client_ip": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "consumer_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "inflight": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "lag": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "last_timestamp": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "broker_name",
+            "queue_id",
+            "broker_offset",
+            "consumer_offset",
+            "lag",
+            "inflight",
+            "last_timestamp"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consume_tps": {
+          "format": "double",
+          "type": "number"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "inflight_total": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "max_queue_lag": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        },
+        "queue_count": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "queues": {
+          "items": {
+            "$ref": "#/$defs/QueueLag"
+          },
+          "type": "array"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "total_lag": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "topic",
+        "consumer_group",
+        "total_lag",
+        "max_queue_lag",
+        "queue_count",
+        "consume_tps",
+        "inflight_total",
+        "queues",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer lag"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "broker_name"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker description"
+    },
+    "description": "Describe broker rows for a broker name in the selected cluster.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
     "name": "mq_describe_broker",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "BrokerSummary": {
+          "properties": {
+            "broker_active": {
+              "type": "boolean"
+            },
+            "broker_addr": {
+              "type": "string"
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "hour": {
+              "type": "string"
+            },
+            "in_tps": {
+              "type": "string"
+            },
+            "out_tps": {
+              "type": "string"
+            },
+            "page_cache_lock_time_millis": {
+              "type": "string"
+            },
+            "space": {
+              "type": "string"
+            },
+            "timer_progress": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "broker_id",
+            "broker_addr",
+            "version",
+            "in_tps",
+            "out_tps",
+            "timer_progress",
+            "page_cache_lock_time_millis",
+            "hour",
+            "space",
+            "broker_active"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "brokers": {
+          "items": {
+            "$ref": "#/$defs/BrokerSummary"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "namesrv_addr": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "namesrv_addr",
+        "broker_name",
+        "brokers",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker description"
   },
   {
-    "destructive": false,
-    "idempotent": true,
-    "input_required": [
-      "cluster",
-      "topic",
-      "consumer_group"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer lag diagnosis"
+    },
+    "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "lag_threshold": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "time_range": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
     "name": "mq_diagnose_consumer_lag",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": true
+    "outputSchema": {
+      "$defs": {
+        "Evidence": {
+          "properties": {
+            "data": true,
+            "id": {
+              "type": "string"
+            },
+            "source_tool": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/$defs/EvidenceStatus"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "source_tool",
+            "status",
+            "summary",
+            "data"
+          ],
+          "type": "object"
+        },
+        "EvidenceStatus": {
+          "enum": [
+            "Present",
+            "Missing",
+            "Error"
+          ],
+          "type": "string"
+        },
+        "ImpactItem": {
+          "properties": {
+            "area": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "severity": {
+              "$ref": "#/$defs/Severity"
+            }
+          },
+          "required": [
+            "area",
+            "description",
+            "severity"
+          ],
+          "type": "object"
+        },
+        "MetricWatchItem": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "target",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "Recommendation": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string"
+            },
+            "rationale": {
+              "type": "string"
+            },
+            "risk": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "priority",
+            "rationale",
+            "risk"
+          ],
+          "type": "object"
+        },
+        "RootCauseCandidate": {
+          "properties": {
+            "cause": {
+              "type": "string"
+            },
+            "confidence": {
+              "format": "float",
+              "type": "number"
+            },
+            "evidence_refs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reasoning": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cause",
+            "confidence",
+            "evidence_refs",
+            "reasoning"
+          ],
+          "type": "object"
+        },
+        "Severity": {
+          "enum": [
+            "Healthy",
+            "Low",
+            "Medium",
+            "High",
+            "Critical",
+            "Unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confidence": {
+          "format": "float",
+          "type": "number"
+        },
+        "evidences": {
+          "items": {
+            "$ref": "#/$defs/Evidence"
+          },
+          "type": "array"
+        },
+        "follow_up_metrics": {
+          "items": {
+            "$ref": "#/$defs/MetricWatchItem"
+          },
+          "type": "array"
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "impacts": {
+          "items": {
+            "$ref": "#/$defs/ImpactItem"
+          },
+          "type": "array"
+        },
+        "recommendations": {
+          "items": {
+            "$ref": "#/$defs/Recommendation"
+          },
+          "type": "array"
+        },
+        "report_type": {
+          "type": "string"
+        },
+        "risks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "root_causes": {
+          "items": {
+            "$ref": "#/$defs/RootCauseCandidate"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "target": true
+      },
+      "required": [
+        "report_type",
+        "cluster",
+        "target",
+        "severity",
+        "confidence",
+        "summary",
+        "impacts",
+        "evidences",
+        "root_causes",
+        "recommendations",
+        "risks",
+        "follow_up_metrics",
+        "generated_at"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer lag diagnosis"
   },
   {
-    "destructive": false,
-    "idempotent": false,
-    "input_required": [
-      "cluster",
-      "mode",
-      "operator",
-      "reason",
-      "payload"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false,
+      "title": "RocketMQ create topic plan"
+    },
+    "description": "Generate a dry-run change plan for future topic creation support.",
+    "inputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "CreateTopicPayload": {
+          "properties": {
+            "perm": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "read_queue_nums": {
+              "default": null,
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "topic": {
+              "type": "string"
+            },
+            "write_queue_nums": {
+              "default": null,
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "topic"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_token": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/CreateTopicPayload"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "payload"
+      ],
+      "type": "object"
+    },
     "name": "mq_create_topic",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": false
+    "outputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ConfirmChallenge": {
+          "properties": {
+            "challenge_id": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "challenge_id",
+            "instruction"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "applied": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_challenge": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfirmChallenge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "impact_analysis": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "planned_changes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "rollback_suggestions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "summary",
+        "planned_changes",
+        "impact_analysis",
+        "rollback_suggestions",
+        "applied"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ create topic plan"
   },
   {
-    "destructive": false,
-    "idempotent": false,
-    "input_required": [
-      "cluster",
-      "mode",
-      "operator",
-      "reason",
-      "payload"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false,
+      "title": "RocketMQ update topic config plan"
+    },
+    "description": "Generate a dry-run change plan for future topic config updates.",
+    "inputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "UpdateTopicConfigPayload": {
+          "properties": {
+            "config_key": {
+              "type": "string"
+            },
+            "config_value": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "config_key",
+            "config_value"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_token": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/UpdateTopicConfigPayload"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "payload"
+      ],
+      "type": "object"
+    },
     "name": "mq_update_topic_config",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": false
+    "outputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ConfirmChallenge": {
+          "properties": {
+            "challenge_id": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "challenge_id",
+            "instruction"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "applied": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_challenge": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfirmChallenge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "impact_analysis": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "planned_changes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "rollback_suggestions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "summary",
+        "planned_changes",
+        "impact_analysis",
+        "rollback_suggestions",
+        "applied"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ update topic config plan"
   },
   {
-    "destructive": false,
-    "idempotent": false,
-    "input_required": [
-      "cluster",
-      "mode",
-      "operator",
-      "reason",
-      "payload"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false,
+      "title": "RocketMQ update topic permission plan"
+    },
+    "description": "Generate a dry-run change plan for future topic permission updates.",
+    "inputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "UpdateTopicPermPayload": {
+          "properties": {
+            "perm": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "perm"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_token": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/UpdateTopicPermPayload"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "payload"
+      ],
+      "type": "object"
+    },
     "name": "mq_update_topic_perm",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": false
+    "outputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ConfirmChallenge": {
+          "properties": {
+            "challenge_id": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "challenge_id",
+            "instruction"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "applied": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_challenge": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfirmChallenge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "impact_analysis": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "planned_changes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "rollback_suggestions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "summary",
+        "planned_changes",
+        "impact_analysis",
+        "rollback_suggestions",
+        "applied"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ update topic permission plan"
   },
   {
-    "destructive": false,
-    "idempotent": false,
-    "input_required": [
-      "cluster",
-      "mode",
-      "operator",
-      "reason",
-      "payload"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false,
+      "title": "RocketMQ update broker config plan"
+    },
+    "description": "Generate a dry-run change plan for future broker config updates.",
+    "inputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "UpdateBrokerConfigPayload": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "config_key": {
+              "type": "string"
+            },
+            "config_value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name",
+            "config_key",
+            "config_value"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_token": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/UpdateBrokerConfigPayload"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "payload"
+      ],
+      "type": "object"
+    },
     "name": "mq_update_broker_config",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": false
+    "outputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ConfirmChallenge": {
+          "properties": {
+            "challenge_id": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "challenge_id",
+            "instruction"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "applied": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_challenge": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfirmChallenge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "impact_analysis": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "planned_changes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "rollback_suggestions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "summary",
+        "planned_changes",
+        "impact_analysis",
+        "rollback_suggestions",
+        "applied"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ update broker config plan"
   },
   {
-    "destructive": false,
-    "idempotent": false,
-    "input_required": [
-      "cluster",
-      "mode",
-      "operator",
-      "reason",
-      "payload"
-    ],
-    "input_type": "object",
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": false,
+      "title": "RocketMQ reset consumer offset plan"
+    },
+    "description": "Generate a dry-run impact plan for future consumer offset resets.",
+    "inputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ResetConsumerOffsetPayload": {
+          "properties": {
+            "consumer_group": {
+              "type": "string"
+            },
+            "target_offset": {
+              "default": null,
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "timestamp_millis": {
+              "default": null,
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "consumer_group"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_token": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "payload": {
+          "$ref": "#/$defs/ResetConsumerOffsetPayload"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "payload"
+      ],
+      "type": "object"
+    },
     "name": "mq_reset_consumer_offset",
-    "open_world": true,
-    "output_type": "object",
-    "read_only": false
+    "outputSchema": {
+      "$defs": {
+        "ChangeMode": {
+          "enum": [
+            "dry_run",
+            "apply"
+          ],
+          "type": "string"
+        },
+        "ConfirmChallenge": {
+          "properties": {
+            "challenge_id": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "challenge_id",
+            "instruction"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "applied": {
+          "type": "boolean"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "confirm_challenge": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfirmChallenge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "impact_analysis": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/ChangeMode"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "planned_changes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "rollback_suggestions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "cluster",
+        "mode",
+        "operator",
+        "reason",
+        "summary",
+        "planned_changes",
+        "impact_analysis",
+        "rollback_suggestions",
+        "applied"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ reset consumer offset plan"
   }
 ]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8159

### Brief Description

- Add the accepted target architecture decisions for the unreleased `rocketmq-mcp` clean-break refactor.
- Record the current protocol surface and three-, four-, and five-lifecycle admin-client call-graph baselines.
- Freeze the final MCP 2025-11-25 Tool, Resource URI, feature, security, diagnosis, and module-layout decisions for later implementation pull requests.
- Expand default and optional Tool/protocol snapshots to cover complete schemas, annotations, Resource descriptors, templates, and Prompt arguments.
- Link the architecture ADR and baseline report from the English documentation index.

### How Did You Test This Change?

- `cargo fmt --all -- --check` - passed.
- `cargo check -p rocketmq-mcp` - passed.
- `cargo test -p rocketmq-mcp` - passed with 40 unit tests and 1 stdio integration test.
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings` - passed.
- `cargo doc -p rocketmq-mcp --no-deps` - passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.
- `git diff --check` - passed.

The build emitted existing MSVC linker messages and the existing `proc-macro-error2` future-incompatibility notice; all required commands exited successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record for the RocketMQ MCP refactor, covering safety boundaries, protocol support, workflow diagnosis, and planning safeguards.
  * Added a baseline report documenting the current MCP surface, validation results, lifecycle analysis, and future milestones.
  * Linked both documents from the English design-document index.

* **Tests**
  * Improved protocol and tool contract snapshots to capture complete descriptor details, including tools, resources, and prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->