### PR TITLE
[ISSUE #8256]♻️Prepare R0, R1 and next-major release package

### DIFF
--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -77,6 +77,9 @@ jobs:
       - name: Check dependency baseline
         run: python scripts/architecture_dependency_guard.py --mode baseline
 
+      - name: Check architecture release package
+        run: python scripts/architecture_release_guard.py
+
       - name: Check shared-mutation fixtures
         run: python scripts/arc_mut_guard.py --fixtures
 

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 57 | 0 | 25 未开始；合计 25 尚未完成 | 82 |
+| PR 级工作包 | 58 | 0 | 24 未开始；合计 24 尚未完成 | 82 |
 | 里程碑 | 8（M01–M08） | 1（M09） | 3（M10–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 1 | 1（Phase 2） | 2（Phase 3、Phase 4） | 4 |
 
-剩余 25 个未开始工作包分布：M09 为 2 个、M10 为 5 个、M11 为 12 个、M12 为 6 个。
-PR-M09-04 已完成 Client allowlist 与跨项目消费者验证，当前下一工作包为 PR-M09-05。
+剩余 24 个未开始工作包分布：M09 为 1 个、M10 为 5 个、M11 为 12 个、M12 为 6 个。
+PR-M09-05 已完成 R0/R1/next-major 发布包，当前下一工作包为 PR-M09-06。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -429,7 +429,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Example、Tauri frontend/backend、Web frontend/backend 全部按最近 AGENTS 验证通过；GPUI 条件未触发
   - [x] [`M09-04 跨项目证据`](phase-2-core-boundaries/09-client-allowlist-cross-project-evidence.md) 已记录 allowlist、三条处置、锁文件差分、提示与回滚边界
   - [x] 57/82 已完成、25 未完成，下一工作包 PR-M09-05
-- [ ] PR-M09-05：准备 R0/R1/下一 major 发布包
+- [x] PR-M09-05：准备 R0/R1/下一 major 发布包
+  - [x] 32-package publish order 按目标 DAG 固定，并保留六阶段 conceptual release chain
+  - [x] R0 release notes 完整列出 10 个新 crate、canonical/deprecated owner、无行为变化声明与回滚
+  - [x] R1 consumer plan 精确覆盖 12 个 caller、29 条兼容边；CI baseline/release guards 禁止新增或扩张
+  - [x] 外部用量采集覆盖 crates.io、GitHub code search、Issue/Discussion 与 release feedback，未知信号 fail closed
+  - [x] next-major 精确列出 4 条依赖边及 admin legacy、common compat、remoting 深路径、Proxy mode feature 范围
+  - [x] 2 条长期 Store composition 边明确排除；破坏性删除仍须 next-major 独立证据 Gate
+  - [x] [`M09-05 发布包证据`](phase-2-core-boundaries/09-r0-r1-next-major-release-package-evidence.md) 已记录机器合同、CI、验证与回滚边界
+  - [x] 58/82 已完成、24 未完成，下一工作包 PR-M09-06
 - [ ] PR-M09-06：冻结快照并执行 Phase 2 Gate
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 2，M09-04 已完成，下一工作包为 PR-M09-05）
+> 状态：实施中（Phase 2，M09-05 已完成，下一工作包为 PR-M09-06）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；57/82 工作包完成，剩余 25 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；58/82 工作包完成，剩余 24 个
 
 ## 1. 使用方式
 
@@ -187,6 +187,12 @@ MCP 与 Dashboard 只能经 `rocketmq-admin-core` 的受控 adapter 间接到达
 - 删除 admin-core 的 `legacy-common-compat`、common 的 protocol/observability compatibility dependency，以及已经排空的 remoting/legacy 深路径。
 - `rocketmq-store` 的 backend composition 职责可长期保留，不因目录整齐而强制删除。
 
+M09-05 发布包索引：[`R0 release notes`](phase-2-core-boundaries/09-r0-release-notes.md)、
+[`R1 consumer migration plan`](phase-2-core-boundaries/09-r1-consumer-migration-plan.md)、
+[`next-major removal plan`](phase-2-core-boundaries/09-next-major-removal-plan.md) 与
+[`release package evidence`](phase-2-core-boundaries/09-r0-r1-next-major-release-package-evidence.md)。机器可读版本为
+`scripts/architecture-release-plan.json`，由 `scripts/architecture_release_guard.py` 和 CI 同步守卫。
+
 ## 8. 全局不变量
 
 - CommitLog 是唯一权威 WAL；CQ、Index、RocksDB、Tiered、Compaction 只持久 cursor/watermark 等派生元数据。
@@ -206,6 +212,10 @@ MCP 与 Dashboard 只能经 `rocketmq-admin-core` 的受控 adapter 间接到达
 ```powershell
 cargo fmt --all -- --check
 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+python scripts/architecture_dependency_guard.py --mode target
+python scripts/architecture_dependency_guard.py --mode baseline
+python scripts/architecture_release_guard.py
+python scripts/arc_mut_guard.py
 .\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline
 .\scripts\check-error-hygiene.ps1
 python scripts/error_architecture_guard.py
@@ -217,11 +227,9 @@ git diff --check
 
 ### 9.2 由里程碑新增后才执行的命令
 
-下列脚本是 M01/M10/M11 的计划交付物，当前不能作为已存在的门禁报告成功：
+下列脚本是 M10/M11 的计划交付物，当前不能作为已存在的门禁报告成功：
 
 ```powershell
-python scripts/architecture_dependency_guard.py
-python scripts/arc_mut_guard.py
 python scripts/architecture_performance_guard.py --baseline <baseline.json> --candidate <candidate.json>
 python scripts/telemetry_semantic_guard.py
 .\scripts\kind-architecture-refactor-e2e.ps1

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-facade-and-package-closeout.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-facade-and-package-closeout.md
@@ -97,11 +97,15 @@ lifecycle 边纳入目标 DAG，M09-04 ledger 3 → 0、总 ledger 38 → 35。M
 
 ### PR-M09-05：R0/R1/下一 major 发布包
 
-- [ ] `[ARCH]` 按 model/error/runtime/security/store-api → protocol/observability → transport/auth/local/tiered → rocks → facade → service/tool 固定发布拓扑。
-- [ ] `[DEV]` 生成 R0 release note：新 crate、canonical path、deprecated path、无行为变化声明和回滚方式。
-- [ ] `[DEV]` 生成 R1 consumer list和 CI 禁止新 facade 边规则；记录外部用量采集方式。
-- [ ] `[ARCH]` 生成下一 major 删除列表：admin legacy、common compat、remoting 深路径、Proxy optional mode feature。
-- [ ] `[HUMAN]` 批准版本窗口和外部通知，不在代码中提前删除。
+- [x] `[ARCH]` 按 model/error/runtime/security/store-api → protocol/observability → transport/auth/local/tiered → rocks → facade → service/tool 固定发布拓扑。
+- [x] `[DEV]` 生成 R0 release note：新 crate、canonical path、deprecated path、无行为变化声明和回滚方式。
+- [x] `[DEV]` 生成 R1 consumer list和 CI 禁止新 facade 边规则；记录外部用量采集方式。
+- [x] `[ARCH]` 生成下一 major 删除列表：admin legacy、common compat、remoting 深路径、Proxy optional mode feature。
+- [x] `[HUMAN]` 批准版本窗口和外部通知，不在代码中提前删除。
+
+完成证据：[`09-r0-r1-next-major-release-package-evidence.md`](09-r0-r1-next-major-release-package-evidence.md)。发布计划将
+32-package 拓扑、10 个 R0 canonical crate、R1 29 条兼容边、next-major 4 条兼容边与 2 条长期 composition 边固化为
+机器可读合同；CI 同时执行依赖基线守卫和 release package 守卫，next-major 删除与 Proxy mode feature 激活仍须独立证据 Gate。
 
 ### PR-M09-06：冻结快照并执行 Phase 2 Gate
 

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-next-major-removal-plan.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-next-major-removal-plan.md
@@ -1,0 +1,67 @@
+# M09-05 next-major removal plan
+
+## Authorization boundary
+
+The relative next-major window and external notification plan are approved. Destructive removal remains
+`pending-next-major-evidence-gate`: this document does not approve early deletion, does not remove a public API, and does
+not activate the Proxy optional mode feature in R0/R1.
+
+## Dependency-ledger removals
+
+Exactly four dependency edges are scheduled for next-major:
+
+| Consumer | Target | Kind | Reason |
+|---|---|---|---|
+| standalone `rocketmq-example` | `rocketmq-common` | dev | examples use canonical Model/Protocol/Runtime owners |
+| standalone `rocketmq-example` | `rocketmq-remoting` | dev | examples use canonical Protocol/Transport owners |
+| standalone `rocketmq-example` | `rocketmq-rust` | dev | examples use `rocketmq-runtime` directly |
+| `rocketmq-common` | `rocketmq-protocol` | normal | remove the Common protocol compatibility re-export after external migration |
+
+These four manifest edges are the quantitative dependency ledger. The public removal scopes below are additional API
+and feature decisions and must each have their own API/feature evidence.
+
+## Public API and feature removal scopes
+
+1. **admin legacy**: remove deprecated Admin facade signatures and `legacy-common-compat` only after MCP, Dashboard,
+   CLI/TUI, standalone users, and external consumers compile against Admin Core canonical contracts.
+2. **common compat**: remove deprecated Common model/protocol/runtime re-exports only after the four dependency edges
+   above and external deep-path usages reach their gates.
+3. **remoting deep path**: remove deprecated Remoting protocol/transport deep paths only after public API diff and code
+   search prove the canonical Protocol/Transport replacements are adopted.
+4. **Proxy optional mode feature**: replace R0’s always-present Cluster/Local adapter dependencies with the
+   `cluster-mode`, `local-mode`, `compat-all-modes`, and `tieredstore` closure defined in
+   `scripts/fixtures/proxy-next-major-features.toml`.
+
+The approved long-term `rocketmq-broker → rocketmq-store` and `rocketmq-store-inspect → rocketmq-store` composition
+edges are explicitly outside this removal list.
+
+## Evidence gates
+
+Removal may begin only when all of the following are true on one frozen candidate snapshot:
+
+- at least two deprecation releases and one major-version boundary have elapsed;
+- workspace and all routed standalone internal usages are zero;
+- unresolved high-impact external consumers are zero, based on the signed external usage snapshot;
+- migration guide, canonical replacements, release notes, tracking issue/discussion, and rollback instructions are
+  published;
+- public API, feature/default, wire, storage, Serde, standalone, and Proxy closure matrices pass;
+- release manager and Human approval are recorded for the destructive candidate, separately from this planning approval.
+
+An unknown or unavailable external-usage signal fails closed. A deadline alone is not removal evidence.
+
+## Proxy activation and rollback
+
+Before next-major, active `rocketmq-proxy/Cargo.toml` must keep `default = []`, keep Cluster/Local dependencies
+non-optional, and omit `cluster-mode`, `local-mode`, and `compat-all-modes`. The fixture is tested but inactive.
+
+If the next-major candidate fails, restore the deprecated forwarding paths and R0 Proxy dependency closure, republish
+the previous compatible major, and rerun public API/feature/wire/storage and cross-project matrices. Persisted data and
+wire formats are never rolled back by conversion.
+
+## next-major checklist
+
+- [x] Four dependency-ledger edges are listed exactly.
+- [x] admin legacy, common compat, remoting deep path, and Proxy optional mode feature scopes are explicit.
+- [x] Two long-term Store composition edges are excluded from deletion.
+- [x] Evidence thresholds and a separate destructive Human approval are required.
+- [x] Current R0/R1 source is guarded against early removal and early Proxy feature activation.

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-r1-next-major-release-package-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-r1-next-major-release-package-evidence.md
@@ -1,0 +1,70 @@
+# M09-05 R0/R1/next-major release package evidence
+
+## Result
+
+M09-05 converts the approved release migration policy into a machine-readable plan, an executable guard, CI
+enforcement, and three release-facing documents. The overall architecture-refactor inventory advances to **58/82**
+work packages completed, with 24 remaining; M09 has one remaining package, PR-M09-06.
+
+## Traceability
+
+| Field | Value |
+|---|---|
+| Work package | `PR-M09-05` |
+| Issue | [#8256](https://github.com/mxsm/rocketmq-rust/issues/8256) |
+| Branch | `mxsm/architecture-refactor-r0-r1-next-major-release-package` |
+| Design source | `docs/architecture-refactor-design.md` release migration and compatibility strategy |
+| Plan | `scripts/architecture-release-plan.json` |
+| Guard | `scripts/architecture_release_guard.py` |
+| CI | `.github/workflows/rocketmq-rust-ci.yaml` architecture guard job |
+
+## Delivered decisions
+
+- [x] The exact 32-package publish order follows the target DAG and preserves the approved six-stage release chain.
+- [x] R0 lists all ten new crates, canonical imports, deprecated compatibility owners, a no behavior change statement,
+  and rollback.
+- [x] R1 lists the exact 29 ledger edges across 12 consumers and retains the existing Linux/Windows CI no-growth rule.
+- [x] External usage collection has four sources, a release cadence, fail-closed uncertainty handling, four notification
+  channels, and measurable next-major thresholds.
+- [x] next-major records the exact four dependency edges plus admin legacy, common compat, remoting deep path, and Proxy
+  optional mode feature removal scopes.
+- [x] The two long-term Store composition edges remain outside the deletion plan.
+- [x] Human approval covers the relative release windows and notification plan; destructive removal remains pending a
+  separate signed next-major evidence gate.
+
+## Automated invariants
+
+`scripts/architecture_release_guard.py` fails when any of these drift:
+
+1. a package is missing, duplicated, or published before a target-DAG dependency;
+2. the ten-crate inventory changes;
+3. R1 29 / next-major 4 / long-term 2 differs from the compatibility baseline;
+4. a planned compatibility edge is removed before its window;
+5. Proxy next-major features are activated early;
+6. external-usage thresholds, Human approval boundary, release documents, or CI hooks disappear.
+
+## Validation record
+
+| Command | Result |
+|---|---|
+| `python scripts/architecture_release_guard.py` | passed: topology 32/32, crates 10/10, windows 29/4/2, early activation 0 |
+| `python -m unittest scripts.tests.test_architecture_release_guard -v` | passed: 6/6 |
+| `python scripts/architecture_dependency_guard.py --mode target` | passed: compatibility 35/35, dev-only 3/3, unauthorized 0 |
+| `python scripts/architecture_dependency_guard.py --mode baseline` | passed |
+| architecture dependency guard unit/fixture tests | passed: 43/43; built-in fixtures clean 1, expected violations 6 |
+| Proxy next-major feature closure tests | passed: 7/7 |
+| M09 target/facade/client affected contracts | passed: 16/16 |
+| CI `test_*guard.py` discovery | passed: 114/114 |
+| `cargo metadata --format-version 1 --locked --no-deps` | passed: exact lockfile metadata resolved |
+| `./scripts/check-agents-routing.ps1` | passed: standalone Cargo 4, Node 3, routes 8 |
+| `git diff --check` | passed |
+
+This package changes Python policy tooling, CI wiring, and Markdown only. It does not change Rust source, Cargo manifests,
+features, public API, wire/storage format, or runtime behavior; root Cargo fmt/Clippy are therefore not triggered by the
+documentation-only Rust validation policy. Workflow routing validation remains mandatory and is recorded above.
+
+## Rollback boundary
+
+Revert the plan, guard, CI hook, and release documents together. Do not roll back by deleting canonical crates, restoring
+duplicated facade implementations, changing feature defaults, or rewriting persisted/wire data. Any future destructive
+removal is a separate next-major work item with a fresh frozen snapshot and approval.

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-release-notes.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-release-notes.md
@@ -1,0 +1,65 @@
+# M09-05 R0 compatibility release notes
+
+## Release intent
+
+R0 is the first compatibility release after the Phase 2 gate. It publishes the ten canonical boundary crates while
+keeping the current public paths, default features, wire formats, storage formats, service behavior, and deployment
+modes available. The package version of every workspace crate remains lockstep.
+
+**No behavior change / no behavior change:** R0 is an ownership and package-boundary release. It does not authorize a
+behavior change, a public-item removal, a default-feature change, a wire/storage migration, or early activation of the
+Proxy mode features.
+
+## Release topology
+
+The conceptual chain approved by the architecture design is:
+
+`model/error/runtime/security/store-api → protocol/observability → transport/auth/local/tiered → rocks → facade → service/tool`
+
+The executable order is recorded in `scripts/architecture-release-plan.json`. It refines the conceptual chain by
+publishing `rocketmq-error`, `rocketmq-macros`, and `rocketmq-runtime` before packages that compile against them, and it
+checks all 32 packages against `scripts/architecture-dependency-policy.json`. A facade or service/tool release must not
+reference a canonical owner version that has not been published.
+
+## Ten new canonical crates
+
+| Canonical package/import | Canonical responsibility | R0 deprecated compatibility owner |
+|---|---|---|
+| `rocketmq-model` / `rocketmq_model` | model and message DTOs | matching `rocketmq-common` model/message paths |
+| `rocketmq-protocol` / `rocketmq_protocol` | protocol headers, codes, codecs, and wire contracts | matching `rocketmq-remoting` protocol and `rocketmq-common` boundary paths |
+| `rocketmq-transport` / `rocketmq_transport` | network transport contracts and implementation | matching `rocketmq-remoting` transport paths |
+| `rocketmq-security-api` / `rocketmq_security_api` | security-neutral contracts and principals | matching Common/Remoting security contract paths |
+| `rocketmq-store-api` / `rocketmq_store_api` | public store contracts | matching `rocketmq-store` contract paths |
+| `rocketmq-store-local` / `rocketmq_store_local` | local-file store implementation | matching `rocketmq-store` local implementation paths |
+| `rocketmq-store-rocksdb` / `rocketmq_store_rocksdb` | RocksDB store implementation | matching `rocketmq-store` RocksDB paths |
+| `rocketmq-proxy-core` / `rocketmq_proxy_core` | mode-neutral Proxy contracts | matching `rocketmq-proxy` core paths |
+| `rocketmq-proxy-cluster` / `rocketmq_proxy_cluster` | remote-cluster adapter and client lifecycle | matching `rocketmq-proxy` cluster paths |
+| `rocketmq-proxy-local` / `rocketmq_proxy_local` | embedded Broker/Store adapter | matching `rocketmq-proxy` local paths |
+
+“Deprecated” identifies a migration path, not an R0 deletion. Existing compatibility owners continue forwarding or
+composing canonical owners. Consumers should use the canonical import in new code and migrate existing imports during
+R1.
+
+## Compatibility guarantees
+
+- Public API: canonical and legacy compile fixtures remain green; no unapproved breaking diff is allowed.
+- Features: existing default and no-default behavior remains unchanged; the next-major Proxy fixture is documentation,
+  not the active `rocketmq-proxy/Cargo.toml` feature set.
+- Wire/storage: JSON/binary protocol goldens, Serde names/defaults, CommitLog/CQ/Index and RocksDB semantics remain
+  unchanged.
+- Runtime: no new detached background work or blocking boundary is introduced by this release package.
+
+## Rollback
+
+If R0 release validation fails, stop the facade/service publication, withdraw the affected version, and republish the
+previous lockstep workspace version. Keep both canonical crates and deprecated forwarding paths in source while the
+failure is corrected. The rollback must not delete persisted data, rewrite wire/storage formats, or reactivate copied
+implementations inside compatibility facades.
+
+## R0 checklist
+
+- [x] Ten new crates, canonical imports, and deprecated compatibility owners are listed.
+- [x] The exact 32-package publication order is machine-readable and dependency-checked.
+- [x] The no behavior change statement covers API, features, wire, storage, and runtime behavior.
+- [x] The rollback preserves compatibility paths and persisted/wire data.
+- [x] Early next-major deletion and Proxy mode activation are explicitly forbidden.

--- a/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r1-consumer-migration-plan.md
+++ b/docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r1-consumer-migration-plan.md
@@ -1,0 +1,66 @@
+# M09-05 R1 consumer migration plan
+
+## Scope
+
+R1 migrates internal consumers away from compatibility facades while keeping external deprecated paths compilable.
+The authoritative inventory is the 29 `remove_by = "R1"` edges in
+`scripts/architecture-dependency-baseline.json`; `scripts/architecture-release-plan.json` independently records the
+same consumer set and the release guard rejects any difference.
+
+## Exact 29-edge consumer list
+
+| Consumer | Manifest | Compatibility targets | Edge count | R1 action |
+|---|---|---|---:|---|
+| `rocketmq-admin-cli` | `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | use Admin/Core canonical DTO, transport, runtime and error paths |
+| `rocketmq-admin-core` | `rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml` | Common | 1 | isolate legacy facade behind its compatibility surface; keep canonical core independent |
+| `rocketmq-admin-tui` | `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | consume Admin/Core and canonical owners |
+| `rocketmq-auth` | `rocketmq-auth/Cargo.toml` | Common, Remoting | 2 | use Security API, Protocol and Transport owners |
+| `rocketmq-broker` | `rocketmq-broker/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | use Model/Protocol/Transport/Runtime owners; keep approved Store composition separately |
+| `rocketmq-client-rust` | `rocketmq-client/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | use Model/Protocol/Transport/Runtime owners |
+| `rocketmq-common` | `rocketmq-common/Cargo.toml` | legacy Runtime | 1 | forward runtime compatibility directly to `rocketmq-runtime` |
+| `rocketmq-controller` | `rocketmq-controller/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | use Model/Protocol/Transport/Runtime owners |
+| `rocketmq-namesrv` | `rocketmq-namesrv/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | use Model/Protocol/Transport/Runtime owners |
+| `rocketmq-proxy` | `rocketmq-proxy/Cargo.toml` | Common, Remoting | 2 | compose Proxy adapters and canonical contracts only |
+| `rocketmq-remoting` | `rocketmq-remoting/Cargo.toml` | Common, legacy Runtime | 2 | forward deprecated paths to Protocol/Transport/Runtime owners |
+| `rocketmq-store` | `rocketmq-store/Cargo.toml` | Common, Remoting, legacy Runtime | 3 | compose Store API/Local/Rocks/Tiered and canonical Runtime owners |
+| **Total** |  |  | **29** | all edges reach zero during R1; external deprecated paths remain until next-major gates pass |
+
+The two `long-term` Store composition edges and four `next-major` compatibility edges are not part of the 29-edge R1
+burn-down and must not be silently counted as R1 work.
+
+## CI no-growth rule
+
+CI runs `python scripts/architecture_dependency_guard.py --mode baseline` on Linux and Windows. The baseline guard
+matches caller, target, dependency kind, manifest path, alias, and count; therefore it rejects a new facade edge, a
+renamed bypass, or growth of an existing allowance. CI also runs `python scripts/architecture_release_guard.py`, which
+requires the R1 plan to remain exactly equal to the 29-edge ledger.
+
+R1 work removes an entry only after the corresponding source imports, feature closure, tests, and standalone consumers
+have migrated. It never “fixes” a finding by widening the allowlist.
+
+## External usage collection
+
+The external usage snapshot is collected at R0, refreshed on every R1 minor release, and signed before next-major:
+
+1. crates.io reverse-dependency inventory and download trend for compatibility and canonical crates;
+2. GitHub code search for old crate/module paths, with repository and last-activity deduplication;
+3. project issues/discussions labeled `architecture-migration`, including blocked downstream builds;
+4. release deprecation feedback and opt-in telemetry where such telemetry is available and privacy-safe.
+
+Each snapshot records query/time, raw count, deduplicated active consumers, known migration owner, blocker severity, and
+canonical replacement. Absence of telemetry is recorded as unknown evidence, never as zero usage.
+
+## Notifications and exit criteria
+
+External notification uses R0/R1 release notes, a versioned migration guide, a GitHub tracking issue/discussion, and
+Rust deprecation notes containing the canonical replacement. R1 is complete when all 29 internal edges are zero, root
+and standalone verification passes, CI still rejects new facade edges, and remaining external consumers have an owner
+or a documented next-major disposition.
+
+## R1 checklist
+
+- [x] The consumer table totals exactly 29 edges and matches the machine-readable plan.
+- [x] The CI rule forbids new or expanded facade edges.
+- [x] External usage sources, cadence, uncertainty handling, and notification channels are defined.
+- [x] R1 is separated from the four next-major and two long-term edges.
+- [x] Removing an allowlist entry requires real consumer migration and validation.

--- a/scripts/architecture-release-plan.json
+++ b/scripts/architecture-release-plan.json
@@ -1,0 +1,280 @@
+{
+  "schema_version": 1,
+  "milestone": "M09-05",
+  "design_source": "docs/architecture-refactor-design.md#59-发布迁移与兼容策略",
+  "human_approval": {
+    "scope": "R0, R1 and next-major relative release windows plus external notification plan",
+    "status": "approved",
+    "recorded_on": "2026-07-17",
+    "destructive_removal": "pending-next-major-evidence-gate",
+    "constraint": "Approval of the release package does not authorize early removal of compatibility paths or early activation of Proxy mode features."
+  },
+  "release_topology": {
+    "required_chain": [
+      "model/error/runtime/security/store-api",
+      "protocol/observability",
+      "transport/auth/local/tiered",
+      "rocks",
+      "facade",
+      "service/tool"
+    ],
+    "publish_order": [
+      "rocketmq-error",
+      "rocketmq-macros",
+      "rocketmq-runtime",
+      "rocketmq-model",
+      "rocketmq-security-api",
+      "rocketmq-store-api",
+      "rocketmq-protocol",
+      "rocketmq-observability",
+      "rocketmq-transport",
+      "rocketmq-auth",
+      "rocketmq-store-local",
+      "rocketmq-tieredstore",
+      "rocketmq-filter",
+      "rocketmq-store-rocksdb",
+      "rocketmq-common",
+      "rocketmq-remoting",
+      "rocketmq-store",
+      "rocketmq-rust",
+      "rocketmq-client-rust",
+      "rocketmq-controller",
+      "rocketmq-proxy-core",
+      "rocketmq-dashboard-common",
+      "rocketmq-admin-core",
+      "rocketmq-broker",
+      "rocketmq-namesrv",
+      "rocketmq-proxy-cluster",
+      "rocketmq-store-inspect",
+      "rocketmq-admin-cli",
+      "rocketmq-admin-tui",
+      "rocketmq-mcp",
+      "rocketmq-proxy-local",
+      "rocketmq-proxy"
+    ],
+    "rule": "A package is published only after every package in its target-DAG dependency set is available at the same release version."
+  },
+  "r0": {
+    "window": "first compatibility release after Phase 2 approval",
+    "behavior_contract": "No behavior, wire-format, storage-format, default-feature or public-path removal is permitted in the R0 release package.",
+    "new_crates": [
+      {
+        "package": "rocketmq-model",
+        "path": "rocketmq-model/Cargo.toml",
+        "canonical_import": "rocketmq_model",
+        "legacy_owner": "rocketmq-common model and message paths"
+      },
+      {
+        "package": "rocketmq-protocol",
+        "path": "rocketmq-protocol/Cargo.toml",
+        "canonical_import": "rocketmq_protocol",
+        "legacy_owner": "rocketmq-remoting protocol and rocketmq-common boundary paths"
+      },
+      {
+        "package": "rocketmq-transport",
+        "path": "rocketmq-transport/Cargo.toml",
+        "canonical_import": "rocketmq_transport",
+        "legacy_owner": "rocketmq-remoting transport paths"
+      },
+      {
+        "package": "rocketmq-security-api",
+        "path": "rocketmq-security-api/Cargo.toml",
+        "canonical_import": "rocketmq_security_api",
+        "legacy_owner": "rocketmq-common and rocketmq-remoting security contracts"
+      },
+      {
+        "package": "rocketmq-store-api",
+        "path": "rocketmq-store-api/Cargo.toml",
+        "canonical_import": "rocketmq_store_api",
+        "legacy_owner": "rocketmq-store public store contracts"
+      },
+      {
+        "package": "rocketmq-store-local",
+        "path": "rocketmq-store-local/Cargo.toml",
+        "canonical_import": "rocketmq_store_local",
+        "legacy_owner": "rocketmq-store local implementation paths"
+      },
+      {
+        "package": "rocketmq-store-rocksdb",
+        "path": "rocketmq-store-rocksdb/Cargo.toml",
+        "canonical_import": "rocketmq_store_rocksdb",
+        "legacy_owner": "rocketmq-store RocksDB implementation paths"
+      },
+      {
+        "package": "rocketmq-proxy-core",
+        "path": "rocketmq-proxy-core/Cargo.toml",
+        "canonical_import": "rocketmq_proxy_core",
+        "legacy_owner": "rocketmq-proxy mode-neutral contracts"
+      },
+      {
+        "package": "rocketmq-proxy-cluster",
+        "path": "rocketmq-proxy-cluster/Cargo.toml",
+        "canonical_import": "rocketmq_proxy_cluster",
+        "legacy_owner": "rocketmq-proxy cluster adapter paths"
+      },
+      {
+        "package": "rocketmq-proxy-local",
+        "path": "rocketmq-proxy-local/Cargo.toml",
+        "canonical_import": "rocketmq_proxy_local",
+        "legacy_owner": "rocketmq-proxy local adapter paths"
+      }
+    ],
+    "rollback": "Withdraw the facade/service release, republish the previous lockstep version, and keep canonical crates plus deprecated forwarding paths intact; never roll back by deleting persisted data or rewriting wire/storage formats."
+  },
+  "r1": {
+    "window": "the release train immediately following R0",
+    "expected_edges": 29,
+    "consumers": [
+      {
+        "caller": "rocketmq-admin-cli",
+        "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-admin-core",
+        "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml",
+        "targets": ["rocketmq-common"]
+      },
+      {
+        "caller": "rocketmq-admin-tui",
+        "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-auth",
+        "path": "rocketmq-auth/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting"]
+      },
+      {
+        "caller": "rocketmq-broker",
+        "path": "rocketmq-broker/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-client-rust",
+        "path": "rocketmq-client/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-common",
+        "path": "rocketmq-common/Cargo.toml",
+        "targets": ["rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-controller",
+        "path": "rocketmq-controller/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-namesrv",
+        "path": "rocketmq-namesrv/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-proxy",
+        "path": "rocketmq-proxy/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting"]
+      },
+      {
+        "caller": "rocketmq-remoting",
+        "path": "rocketmq-remoting/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-rust"]
+      },
+      {
+        "caller": "rocketmq-store",
+        "path": "rocketmq-store/Cargo.toml",
+        "targets": ["rocketmq-common", "rocketmq-remoting", "rocketmq-rust"]
+      }
+    ],
+    "ci_policy": "scripts/architecture_dependency_guard.py --mode baseline runs on Linux and Windows and rejects every unregistered caller/target/kind/path/alias facade edge or any count increase."
+  },
+  "next_major": {
+    "window": "first major release after all evidence gates are satisfied",
+    "expected_edges": 4,
+    "dependency_edges": [
+      {
+        "caller": "rocketmq-example",
+        "target": "rocketmq-common",
+        "kind": "dev",
+        "path": "rocketmq-example/Cargo.toml",
+        "alias": "rocketmq_common"
+      },
+      {
+        "caller": "rocketmq-example",
+        "target": "rocketmq-remoting",
+        "kind": "dev",
+        "path": "rocketmq-example/Cargo.toml",
+        "alias": "rocketmq_remoting"
+      },
+      {
+        "caller": "rocketmq-example",
+        "target": "rocketmq-rust",
+        "kind": "dev",
+        "path": "rocketmq-example/Cargo.toml",
+        "alias": "rocketmq_rust"
+      },
+      {
+        "caller": "rocketmq-common",
+        "target": "rocketmq-protocol",
+        "kind": "normal",
+        "path": "rocketmq-common/Cargo.toml",
+        "alias": "rocketmq_protocol"
+      }
+    ],
+    "removal_scopes": [
+      "admin legacy and legacy-common-compat public API",
+      "rocketmq-common compatibility re-exports",
+      "rocketmq-remoting deprecated deep public paths",
+      "rocketmq-proxy optional cluster-mode/local-mode feature activation"
+    ],
+    "proxy_feature_fixture": "scripts/fixtures/proxy-next-major-features.toml"
+  },
+  "long_term": {
+    "expected_edges": 2,
+    "preserved_edges": [
+      {
+        "caller": "rocketmq-broker",
+        "target": "rocketmq-store",
+        "kind": "normal",
+        "path": "rocketmq-broker/Cargo.toml",
+        "alias": "rocketmq_store"
+      },
+      {
+        "caller": "rocketmq-store-inspect",
+        "target": "rocketmq-store",
+        "kind": "normal",
+        "path": "rocketmq-tools/rocketmq-store-inspect/Cargo.toml",
+        "alias": "rocketmq_store"
+      }
+    ]
+  },
+  "external_usage": {
+    "collection_sources": [
+      "crates.io reverse dependencies and download trend",
+      "GitHub code search for deprecated crate and module paths",
+      "GitHub issues and discussions labeled architecture-migration",
+      "release deprecation feedback and opt-in telemetry when available"
+    ],
+    "cadence": "capture at R0, refresh for every R1 minor release, and freeze a signed snapshot before next-major removal",
+    "removal_gates": {
+      "minimum_deprecation_releases": 2,
+      "minimum_major_boundaries": 1,
+      "workspace_and_standalone_internal_usages": 0,
+      "unresolved_high_impact_external_consumers": 0,
+      "migration_guide_published": true,
+      "release_manager_and_human_approval_required": true
+    },
+    "notification_channels": [
+      "R0 and R1 release notes",
+      "versioned migration guide",
+      "GitHub tracking issue and discussion",
+      "Rust deprecation attributes and canonical replacement notes"
+    ]
+  },
+  "documents": {
+    "r0": "docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-release-notes.md",
+    "r1": "docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r1-consumer-migration-plan.md",
+    "next_major": "docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-next-major-removal-plan.md",
+    "evidence": "docs/plans/architecture-refactor-migration/phase-2-core-boundaries/09-r0-r1-next-major-release-package-evidence.md"
+  }
+}

--- a/scripts/architecture_release_guard.py
+++ b/scripts/architecture_release_guard.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate the M09 R0/R1/next-major architecture release package."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN_PATH = ROOT / "scripts" / "architecture-release-plan.json"
+POLICY_PATH = ROOT / "scripts" / "architecture-dependency-policy.json"
+BASELINE_PATH = ROOT / "scripts" / "architecture-dependency-baseline.json"
+CI_PATH = ROOT / ".github" / "workflows" / "rocketmq-rust-ci.yaml"
+PROXY_MANIFEST = ROOT / "rocketmq-proxy" / "Cargo.toml"
+
+REQUIRED_CHAIN = [
+    "model/error/runtime/security/store-api",
+    "protocol/observability",
+    "transport/auth/local/tiered",
+    "rocks",
+    "facade",
+    "service/tool",
+]
+NEW_CRATES = {
+    "rocketmq-model",
+    "rocketmq-protocol",
+    "rocketmq-transport",
+    "rocketmq-security-api",
+    "rocketmq-store-api",
+    "rocketmq-store-local",
+    "rocketmq-store-rocksdb",
+    "rocketmq-proxy-core",
+    "rocketmq-proxy-cluster",
+    "rocketmq-proxy-local",
+}
+EDGE_FIELDS = ("caller", "target", "kind", "path", "alias")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def edge_identity(edge: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(str(edge[field]) for field in EDGE_FIELDS)
+
+
+def baseline_edges(baseline: dict[str, Any], window: str) -> set[tuple[str, ...]]:
+    return {
+        edge_identity(edge)
+        for edge in baseline["compatibility_manifest_exceptions"]
+        if edge["remove_by"] == window
+    }
+
+
+def expand_r1_consumers(plan: dict[str, Any]) -> set[tuple[str, ...]]:
+    edges: set[tuple[str, ...]] = set()
+    for consumer in plan["r1"]["consumers"]:
+        for target in consumer["targets"]:
+            edges.add(
+                (
+                    consumer["caller"],
+                    target,
+                    "normal",
+                    consumer["path"],
+                    target.replace("-", "_"),
+                )
+            )
+    return edges
+
+
+def manifest_has_edge(edge: tuple[str, ...]) -> bool:
+    _, target, kind, relative_path, alias = edge
+    manifest = tomllib.loads((ROOT / relative_path).read_text(encoding="utf-8"))
+    section = "dev-dependencies" if kind == "dev" else "dependencies"
+    dependencies = manifest.get(section, {})
+    manifest_key = alias if alias in dependencies else target
+    dependency = dependencies.get(manifest_key)
+    if dependency is None:
+        return False
+    package = dependency.get("package") if isinstance(dependency, dict) else None
+    return (package or manifest_key.replace("_", "-")) == target
+
+
+def check_release_topology(
+    plan: dict[str, Any], policy: dict[str, Any], findings: list[str]
+) -> None:
+    topology = plan["release_topology"]
+    if topology.get("required_chain") != REQUIRED_CHAIN:
+        findings.append("release topology does not preserve the approved six-stage chain")
+
+    publish_order = topology.get("publish_order", [])
+    target_dag = policy["target_dag"]
+    if len(publish_order) != len(set(publish_order)):
+        findings.append("release publish order contains duplicate packages")
+    if set(publish_order) != set(target_dag):
+        missing = sorted(set(target_dag) - set(publish_order))
+        extra = sorted(set(publish_order) - set(target_dag))
+        findings.append(f"release publish order package mismatch: missing={missing}, extra={extra}")
+        return
+
+    position = {package: index for index, package in enumerate(publish_order)}
+    for caller, dependencies in target_dag.items():
+        for dependency in dependencies:
+            if position[dependency] >= position[caller]:
+                findings.append(
+                    f"publish order violation: {dependency} must precede {caller}"
+                )
+
+
+def check_release_windows(
+    plan: dict[str, Any], baseline: dict[str, Any], findings: list[str]
+) -> None:
+    new_crates = {item["package"] for item in plan["r0"]["new_crates"]}
+    if new_crates != NEW_CRATES or len(plan["r0"]["new_crates"]) != 10:
+        findings.append("R0 new-crate inventory must contain the exact ten approved crates")
+    for item in plan["r0"]["new_crates"]:
+        if not (ROOT / item["path"]).is_file():
+            findings.append(f"R0 new crate manifest is missing: {item['path']}")
+
+    planned_r1 = expand_r1_consumers(plan)
+    recorded_r1 = baseline_edges(baseline, "R1")
+    if planned_r1 != recorded_r1 or plan["r1"].get("expected_edges") != 29:
+        findings.append(
+            "R1 consumer plan must exactly match the 29-edge compatibility baseline"
+        )
+
+    planned_next_major = {
+        edge_identity(edge) for edge in plan["next_major"]["dependency_edges"]
+    }
+    recorded_next_major = baseline_edges(baseline, "next-major")
+    if (
+        planned_next_major != recorded_next_major
+        or plan["next_major"].get("expected_edges") != 4
+    ):
+        findings.append(
+            "next-major plan must exactly match the four-edge compatibility baseline"
+        )
+
+    preserved = {
+        edge_identity(edge) for edge in plan["long_term"]["preserved_edges"]
+    }
+    recorded_long_term = baseline_edges(baseline, "long-term")
+    if preserved != recorded_long_term or plan["long_term"].get("expected_edges") != 2:
+        findings.append("long-term plan must preserve the two approved composition edges")
+
+    for edge in sorted(planned_r1 | planned_next_major | preserved):
+        if not manifest_has_edge(edge):
+            findings.append(
+                "release package removed a compatibility edge before its approved window: "
+                + "|".join(edge)
+            )
+
+
+def check_proxy_activation(plan: dict[str, Any], findings: list[str]) -> None:
+    fixture_path = ROOT / plan["next_major"]["proxy_feature_fixture"]
+    fixture = tomllib.loads(fixture_path.read_text(encoding="utf-8"))
+    proxy = tomllib.loads(PROXY_MANIFEST.read_text(encoding="utf-8"))
+    if fixture.get("activation_window") != "next-major":
+        findings.append("Proxy feature fixture activation window is not next-major")
+
+    current_features = proxy.get("features", {})
+    for feature in ("cluster-mode", "local-mode", "compat-all-modes"):
+        if feature in current_features:
+            findings.append(f"Proxy next-major feature was activated early: {feature}")
+    for dependency in ("rocketmq-proxy-cluster", "rocketmq-proxy-local"):
+        specification = proxy.get("dependencies", {}).get(dependency)
+        if not isinstance(specification, dict) or specification.get("optional", False):
+            findings.append(
+                f"Proxy adapter dependency changed before next-major: {dependency}"
+            )
+
+
+def check_usage_and_approval(plan: dict[str, Any], findings: list[str]) -> None:
+    approval = plan.get("human_approval", {})
+    if approval.get("status") != "approved":
+        findings.append("relative release windows and notification plan lack Human approval")
+    if approval.get("destructive_removal") != "pending-next-major-evidence-gate":
+        findings.append("destructive removal must remain pending the next-major evidence gate")
+
+    external = plan.get("external_usage", {})
+    if len(external.get("collection_sources", [])) < 4:
+        findings.append("external usage collection must cover at least four independent sources")
+    gates = external.get("removal_gates", {})
+    expected_gates = {
+        "minimum_deprecation_releases": 2,
+        "minimum_major_boundaries": 1,
+        "workspace_and_standalone_internal_usages": 0,
+        "unresolved_high_impact_external_consumers": 0,
+        "migration_guide_published": True,
+        "release_manager_and_human_approval_required": True,
+    }
+    if gates != expected_gates:
+        findings.append("external usage removal gates differ from the approved thresholds")
+    if len(external.get("notification_channels", [])) < 4:
+        findings.append("external notification plan must contain at least four channels")
+
+
+def check_ci_and_documents(plan: dict[str, Any], findings: list[str]) -> None:
+    workflow = CI_PATH.read_text(encoding="utf-8")
+    for command in (
+        "python scripts/architecture_dependency_guard.py --mode baseline",
+        "python scripts/architecture_release_guard.py",
+    ):
+        if command not in workflow:
+            findings.append(f"CI workflow does not enforce release rule: {command}")
+
+    document_tokens = {
+        "r0": ("R0", "canonical", "deprecated", "no behavior change", "rollback"),
+        "r1": ("R1", "29", "CI", "external usage"),
+        "next_major": (
+            "next-major",
+            "admin legacy",
+            "common compat",
+            "remoting deep path",
+            "Proxy optional mode feature",
+        ),
+        "evidence": ("M09-05", "58/82"),
+    }
+    for key, tokens in document_tokens.items():
+        path = ROOT / plan["documents"][key]
+        if not path.is_file():
+            findings.append(f"release document is missing: {path.relative_to(ROOT)}")
+            continue
+        content = path.read_text(encoding="utf-8")
+        for token in tokens:
+            if token not in content:
+                findings.append(
+                    f"release document {path.name} is missing required marker: {token}"
+                )
+
+
+def validate() -> list[str]:
+    plan = load_json(PLAN_PATH)
+    policy = load_json(POLICY_PATH)
+    baseline = load_json(BASELINE_PATH)
+    findings: list[str] = []
+
+    if plan.get("schema_version") != 1 or plan.get("milestone") != "M09-05":
+        findings.append("release plan schema or milestone is invalid")
+    check_release_topology(plan, policy, findings)
+    check_release_windows(plan, baseline, findings)
+    check_proxy_activation(plan, findings)
+    check_usage_and_approval(plan, findings)
+    check_ci_and_documents(plan, findings)
+    return findings
+
+
+def main() -> int:
+    findings = validate()
+    if findings:
+        print(f"architecture release guard: FAILED ({len(findings)} finding(s))")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+    print("architecture release guard: PASSED")
+    print("- release topology: 32/32 packages in dependency order")
+    print("- R0 new crates: 10/10")
+    print("- compatibility windows: R1 29, next-major 4, long-term 2")
+    print("- early removals/Proxy feature activation: 0")
+    print("- external usage and notification gates: approved and enforced")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_architecture_release_guard.py
+++ b/scripts/tests/test_architecture_release_guard.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import architecture_release_guard as guard  # noqa: E402
+
+
+class ArchitectureReleaseGuardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.plan = json.loads(guard.PLAN_PATH.read_text(encoding="utf-8"))
+        cls.policy = json.loads(guard.POLICY_PATH.read_text(encoding="utf-8"))
+        cls.baseline = json.loads(guard.BASELINE_PATH.read_text(encoding="utf-8"))
+
+    def test_live_release_package_passes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "architecture_release_guard.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("R1 29, next-major 4, long-term 2", result.stdout)
+
+    def test_publish_order_covers_target_dag_and_respects_dependencies(self) -> None:
+        findings: list[str] = []
+        guard.check_release_topology(self.plan, self.policy, findings)
+        self.assertEqual([], findings)
+
+        invalid = copy.deepcopy(self.plan)
+        order = invalid["release_topology"]["publish_order"]
+        order.remove("rocketmq-protocol")
+        order.append("rocketmq-protocol")
+        findings = []
+        guard.check_release_topology(invalid, self.policy, findings)
+        self.assertTrue(
+            any("publish order violation" in finding for finding in findings),
+            findings,
+        )
+
+    def test_release_windows_exactly_match_compatibility_ledger(self) -> None:
+        self.assertEqual(29, len(guard.expand_r1_consumers(self.plan)))
+        self.assertEqual(29, len(guard.baseline_edges(self.baseline, "R1")))
+        self.assertEqual(4, len(guard.baseline_edges(self.baseline, "next-major")))
+        self.assertEqual(2, len(guard.baseline_edges(self.baseline, "long-term")))
+
+        invalid = copy.deepcopy(self.plan)
+        invalid["r1"]["consumers"][0]["targets"].pop()
+        findings: list[str] = []
+        guard.check_release_windows(invalid, self.baseline, findings)
+        self.assertIn(
+            "R1 consumer plan must exactly match the 29-edge compatibility baseline",
+            findings,
+        )
+
+    def test_ten_new_crates_and_release_documents_are_complete(self) -> None:
+        self.assertEqual(
+            guard.NEW_CRATES,
+            {item["package"] for item in self.plan["r0"]["new_crates"]},
+        )
+        findings: list[str] = []
+        guard.check_ci_and_documents(self.plan, findings)
+        self.assertEqual([], findings)
+
+    def test_proxy_next_major_features_are_not_activated_early(self) -> None:
+        findings: list[str] = []
+        guard.check_proxy_activation(self.plan, findings)
+        self.assertEqual([], findings)
+
+    def test_human_approval_does_not_approve_early_removal(self) -> None:
+        findings: list[str] = []
+        guard.check_usage_and_approval(self.plan, findings)
+        self.assertEqual([], findings)
+        self.assertEqual(
+            "pending-next-major-evidence-gate",
+            self.plan["human_approval"]["destructive_removal"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #8256.

Completes PR-M09-05 by turning the approved release migration strategy into an executable R0/R1/next-major package, while keeping compatibility paths and Proxy R0 feature behavior intact.

## Changes

- Add a machine-readable 32-package publication order and validate it against every target-DAG dependency.
- Freeze the exact ten R0 canonical boundary crates, compatibility owners, no-behavior-change contract, and rollback policy.
- Freeze the exact 29-edge R1 consumer list across 12 callers and the existing Linux/Windows CI no-growth policy.
- Define four external-usage sources, a release cadence, four notification channels, fail-closed uncertainty handling, and measurable removal gates.
- Freeze the four next-major dependency edges plus admin legacy, Common compatibility, Remoting deep-path, and Proxy optional-mode removal scopes.
- Preserve the two approved long-term Store composition edges and require separate destructive next-major approval.
- Add the release guard to CI, six focused contract tests, four release/evidence documents, and update M09 progress to 58/82 with PR-M09-06 next.

## Validation

- `python scripts/architecture_release_guard.py`: passed; topology 32/32, new crates 10/10, compatibility windows R1 29 / next-major 4 / long-term 2, early removals/Proxy activation 0.
- Release guard unit contracts: 6/6 passed.
- Dependency target and baseline guards: passed; active compatibility 35/35, dev-only 3/3, unauthorized 0.
- Dependency guard fixtures and unit contracts: clean 1 + expected violations 6; 43/43 passed.
- Proxy next-major feature closure: 7/7 passed.
- M09 target/facade/client affected contracts: 16/16 passed.
- CI `test_*guard.py` discovery: 114/114 passed.
- `cargo metadata --format-version 1 --locked --no-deps`: passed.
- AGENTS routing drift check: passed; standalone Cargo 4, Node 3, routes 8.
- `git diff --check` and staged diff check: passed.

The first release-guard run exposed that the compatibility ledger stores Rust import aliases with underscores while manifests use hyphenated package keys. The parser was corrected to resolve either key and the full validation set above was rerun successfully.

Root Cargo fmt/Clippy were not triggered because this package changes Python policy tooling, CI wiring, and Markdown only; it does not change Rust source, Cargo manifests, features, public API, wire/storage formats, or runtime behavior.

## Compatibility and rollback

- R0 remains a no-behavior-change release; deprecated paths remain available.
- Current Proxy Cluster/Local dependencies remain non-optional and mode features remain inactive until next-major gates pass.
- Revert the plan, guard, CI hook, and release documents together; do not delete canonical crates, restore duplicated facade implementations, change defaults, or rewrite persisted/wire data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture release planning and validation for R0, R1, and next-major milestones.
  * Added checks for package topology, dependency compatibility, release sequencing, approvals, usage evidence, rollback readiness, and required documentation.
  * Added release notes, migration guidance, and next-major removal planning.

* **CI**
  * CI now automatically validates architecture release packages.

* **Documentation**
  * Updated migration progress, completion evidence, release procedures, and consumer migration checklists.

* **Tests**
  * Added coverage for release ordering, compatibility ledgers, documentation completeness, approval gates, and activation safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->