### PR TITLE
[ISSUE #8244]♻️Close Proxy composition facade boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,7 +4764,6 @@ dependencies = [
  "rocketmq-proxy-local",
  "rocketmq-remoting",
  "rocketmq-runtime",
- "rocketmq-rust",
  "serde",
  "serde_json",
  "sha1",

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,19 +29,35 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 51 | 0 | 31 未开始；合计 31 尚未完成 | 82 |
+| PR 级工作包 | 52 | 0 | 30 未开始；合计 30 尚未完成 | 82 |
 | 里程碑 | 7（M01–M07） | 1（M08） | 4（M09–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 1 | 1（Phase 2） | 2（Phase 3、Phase 4） | 4 |
 
-剩余 31 个未开始工作包分布：M08 为 2 个、M09 为 6 个、M10 为 5 个、M11 为 12 个、M12 为 6 个。
-PR-M08-04 已完成 Local adapter 与嵌入式 Broker runtime 的物理迁移；M08 进行中，当前下一工作包为 PR-M08-05。
+剩余 30 个未开始工作包分布：M08 为 1 个、M09 为 6 个、M10 为 5 个、M11 为 12 个、M12 为 6 个。
+PR-M08-05 已完成 Proxy composition/facade 收口与 R0 依赖/feature 语义冻结；M08 进行中，当前下一工作包为 PR-M08-06。
 
 目标态差距快照不能与工作包计数混用：`architecture_dependency_guard.py --mode target`
-当前 32 个目标 package 已全部创建，剩余 49 项差距：目标 DAG 直接边 47、传递闭包边 2。
+当前 32 个目标 package 已全部创建，剩余 48 项差距：目标 DAG 直接边 46、传递闭包边 2。
 `rocketmq-proxy-core`、`rocketmq-proxy-cluster` 与 `rocketmq-proxy-local` 均无所属边界的 target finding；Client 临时账本 manifest/source 均为 0，
 历史 Proxy manifest 1、source 13 已由 PR-M08-03 完整消费，后续工作不得恢复 facade 对完整 Client 的直接依赖。
+
+剩余目标差距按 caller 精确分布如下；这里是依赖目标态差距，不是剩余工作包数量：
+
+| Caller | 差距数 | 后续收口重点 |
+|---|---:|---|
+| `rocketmq-store` | 6 | Common/Error/Observability/Remoting/Runtime/legacy runtime |
+| `rocketmq-broker` | 5 | Common/Error/Remoting/Runtime/legacy runtime |
+| `rocketmq-remoting` | 5 | Common/Macros/Runtime/legacy runtime 与 facade 纯化 |
+| `rocketmq-namesrv` | 4 | Common/Error/Remoting/legacy runtime |
+| `rocketmq-proxy` | 4 | Common/Error/Model/Remoting ingress 兼容边；Client/Broker/Store/legacy runtime 已清零 |
+| `rocketmq-admin-cli`、`rocketmq-admin-tui`、`rocketmq-client-rust`、`rocketmq-controller`、`rocketmq-mcp`、`rocketmq-tieredstore` | 各 3 | M09 facade/consumer closeout 与后续 owner 收口 |
+| `rocketmq-auth` | 2 | 目标 DAG 直边收口 |
+| `rocketmq-common`、`rocketmq-filter`、`rocketmq-rust`、`rocketmq-store-inspect` | 各 1 | 单点 legacy/facade 边收口 |
+
+其中 46 项为直接边，另有 `rocketmq-tieredstore → rocketmq-common` 与
+`rocketmq-tieredstore → rocketmq-common → rocketmq-rust` 两项传递闭包差距；严格 target mode 仍应失败，直到 M09-01 收口为零。
 
 ## 3. Phase 1：安全性与基础治理
 
@@ -350,7 +366,15 @@ PR-M08-04 已完成 Local adapter 与嵌入式 Broker runtime 的物理迁移；
   - [x] baseline guard 通过；target guard 由 51 降至 49（目标 DAG 直接边 47 + 传递闭包边 2），无缺失计划 package，Core/Cluster/Local 均为零 finding
   - [x] architecture contract 354、ArcMut 实际 guard + fixture 24、runtime enforcing audit、32-package workspace fmt/strict Clippy 与 AGENTS routing 全绿；typed-error 仅复现 main 既有 11 项，零新增
   - [x] 51/82 已完成、31 未完成，下一工作包 PR-M08-05
-- [ ] PR-M08-05：将现有 Proxy 降为 composition/facade
+- [x] PR-M08-05：将现有 Proxy 降为 composition/facade
+  - [x] 删除 Proxy 未使用的 `rocketmq-rust` manifest/lockfile 直边，target gap 由 49 降至 48
+  - [x] facade 继续以非 optional 方式依赖 Core/Cluster/Local，保持 R0 `default = []`；未提前定义下一 major mode feature
+  - [x] ProxyConfig 继续持有 Serde/env/CLI envelope，并将 Core/Cluster/Local normalized config 交给各自 owner
+  - [x] processor/service/cluster/local 等业务 owner 路径保持精确 re-export；Proxy 只保留 bootstrap/config/auth/observability/binary、gRPC/Remoting ingress adapter 与兼容导出
+  - [x] 新增静态合同，禁止 Client/Broker/Store/legacy runtime 回流，并验证 Core/Local 不经 facade 反向到 Cluster/Client
+  - [x] Proxy default/no-default 各 82 unit + 1 binary + 4 compatibility + 9 gRPC + 3 Remoting 共 99 项通过
+  - [x] architecture contract 355、根 fmt/32-package strict Clippy、baseline guard、ArcMut、runtime audit、AGENTS routing 与 diff check 全绿；target 按预期精确剩余 48，typed-error 仅复现 main 既有 11 项
+  - [x] 52/82 已完成、30 未完成，下一工作包 PR-M08-06
 - [ ] PR-M08-06：验证 feature closure 与下一 major fixture
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 2，M04–M07 已完成，M08 进行中，下一工作包为 PR-M08-05）
+> 状态：实施中（Phase 2，M04–M07 已完成，M08 进行中，下一工作包为 PR-M08-06）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；51/82 工作包完成，剩余 31 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；52/82 工作包完成，剩余 30 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/07-client-edge-closeout-handoff.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/07-client-edge-closeout-handoff.md
@@ -204,3 +204,18 @@ Client 临时账本归零且 32-package/target-DAG 证据可重复。
   不再有缺失计划 package，Core/Cluster/Local 均无 target finding。architecture contract 354、ArcMut 实际
   guard + fixture 24、runtime enforcing audit、32-package workspace fmt/strict Clippy 与 AGENTS routing 全绿；
   typed-error 仅复现 main 已登记的 11 项且本切片零新增；51/82 工作包完成、31 个未完成。
+
+## 13. PR-M08-05 消费记录（2026-07-17）
+
+- 现有 Proxy 已按 R0 冻结为 composition/facade：Core/Cluster/Local 仍为非 optional 且 `default = []`，下一 major
+  的 mode feature 没有提前启用；Proxy 未使用的 `rocketmq-rust` manifest/lockfile 直边已删除。
+- processor/service/cluster/local 等 owner 路径继续精确 re-export；Proxy 实现态只保 bootstrap、config/auth、
+  observability、binary、gRPC/Remoting ingress adapter 与兼容转换。静态合同禁止 Client/Broker/Store/legacy
+  runtime 回流，并禁止 Core/Local 反向依赖 facade、Cluster 或 Client。
+- ProxyConfig 的公开 Serde/env/CLI envelope 与默认模式不变，Core/Cluster/Local normalized config 仍由各自
+  canonical owner 定义和消费；默认/no-default 行为均保留双 adapter。
+- target guard 从 49 降至 48（直接边 46 + 传递闭包边 2）；Core/Cluster/Local 零 finding，Proxy 剩余的
+  Common/Error/Model/Remoting 4 项 ingress 兼容直边显式进入 M09 strict target closeout，不以 re-export 绕行。
+- Proxy default/no-default 各 99 项、architecture contract 355 项、根 fmt/strict Clippy、baseline、ArcMut、runtime、
+  routing 与 diff check 通过；typed-error 仅复现 main 既有 11 项且本切片零新增。
+- 52/82 个工作包已完成、30 个未完成，M08 只剩 PR-M08-06 feature closure 与下一 major fixture。

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/08-proxy-three-way-split.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/08-proxy-three-way-split.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 2：核心边界与 API 收敛 |
-| 状态 | 实施中；PR-M08-04 已完成，下一工作包为 PR-M08-05 |
+| 状态 | 实施中；PR-M08-05 已完成，下一工作包为 PR-M08-06 |
 | 预计周期 | 3–4 周 |
 | 工作包 | WP19 `proxy-three-way-split` |
 | 前置条件 | model/protocol/transport/security/store-api 边界稳定；除 Proxy 外 Client 清边完成 |
@@ -172,12 +172,33 @@ M07 已交付 [`Client 边界收口与 M08 交接清单`](07-client-edge-closeou
 
 ### PR-M08-05：现有 Proxy 降为 composition/facade
 
-- [ ] `[DEV]` 只保 bootstrap、分区 config conversion、auth runtime、observability、binary 和旧 public path re-export。
-- [ ] `[DEV]` R0 facade 对 cluster/local 使用非 optional dependency，继续 `default = []`；保持 facade 不恢复完整 Client direct edge。
-- [ ] `[DEV]` 保持 ProxyConfig Serde/env/CLI 默认模式；core/cluster/local 分别消费 normalized config。
-- [ ] `[TEST]` 运行现有默认和 no-default，两者继续编译两端并保持运行行为。
-- [ ] `[REV]` 检查 facade 不新增业务算法，core/local 不经 facade 反向到 cluster/client。
-- [ ] 回滚点：按 bootstrap/config/re-export 适配器回滚；不得提前启用下一 major feature 语义。
+- [x] `[DEV]` 只保 bootstrap、分区 config conversion、auth runtime、observability、binary 和旧 public path re-export。
+- [x] `[DEV]` R0 facade 对 cluster/local 使用非 optional dependency，继续 `default = []`；保持 facade 不恢复完整 Client direct edge。
+- [x] `[DEV]` 保持 ProxyConfig Serde/env/CLI 默认模式；core/cluster/local 分别消费 normalized config。
+- [x] `[TEST]` 运行现有默认和 no-default，两者继续编译两端并保持运行行为。
+- [x] `[REV]` 检查 facade 不新增业务算法，core/local 不经 facade 反向到 cluster/client。
+- [x] 回滚点：按 bootstrap/config/re-export 适配器回滚；不得提前启用下一 major feature 语义。
+
+#### PR-M08-05 实施结果
+
+- **Facade boundary**：Proxy manifest 删除未使用的 `rocketmq-rust`，继续只在 composition root 同时看见
+  Core/Cluster/Local；三者保持非 optional 且 `default = []`，`cluster-mode`、`local-mode`、
+  `compat-all-modes` 仍只属于下一 major 设计，不进入 R0 manifest。
+- **Ownership**：processor/service/cluster/local 与 core context/error/status/proto 等旧路径继续精确转发 canonical
+  owner。实现态文件只承担 bootstrap、config/auth/observability、gRPC/Remoting wire ingress、binary 与兼容转换，
+  不重新定义 MessagingProcessor、ServiceManager 或 Cluster/Local runtime owner。
+- **Config/compatibility**：`ProxyConfig` 的公开字段、Serde/env/CLI 默认模式不变；Core 的
+  Grpc/Remoting/Runtime/Session、Cluster 的 ClusterConfig 与 Local 的 LocalConfig 继续由各自 owner 定义并由
+  facade 分区交付。默认/no-default 均继续编译 Cluster 与 Local。
+- **Guard evidence**：M08 合同新增 R0 facade dependency/source/reverse-edge 断言，禁止 Client、Broker、Store 和
+  legacy runtime 回流；Core/Cluster/Local 继续零 target finding。target gap 由 49 降至 48（46 项直接边 + 2 项
+  传递闭包边），Proxy 自身剩余 Common/Error/Model/Remoting 4 项 ingress 兼容直边，交由 M09 strict target
+  closeout 统一收口，不把目标债务误记为完成。
+- **Validation**：Proxy default/no-default 各 99 项、architecture contract 355 项、根 workspace fmt 与 32-package
+  all-target/all-feature strict Clippy、baseline guard、ArcMut 实际扫描、runtime enforcing audit、AGENTS routing 和
+  diff check 全绿。typed-error guard 仅复现 main 已登记的 Broker source stringification 1、MCP anyhow 8、缺失治理
+  文档 2，共 11 项；本切片零新增，不将该门禁误报为通过。
+- **Progress**：52/82 个工作包完成，30 个尚未完成；下一串行工作包为 PR-M08-06。
 
 ### PR-M08-06：Feature closure 与下一 major fixture
 

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -45,7 +45,6 @@ rocketmq-proxy-cluster = { workspace = true }
 rocketmq-proxy-local = { workspace = true }
 rocketmq-remoting    = { workspace = true }
 rocketmq-auth        = { workspace = true, features = ["grpc"] }
-rocketmq-rust        = { workspace = true }
 rocketmq-observability = { workspace = true }
 rocketmq-runtime     = { workspace = true }
 

--- a/scripts/tests/test_m08_proxy_core_contract.py
+++ b/scripts/tests/test_m08_proxy_core_contract.py
@@ -92,6 +92,18 @@ EXPECTED_LOCAL_INTERNAL_DEPENDENCIES = {
     "rocketmq-proxy-core",
     "rocketmq-runtime",
 }
+EXPECTED_FACADE_INTERNAL_DEPENDENCIES = {
+    "rocketmq-auth",
+    "rocketmq-common",
+    "rocketmq-error",
+    "rocketmq-model",
+    "rocketmq-observability",
+    "rocketmq-proxy-cluster",
+    "rocketmq-proxy-core",
+    "rocketmq-proxy-local",
+    "rocketmq-remoting",
+    "rocketmq-runtime",
+}
 FORBIDDEN_LOCAL_TOKENS = (
     "rocketmq_auth",
     "rocketmq_client_rust",
@@ -194,10 +206,10 @@ class ProxyCoreContractTests(unittest.TestCase):
         self.assertEqual(1, guard.returncode)
         output = guard.stdout + guard.stderr
         findings = [line for line in output.splitlines() if line.startswith("VIOLATION ")]
-        self.assertEqual(49, len(findings))
+        self.assertEqual(48, len(findings))
         self.assertEqual(0, sum("rule=client-manifest-allowlist" in line for line in findings))
         self.assertEqual(0, sum("rule=client-source-allowlist" in line for line in findings))
-        self.assertEqual(47, sum("rule=target-dag-direct-dependency" in line for line in findings))
+        self.assertEqual(46, sum("rule=target-dag-direct-dependency" in line for line in findings))
         self.assertEqual(2, sum("rule=transitive-forbidden-reachability" in line for line in findings))
         self.assertFalse(any("caller=rocketmq-proxy-core " in line for line in findings))
         self.assertFalse(any("caller=rocketmq-proxy-cluster " in line for line in findings))
@@ -388,6 +400,75 @@ class ProxyCoreContractTests(unittest.TestCase):
         self.assertIn("pub use rocketmq_proxy_cluster::service::*;", service)
         self.assertNotIn("pub struct ClusterServiceManager", service)
 
+    def test_r0_facade_manifest_and_source_are_composition_only(self) -> None:
+        manifest = load_manifest(FACADE / "Cargo.toml")
+        internal = {name for name in manifest["dependencies"] if name.startswith("rocketmq-")}
+        self.assertEqual(EXPECTED_FACADE_INTERNAL_DEPENDENCIES, internal)
+        self.assertEqual([], manifest["features"]["default"])
+
+        for adapter in ("rocketmq-proxy-core", "rocketmq-proxy-cluster", "rocketmq-proxy-local"):
+            dependency = manifest["dependencies"][adapter]
+            self.assertNotEqual(True, dependency.get("optional", False), adapter)
+
+        for next_major_feature in ("cluster-mode", "local-mode", "compat-all-modes"):
+            self.assertNotIn(next_major_feature, manifest["features"])
+
+        for forbidden_dependency in (
+            "rocketmq-broker",
+            "rocketmq-client-rust",
+            "rocketmq-rust",
+            "rocketmq-store",
+        ):
+            self.assertNotIn(forbidden_dependency, manifest["dependencies"])
+
+        source = "\n".join(path.read_text(encoding="utf-8") for path in (FACADE / "src").rglob("*.rs"))
+        for forbidden_token in (
+            "rocketmq_broker",
+            "rocketmq_client_rust",
+            "rocketmq_rust",
+            "rocketmq_store::",
+        ):
+            self.assertNotIn(forbidden_token, source, forbidden_token)
+
+        config = (FACADE / "src" / "config.rs").read_text(encoding="utf-8")
+        for normalized_owner in (
+            "rocketmq_proxy_core::config::GrpcConfig",
+            "rocketmq_proxy_core::config::RemotingConfig",
+            "rocketmq_proxy_core::config::RuntimeConfig",
+            "rocketmq_proxy_core::config::SessionConfig",
+            "rocketmq_proxy_cluster::ClusterConfig",
+            "rocketmq_proxy_local::LocalConfig",
+        ):
+            self.assertIn(normalized_owner, config, normalized_owner)
+
+        bootstrap = (FACADE / "src" / "bootstrap.rs").read_text(encoding="utf-8")
+        for composition_contract in (
+            "default_service_manager_and_backend",
+            "config.cluster.clone()",
+            "config.local.clone()",
+            "ClusterServiceManager::from_cluster_client",
+            "local_components_from_config_with_service_context",
+        ):
+            self.assertIn(composition_contract, bootstrap, composition_contract)
+
+        owner_declarations = {
+            "processor.rs": ("pub trait MessagingProcessor", "pub struct DefaultMessagingProcessor"),
+            "service.rs": ("pub trait ServiceManager", "pub struct ClusterServiceManager", "pub struct LocalServiceManager"),
+            "cluster.rs": ("pub trait ClusterClient", "pub struct RocketmqClusterClient"),
+            "local.rs": ("pub struct LocalServiceManager",),
+        }
+        for name, declarations in owner_declarations.items():
+            wrapper = (FACADE / "src" / name).read_text(encoding="utf-8")
+            for declaration in declarations:
+                self.assertNotIn(declaration, wrapper, f"{name}: {declaration}")
+
+        core_source = "\n".join(path.read_text(encoding="utf-8") for path in (CORE / "src").rglob("*.rs"))
+        local_source = "\n".join(path.read_text(encoding="utf-8") for path in (LOCAL / "src").rglob("*.rs"))
+        for reverse_token in ("rocketmq_proxy::", "rocketmq_proxy_cluster", "rocketmq_client_rust"):
+            self.assertNotIn(reverse_token, core_source, reverse_token)
+        for reverse_token in ("rocketmq_proxy::", "rocketmq_proxy_cluster", "rocketmq_client_rust"):
+            self.assertNotIn(reverse_token, local_source, reverse_token)
+
     def test_core_owns_error_status_context_session_identity_and_ingress_config(self) -> None:
         for name in ("config.rs", "context.rs", "error.rs", "identity.rs", "proto.rs", "session.rs", "status.rs"):
             self.assertTrue((CORE / "src" / name).is_file(), name)
@@ -494,28 +575,29 @@ class ProxyCoreContractTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         readme = (PLAN_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("| PR 级工作包 | 51 | 0 | 31 未开始；合计 31 尚未完成 | 82 |", checklist)
+        self.assertIn("| PR 级工作包 | 52 | 0 | 30 未开始；合计 30 尚未完成 | 82 |", checklist)
         self.assertIn("- [x] PR-M08-01：创建 `rocketmq-proxy-core` 与 proto owner", checklist)
         self.assertIn("- [x] PR-M08-02：迁移中立 plan、port、service 与 ingress", checklist)
         self.assertIn("- [x] PR-M08-03：创建 Cluster adapter", checklist)
         self.assertIn("- [x] PR-M08-04：创建 Local adapter", checklist)
-        self.assertIn("当前下一工作包为 PR-M08-05", checklist)
+        self.assertIn("- [x] PR-M08-05：将现有 Proxy 降为 composition/facade", checklist)
+        self.assertIn("当前下一工作包为 PR-M08-06", checklist)
         work_packages = re.findall(r"^- \[([ x])\] (PR-M\d{2}-\d{2}[a-z]?)：", checklist, re.MULTILINE)
         self.assertEqual(82, len(work_packages))
-        self.assertEqual(51, sum(state == "x" for state, _ in work_packages))
-        self.assertEqual(31, sum(state == " " for state, _ in work_packages))
+        self.assertEqual(52, sum(state == "x" for state, _ in work_packages))
+        self.assertEqual(30, sum(state == " " for state, _ in work_packages))
         open_by_milestone: dict[str, int] = {}
         for state, package in work_packages:
             if state == " ":
                 milestone = package.split("-")[1]
                 open_by_milestone[milestone] = open_by_milestone.get(milestone, 0) + 1
-        self.assertEqual({"M08": 2, "M09": 6, "M10": 5, "M11": 12, "M12": 6}, open_by_milestone)
+        self.assertEqual({"M08": 1, "M09": 6, "M10": 5, "M11": 12, "M12": 6}, open_by_milestone)
         self.assertIn("Local 8 项", checklist)
-        self.assertIn("PR-M08-04 已完成，下一工作包为 PR-M08-05", task)
+        self.assertIn("PR-M08-05 已完成，下一工作包为 PR-M08-06", task)
         self.assertIn("- [x] `[DEV]` 按 send/pull/pop/ack/route/transaction 迁 plan 和 port", task)
         self.assertIn("## 12. PR-M08-04 消费记录（2026-07-17）", handoff)
         self.assertIn("根 workspace 已达到目标 32 个 package", readme)
-        self.assertIn("下一工作包为 PR-M08-05", readme)
+        self.assertIn("下一工作包为 PR-M08-06", readme)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8244

### Brief Description

- Remove the unused `rocketmq-rust` direct dependency from the Proxy composition crate and its lockfile entry.
- Add an executable R0 facade contract that freezes non-optional Core, Cluster, and Local dependencies, `default = []`, normalized configuration ownership, compatibility re-exports, and reverse-edge restrictions.
- Preserve Proxy bootstrap, authentication, observability, gRPC/Remoting ingress, binary, configuration, and public compatibility behavior.
- Update the migration evidence to 52 of 82 completed work packages and inventory all 48 remaining target-DAG findings by caller.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy`: 99 tests passed.
- `cargo test -p rocketmq-proxy --no-default-features`: 99 tests passed.
- `python -m unittest discover -s scripts/tests -p "test_*.py"`: 355 tests passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed for all 32 workspace packages.
- `python scripts/architecture_dependency_guard.py --mode baseline`: passed.
- Target dependency guard produced the expected incomplete result: 48 findings, comprising 46 direct edges and 2 transitive closure edges.
- `python scripts/arc_mut_guard.py`: passed.
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `./scripts/check-agents-routing.ps1`: passed.
- `git diff --check`: passed.
- `./scripts/check-error-hygiene.ps1` reproduced exactly 11 pre-existing findings (1 Broker source stringification, 8 MCP `anyhow` uses, and 2 missing governance documents); this change added none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Architecture**
  * Simplified the proxy layer into a composition-focused facade.
  * Removed unused direct dependency paths and enforced stricter module boundaries.
  * Preserved compatibility re-exports while preventing invalid reverse dependencies.

* **Documentation**
  * Updated Phase 2 migration progress, completion metrics, dependency-gap snapshots, and next steps.
  * Marked PR-M08-05 complete and advanced the roadmap to PR-M08-06.

* **Tests**
  * Added contract checks validating facade composition, allowed dependencies, re-exports, and prohibited dependency backflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->