### PR TITLE
[ISSUE #8218]♻️Close the storage dependency graph and consumer boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ rocketmq-security-api = { version = "1.0.0", path = "./rocketmq-security-api" }
 rocketmq-store-api     = { version = "1.0.0", path = "./rocketmq-store-api", default-features = false }
 rocketmq-store-local   = { version = "1.0.0", path = "./rocketmq-store-local", default-features = false }
 rocketmq-store-rocksdb = { version = "1.0.0", path = "./rocketmq-store-rocksdb", default-features = false }
+rocketmq-tieredstore   = { version = "1.0.0", path = "./rocketmq-tieredstore" }
 rocketmq-transport    = { version = "1.0.0", path = "./rocketmq-transport", default-features = false }
 
 tokio        = { version = "1.52", features = ["full"] }

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 39 | 0 | 43 未开始；合计 43 尚未完成 | 82 |
-| 里程碑 | 5（M01–M05） | 1（M06） | 6（M07–M12） | 12 |
+| PR 级工作包 | 40 | 0 | 42 未开始；合计 42 尚未完成 | 82 |
+| 里程碑 | 6（M01–M06） | 0 | 6（M07–M12） | 12 |
 | 新增边界 crate | 7 | 0 | 3（proxy-core/cluster/local） | 10 |
 | 根 workspace package | 29 | — | 还差 3 | 32 |
 | Phase Gate | 1 | 1（Phase 2） | 2（Phase 3、Phase 4） | 4 |
 
-剩余 43 个未开始工作包分布：M06-12 为 1 个、M07 为 7 个、M08 为 6 个、M09 为 6 个、
-M10 为 5 个、M11 为 12 个、M12 为 6 个。PR-M06-11 已完成 Store facade、Tiered 反转与 feature 所有权；当前下一工作包为 PR-M06-12。
+剩余 42 个未开始工作包分布：M07 为 7 个、M08 为 6 个、M09 为 6 个、M10 为 5 个、M11 为 12 个、
+M12 为 6 个。PR-M06-12 已完成依赖图与消费方收口，M06 Gate 已关闭；当前下一工作包为 PR-M07-01。
 
 ## 3. Phase 1：安全性与基础治理
 
@@ -232,8 +232,15 @@ M10 为 5 个、M11 为 12 个、M12 为 6 个。PR-M06-11 已完成 Store facad
   - [x] no-default/default/local/fast/safe/fast+safe/io_uring/rocks/tiered/observability 精确矩阵全部通过
   - [x] Tiered lifecycle、写入 dispatch、读取 fallback、fast+safe 优先级与 195 项 M06 contract 通过
   - [x] 独立兼容 ledger、7 条 ArcMut 一对一 relocation 与 39/43 顶层工作包盘点已冻结
-- [ ] PR-M06-12：完成依赖图与消费方收口
-- [ ] 对应任务文档的 Exit Checklist 全部通过
+- [x] PR-M06-12：完成依赖图与消费方收口
+  - [x] root workspace 统一登记 API/Local/Rocks/Tiered dependency，当前 29/32，剩余仅三个 Proxy package
+  - [x] architecture policy 新增 Store facade 禁止反向依赖 Client/Broker/NameServer/Controller/Proxy 的规则
+  - [x] storage 子图精确冻结为 `api ← local ← rocks`、`api ← tiered` 与 `store → 四个 owner`
+  - [x] Broker send processor 直连 `MessageAppender + StoreHealth`；Store facade consumer 固定为 Broker/Proxy/store-inspect
+  - [x] 四个 standalone Cargo 项目无 storage 直接边，canonical/legacy compile 与十项 feature matrix 通过
+  - [x] 完整 M06 contract 200/200、architecture/runtime/ArcMut/routing 与 consumer all-feature checks 通过
+  - [x] closeout ledger、回滚点、M07/M09/M10 交接物与 40/42 顶层工作包盘点已冻结
+- [x] 对应任务文档的 Exit Checklist 全部通过
 
 ### M07 Legacy Runtime 排空与 Client 依赖边收敛
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,6 +1,6 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 2，M04/M05 已完成，M06 进行中）
+> 状态：实施中（Phase 2，M04/M05/M06 已完成，下一工作包为 PR-M07-01）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/06-storage-boundary-extraction.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/06-storage-boundary-extraction.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 2：核心边界与 API 收敛 |
-| 状态 | 进行中；M06-01/M06-02/PR-M06-03/PR-M06-04/PR-M06-05/PR-M06-06/PR-M06-07/PR-M06-08/PR-M06-09/PR-M06-10/PR-M06-11 已完成，继续 PR-M06-12 |
+| 状态 | 已完成；M06-01～M06-12、兼容台账、依赖图、消费方验证与 Exit Checklist 已关闭 |
 | 预计周期 | 4–6 周 |
 | 工作包 | WP11 `storage-capability-spike`、WP12 `store-local-extract`、WP13 `store-rocks-extract`；承接 WP02 |
 | 前置条件 | flush/watermark 语义稳定；model 查询值可用；storage golden 和 RocksDB baseline 已冻结 |
@@ -29,7 +29,7 @@
 ## 入口条件
 
 - [x] `[ARCH]` 冻结 capability、AppendReceipt/DerivedProgress/StoreError 语义和 legacy adapter 边界。
-- [ ] `[TEST]` 准备 dirty-tail、flush、HA、recovery、20B CQ/Index、Local/Rocks parity corpus。
+- [x] `[TEST]` 准备 dirty-tail、flush、HA、recovery、20B CQ/Index、Local/Rocks parity corpus。
 - [x] `[DEV]` 检查 store/broker/tieredstore 目标文件和现有用户修改无重叠。
 - [x] `[HUMAN]` 批准 CommitLog 唯一 WAL 与 `rocks → local → api` 单向关系。
 
@@ -157,12 +157,12 @@
 
 ### PR-M06-12：依赖图与消费方收口
 
-- [ ] 入口：`[TEST]` PR-M06-03至11的focused evidence齐全且对应同一候选快照。
-- [ ] `[DEV]` 更新root workspace和dependency policy；累计package数增加3；新processor直连store-api。
-- [ ] `[TEST]` 运行canonical/legacy compile、完整精确feature矩阵、Broker和受影响standalone path consumers。
-- [ ] `[REV]` 证明local/rocks/tiered/facade四个closure符合目标DAG，机械迁移与行为修复提交可追溯分离。
-- [ ] 回滚点：closeout失败返回具体PR修复并重新冻结，不通过扩大policy baseline收口。
-- [ ] `[HUMAN]` 签署storage compatibility、唯一WAL和M06 Gate。
+- [x] 入口：`[TEST]` PR-M06-03至11的focused evidence齐全且对应同一候选快照。
+- [x] `[DEV]` 更新root workspace和dependency policy；累计package数增加3；新processor直连store-api。
+- [x] `[TEST]` 运行canonical/legacy compile、完整精确feature矩阵、Broker和受影响standalone path consumers。
+- [x] `[REV]` 证明local/rocks/tiered/facade四个closure符合目标DAG，机械迁移与行为修复提交可追溯分离。
+- [x] 回滚点：closeout失败返回具体PR修复并重新冻结，不通过扩大policy baseline收口。
+- [x] `[HUMAN]` 签署storage compatibility、唯一WAL和M06 Gate。
 
 ## 公共兼容面
 
@@ -220,14 +220,14 @@ python scripts/arc_mut_guard.py
 
 ## Exit Checklist
 
-- [ ] `[REV]` store-api 无实现泄漏，capability 足够窄。
-- [ ] `[TEST]` Local dirty-tail/flush/HA/CQ/Index/recovery golden 全绿。
-- [ ] `[TEST]` Rocks foundation/semantics/Broker parity 全绿，默认 tree 无 native RocksDB。
-- [ ] `[REV]` CommitLog 只在 Local，Rocks/Tiered 只持派生状态。
-- [ ] `[DEV]` store facade 无算法回流，旧路径/feature alias 可编译。
-- [ ] `[TEST]` 精确 feature matrix 和受影响 consumer 验证完成。
-- [ ] `[DEV]` dependency policy/package 数与实际一致。
-- [ ] `[HUMAN]` 唯一 WAL、持久兼容与 M06 Gate 已签署。
+- [x] `[REV]` store-api 无实现泄漏，capability 足够窄。
+- [x] `[TEST]` Local dirty-tail/flush/HA/CQ/Index/recovery golden 全绿。
+- [x] `[TEST]` Rocks foundation/semantics/Broker parity 全绿，默认 tree 无 native RocksDB。
+- [x] `[REV]` CommitLog 只在 Local，Rocks/Tiered 只持派生状态。
+- [x] `[DEV]` store facade 无算法回流，旧路径/feature alias 可编译。
+- [x] `[TEST]` 精确 feature matrix 和受影响 consumer 验证完成。
+- [x] `[DEV]` dependency policy/package 数与实际一致。
+- [x] `[HUMAN]` 唯一 WAL、持久兼容与 M06 Gate 已签署。
 
 ## 交接物
 
@@ -2495,3 +2495,28 @@ python scripts/arc_mut_guard.py
   分别回滚；legacy re-export/no-default Local path 始终保留，不得恢复第二 CommitLog 或 Tiered→Store 反向依赖。
 - [x] `[INVENTORY]` PR-M06-11 父项关闭；82 个顶层工作包更新为 39 已完成、0 进行中、43 未开始，即 43 个尚未完成。
   M06 整体仍进行中且 Exit Checklist 保持未完成；唯一下一工作包为 PR-M06-12。
+
+## M06-12 Storage 依赖图与消费方收口 evidence
+
+- [x] `[ARCH/DAG]` root workspace 统一登记 Tiered owner，Store 的 Tiered 边改用 workspace dependency；最终 storage
+  子图精确固定为 Local→API、Rocks→Local/API、Tiered→API、Store→API/Local/Rocks/Tiered。Architecture policy 新增
+  `store-facade-no-high-level-services`，禁止 Store facade 直接依赖 Client、Broker、NameServer、Controller 或 Proxy，且未扩大 baseline。
+- [x] `[CONSUMER]` root workspace 直接 consumer inventory 已逐 manifest 冻结：API 由 Broker/Store/Local/Rocks/Tiered
+  消费，Store 由 Broker/Proxy/store-inspect 消费，Local 由 Store/Rocks 消费，Rocks 与 Tiered 均只由 Store 消费；Broker
+  `send_message_processor.rs` 是唯一直接消费 Store API 的 Broker source，并通过 `MessageAppender + StoreHealth` 使用 capability。
+  四个 standalone Cargo 项目均无 storage package 直接边，因此没有遗漏的 standalone consumer 迁移。
+- [x] `[TEST/CANONICAL]` Store API no-default check 与 18 项 contract、Local no-default check 与 185 项 all-feature lib、
+  Rocks no-default check 与 4 项 owner test、Tiered all-feature lib 55/55、Store legacy adapter 9/9 全部通过。
+- [x] `[TEST/MATRIX]` Store no-default、default、local、fast、safe、fast+safe、io_uring、rocksdb_store、tieredstore、
+  observability 十项精确 feature matrix 逐项通过；Broker、Proxy、store-inspect 三个实际 facade consumer 的 all-feature check 通过。
+- [x] `[CONTRACT/GOVERNANCE]` 新增 5 项 closeout contract 后完整 M06 contract 200/200（606.671s）通过；architecture
+  dependency 35 项单测与 6 个 violation fixtures、ArcMut guard、runtime enforcing audit、AGENTS routing 均通过。
+- [x] `[ERROR]` error architecture guard 仅复现 main 既有 11 项：Broker source stringification 1、MCP anyhow 8、缺失
+  治理文档 2；本工作包没有新增 finding，仍诚实记录为 pre-existing failure，不计为通过。
+- [x] `[FINAL]` workspace exact fmt 与 workspace all-target/all-feature strict Clippy 通过；最终 closeout contract 5/5、
+  architecture dependency baseline、ArcMut guard、Python compile、82 项 checklist 计数（40/42）与 `git diff --check` 同步通过。
+- [x] `[COMPAT/ROLLBACK]` 独立
+  [`09-storage-dependency-consumer-closeout.md`](09-storage-dependency-consumer-closeout.md) 冻结最终 DAG、consumer inventory、
+  feature/consumer 验证、失败路由和分层回滚点；回滚不得恢复第二 CommitLog、backend→Store 反向边或关闭 R0 legacy path。
+- [x] `[INVENTORY/GATE]` PR-M06-12 与 M06 Exit Checklist 全部关闭；82 个顶层工作包更新为 40 已完成、0 进行中、
+  42 未开始。M06 Gate 完成，下一目标为 PR-M07-01 Legacy Runtime 排空。

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-storage-dependency-consumer-closeout.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-storage-dependency-consumer-closeout.md
@@ -1,0 +1,84 @@
+# PR-M06-12 Storage 依赖图与消费方收口
+
+## 元数据
+
+| 字段 | 值 |
+|---|---|
+| 所属里程碑 | M06 Store API、Local 与 RocksDB 边界提取 |
+| 状态 | 已完成；M06 Gate 已关闭 |
+| 候选快照 | PR-M06-03～M06-12 的同一 main 继承链 |
+| 下一工作包 | PR-M07-01 Legacy Runtime 排空 |
+
+## 目标完成定义
+
+- root workspace 同时登记 `rocketmq-store-api`、`rocketmq-store-local`、`rocketmq-store-rocksdb`、`rocketmq-tieredstore` 与 Store facade，新增三个 storage package 后为 29/32。
+- storage 子图中不存在 backend→facade 或 backend→高层 service 反向边；Store facade 不得依赖 Client、Broker、NameServer、Controller 或 Proxy。
+- Broker send processor 直接消费 `MessageAppender + StoreHealth`，legacy adapter 仍由 Store facade 提供。
+- canonical owner、legacy path、十项 feature matrix、实际 facade consumer 与 standalone inventory 在同一候选快照验证。
+- 唯一 CommitLog/WAL、20B CQ/Index、Rocks column family、Tiered 派生状态和 R0 public path 兼容签署不变。
+
+## 最终 Storage 子图
+
+```mermaid
+flowchart TD
+    API["rocketmq-store-api"]
+    LOCAL["rocketmq-store-local\n唯一 CommitLog/WAL"]
+    ROCKS["rocketmq-store-rocksdb\nCQ/Index 派生状态"]
+    TIERED["rocketmq-tieredstore\nTiered 派生状态"]
+    STORE["rocketmq-store\ncomposition + compatibility facade"]
+    BROKER["rocketmq-broker\nsend processor capability consumer"]
+
+    LOCAL --> API
+    ROCKS --> LOCAL
+    ROCKS --> API
+    TIERED --> API
+    STORE --> API
+    STORE --> LOCAL
+    STORE --> ROCKS
+    STORE --> TIERED
+    BROKER --> API
+    BROKER --> STORE
+```
+
+## 精确 Consumer Inventory
+
+| Target | root workspace 直接 consumer |
+|---|---|
+| `rocketmq-store-api` | Broker、Store facade、Local、Rocks、Tiered |
+| `rocketmq-store` | Broker、Proxy、store-inspect |
+| `rocketmq-store-local` | Store facade、Rocks |
+| `rocketmq-store-rocksdb` | Store facade |
+| `rocketmq-tieredstore` | Store facade |
+
+四个 standalone Cargo 项目（example、Dashboard GPUI、Tauri backend、Web backend）均无 storage package 直接依赖，
+因此本工作包不存在需要迁移的 standalone storage consumer；该“零边”由 source contract 固定，不以目录名称推断。
+
+## 实施结果
+
+- root `[workspace.dependencies]` 新增 `rocketmq-tieredstore`，Store 改用 `workspace = true, optional = true`，保留 Tiered 默认 provider feature。
+- architecture dependency policy 新增 `store-facade-no-high-level-services`，禁止 Store facade 直接依赖 Client/Broker/NameServer/Controller/Proxy；没有扩大 baseline。
+- 新增 `test_m06_storage_closeout_contract.py` 5 项，精确冻结 package count、workspace registration、storage subgraph、policy、consumer inventory、standalone 零边和 Broker capability consumer。
+- 当前 root workspace 为 29/32；尚未创建的 package 仅为 `rocketmq-proxy-core`、`rocketmq-proxy-cluster`、`rocketmq-proxy-local`，由 M08 负责。
+
+## 验证证据
+
+- Store API no-default check 与 18 项 unit/integration contract 通过；Local no-default check 与 185 项 all-feature lib 通过。
+- Rocks no-default check 与 4 项 owner test 通过；Tiered all-feature lib 55/55；Store legacy adapter 9/9。
+- Store no-default/default/local/fast/safe/fast+safe/io_uring/rocks/tiered/observability 十项 matrix 逐项通过。
+- Broker、Proxy、store-inspect 三个实际 Store facade consumer 的 all-feature check 通过；四个 standalone 的零直接边由 contract 证明。
+- 完整 M06 contract 200/200 通过（606.671s）。Architecture dependency baseline、35 项单测、6 个 violation fixtures、ArcMut guard、runtime enforcing audit 与 AGENTS routing 通过。
+- Error architecture guard 仅复现 main 既有 11 项（Broker source stringification 1、MCP anyhow 8、缺失治理文档 2）；本工作包无新增 finding，不将该门禁记为通过。
+
+## 回滚与失败路由
+
+1. root Tiered workspace dependency 可恢复为 Store 的等价直接 path dependency，不改变 feature、provider 或运行行为。
+2. policy 规则若误报，只能修正实际依赖或精确规则；不得扩大 architecture baseline 绕过失败。
+3. canonical/legacy compile、feature matrix 或 consumer check 任一失败，返回对应 PR-M06-03～M06-11 修复并重新冻结整个候选快照。
+4. 回滚不得恢复第二 CommitLog、backend→Store 反向边、native Rocks 默认依赖，或关闭 R0 legacy path。
+
+## M06 Gate 签署与交接
+
+- 唯一 WAL、持久格式、Store API 中立性、Local/Rocks/Tiered owner、Store facade 与兼容删除窗口已签署。
+- 向 M07 交付 Broker capability consumer、Store facade 可见性规则与 consumer inventory。
+- 向 M09 交付 Store facade/legacy path ledger 和下一 major 删除条件。
+- 向 M10 交付唯一 WAL、Local/Rocks parity、Tiered decorator、完整 feature matrix 与故障 corpus。

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -64,7 +64,7 @@ rocketmq-store-local = { workspace = true }
 rocketmq-store-rocksdb = { workspace = true, optional = true }
 rocketmq-observability = { workspace = true }
 rocketmq-runtime  = { workspace = true }
-rocketmq-tieredstore = { version = "1.0.0", path = "../rocketmq-tieredstore", optional = true }
+rocketmq-tieredstore = { workspace = true, optional = true }
 
 #tools
 dirs.workspace = true

--- a/scripts/architecture-dependency-policy.json
+++ b/scripts/architecture-dependency-policy.json
@@ -134,6 +134,17 @@
       ]
     },
     {
+      "id": "store-facade-no-high-level-services",
+      "callers": ["rocketmq-store"],
+      "forbidden_targets": [
+        "rocketmq-client-rust",
+        "rocketmq-broker",
+        "rocketmq-namesrv",
+        "rocketmq-controller",
+        "rocketmq-proxy"
+      ]
+    },
+    {
       "id": "proxy-local-no-client",
       "callers": ["rocketmq-proxy-local"],
       "forbidden_targets": ["rocketmq-client-rust"]

--- a/scripts/tests/test_m06_storage_closeout_contract.py
+++ b/scripts/tests/test_m06_storage_closeout_contract.py
@@ -1,0 +1,269 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "scripts" / "architecture-dependency-policy.json"
+STANDALONE_MANIFESTS = (
+    "rocketmq-example/Cargo.toml",
+    "rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml",
+    "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml",
+    "rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml",
+)
+STORAGE_PACKAGES = {
+    "rocketmq-store-api",
+    "rocketmq-store-local",
+    "rocketmq-store-rocksdb",
+    "rocketmq-tieredstore",
+    "rocketmq-store",
+}
+
+
+def load_manifest(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def normal_dependency_names(manifest: dict) -> set[str]:
+    tables = [manifest.get("dependencies", {})]
+    tables.extend(
+        target.get("dependencies", {})
+        for target in manifest.get("target", {}).values()
+    )
+    names: set[str] = set()
+    for table in tables:
+        for alias, specification in table.items():
+            package = (
+                specification.get("package")
+                if isinstance(specification, dict)
+                else None
+            )
+            names.add(package or alias)
+    return names
+
+
+def all_dependency_names(manifest: dict) -> set[str]:
+    names = normal_dependency_names(manifest)
+    for table_name in ("dev-dependencies", "build-dependencies"):
+        table = manifest.get(table_name, {})
+        for alias, specification in table.items():
+            package = (
+                specification.get("package")
+                if isinstance(specification, dict)
+                else None
+            )
+            names.add(package or alias)
+    for target in manifest.get("target", {}).values():
+        for table_name in ("dev-dependencies", "build-dependencies"):
+            table = target.get(table_name, {})
+            for alias, specification in table.items():
+                package = (
+                    specification.get("package")
+                    if isinstance(specification, dict)
+                    else None
+                )
+                names.add(package or alias)
+    return names
+
+
+def workspace_manifests() -> dict[str, tuple[Path, dict]]:
+    root = load_manifest(ROOT / "Cargo.toml")
+    manifests: dict[str, tuple[Path, dict]] = {}
+    for member in root["workspace"]["members"]:
+        path = ROOT / member / "Cargo.toml"
+        manifest = load_manifest(path)
+        manifests[manifest["package"]["name"]] = (path, manifest)
+    return manifests
+
+
+class StorageCloseoutContractTests(unittest.TestCase):
+    def test_workspace_registration_and_package_count_are_exact(self) -> None:
+        root = load_manifest(ROOT / "Cargo.toml")
+        members = root["workspace"]["members"]
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(29, len(members))
+        self.assertTrue(STORAGE_PACKAGES.issubset(set(members)))
+        self.assertEqual(32, policy["package_counts"]["target"])
+        self.assertEqual(
+            {
+                "rocketmq-proxy-core",
+                "rocketmq-proxy-cluster",
+                "rocketmq-proxy-local",
+            },
+            set(policy["planned_packages"]) - set(members),
+        )
+
+        dependencies = root["workspace"]["dependencies"]
+        for package in (
+            "rocketmq-store-api",
+            "rocketmq-store-local",
+            "rocketmq-store-rocksdb",
+        ):
+            self.assertFalse(dependencies[package]["default-features"], package)
+        self.assertEqual(
+            {
+                "version": "1.0.0",
+                "path": "./rocketmq-tieredstore",
+            },
+            dependencies["rocketmq-tieredstore"],
+        )
+
+    def test_storage_subgraph_matches_the_target_dag(self) -> None:
+        manifests = workspace_manifests()
+        actual = {
+            package: normal_dependency_names(manifests[package][1])
+            & STORAGE_PACKAGES
+            for package in STORAGE_PACKAGES
+        }
+        self.assertEqual(
+            {
+                "rocketmq-store-api": set(),
+                "rocketmq-store-local": {"rocketmq-store-api"},
+                "rocketmq-store-rocksdb": {
+                    "rocketmq-store-api",
+                    "rocketmq-store-local",
+                },
+                "rocketmq-tieredstore": {"rocketmq-store-api"},
+                "rocketmq-store": {
+                    "rocketmq-store-api",
+                    "rocketmq-store-local",
+                    "rocketmq-store-rocksdb",
+                    "rocketmq-tieredstore",
+                },
+            },
+            actual,
+        )
+
+        store = manifests["rocketmq-store"][1]["dependencies"]
+        self.assertEqual({"workspace": True}, store["rocketmq-store-api"])
+        self.assertEqual({"workspace": True}, store["rocketmq-store-local"])
+        self.assertEqual(
+            {"workspace": True, "optional": True},
+            store["rocketmq-store-rocksdb"],
+        )
+        self.assertEqual(
+            {"workspace": True, "optional": True},
+            store["rocketmq-tieredstore"],
+        )
+
+    def test_dependency_policy_freezes_backend_and_facade_direction(self) -> None:
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        rules = {rule["id"]: rule for rule in policy["package_rules"]}
+
+        self.assertEqual(
+            ["rocketmq-store"],
+            rules["store-facade-no-high-level-services"]["callers"],
+        )
+        self.assertEqual(
+            {
+                "rocketmq-client-rust",
+                "rocketmq-broker",
+                "rocketmq-namesrv",
+                "rocketmq-controller",
+                "rocketmq-proxy",
+            },
+            set(rules["store-facade-no-high-level-services"]["forbidden_targets"]),
+        )
+        self.assertEqual(
+            {"rocketmq-store-api"},
+            set(policy["target_dag"]["rocketmq-tieredstore"])
+            & STORAGE_PACKAGES,
+        )
+        self.assertEqual(
+            STORAGE_PACKAGES - {"rocketmq-store"},
+            set(policy["target_dag"]["rocketmq-store"]),
+        )
+
+    def test_workspace_and_standalone_consumer_inventory_is_exact(self) -> None:
+        manifests = workspace_manifests()
+        dependencies = {
+            package: normal_dependency_names(manifest)
+            for package, (_, manifest) in manifests.items()
+        }
+
+        consumers = {
+            target: {
+                package
+                for package, direct_dependencies in dependencies.items()
+                if target in direct_dependencies
+            }
+            for target in STORAGE_PACKAGES
+        }
+        self.assertEqual(
+            {
+                "rocketmq-broker",
+                "rocketmq-store",
+                "rocketmq-store-local",
+                "rocketmq-store-rocksdb",
+                "rocketmq-tieredstore",
+            },
+            consumers["rocketmq-store-api"],
+        )
+        self.assertEqual(
+            {"rocketmq-broker", "rocketmq-proxy", "rocketmq-store-inspect"},
+            consumers["rocketmq-store"],
+        )
+        self.assertEqual(
+            {"rocketmq-store", "rocketmq-store-rocksdb"},
+            consumers["rocketmq-store-local"],
+        )
+        self.assertEqual(
+            {"rocketmq-store"},
+            consumers["rocketmq-store-rocksdb"],
+        )
+        self.assertEqual({"rocketmq-store"}, consumers["rocketmq-tieredstore"])
+
+        for relative_path in STANDALONE_MANIFESTS:
+            manifest = load_manifest(ROOT / relative_path)
+            self.assertTrue(
+                STORAGE_PACKAGES.isdisjoint(all_dependency_names(manifest)),
+                relative_path,
+            )
+
+    def test_broker_send_processor_is_the_direct_capability_consumer(self) -> None:
+        broker_manifest = load_manifest(ROOT / "rocketmq-broker/Cargo.toml")
+        self.assertEqual(
+            {"workspace": True},
+            broker_manifest["dependencies"]["rocketmq-store-api"],
+        )
+
+        processor = (
+            ROOT / "rocketmq-broker/src/processor/send_message_processor.rs"
+        ).read_text(encoding="utf-8")
+        production = processor.split("#[cfg(test)]", 1)[0]
+        self.assertIn("use rocketmq_store_api::MessageAppender;", production)
+        self.assertIn("use rocketmq_store_api::StoreHealth;", production)
+        self.assertIn("S: MessageAppender<M>", production)
+        self.assertIn("S: StoreHealth<Snapshot = StoreHealthSnapshot>", production)
+
+        direct_broker_files = {
+            path.relative_to(ROOT).as_posix()
+            for path in (ROOT / "rocketmq-broker/src").rglob("*.rs")
+            if "rocketmq_store_api" in path.read_text(encoding="utf-8")
+        }
+        self.assertEqual(
+            {"rocketmq-broker/src/processor/send_message_processor.rs"},
+            direct_broker_files,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8218

### Brief Description

- Register the Tiered store owner as a workspace dependency while preserving the Store facade's optional feature behavior.
- Prevent the Store facade from acquiring direct dependencies on high-level client and service crates.
- Freeze the exact storage DAG, direct consumer inventory, standalone-project zero edges, and Broker capability consumer in five executable contracts.
- Close PR-M06-12 and the M06 gate with a dedicated rollback ledger and synchronized 40/82 migration checklist.

### How Did You Test This Change?

- Passed the five PR-M06-12 closeout contracts and the complete M06 contract suite (200/200).
- Passed Store API, Local, RocksDB, Tiered, and legacy adapter checks and tests (18, 185, 4, 55, and 9 tests respectively).
- Passed the exact ten-entry Store feature matrix and all-feature checks for Broker, Proxy, and store-inspect.
- Passed the architecture dependency baseline, 35 guard tests, six violation fixtures, ArcMut guard, enforcing runtime audit, and AGENTS routing check.
- Passed `cargo fmt --all -- --check` and workspace all-target/all-feature Clippy with warnings denied.
- The error architecture guard reproduced only the 11 findings already present on main; this PR adds no new finding and does not claim that pre-existing gate as passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Completed the storage architecture milestone and finalized its migration status.
  - Improved architectural boundaries and clarified how storage components interact.

- **Documentation**
  - Added comprehensive guidance covering storage boundaries, validation evidence, rollout handoff, and recovery procedures.
  - Updated project progress tracking and identified the next migration milestone.

- **Tests**
  - Added automated checks to verify storage architecture rules, component relationships, and consumer coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->