### PR TITLE
[ISSUE #8174]♻️Correct controlled change planning semantics

### DIFF
--- a/rocketmq-doc/en/adr-009-future-mcp-change-executor.md
+++ b/rocketmq-doc/en/adr-009-future-mcp-change-executor.md
@@ -1,0 +1,19 @@
+# ADR-009: Keep Change Execution Outside RocketMQ MCP
+
+## Status
+
+Accepted.
+
+## Decision
+
+`rocketmq-mcp` exposes only ephemeral, immutable, non-mutating change plans.
+It does not persist plans, accept confirmation tokens, expose an Apply mode, or
+call RocketMQ mutation APIs. A future Change Executor must be a separately
+reviewed service with its own identity, approval workflow, persistence,
+idempotency model, audit retention, and rollback authority.
+
+## Consequences
+
+Planning Tools remain read-only, non-destructive, and idempotent. Their
+precondition and plan hashes bind the plan to a queried current-state snapshot;
+an executor must revalidate those preconditions before any mutation.

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -1,6 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
-assertion_line: 239
+assertion_line: 283
 expression: surface
 ---
 {
@@ -2136,6 +2136,18 @@ expression: surface
               "cluster": {
                 "type": "string"
               },
+              "current_state": true,
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expires_in_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "immutable": {
+                "type": "boolean"
+              },
               "impact_analysis": {
                 "items": {
                   "type": "string"
@@ -2144,6 +2156,12 @@ expression: surface
               },
               "mutates_cluster": {
                 "type": "boolean"
+              },
+              "plan_hash": {
+                "type": "string"
+              },
+              "plan_id": {
+                "type": "string"
               },
               "plan_type": {
                 "$ref": "#/$defs/ChangePlanType"
@@ -2154,6 +2172,9 @@ expression: surface
                 },
                 "type": "array"
               },
+              "precondition_hash": {
+                "type": "string"
+              },
               "reason": {
                 "type": "string"
               },
@@ -2163,11 +2184,22 @@ expression: surface
                 },
                 "type": "array"
               },
+              "schema_version": {
+                "type": "string"
+              },
               "summary": {
                 "type": "string"
               }
             },
             "required": [
+              "schema_version",
+              "plan_id",
+              "plan_hash",
+              "precondition_hash",
+              "current_state",
+              "expires_in_seconds",
+              "ephemeral",
+              "immutable",
               "plan_type",
               "cluster",
               "reason",
@@ -2311,6 +2343,18 @@ expression: surface
               "cluster": {
                 "type": "string"
               },
+              "current_state": true,
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expires_in_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "immutable": {
+                "type": "boolean"
+              },
               "impact_analysis": {
                 "items": {
                   "type": "string"
@@ -2319,6 +2363,12 @@ expression: surface
               },
               "mutates_cluster": {
                 "type": "boolean"
+              },
+              "plan_hash": {
+                "type": "string"
+              },
+              "plan_id": {
+                "type": "string"
               },
               "plan_type": {
                 "$ref": "#/$defs/ChangePlanType"
@@ -2329,6 +2379,9 @@ expression: surface
                 },
                 "type": "array"
               },
+              "precondition_hash": {
+                "type": "string"
+              },
               "reason": {
                 "type": "string"
               },
@@ -2338,11 +2391,22 @@ expression: surface
                 },
                 "type": "array"
               },
+              "schema_version": {
+                "type": "string"
+              },
               "summary": {
                 "type": "string"
               }
             },
             "required": [
+              "schema_version",
+              "plan_id",
+              "plan_hash",
+              "precondition_hash",
+              "current_state",
+              "expires_in_seconds",
+              "ephemeral",
+              "immutable",
               "plan_type",
               "cluster",
               "reason",
@@ -2482,6 +2546,18 @@ expression: surface
               "cluster": {
                 "type": "string"
               },
+              "current_state": true,
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expires_in_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "immutable": {
+                "type": "boolean"
+              },
               "impact_analysis": {
                 "items": {
                   "type": "string"
@@ -2490,6 +2566,12 @@ expression: surface
               },
               "mutates_cluster": {
                 "type": "boolean"
+              },
+              "plan_hash": {
+                "type": "string"
+              },
+              "plan_id": {
+                "type": "string"
               },
               "plan_type": {
                 "$ref": "#/$defs/ChangePlanType"
@@ -2500,6 +2582,9 @@ expression: surface
                 },
                 "type": "array"
               },
+              "precondition_hash": {
+                "type": "string"
+              },
               "reason": {
                 "type": "string"
               },
@@ -2509,11 +2594,22 @@ expression: surface
                 },
                 "type": "array"
               },
+              "schema_version": {
+                "type": "string"
+              },
               "summary": {
                 "type": "string"
               }
             },
             "required": [
+              "schema_version",
+              "plan_id",
+              "plan_hash",
+              "precondition_hash",
+              "current_state",
+              "expires_in_seconds",
+              "ephemeral",
+              "immutable",
               "plan_type",
               "cluster",
               "reason",
@@ -2657,6 +2753,18 @@ expression: surface
               "cluster": {
                 "type": "string"
               },
+              "current_state": true,
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expires_in_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "immutable": {
+                "type": "boolean"
+              },
               "impact_analysis": {
                 "items": {
                   "type": "string"
@@ -2665,6 +2773,12 @@ expression: surface
               },
               "mutates_cluster": {
                 "type": "boolean"
+              },
+              "plan_hash": {
+                "type": "string"
+              },
+              "plan_id": {
+                "type": "string"
               },
               "plan_type": {
                 "$ref": "#/$defs/ChangePlanType"
@@ -2675,6 +2789,9 @@ expression: surface
                 },
                 "type": "array"
               },
+              "precondition_hash": {
+                "type": "string"
+              },
               "reason": {
                 "type": "string"
               },
@@ -2684,11 +2801,22 @@ expression: surface
                 },
                 "type": "array"
               },
+              "schema_version": {
+                "type": "string"
+              },
               "summary": {
                 "type": "string"
               }
             },
             "required": [
+              "schema_version",
+              "plan_id",
+              "plan_hash",
+              "precondition_hash",
+              "current_state",
+              "expires_in_seconds",
+              "ephemeral",
+              "immutable",
               "plan_type",
               "cluster",
               "reason",
@@ -2844,6 +2972,18 @@ expression: surface
               "cluster": {
                 "type": "string"
               },
+              "current_state": true,
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expires_in_seconds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "immutable": {
+                "type": "boolean"
+              },
               "impact_analysis": {
                 "items": {
                   "type": "string"
@@ -2852,6 +2992,12 @@ expression: surface
               },
               "mutates_cluster": {
                 "type": "boolean"
+              },
+              "plan_hash": {
+                "type": "string"
+              },
+              "plan_id": {
+                "type": "string"
               },
               "plan_type": {
                 "$ref": "#/$defs/ChangePlanType"
@@ -2862,6 +3008,9 @@ expression: surface
                 },
                 "type": "array"
               },
+              "precondition_hash": {
+                "type": "string"
+              },
               "reason": {
                 "type": "string"
               },
@@ -2871,11 +3020,22 @@ expression: surface
                 },
                 "type": "array"
               },
+              "schema_version": {
+                "type": "string"
+              },
               "summary": {
                 "type": "string"
               }
             },
             "required": [
+              "schema_version",
+              "plan_id",
+              "plan_hash",
+              "precondition_hash",
+              "current_state",
+              "expires_in_seconds",
+              "ephemeral",
+              "immutable",
               "plan_type",
               "cluster",
               "reason",

--- a/rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
@@ -363,4 +363,31 @@ mod tests {
         #[cfg(feature = "change-planning")]
         insta::assert_json_snapshot!("tool_contract_schema_metadata_with_change_planning", contracts);
     }
+
+    #[cfg(feature = "change-planning")]
+    #[test]
+    fn change_planning_catalog_is_read_only_and_uses_only_canonical_names() {
+        let planning = ToolId::ALL
+            .iter()
+            .map(|tool_id| tool_id.descriptor())
+            .filter(|descriptor| descriptor.risk_level == RiskLevel::Plan)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            planning.iter().map(|descriptor| descriptor.name).collect::<Vec<_>>(),
+            vec![
+                "rocketmq_plan_create_topic",
+                "rocketmq_plan_update_topic_config",
+                "rocketmq_plan_update_topic_permissions",
+                "rocketmq_plan_update_broker_config",
+                "rocketmq_plan_reset_consumer_offset",
+            ]
+        );
+        assert!(planning.iter().all(|descriptor| {
+            descriptor.annotations.read_only
+                && !descriptor.annotations.destructive
+                && descriptor.annotations.idempotent
+                && !descriptor.name.starts_with("mq_")
+        }));
+    }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/change_tools.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/change_tools.rs
@@ -15,6 +15,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+const PLAN_TTL_SECONDS: u64 = 300;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -88,6 +92,14 @@ pub enum ChangePlanType {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct ChangePlan {
+    pub schema_version: String,
+    pub plan_id: String,
+    pub plan_hash: String,
+    pub precondition_hash: String,
+    pub current_state: serde_json::Value,
+    pub expires_in_seconds: u64,
+    pub ephemeral: bool,
+    pub immutable: bool,
     pub plan_type: ChangePlanType,
     pub cluster: String,
     pub reason: String,
@@ -99,9 +111,14 @@ pub struct ChangePlan {
 }
 
 pub fn plan_create_topic(request: CreateTopicArgs) -> ChangePlan {
+    plan_create_topic_with_current_state(request, serde_json::Value::Null)
+}
+
+pub fn plan_create_topic_with_current_state(request: CreateTopicArgs, current_state: serde_json::Value) -> ChangePlan {
     planned_change(
         ChangePlanType::CreateTopic,
         request,
+        current_state,
         |desired| {
             vec![format!(
                 "Create topic `{}` with read_queue_nums={:?}, write_queue_nums={:?}, perm={:?}.",
@@ -124,9 +141,17 @@ pub fn plan_create_topic(request: CreateTopicArgs) -> ChangePlan {
 }
 
 pub fn plan_update_topic_config(request: UpdateTopicConfigArgs) -> ChangePlan {
+    plan_update_topic_config_with_current_state(request, serde_json::Value::Null)
+}
+
+pub fn plan_update_topic_config_with_current_state(
+    request: UpdateTopicConfigArgs,
+    current_state: serde_json::Value,
+) -> ChangePlan {
     planned_change(
         ChangePlanType::UpdateTopicConfig,
         request,
+        current_state,
         |desired| {
             vec![format!(
                 "Update topic `{}` config `{}` to `{}`.",
@@ -149,9 +174,17 @@ pub fn plan_update_topic_config(request: UpdateTopicConfigArgs) -> ChangePlan {
 }
 
 pub fn plan_update_topic_perm(request: UpdateTopicPermArgs) -> ChangePlan {
+    plan_update_topic_perm_with_current_state(request, serde_json::Value::Null)
+}
+
+pub fn plan_update_topic_perm_with_current_state(
+    request: UpdateTopicPermArgs,
+    current_state: serde_json::Value,
+) -> ChangePlan {
     planned_change(
         ChangePlanType::UpdateTopicPermissions,
         request,
+        current_state,
         |desired| {
             vec![format!(
                 "Update topic `{}` permission to `{}`.",
@@ -174,9 +207,17 @@ pub fn plan_update_topic_perm(request: UpdateTopicPermArgs) -> ChangePlan {
 }
 
 pub fn plan_update_broker_config(request: UpdateBrokerConfigArgs) -> ChangePlan {
+    plan_update_broker_config_with_current_state(request, serde_json::Value::Null)
+}
+
+pub fn plan_update_broker_config_with_current_state(
+    request: UpdateBrokerConfigArgs,
+    current_state: serde_json::Value,
+) -> ChangePlan {
     planned_change(
         ChangePlanType::UpdateBrokerConfig,
         request,
+        current_state,
         |desired| {
             vec![format!(
                 "Update broker `{}` config `{}` to `{}`.",
@@ -199,9 +240,17 @@ pub fn plan_update_broker_config(request: UpdateBrokerConfigArgs) -> ChangePlan 
 }
 
 pub fn plan_reset_consumer_offset(request: ResetConsumerOffsetArgs) -> ChangePlan {
+    plan_reset_consumer_offset_with_current_state(request, serde_json::Value::Null)
+}
+
+pub fn plan_reset_consumer_offset_with_current_state(
+    request: ResetConsumerOffsetArgs,
+    current_state: serde_json::Value,
+) -> ChangePlan {
     planned_change(
         ChangePlanType::ResetConsumerOffset,
         request,
+        current_state,
         |desired| {
             vec![format!(
                 "Reset consumer group `{}` offset for topic `{}` to offset {:?} or timestamp {:?}.",
@@ -226,25 +275,56 @@ pub fn plan_reset_consumer_offset(request: ResetConsumerOffsetArgs) -> ChangePla
 fn planned_change<T, P, I, R>(
     plan_type: ChangePlanType,
     request: PlanRequest<T>,
+    current_state: serde_json::Value,
     planned_changes: P,
     impact_analysis: I,
     rollback_suggestions: R,
 ) -> ChangePlan
 where
+    T: Serialize,
     P: FnOnce(&T) -> Vec<String>,
     I: FnOnce(&T) -> Vec<String>,
     R: FnOnce(&T) -> Vec<String>,
 {
+    let planned_changes = planned_changes(&request.desired);
+    let impact_analysis = impact_analysis(&request.desired);
+    let rollback_suggestions = rollback_suggestions(&request.desired);
+    let precondition_hash = stable_hash(&serde_json::json!({
+        "cluster": request.cluster.clone(),
+        "plan_type": plan_type,
+        "desired": &request.desired,
+        "current_state": &current_state,
+    }));
+    let plan_hash = stable_hash(&serde_json::json!({
+        "precondition_hash": precondition_hash,
+        "reason": request.reason.clone(),
+        "planned_changes": &planned_changes,
+        "impact_analysis": &impact_analysis,
+        "rollback_suggestions": &rollback_suggestions,
+    }));
     ChangePlan {
+        schema_version: "rocketmq-change-plan.v2".to_string(),
+        plan_id: format!("plan-{}", &plan_hash[..24]),
+        plan_hash,
+        precondition_hash,
+        current_state,
+        expires_in_seconds: PLAN_TTL_SECONDS,
+        ephemeral: true,
+        immutable: true,
         plan_type,
         cluster: request.cluster,
         reason: request.reason,
         summary: format!("Generated a non-mutating {:?} plan.", plan_type),
-        planned_changes: planned_changes(&request.desired),
-        impact_analysis: impact_analysis(&request.desired),
-        rollback_suggestions: rollback_suggestions(&request.desired),
+        planned_changes,
+        impact_analysis,
+        rollback_suggestions,
         mutates_cluster: false,
     }
+}
+
+fn stable_hash(value: &serde_json::Value) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    Sha256::digest(bytes).iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 #[cfg(test)]
@@ -266,6 +346,68 @@ mod tests {
 
         assert_eq!(plan.plan_type, ChangePlanType::CreateTopic);
         assert!(!plan.mutates_cluster);
+        assert!(plan.ephemeral && plan.immutable);
+        assert_eq!(plan.plan_id, format!("plan-{}", &plan.plan_hash[..24]));
         assert!(!plan.planned_changes.is_empty());
+    }
+
+    #[test]
+    fn identical_requests_produce_deterministic_immutable_plans() {
+        let request = PlanRequest {
+            cluster: "local-dev".to_string(),
+            reason: "capacity preparation".to_string(),
+            desired: CreateTopicDesiredState {
+                topic: "orders".to_string(),
+                read_queue_nums: Some(8),
+                write_queue_nums: Some(8),
+                perm: Some("read_write".to_string()),
+            },
+        };
+        let first = plan_create_topic(request.clone());
+        let second = plan_create_topic(request);
+
+        assert_eq!(first.plan_hash, second.plan_hash);
+        assert_eq!(first.precondition_hash, second.precondition_hash);
+        assert_eq!(first.plan_id, second.plan_id);
+        assert_eq!(first.expires_in_seconds, PLAN_TTL_SECONDS);
+    }
+
+    #[test]
+    fn changing_current_state_changes_precondition_and_plan_hash() {
+        let request = PlanRequest {
+            cluster: "local-dev".to_string(),
+            reason: "capacity preparation".to_string(),
+            desired: CreateTopicDesiredState {
+                topic: "orders".to_string(),
+                read_queue_nums: Some(8),
+                write_queue_nums: Some(8),
+                perm: Some("read_write".to_string()),
+            },
+        };
+        let absent = plan_create_topic_with_current_state(request.clone(), serde_json::json!({"exists": false}));
+        let present = plan_create_topic_with_current_state(request, serde_json::json!({"exists": true}));
+
+        assert_ne!(absent.precondition_hash, present.precondition_hash);
+        assert_ne!(absent.plan_hash, present.plan_hash);
+        assert_ne!(absent.plan_id, present.plan_id);
+    }
+
+    #[test]
+    fn plan_requests_reject_legacy_execution_fields() {
+        let request = serde_json::json!({
+            "cluster": "local-dev",
+            "reason": "capacity preparation",
+            "desired": { "topic": "orders" },
+            "mode": "apply",
+        });
+        assert!(serde_json::from_value::<CreateTopicArgs>(request).is_err());
+
+        let request = serde_json::json!({
+            "cluster": "local-dev",
+            "reason": "capacity preparation",
+            "desired": { "topic": "orders" },
+            "operator": "alice",
+        });
+        assert!(serde_json::from_value::<CreateTopicArgs>(request).is_err());
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -311,9 +311,19 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
-                let output = change_tools::plan_create_topic(args);
-                let summary = summary_change_plan(&output);
-                success_live_result(descriptor, request_id, cluster, summary, output)
+                self.adapter
+                    .list_topics(topic_tools::ListTopicsArgs {
+                        cluster: Some(cluster.clone()),
+                        filter: None,
+                        page: crate::model::contract::PageRequest::default(),
+                    })
+                    .await
+                    .and_then(|current| {
+                        let current = canonical_current_state(&current)?;
+                        let output = change_tools::plan_create_topic_with_current_state(args, current);
+                        let summary = summary_change_plan(&output);
+                        success_live_result(descriptor, request_id, cluster, summary, output)
+                    })
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateTopicConfig => {
@@ -322,9 +332,19 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
-                let output = change_tools::plan_update_topic_config(args);
-                let summary = summary_change_plan(&output);
-                success_live_result(descriptor, request_id, cluster, summary, output)
+                self.adapter
+                    .describe_topic(topic_tools::DescribeTopicArgs {
+                        cluster: cluster.clone(),
+                        topic: args.desired.topic.clone(),
+                        page: crate::model::contract::PageRequest::default(),
+                    })
+                    .await
+                    .and_then(|current| {
+                        let current = canonical_current_state(&current)?;
+                        let output = change_tools::plan_update_topic_config_with_current_state(args, current);
+                        let summary = summary_change_plan(&output);
+                        success_live_result(descriptor, request_id, cluster, summary, output)
+                    })
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateTopicPermissions => {
@@ -333,9 +353,19 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
-                let output = change_tools::plan_update_topic_perm(args);
-                let summary = summary_change_plan(&output);
-                success_live_result(descriptor, request_id, cluster, summary, output)
+                self.adapter
+                    .describe_topic(topic_tools::DescribeTopicArgs {
+                        cluster: cluster.clone(),
+                        topic: args.desired.topic.clone(),
+                        page: crate::model::contract::PageRequest::default(),
+                    })
+                    .await
+                    .and_then(|current| {
+                        let current = canonical_current_state(&current)?;
+                        let output = change_tools::plan_update_topic_perm_with_current_state(args, current);
+                        let summary = summary_change_plan(&output);
+                        success_live_result(descriptor, request_id, cluster, summary, output)
+                    })
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanUpdateBrokerConfig => {
@@ -344,9 +374,18 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
-                let output = change_tools::plan_update_broker_config(args);
-                let summary = summary_change_plan(&output);
-                success_live_result(descriptor, request_id, cluster, summary, output)
+                self.adapter
+                    .describe_broker(broker_tools::DescribeBrokerArgs {
+                        cluster: cluster.clone(),
+                        broker_name: args.desired.broker_name.clone(),
+                    })
+                    .await
+                    .and_then(|current| {
+                        let current = canonical_current_state(&current)?;
+                        let output = change_tools::plan_update_broker_config_with_current_state(args, current);
+                        let summary = summary_change_plan(&output);
+                        success_live_result(descriptor, request_id, cluster, summary, output)
+                    })
             }
             #[cfg(feature = "change-planning")]
             ToolId::PlanResetConsumerOffset => {
@@ -355,9 +394,20 @@ where
                     Err(error) => return Ok(guarded_call.finish_result(error_result(&tool_name, request_id, error))),
                 };
                 let cluster = args.cluster.clone();
-                let output = change_tools::plan_reset_consumer_offset(args);
-                let summary = summary_change_plan(&output);
-                success_live_result(descriptor, request_id, cluster, summary, output)
+                self.adapter
+                    .query_consumer_lag(consumer_tools::QueryConsumerLagArgs {
+                        cluster: cluster.clone(),
+                        topic: args.desired.topic.clone(),
+                        consumer_group: args.desired.consumer_group.clone(),
+                        page: crate::model::contract::PageRequest::default(),
+                    })
+                    .await
+                    .and_then(|current| {
+                        let current = canonical_current_state(&current)?;
+                        let output = change_tools::plan_reset_consumer_offset_with_current_state(args, current);
+                        let summary = summary_change_plan(&output);
+                        success_live_result(descriptor, request_id, cluster, summary, output)
+                    })
             }
         };
 
@@ -555,6 +605,25 @@ fn summary_change_plan(output: &change_tools::ChangePlan) -> String {
     )
 }
 
+#[cfg(feature = "change-planning")]
+fn canonical_current_state<T: Serialize>(current: &QueryResult<T>) -> Result<Value, ToolExecutionError> {
+    let mut state = serde_json::to_value(&current.data).map_err(ToolExecutionError::internal)?;
+    remove_transient_state_fields(&mut state);
+    Ok(state)
+}
+
+#[cfg(feature = "change-planning")]
+fn remove_transient_state_fields(value: &mut Value) {
+    match value {
+        Value::Array(values) => values.iter_mut().for_each(remove_transient_state_fields),
+        Value::Object(values) => {
+            values.remove("generated_at");
+            values.values_mut().for_each(remove_transient_state_fields);
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::AuditConfig;
@@ -593,9 +662,20 @@ mod tests {
 
         async fn list_topics(
             &self,
-            _args: topic_tools::ListTopicsArgs,
+            args: topic_tools::ListTopicsArgs,
         ) -> Result<QueryResult<topic_tools::ListTopicsOutput>, ToolExecutionError> {
-            unimplemented!("not needed by this test")
+            Ok(QueryResult::bypass(topic_tools::ListTopicsOutput {
+                cluster: args.cluster.unwrap_or_else(|| "local-dev".to_string()),
+                namesrv_addr: "127.0.0.1:9876".to_string(),
+                page: crate::model::contract::Page {
+                    items: Vec::new(),
+                    count: 0,
+                    total_count: 0,
+                    has_more: false,
+                    next_cursor: None,
+                },
+                generated_at: "transient-test-time".to_string(),
+            }))
         }
 
         async fn describe_topic(
@@ -785,7 +865,41 @@ mod tests {
         let structured = result.structured_content.as_ref().unwrap();
         assert_eq!(structured["data"]["plan_type"], "create_topic");
         assert_eq!(structured["data"]["mutates_cluster"], false);
+        assert_eq!(structured["data"]["ephemeral"], true);
+        assert_eq!(structured["data"]["immutable"], true);
+        assert!(structured["data"]["current_state"].get("generated_at").is_none());
         assert_eq!(guard.audit_log().records()[0].status, AuditStatus::Success);
+    }
+
+    #[cfg(feature = "change-planning")]
+    #[test]
+    fn current_state_snapshot_excludes_transient_fields() {
+        let first = QueryResult {
+            data: serde_json::json!({
+                "value": "unchanged",
+                "nested": { "generated_at": "first" },
+                "generated_at": "first",
+            }),
+            observed_at: "first".to_string(),
+            freshness_ms: 0,
+            cache_status: crate::model::contract::CacheStatus::Bypass,
+        };
+        let second = QueryResult {
+            data: serde_json::json!({
+                "value": "unchanged",
+                "nested": { "generated_at": "second" },
+                "generated_at": "second",
+            }),
+            observed_at: "second".to_string(),
+            freshness_ms: 100,
+            cache_status: crate::model::contract::CacheStatus::Hit,
+        };
+
+        let first = canonical_current_state(&first).unwrap();
+        let second = canonical_current_state(&second).unwrap();
+
+        assert_eq!(first, serde_json::json!({ "value": "unchanged", "nested": {} }));
+        assert_eq!(first, second);
     }
 
     #[cfg(feature = "change-planning")]

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -1,6 +1,6 @@
 ---
 source: rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
-assertion_line: 354
+assertion_line: 364
 expression: contracts
 ---
 [
@@ -2022,6 +2022,18 @@ expression: contracts
             "cluster": {
               "type": "string"
             },
+            "current_state": true,
+            "ephemeral": {
+              "type": "boolean"
+            },
+            "expires_in_seconds": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "immutable": {
+              "type": "boolean"
+            },
             "impact_analysis": {
               "items": {
                 "type": "string"
@@ -2030,6 +2042,12 @@ expression: contracts
             },
             "mutates_cluster": {
               "type": "boolean"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "plan_id": {
+              "type": "string"
             },
             "plan_type": {
               "$ref": "#/$defs/ChangePlanType"
@@ -2040,6 +2058,9 @@ expression: contracts
               },
               "type": "array"
             },
+            "precondition_hash": {
+              "type": "string"
+            },
             "reason": {
               "type": "string"
             },
@@ -2049,11 +2070,22 @@ expression: contracts
               },
               "type": "array"
             },
+            "schema_version": {
+              "type": "string"
+            },
             "summary": {
               "type": "string"
             }
           },
           "required": [
+            "schema_version",
+            "plan_id",
+            "plan_hash",
+            "precondition_hash",
+            "current_state",
+            "expires_in_seconds",
+            "ephemeral",
+            "immutable",
             "plan_type",
             "cluster",
             "reason",
@@ -2197,6 +2229,18 @@ expression: contracts
             "cluster": {
               "type": "string"
             },
+            "current_state": true,
+            "ephemeral": {
+              "type": "boolean"
+            },
+            "expires_in_seconds": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "immutable": {
+              "type": "boolean"
+            },
             "impact_analysis": {
               "items": {
                 "type": "string"
@@ -2205,6 +2249,12 @@ expression: contracts
             },
             "mutates_cluster": {
               "type": "boolean"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "plan_id": {
+              "type": "string"
             },
             "plan_type": {
               "$ref": "#/$defs/ChangePlanType"
@@ -2215,6 +2265,9 @@ expression: contracts
               },
               "type": "array"
             },
+            "precondition_hash": {
+              "type": "string"
+            },
             "reason": {
               "type": "string"
             },
@@ -2224,11 +2277,22 @@ expression: contracts
               },
               "type": "array"
             },
+            "schema_version": {
+              "type": "string"
+            },
             "summary": {
               "type": "string"
             }
           },
           "required": [
+            "schema_version",
+            "plan_id",
+            "plan_hash",
+            "precondition_hash",
+            "current_state",
+            "expires_in_seconds",
+            "ephemeral",
+            "immutable",
             "plan_type",
             "cluster",
             "reason",
@@ -2368,6 +2432,18 @@ expression: contracts
             "cluster": {
               "type": "string"
             },
+            "current_state": true,
+            "ephemeral": {
+              "type": "boolean"
+            },
+            "expires_in_seconds": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "immutable": {
+              "type": "boolean"
+            },
             "impact_analysis": {
               "items": {
                 "type": "string"
@@ -2376,6 +2452,12 @@ expression: contracts
             },
             "mutates_cluster": {
               "type": "boolean"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "plan_id": {
+              "type": "string"
             },
             "plan_type": {
               "$ref": "#/$defs/ChangePlanType"
@@ -2386,6 +2468,9 @@ expression: contracts
               },
               "type": "array"
             },
+            "precondition_hash": {
+              "type": "string"
+            },
             "reason": {
               "type": "string"
             },
@@ -2395,11 +2480,22 @@ expression: contracts
               },
               "type": "array"
             },
+            "schema_version": {
+              "type": "string"
+            },
             "summary": {
               "type": "string"
             }
           },
           "required": [
+            "schema_version",
+            "plan_id",
+            "plan_hash",
+            "precondition_hash",
+            "current_state",
+            "expires_in_seconds",
+            "ephemeral",
+            "immutable",
             "plan_type",
             "cluster",
             "reason",
@@ -2543,6 +2639,18 @@ expression: contracts
             "cluster": {
               "type": "string"
             },
+            "current_state": true,
+            "ephemeral": {
+              "type": "boolean"
+            },
+            "expires_in_seconds": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "immutable": {
+              "type": "boolean"
+            },
             "impact_analysis": {
               "items": {
                 "type": "string"
@@ -2551,6 +2659,12 @@ expression: contracts
             },
             "mutates_cluster": {
               "type": "boolean"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "plan_id": {
+              "type": "string"
             },
             "plan_type": {
               "$ref": "#/$defs/ChangePlanType"
@@ -2561,6 +2675,9 @@ expression: contracts
               },
               "type": "array"
             },
+            "precondition_hash": {
+              "type": "string"
+            },
             "reason": {
               "type": "string"
             },
@@ -2570,11 +2687,22 @@ expression: contracts
               },
               "type": "array"
             },
+            "schema_version": {
+              "type": "string"
+            },
             "summary": {
               "type": "string"
             }
           },
           "required": [
+            "schema_version",
+            "plan_id",
+            "plan_hash",
+            "precondition_hash",
+            "current_state",
+            "expires_in_seconds",
+            "ephemeral",
+            "immutable",
             "plan_type",
             "cluster",
             "reason",
@@ -2730,6 +2858,18 @@ expression: contracts
             "cluster": {
               "type": "string"
             },
+            "current_state": true,
+            "ephemeral": {
+              "type": "boolean"
+            },
+            "expires_in_seconds": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "immutable": {
+              "type": "boolean"
+            },
             "impact_analysis": {
               "items": {
                 "type": "string"
@@ -2738,6 +2878,12 @@ expression: contracts
             },
             "mutates_cluster": {
               "type": "boolean"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "plan_id": {
+              "type": "string"
             },
             "plan_type": {
               "$ref": "#/$defs/ChangePlanType"
@@ -2748,6 +2894,9 @@ expression: contracts
               },
               "type": "array"
             },
+            "precondition_hash": {
+              "type": "string"
+            },
             "reason": {
               "type": "string"
             },
@@ -2757,11 +2906,22 @@ expression: contracts
               },
               "type": "array"
             },
+            "schema_version": {
+              "type": "string"
+            },
             "summary": {
               "type": "string"
             }
           },
           "required": [
+            "schema_version",
+            "plan_id",
+            "plan_hash",
+            "precondition_hash",
+            "current_state",
+            "expires_in_seconds",
+            "ephemeral",
+            "immutable",
             "plan_type",
             "cluster",
             "reason",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8174

### Brief Description

- Query live RocketMQ state before generating each change plan, and bind the
  immutable, ephemeral plan to a canonical precondition hash.
- Reject legacy execution fields, enforce the five canonical read-only plan
  Tool contracts, and update their MCP schema snapshots.
- Document the separate future Change Executor boundary in ADR-009.

### How Did You Test This Change?

- `cargo test -p rocketmq-mcp --all-features` (88 unit tests and 2 integration
  tests passed; 1 external-cluster test remained ignored because its required
  environment was not configured)
- `cargo check -p rocketmq-mcp`
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings`
- `cargo doc -p rocketmq-mcp --no-deps`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured, read-only change plans with unique identifiers, expiration details, immutable status, and precondition tracking.
  * Plans now capture a consistent current-state snapshot and generate deterministic hashes for validation.
  * Added safeguards to exclude transient data from state snapshots.

* **Documentation**
  * Documented that change planning is non-mutating and that any future execution capability must be provided by a separately reviewed service.

* **Tests**
  * Expanded coverage for deterministic plan identity, state-sensitive validation, read-only behavior, and transient-field filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->