### PR TITLE
[ISSUE #8167]♻️Add evidence-based consumer lag diagnosis v2

### DIFF
--- a/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-baseline-report.md
@@ -242,3 +242,15 @@ cargo doc -p rocketmq-mcp --no-deps --all-features
 These tests use an injected session factory and do not claim live-cluster
 latency or throughput. Production cluster integration remains a P6 release
 gate.
+
+### P4 Evidence and Rules Replacement
+
+P4 separates consumer-lag evidence collection from deterministic rule
+evaluation. `EvidenceSnapshot` records a stable query hash, per-item status,
+freshness, payload or error code, and the observation time. The report carries
+the snapshot together with v2 rule/evidence versions, policy profile,
+confidence band, partial state, missing evidence, and evidence references.
+
+The consumer-lag threshold is now a server configuration value under
+`diagnosis`; `time_range` and caller-supplied thresholds were removed from the
+MCP Tool schema because the server has no historical metrics source.

--- a/rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md
@@ -161,6 +161,14 @@ Consumer-lag diagnosis results include independent provenance fields:
 }
 ```
 
+Consumer-lag diagnosis v2 returns a replayable `evidence_snapshot`, a
+server-owned `policy_profile`, `confidence_band`, `partial`,
+`missing_evidence`, and `evidence_refs`. Evidence status is one of `present`,
+`missing`, `unavailable`, `timeout`, `unauthorized`, or `invalid`. Root causes
+may reference only `present` evidence. The Tool schema accepts cluster, topic,
+and consumer group only; historical time-range analysis and caller-controlled
+lag thresholds are unavailable until a historical metrics source is introduced.
+
 ## Resource URIs
 
 Resources are always scoped to an explicit configured cluster:

--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -91,6 +91,8 @@ Important fields:
 - `cache.enabled`: enables or bypasses the shared query cache.
 - `cache.max_entries`: maximum number of in-memory entries; it must be greater than zero when caching is enabled.
 - `cache.*_ttl_ms`: per-query-family freshness windows for overview, topic, broker, and consumer-lag data.
+- `diagnosis.consumer_lag_policy_profile`: server-owned policy identifier reported with each diagnosis.
+- `diagnosis.consumer_lag_threshold`: server-owned threshold used by consumer-lag rules.
 
 Cache keys include the schema version, visibility class, query kind, resolved cluster, and normalized query parameters. Failures are not cached. Concurrent misses for the same key are coalesced, and `cache_status` reports `miss`, `hit`, or `bypass`. Embedders can call `McpApp::invalidate_cache()` to clear all entries explicitly. Cumulative hit, miss, bypass, eviction, invalidation, and coalesced-waiter counters are emitted at trace level after Tool and Resource requests.
 
@@ -214,6 +216,8 @@ For HTTP-capable clients, use the Streamable HTTP URL `http://127.0.0.1:8089/mcp
 - `rocketmq_get_consumer_lag`: get bounded consumer progress and lag rows.
 - `rocketmq_describe_broker`: describe broker state.
 - `rocketmq_diagnose_consumer_lag`: aggregate read-only evidence and return a diagnosis report.
+
+Consumer-lag diagnoses use versioned Evidence Snapshots and a server-side rule policy. The Tool accepts only cluster, topic, and consumer group; historical `time_range` and caller-controlled thresholds are intentionally unavailable until a historical metrics source exists.
 
 Feature-gated planning Tools, available only with `change-planning`, never mutate the cluster:
 

--- a/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
@@ -37,3 +37,7 @@ cluster_overview_ttl_ms = 3000
 topic_list_ttl_ms = 5000
 broker_metrics_ttl_ms = 2000
 consumer_lag_ttl_ms = 1000
+
+[diagnosis]
+consumer_lag_policy_profile = "production-default"
+consumer_lag_threshold = 1000

--- a/rocketmq-tools/rocketmq-mcp/prompts/diagnose_consumer_lag.md
+++ b/rocketmq-tools/rocketmq-mcp/prompts/diagnose_consumer_lag.md
@@ -12,9 +12,6 @@ arguments:
   - name: consumer_group
     required: true
     description: Consumer group name.
-  - name: time_range
-    required: false
-    description: Optional investigation time range.
 ---
 # Consumer Lag Diagnosis Task
 
@@ -28,10 +25,11 @@ You are the rocketmq-rust AI SRE. Diagnose consumer lag for topic `{{topic}}` in
 4. `rocketmq_get_topic_route`
 5. `rocketmq_describe_broker`
 
-## Optional Context
+## Evidence Constraints
 
-- Time range: `{{time_range}}`
 - Use `rocketmq://clusters/{{cluster}}/consumer-groups` and `rocketmq://clusters/{{cluster}}/topics` only as read-only context if useful.
+- Treat `partial=true` or `missing_evidence` as an incomplete diagnosis and do not infer a root cause from unavailable evidence.
+- The server does not provide historical metrics; do not describe this diagnosis as a time-range analysis.
 
 ## Forbidden Actions
 
@@ -51,3 +49,4 @@ You are the rocketmq-rust AI SRE. Diagnose consumer lag for topic `{{topic}}` in
 ## 5. Recommendations
 ## 6. Risks
 ## 7. Follow-up Metrics
+## 8. Missing Evidence and Verification Steps

--- a/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
@@ -35,7 +35,8 @@ use crate::model::contract::QueryResult;
 use crate::model::contract::DEFAULT_PAGE_LIMIT;
 use crate::model::contract::SCHEMA_VERSION;
 use crate::model::diagnosis::DiagnosisReport;
-use crate::service::diagnosis_service;
+use crate::service::diagnosis_collector::ConsumerLagEvidence;
+use crate::service::diagnosis_rules;
 use crate::tools::broker_tools::DescribeBrokerArgs;
 use crate::tools::broker_tools::DescribeBrokerOutput;
 use crate::tools::cluster_tools::ClusterOverviewArgs;
@@ -329,7 +330,7 @@ where
                 ttl,
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
-                || async {
+                move || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let mut groups = session.consumer_groups().await?;
@@ -377,7 +378,7 @@ where
                 ttl,
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
-                || async {
+                move || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let lag = session.consumer_lag(&args.topic, &args.consumer_group).await?;
@@ -428,19 +429,17 @@ where
         let key = self.cache_key(
             "diagnose_consumer_lag",
             &cluster.name,
-            &format!(
-                "topic={}|group={}|threshold={:?}|time_range={:?}",
-                args.topic, args.consumer_group, args.lag_threshold, args.time_range
-            ),
+            &format!("topic={}|group={}", args.topic, args.consumer_group),
         );
         let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
+        let policy = diagnosis_rules::ConsumerLagPolicy::from(&self.config.diagnosis);
         self.cache
             .get_or_try_init_cancellable(
                 key,
                 ttl,
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
-                || async {
+                move || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let lag_result =
@@ -474,12 +473,15 @@ where
                                 None => None,
                             };
 
-                            Ok(diagnosis_service::build_consumer_lag_report(
-                                args,
-                                lag_result,
-                                topic_result,
-                                route_result,
-                                broker_result,
+                            Ok(diagnosis_rules::evaluate(
+                                &args,
+                                ConsumerLagEvidence {
+                                    lag: lag_result,
+                                    topic: topic_result,
+                                    route: route_result,
+                                    broker: broker_result,
+                                },
+                                &policy,
                             ))
                         })
                     })
@@ -941,14 +943,15 @@ mod tests {
                 cluster: "local-dev".to_string(),
                 topic: "orders".to_string(),
                 consumer_group: "order-service".to_string(),
-                time_range: None,
-                lag_threshold: Some(1_000),
             })
             .await
             .unwrap();
 
-        assert_eq!(report.evidence_version, "rocketmq-mcp.evidence.consumer-lag.v1");
-        assert_eq!(report.rules_version, "rocketmq-mcp.rules.consumer-lag.v1");
+        assert_eq!(report.evidence_version, "rocketmq-mcp.evidence.consumer-lag.v2");
+        assert_eq!(report.rules_version, "rocketmq-mcp.rules.consumer-lag.v2");
+        assert_eq!(report.policy_profile, "production-default");
+        assert!(!report.partial);
+        assert!(report.evidence_snapshot.is_some());
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
         assert_eq!(counters.consumer_lag_queries.load(Ordering::SeqCst), 1);
@@ -972,7 +975,7 @@ mod tests {
             .evidences
             .iter()
             .any(|evidence| evidence.id == "broker_description"
-                && evidence.status == crate::model::diagnosis::EvidenceStatus::Error));
+                && evidence.status == crate::model::diagnosis::EvidenceStatus::Unavailable));
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
         assert_eq!(counters.route_queries.load(Ordering::SeqCst), 1);
@@ -1256,8 +1259,6 @@ mod tests {
             cluster: "local-dev".to_string(),
             topic: "orders".to_string(),
             consumer_group: "order-service".to_string(),
-            time_range: None,
-            lag_threshold: Some(1_000),
         }
     }
 

--- a/rocketmq-tools/rocketmq-mcp/src/config.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/config.rs
@@ -43,6 +43,8 @@ pub struct McpConfig {
     pub security: SecurityConfig,
     pub audit: AuditConfig,
     pub cache: CacheConfig,
+    #[serde(default)]
+    pub diagnosis: DiagnosisConfig,
 }
 
 impl McpConfig {
@@ -135,6 +137,15 @@ impl McpConfig {
         if self.cache.enabled && self.cache.max_entries == 0 {
             return Err(McpError::InvalidConfig(
                 "cache.max_entries must be greater than zero when cache is enabled".to_string(),
+            ));
+        }
+        validate_non_empty(
+            "diagnosis.consumer_lag_policy_profile",
+            &self.diagnosis.consumer_lag_policy_profile,
+        )?;
+        if self.diagnosis.consumer_lag_threshold < 0 {
+            return Err(McpError::InvalidConfig(
+                "diagnosis.consumer_lag_threshold must not be negative".to_string(),
             ));
         }
 
@@ -239,6 +250,21 @@ pub struct CacheConfig {
     pub consumer_lag_ttl_ms: u64,
 }
 
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct DiagnosisConfig {
+    pub consumer_lag_policy_profile: String,
+    pub consumer_lag_threshold: i64,
+}
+
+impl Default for DiagnosisConfig {
+    fn default() -> Self {
+        Self {
+            consumer_lag_policy_profile: "production-default".to_string(),
+            consumer_lag_threshold: 1_000,
+        }
+    }
+}
+
 fn validate_non_empty(field: &str, value: &str) -> Result<(), McpError> {
     if value.trim().is_empty() {
         return Err(McpError::InvalidConfig(format!("{field} must not be empty")));
@@ -297,6 +323,8 @@ mod tests {
         assert_eq!(config.server.transport, TransportKind::Stdio);
         assert_eq!(config.clusters.len(), 1);
         assert_eq!(config.clusters[0].namesrv_addr, "127.0.0.1:9876");
+        assert_eq!(config.diagnosis.consumer_lag_policy_profile, "production-default");
+        assert_eq!(config.diagnosis.consumer_lag_threshold, 1_000);
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-mcp/src/model/diagnosis.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/model/diagnosis.rs
@@ -18,6 +18,15 @@ use serde::Serialize;
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    ConsumerLag,
+    TopicRoute,
+    BrokerSummary,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum Severity {
     Healthy,
     Low,
@@ -28,10 +37,46 @@ pub enum Severity {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum EvidenceStatus {
     Present,
     Missing,
-    Error,
+    Unavailable,
+    Timeout,
+    Unauthorized,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum EvidencePayload {
+    ConsumerLag(Value),
+    TopicRoute(Value),
+    BrokerSummary(Value),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct EvidenceItem {
+    pub id: String,
+    pub kind: EvidenceKind,
+    pub source_tool: String,
+    pub observed_at: String,
+    pub freshness_ms: u64,
+    pub status: EvidenceStatus,
+    pub query_hash: String,
+    pub payload: Option<EvidencePayload>,
+    pub error_code: Option<String>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct EvidenceSnapshot {
+    pub evidence_version: String,
+    pub query_hash: String,
+    pub cluster: String,
+    pub target: Value,
+    pub observed_at: String,
+    pub items: Vec<EvidenceItem>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -43,6 +88,12 @@ pub struct DiagnosisReport {
     pub target: Value,
     pub severity: Severity,
     pub confidence: f32,
+    pub confidence_band: ConfidenceBand,
+    pub policy_profile: String,
+    pub partial: bool,
+    pub missing_evidence: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub evidence_snapshot: Option<EvidenceSnapshot>,
     pub summary: String,
     pub impacts: Vec<ImpactItem>,
     pub evidences: Vec<Evidence>,
@@ -51,6 +102,14 @@ pub struct DiagnosisReport {
     pub risks: Vec<String>,
     pub follow_up_metrics: Vec<MetricWatchItem>,
     pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfidenceBand {
+    Low,
+    Medium,
+    High,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -83,6 +142,7 @@ pub struct Recommendation {
     pub priority: String,
     pub rationale: String,
     pub risk: String,
+    pub verification: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -1,5 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+assertion_line: 236
 expression: surface
 ---
 {
@@ -20,11 +21,6 @@ expression: surface
           "description": "Consumer group name.",
           "name": "consumer_group",
           "required": true
-        },
-        {
-          "description": "Optional investigation time range.",
-          "name": "time_range",
-          "required": false
         }
       ],
       "description": "Diagnose consumer lag for a RocketMQ topic and consumer group.",
@@ -1569,21 +1565,6 @@ expression: surface
           "consumer_group": {
             "type": "string"
           },
-          "lag_threshold": {
-            "default": null,
-            "format": "int64",
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "time_range": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "topic": {
             "type": "string"
           }
@@ -1606,6 +1587,14 @@ expression: surface
             ],
             "type": "string"
           },
+          "ConfidenceBand": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          },
           "DiagnosisReport": {
             "properties": {
               "cluster": {
@@ -1614,6 +1603,25 @@ expression: surface
               "confidence": {
                 "format": "float",
                 "type": "number"
+              },
+              "confidence_band": {
+                "$ref": "#/$defs/ConfidenceBand"
+              },
+              "evidence_refs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "evidence_snapshot": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/EvidenceSnapshot"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "evidence_version": {
                 "type": "string"
@@ -1638,6 +1646,18 @@ expression: surface
                   "$ref": "#/$defs/ImpactItem"
                 },
                 "type": "array"
+              },
+              "missing_evidence": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "partial": {
+                "type": "boolean"
+              },
+              "policy_profile": {
+                "type": "string"
               },
               "recommendations": {
                 "items": {
@@ -1679,6 +1699,11 @@ expression: surface
               "target",
               "severity",
               "confidence",
+              "confidence_band",
+              "policy_profile",
+              "partial",
+              "missing_evidence",
+              "evidence_refs",
               "summary",
               "impacts",
               "evidences",
@@ -1715,11 +1740,157 @@ expression: surface
             ],
             "type": "object"
           },
+          "EvidenceItem": {
+            "properties": {
+              "error_code": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "freshness_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "$ref": "#/$defs/EvidenceKind"
+              },
+              "observed_at": {
+                "type": "string"
+              },
+              "payload": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/EvidencePayload"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "query_hash": {
+                "type": "string"
+              },
+              "source_tool": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/$defs/EvidenceStatus"
+              },
+              "summary": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "source_tool",
+              "observed_at",
+              "freshness_ms",
+              "status",
+              "query_hash",
+              "summary"
+            ],
+            "type": "object"
+          },
+          "EvidenceKind": {
+            "enum": [
+              "consumer_lag",
+              "topic_route",
+              "broker_summary"
+            ],
+            "type": "string"
+          },
+          "EvidencePayload": {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "consumer_lag",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "topic_route",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "broker_summary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "EvidenceSnapshot": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "evidence_version": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/EvidenceItem"
+                },
+                "type": "array"
+              },
+              "observed_at": {
+                "type": "string"
+              },
+              "query_hash": {
+                "type": "string"
+              },
+              "target": true
+            },
+            "required": [
+              "evidence_version",
+              "query_hash",
+              "cluster",
+              "target",
+              "observed_at",
+              "items"
+            ],
+            "type": "object"
+          },
           "EvidenceStatus": {
             "enum": [
               "Present",
               "Missing",
-              "Error"
+              "Unavailable",
+              "Timeout",
+              "Unauthorized",
+              "Invalid"
             ],
             "type": "string"
           },
@@ -1774,13 +1945,17 @@ expression: surface
               },
               "risk": {
                 "type": "string"
+              },
+              "verification": {
+                "type": "string"
               }
             },
             "required": [
               "action",
               "priority",
               "rationale",
-              "risk"
+              "risk",
+              "verification"
             ],
             "type": "object"
           },

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -1,5 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+assertion_line: 239
 expression: surface
 ---
 {
@@ -20,11 +21,6 @@ expression: surface
           "description": "Consumer group name.",
           "name": "consumer_group",
           "required": true
-        },
-        {
-          "description": "Optional investigation time range.",
-          "name": "time_range",
-          "required": false
         }
       ],
       "description": "Diagnose consumer lag for a RocketMQ topic and consumer group.",
@@ -1569,21 +1565,6 @@ expression: surface
           "consumer_group": {
             "type": "string"
           },
-          "lag_threshold": {
-            "default": null,
-            "format": "int64",
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "time_range": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "topic": {
             "type": "string"
           }
@@ -1606,6 +1587,14 @@ expression: surface
             ],
             "type": "string"
           },
+          "ConfidenceBand": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          },
           "DiagnosisReport": {
             "properties": {
               "cluster": {
@@ -1614,6 +1603,25 @@ expression: surface
               "confidence": {
                 "format": "float",
                 "type": "number"
+              },
+              "confidence_band": {
+                "$ref": "#/$defs/ConfidenceBand"
+              },
+              "evidence_refs": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "evidence_snapshot": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/EvidenceSnapshot"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "evidence_version": {
                 "type": "string"
@@ -1638,6 +1646,18 @@ expression: surface
                   "$ref": "#/$defs/ImpactItem"
                 },
                 "type": "array"
+              },
+              "missing_evidence": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "partial": {
+                "type": "boolean"
+              },
+              "policy_profile": {
+                "type": "string"
               },
               "recommendations": {
                 "items": {
@@ -1679,6 +1699,11 @@ expression: surface
               "target",
               "severity",
               "confidence",
+              "confidence_band",
+              "policy_profile",
+              "partial",
+              "missing_evidence",
+              "evidence_refs",
               "summary",
               "impacts",
               "evidences",
@@ -1715,11 +1740,157 @@ expression: surface
             ],
             "type": "object"
           },
+          "EvidenceItem": {
+            "properties": {
+              "error_code": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "freshness_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "$ref": "#/$defs/EvidenceKind"
+              },
+              "observed_at": {
+                "type": "string"
+              },
+              "payload": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/EvidencePayload"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "query_hash": {
+                "type": "string"
+              },
+              "source_tool": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/$defs/EvidenceStatus"
+              },
+              "summary": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "source_tool",
+              "observed_at",
+              "freshness_ms",
+              "status",
+              "query_hash",
+              "summary"
+            ],
+            "type": "object"
+          },
+          "EvidenceKind": {
+            "enum": [
+              "consumer_lag",
+              "topic_route",
+              "broker_summary"
+            ],
+            "type": "string"
+          },
+          "EvidencePayload": {
+            "oneOf": [
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "consumer_lag",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "topic_route",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "data": true,
+                  "kind": {
+                    "const": "broker_summary",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "data"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "EvidenceSnapshot": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "evidence_version": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/EvidenceItem"
+                },
+                "type": "array"
+              },
+              "observed_at": {
+                "type": "string"
+              },
+              "query_hash": {
+                "type": "string"
+              },
+              "target": true
+            },
+            "required": [
+              "evidence_version",
+              "query_hash",
+              "cluster",
+              "target",
+              "observed_at",
+              "items"
+            ],
+            "type": "object"
+          },
           "EvidenceStatus": {
             "enum": [
-              "Present",
-              "Missing",
-              "Error"
+              "present",
+              "missing",
+              "unavailable",
+              "timeout",
+              "unauthorized",
+              "invalid"
             ],
             "type": "string"
           },
@@ -1774,13 +1945,17 @@ expression: surface
               },
               "risk": {
                 "type": "string"
+              },
+              "verification": {
+                "type": "string"
               }
             },
             "required": [
               "action",
               "priority",
               "rationale",
-              "risk"
+              "risk",
+              "verification"
             ],
             "type": "object"
           },
@@ -1813,12 +1988,12 @@ expression: surface
           },
           "Severity": {
             "enum": [
-              "Healthy",
-              "Low",
-              "Medium",
-              "High",
-              "Critical",
-              "Unknown"
+              "healthy",
+              "low",
+              "medium",
+              "high",
+              "critical",
+              "unknown"
             ],
             "type": "string"
           }

--- a/rocketmq-tools/rocketmq-mcp/src/service.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service.rs
@@ -14,4 +14,6 @@
 
 //! Higher-level MCP services built from read-only evidence tools.
 
+pub mod diagnosis_collector;
+pub mod diagnosis_rules;
 pub mod diagnosis_service;

--- a/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_collector.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_collector.rs
@@ -1,0 +1,201 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Serialize;
+use serde_json::json;
+use serde_json::Value;
+use sha2::Digest;
+use sha2::Sha256;
+
+use crate::model::contract::observed_at;
+use crate::model::diagnosis::EvidenceItem;
+use crate::model::diagnosis::EvidenceKind;
+use crate::model::diagnosis::EvidencePayload;
+use crate::model::diagnosis::EvidenceSnapshot;
+use crate::model::diagnosis::EvidenceStatus;
+use crate::tools::broker_tools::DescribeBrokerOutput;
+use crate::tools::consumer_tools::QueryConsumerLagOutput;
+use crate::tools::diagnosis_tools::DiagnoseConsumerLagArgs;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools::DescribeTopicOutput;
+use crate::tools::topic_tools::QueryTopicRouteOutput;
+
+pub(crate) const CONSUMER_LAG_EVIDENCE_VERSION_V2: &str = "rocketmq-mcp.evidence.consumer-lag.v2";
+
+pub(crate) struct ConsumerLagEvidence {
+    pub lag: Result<QueryConsumerLagOutput, ToolExecutionError>,
+    pub topic: Result<DescribeTopicOutput, ToolExecutionError>,
+    pub route: Result<QueryTopicRouteOutput, ToolExecutionError>,
+    pub broker: Option<Result<DescribeBrokerOutput, ToolExecutionError>>,
+}
+
+impl ConsumerLagEvidence {
+    pub(crate) fn snapshot(&self, args: &DiagnoseConsumerLagArgs) -> EvidenceSnapshot {
+        let query_hash = query_hash(args);
+        let mut items = vec![
+            item(
+                "consumer_lag",
+                "rocketmq_get_consumer_lag",
+                EvidenceKind::ConsumerLag,
+                &query_hash,
+                &self.lag,
+            ),
+            item(
+                "topic_description",
+                "rocketmq_describe_topic",
+                EvidenceKind::TopicRoute,
+                &query_hash,
+                &self.topic,
+            ),
+            item(
+                "topic_route",
+                "rocketmq_get_topic_route",
+                EvidenceKind::TopicRoute,
+                &query_hash,
+                &self.route,
+            ),
+        ];
+        items.push(match &self.broker {
+            Some(result) => item(
+                "broker_summary",
+                "rocketmq_describe_broker",
+                EvidenceKind::BrokerSummary,
+                &query_hash,
+                result,
+            ),
+            None => missing_broker_item(&query_hash),
+        });
+        EvidenceSnapshot {
+            evidence_version: CONSUMER_LAG_EVIDENCE_VERSION_V2.to_string(),
+            query_hash,
+            cluster: args.cluster.clone(),
+            target: json!({ "topic": args.topic, "consumer_group": args.consumer_group }),
+            observed_at: observed_at(),
+            items,
+        }
+    }
+}
+
+fn query_hash(args: &DiagnoseConsumerLagArgs) -> String {
+    let mut digest = Sha256::new();
+    digest.update(args.cluster.as_bytes());
+    digest.update([0]);
+    digest.update(args.topic.as_bytes());
+    digest.update([0]);
+    digest.update(args.consumer_group.as_bytes());
+    digest.finalize().iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn item<T>(
+    id: &str,
+    source_tool: &str,
+    kind: EvidenceKind,
+    query_hash: &str,
+    result: &Result<T, ToolExecutionError>,
+) -> EvidenceItem
+where
+    T: Serialize,
+{
+    match result {
+        Ok(value) => EvidenceItem {
+            id: id.to_string(),
+            kind,
+            source_tool: source_tool.to_string(),
+            observed_at: observed_at(),
+            freshness_ms: 0,
+            status: EvidenceStatus::Present,
+            query_hash: query_hash.to_string(),
+            payload: Some(payload(kind, value)),
+            error_code: None,
+            summary: format!("{source_tool} returned evidence."),
+        },
+        Err(error) => EvidenceItem {
+            id: id.to_string(),
+            kind,
+            source_tool: source_tool.to_string(),
+            observed_at: observed_at(),
+            freshness_ms: 0,
+            status: error_status(error),
+            query_hash: query_hash.to_string(),
+            payload: None,
+            error_code: Some(error.code().to_string()),
+            summary: error.to_string(),
+        },
+    }
+}
+
+fn payload<T>(kind: EvidenceKind, value: &T) -> EvidencePayload
+where
+    T: Serialize,
+{
+    let value = serde_json::to_value(value).unwrap_or(Value::Null);
+    match kind {
+        EvidenceKind::ConsumerLag => EvidencePayload::ConsumerLag(value),
+        EvidenceKind::TopicRoute => EvidencePayload::TopicRoute(value),
+        EvidenceKind::BrokerSummary => EvidencePayload::BrokerSummary(value),
+    }
+}
+
+fn error_status(error: &ToolExecutionError) -> EvidenceStatus {
+    match error {
+        ToolExecutionError::TimedOut { .. } => EvidenceStatus::Timeout,
+        ToolExecutionError::PermissionDenied(_) => EvidenceStatus::Unauthorized,
+        ToolExecutionError::InvalidArguments(_) => EvidenceStatus::Invalid,
+        _ => EvidenceStatus::Unavailable,
+    }
+}
+
+fn missing_broker_item(query_hash: &str) -> EvidenceItem {
+    EvidenceItem {
+        id: "broker_summary".to_string(),
+        kind: EvidenceKind::BrokerSummary,
+        source_tool: "rocketmq_describe_broker".to_string(),
+        observed_at: observed_at(),
+        freshness_ms: 0,
+        status: EvidenceStatus::Missing,
+        query_hash: query_hash.to_string(),
+        payload: None,
+        error_code: None,
+        summary: "No broker was selected because consumer lag evidence was unavailable.".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_is_replayable_and_marks_missing_evidence() {
+        let args = DiagnoseConsumerLagArgs {
+            cluster: "local-dev".to_string(),
+            topic: "orders".to_string(),
+            consumer_group: "order-service".to_string(),
+        };
+        let evidence = ConsumerLagEvidence {
+            lag: Err(ToolExecutionError::backend("nameserver unavailable")),
+            topic: Err(ToolExecutionError::backend("topic route unavailable")),
+            route: Err(ToolExecutionError::TimedOut { timeout_ms: 5_000 }),
+            broker: None,
+        };
+
+        let first = evidence.snapshot(&args);
+        let second = evidence.snapshot(&args);
+
+        assert_eq!(first.query_hash, second.query_hash);
+        assert_eq!(first.evidence_version, CONSUMER_LAG_EVIDENCE_VERSION_V2);
+        assert_eq!(first.items[0].status, EvidenceStatus::Unavailable);
+        assert_eq!(first.items[2].status, EvidenceStatus::Timeout);
+        assert_eq!(first.items[3].status, EvidenceStatus::Missing);
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_rules.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_rules.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use crate::config::DiagnosisConfig;
+use crate::model::diagnosis::DiagnosisReport;
+use crate::model::diagnosis::EvidenceStatus;
+use crate::service::diagnosis_collector::ConsumerLagEvidence;
+use crate::tools::diagnosis_tools::DiagnoseConsumerLagArgs;
+
+pub(crate) const CONSUMER_LAG_RULES_VERSION_V2: &str = "rocketmq-mcp.rules.consumer-lag.v2";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConsumerLagPolicy {
+    pub profile: String,
+    pub lag_threshold: i64,
+}
+
+impl Default for ConsumerLagPolicy {
+    fn default() -> Self {
+        Self {
+            profile: "production-default".to_string(),
+            lag_threshold: 1_000,
+        }
+    }
+}
+
+impl From<&DiagnosisConfig> for ConsumerLagPolicy {
+    fn from(config: &DiagnosisConfig) -> Self {
+        Self {
+            profile: config.consumer_lag_policy_profile.clone(),
+            lag_threshold: config.consumer_lag_threshold,
+        }
+    }
+}
+
+pub(crate) fn evaluate(
+    args: &DiagnoseConsumerLagArgs,
+    evidence: ConsumerLagEvidence,
+    policy: &ConsumerLagPolicy,
+) -> DiagnosisReport {
+    let snapshot = evidence.snapshot(args);
+    let legacy_args = args.clone();
+    let mut report = crate::service::diagnosis_service::build_consumer_lag_report_with_threshold(
+        legacy_args,
+        policy.lag_threshold,
+        evidence.lag,
+        evidence.topic,
+        evidence.route,
+        evidence.broker,
+    );
+    let present = snapshot
+        .items
+        .iter()
+        .filter(|item| item.status == EvidenceStatus::Present)
+        .map(|item| item.id.as_str())
+        .collect::<HashSet<_>>();
+    report.evidence_version = snapshot.evidence_version.clone();
+    report.rules_version = CONSUMER_LAG_RULES_VERSION_V2.to_string();
+    report.policy_profile = policy.profile.clone();
+    report.partial = snapshot.items.iter().any(|item| item.status != EvidenceStatus::Present);
+    report.missing_evidence = snapshot
+        .items
+        .iter()
+        .filter(|item| item.status != EvidenceStatus::Present)
+        .map(|item| item.id.clone())
+        .collect();
+    report.evidence_refs = snapshot
+        .items
+        .iter()
+        .filter(|item| item.status == EvidenceStatus::Present)
+        .map(|item| item.id.clone())
+        .collect();
+    report.evidence_snapshot = Some(snapshot.clone());
+    report.root_causes.retain(|cause| {
+        cause
+            .evidence_refs
+            .iter()
+            .all(|reference| present.contains(reference.as_str()))
+    });
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_evidence_produces_partial_unknown_without_root_causes() {
+        let args = DiagnoseConsumerLagArgs {
+            cluster: "local-dev".to_string(),
+            topic: "orders".to_string(),
+            consumer_group: "order-service".to_string(),
+        };
+        let report = evaluate(
+            &args,
+            ConsumerLagEvidence {
+                lag: Err(crate::tools::executor::ToolExecutionError::TimedOut { timeout_ms: 5_000 }),
+                topic: Err(crate::tools::executor::ToolExecutionError::backend(
+                    "topic route unavailable",
+                )),
+                route: Err(crate::tools::executor::ToolExecutionError::backend(
+                    "topic route unavailable",
+                )),
+                broker: None,
+            },
+            &ConsumerLagPolicy::default(),
+        );
+
+        assert!(report.partial);
+        assert_eq!(report.severity, crate::model::diagnosis::Severity::Unknown);
+        assert!(report.root_causes.is_empty());
+        assert!(report.missing_evidence.contains(&"consumer_lag".to_string()));
+    }
+}

--- a/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
@@ -23,6 +23,7 @@ use crate::model::contract::observed_at;
 use crate::model::contract::PageRequest;
 #[cfg(test)]
 use crate::model::contract::QueryResult;
+use crate::model::diagnosis::ConfidenceBand;
 use crate::model::diagnosis::DiagnosisReport;
 use crate::model::diagnosis::Evidence;
 use crate::model::diagnosis::EvidenceStatus;
@@ -43,6 +44,7 @@ use crate::tools::topic_tools::DescribeTopicArgs;
 #[cfg(test)]
 use crate::tools::topic_tools::QueryTopicRouteArgs;
 
+#[cfg(test)]
 const DEFAULT_LAG_THRESHOLD: i64 = 1_000;
 const SKEW_RATIO_THRESHOLD: f64 = 0.70;
 pub(crate) const CONSUMER_LAG_EVIDENCE_VERSION: &str = "rocketmq-mcp.evidence.consumer-lag.v1";
@@ -103,6 +105,7 @@ where
     ))
 }
 
+#[cfg(test)]
 pub(crate) fn build_consumer_lag_report<Topic, Route, Broker>(
     args: DiagnoseConsumerLagArgs,
     lag_result: Result<QueryConsumerLagOutput, ToolExecutionError>,
@@ -115,7 +118,30 @@ where
     Route: Serialize,
     Broker: Serialize,
 {
-    let threshold = args.lag_threshold.unwrap_or(DEFAULT_LAG_THRESHOLD).max(0);
+    build_consumer_lag_report_with_threshold(
+        args,
+        DEFAULT_LAG_THRESHOLD,
+        lag_result,
+        topic_result,
+        route_result,
+        broker_result,
+    )
+}
+
+pub(crate) fn build_consumer_lag_report_with_threshold<Topic, Route, Broker>(
+    args: DiagnoseConsumerLagArgs,
+    threshold: i64,
+    lag_result: Result<QueryConsumerLagOutput, ToolExecutionError>,
+    topic_result: Result<Topic, ToolExecutionError>,
+    route_result: Result<Route, ToolExecutionError>,
+    broker_result: Option<Result<Broker, ToolExecutionError>>,
+) -> DiagnosisReport
+where
+    Topic: Serialize,
+    Route: Serialize,
+    Broker: Serialize,
+{
+    let threshold = threshold.max(0);
     let lag = lag_result.as_ref().ok();
     let severity = severity_for_lag(lag, threshold);
     let confidence = confidence_for_evidence(lag, topic_result.as_ref().ok(), route_result.as_ref().ok());
@@ -151,6 +177,19 @@ where
             data: Value::Null,
         });
     }
+    let partial = evidences
+        .iter()
+        .any(|evidence| evidence.status != EvidenceStatus::Present);
+    let missing_evidence = evidences
+        .iter()
+        .filter(|evidence| evidence.status != EvidenceStatus::Present)
+        .map(|evidence| evidence.id.clone())
+        .collect();
+    let evidence_refs = evidences
+        .iter()
+        .filter(|evidence| evidence.status == EvidenceStatus::Present)
+        .map(|evidence| evidence.id.clone())
+        .collect();
 
     DiagnosisReport {
         report_type: "consumer_lag".to_string(),
@@ -160,11 +199,16 @@ where
         target: json!({
             "topic": args.topic,
             "consumer_group": args.consumer_group,
-            "time_range": args.time_range,
             "lag_threshold": threshold,
         }),
         severity,
         confidence,
+        confidence_band: confidence_band(confidence),
+        policy_profile: "default".to_string(),
+        partial,
+        missing_evidence,
+        evidence_refs,
+        evidence_snapshot: None,
         summary,
         impacts: impacts_for_lag(lag, severity),
         evidences,
@@ -173,6 +217,16 @@ where
         risks: risks_for_lag(lag, severity),
         follow_up_metrics: follow_up_metrics(),
         generated_at: observed_at(),
+    }
+}
+
+fn confidence_band(confidence: f32) -> ConfidenceBand {
+    if confidence >= 0.8 {
+        ConfidenceBand::High
+    } else if confidence >= 0.5 {
+        ConfidenceBand::Medium
+    } else {
+        ConfidenceBand::Low
     }
 }
 
@@ -324,12 +378,14 @@ fn recommendations_for_lag(lag: Option<&QueryConsumerLagOutput>, severity: Sever
             priority: "high".to_string(),
             rationale: "The report is Unknown because required evidence is missing or empty.".to_string(),
             risk: "Do not change offsets or topic configuration without evidence.".to_string(),
+            verification: "Re-run the diagnosis after all required evidence is available.".to_string(),
         }],
         (Some(_), Severity::Healthy) => vec![Recommendation {
             action: "Continue monitoring consumer lag.".to_string(),
             priority: "low".to_string(),
             rationale: "Lag is within the configured threshold.".to_string(),
             risk: "No immediate operational change is recommended.".to_string(),
+            verification: "Confirm total_lag remains within the policy threshold.".to_string(),
         }],
         (Some(lag), _) => vec![
             Recommendation {
@@ -337,6 +393,7 @@ fn recommendations_for_lag(lag: Option<&QueryConsumerLagOutput>, severity: Sever
                 priority: "high".to_string(),
                 rationale: format!("total_lag={} is above the configured threshold.", lag.total_lag),
                 risk: "Scaling consumers can increase broker fetch pressure; watch broker latency.".to_string(),
+                verification: "Confirm consume_tps rises and total_lag declines after scaling.".to_string(),
             },
             Recommendation {
                 action: "Inspect queues with the highest lag and their broker placement.".to_string(),
@@ -346,6 +403,7 @@ fn recommendations_for_lag(lag: Option<&QueryConsumerLagOutput>, severity: Sever
                     lag.max_queue_lag
                 ),
                 risk: "Queue-level findings require route evidence before rebalancing decisions.".to_string(),
+                verification: "Confirm max_queue_lag converges after the placement review.".to_string(),
             },
         ],
     }
@@ -402,7 +460,7 @@ where
         Err(error) => Evidence {
             id: id.to_string(),
             source_tool: source_tool.to_string(),
-            status: EvidenceStatus::Error,
+            status: EvidenceStatus::Unavailable,
             summary: error.to_string(),
             data: Value::Null,
         },
@@ -626,7 +684,7 @@ mod tests {
         assert!(report
             .evidences
             .iter()
-            .any(|evidence| evidence.id == "consumer_lag" && evidence.status == EvidenceStatus::Error));
+            .any(|evidence| evidence.id == "consumer_lag" && evidence.status == EvidenceStatus::Unavailable));
     }
 
     fn request() -> DiagnoseConsumerLagArgs {
@@ -634,8 +692,6 @@ mod tests {
             cluster: "local-dev".to_string(),
             topic: "orders".to_string(),
             consumer_group: "order-service".to_string(),
-            time_range: None,
-            lag_threshold: Some(1_000),
         }
     }
 

--- a/rocketmq-tools/rocketmq-mcp/src/tools/diagnosis_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/diagnosis_tools.rs
@@ -22,8 +22,4 @@ pub struct DiagnoseConsumerLagArgs {
     pub cluster: String,
     pub topic: String,
     pub consumer_group: String,
-    #[serde(default)]
-    pub time_range: Option<String>,
-    #[serde(default)]
-    pub lag_threshold: Option<i64>,
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -81,7 +81,7 @@ impl ToolExecutionError {
         Self::Internal(error.to_string())
     }
 
-    fn code(&self) -> &'static str {
+    pub(crate) fn code(&self) -> &'static str {
         match self {
             Self::InvalidArguments(_) => "invalid_arguments",
             Self::Backend(_) => "backend_error",

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -1,5 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
+assertion_line: 351
 expression: contracts
 ---
 [
@@ -1450,21 +1451,6 @@ expression: contracts
         "consumer_group": {
           "type": "string"
         },
-        "lag_threshold": {
-          "default": null,
-          "format": "int64",
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "time_range": {
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "topic": {
           "type": "string"
         }
@@ -1487,6 +1473,14 @@ expression: contracts
           ],
           "type": "string"
         },
+        "ConfidenceBand": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "type": "string"
+        },
         "DiagnosisReport": {
           "properties": {
             "cluster": {
@@ -1495,6 +1489,25 @@ expression: contracts
             "confidence": {
               "format": "float",
               "type": "number"
+            },
+            "confidence_band": {
+              "$ref": "#/$defs/ConfidenceBand"
+            },
+            "evidence_refs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "evidence_snapshot": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EvidenceSnapshot"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "evidence_version": {
               "type": "string"
@@ -1519,6 +1532,18 @@ expression: contracts
                 "$ref": "#/$defs/ImpactItem"
               },
               "type": "array"
+            },
+            "missing_evidence": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "partial": {
+              "type": "boolean"
+            },
+            "policy_profile": {
+              "type": "string"
             },
             "recommendations": {
               "items": {
@@ -1560,6 +1585,11 @@ expression: contracts
             "target",
             "severity",
             "confidence",
+            "confidence_band",
+            "policy_profile",
+            "partial",
+            "missing_evidence",
+            "evidence_refs",
             "summary",
             "impacts",
             "evidences",
@@ -1596,11 +1626,157 @@ expression: contracts
           ],
           "type": "object"
         },
+        "EvidenceItem": {
+          "properties": {
+            "error_code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "freshness_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/$defs/EvidenceKind"
+            },
+            "observed_at": {
+              "type": "string"
+            },
+            "payload": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EvidencePayload"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query_hash": {
+              "type": "string"
+            },
+            "source_tool": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/$defs/EvidenceStatus"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "source_tool",
+            "observed_at",
+            "freshness_ms",
+            "status",
+            "query_hash",
+            "summary"
+          ],
+          "type": "object"
+        },
+        "EvidenceKind": {
+          "enum": [
+            "consumer_lag",
+            "topic_route",
+            "broker_summary"
+          ],
+          "type": "string"
+        },
+        "EvidencePayload": {
+          "oneOf": [
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "consumer_lag",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "topic_route",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "broker_summary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "EvidenceSnapshot": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "evidence_version": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/EvidenceItem"
+              },
+              "type": "array"
+            },
+            "observed_at": {
+              "type": "string"
+            },
+            "query_hash": {
+              "type": "string"
+            },
+            "target": true
+          },
+          "required": [
+            "evidence_version",
+            "query_hash",
+            "cluster",
+            "target",
+            "observed_at",
+            "items"
+          ],
+          "type": "object"
+        },
         "EvidenceStatus": {
           "enum": [
             "Present",
             "Missing",
-            "Error"
+            "Unavailable",
+            "Timeout",
+            "Unauthorized",
+            "Invalid"
           ],
           "type": "string"
         },
@@ -1655,13 +1831,17 @@ expression: contracts
             },
             "risk": {
               "type": "string"
+            },
+            "verification": {
+              "type": "string"
             }
           },
           "required": [
             "action",
             "priority",
             "rationale",
-            "risk"
+            "risk",
+            "verification"
           ],
           "type": "object"
         },

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -1,5 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
+assertion_line: 354
 expression: contracts
 ---
 [
@@ -1450,21 +1451,6 @@ expression: contracts
         "consumer_group": {
           "type": "string"
         },
-        "lag_threshold": {
-          "default": null,
-          "format": "int64",
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "time_range": {
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "topic": {
           "type": "string"
         }
@@ -1487,6 +1473,14 @@ expression: contracts
           ],
           "type": "string"
         },
+        "ConfidenceBand": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "type": "string"
+        },
         "DiagnosisReport": {
           "properties": {
             "cluster": {
@@ -1495,6 +1489,25 @@ expression: contracts
             "confidence": {
               "format": "float",
               "type": "number"
+            },
+            "confidence_band": {
+              "$ref": "#/$defs/ConfidenceBand"
+            },
+            "evidence_refs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "evidence_snapshot": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EvidenceSnapshot"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "evidence_version": {
               "type": "string"
@@ -1519,6 +1532,18 @@ expression: contracts
                 "$ref": "#/$defs/ImpactItem"
               },
               "type": "array"
+            },
+            "missing_evidence": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "partial": {
+              "type": "boolean"
+            },
+            "policy_profile": {
+              "type": "string"
             },
             "recommendations": {
               "items": {
@@ -1560,6 +1585,11 @@ expression: contracts
             "target",
             "severity",
             "confidence",
+            "confidence_band",
+            "policy_profile",
+            "partial",
+            "missing_evidence",
+            "evidence_refs",
             "summary",
             "impacts",
             "evidences",
@@ -1596,11 +1626,157 @@ expression: contracts
           ],
           "type": "object"
         },
+        "EvidenceItem": {
+          "properties": {
+            "error_code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "freshness_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/$defs/EvidenceKind"
+            },
+            "observed_at": {
+              "type": "string"
+            },
+            "payload": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EvidencePayload"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "query_hash": {
+              "type": "string"
+            },
+            "source_tool": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/$defs/EvidenceStatus"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "kind",
+            "source_tool",
+            "observed_at",
+            "freshness_ms",
+            "status",
+            "query_hash",
+            "summary"
+          ],
+          "type": "object"
+        },
+        "EvidenceKind": {
+          "enum": [
+            "consumer_lag",
+            "topic_route",
+            "broker_summary"
+          ],
+          "type": "string"
+        },
+        "EvidencePayload": {
+          "oneOf": [
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "consumer_lag",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "topic_route",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "data": true,
+                "kind": {
+                  "const": "broker_summary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "EvidenceSnapshot": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "evidence_version": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/EvidenceItem"
+              },
+              "type": "array"
+            },
+            "observed_at": {
+              "type": "string"
+            },
+            "query_hash": {
+              "type": "string"
+            },
+            "target": true
+          },
+          "required": [
+            "evidence_version",
+            "query_hash",
+            "cluster",
+            "target",
+            "observed_at",
+            "items"
+          ],
+          "type": "object"
+        },
         "EvidenceStatus": {
           "enum": [
-            "Present",
-            "Missing",
-            "Error"
+            "present",
+            "missing",
+            "unavailable",
+            "timeout",
+            "unauthorized",
+            "invalid"
           ],
           "type": "string"
         },
@@ -1655,13 +1831,17 @@ expression: contracts
             },
             "risk": {
               "type": "string"
+            },
+            "verification": {
+              "type": "string"
             }
           },
           "required": [
             "action",
             "priority",
             "rationale",
-            "risk"
+            "risk",
+            "verification"
           ],
           "type": "object"
         },
@@ -1694,12 +1874,12 @@ expression: contracts
         },
         "Severity": {
           "enum": [
-            "Healthy",
-            "Low",
-            "Medium",
-            "High",
-            "Critical",
-            "Unknown"
+            "healthy",
+            "low",
+            "medium",
+            "high",
+            "critical",
+            "unknown"
           ],
           "type": "string"
         }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8167

### Brief Description

- Split consumer-lag diagnosis into evidence collection and deterministic v2 rule evaluation.
- Add replayable Evidence Snapshots, partial and missing-evidence reporting, server-side diagnosis policy, and recommendation verification steps.
- Remove unsupported historical time ranges and caller-controlled lag thresholds from the MCP contract, prompt, schemas, snapshots, and documentation.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo check -p rocketmq-mcp`
- `cargo test -p rocketmq-mcp --all-features` (80 unit tests and 2 integration tests passed)
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-mcp --no-deps`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer consumer-lag diagnosis reports with evidence snapshots, confidence levels, policy information, verification guidance, and missing-evidence details.
  * Added server-side configuration for diagnosis policy profiles and lag thresholds.
  * Improved handling and reporting of unavailable, timed-out, unauthorized, and invalid evidence.

* **Changes**
  * Consumer-lag diagnosis now accepts only cluster, topic, and consumer group inputs.
  * Removed historical time-range analysis and caller-defined thresholds until historical metrics are available.
  * Updated documentation and configuration examples for the revised diagnosis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->