### PR TITLE
[ISSUE #8172]✨Add production integration tests and release gates

### DIFF
--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -123,6 +123,9 @@ jobs:
       - name: Test rocketmq-mcp
         run: cargo test -p rocketmq-mcp
 
+      - name: Test rocketmq-mcp all features
+        run: cargo test -p rocketmq-mcp --all-features
+
       - name: Clippy rocketmq-mcp
         run: cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -76,6 +76,7 @@ validator          = { version = "0.20", features = ["derive"] }
 insta             = { version = "1.43", features = ["json"] }
 mockall           = { workspace = true }
 pretty_assertions = "1.4"
+tower             = { version = "0.5", features = ["util"] }
 
 [[bin]]
 name = "rocketmq-mcp"

--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -3,6 +3,8 @@
 `rocketmq-mcp` is the Model Context Protocol server for RocketMQ-Rust AI SRE and diagnostics workflows. It exposes read-only RocketMQ context, diagnostic tools, and runbook prompts to MCP clients such as Claude Desktop, Cursor, Codex, and MCP Inspector.
 
 The frozen MCP 2025-11-25 contract is documented in `rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md`.
+Production release gates, external-cluster expectations, and rollback guidance are documented in
+`docs/production-validation.md`.
 
 ## What It Is
 

--- a/rocketmq-tools/rocketmq-mcp/src/transport/streamable_http.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/streamable_http.rs
@@ -156,7 +156,15 @@ fn allowed_hosts(bind: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::header::HOST;
+    use axum::http::header::ORIGIN;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
     use super::*;
+    use crate::app::McpApp;
     use crate::config::McpConfig;
 
     #[test]
@@ -194,6 +202,63 @@ mod tests {
 
         assert_eq!(metadata["resource"], "http://127.0.0.1:8089/mcp");
         assert_eq!(metadata["scopes_supported"], serde_json::json!(["rocketmq:read"]));
+    }
+
+    #[tokio::test]
+    async fn router_exposes_metadata_and_enforces_http_security_boundaries() {
+        let _environment = development_token_environment_lock().lock().await;
+        std::env::set_var("ROCKETMQ_MCP_HTTP_TOKEN", "router-test-token");
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.audit.enabled = false;
+        let app = McpApp::new(config).unwrap();
+        let router = build_router(app, CancellationToken::new()).unwrap();
+
+        let metadata = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/oauth-protected-resource")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(metadata.status(), StatusCode::OK);
+
+        let unauthorized = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let forbidden_origin = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .header(AUTHORIZATION, "Bearer router-test-token")
+                    .header(HOST, "localhost")
+                    .header(ORIGIN, "https://untrusted.example.test")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forbidden_origin.status(), StatusCode::FORBIDDEN);
+
+        std::env::remove_var("ROCKETMQ_MCP_HTTP_TOKEN");
+    }
+
+    fn development_token_environment_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(tokio::sync::Mutex::default)
     }
 
     fn example_config_path() -> std::path::PathBuf {

--- a/rocketmq-tools/rocketmq-mcp/tests/integration.rs
+++ b/rocketmq-tools/rocketmq-mcp/tests/integration.rs
@@ -91,6 +91,41 @@ fn unsupported_protocol_version_is_rejected_during_initialize() {
         .contains("requires 2025-11-25"));
 }
 
+#[test]
+#[ignore = "requires ROCKETMQ_MCP_E2E_NAMESRV_ADDR, TOPIC, CONSUMER_GROUP, and BROKER"]
+fn external_cluster_exercises_mvp_tools_and_resources() {
+    let namesrv_addr = required_e2e_environment("ROCKETMQ_MCP_E2E_NAMESRV_ADDR");
+    let topic = required_e2e_environment("ROCKETMQ_MCP_E2E_TOPIC");
+    let consumer_group = required_e2e_environment("ROCKETMQ_MCP_E2E_CONSUMER_GROUP");
+    let broker = required_e2e_environment("ROCKETMQ_MCP_E2E_BROKER");
+    let input = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2025-11-25","capabilities":{{}},"clientInfo":{{"name":"external-cluster-e2e","version":"1.0.0"}}}}}}
+{{"jsonrpc":"2.0","method":"notifications/initialized","params":{{}}}}
+{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"rocketmq_get_cluster_overview","arguments":{{"cluster":"local-dev"}}}}}}
+{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"rocketmq_list_topics","arguments":{{"cluster":"local-dev"}}}}}}
+{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"rocketmq_describe_topic","arguments":{{"cluster":"local-dev","topic":"{topic}"}}}}}}
+{{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{{"name":"rocketmq_get_topic_route","arguments":{{"cluster":"local-dev","topic":"{topic}"}}}}}}
+{{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{{"name":"rocketmq_list_consumer_groups","arguments":{{"cluster":"local-dev"}}}}}}
+{{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{{"name":"rocketmq_get_consumer_lag","arguments":{{"cluster":"local-dev","topic":"{topic}","consumer_group":"{consumer_group}"}}}}}}
+{{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{{"name":"rocketmq_describe_broker","arguments":{{"cluster":"local-dev","broker_name":"{broker}"}}}}}}
+{{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{{"name":"rocketmq_diagnose_consumer_lag","arguments":{{"cluster":"local-dev","topic":"{topic}","consumer_group":"{consumer_group}"}}}}}}
+{{"jsonrpc":"2.0","id":10,"method":"resources/read","params":{{"uri":"rocketmq://clusters/local-dev/topics/{topic}"}}}}
+"#
+    );
+    let output = run_stdio_server_with_namesrv(&input, &namesrv_addr);
+
+    assert!(output.status.success(), "server failed: {}", output.stderr);
+    let responses = parse_stdout_json(&output.stdout);
+    for request_id in 2..=9 {
+        assert_eq!(
+            responses[&request_id]["result"]["isError"], false,
+            "request {request_id} failed: {}",
+            responses[&request_id]
+        );
+    }
+    assert!(responses[&10]["result"]["contents"].is_array());
+}
+
 struct StdioOutput {
     status: std::process::ExitStatus,
     stdout: String,
@@ -98,8 +133,12 @@ struct StdioOutput {
 }
 
 fn run_stdio_server(input: &str) -> StdioOutput {
+    run_stdio_server_with_namesrv(input, "127.0.0.1:9876")
+}
+
+fn run_stdio_server_with_namesrv(input: &str, namesrv_addr: &str) -> StdioOutput {
     let binary = env!("CARGO_BIN_EXE_rocketmq-mcp");
-    let config = temporary_memory_audit_config();
+    let config = temporary_memory_audit_config(namesrv_addr);
     let mut child = Command::new(binary)
         .arg("--config")
         .arg(&config)
@@ -129,7 +168,7 @@ fn run_stdio_server(input: &str) -> StdioOutput {
     }
 }
 
-fn temporary_memory_audit_config() -> std::path::PathBuf {
+fn temporary_memory_audit_config(namesrv_addr: &str) -> std::path::PathBuf {
     let example = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("conf")
         .join("mcp.example.toml");
@@ -139,7 +178,11 @@ fn temporary_memory_audit_config() -> std::path::PathBuf {
     let config = std::fs::read_to_string(example).expect("read example config");
     let config = config
         .replace("sink = \"file\"", "sink = \"memory\"")
-        .replace("path = \"./logs/rocketmq-mcp-audit.log\"", "path = \"\"");
+        .replace("path = \"./logs/rocketmq-mcp-audit.log\"", "path = \"\"")
+        .replace(
+            "namesrv_addr = \"127.0.0.1:9876\"",
+            &format!("namesrv_addr = \"{namesrv_addr}\""),
+        );
     let suffix = NEXT_TEMP_CONFIG_ID.fetch_add(1, Ordering::Relaxed);
     let directory = std::env::temp_dir().join(format!("rocketmq-mcp-integration-{}-{suffix}", std::process::id()));
     std::fs::create_dir_all(&directory).expect("create temp config directory");
@@ -147,6 +190,10 @@ fn temporary_memory_audit_config() -> std::path::PathBuf {
     std::fs::write(&path, config).expect("write temp config");
     std::fs::copy(permissions, path.with_file_name("permissions.example.toml")).expect("copy permissions config");
     path
+}
+
+fn required_e2e_environment(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set for external-cluster E2E"))
 }
 
 fn parse_stdout_json(stdout: &str) -> HashMap<i64, Value> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8172

### Brief Description

Adds production validation gates for RocketMQ MCP. CI now runs the full-feature MCP test suite, the Streamable HTTP router has end-to-end security coverage for protected-resource metadata, missing authentication, and origin rejection, and the stdio integration suite includes an explicit real-cluster contract for all MVP Tools and a live Resource.

The external-cluster contract is intentionally ignored until a disposable NameServer, Broker, topic, consumer group, and broker name are supplied. It is documented as a required release gate rather than a passing default test. Production validation, performance measurements, rollback guidance, and release expectations are documented in `rocketmq-tools/rocketmq-mcp/docs/production-validation.md`.

### How Did You Test This Change?

- `cargo test -p rocketmq-mcp --all-features` (83 unit tests and 2 default integration tests passed; one documented external-cluster test ignored because its environment was not configured)
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings` (passed)
- `cargo doc -p rocketmq-mcp --no-deps` (passed)
- `cargo fmt --all -- --check` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `./scripts/check-agents-routing.ps1` and `git diff --check` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added coverage for HTTP security boundaries, including authentication and trusted-origin checks.
  * Improved external-cluster integration validation for MCP tools and resources.

* **Tests**
  * Added all-features MCP test coverage to CI.
  * Added end-to-end validation using configurable external cluster settings.

* **Documentation**
  * Added guidance for production validation, external-cluster expectations, and rollback procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->