### PR TITLE
[ISSUE #8165]♻️Add bounded shared cache and MCP resource templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "jsonschema",
  "mockall",
  "once_cell",
+ "percent-encoding",
  "pretty_assertions",
  "regex",
  "rmcp",

--- a/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
@@ -35,6 +35,7 @@ diagnosis efficient without creating a global connection pool prematurely.
 | ADR-007 | Version Evidence and Rules independently. Diagnosis output identifies the evidence and rule versions that produced it. |
 | ADR-008 | Target MCP `2025-11-25` only. The refactor does not promise a dual-version protocol bridge with MCP `2025-06-18`. |
 | ADR-009 | Replace the current implementation with a clean break because it is unused. Do not retain legacy Tool, URI, schema, configuration, or feature aliases. |
+| ADR-010 | Keep a bounded, process-local TTL cache inside the shared `QueryFacade`. Keys include schema version, visibility class, query kind, resolved cluster, and normalized parameters; failures are not cached, and identical concurrent misses use singleflight. |
 
 ## Frozen Public Contract
 
@@ -79,7 +80,7 @@ Tool, URI, schema, configuration, or feature alias is allowed.
 transport and protocol
         -> RequestContext identity and authorization
         -> Tool, Resource, and Prompt handlers
-        -> QueryFacade / planning workflows / diagnosis rules
+        -> QueryFacade / bounded cache / planning workflows / diagnosis rules
         -> workflow-scoped AdminSession
         -> rocketmq-admin-core
 ```
@@ -89,13 +90,21 @@ normalization, and read-model construction. Resources and Tools are different
 MCP presentations of the same query results. Diagnosis consumes the same
 facade, adds versioned evidence, and evaluates versioned rules.
 
+The cache stores normalized query results, not protocol envelopes. This keeps
+request identifiers and output policy request-specific while allowing Tools
+and Resources to reuse the same observed data. Visibility class is part of the
+key so later principal-aware authorization can isolate results without
+duplicating the query implementation.
+
 ## Consequences
 
 P0 records the baseline and freezes the destination contract. It deliberately
 does not change the production Tool names, resource URIs, protocol version,
 feature flags, or admin lifecycle. P1 introduces the clean-break module and
 protocol contract. P2 introduces `QueryFacade`, `AdminSession`, and measurable
-workflow lifecycle counters. Subsequent work may add planning and Apply only
+workflow lifecycle counters. P3 adds live parameterized Resources, bounded TTL
+caching, and singleflight without introducing a global admin-client pool.
+Subsequent work may add planning and Apply only
 through the Plan/Apply boundary defined here.
 
 The migration cost is intentional: existing integrations must move directly to

--- a/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
@@ -206,3 +206,39 @@ cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
 
 These are deterministic local lifecycle and contract results. They do not
 claim live-cluster connection latency, request latency, or throughput.
+
+### P3 Resource and Cache Replacement
+
+P3 replaces placeholder Resource discovery with the final cluster-scoped URI
+surface and adds a shared bounded TTL cache inside `QueryFacade`. The cache is
+configured by `cache.enabled`, `cache.max_entries`, and the query-family TTL
+fields. Its normalized key includes schema version, visibility class, query
+kind, resolved cluster, filter, page limit, and cursor where applicable.
+
+| Target | Recorded deterministic evidence |
+| --- | --- |
+| Tool/Resource reuse | `query_facade_reuses_cached_results_across_tool_and_resource_queries`: first Tool result is `miss`, Resource replay is `hit`, start 1, shutdown 1, topic query 1. |
+| Singleflight | `query_facade_singleflight_coalesces_concurrent_identical_misses`: 8 concurrent calls produce 1 miss, 7 hits, 7 coalesced waiters, start 1, shutdown 1, topic query 1. |
+| Visibility isolation | `query_facade_cache_isolates_visibility_classes`: two visibility classes produce two misses and two independent admin sessions. |
+| Cache bounds | Cache unit tests cover hit, miss, expiry, FIFO eviction, explicit invalidation, disabled bypass, failed-load retry, and concurrent singleflight. |
+| URI contract | URI and reader tests cover all four roots and five parameterized forms, reject legacy/incomplete forms, and map unknown live entities to Resource Not Found. |
+| Discovery pagination | `registry_cursor_resumes_resource_discovery` returns 50 descriptors and resumes the remaining two with the opaque cursor; invalid cursors are rejected. |
+
+The default and `change-planning` protocol snapshots now contain five Resource
+templates. Read-only Tool results include a ResourceLink, and Resource payloads
+include `observed_at`, `freshness_ms`, and `cache_status`. Cache counters are
+emitted through trace-level events after Tool and Resource requests.
+
+Recorded validation:
+
+```bash
+cargo test -p rocketmq-mcp
+cargo test -p rocketmq-mcp --all-features
+cargo clippy -p rocketmq-mcp --all-targets --all-features -- -D warnings
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+cargo doc -p rocketmq-mcp --no-deps --all-features
+```
+
+These tests use an injected session factory and do not claim live-cluster
+latency or throughput. Production cluster integration remains a P6 release
+gate.

--- a/rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md
@@ -65,17 +65,18 @@ Successful Tool calls return `structuredContent` matching this envelope:
   "cluster": "prod-a",
   "observed_at": "2026-07-10T15:30:00.000Z",
   "freshness_ms": 0,
-  "cache_status": "bypass",
+  "cache_status": "miss",
   "partial": false,
   "warnings": [],
   "data": {}
 }
 ```
 
-`observed_at` is RFC 3339. `freshness_ms` and `cache_status` become meaningful
-when the shared query cache is introduced. `partial: true` requires at least
-one warning describing the unavailable source. A text summary and serialized
-JSON text block accompany `structuredContent` for client compatibility.
+`observed_at` is RFC 3339. `freshness_ms` is zero for a newly loaded value and
+increases for a cache hit. `cache_status` is `miss`, `hit`, or `bypass`.
+`partial: true` requires at least one warning describing the unavailable
+source. A text summary, serialized JSON text block, and a ResourceLink for the
+corresponding replayable read model accompany `structuredContent`.
 
 Before a response is returned, it is validated against the Tool output schema
 and limited to 1 MiB. The default output policy removes NameServer addresses,
@@ -142,6 +143,15 @@ The session is explicitly shut down and awaited after success, failure,
 timeout, or MCP request cancellation. There is no process-global admin-client
 pool.
 
+`McpApp` owns one shared `QueryFacade` and bounded in-memory TTL cache. Cache
+keys contain the schema version, visibility class, query kind, resolved
+cluster, and normalized parameters. Errors are not cached. Identical
+concurrent misses are coalesced by singleflight and start one `AdminSession`.
+Cache disablement or a zero TTL bypasses storage without changing query
+correctness. Trace-level cache metrics report cumulative hit, miss, bypass,
+eviction, invalidation, and coalesced-waiter counts. Embedders can explicitly
+clear all entries through `McpApp::invalidate_cache()`.
+
 Consumer-lag diagnosis results include independent provenance fields:
 
 ```json
@@ -157,13 +167,34 @@ Resources are always scoped to an explicit configured cluster:
 
 - `rocketmq://clusters/{cluster}/overview`
 - `rocketmq://clusters/{cluster}/topics`
+- `rocketmq://clusters/{cluster}/topics/{topic}`
+- `rocketmq://clusters/{cluster}/topics/{topic}/route`
 - `rocketmq://clusters/{cluster}/brokers`
+- `rocketmq://clusters/{cluster}/brokers/{broker}`
 - `rocketmq://clusters/{cluster}/consumer-groups`
+- `rocketmq://clusters/{cluster}/consumer-groups/{group}`
+- `rocketmq://clusters/{cluster}/consumer-groups/{group}/lag?topic={topic}`
 
 Resource readers execute live queries through `QueryFacade`. Successful
-payloads identify `source` as `live`, set `partial` to `false`, and include the
-same normalized read models used by Tools. A backend failure is returned as a
-Resource error rather than being represented as an empty inventory.
+payloads identify `source` as `live`, include `observed_at`, `freshness_ms`, and
+`cache_status`, set `partial` to `false`, and contain the same normalized read
+models used by Tools. A backend failure is returned as a Resource error rather
+than being represented as an empty inventory.
+
+Resource errors use Resource Not Found for invalid URIs, unknown clusters, and
+unknown entities. Other failures retain a non-sensitive machine-readable data
+code: `resource_permission_denied`, `resource_rate_limited`,
+`resource_query_timeout`, `resource_query_cancelled`, or
+`resource_backend_unavailable`.
+
+`resources/list` exposes only the four cluster root Resources and uses an
+opaque versioned MCP cursor when more than 50 descriptors exist.
+`resources/templates/list` publishes RFC 6570 templates for topic, topic
+route, consumer group, consumer lag, and broker Resources. Invalid cursors,
+legacy URIs, and incomplete parameterized URIs are rejected rather than
+silently mapped to another Resource.
+Cluster and entity substitutions use UTF-8 percent-encoding, so names such as
+`%RETRY%orders` round-trip without producing an invalid URI.
 
 ## Verification
 

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -55,6 +55,7 @@ clap               = { version = "4.6.1", features = ["derive"] }
 config             = { workspace = true }
 jsonschema         = { version = "0.47", default-features = false }
 once_cell          = "1.21"
+percent-encoding   = "2.3"
 regex              = "1.12.4"
 rmcp               = { version = "2.2", features = ["server", "macros", "schemars"] }
 schemars           = "1.1"

--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -46,6 +46,8 @@ The server targets MCP protocol version `2025-11-25`. Clients requesting another
 
 Successful Tool calls return a `rocketmq-mcp.v2` envelope with `request_id`, cluster, RFC 3339 observation time, freshness, cache status, partial status, warnings, and typed data. Correctable input and backend failures return Tool execution errors with a stable code, retryability, suggestions, and the request identifier.
 
+Read-only Tool calls also return a ResourceLink for the corresponding live Resource. Tool and Resource requests share the application-level `QueryFacade`, bounded TTL cache, and singleflight coordination, so an identical query can be replayed without starting a second admin session while its entry is fresh.
+
 ## Build
 
 Run commands from the repository root.
@@ -86,6 +88,11 @@ Important fields:
 - `clusters[].name`: logical cluster name used by tools, resources, and prompts.
 - `clusters[].namesrv_addr`: RocketMQ namesrv address for admin queries.
 - `audit.sink`: `memory`, `file`, or `tracing`.
+- `cache.enabled`: enables or bypasses the shared query cache.
+- `cache.max_entries`: maximum number of in-memory entries; it must be greater than zero when caching is enabled.
+- `cache.*_ttl_ms`: per-query-family freshness windows for overview, topic, broker, and consumer-lag data.
+
+Cache keys include the schema version, visibility class, query kind, resolved cluster, and normalized query parameters. Failures are not cached. Concurrent misses for the same key are coalesced, and `cache_status` reports `miss`, `hit`, or `bypass`. Embedders can call `McpApp::invalidate_cache()` to clear all entries explicitly. Cumulative hit, miss, bypass, eviction, invalidation, and coalesced-waiter counters are emitted at trace level after Tool and Resource requests.
 
 Command-line overrides:
 
@@ -220,8 +227,16 @@ Feature-gated planning Tools, available only with `change-planning`, never mutat
 
 - `rocketmq://clusters/{cluster}/overview`
 - `rocketmq://clusters/{cluster}/topics`
+- `rocketmq://clusters/{cluster}/topics/{topic}`
+- `rocketmq://clusters/{cluster}/topics/{topic}/route`
 - `rocketmq://clusters/{cluster}/brokers`
+- `rocketmq://clusters/{cluster}/brokers/{broker}`
 - `rocketmq://clusters/{cluster}/consumer-groups`
+- `rocketmq://clusters/{cluster}/consumer-groups/{group}`
+- `rocketmq://clusters/{cluster}/consumer-groups/{group}/lag?topic={topic}`
+
+`resources/list` returns cluster root Resources in cursor-paginated pages. `resources/templates/list` publishes the five parameterized forms. All accepted URIs are explicit cluster-scoped v2 URIs; unsupported or incomplete forms return Resource Not Found instead of a placeholder payload.
+Cluster and RocketMQ entity names are UTF-8 percent-encoded as URI path or query components, including retry topics and groups that contain `%RETRY%`.
 
 ## Prompts
 

--- a/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
@@ -31,6 +31,8 @@ sink = "file"
 path = "./logs/rocketmq-mcp-audit.log"
 
 [cache]
+enabled = true
+max_entries = 256
 cluster_overview_ttl_ms = 3000
 topic_list_ttl_ms = 5000
 broker_metrics_ttl_ms = 2000

--- a/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -25,9 +26,14 @@ use crate::adapter::admin_session::ResolvedCluster;
 use crate::adapter::admin_session::SessionConsumerLag;
 use crate::adapter::admin_session::SessionTopicRoute;
 use crate::config::McpConfig;
+use crate::infrastructure::cache::CacheMetricsSnapshot;
+use crate::infrastructure::cache::QueryCache;
 use crate::model::contract::observed_at;
 use crate::model::contract::paginate;
 use crate::model::contract::PageRequest;
+use crate::model::contract::QueryResult;
+use crate::model::contract::DEFAULT_PAGE_LIMIT;
+use crate::model::contract::SCHEMA_VERSION;
 use crate::model::diagnosis::DiagnosisReport;
 use crate::service::diagnosis_service;
 use crate::tools::broker_tools::DescribeBrokerArgs;
@@ -69,28 +75,42 @@ type WorkflowFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ToolExecution
 
 #[async_trait::async_trait]
 pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
-    async fn cluster_overview(&self, args: ClusterOverviewArgs) -> Result<ClusterOverviewOutput, ToolExecutionError>;
+    async fn cluster_overview(
+        &self,
+        args: ClusterOverviewArgs,
+    ) -> Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError>;
 
-    async fn list_topics(&self, args: ListTopicsArgs) -> Result<ListTopicsOutput, ToolExecutionError>;
+    async fn list_topics(&self, args: ListTopicsArgs) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError>;
 
-    async fn describe_topic(&self, args: DescribeTopicArgs) -> Result<DescribeTopicOutput, ToolExecutionError>;
+    async fn describe_topic(
+        &self,
+        args: DescribeTopicArgs,
+    ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError>;
 
-    async fn query_topic_route(&self, args: QueryTopicRouteArgs) -> Result<QueryTopicRouteOutput, ToolExecutionError>;
+    async fn query_topic_route(
+        &self,
+        args: QueryTopicRouteArgs,
+    ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError>;
 
     async fn list_consumer_groups(
         &self,
         args: ListConsumerGroupsArgs,
-    ) -> Result<ListConsumerGroupsOutput, ToolExecutionError>;
+    ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError>;
 
     async fn query_consumer_lag(
         &self,
         args: QueryConsumerLagArgs,
-    ) -> Result<QueryConsumerLagOutput, ToolExecutionError>;
+    ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError>;
 
-    async fn describe_broker(&self, args: DescribeBrokerArgs) -> Result<DescribeBrokerOutput, ToolExecutionError>;
+    async fn describe_broker(
+        &self,
+        args: DescribeBrokerArgs,
+    ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError>;
 
-    async fn diagnose_consumer_lag(&self, args: DiagnoseConsumerLagArgs)
-        -> Result<DiagnosisReport, ToolExecutionError>;
+    async fn diagnose_consumer_lag(
+        &self,
+        args: DiagnoseConsumerLagArgs,
+    ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError>;
 }
 
 #[derive(Clone)]
@@ -98,6 +118,23 @@ pub(crate) struct QueryFacade<F> {
     config: McpConfig,
     factory: F,
     control: WorkflowControl,
+    cache: QueryCache,
+    visibility_class: String,
+}
+
+impl<F> fmt::Debug for QueryFacade<F>
+where
+    F: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QueryFacade")
+            .field("config", &self.config)
+            .field("factory", &self.factory)
+            .field("control", &self.control)
+            .field("visibility_class", &self.visibility_class)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<F> QueryFacade<F>
@@ -110,9 +147,11 @@ where
 
     pub(crate) fn with_factory_and_control(config: McpConfig, factory: F, control: WorkflowControl) -> Self {
         Self {
+            cache: QueryCache::new(config.cache.enabled, config.cache.max_entries),
             config,
             factory,
             control,
+            visibility_class: "local".to_string(),
         }
     }
 
@@ -121,174 +160,333 @@ where
         self
     }
 
+    pub(crate) fn with_visibility_class(mut self, visibility_class: impl Into<String>) -> Self {
+        self.visibility_class = visibility_class.into();
+        self
+    }
+
+    pub(crate) fn cache_metrics(&self) -> CacheMetricsSnapshot {
+        self.cache.metrics()
+    }
+
+    pub(crate) async fn invalidate_cache(&self) -> usize {
+        self.cache.clear().await
+    }
+
     pub(crate) async fn cluster_overview(
         &self,
         args: ClusterOverviewArgs,
-    ) -> Result<ClusterOverviewOutput, ToolExecutionError> {
+    ) -> Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError> {
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, |session, cluster| {
-            Box::pin(async move {
-                let brokers = session.broker_rows().await?;
-                let topics = session.topic_entries().await?;
-                let consumer_groups = session.consumer_groups().await?;
-                Ok(ClusterOverviewOutput {
-                    cluster: cluster.name.clone(),
-                    namesrv_addr: cluster.namesrv_addr.clone(),
-                    brokers,
-                    topic_count: topics.len(),
-                    consumer_group_count: consumer_groups.len(),
-                    generated_at: observed_at(),
-                })
-            })
-        })
-        .await
+        let key = self.cache_key("cluster_overview", &cluster.name, "");
+        let ttl = Duration::from_millis(self.config.cache.cluster_overview_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, |session, cluster| {
+                        Box::pin(async move {
+                            let brokers = session.broker_rows().await?;
+                            let topics = session.topic_entries().await?;
+                            let consumer_groups = session.consumer_groups().await?;
+                            Ok(ClusterOverviewOutput {
+                                cluster: cluster.name.clone(),
+                                namesrv_addr: cluster.namesrv_addr.clone(),
+                                brokers,
+                                topic_count: topics.len(),
+                                consumer_group_count: consumer_groups.len(),
+                                generated_at: observed_at(),
+                            })
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
-    pub(crate) async fn list_topics(&self, args: ListTopicsArgs) -> Result<ListTopicsOutput, ToolExecutionError> {
+    pub(crate) async fn list_topics(
+        &self,
+        args: ListTopicsArgs,
+    ) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError> {
         let cluster = self.resolve_cluster(args.cluster.as_deref())?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let mut topics = session.topic_entries().await?;
-                topics.sort_by(|left, right| left.topic.cmp(&right.topic));
-                if let Some(filter) = normalized_filter(args.filter.as_deref()) {
-                    topics.retain(|entry| entry.topic.to_ascii_lowercase().contains(&filter));
-                }
-                let page = paginate(topics, &args.page)
-                    .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
-                Ok(ListTopicsOutput {
-                    cluster: cluster.name.clone(),
-                    namesrv_addr: cluster.namesrv_addr.clone(),
-                    page,
-                    generated_at: observed_at(),
-                })
-            })
-        })
-        .await
+        let key = self.cache_key(
+            "list_topics",
+            &cluster.name,
+            &list_key(args.filter.as_deref(), &args.page),
+        );
+        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let mut topics = session.topic_entries().await?;
+                            topics.sort_by(|left, right| left.topic.cmp(&right.topic));
+                            if let Some(filter) = normalized_filter(args.filter.as_deref()) {
+                                topics.retain(|entry| entry.topic.to_ascii_lowercase().contains(&filter));
+                            }
+                            let page = paginate(topics, &args.page)
+                                .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
+                            Ok(ListTopicsOutput {
+                                cluster: cluster.name.clone(),
+                                namesrv_addr: cluster.namesrv_addr.clone(),
+                                page,
+                                generated_at: observed_at(),
+                            })
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn describe_topic(
         &self,
-        args: DescribeTopicArgs,
-    ) -> Result<DescribeTopicOutput, ToolExecutionError> {
+        mut args: DescribeTopicArgs,
+    ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError> {
+        args.topic = normalized_identifier("topic", &args.topic)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let route = session.topic_route(&args.topic).await?;
-                let route = topic_route_output(cluster, &args.topic, route, &args.page)?;
-                Ok(describe_topic_output(&route))
-            })
-        })
-        .await
+        let key = self.cache_key(
+            "describe_topic",
+            &cluster.name,
+            &format!("topic={}|{}", args.topic, page_key(&args.page)),
+        );
+        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let route = session.topic_route(&args.topic).await?;
+                            let route = topic_route_output(cluster, &args.topic, route, &args.page)?;
+                            Ok(describe_topic_output(&route))
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn query_topic_route(
         &self,
-        args: QueryTopicRouteArgs,
-    ) -> Result<QueryTopicRouteOutput, ToolExecutionError> {
+        mut args: QueryTopicRouteArgs,
+    ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
+        args.topic = normalized_identifier("topic", &args.topic)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let route = session.topic_route(&args.topic).await?;
-                topic_route_output(cluster, &args.topic, route, &args.page)
-            })
-        })
-        .await
+        let key = self.cache_key(
+            "topic_route",
+            &cluster.name,
+            &format!("topic={}|{}", args.topic, page_key(&args.page)),
+        );
+        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let route = session.topic_route(&args.topic).await?;
+                            topic_route_output(cluster, &args.topic, route, &args.page)
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn list_consumer_groups(
         &self,
         args: ListConsumerGroupsArgs,
-    ) -> Result<ListConsumerGroupsOutput, ToolExecutionError> {
+    ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError> {
         let cluster = self.resolve_cluster(args.cluster.as_deref())?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let mut groups = session.consumer_groups().await?;
-                groups.sort_by(|left, right| left.group.cmp(&right.group));
-                if let Some(filter) = normalized_filter(args.filter.as_deref()) {
-                    groups.retain(|entry| entry.group.to_ascii_lowercase().contains(&filter));
-                }
-                let page = paginate(groups, &args.page)
-                    .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
-                Ok(ListConsumerGroupsOutput {
-                    cluster: cluster.name.clone(),
-                    namesrv_addr: cluster.namesrv_addr.clone(),
-                    page,
-                    generated_at: observed_at(),
-                })
-            })
-        })
-        .await
+        let key = self.cache_key(
+            "list_consumer_groups",
+            &cluster.name,
+            &list_key(args.filter.as_deref(), &args.page),
+        );
+        let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let mut groups = session.consumer_groups().await?;
+                            groups.sort_by(|left, right| left.group.cmp(&right.group));
+                            if let Some(filter) = normalized_filter(args.filter.as_deref()) {
+                                groups.retain(|entry| entry.group.to_ascii_lowercase().contains(&filter));
+                            }
+                            let page = paginate(groups, &args.page)
+                                .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
+                            Ok(ListConsumerGroupsOutput {
+                                cluster: cluster.name.clone(),
+                                namesrv_addr: cluster.namesrv_addr.clone(),
+                                page,
+                                generated_at: observed_at(),
+                            })
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn query_consumer_lag(
         &self,
-        args: QueryConsumerLagArgs,
-    ) -> Result<QueryConsumerLagOutput, ToolExecutionError> {
+        mut args: QueryConsumerLagArgs,
+    ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError> {
+        args.topic = normalized_identifier("topic", &args.topic)?;
+        args.consumer_group = normalized_identifier("consumer_group", &args.consumer_group)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let lag = session.consumer_lag(&args.topic, &args.consumer_group).await?;
-                consumer_lag_output(cluster, args.topic, args.consumer_group, &args.page, lag)
-            })
-        })
-        .await
+        let key = self.cache_key(
+            "consumer_lag",
+            &cluster.name,
+            &format!(
+                "topic={}|group={}|{}",
+                args.topic,
+                args.consumer_group,
+                page_key(&args.page)
+            ),
+        );
+        let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let lag = session.consumer_lag(&args.topic, &args.consumer_group).await?;
+                            consumer_lag_output(cluster, args.topic, args.consumer_group, &args.page, lag)
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn describe_broker(
         &self,
-        args: DescribeBrokerArgs,
-    ) -> Result<DescribeBrokerOutput, ToolExecutionError> {
+        mut args: DescribeBrokerArgs,
+    ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError> {
+        args.broker_name = normalized_identifier("broker_name", &args.broker_name)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(describe_broker_in_session(session, cluster, args.broker_name))
-        })
-        .await
+        let key = self.cache_key(
+            "describe_broker",
+            &cluster.name,
+            &format!("broker={}", args.broker_name),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(describe_broker_in_session(session, cluster, args.broker_name))
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     pub(crate) async fn diagnose_consumer_lag(
         &self,
-        args: DiagnoseConsumerLagArgs,
-    ) -> Result<DiagnosisReport, ToolExecutionError> {
+        mut args: DiagnoseConsumerLagArgs,
+    ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError> {
+        args.topic = normalized_identifier("topic", &args.topic)?;
+        args.consumer_group = normalized_identifier("consumer_group", &args.consumer_group)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        self.run_workflow(cluster, move |session, cluster| {
-            Box::pin(async move {
-                let lag_result = session
-                    .consumer_lag(&args.topic, &args.consumer_group)
-                    .await
-                    .and_then(|lag| {
-                        consumer_lag_output(
-                            cluster,
-                            args.topic.clone(),
-                            args.consumer_group.clone(),
-                            &PageRequest::default(),
-                            lag,
-                        )
-                    });
-                let (topic_result, route_result) = match session.topic_route(&args.topic).await {
-                    Ok(route) => {
-                        let route = topic_route_output(cluster, &args.topic, route, &PageRequest::default())?;
-                        (Ok(describe_topic_output(&route)), Ok(route))
-                    }
-                    Err(error) => {
-                        let message = error.to_string();
-                        (Err(ToolExecutionError::backend(&message)), Err(error))
-                    }
-                };
-                let broker_result = match top_lag_broker(lag_result.as_ref().ok()) {
-                    Some(broker_name) => Some(describe_broker_in_session(session, cluster, broker_name).await),
-                    None => None,
-                };
+        let key = self.cache_key(
+            "diagnose_consumer_lag",
+            &cluster.name,
+            &format!(
+                "topic={}|group={}|threshold={:?}|time_range={:?}",
+                args.topic, args.consumer_group, args.lag_threshold, args.time_range
+            ),
+        );
+        let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, cluster| {
+                        Box::pin(async move {
+                            let lag_result =
+                                session
+                                    .consumer_lag(&args.topic, &args.consumer_group)
+                                    .await
+                                    .and_then(|lag| {
+                                        consumer_lag_output(
+                                            cluster,
+                                            args.topic.clone(),
+                                            args.consumer_group.clone(),
+                                            &PageRequest::default(),
+                                            lag,
+                                        )
+                                    });
+                            let (topic_result, route_result) = match session.topic_route(&args.topic).await {
+                                Ok(route) => {
+                                    let route =
+                                        topic_route_output(cluster, &args.topic, route, &PageRequest::default())?;
+                                    (Ok(describe_topic_output(&route)), Ok(route))
+                                }
+                                Err(error) => {
+                                    let message = error.to_string();
+                                    (Err(ToolExecutionError::backend(&message)), Err(error))
+                                }
+                            };
+                            let broker_result = match top_lag_broker(lag_result.as_ref().ok()) {
+                                Some(broker_name) => {
+                                    Some(describe_broker_in_session(session, cluster, broker_name).await)
+                                }
+                                None => None,
+                            };
 
-                Ok(diagnosis_service::build_consumer_lag_report(
-                    args,
-                    lag_result,
-                    topic_result,
-                    route_result,
-                    broker_result,
-                ))
-            })
-        })
-        .await
+                            Ok(diagnosis_service::build_consumer_lag_report(
+                                args,
+                                lag_result,
+                                topic_result,
+                                route_result,
+                                broker_result,
+                            ))
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
     }
 
     async fn run_workflow<T, O>(&self, cluster: ResolvedCluster, operation: O) -> Result<T, ToolExecutionError>
@@ -355,6 +553,14 @@ where
             namesrv_addr: config.namesrv_addr.clone(),
         })
     }
+
+    fn cache_key(&self, kind: &str, cluster: &str, parameters: &str) -> String {
+        format!(
+            "{SCHEMA_VERSION}|{}|{kind}|cluster={}|{parameters}",
+            self.visibility_class,
+            cluster.trim()
+        )
+    }
 }
 
 impl QueryFacade<AdminCoreSessionFactory> {
@@ -368,44 +574,56 @@ impl<F> ReadOnlyQuery for QueryFacade<F>
 where
     F: AdminSessionFactory,
 {
-    async fn cluster_overview(&self, args: ClusterOverviewArgs) -> Result<ClusterOverviewOutput, ToolExecutionError> {
+    async fn cluster_overview(
+        &self,
+        args: ClusterOverviewArgs,
+    ) -> Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError> {
         QueryFacade::cluster_overview(self, args).await
     }
 
-    async fn list_topics(&self, args: ListTopicsArgs) -> Result<ListTopicsOutput, ToolExecutionError> {
+    async fn list_topics(&self, args: ListTopicsArgs) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError> {
         QueryFacade::list_topics(self, args).await
     }
 
-    async fn describe_topic(&self, args: DescribeTopicArgs) -> Result<DescribeTopicOutput, ToolExecutionError> {
+    async fn describe_topic(
+        &self,
+        args: DescribeTopicArgs,
+    ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError> {
         QueryFacade::describe_topic(self, args).await
     }
 
-    async fn query_topic_route(&self, args: QueryTopicRouteArgs) -> Result<QueryTopicRouteOutput, ToolExecutionError> {
+    async fn query_topic_route(
+        &self,
+        args: QueryTopicRouteArgs,
+    ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
         QueryFacade::query_topic_route(self, args).await
     }
 
     async fn list_consumer_groups(
         &self,
         args: ListConsumerGroupsArgs,
-    ) -> Result<ListConsumerGroupsOutput, ToolExecutionError> {
+    ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError> {
         QueryFacade::list_consumer_groups(self, args).await
     }
 
     async fn query_consumer_lag(
         &self,
         args: QueryConsumerLagArgs,
-    ) -> Result<QueryConsumerLagOutput, ToolExecutionError> {
+    ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError> {
         QueryFacade::query_consumer_lag(self, args).await
     }
 
-    async fn describe_broker(&self, args: DescribeBrokerArgs) -> Result<DescribeBrokerOutput, ToolExecutionError> {
+    async fn describe_broker(
+        &self,
+        args: DescribeBrokerArgs,
+    ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError> {
         QueryFacade::describe_broker(self, args).await
     }
 
     async fn diagnose_consumer_lag(
         &self,
         args: DiagnoseConsumerLagArgs,
-    ) -> Result<DiagnosisReport, ToolExecutionError> {
+    ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError> {
         QueryFacade::diagnose_consumer_lag(self, args).await
     }
 }
@@ -493,7 +711,7 @@ where
         .collect::<Vec<_>>();
     if brokers.is_empty() {
         session.probe_broker_runtime().await?;
-        return Err(ToolExecutionError::Backend(format!(
+        return Err(ToolExecutionError::InvalidArguments(format!(
             "broker not found in cluster {}: {broker_name}",
             cluster.name
         )));
@@ -524,6 +742,32 @@ fn normalized_filter(filter: Option<&str>) -> Option<String> {
         .map(str::to_ascii_lowercase)
 }
 
+fn normalized_identifier(field: &str, value: &str) -> Result<String, ToolExecutionError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ToolExecutionError::InvalidArguments(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+fn list_key(filter: Option<&str>, page: &PageRequest) -> String {
+    format!(
+        "filter={}|{}",
+        normalized_filter(filter).unwrap_or_default(),
+        page_key(page)
+    )
+}
+
+fn page_key(page: &PageRequest) -> String {
+    format!(
+        "limit={}|cursor={}",
+        page.limit.unwrap_or(DEFAULT_PAGE_LIMIT),
+        page.cursor.as_deref().unwrap_or_default()
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicUsize;
@@ -534,6 +778,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use crate::config::McpConfig;
+    use crate::model::contract::CacheStatus;
     use crate::resources;
     use crate::tools::cluster_tools::BrokerSummary;
     use crate::tools::cluster_tools::ClusterOverviewArgs;
@@ -563,6 +808,8 @@ mod tests {
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
         hang_broker_query: bool,
+        hang_topic_query: bool,
+        delay_topic_query: bool,
         fail_topic_query: bool,
     }
 
@@ -577,6 +824,8 @@ mod tests {
                 counters: self.counters.clone(),
                 selected_broker_missing: self.selected_broker_missing,
                 hang_broker_query: self.hang_broker_query,
+                hang_topic_query: self.hang_topic_query,
+                delay_topic_query: self.delay_topic_query,
                 fail_topic_query: self.fail_topic_query,
             })
         }
@@ -587,6 +836,8 @@ mod tests {
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
         hang_broker_query: bool,
+        hang_topic_query: bool,
+        delay_topic_query: bool,
         fail_topic_query: bool,
     }
 
@@ -607,6 +858,12 @@ mod tests {
 
         async fn topic_entries(&mut self) -> Result<Vec<TopicListEntry>, ToolExecutionError> {
             self.counters.topic_queries.fetch_add(1, Ordering::SeqCst);
+            if self.hang_topic_query {
+                std::future::pending::<()>().await;
+            }
+            if self.delay_topic_query {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
             if self.fail_topic_query {
                 return Err(ToolExecutionError::backend("topic query failed"));
             }
@@ -823,6 +1080,166 @@ mod tests {
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
         assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn query_facade_reuses_cached_results_across_tool_and_resource_queries() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let request = ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest::default(),
+        };
+
+        let tool_result = facade.list_topics(request).await.unwrap();
+        let resource_result = resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/topics")
+            .await
+            .unwrap();
+        let payload = match &resource_result.contents[0] {
+            rmcp::model::ResourceContents::TextResourceContents { text, .. } => {
+                serde_json::from_str::<serde_json::Value>(text).unwrap()
+            }
+            _ => panic!("resource should contain JSON text"),
+        };
+
+        assert_eq!(tool_result.cache_status, CacheStatus::Miss);
+        assert_eq!(payload["cache_status"], "hit");
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            facade.cache_metrics(),
+            CacheMetricsSnapshot {
+                hits: 1,
+                misses: 1,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn query_facade_singleflight_coalesces_concurrent_identical_misses() {
+        let factory = FakeSessionFactory {
+            delay_topic_query: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..8 {
+            let facade = facade.clone();
+            tasks.spawn(async move {
+                facade
+                    .list_topics(ListTopicsArgs {
+                        cluster: Some("local-dev".to_string()),
+                        filter: None,
+                        page: PageRequest::default(),
+                    })
+                    .await
+                    .unwrap()
+                    .cache_status
+            });
+        }
+
+        let mut statuses = Vec::new();
+        while let Some(status) = tasks.join_next().await {
+            statuses.push(status.unwrap());
+        }
+
+        assert_eq!(
+            statuses.iter().filter(|status| **status == CacheStatus::Miss).count(),
+            1
+        );
+        assert_eq!(statuses.iter().filter(|status| **status == CacheStatus::Hit).count(), 7);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 7);
+    }
+
+    #[tokio::test]
+    async fn query_facade_singleflight_waiter_observes_its_cancellation() {
+        let factory = FakeSessionFactory {
+            hang_topic_query: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let leader_cancellation = CancellationToken::new();
+        let control = WorkflowControl::new(Duration::from_secs(1), leader_cancellation.clone());
+        let facade = QueryFacade::with_factory_and_control(example_config(), factory, control);
+        let request = || ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest::default(),
+        };
+        let leader_facade = facade.clone();
+        let leader = tokio::spawn(async move { leader_facade.list_topics(request()).await });
+        while counters.topic_queries.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        let waiter_cancellation = CancellationToken::new();
+        let waiter_facade = facade.clone().with_cancellation(waiter_cancellation.clone());
+        let waiter = tokio::spawn(async move { waiter_facade.list_topics(request()).await });
+        tokio::task::yield_now().await;
+        waiter_cancellation.cancel();
+        let waiter_error = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("cancelled waiter must not wait for the leader")
+            .unwrap()
+            .unwrap_err();
+
+        assert!(matches!(waiter_error, ToolExecutionError::Cancelled));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        leader_cancellation.cancel();
+        assert!(matches!(leader.await.unwrap(), Err(ToolExecutionError::Cancelled)));
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn query_facade_cache_isolates_visibility_classes() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let reader = facade.clone().with_visibility_class("reader");
+        let topology_reader = facade.with_visibility_class("topology-reader");
+        let request = || ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest::default(),
+        };
+
+        let first = reader.list_topics(request()).await.unwrap();
+        let second = topology_reader.list_topics(request()).await.unwrap();
+
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Miss);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn query_facade_normalizes_identifiers_before_caching_and_querying() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let request = |topic: &str| QueryTopicRouteArgs {
+            cluster: "local-dev".to_string(),
+            topic: topic.to_string(),
+            page: PageRequest::default(),
+        };
+
+        let first = facade.query_topic_route(request(" orders ")).await.unwrap();
+        let second = facade.query_topic_route(request("orders")).await.unwrap();
+
+        assert_eq!(first.topic, "orders");
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 1);
     }
 
     fn example_config() -> McpConfig {

--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use crate::adapter::admin_session::AdminCoreSessionFactory;
+use crate::adapter::query_facade::QueryFacade;
 use crate::config::Args;
 use crate::config::McpConfig;
 use crate::config::TransportKind;
@@ -21,12 +25,14 @@ use crate::guard::Guard;
 pub struct McpApp {
     config: McpConfig,
     guard: Guard,
+    query: Arc<QueryFacade<AdminCoreSessionFactory>>,
 }
 
 impl McpApp {
     pub fn new(config: McpConfig) -> Self {
         let guard = Guard::new(config.security.clone(), config.audit.clone(), &config.clusters);
-        Self { config, guard }
+        let query = Arc::new(QueryFacade::new(config.clone()).with_visibility_class("local"));
+        Self { config, guard, query }
     }
 
     pub async fn bootstrap(args: Args) -> anyhow::Result<Self> {
@@ -41,6 +47,28 @@ impl McpApp {
 
     pub fn guard(&self) -> &Guard {
         &self.guard
+    }
+
+    pub(crate) fn query(&self) -> &Arc<QueryFacade<AdminCoreSessionFactory>> {
+        &self.query
+    }
+
+    pub(crate) fn trace_cache_metrics(&self) {
+        let metrics = self.query.cache_metrics();
+        tracing::trace!(
+            cache_hits = metrics.hits,
+            cache_misses = metrics.misses,
+            cache_bypasses = metrics.bypasses,
+            cache_evictions = metrics.evictions,
+            cache_invalidations = metrics.invalidations,
+            cache_coalesced_waiters = metrics.coalesced_waiters,
+            "rocketmq-mcp cache metrics"
+        );
+    }
+
+    /// Clears all cached RocketMQ query results and returns the number of removed entries.
+    pub async fn invalidate_cache(&self) -> usize {
+        self.query.invalidate_cache().await
     }
 
     pub fn transport(&self) -> TransportKind {

--- a/rocketmq-tools/rocketmq-mcp/src/config.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/config.rs
@@ -132,6 +132,12 @@ impl McpConfig {
             validate_non_empty("audit.path", &self.audit.path)?;
         }
 
+        if self.cache.enabled && self.cache.max_entries == 0 {
+            return Err(McpError::InvalidConfig(
+                "cache.max_entries must be greater than zero when cache is enabled".to_string(),
+            ));
+        }
+
         Ok(())
     }
 }
@@ -225,6 +231,8 @@ pub struct AuditConfig {
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct CacheConfig {
+    pub enabled: bool,
+    pub max_entries: usize,
     pub cluster_overview_ttl_ms: u64,
     pub topic_list_ttl_ms: u64,
     pub broker_metrics_ttl_ms: u64,
@@ -325,6 +333,8 @@ sink = "file"
 path = "./logs/rocketmq-mcp-audit.log"
 
 [cache]
+enabled = true
+max_entries = 256
 cluster_overview_ttl_ms = 3000
 topic_list_ttl_ms = 5000
 broker_metrics_ttl_ms = 2000
@@ -366,6 +376,16 @@ consumer_lag_ttl_ms = 1000
         let err = config.apply_overrides(&args).unwrap_err();
 
         assert!(err.to_string().contains("endpoint must start"));
+    }
+
+    #[test]
+    fn enabled_cache_requires_positive_capacity() {
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.cache.max_entries = 0;
+
+        let error = config.validate().unwrap_err();
+
+        assert!(error.to_string().contains("cache.max_entries"));
     }
 
     fn write_temp_config(contents: &str) -> std::path::PathBuf {

--- a/rocketmq-tools/rocketmq-mcp/src/infrastructure.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/infrastructure.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
-
-//! Model Context Protocol server for RocketMQ-Rust diagnostics.
-
-pub mod adapter;
-pub mod app;
-pub mod config;
-pub mod error;
-pub mod guard;
-pub(crate) mod infrastructure;
-pub mod model;
-pub mod prompts;
-pub mod protocol;
-pub mod resources;
-pub mod service;
-pub mod tools;
-pub mod transport;
+pub(crate) mod cache;

--- a/rocketmq-tools/rocketmq-mcp/src/infrastructure/cache.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/infrastructure/cache.rs
@@ -1,0 +1,445 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use crate::model::contract::observed_at;
+use crate::model::contract::CacheStatus;
+use crate::model::contract::QueryResult;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CacheMetricsSnapshot {
+    pub hits: u64,
+    pub misses: u64,
+    pub bypasses: u64,
+    pub evictions: u64,
+    pub invalidations: u64,
+    pub coalesced_waiters: u64,
+}
+
+#[derive(Debug, Default)]
+struct CacheMetrics {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    bypasses: AtomicU64,
+    evictions: AtomicU64,
+    invalidations: AtomicU64,
+    coalesced_waiters: AtomicU64,
+}
+
+#[derive(Clone)]
+pub(crate) struct QueryCache {
+    inner: Arc<QueryCacheInner>,
+}
+
+struct QueryCacheInner {
+    enabled: bool,
+    capacity: usize,
+    generation: AtomicU64,
+    state: Mutex<CacheState>,
+    flights: Mutex<HashMap<String, Weak<Mutex<()>>>>,
+    metrics: CacheMetrics,
+}
+
+#[derive(Default)]
+struct CacheState {
+    entries: HashMap<String, CacheEntry>,
+    insertion_order: VecDeque<String>,
+}
+
+struct CacheEntry {
+    value: Arc<dyn Any + Send + Sync>,
+    observed_at: String,
+    inserted_at: Instant,
+    expires_at: Instant,
+}
+
+impl QueryCache {
+    pub(crate) fn new(enabled: bool, capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(QueryCacheInner {
+                enabled,
+                capacity,
+                generation: AtomicU64::new(0),
+                state: Mutex::new(CacheState::default()),
+                flights: Mutex::new(HashMap::new()),
+                metrics: CacheMetrics::default(),
+            }),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn get_or_try_init<T, E, Load, LoadFuture>(
+        &self,
+        key: String,
+        ttl: Duration,
+        load: Load,
+    ) -> Result<QueryResult<T>, E>
+    where
+        T: Clone + Send + Sync + 'static,
+        Load: FnOnce() -> LoadFuture,
+        LoadFuture: Future<Output = Result<T, E>>,
+    {
+        let cancellation = CancellationToken::new();
+        self.get_or_try_init_cancellable(key, ttl, &cancellation, || unreachable!(), load)
+            .await
+    }
+
+    pub(crate) async fn get_or_try_init_cancellable<T, E, Load, LoadFuture, Cancelled>(
+        &self,
+        key: String,
+        ttl: Duration,
+        cancellation: &CancellationToken,
+        cancelled: Cancelled,
+        load: Load,
+    ) -> Result<QueryResult<T>, E>
+    where
+        T: Clone + Send + Sync + 'static,
+        Load: FnOnce() -> LoadFuture,
+        LoadFuture: Future<Output = Result<T, E>>,
+        Cancelled: FnOnce() -> E,
+    {
+        if !self.inner.enabled || self.inner.capacity == 0 || ttl.is_zero() {
+            self.inner.metrics.bypasses.fetch_add(1, Ordering::Relaxed);
+            return load().await.map(|data| QueryResult {
+                data,
+                observed_at: observed_at(),
+                freshness_ms: 0,
+                cache_status: CacheStatus::Bypass,
+            });
+        }
+
+        if let Some(result) = self.get(&key).await {
+            return Ok(result);
+        }
+
+        let (flight, coalesced) = self.flight_lock(&key).await;
+        if coalesced {
+            self.inner.metrics.coalesced_waiters.fetch_add(1, Ordering::Relaxed);
+        }
+        let _flight_guard = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(cancelled()),
+            guard = flight.lock() => guard,
+        };
+        if let Some(result) = self.get(&key).await {
+            return Ok(result);
+        }
+
+        let generation = self.inner.generation.load(Ordering::Acquire);
+        let data = load().await?;
+        let observed_at = observed_at();
+        self.insert_if_current(key, data.clone(), observed_at.clone(), ttl, generation)
+            .await;
+        self.inner.metrics.misses.fetch_add(1, Ordering::Relaxed);
+        Ok(QueryResult {
+            data,
+            observed_at,
+            freshness_ms: 0,
+            cache_status: CacheStatus::Miss,
+        })
+    }
+
+    pub(crate) fn metrics(&self) -> CacheMetricsSnapshot {
+        CacheMetricsSnapshot {
+            hits: self.inner.metrics.hits.load(Ordering::Relaxed),
+            misses: self.inner.metrics.misses.load(Ordering::Relaxed),
+            bypasses: self.inner.metrics.bypasses.load(Ordering::Relaxed),
+            evictions: self.inner.metrics.evictions.load(Ordering::Relaxed),
+            invalidations: self.inner.metrics.invalidations.load(Ordering::Relaxed),
+            coalesced_waiters: self.inner.metrics.coalesced_waiters.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(crate) async fn clear(&self) -> usize {
+        let mut state = self.inner.state.lock().await;
+        self.inner.generation.fetch_add(1, Ordering::AcqRel);
+        let removed = state.entries.len();
+        state.entries.clear();
+        state.insertion_order.clear();
+        self.inner.metrics.invalidations.fetch_add(1, Ordering::Relaxed);
+        removed
+    }
+
+    async fn get<T>(&self, key: &str) -> Option<QueryResult<T>>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let mut state = self.inner.state.lock().await;
+        let now = Instant::now();
+        let expired = state.entries.get(key).is_some_and(|entry| entry.expires_at <= now);
+        if expired {
+            remove_entry(&mut state, key);
+            return None;
+        }
+        let entry = state.entries.get(key)?;
+        let data = entry.value.downcast_ref::<T>()?.clone();
+        let freshness_ms = now
+            .saturating_duration_since(entry.inserted_at)
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let result = QueryResult {
+            data,
+            observed_at: entry.observed_at.clone(),
+            freshness_ms,
+            cache_status: CacheStatus::Hit,
+        };
+        self.inner.metrics.hits.fetch_add(1, Ordering::Relaxed);
+        Some(result)
+    }
+
+    async fn insert_if_current<T>(&self, key: String, value: T, observed_at: String, ttl: Duration, generation: u64)
+    where
+        T: Send + Sync + 'static,
+    {
+        let mut state = self.inner.state.lock().await;
+        if self.inner.generation.load(Ordering::Acquire) != generation {
+            return;
+        }
+        remove_entry(&mut state, &key);
+        while state.entries.len() >= self.inner.capacity {
+            let Some(oldest) = state.insertion_order.pop_front() else {
+                break;
+            };
+            if state.entries.remove(&oldest).is_some() {
+                self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let inserted_at = Instant::now();
+        state.insertion_order.push_back(key.clone());
+        state.entries.insert(
+            key,
+            CacheEntry {
+                value: Arc::new(value),
+                observed_at,
+                inserted_at,
+                expires_at: inserted_at + ttl,
+            },
+        );
+    }
+
+    async fn flight_lock(&self, key: &str) -> (Arc<Mutex<()>>, bool) {
+        let mut flights = self.inner.flights.lock().await;
+        flights.retain(|_, flight| flight.strong_count() > 0);
+        if let Some(flight) = flights.get(key).and_then(Weak::upgrade) {
+            return (flight, true);
+        }
+        let flight = Arc::new(Mutex::new(()));
+        flights.insert(key.to_string(), Arc::downgrade(&flight));
+        (flight, false)
+    }
+
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.inner.state.lock().await.entries.len()
+    }
+}
+
+fn remove_entry(state: &mut CacheState, key: &str) {
+    if state.entries.remove(key).is_some() {
+        state.insertion_order.retain(|candidate| candidate != key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::Notify;
+
+    use crate::model::contract::CacheStatus;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cache_returns_miss_then_hit_without_reloading() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let first = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+        let second = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(first.data, second.data);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_reloads_expired_entries() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let _ = load_string(&cache, "topic:orders", Duration::from_millis(5), calls.clone()).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let result = load_string(&cache, "topic:orders", Duration::from_millis(5), calls.clone()).await;
+
+        assert_eq!(result.cache_status, CacheStatus::Miss);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_evicts_oldest_entry_at_capacity() {
+        let cache = QueryCache::new(true, 2);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let _ = load_string(&cache, "a", Duration::from_secs(1), calls.clone()).await;
+        let _ = load_string(&cache, "b", Duration::from_secs(1), calls.clone()).await;
+        let _ = load_string(&cache, "c", Duration::from_secs(1), calls.clone()).await;
+        let result = load_string(&cache, "a", Duration::from_secs(1), calls.clone()).await;
+
+        assert_eq!(result.cache_status, CacheStatus::Miss);
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert_eq!(cache.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn cache_singleflight_coalesces_concurrent_misses() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let calls = calls.clone();
+            tasks.push(tokio::spawn(async move {
+                cache
+                    .get_or_try_init("shared".to_string(), Duration::from_secs(1), || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        Ok::<_, ()>("value".to_string())
+                    })
+                    .await
+                    .unwrap()
+            }));
+        }
+
+        let mut misses = 0;
+        let mut hits = 0;
+        for task in tasks {
+            match task.await.unwrap().cache_status {
+                CacheStatus::Miss => misses += 1,
+                CacheStatus::Hit => hits += 1,
+                CacheStatus::Bypass => panic!("enabled cache should not bypass"),
+            }
+        }
+        assert_eq!(misses, 1);
+        assert_eq!(hits, 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_cache_bypasses_without_changing_results() {
+        let cache = QueryCache::new(false, 0);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let first = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+        let second = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+
+        assert_eq!(first.cache_status, CacheStatus::Bypass);
+        assert_eq!(second.cache_status, CacheStatus::Bypass);
+        assert_eq!(first.data, "value-1");
+        assert_eq!(second.data, "value-2");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_loads_are_not_cached() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let failed_calls = calls.clone();
+
+        let first = cache
+            .get_or_try_init("topic:orders".to_string(), Duration::from_secs(1), || async move {
+                failed_calls.fetch_add(1, Ordering::SeqCst);
+                Err::<String, _>("backend unavailable")
+            })
+            .await;
+        let second = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+
+        assert_eq!(first, Err("backend unavailable"));
+        assert_eq!(second.cache_status, CacheStatus::Miss);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn explicit_invalidation_forces_reload() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let _ = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+        let removed = cache.clear().await;
+        let reloaded = load_string(&cache, "topic:orders", Duration::from_secs(1), calls.clone()).await;
+
+        assert_eq!(removed, 1);
+        assert_eq!(reloaded.cache_status, CacheStatus::Miss);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.metrics().invalidations, 1);
+    }
+
+    #[tokio::test]
+    async fn invalidation_during_load_prevents_stale_reinsert() {
+        let cache = QueryCache::new(true, 8);
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let task_cache = cache.clone();
+        let task_started = started.clone();
+        let task_release = release.clone();
+        let task = tokio::spawn(async move {
+            task_cache
+                .get_or_try_init("topic:orders".to_string(), Duration::from_secs(1), || async move {
+                    task_started.notify_one();
+                    task_release.notified().await;
+                    Ok::<_, ()>("stale".to_string())
+                })
+                .await
+                .unwrap()
+        });
+
+        started.notified().await;
+        assert_eq!(cache.clear().await, 0);
+        release.notify_one();
+        let result = task.await.unwrap();
+
+        assert_eq!(result.data, "stale");
+        assert_eq!(result.cache_status, CacheStatus::Miss);
+        assert_eq!(cache.len().await, 0);
+    }
+
+    async fn load_string(cache: &QueryCache, key: &str, ttl: Duration, calls: Arc<AtomicUsize>) -> QueryResult<String> {
+        cache
+            .get_or_try_init(key.to_string(), ttl, || async move {
+                let call = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                Ok::<_, ()>(format!("value-{call}"))
+            })
+            .await
+            .unwrap()
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/model/contract.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+
 use chrono::SecondsFormat;
 use chrono::Utc;
 use schemars::JsonSchema;
@@ -41,12 +43,40 @@ pub struct Page<T> {
     pub next_cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CacheStatus {
     Bypass,
     Hit,
     Miss,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct QueryResult<T> {
+    pub data: T,
+    pub observed_at: String,
+    pub freshness_ms: u64,
+    pub cache_status: CacheStatus,
+}
+
+impl<T> QueryResult<T> {
+    #[cfg(test)]
+    pub(crate) fn bypass(data: T) -> Self {
+        Self {
+            data,
+            observed_at: observed_at(),
+            freshness_ms: 0,
+            cache_status: CacheStatus::Bypass,
+        }
+    }
+}
+
+impl<T> Deref for QueryResult<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -74,6 +104,24 @@ impl<T> ToolResponse<T> {
             partial: false,
             warnings: Vec::new(),
             data,
+        }
+    }
+
+    pub(crate) fn from_query(
+        request_id: impl Into<String>,
+        cluster: impl Into<String>,
+        result: QueryResult<T>,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            request_id: request_id.into(),
+            cluster: cluster.into(),
+            observed_at: result.observed_at,
+            freshness_ms: result.freshness_ms,
+            cache_status: result.cache_status,
+            partial: false,
+            warnings: Vec::new(),
+            data: result.data,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -36,7 +36,6 @@ use rmcp::RoleServer;
 use rmcp::ServerHandler;
 use serde_json::json;
 
-use crate::adapter::query_facade::QueryFacade;
 use crate::app::McpApp;
 use crate::prompts;
 use crate::resources;
@@ -98,18 +97,18 @@ impl ServerHandler for RocketmqMcpServer {
 
     async fn list_resources(
         &self,
-        _request: Option<PaginatedRequestParams>,
+        request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        Ok(resources::registry::list_resources(self.app.config()))
+        resources::registry::list_resources(self.app.config(), request.as_ref())
     }
 
     async fn list_resource_templates(
         &self,
-        _request: Option<PaginatedRequestParams>,
+        request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, ErrorData> {
-        Ok(resources::registry::list_resource_templates())
+        resources::registry::list_resource_templates(request.as_ref())
     }
 
     async fn read_resource(
@@ -117,8 +116,10 @@ impl ServerHandler for RocketmqMcpServer {
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        let query = QueryFacade::new(self.app.config().clone()).with_cancellation(context.ct);
-        resources::reader::read_resource(&query, &request.uri).await
+        let query = self.app.query().as_ref().clone().with_cancellation(context.ct);
+        let result = resources::reader::read_resource(&query, &request.uri).await;
+        self.app.trace_cache_metrics();
+        result
     }
 
     async fn list_prompts(
@@ -150,10 +151,12 @@ impl ServerHandler for RocketmqMcpServer {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let query = QueryFacade::new(self.app.config().clone()).with_cancellation(context.ct.clone());
-        ToolExecutor::new(query, self.app.guard().clone())
+        let query = self.app.query().as_ref().clone().with_cancellation(context.ct.clone());
+        let result = ToolExecutor::new(query, self.app.guard().clone())
             .call_with_request_id(request, &request_id_string(&context.id))
-            .await
+            .await;
+        self.app.trace_cache_metrics();
+        result
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
@@ -203,14 +206,18 @@ mod tests {
             .into_iter()
             .map(|tool| serde_json::to_value(tool).expect("tool descriptor serializes"))
             .collect::<Vec<_>>();
-        let resources = resources::registry::list_resources(&McpConfig::load(example_config_path()).unwrap())
+        let resources = resources::registry::list_resources(&McpConfig::load(example_config_path()).unwrap(), None)
+            .unwrap()
             .resources
             .into_iter()
             .map(|resource| serde_json::to_value(resource).expect("resource descriptor serializes"))
             .collect::<Vec<_>>();
-        let resource_templates =
-            serde_json::to_value(resources::registry::list_resource_templates().resource_templates)
-                .expect("resource templates serialize");
+        let resource_templates = serde_json::to_value(
+            resources::registry::list_resource_templates(None)
+                .unwrap()
+                .resource_templates,
+        )
+        .expect("resource templates serialize");
         let prompts = prompts::registry::list_prompts()
             .unwrap()
             .prompts

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -54,7 +54,43 @@ expression: surface
       "title": "Broker Health Check"
     }
   ],
-  "resource_templates": [],
+  "resource_templates": [
+    {
+      "description": "Read-only details for one RocketMQ topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic",
+      "title": "RocketMQ topic",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}"
+    },
+    {
+      "description": "Read-only routing information for one RocketMQ topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_route",
+      "title": "RocketMQ topic route",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}/route"
+    },
+    {
+      "description": "Read-only details for one RocketMQ consumer group.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_group",
+      "title": "RocketMQ consumer group",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}"
+    },
+    {
+      "description": "Read-only lag details for one consumer group and topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_lag",
+      "title": "RocketMQ consumer lag",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}"
+    },
+    {
+      "description": "Read-only details for one RocketMQ broker.",
+      "mimeType": "application/json",
+      "name": "rocketmq_broker",
+      "title": "RocketMQ broker",
+      "uriTemplate": "rocketmq://clusters/{cluster}/brokers/{broker}"
+    }
+  ],
   "resources": [
     {
       "description": "Read-only overview for one configured RocketMQ cluster.",

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -54,7 +54,43 @@ expression: surface
       "title": "Broker Health Check"
     }
   ],
-  "resource_templates": [],
+  "resource_templates": [
+    {
+      "description": "Read-only details for one RocketMQ topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic",
+      "title": "RocketMQ topic",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}"
+    },
+    {
+      "description": "Read-only routing information for one RocketMQ topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_route",
+      "title": "RocketMQ topic route",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}/route"
+    },
+    {
+      "description": "Read-only details for one RocketMQ consumer group.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_group",
+      "title": "RocketMQ consumer group",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}"
+    },
+    {
+      "description": "Read-only lag details for one consumer group and topic.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_lag",
+      "title": "RocketMQ consumer lag",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}"
+    },
+    {
+      "description": "Read-only details for one RocketMQ broker.",
+      "mimeType": "application/json",
+      "name": "rocketmq_broker",
+      "title": "RocketMQ broker",
+      "uriTemplate": "rocketmq://clusters/{cluster}/brokers/{broker}"
+    }
+  ],
   "resources": [
     {
       "description": "Read-only overview for one configured RocketMQ cluster.",

--- a/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
@@ -24,10 +24,14 @@ use crate::model::contract::SCHEMA_VERSION;
 use crate::resources::uri::ResourceKind;
 use crate::resources::uri::RocketmqResourceUri;
 use crate::resources::uri::JSON_MIME_TYPE;
+use crate::tools::broker_tools::DescribeBrokerArgs;
 use crate::tools::cluster_tools::ClusterOverviewArgs;
 use crate::tools::consumer_tools::ListConsumerGroupsArgs;
+use crate::tools::consumer_tools::QueryConsumerLagArgs;
 use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools::DescribeTopicArgs;
 use crate::tools::topic_tools::ListTopicsArgs;
+use crate::tools::topic_tools::QueryTopicRouteArgs;
 
 pub(crate) async fn read_resource<Q>(query: &Q, uri: &str) -> Result<ReadResourceResult, ErrorData>
 where
@@ -50,7 +54,7 @@ async fn resource_payload<Q>(query: &Q, uri: &RocketmqResourceUri) -> Result<Val
 where
     Q: ReadOnlyQuery,
 {
-    match uri.kind {
+    match &uri.kind {
         ResourceKind::Overview => {
             let output = query
                 .cluster_overview(ClusterOverviewArgs {
@@ -60,8 +64,10 @@ where
             Ok(live_payload(
                 uri,
                 "overview",
-                output.generated_at.clone(),
-                json!(output),
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data),
             ))
         }
         ResourceKind::Topics => {
@@ -75,8 +81,44 @@ where
             Ok(live_payload(
                 uri,
                 "topics",
-                output.generated_at.clone(),
-                json!(output.page),
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data.page),
+            ))
+        }
+        ResourceKind::Topic(topic) => {
+            let output = query
+                .describe_topic(DescribeTopicArgs {
+                    cluster: uri.cluster.clone(),
+                    topic: topic.clone(),
+                    page: PageRequest::default(),
+                })
+                .await?;
+            Ok(live_payload(
+                uri,
+                "topic",
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data),
+            ))
+        }
+        ResourceKind::TopicRoute(topic) => {
+            let output = query
+                .query_topic_route(QueryTopicRouteArgs {
+                    cluster: uri.cluster.clone(),
+                    topic: topic.clone(),
+                    page: PageRequest::default(),
+                })
+                .await?;
+            Ok(live_payload(
+                uri,
+                "route",
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data),
             ))
         }
         ResourceKind::Brokers => {
@@ -88,8 +130,32 @@ where
             Ok(live_payload(
                 uri,
                 "brokers",
-                output.generated_at.clone(),
-                json!(output.brokers),
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data.brokers),
+            ))
+        }
+        ResourceKind::Broker(broker) => {
+            let output = query
+                .describe_broker(DescribeBrokerArgs {
+                    cluster: uri.cluster.clone(),
+                    broker_name: broker.clone(),
+                })
+                .await?;
+            if output.data.brokers.is_empty() {
+                return Err(ToolExecutionError::InvalidArguments(format!(
+                    "broker not found in cluster {}: {broker}",
+                    uri.cluster
+                )));
+            }
+            Ok(live_payload(
+                uri,
+                "broker",
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data),
             ))
         }
         ResourceKind::ConsumerGroups => {
@@ -103,19 +169,78 @@ where
             Ok(live_payload(
                 uri,
                 "consumer_groups",
-                output.generated_at.clone(),
-                json!(output.page),
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data.page),
+            ))
+        }
+        ResourceKind::ConsumerGroup(group) => {
+            let output = query
+                .list_consumer_groups(ListConsumerGroupsArgs {
+                    cluster: Some(uri.cluster.clone()),
+                    filter: Some(group.clone()),
+                    page: PageRequest::default(),
+                })
+                .await?;
+            let consumer_group = output
+                .data
+                .page
+                .items
+                .iter()
+                .find(|item| item.group == *group)
+                .cloned()
+                .ok_or_else(|| {
+                    ToolExecutionError::InvalidArguments(format!(
+                        "consumer group not found in cluster {}: {group}",
+                        uri.cluster
+                    ))
+                })?;
+            Ok(live_payload(
+                uri,
+                "consumer_group",
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(consumer_group),
+            ))
+        }
+        ResourceKind::ConsumerLag { group, topic } => {
+            let output = query
+                .query_consumer_lag(QueryConsumerLagArgs {
+                    cluster: uri.cluster.clone(),
+                    topic: topic.clone(),
+                    consumer_group: group.clone(),
+                    page: PageRequest::default(),
+                })
+                .await?;
+            Ok(live_payload(
+                uri,
+                "consumer_lag",
+                output.observed_at,
+                output.freshness_ms,
+                output.cache_status,
+                json!(output.data),
             ))
         }
     }
 }
 
-fn live_payload(uri: &RocketmqResourceUri, field: &str, observed_at: String, data: Value) -> Value {
+fn live_payload(
+    uri: &RocketmqResourceUri,
+    field: &str,
+    observed_at: String,
+    freshness_ms: u64,
+    cache_status: crate::model::contract::CacheStatus,
+    data: Value,
+) -> Value {
     let mut payload = serde_json::Map::from_iter([
         ("schema_version".to_string(), json!(SCHEMA_VERSION)),
         ("resource".to_string(), json!(uri.as_string())),
         ("cluster".to_string(), json!(uri.cluster)),
         ("observed_at".to_string(), json!(observed_at)),
+        ("freshness_ms".to_string(), json!(freshness_ms)),
+        ("cache_status".to_string(), json!(cache_status)),
         ("source".to_string(), json!("live")),
         ("partial".to_string(), json!(false)),
         ("warnings".to_string(), json!([])),
@@ -127,9 +252,35 @@ fn live_payload(uri: &RocketmqResourceUri, field: &str, observed_at: String, dat
 fn resource_error(uri: &str, error: ToolExecutionError) -> ErrorData {
     match error {
         ToolExecutionError::InvalidArguments(message) => ErrorData::resource_not_found(message, None),
-        _ => ErrorData::internal_error(
+        ToolExecutionError::TimedOut { timeout_ms } => ErrorData::internal_error(
+            format!("live RocketMQ resource query timed out: {uri}"),
+            Some(json!({
+                "code": "resource_query_timeout",
+                "retryable": true,
+                "timeout_ms": timeout_ms,
+            })),
+        ),
+        ToolExecutionError::Cancelled => ErrorData::internal_error(
+            format!("live RocketMQ resource query was cancelled: {uri}"),
+            Some(json!({ "code": "resource_query_cancelled", "retryable": true })),
+        ),
+        ToolExecutionError::PermissionDenied(_) => ErrorData::internal_error(
+            format!("permission denied for RocketMQ resource: {uri}"),
+            Some(json!({ "code": "resource_permission_denied", "retryable": false })),
+        ),
+        ToolExecutionError::RateLimited(_) => ErrorData::internal_error(
+            format!("rate limit exceeded for RocketMQ resource: {uri}"),
+            Some(json!({ "code": "resource_rate_limited", "retryable": true })),
+        ),
+        ToolExecutionError::Backend(_) => ErrorData::internal_error(
             format!("live RocketMQ resource query failed: {uri}"),
-            Some(json!({ "code": "resource_query_failed" })),
+            Some(json!({ "code": "resource_backend_unavailable", "retryable": true })),
+        ),
+        ToolExecutionError::ChangePlanningDisabled(_)
+        | ToolExecutionError::Internal(_)
+        | ToolExecutionError::OutputTooLarge { .. } => ErrorData::internal_error(
+            format!("live RocketMQ resource query failed: {uri}"),
+            Some(json!({ "code": "resource_query_failed", "retryable": false })),
         ),
     }
 }
@@ -137,9 +288,12 @@ fn resource_error(uri: &str, error: ToolExecutionError) -> ErrorData {
 #[cfg(test)]
 mod tests {
     use crate::model::contract::Page;
+    use crate::model::contract::QueryResult;
     use crate::model::diagnosis::DiagnosisReport;
     use crate::tools::broker_tools::DescribeBrokerArgs;
     use crate::tools::broker_tools::DescribeBrokerOutput;
+    use crate::tools::cluster_tools::BrokerSummary;
+    use crate::tools::consumer_tools::ConsumerGroupSummary;
     use crate::tools::consumer_tools::ListConsumerGroupsOutput;
     use crate::tools::consumer_tools::QueryConsumerLagArgs;
     use crate::tools::consumer_tools::QueryConsumerLagOutput;
@@ -158,71 +312,141 @@ mod tests {
         async fn cluster_overview(
             &self,
             args: ClusterOverviewArgs,
-        ) -> Result<crate::tools::cluster_tools::ClusterOverviewOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<crate::tools::cluster_tools::ClusterOverviewOutput>, ToolExecutionError> {
             if args.cluster != "local-dev" {
                 return Err(ToolExecutionError::InvalidArguments(format!(
                     "unknown cluster: {}",
                     args.cluster
                 )));
             }
-            Ok(crate::tools::cluster_tools::ClusterOverviewOutput {
+            Ok(QueryResult::bypass(
+                crate::tools::cluster_tools::ClusterOverviewOutput {
+                    cluster: args.cluster,
+                    namesrv_addr: "hidden".to_string(),
+                    brokers: Vec::new(),
+                    topic_count: 0,
+                    consumer_group_count: 0,
+                    generated_at: "2026-07-10T00:00:00.000Z".to_string(),
+                },
+            ))
+        }
+
+        async fn list_topics(
+            &self,
+            _args: ListTopicsArgs,
+        ) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError> {
+            unimplemented!("not needed by reader tests")
+        }
+
+        async fn describe_topic(
+            &self,
+            args: DescribeTopicArgs,
+        ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError> {
+            if args.topic != "orders" {
+                return Err(ToolExecutionError::InvalidArguments(format!(
+                    "topic not found: {}",
+                    args.topic
+                )));
+            }
+            Ok(QueryResult::bypass(DescribeTopicOutput {
                 cluster: args.cluster,
                 namesrv_addr: "hidden".to_string(),
+                topic: args.topic,
+                broker_names: vec!["broker-a".to_string()],
+                read_queue_count: 0,
+                write_queue_count: 0,
                 brokers: Vec::new(),
-                topic_count: 0,
-                consumer_group_count: 0,
+                page: empty_page(),
                 generated_at: "2026-07-10T00:00:00.000Z".to_string(),
-            })
-        }
-
-        async fn list_topics(&self, _args: ListTopicsArgs) -> Result<ListTopicsOutput, ToolExecutionError> {
-            unimplemented!("not needed by reader tests")
-        }
-
-        async fn describe_topic(&self, _args: DescribeTopicArgs) -> Result<DescribeTopicOutput, ToolExecutionError> {
-            unimplemented!("not needed by reader tests")
+            }))
         }
 
         async fn query_topic_route(
             &self,
-            _args: QueryTopicRouteArgs,
-        ) -> Result<QueryTopicRouteOutput, ToolExecutionError> {
-            unimplemented!("not needed by reader tests")
+            args: QueryTopicRouteArgs,
+        ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(QueryTopicRouteOutput {
+                cluster: args.cluster,
+                namesrv_addr: "hidden".to_string(),
+                topic: args.topic,
+                brokers: Vec::new(),
+                read_queue_count: 0,
+                write_queue_count: 0,
+                page: empty_page(),
+                generated_at: "2026-07-10T00:00:00.000Z".to_string(),
+            }))
         }
 
         async fn list_consumer_groups(
             &self,
             args: ListConsumerGroupsArgs,
-        ) -> Result<ListConsumerGroupsOutput, ToolExecutionError> {
-            Ok(ListConsumerGroupsOutput {
+        ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError> {
+            let items = (args.filter.as_deref().is_none() || args.filter.as_deref() == Some("order-service"))
+                .then(|| ConsumerGroupSummary {
+                    group: "order-service".to_string(),
+                    version: 1,
+                    client_count: 1,
+                    consume_type: "CONSUME_PASSIVELY".to_string(),
+                    message_model: "CLUSTERING".to_string(),
+                    consume_tps: 1.0,
+                    diff_total: 0,
+                })
+                .into_iter()
+                .collect::<Vec<_>>();
+            let count = items.len();
+            Ok(QueryResult::bypass(ListConsumerGroupsOutput {
                 cluster: args.cluster.unwrap_or_else(|| "local-dev".to_string()),
                 namesrv_addr: "hidden".to_string(),
                 page: Page {
-                    items: Vec::new(),
-                    count: 0,
-                    total_count: 0,
+                    items,
+                    count,
+                    total_count: count,
                     has_more: false,
                     next_cursor: None,
                 },
                 generated_at: "2026-07-10T00:00:00.000Z".to_string(),
-            })
+            }))
         }
 
         async fn query_consumer_lag(
             &self,
-            _args: QueryConsumerLagArgs,
-        ) -> Result<QueryConsumerLagOutput, ToolExecutionError> {
-            unimplemented!("not needed by reader tests")
+            args: QueryConsumerLagArgs,
+        ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(QueryConsumerLagOutput {
+                cluster: args.cluster,
+                namesrv_addr: "hidden".to_string(),
+                topic: args.topic,
+                consumer_group: args.consumer_group,
+                total_lag: 0,
+                max_queue_lag: 0,
+                consume_tps: 1.0,
+                inflight_total: 0,
+                page: empty_page(),
+                generated_at: "2026-07-10T00:00:00.000Z".to_string(),
+            }))
         }
 
-        async fn describe_broker(&self, _args: DescribeBrokerArgs) -> Result<DescribeBrokerOutput, ToolExecutionError> {
-            unimplemented!("not needed by reader tests")
+        async fn describe_broker(
+            &self,
+            args: DescribeBrokerArgs,
+        ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError> {
+            let brokers = (args.broker_name == "broker-a")
+                .then(|| broker_summary(&args.cluster, &args.broker_name))
+                .into_iter()
+                .collect();
+            Ok(QueryResult::bypass(DescribeBrokerOutput {
+                cluster: args.cluster,
+                namesrv_addr: "hidden".to_string(),
+                broker_name: args.broker_name,
+                brokers,
+                generated_at: "2026-07-10T00:00:00.000Z".to_string(),
+            }))
         }
 
         async fn diagnose_consumer_lag(
             &self,
             _args: DiagnoseConsumerLagArgs,
-        ) -> Result<DiagnosisReport, ToolExecutionError> {
+        ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError> {
             unimplemented!("not needed by reader tests")
         }
     }
@@ -252,7 +476,42 @@ mod tests {
         assert_eq!(payload["schema_version"], SCHEMA_VERSION);
         assert_eq!(payload["source"], "live");
         assert_eq!(payload["partial"], false);
-        assert_eq!(payload["consumer_groups"]["total_count"], 0);
+        assert_eq!(payload["consumer_groups"]["total_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn read_parameterized_resources_returns_live_data() {
+        let cases = [
+            ("rocketmq://clusters/local-dev/topics/orders", "topic"),
+            ("rocketmq://clusters/local-dev/topics/orders/route", "route"),
+            (
+                "rocketmq://clusters/local-dev/consumer-groups/order-service",
+                "consumer_group",
+            ),
+            (
+                "rocketmq://clusters/local-dev/consumer-groups/order-service/lag?topic=orders",
+                "consumer_lag",
+            ),
+            ("rocketmq://clusters/local-dev/brokers/broker-a", "broker"),
+        ];
+
+        for (uri, field) in cases {
+            let result = read_resource(&FakeQuery, uri).await.unwrap();
+            let payload = read_json_payload(&result);
+
+            assert_eq!(payload["resource"], uri);
+            assert_eq!(payload["source"], "live");
+            assert!(payload.get(field).is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn read_unknown_parameterized_resource_returns_not_found() {
+        let error = read_resource(&FakeQuery, "rocketmq://clusters/local-dev/brokers/missing")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, rmcp::model::ErrorCode::RESOURCE_NOT_FOUND);
     }
 
     #[tokio::test]
@@ -268,6 +527,27 @@ mod tests {
         assert_eq!(unknown_cluster.code, rmcp::model::ErrorCode::RESOURCE_NOT_FOUND);
     }
 
+    #[test]
+    fn resource_errors_distinguish_permission_timeout_and_backend_failure() {
+        let permission = resource_error(
+            "rocketmq://clusters/local-dev/topics",
+            ToolExecutionError::PermissionDenied("missing scope".to_string()),
+        );
+        let timeout = resource_error(
+            "rocketmq://clusters/local-dev/topics",
+            ToolExecutionError::TimedOut { timeout_ms: 5000 },
+        );
+        let backend = resource_error(
+            "rocketmq://clusters/local-dev/topics",
+            ToolExecutionError::backend("nameserver unavailable secret_key=hidden"),
+        );
+
+        assert_eq!(permission.data.unwrap()["code"], "resource_permission_denied");
+        assert_eq!(timeout.data.unwrap()["code"], "resource_query_timeout");
+        assert_eq!(backend.data.unwrap()["code"], "resource_backend_unavailable");
+        assert!(!backend.message.contains("secret_key"));
+    }
+
     fn read_json_payload(result: &ReadResourceResult) -> Value {
         assert_eq!(result.contents.len(), 1);
         match &result.contents[0] {
@@ -277,6 +557,33 @@ mod tests {
             }
             ResourceContents::BlobResourceContents { .. } => panic!("resource should be returned as text"),
             _ => panic!("unsupported resource content variant"),
+        }
+    }
+
+    fn empty_page<T>() -> Page<T> {
+        Page {
+            items: Vec::new(),
+            count: 0,
+            total_count: 0,
+            has_more: false,
+            next_cursor: None,
+        }
+    }
+
+    fn broker_summary(cluster: &str, broker_name: &str) -> BrokerSummary {
+        BrokerSummary {
+            cluster: cluster.to_string(),
+            broker_name: broker_name.to_string(),
+            broker_id: 0,
+            broker_addr: "hidden".to_string(),
+            version: "test".to_string(),
+            in_tps: "0".to_string(),
+            out_tps: "0".to_string(),
+            timer_progress: "0".to_string(),
+            page_cache_lock_time_millis: "0".to_string(),
+            hour: "0".to_string(),
+            space: "0".to_string(),
+            broker_active: true,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
@@ -14,29 +14,83 @@
 
 use rmcp::model::ListResourceTemplatesResult;
 use rmcp::model::ListResourcesResult;
+use rmcp::model::PaginatedRequestParams;
 use rmcp::model::Resource;
+use rmcp::model::ResourceTemplate;
+use rmcp::ErrorData;
 
 use crate::config::McpConfig;
+use crate::model::contract::paginate;
+use crate::model::contract::PageRequest;
 use crate::resources::uri::ResourceKind;
 use crate::resources::uri::RocketmqResourceUri;
 use crate::resources::uri::JSON_MIME_TYPE;
 
-pub fn list_resources(config: &McpConfig) -> ListResourcesResult {
+const DISCOVERY_PAGE_LIMIT: u32 = 50;
+
+pub fn list_resources(
+    config: &McpConfig,
+    request: Option<&PaginatedRequestParams>,
+) -> Result<ListResourcesResult, ErrorData> {
     let resources = config
         .clusters
         .iter()
         .flat_map(|cluster| {
-            ResourceKind::ALL
+            ResourceKind::ROOTS
                 .into_iter()
                 .map(|kind| RocketmqResourceUri::new(cluster.name.clone(), kind))
         })
         .map(resource_descriptor)
-        .collect();
-    ListResourcesResult::with_all_items(resources)
+        .collect::<Vec<_>>();
+    let page = discovery_page(resources, request)?;
+    Ok(ListResourcesResult {
+        meta: None,
+        next_cursor: page.next_cursor,
+        resources: page.items,
+    })
 }
 
-pub fn list_resource_templates() -> ListResourceTemplatesResult {
-    ListResourceTemplatesResult::default()
+pub fn list_resource_templates(
+    request: Option<&PaginatedRequestParams>,
+) -> Result<ListResourceTemplatesResult, ErrorData> {
+    let templates = vec![
+        resource_template(
+            "rocketmq://clusters/{cluster}/topics/{topic}",
+            "rocketmq_topic",
+            "RocketMQ topic",
+            "Read-only details for one RocketMQ topic.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/topics/{topic}/route",
+            "rocketmq_topic_route",
+            "RocketMQ topic route",
+            "Read-only routing information for one RocketMQ topic.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/consumer-groups/{group}",
+            "rocketmq_consumer_group",
+            "RocketMQ consumer group",
+            "Read-only details for one RocketMQ consumer group.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}",
+            "rocketmq_consumer_lag",
+            "RocketMQ consumer lag",
+            "Read-only lag details for one consumer group and topic.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/brokers/{broker}",
+            "rocketmq_broker",
+            "RocketMQ broker",
+            "Read-only details for one RocketMQ broker.",
+        ),
+    ];
+    let page = discovery_page(templates, request)?;
+    Ok(ListResourceTemplatesResult {
+        meta: None,
+        next_cursor: page.next_cursor,
+        resource_templates: page.items,
+    })
 }
 
 fn resource_descriptor(uri: RocketmqResourceUri) -> Resource {
@@ -46,6 +100,27 @@ fn resource_descriptor(uri: RocketmqResourceUri) -> Resource {
         .with_mime_type(JSON_MIME_TYPE)
 }
 
+fn resource_template(uri: &str, name: &str, title: &str, description: &str) -> ResourceTemplate {
+    ResourceTemplate::new(uri, name)
+        .with_title(title)
+        .with_description(description)
+        .with_mime_type(JSON_MIME_TYPE)
+}
+
+fn discovery_page<T>(
+    items: Vec<T>,
+    request: Option<&PaginatedRequestParams>,
+) -> Result<crate::model::contract::Page<T>, ErrorData> {
+    paginate(
+        items,
+        &PageRequest {
+            limit: Some(DISCOVERY_PAGE_LIMIT),
+            cursor: request.and_then(|request| request.cursor.clone()),
+        },
+    )
+    .map_err(|error| ErrorData::invalid_params(error.to_string(), None))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -53,7 +128,7 @@ mod tests {
     #[test]
     fn registry_lists_cluster_scoped_resources() {
         let config = McpConfig::load(example_config_path()).unwrap();
-        let result = list_resources(&config);
+        let result = list_resources(&config, None).unwrap();
         let uris = result
             .resources
             .iter()
@@ -70,6 +145,58 @@ mod tests {
             ]
         );
         assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn registry_lists_parameterized_resource_templates() {
+        let result = list_resource_templates(None).unwrap();
+        let templates = result
+            .resource_templates
+            .iter()
+            .map(|template| template.uri_template.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            templates,
+            [
+                "rocketmq://clusters/{cluster}/topics/{topic}",
+                "rocketmq://clusters/{cluster}/topics/{topic}/route",
+                "rocketmq://clusters/{cluster}/consumer-groups/{group}",
+                "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}",
+                "rocketmq://clusters/{cluster}/brokers/{broker}",
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_rejects_invalid_discovery_cursor() {
+        let config = McpConfig::load(example_config_path()).unwrap();
+        let request = PaginatedRequestParams::default().with_cursor(Some("legacy-cursor".to_string()));
+
+        assert!(list_resources(&config, Some(&request)).is_err());
+    }
+
+    #[test]
+    fn registry_cursor_resumes_resource_discovery() {
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        let cluster = config.clusters[0].clone();
+        config.clusters = (0..13)
+            .map(|index| {
+                let mut cluster = cluster.clone();
+                cluster.name = format!("cluster-{index}");
+                cluster
+            })
+            .collect();
+
+        let first = list_resources(&config, None).unwrap();
+        let request = PaginatedRequestParams::default().with_cursor(first.next_cursor.clone());
+        let second = list_resources(&config, Some(&request)).unwrap();
+
+        assert_eq!(first.resources.len(), 50);
+        assert!(first.next_cursor.is_some());
+        assert_eq!(second.resources.len(), 2);
+        assert!(second.next_cursor.is_none());
+        assert_ne!(first.resources[0].uri, second.resources[0].uri);
     }
 
     fn example_config_path() -> std::path::PathBuf {

--- a/rocketmq-tools/rocketmq-mcp/src/resources/uri.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/uri.rs
@@ -12,44 +12,85 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use percent_encoding::percent_decode_str;
+use percent_encoding::utf8_percent_encode;
+use percent_encoding::AsciiSet;
+use percent_encoding::CONTROLS;
+
 pub const JSON_MIME_TYPE: &str = "application/json";
 const URI_PREFIX: &str = "rocketmq://clusters/";
+const RESOURCE_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'&')
+    .add(b'/')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'`');
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceKind {
     Overview,
     Topics,
+    Topic(String),
+    TopicRoute(String),
     Brokers,
+    Broker(String),
     ConsumerGroups,
+    ConsumerGroup(String),
+    ConsumerLag { group: String, topic: String },
 }
 
 impl ResourceKind {
-    pub const ALL: [Self; 4] = [Self::Overview, Self::Topics, Self::Brokers, Self::ConsumerGroups];
+    pub const ROOTS: [Self; 4] = [Self::Overview, Self::Topics, Self::Brokers, Self::ConsumerGroups];
 
-    fn path(self) -> &'static str {
+    fn path(&self) -> String {
         match self {
-            Self::Overview => "overview",
-            Self::Topics => "topics",
-            Self::Brokers => "brokers",
-            Self::ConsumerGroups => "consumer-groups",
+            Self::Overview => "overview".to_string(),
+            Self::Topics => "topics".to_string(),
+            Self::Topic(topic) => format!("topics/{}", encode_segment(topic)),
+            Self::TopicRoute(topic) => format!("topics/{}/route", encode_segment(topic)),
+            Self::Brokers => "brokers".to_string(),
+            Self::Broker(broker) => format!("brokers/{}", encode_segment(broker)),
+            Self::ConsumerGroups => "consumer-groups".to_string(),
+            Self::ConsumerGroup(group) => format!("consumer-groups/{}", encode_segment(group)),
+            Self::ConsumerLag { group, topic } => format!(
+                "consumer-groups/{}/lag?topic={}",
+                encode_segment(group),
+                encode_segment(topic)
+            ),
         }
     }
 
-    pub fn title(self) -> &'static str {
+    pub fn title(&self) -> &'static str {
         match self {
             Self::Overview => "RocketMQ cluster overview",
             Self::Topics => "RocketMQ topics",
+            Self::Topic(_) => "RocketMQ topic",
+            Self::TopicRoute(_) => "RocketMQ topic route",
             Self::Brokers => "RocketMQ brokers",
+            Self::Broker(_) => "RocketMQ broker",
             Self::ConsumerGroups => "RocketMQ consumer groups",
+            Self::ConsumerGroup(_) => "RocketMQ consumer group",
+            Self::ConsumerLag { .. } => "RocketMQ consumer lag",
         }
     }
 
-    pub fn description(self) -> &'static str {
+    pub fn description(&self) -> &'static str {
         match self {
             Self::Overview => "Read-only overview for one configured RocketMQ cluster.",
             Self::Topics => "Read-only topic inventory for one configured RocketMQ cluster.",
+            Self::Topic(_) => "Read-only details for one RocketMQ topic.",
+            Self::TopicRoute(_) => "Read-only routing information for one RocketMQ topic.",
             Self::Brokers => "Read-only broker inventory for one configured RocketMQ cluster.",
+            Self::Broker(_) => "Read-only details for one RocketMQ broker.",
             Self::ConsumerGroups => "Read-only consumer group inventory for one configured RocketMQ cluster.",
+            Self::ConsumerGroup(_) => "Read-only details for one RocketMQ consumer group.",
+            Self::ConsumerLag { .. } => "Read-only lag details for one RocketMQ consumer group and topic.",
         }
     }
 }
@@ -70,27 +111,84 @@ impl RocketmqResourceUri {
 
     pub fn parse(uri: &str) -> Option<Self> {
         let remainder = uri.strip_prefix(URI_PREFIX)?;
-        let (cluster, path) = remainder.split_once('/')?;
-        if cluster.is_empty() || cluster.contains(['?', '#']) || path.contains(['?', '#', '/']) {
+        let (cluster, resource) = remainder.split_once('/')?;
+        if cluster.is_empty() || cluster.contains(['?', '#']) || resource.contains('#') {
             return None;
         }
-        let kind = match path {
-            "overview" => ResourceKind::Overview,
-            "topics" => ResourceKind::Topics,
-            "brokers" => ResourceKind::Brokers,
-            "consumer-groups" => ResourceKind::ConsumerGroups,
+        let cluster = decode_segment(cluster)?;
+        let (path, query) = match resource.split_once('?') {
+            Some((path, query)) if !query.is_empty() => (path, Some(query)),
+            Some(_) => return None,
+            None => (resource, None),
+        };
+        let segments = path.split('/').collect::<Vec<_>>();
+        if segments.iter().any(|segment| segment.is_empty()) {
+            return None;
+        }
+        let kind = match (segments.as_slice(), query) {
+            (["overview"], None) => ResourceKind::Overview,
+            (["topics"], None) => ResourceKind::Topics,
+            (["topics", topic], None) => ResourceKind::Topic(decode_segment(topic)?),
+            (["topics", topic, "route"], None) => ResourceKind::TopicRoute(decode_segment(topic)?),
+            (["brokers"], None) => ResourceKind::Brokers,
+            (["brokers", broker], None) => ResourceKind::Broker(decode_segment(broker)?),
+            (["consumer-groups"], None) => ResourceKind::ConsumerGroups,
+            (["consumer-groups", group], None) => ResourceKind::ConsumerGroup(decode_segment(group)?),
+            (["consumer-groups", group, "lag"], Some(query)) => {
+                let topic = query
+                    .strip_prefix("topic=")
+                    .filter(|topic| !topic.is_empty() && !topic.contains('&'))?;
+                ResourceKind::ConsumerLag {
+                    group: decode_segment(group)?,
+                    topic: decode_segment(topic)?,
+                }
+            }
             _ => return None,
         };
         Some(Self::new(cluster, kind))
     }
 
     pub fn as_string(&self) -> String {
-        format!("{URI_PREFIX}{}/{}", self.cluster, self.kind.path())
+        format!("{URI_PREFIX}{}/{}", encode_segment(&self.cluster), self.kind.path())
     }
 
     pub fn name(&self) -> String {
-        format!("{}_{}", self.cluster, self.kind.path().replace('-', "_"))
+        let path = self.kind.path().replace(['/', '-', '?', '=', '&'], "_");
+        format!("{}_{path}", self.cluster)
     }
+}
+
+fn encode_segment(segment: &str) -> String {
+    utf8_percent_encode(segment, RESOURCE_SEGMENT_ENCODE_SET).to_string()
+}
+
+fn decode_segment(segment: &str) -> Option<String> {
+    if segment.is_empty() || !has_valid_percent_encoding(segment) {
+        return None;
+    }
+    percent_decode_str(segment)
+        .decode_utf8()
+        .ok()
+        .map(|value| value.into_owned())
+}
+
+fn has_valid_percent_encoding(segment: &str) -> bool {
+    let bytes = segment.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return false;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -105,7 +203,49 @@ mod tests {
         assert_eq!(parsed.as_string(), "rocketmq://clusters/local-dev/overview");
 
         assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/unknown").is_none());
-        assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics/orders").is_none());
+        let topic = RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics/orders").unwrap();
+        assert_eq!(topic.kind, ResourceKind::Topic("orders".to_string()));
+
+        let route = RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics/orders/route").unwrap();
+        assert_eq!(route.kind, ResourceKind::TopicRoute("orders".to_string()));
+
+        let lag =
+            RocketmqResourceUri::parse("rocketmq://clusters/local-dev/consumer-groups/orders-service/lag?topic=orders")
+                .unwrap();
+        assert_eq!(
+            lag.kind,
+            ResourceKind::ConsumerLag {
+                group: "orders-service".to_string(),
+                topic: "orders".to_string(),
+            }
+        );
+
+        assert!(
+            RocketmqResourceUri::parse("rocketmq://clusters/local-dev/consumer-groups/orders-service/lag").is_none()
+        );
+        assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics/orders?legacy=true").is_none());
+        assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics/%invalid").is_none());
         assert!(RocketmqResourceUri::parse("file:///etc/passwd").is_none());
+    }
+
+    #[test]
+    fn resource_uri_percent_encoding_round_trips_rocketmq_names() {
+        let uri = RocketmqResourceUri::new(
+            "local/dev",
+            ResourceKind::ConsumerLag {
+                group: "%RETRY%order/service".to_string(),
+                topic: "orders?priority=high".to_string(),
+            },
+        );
+
+        let encoded = uri.as_string();
+        let decoded = RocketmqResourceUri::parse(&encoded).unwrap();
+
+        assert_eq!(
+            encoded,
+            "rocketmq://clusters/local%2Fdev/consumer-groups/%25RETRY%25order%2Fservice/lag?topic=orders%3Fpriority%\
+             3Dhigh"
+        );
+        assert_eq!(decoded, uri);
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
@@ -21,6 +21,8 @@ use crate::adapter::query_facade::ReadOnlyQuery;
 use crate::model::contract::observed_at;
 #[cfg(test)]
 use crate::model::contract::PageRequest;
+#[cfg(test)]
+use crate::model::contract::QueryResult;
 use crate::model::diagnosis::DiagnosisReport;
 use crate::model::diagnosis::Evidence;
 use crate::model::diagnosis::EvidenceStatus;
@@ -61,21 +63,24 @@ where
             consumer_group: args.consumer_group.clone(),
             page: PageRequest::default(),
         })
-        .await;
+        .await
+        .map(|result| result.data);
     let topic_result = adapter
         .describe_topic(DescribeTopicArgs {
             cluster: args.cluster.clone(),
             topic: args.topic.clone(),
             page: PageRequest::default(),
         })
-        .await;
+        .await
+        .map(|result| result.data);
     let route_result = adapter
         .query_topic_route(QueryTopicRouteArgs {
             cluster: args.cluster.clone(),
             topic: args.topic.clone(),
             page: PageRequest::default(),
         })
-        .await;
+        .await
+        .map(|result| result.data);
     let broker_result = match top_lag_broker(lag_result.as_ref().ok()) {
         Some(broker_name) => Some(
             adapter
@@ -83,7 +88,8 @@ where
                     cluster: args.cluster.clone(),
                     broker_name,
                 })
-                .await,
+                .await
+                .map(|result| result.data),
         ),
         None => None,
     };
@@ -451,16 +457,22 @@ mod tests {
         async fn cluster_overview(
             &self,
             _args: ClusterOverviewArgs,
-        ) -> Result<ClusterOverviewOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
-        async fn list_topics(&self, _args: ListTopicsArgs) -> Result<ListTopicsOutput, ToolExecutionError> {
+        async fn list_topics(
+            &self,
+            _args: ListTopicsArgs,
+        ) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
-        async fn describe_topic(&self, args: DescribeTopicArgs) -> Result<DescribeTopicOutput, ToolExecutionError> {
-            Ok(DescribeTopicOutput {
+        async fn describe_topic(
+            &self,
+            args: DescribeTopicArgs,
+        ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(DescribeTopicOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 topic: args.topic,
@@ -476,14 +488,14 @@ mod tests {
                     next_cursor: None,
                 },
                 generated_at: "1".to_string(),
-            })
+            }))
         }
 
         async fn query_topic_route(
             &self,
             args: QueryTopicRouteArgs,
-        ) -> Result<QueryTopicRouteOutput, ToolExecutionError> {
-            Ok(QueryTopicRouteOutput {
+        ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(QueryTopicRouteOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 topic: args.topic,
@@ -498,24 +510,24 @@ mod tests {
                     next_cursor: None,
                 },
                 generated_at: "1".to_string(),
-            })
+            }))
         }
 
         async fn list_consumer_groups(
             &self,
             _args: ListConsumerGroupsArgs,
-        ) -> Result<ListConsumerGroupsOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn query_consumer_lag(
             &self,
             args: QueryConsumerLagArgs,
-        ) -> Result<QueryConsumerLagOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError> {
             if self.missing_lag {
                 return Err(ToolExecutionError::backend("lag evidence unavailable"));
             }
-            Ok(QueryConsumerLagOutput {
+            Ok(QueryResult::bypass(QueryConsumerLagOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 topic: args.topic,
@@ -555,23 +567,26 @@ mod tests {
                     next_cursor: None,
                 },
                 generated_at: "1".to_string(),
-            })
+            }))
         }
 
-        async fn describe_broker(&self, args: DescribeBrokerArgs) -> Result<DescribeBrokerOutput, ToolExecutionError> {
-            Ok(DescribeBrokerOutput {
+        async fn describe_broker(
+            &self,
+            args: DescribeBrokerArgs,
+        ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(DescribeBrokerOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 broker_name: args.broker_name,
                 brokers: vec![broker_summary()],
                 generated_at: "1".to_string(),
-            })
+            }))
         }
 
         async fn diagnose_consumer_lag(
             &self,
             _args: DiagnoseConsumerLagArgs,
-        ) -> Result<DiagnosisReport, ToolExecutionError> {
+        ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError> {
             unimplemented!("the rule tests invoke the test-only composition helper")
         }
     }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -20,12 +20,17 @@ use rmcp::model::CallToolRequestParams;
 use rmcp::model::CallToolResult;
 use rmcp::model::ContentBlock;
 use rmcp::model::JsonObject;
+use rmcp::model::Resource;
 use rmcp::ErrorData;
 
 use crate::adapter::query_facade::ReadOnlyQuery;
 use crate::guard::Guard;
 use crate::guard::GuardError;
+use crate::model::contract::QueryResult;
 use crate::model::contract::ToolResponse;
+use crate::resources::uri::ResourceKind;
+use crate::resources::uri::RocketmqResourceUri;
+use crate::resources::uri::JSON_MIME_TYPE;
 use crate::tools::broker_tools;
 use crate::tools::catalog::ToolDescriptor;
 use crate::tools::catalog::ToolId;
@@ -184,7 +189,8 @@ where
                 self.adapter.cluster_overview(args).await.and_then(|output| {
                     let summary = summary_cluster_overview(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource = RocketmqResourceUri::new(cluster.clone(), ResourceKind::Overview);
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::ListTopics => {
@@ -195,7 +201,8 @@ where
                 self.adapter.list_topics(args).await.and_then(|output| {
                     let summary = summary_list_topics(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource = RocketmqResourceUri::new(cluster.clone(), ResourceKind::Topics);
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::DescribeTopic => {
@@ -206,7 +213,8 @@ where
                 self.adapter.describe_topic(args).await.and_then(|output| {
                     let summary = summary_describe_topic(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource = RocketmqResourceUri::new(cluster.clone(), ResourceKind::Topic(output.topic.clone()));
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::GetTopicRoute => {
@@ -217,7 +225,9 @@ where
                 self.adapter.query_topic_route(args).await.and_then(|output| {
                     let summary = summary_topic_route(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource =
+                        RocketmqResourceUri::new(cluster.clone(), ResourceKind::TopicRoute(output.topic.clone()));
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::ListConsumerGroups => {
@@ -228,7 +238,8 @@ where
                 self.adapter.list_consumer_groups(args).await.and_then(|output| {
                     let summary = summary_consumer_groups(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource = RocketmqResourceUri::new(cluster.clone(), ResourceKind::ConsumerGroups);
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::GetConsumerLag => {
@@ -239,7 +250,14 @@ where
                 self.adapter.query_consumer_lag(args).await.and_then(|output| {
                     let summary = summary_consumer_lag(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource = RocketmqResourceUri::new(
+                        cluster.clone(),
+                        ResourceKind::ConsumerLag {
+                            group: output.consumer_group.clone(),
+                            topic: output.topic.clone(),
+                        },
+                    );
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::DescribeBroker => {
@@ -250,7 +268,9 @@ where
                 self.adapter.describe_broker(args).await.and_then(|output| {
                     let summary = summary_describe_broker(&output);
                     let cluster = output.cluster.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    let resource =
+                        RocketmqResourceUri::new(cluster.clone(), ResourceKind::Broker(output.broker_name.clone()));
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             ToolId::DiagnoseConsumerLag => {
@@ -259,9 +279,16 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
+                let resource = RocketmqResourceUri::new(
+                    cluster.clone(),
+                    ResourceKind::ConsumerLag {
+                        group: args.consumer_group.clone(),
+                        topic: args.topic.clone(),
+                    },
+                );
                 self.adapter.diagnose_consumer_lag(args).await.and_then(|output| {
                     let summary = output.summary.clone();
-                    success_result(descriptor, request_id, cluster, summary, output)
+                    success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
             #[cfg(feature = "change-planning")]
@@ -273,7 +300,7 @@ where
                 let cluster = args.cluster.clone();
                 let output = change_tools::plan_create_topic(args);
                 let summary = summary_change_plan(&output);
-                success_result(descriptor, request_id, cluster, summary, output)
+                success_live_result(descriptor, request_id, cluster, summary, output)
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateTopicConfig => {
@@ -284,7 +311,7 @@ where
                 let cluster = args.cluster.clone();
                 let output = change_tools::plan_update_topic_config(args);
                 let summary = summary_change_plan(&output);
-                success_result(descriptor, request_id, cluster, summary, output)
+                success_live_result(descriptor, request_id, cluster, summary, output)
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateTopicPermissions => {
@@ -295,7 +322,7 @@ where
                 let cluster = args.cluster.clone();
                 let output = change_tools::plan_update_topic_perm(args);
                 let summary = summary_change_plan(&output);
-                success_result(descriptor, request_id, cluster, summary, output)
+                success_live_result(descriptor, request_id, cluster, summary, output)
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateBrokerConfig => {
@@ -306,7 +333,7 @@ where
                 let cluster = args.cluster.clone();
                 let output = change_tools::plan_update_broker_config(args);
                 let summary = summary_change_plan(&output);
-                success_result(descriptor, request_id, cluster, summary, output)
+                success_live_result(descriptor, request_id, cluster, summary, output)
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanResetConsumerOffset => {
@@ -317,7 +344,7 @@ where
                 let cluster = args.cluster.clone();
                 let output = change_tools::plan_reset_consumer_offset(args);
                 let summary = summary_change_plan(&output);
-                success_result(descriptor, request_id, cluster, summary, output)
+                success_live_result(descriptor, request_id, cluster, summary, output)
             }
         };
 
@@ -350,12 +377,44 @@ fn success_result<T>(
     request_id: &str,
     cluster: String,
     summary: String,
+    output: QueryResult<T>,
+    resource: RocketmqResourceUri,
+) -> Result<CallToolResult, ToolExecutionError>
+where
+    T: Serialize,
+{
+    let envelope = ToolResponse::from_query(request_id, cluster, output);
+    render_success(descriptor, summary, envelope, Some(resource))
+}
+
+#[cfg(feature = "change-planning")]
+fn success_live_result<T>(
+    descriptor: ToolDescriptor,
+    request_id: &str,
+    cluster: String,
+    summary: String,
     output: T,
 ) -> Result<CallToolResult, ToolExecutionError>
 where
     T: Serialize,
 {
-    let envelope = ToolResponse::live(request_id, cluster, output);
+    render_success(
+        descriptor,
+        summary,
+        ToolResponse::live(request_id, cluster, output),
+        None,
+    )
+}
+
+fn render_success<T>(
+    descriptor: ToolDescriptor,
+    summary: String,
+    envelope: ToolResponse<T>,
+    resource: Option<RocketmqResourceUri>,
+) -> Result<CallToolResult, ToolExecutionError>
+where
+    T: Serialize,
+{
     let structured = serde_json::to_value(envelope).map_err(ToolExecutionError::internal)?;
     let structured = output_policy::apply(structured)?;
     let definition = descriptor.id.definition();
@@ -365,9 +424,21 @@ where
         .ok_or_else(|| ToolExecutionError::Internal("Tool output schema is missing".to_string()))?;
     validate_schema(output_schema.as_ref(), &structured, "output").map_err(ToolExecutionError::internal)?;
     let json_text = serde_json::to_string(&structured).map_err(ToolExecutionError::internal)?;
-    let mut result = CallToolResult::success(vec![ContentBlock::text(summary), ContentBlock::text(json_text)]);
+    let mut content = vec![ContentBlock::text(summary), ContentBlock::text(json_text)];
+    if let Some(resource) = resource {
+        content.push(resource_link(resource));
+    }
+    let mut result = CallToolResult::success(content);
     result.structured_content = Some(structured);
     Ok(result)
+}
+
+fn resource_link(uri: RocketmqResourceUri) -> ContentBlock {
+    let resource = Resource::new(uri.as_string(), uri.name())
+        .with_title(uri.kind.title())
+        .with_description(uri.kind.description())
+        .with_mime_type(JSON_MIME_TYPE);
+    ContentBlock::resource_link(resource)
 }
 
 fn validate_schema(schema: &JsonObject, value: &Value, label: &str) -> Result<(), String> {
@@ -491,68 +562,68 @@ mod tests {
         async fn cluster_overview(
             &self,
             args: cluster_tools::ClusterOverviewArgs,
-        ) -> Result<cluster_tools::ClusterOverviewOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<cluster_tools::ClusterOverviewOutput>, ToolExecutionError> {
             if self.fail {
                 return Err(ToolExecutionError::backend(
                     "nameserver unavailable secret_key=super-secret",
                 ));
             }
-            Ok(cluster_tools::ClusterOverviewOutput {
+            Ok(QueryResult::bypass(cluster_tools::ClusterOverviewOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 brokers: vec![broker_summary()],
                 topic_count: 2,
                 consumer_group_count: 1,
                 generated_at: "1".to_string(),
-            })
+            }))
         }
 
         async fn list_topics(
             &self,
             _args: topic_tools::ListTopicsArgs,
-        ) -> Result<topic_tools::ListTopicsOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<topic_tools::ListTopicsOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn describe_topic(
             &self,
             _args: topic_tools::DescribeTopicArgs,
-        ) -> Result<topic_tools::DescribeTopicOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<topic_tools::DescribeTopicOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn query_topic_route(
             &self,
             _args: topic_tools::QueryTopicRouteArgs,
-        ) -> Result<topic_tools::QueryTopicRouteOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<topic_tools::QueryTopicRouteOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn list_consumer_groups(
             &self,
             _args: consumer_tools::ListConsumerGroupsArgs,
-        ) -> Result<consumer_tools::ListConsumerGroupsOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<consumer_tools::ListConsumerGroupsOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn query_consumer_lag(
             &self,
             _args: consumer_tools::QueryConsumerLagArgs,
-        ) -> Result<consumer_tools::QueryConsumerLagOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<consumer_tools::QueryConsumerLagOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn describe_broker(
             &self,
             _args: broker_tools::DescribeBrokerArgs,
-        ) -> Result<broker_tools::DescribeBrokerOutput, ToolExecutionError> {
+        ) -> Result<QueryResult<broker_tools::DescribeBrokerOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
 
         async fn diagnose_consumer_lag(
             &self,
             _args: diagnosis_tools::DiagnoseConsumerLagArgs,
-        ) -> Result<crate::model::diagnosis::DiagnosisReport, ToolExecutionError> {
+        ) -> Result<QueryResult<crate::model::diagnosis::DiagnosisReport>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
     }
@@ -583,6 +654,8 @@ mod tests {
         assert!(structured["data"].get("namesrv_addr").is_none());
         assert!(structured["data"]["brokers"][0].get("broker_addr").is_none());
         assert!(!result.content.is_empty());
+        let resource_link = result.content.iter().find_map(ContentBlock::as_resource_link).unwrap();
+        assert_eq!(resource_link.uri, "rocketmq://clusters/local-dev/overview");
         let records = guard.audit_log().records();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].tool, ToolId::GetClusterOverview.descriptor().name);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8165

### Brief Description

- Share one application-level QueryFacade across Tool and Resource requests.
- Add a bounded TTL cache with normalized, visibility-aware keys, singleflight, cancellation-aware waiters, explicit invalidation, metrics, and percent-encoded Resource identifiers.
- Publish live parameterized Resources and templates with cursor-paginated discovery, replayable Tool ResourceLinks, contract snapshots, and implementation evidence.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-mcp --all-features` (78 unit tests and 2 integration tests passed)
- `cargo clippy -p rocketmq-mcp --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-mcp --no-deps --all-features`
- `./scripts/runtime-audit.ps1 -SkipBaseline`
- `./scripts/check-agents-routing.ps1`
- `git diff --check`

The repository-wide error architecture guard remains blocked by pre-existing MCP anyhow entry points, an existing broker source-stringification finding, and missing repository governance documents. This PR adds no new guard findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded TTL caching for read-only queries, including cache hits, misses, bypass status, expiration, eviction, and concurrent request coalescing.
  * Added cache configuration, metrics, and application-level cache invalidation.
  * Added replayable resource links to read-only tool responses.
  * Expanded resource discovery with paginated resources and templates.
  * Added resource types for topics, routes, brokers, consumer groups, and consumer lag.

* **Bug Fixes**
  * Improved URI validation, percent-encoding, identifier normalization, and resource-specific error reporting.

* **Documentation**
  * Updated MCP architecture, contracts, baseline reports, README, and example configuration with caching and resource behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->