### PR TITLE
[ISSUE #8177]🐛Client fallback task completion can race with lease release

### DIFF
--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -197,8 +197,9 @@ where
     let (completion_tx, completion_rx) = std_mpsc::channel();
     task_group
         .spawn_service(task_name, async move {
-            let _fallback_lease = fallback_lease;
+            // Notify waiters only after the fallback lease is released.
             let _completion = ClientTrackedTaskCompletion::new(completion_tx);
+            let _fallback_lease = fallback_lease;
             task.await;
         })
         .map_err(io::Error::other)?;
@@ -435,8 +436,9 @@ where
     let (completion_tx, completion_rx) = std_mpsc::channel();
     let task_id = task_group
         .spawn_service(task_name, async move {
-            let _fallback_guard = fallback_guard;
+            // Notify waiters only after fallback bookkeeping is released.
             let _completion = ClientTrackedTaskCompletion::new(completion_tx);
+            let _fallback_guard = fallback_guard;
             task.await;
         })
         .map_err(io::Error::other)?;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #8177 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion handling to ensure completion notifications are sent only after related cleanup and bookkeeping are finalized.
  * Increased reliability for clients waiting on tracked task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->