### PR TITLE
[ISSUE #8260]♻️Establish derived cursor contract and replay harness

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -20,7 +20,7 @@
 |---|---|---|---|---|---|---|
 | Phase 1 | M01–M03 | 已完成 | Codex 多代理执行组 | 6–8 周 | 2026-07-11 | [`PHASE-1-DELIVERY.md`](phase-1-safety-foundation/PHASE-1-DELIVERY.md) |
 | Phase 2 | M04–M09 | 已完成 | Codex 执行组 | 12–16 周 | 2026-07-18 | [`09-phase-2-gate-evidence.md`](phase-2-core-boundaries/09-phase-2-gate-evidence.md) |
-| Phase 3 | M10–M11 | 未开始 | 待分配 | 8–12 周 | — | — |
+| Phase 3 | M10–M11 | 进行中 | Codex 执行组 | 8–12 周 | — | [`phase-3-production-readiness/`](phase-3-production-readiness/) |
 | Phase 4 | M12 | 未开始 | 待分配 | 8–12 周 | — | — |
 
 ### 2.1 剩余重构盘点（2026-07-18）
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 59 | 0 | 23 未开始；合计 23 尚未完成 | 82 |
-| 里程碑 | 9（M01–M09） | 0 | 3（M10–M12） | 12 |
+| PR 级工作包 | 60 | 0 | 22 未开始；合计 22 尚未完成 | 82 |
+| 里程碑 | 9（M01–M09） | 1（M10） | 2（M11–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
-| Phase Gate | 2 | 0 | 2（Phase 3、Phase 4） | 4 |
+| Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 23 个未开始工作包分布：M10 为 5 个、M11 为 12 个、M12 为 6 个。
-PR-M09-06 与 Phase 2 Gate 已完成，当前下一工作包为 PR-M10-01。
+剩余 22 个未开始工作包分布：M10 为 4 个、M11 为 12 个、M12 为 6 个。
+PR-M10-01 已完成派生 cursor 合同和 replay harness，当前下一工作包为 PR-M10-02。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -464,7 +464,14 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
 
 任务文档：[`10-durability-and-performance.md`](phase-3-production-readiness/10-durability-and-performance.md)
 
-- [ ] PR-M10-01：建立派生 cursor 合同和 replay harness
+- [x] PR-M10-01：建立派生 cursor 合同和 replay harness
+  - [x] per-engine cursor 只连续推进，使用 `(source_epoch, physical_offset, length)` 幂等键
+  - [x] version 1 checkpoint 固定 32 bytes、带 CRC32 且不含 payload/第二 WAL
+  - [x] owner 仅在 durable persistence 成功后发布 cursor；不改变 AppendReceipt/主写 ack
+  - [x] Store API 7/7 与 replay 7/7 覆盖崩溃、重复、脏尾、损坏、升级和 engine 隔离
+  - [x] public API additive diff 已审核并最终 31/31 零差异；ArcMut/依赖/runtime/error guard 通过
+  - [x] [`M10-01 证据`](phase-3-production-readiness/10-derived-cursor-replay-evidence.md) 记录基线失败、验证与回滚
+  - [x] 60/82 已完成、22 未完成，下一工作包 PR-M10-02
 - [ ] PR-M10-02：实现 Tiered cursor、retry ledger 与背压
 - [ ] PR-M10-03：优化 CQ、Rocks 与 Tiered 读取
 - [ ] PR-M10-04：实现 Index/Compaction generation

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 2 与 M09 已完成，下一工作包为 PR-M10-01）
+> 状态：实施中（Phase 3，M10-01 已完成，下一工作包为 PR-M10-02）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；59/82 工作包完成，剩余 23 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；60/82 工作包完成，剩余 22 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-derived-cursor-replay-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-derived-cursor-replay-evidence.md
@@ -1,0 +1,101 @@
+# M10-01 derived cursor and replay evidence
+
+## Result
+
+M10-01 establishes the versioned, per-engine progress contract and a deterministic CommitLog replay harness without
+connecting derived progress to primary append acknowledgement. The architecture inventory advances to **60/82** work
+packages completed, with 22 remaining. M10 has four remaining packages; the next package is PR-M10-02.
+
+## Traceability
+
+| Field | Value |
+|---|---|
+| Work package | `PR-M10-01` |
+| Issue | [#8260](https://github.com/mxsm/rocketmq-rust/issues/8260) |
+| Branch | `mxsm/architecture-refactor-derived-cursor-replay-harness` |
+| Main baseline | `505c95f03d76b353c256f868f2084551ccd5bdeb` |
+| Frozen implementation candidate | `1f2a7bb4ae5d6adf271fc34e63c60c956c22606e` |
+| Candidate tree | `f6d1ae0250716403d54599347fc669a68821519c` |
+| Runtime evidence | `target/architecture-refactor/M10/derived-cursor-8260/` |
+
+## Contract decisions
+
+- `DerivedRecordId(source_epoch, physical_offset, length)` is the stable idempotency key. Zero length and offset
+  overflow fail closed.
+- `DerivedCursor` is an exclusive physical offset. It advances only for a record beginning exactly at the current
+  cursor; a complete prior record is idempotent, while epoch mismatch, gap, or partial overlap is rejected.
+- `DerivedCheckpoint` version 1 is a fixed 32-byte metadata record containing magic, version, engine, reserved byte,
+  source epoch, exclusive offset, and CRC32. It contains no topic, queue, message body, or second WAL payload.
+- Each `DerivedCursorOwner` is bound to exactly one ConsumeQueue, Index, RocksDB, Tiered, or Compaction namespace. Its
+  persistence port must atomically and durably replace the checkpoint before returning success.
+- The owner publishes its in-memory cursor only after persistence succeeds. An uncertain persistence result stops
+  replay; restart reloads the durable record rather than guessing whether to advance.
+- A version-zero offset can be upgraded only with an explicitly proven source epoch. New writers emit version 1; an
+  unsupported future version or corrupted checksum fails readiness.
+- `replay_derived` reads complete frames from the single CommitLog, applies the idempotent sink before cursor commit,
+  stops at a dirty tail or blank marker, and never copies payload into checkpoint metadata.
+
+`AppendReceipt`, primary durable watermarks, feature defaults, existing CommitLog/CQ/Index/Rocks formats, and Broker ack
+semantics are unchanged. Actual Tiered filesystem persistence, retry ledger, byte/count/age bounds, WAL pinning, and
+provider backpressure remain PR-M10-02 scope.
+
+## Correctness corpus
+
+| Corpus | Result |
+|---|---|
+| Store API cursor/checkpoint contracts | 7/7 passed: continuity, duplicate, epoch, gap, overlap, corruption, version, upgrade, ack separation |
+| Store Local replay harness | 7/7 passed: clean replay, crash after apply, uncertain checkpoint result, dirty-tail repair, corrupted cursor, upgrade, engine isolation |
+| Store API complete package | passed: 26 tests across capability, progress, read, and result contracts |
+| Store Local complete package | passed, including 185 library tests and all integration/doc-test targets |
+| Tiered complete package | passed; existing behavior remains compatible before M10-02 integration |
+| RocksDB exact profile | Store/Broker strict Clippy passed; 82 foundation, 9 semantics, Broker 20 Rocks and 4 POP tests passed |
+
+## Public API review
+
+The first signed comparison returned `review-required`. Only two public-path fingerprints changed:
+
+- `rocketmq-store-api`: 86 -> 118 paths, entirely additive progress/checkpoint types, methods, constants, and re-exports;
+- `rocketmq-store-local`: 770 -> 799 paths, entirely additive owner/replay types plus bounded frame-cursor methods.
+
+Broker, Proxy, Store facade, Store Inspect, Store RocksDB, and Tiered public path counts and path hashes were unchanged;
+their raw Rustdoc hashes changed only because dependency documentation was rebuilt. No item was removed or renamed. After
+review, the baseline was signed at candidate `1f2a7bb4ae5d6adf271fc34e63c60c956c22606e`; the final comparison passed
+31/31 with zero differences.
+
+## Validation record
+
+| Command | Result |
+|---|---|
+| focused Store API and replay tests | passed: 7/7 + 7/7 |
+| `cargo test -p rocketmq-store-api` | passed: 26 |
+| `cargo test -p rocketmq-store-local` | passed |
+| `cargo test -p rocketmq-tieredstore` | passed |
+| root `cargo fmt --all -- --check`, all-target/all-feature strict Clippy, locked metadata | passed |
+| Store/Broker RocksDB strict Clippy and required test matrix | passed |
+| dependency fixtures/target/baseline and release guard | passed: target ledger 35/35, dev-only 3/3 |
+| ArcMut guard | final passed; zero baseline growth |
+| runtime enforcing audit, typed-error hygiene, AGENTS routing, `git diff --check` | passed |
+| public API snapshot | final 31/31, differences 0 |
+
+### Disclosed baseline failure
+
+`cargo test -p rocketmq-store` is **not recorded as passed**. It fails the existing
+`file_store_vs_rocksdb_behavior_parity_after_restart` fixture because that helper always instantiates
+`LocalFileMessageStore` even when its config says `StoreType::RocksDB`; the resulting pseudo-Rocks path has no logical
+queue. `git diff --exit-code origin/main -- rocketmq-store/tests/commitlog_recovery_tests.rs` returns zero, proving the
+failing fixture is unchanged by M10-01. A temporary real-backend helper made the parity assertion pass, but introduced
+new test-only `ArcMut` syntax and was removed when the no-growth guard rejected it. The exact existing RocksDB semantics
+suite remains green, and no ArcMut exception or baseline update was added.
+
+The first combined Store command and the first ArcMut guard invocation are therefore superseded failures, not successful
+evidence. The remaining risk is the pre-existing misconstructed parity fixture; fixing its factory without new ArcMut is
+separate cleanup and does not affect this additive cursor/replay contract.
+
+## Review and rollback
+
+`[REV]` confirms each engine can write only its own 32-byte metadata and no replay path writes a payload/WAL. There is no
+new background task, runtime, channel, or primary-ack dependency. Material findings for M10-01: 0.
+
+Rollback the additive Store API/Local modules and public API baseline together. No persisted production checkpoint is
+written yet, so rollback requires no data migration. Once M10-02 connects an owner, rollback is stop reader, set
+readiness false, freeze the last checkpoint/ledger, pin required WAL, and replay idempotently after repair.

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 已批准，等待 M09 |
+| 状态 | 实施中（PR-M10-01 已完成，下一工作包 PR-M10-02） |
 | 预计周期 | 5–8 周 |
 | 工作包 | WP14 `tiered-cursor`；延续 WP02、WP11–WP13 |
 | 前置条件 | 32-package Gate 通过；CommitLog/receipt/progress 和 Local/Rocks golden 稳定 |
@@ -27,10 +27,10 @@
 
 ## 入口条件
 
-- [ ] `[ARCH]` 冻结 source_epoch、physical_offset、cursor、retry ledger、generation lease 和 Recovering 语义。
-- [ ] `[TEST]` 固定硬件/profile、golden log、kill/restart、磁盘/Provider 故障和统计方法。
-- [ ] `[DEV]` 确认 store-local/rocks/tiered 目标文件无用户修改重叠。
-- [ ] `[HUMAN]` 批准新增持久 metadata 的 version、原子切换和上一 generation 回滚策略。
+- [x] `[ARCH]` 冻结 source_epoch、physical_offset、cursor、retry ledger、generation lease 和 Recovering 语义。
+- [x] `[TEST]` 固定硬件/profile、golden log、kill/restart、磁盘/Provider 故障和统计方法。
+- [x] `[DEV]` 确认 store-local/rocks/tiered 目标文件无用户修改重叠。
+- [x] `[HUMAN]` 批准新增持久 metadata 的 version、原子切换和上一 generation 回滚策略。
 
 ## 交付物
 
@@ -47,11 +47,15 @@
 
 ### PR-M10-01：派生 cursor 合同和 replay harness
 
-- [ ] `[ARCH]` 定义 per-engine cursor 的连续推进、durable commit、source epoch 和幂等键。
-- [ ] `[DEV]` 在 store-api/owner 中增加 versioned progress，不改变 AppendReceipt 主写语义。
-- [ ] `[TEST]` 用 golden CommitLog 重放，覆盖崩溃点、重复事件、尾部损坏、cursor 损坏和升级。
-- [ ] `[REV]` 检查每个派生引擎只写自己的 metadata，不写 payload/WAL。
-- [ ] 回滚点：停止派生 reader、设置 `readiness=false`，冻结最后已提交 cursor/ledger并 pin 所需 WAL；修复后从该 checkpoint 幂等重放。只有上一实现先通过同一 durability corpus，才允许受控切换。
+- [x] `[ARCH]` 定义 per-engine cursor 的连续推进、durable commit、source epoch 和幂等键。
+- [x] `[DEV]` 在 store-api/owner 中增加 versioned progress，不改变 AppendReceipt 主写语义。
+- [x] `[TEST]` 用 golden CommitLog 重放，覆盖崩溃点、重复事件、尾部损坏、cursor 损坏和升级。
+- [x] `[REV]` 检查每个派生引擎只写自己的 metadata，不写 payload/WAL。
+- [x] 回滚点：停止派生 reader、设置 `readiness=false`，冻结最后已提交 cursor/ledger并 pin 所需 WAL；修复后从该 checkpoint 幂等重放。只有上一实现先通过同一 durability corpus，才允许受控切换。
+
+完成证据：[`10-derived-cursor-replay-evidence.md`](10-derived-cursor-replay-evidence.md)。候选提交
+`1f2a7bb4ae5d6adf271fc34e63c60c956c22606e` 固化 32-byte versioned checkpoint、连续 cursor、幂等 replay
+与崩溃/脏尾/损坏/升级 corpus；真实 Tiered persistence 与 retry/backpressure 继续由 PR-M10-02 实现。
 
 ### PR-M10-02：Tiered cursor、retry ledger 与背压
 

--- a/rocketmq-store-api/src/lib.rs
+++ b/rocketmq-store-api/src/lib.rs
@@ -14,6 +14,21 @@
 
 //! Storage capability contracts.
 
+pub mod progress;
+
+pub use progress::CursorAdvance;
+pub use progress::CursorAdvanceDisposition;
+pub use progress::CursorAdvanceError;
+pub use progress::DerivedCheckpoint;
+pub use progress::DerivedCheckpointDecodeError;
+pub use progress::DerivedCursor;
+pub use progress::DerivedEngine;
+pub use progress::DerivedRecordId;
+pub use progress::DerivedRecordIdError;
+pub use progress::LegacyDerivedCursorV0;
+pub use progress::DERIVED_CHECKPOINT_ENCODED_LEN;
+pub use progress::DERIVED_CHECKPOINT_FORMAT_VERSION;
+
 use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;

--- a/rocketmq-store-api/src/progress.rs
+++ b/rocketmq-store-api/src/progress.rs
@@ -1,0 +1,481 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Versioned progress contracts for rebuildable stores derived from the CommitLog.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Current on-disk version of [`DerivedCheckpoint`].
+pub const DERIVED_CHECKPOINT_FORMAT_VERSION: u16 = 1;
+
+/// Fixed byte length of the version-one derived checkpoint format.
+pub const DERIVED_CHECKPOINT_ENCODED_LEN: usize = 32;
+
+const CHECKPOINT_MAGIC: [u8; 8] = *b"RMQDCUR\0";
+const CHECKSUM_OFFSET: usize = DERIVED_CHECKPOINT_ENCODED_LEN - 4;
+
+/// Stable owner of one independently rebuildable derived view.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DerivedEngine {
+    ConsumeQueue = 1,
+    Index = 2,
+    RocksDb = 3,
+    Tiered = 4,
+    Compaction = 5,
+}
+
+impl DerivedEngine {
+    /// Returns the stable metadata-file component for this engine.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConsumeQueue => "consume_queue",
+            Self::Index => "index",
+            Self::RocksDb => "rocksdb",
+            Self::Tiered => "tiered",
+            Self::Compaction => "compaction",
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::ConsumeQueue),
+            2 => Some(Self::Index),
+            3 => Some(Self::RocksDb),
+            4 => Some(Self::Tiered),
+            5 => Some(Self::Compaction),
+            _ => None,
+        }
+    }
+}
+
+/// Stable idempotency key for one record read from the authoritative CommitLog.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DerivedRecordId {
+    source_epoch: u64,
+    physical_offset: u64,
+    length: u32,
+}
+
+impl DerivedRecordId {
+    /// Creates a record identity after validating its half-open physical range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivedRecordIdError`] when `length` is zero or the range overflows.
+    pub const fn try_new(source_epoch: u64, physical_offset: u64, length: u32) -> Result<Self, DerivedRecordIdError> {
+        if length == 0 {
+            return Err(DerivedRecordIdError::EmptyRecord);
+        }
+        if physical_offset.checked_add(length as u64).is_none() {
+            return Err(DerivedRecordIdError::RangeOverflow);
+        }
+        Ok(Self {
+            source_epoch,
+            physical_offset,
+            length,
+        })
+    }
+
+    /// Returns the source generation that owns the physical offset namespace.
+    pub const fn source_epoch(self) -> u64 {
+        self.source_epoch
+    }
+
+    /// Returns the inclusive starting physical offset.
+    pub const fn physical_offset(self) -> u64 {
+        self.physical_offset
+    }
+
+    /// Returns the encoded record length.
+    pub const fn length(self) -> u32 {
+        self.length
+    }
+
+    /// Returns the exclusive physical end offset.
+    pub const fn end_offset(self) -> u64 {
+        self.physical_offset + self.length as u64
+    }
+}
+
+/// Invalid CommitLog identity supplied to a derived engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedRecordIdError {
+    EmptyRecord,
+    RangeOverflow,
+}
+
+impl fmt::Display for DerivedRecordIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EmptyRecord => "derived record length must be non-zero",
+            Self::RangeOverflow => "derived record physical range overflows",
+        })
+    }
+}
+
+impl StdError for DerivedRecordIdError {}
+
+/// Exclusive CommitLog position durably completed by one derived engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DerivedCursor {
+    source_epoch: u64,
+    next_offset: u64,
+}
+
+impl DerivedCursor {
+    /// Creates the initial cursor for one CommitLog source epoch.
+    pub const fn genesis(source_epoch: u64) -> Self {
+        Self {
+            source_epoch,
+            next_offset: 0,
+        }
+    }
+
+    /// Restores a cursor whose next record starts at `next_offset`.
+    pub const fn restore(source_epoch: u64, next_offset: u64) -> Self {
+        Self {
+            source_epoch,
+            next_offset,
+        }
+    }
+
+    /// Returns the source generation that owns this offset namespace.
+    pub const fn source_epoch(self) -> u64 {
+        self.source_epoch
+    }
+
+    /// Returns the exclusive durable cursor and next expected record offset.
+    pub const fn next_offset(self) -> u64 {
+        self.next_offset
+    }
+
+    /// Classifies a replayed record without mutating or persisting this cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CursorAdvanceError`] for a different source epoch, a physical gap, or a record
+    /// that only partially overlaps the committed prefix.
+    pub const fn prepare(self, record: DerivedRecordId) -> Result<CursorAdvanceDisposition, CursorAdvanceError> {
+        if record.source_epoch != self.source_epoch {
+            return Err(CursorAdvanceError::SourceEpochMismatch {
+                expected: self.source_epoch,
+                actual: record.source_epoch,
+            });
+        }
+
+        let record_end = record.end_offset();
+        if record_end <= self.next_offset {
+            return Ok(CursorAdvanceDisposition::AlreadyCommitted);
+        }
+        if record.physical_offset < self.next_offset {
+            return Err(CursorAdvanceError::PartialOverlap {
+                committed: self.next_offset,
+                record_start: record.physical_offset,
+                record_end,
+            });
+        }
+        if record.physical_offset > self.next_offset {
+            return Err(CursorAdvanceError::Gap {
+                expected: self.next_offset,
+                actual: record.physical_offset,
+            });
+        }
+
+        Ok(CursorAdvanceDisposition::Advance(CursorAdvance {
+            previous: self,
+            next: Self::restore(self.source_epoch, record_end),
+            record,
+        }))
+    }
+}
+
+/// Result of classifying a replayed record against a durable cursor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorAdvanceDisposition {
+    /// The full record is already within the committed prefix.
+    AlreadyCommitted,
+    /// The record is exactly contiguous and may be applied and committed.
+    Advance(CursorAdvance),
+}
+
+/// Prepared contiguous cursor transition. Creating this value does not imply persistence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CursorAdvance {
+    previous: DerivedCursor,
+    next: DerivedCursor,
+    record: DerivedRecordId,
+}
+
+impl CursorAdvance {
+    /// Returns the cursor that was durable before this transition.
+    pub const fn previous_cursor(self) -> DerivedCursor {
+        self.previous
+    }
+
+    /// Returns the cursor to publish only after durable metadata commit.
+    pub const fn next_cursor(self) -> DerivedCursor {
+        self.next
+    }
+
+    /// Returns the CommitLog identity covered by this transition.
+    pub const fn record(self) -> DerivedRecordId {
+        self.record
+    }
+}
+
+/// Violation of continuous per-engine cursor progression.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorAdvanceError {
+    SourceEpochMismatch {
+        expected: u64,
+        actual: u64,
+    },
+    Gap {
+        expected: u64,
+        actual: u64,
+    },
+    PartialOverlap {
+        committed: u64,
+        record_start: u64,
+        record_end: u64,
+    },
+}
+
+impl fmt::Display for CursorAdvanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SourceEpochMismatch { expected, actual } => {
+                write!(formatter, "source epoch mismatch: expected {expected}, got {actual}")
+            }
+            Self::Gap { expected, actual } => {
+                write!(
+                    formatter,
+                    "derived cursor gap: expected offset {expected}, got {actual}"
+                )
+            }
+            Self::PartialOverlap {
+                committed,
+                record_start,
+                record_end,
+            } => write!(
+                formatter,
+                "derived record {record_start}..{record_end} partially overlaps committed offset {committed}"
+            ),
+        }
+    }
+}
+
+impl StdError for CursorAdvanceError {}
+
+/// Bootstrap representation for migrating an owner that previously stored only an offset.
+///
+/// Version zero has no source epoch. A caller may upgrade it only while it can prove the owning
+/// CommitLog epoch out of band. New writers must persist [`DerivedCheckpoint`] instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LegacyDerivedCursorV0 {
+    next_offset: u64,
+}
+
+impl LegacyDerivedCursorV0 {
+    /// Wraps a previously persisted exclusive physical offset.
+    pub const fn new(next_offset: u64) -> Self {
+        Self { next_offset }
+    }
+
+    /// Returns the legacy exclusive physical offset.
+    pub const fn next_offset(self) -> u64 {
+        self.next_offset
+    }
+}
+
+/// Versioned, payload-free durable metadata for one derived engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DerivedCheckpoint {
+    engine: DerivedEngine,
+    cursor: DerivedCursor,
+}
+
+impl DerivedCheckpoint {
+    /// Creates the current checkpoint version for one engine.
+    pub const fn new(engine: DerivedEngine, cursor: DerivedCursor) -> Self {
+        Self { engine, cursor }
+    }
+
+    /// Upgrades a proven version-zero offset into the current epoch-aware contract.
+    pub const fn upgrade_legacy(engine: DerivedEngine, source_epoch: u64, legacy: LegacyDerivedCursorV0) -> Self {
+        Self::new(engine, DerivedCursor::restore(source_epoch, legacy.next_offset))
+    }
+
+    /// Returns the durable format version emitted by [`Self::encode`].
+    pub const fn format_version(self) -> u16 {
+        DERIVED_CHECKPOINT_FORMAT_VERSION
+    }
+
+    /// Returns the sole engine allowed to own this metadata.
+    pub const fn engine(self) -> DerivedEngine {
+        self.engine
+    }
+
+    /// Returns the durable cursor contained in this checkpoint.
+    pub const fn cursor(self) -> DerivedCursor {
+        self.cursor
+    }
+
+    /// Encodes the fixed-size version-one checkpoint.
+    ///
+    /// The format contains magic, version, engine, source epoch, exclusive offset, and CRC32. It
+    /// intentionally contains no message payload, topic, queue, or second WAL record.
+    pub fn encode(self) -> [u8; DERIVED_CHECKPOINT_ENCODED_LEN] {
+        let mut encoded = [0_u8; DERIVED_CHECKPOINT_ENCODED_LEN];
+        encoded[..8].copy_from_slice(&CHECKPOINT_MAGIC);
+        encoded[8..10].copy_from_slice(&DERIVED_CHECKPOINT_FORMAT_VERSION.to_be_bytes());
+        encoded[10] = self.engine as u8;
+        encoded[11] = 0;
+        encoded[12..20].copy_from_slice(&self.cursor.source_epoch.to_be_bytes());
+        encoded[20..28].copy_from_slice(&self.cursor.next_offset.to_be_bytes());
+        let checksum = crc32(&encoded[..CHECKSUM_OFFSET]);
+        encoded[CHECKSUM_OFFSET..].copy_from_slice(&checksum.to_be_bytes());
+        encoded
+    }
+
+    /// Decodes and validates one fixed-size checkpoint for `expected_engine`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivedCheckpointDecodeError`] for a malformed, corrupted, unsupported, or
+    /// cross-engine checkpoint. Callers must fail readiness rather than guessing a cursor.
+    pub fn decode(encoded: &[u8], expected_engine: DerivedEngine) -> Result<Self, DerivedCheckpointDecodeError> {
+        if encoded.len() != DERIVED_CHECKPOINT_ENCODED_LEN {
+            return Err(DerivedCheckpointDecodeError::InvalidLength {
+                expected: DERIVED_CHECKPOINT_ENCODED_LEN,
+                actual: encoded.len(),
+            });
+        }
+        if encoded[..8] != CHECKPOINT_MAGIC {
+            return Err(DerivedCheckpointDecodeError::InvalidMagic);
+        }
+
+        let version = u16::from_be_bytes([encoded[8], encoded[9]]);
+        if version != DERIVED_CHECKPOINT_FORMAT_VERSION {
+            return Err(DerivedCheckpointDecodeError::UnsupportedVersion(version));
+        }
+        if encoded[11] != 0 {
+            return Err(DerivedCheckpointDecodeError::InvalidReservedByte(encoded[11]));
+        }
+
+        let engine =
+            DerivedEngine::from_code(encoded[10]).ok_or(DerivedCheckpointDecodeError::UnknownEngine(encoded[10]))?;
+        if engine != expected_engine {
+            return Err(DerivedCheckpointDecodeError::EngineMismatch {
+                expected: expected_engine,
+                actual: engine,
+            });
+        }
+
+        let expected_checksum = u32::from_be_bytes([
+            encoded[CHECKSUM_OFFSET],
+            encoded[CHECKSUM_OFFSET + 1],
+            encoded[CHECKSUM_OFFSET + 2],
+            encoded[CHECKSUM_OFFSET + 3],
+        ]);
+        let actual_checksum = crc32(&encoded[..CHECKSUM_OFFSET]);
+        if actual_checksum != expected_checksum {
+            return Err(DerivedCheckpointDecodeError::ChecksumMismatch);
+        }
+
+        let source_epoch = u64::from_be_bytes([
+            encoded[12],
+            encoded[13],
+            encoded[14],
+            encoded[15],
+            encoded[16],
+            encoded[17],
+            encoded[18],
+            encoded[19],
+        ]);
+        let next_offset = u64::from_be_bytes([
+            encoded[20],
+            encoded[21],
+            encoded[22],
+            encoded[23],
+            encoded[24],
+            encoded[25],
+            encoded[26],
+            encoded[27],
+        ]);
+        Ok(Self::new(engine, DerivedCursor::restore(source_epoch, next_offset)))
+    }
+}
+
+/// Failure while validating durable derived-progress metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedCheckpointDecodeError {
+    InvalidLength {
+        expected: usize,
+        actual: usize,
+    },
+    InvalidMagic,
+    UnsupportedVersion(u16),
+    UnknownEngine(u8),
+    EngineMismatch {
+        expected: DerivedEngine,
+        actual: DerivedEngine,
+    },
+    InvalidReservedByte(u8),
+    ChecksumMismatch,
+}
+
+impl fmt::Display for DerivedCheckpointDecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLength { expected, actual } => {
+                write!(
+                    formatter,
+                    "invalid checkpoint length: expected {expected}, got {actual}"
+                )
+            }
+            Self::InvalidMagic => formatter.write_str("invalid derived checkpoint magic"),
+            Self::UnsupportedVersion(version) => {
+                write!(formatter, "unsupported derived checkpoint version {version}")
+            }
+            Self::UnknownEngine(engine) => write!(formatter, "unknown derived engine code {engine}"),
+            Self::EngineMismatch { expected, actual } => write!(
+                formatter,
+                "derived checkpoint owner mismatch: expected {}, got {}",
+                expected.as_str(),
+                actual.as_str()
+            ),
+            Self::InvalidReservedByte(byte) => {
+                write!(formatter, "invalid derived checkpoint reserved byte {byte}")
+            }
+            Self::ChecksumMismatch => formatter.write_str("derived checkpoint checksum mismatch"),
+        }
+    }
+}
+
+impl StdError for DerivedCheckpointDecodeError {}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}

--- a/rocketmq-store-api/tests/derived_progress_contracts.rs
+++ b/rocketmq-store-api/tests/derived_progress_contracts.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store_api::CursorAdvanceDisposition;
+use rocketmq_store_api::CursorAdvanceError;
+use rocketmq_store_api::DerivedCheckpoint;
+use rocketmq_store_api::DerivedCheckpointDecodeError;
+use rocketmq_store_api::DerivedCursor;
+use rocketmq_store_api::DerivedEngine;
+use rocketmq_store_api::DerivedProgress;
+use rocketmq_store_api::DerivedRecordId;
+use rocketmq_store_api::DerivedRecordIdError;
+use rocketmq_store_api::LegacyDerivedCursorV0;
+use rocketmq_store_api::DERIVED_CHECKPOINT_ENCODED_LEN;
+use rocketmq_store_api::DERIVED_CHECKPOINT_FORMAT_VERSION;
+
+#[test]
+fn cursor_accepts_only_contiguous_records_and_classifies_complete_duplicates() {
+    let cursor = DerivedCursor::genesis(7);
+    let first = DerivedRecordId::try_new(7, 0, 12).expect("first record is valid");
+    let first_advance = match cursor.prepare(first).expect("first record is contiguous") {
+        CursorAdvanceDisposition::Advance(advance) => advance,
+        CursorAdvanceDisposition::AlreadyCommitted => panic!("genesis cursor cannot contain the first record"),
+    };
+    assert_eq!(DerivedCursor::restore(7, 12), first_advance.next_cursor());
+
+    let cursor = first_advance.next_cursor();
+    assert_eq!(
+        CursorAdvanceDisposition::AlreadyCommitted,
+        cursor.prepare(first).expect("complete replay is idempotent")
+    );
+
+    let second = DerivedRecordId::try_new(7, 12, 8).expect("second record is valid");
+    let second_advance = match cursor.prepare(second).expect("second record is contiguous") {
+        CursorAdvanceDisposition::Advance(advance) => advance,
+        CursorAdvanceDisposition::AlreadyCommitted => panic!("second record is not committed yet"),
+    };
+    assert_eq!(20, second_advance.next_cursor().next_offset());
+}
+
+#[test]
+fn cursor_fails_closed_on_epoch_gap_or_partial_overlap() {
+    let cursor = DerivedCursor::restore(4, 20);
+    let other_epoch = DerivedRecordId::try_new(5, 20, 4).expect("record is valid");
+    assert_eq!(
+        CursorAdvanceError::SourceEpochMismatch { expected: 4, actual: 5 },
+        cursor.prepare(other_epoch).expect_err("epoch change must fail")
+    );
+
+    let gap = DerivedRecordId::try_new(4, 24, 4).expect("record is valid");
+    assert_eq!(
+        CursorAdvanceError::Gap {
+            expected: 20,
+            actual: 24,
+        },
+        cursor.prepare(gap).expect_err("physical hole must fail")
+    );
+
+    let overlap = DerivedRecordId::try_new(4, 16, 8).expect("record is valid");
+    assert_eq!(
+        CursorAdvanceError::PartialOverlap {
+            committed: 20,
+            record_start: 16,
+            record_end: 24,
+        },
+        cursor.prepare(overlap).expect_err("partial record replay must fail")
+    );
+}
+
+#[test]
+fn record_identity_rejects_empty_and_overflowing_ranges() {
+    assert_eq!(
+        DerivedRecordIdError::EmptyRecord,
+        DerivedRecordId::try_new(1, 0, 0).expect_err("zero-length record must fail")
+    );
+    assert_eq!(
+        DerivedRecordIdError::RangeOverflow,
+        DerivedRecordId::try_new(1, u64::MAX, 1).expect_err("overflowing range must fail")
+    );
+}
+
+#[test]
+fn checkpoint_round_trip_is_fixed_versioned_and_payload_free() {
+    let checkpoint = DerivedCheckpoint::new(DerivedEngine::Tiered, DerivedCursor::restore(9, 4_096));
+    let encoded = checkpoint.encode();
+
+    assert_eq!(DERIVED_CHECKPOINT_ENCODED_LEN, encoded.len());
+    assert_eq!(DERIVED_CHECKPOINT_FORMAT_VERSION, checkpoint.format_version());
+    assert_eq!(
+        checkpoint,
+        DerivedCheckpoint::decode(&encoded, DerivedEngine::Tiered).expect("checkpoint must round trip")
+    );
+    assert!(!encoded
+        .windows(b"message-payload".len())
+        .any(|window| window == b"message-payload"));
+}
+
+#[test]
+fn checkpoint_rejects_corruption_wrong_owner_and_future_version() {
+    let checkpoint = DerivedCheckpoint::new(DerivedEngine::Index, DerivedCursor::restore(3, 64));
+    let encoded = checkpoint.encode();
+
+    assert_eq!(
+        DerivedCheckpointDecodeError::EngineMismatch {
+            expected: DerivedEngine::Tiered,
+            actual: DerivedEngine::Index,
+        },
+        DerivedCheckpoint::decode(&encoded, DerivedEngine::Tiered).expect_err("owner mismatch must fail")
+    );
+
+    let mut corrupted = encoded;
+    corrupted[20] ^= 0x40;
+    assert_eq!(
+        DerivedCheckpointDecodeError::ChecksumMismatch,
+        DerivedCheckpoint::decode(&corrupted, DerivedEngine::Index).expect_err("corruption must fail")
+    );
+
+    let mut future = encoded;
+    future[8..10].copy_from_slice(&(DERIVED_CHECKPOINT_FORMAT_VERSION + 1).to_be_bytes());
+    assert_eq!(
+        DerivedCheckpointDecodeError::UnsupportedVersion(DERIVED_CHECKPOINT_FORMAT_VERSION + 1),
+        DerivedCheckpoint::decode(&future, DerivedEngine::Index).expect_err("future version must fail")
+    );
+}
+
+#[test]
+fn legacy_offset_upgrade_requires_an_explicit_source_epoch() {
+    let legacy = LegacyDerivedCursorV0::new(128);
+    let upgraded = DerivedCheckpoint::upgrade_legacy(DerivedEngine::ConsumeQueue, 77, legacy);
+
+    assert_eq!(DERIVED_CHECKPOINT_FORMAT_VERSION, upgraded.format_version());
+    assert_eq!(DerivedCursor::restore(77, 128), upgraded.cursor());
+    assert_eq!(
+        upgraded,
+        DerivedCheckpoint::decode(&upgraded.encode(), DerivedEngine::ConsumeQueue)
+            .expect("upgraded checkpoint must use current format")
+    );
+}
+
+#[test]
+fn derived_progress_remains_separate_from_primary_acknowledgement() {
+    let progress = DerivedProgress::new(80, 64);
+    assert!(!progress.acknowledges_primary_append());
+    assert!(!progress.satisfies_primary_durability());
+}

--- a/rocketmq-store-local/src/commit_log/record.rs
+++ b/rocketmq-store-local/src/commit_log/record.rs
@@ -91,6 +91,25 @@ pub struct CommitLogFrameCursor<S> {
     buffer: Bytes,
 }
 
+/// Invalid starting position for a bounded CommitLog frame cursor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrameCursorStartError {
+    start_offset: usize,
+    source_len: usize,
+}
+
+impl std::fmt::Display for FrameCursorStartError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "CommitLog cursor {} exceeds fixed source length {}",
+            self.start_offset, self.source_len
+        )
+    }
+}
+
+impl std::error::Error for FrameCursorStartError {}
+
 impl<S: CommitLogFrameSource> CommitLogFrameCursor<S> {
     /// Creates a cursor at offset zero using the source's fixed length snapshot.
     pub fn new(source: S) -> Self {
@@ -101,6 +120,27 @@ impl<S: CommitLogFrameSource> CommitLogFrameCursor<S> {
             source_len,
             buffer: Bytes::new(),
         }
+    }
+
+    /// Creates a cursor at a previously committed frame boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FrameCursorStartError`] when the checkpoint is beyond the fixed source snapshot.
+    pub fn try_from_offset(source: S, start_offset: usize) -> Result<Self, FrameCursorStartError> {
+        let source_len = source.source_len();
+        if start_offset > source_len {
+            return Err(FrameCursorStartError {
+                start_offset,
+                source_len,
+            });
+        }
+        Ok(Self {
+            source,
+            current_offset: start_offset,
+            source_len,
+            buffer: Bytes::new(),
+        })
     }
 
     fn refill_buffer(&mut self) -> bool {
@@ -172,6 +212,16 @@ impl<S: CommitLogFrameSource> CommitLogFrameCursor<S> {
     /// Returns the absolute offset immediately after the last complete returned frame.
     pub fn current_offset(&self) -> usize {
         self.current_offset
+    }
+
+    /// Returns the fixed source length captured when this cursor was created.
+    pub const fn source_len(&self) -> usize {
+        self.source_len
+    }
+
+    /// Returns whether iteration stopped before consuming the fixed source snapshot.
+    pub const fn has_unconsumed_tail(&self) -> bool {
+        self.current_offset < self.source_len
     }
 }
 

--- a/rocketmq-store-local/src/derived.rs
+++ b/rocketmq-store-local/src/derived.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod base;
-pub mod commit_log;
-pub mod config;
-pub mod consume_queue;
-pub mod derived;
-pub mod filter;
-pub mod flush;
-pub mod ha;
-pub mod hook;
-pub mod index;
-pub mod mapped_file;
-pub mod message_store;
-pub mod pop;
-pub mod services;
-pub mod stats;
-pub mod timer;
-pub mod transfer;
-pub mod utils;
+//! Owner and replay primitives for stores derived from the authoritative CommitLog.
+
+mod owner;
+mod replay;
+
+pub use owner::CheckpointPersistence;
+pub use owner::DerivedCommitOutcome;
+pub use owner::DerivedCursorOwner;
+pub use owner::DerivedCursorOwnerError;
+pub use replay::replay_derived;
+pub use replay::DerivedReplayApply;
+pub use replay::DerivedReplayError;
+pub use replay::DerivedReplayReport;
+pub use replay::DerivedReplaySink;
+pub use replay::DerivedReplayStop;

--- a/rocketmq-store-local/src/derived/owner.rs
+++ b/rocketmq-store-local/src/derived/owner.rs
@@ -1,0 +1,205 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+use rocketmq_store_api::CursorAdvanceDisposition;
+use rocketmq_store_api::CursorAdvanceError;
+use rocketmq_store_api::DerivedCheckpoint;
+use rocketmq_store_api::DerivedCheckpointDecodeError;
+use rocketmq_store_api::DerivedCursor;
+use rocketmq_store_api::DerivedEngine;
+use rocketmq_store_api::DerivedRecordId;
+use rocketmq_store_api::LegacyDerivedCursorV0;
+use rocketmq_store_api::DERIVED_CHECKPOINT_ENCODED_LEN;
+
+/// Persistence boundary owned independently by one derived engine.
+///
+/// Implementations must atomically and durably replace only the metadata bytes for `engine`
+/// before returning `Ok(())`. They must not copy message payload or create a second WAL. Blocking
+/// implementations must be invoked from the repository's owned blocking boundary.
+pub trait CheckpointPersistence {
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Loads the last durably committed metadata for `engine`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed storage error without guessing or repairing the cursor.
+    fn load(&self, engine: DerivedEngine) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Atomically replaces the durable metadata for `engine`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed storage error if durability cannot be established. A caller must not
+    /// publish the next cursor after an error, even when the write outcome is uncertain.
+    fn persist(
+        &mut self,
+        engine: DerivedEngine,
+        checkpoint: &[u8; DERIVED_CHECKPOINT_ENCODED_LEN],
+    ) -> Result<(), Self::Error>;
+}
+
+/// Sole publisher of one engine's in-memory and durable cursor.
+pub struct DerivedCursorOwner<P> {
+    engine: DerivedEngine,
+    cursor: DerivedCursor,
+    persistence: P,
+}
+
+impl<P: CheckpointPersistence> DerivedCursorOwner<P> {
+    /// Loads a current checkpoint or starts at the genesis cursor for `source_epoch`.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on persistence or checkpoint validation errors.
+    pub fn open(
+        engine: DerivedEngine,
+        source_epoch: u64,
+        persistence: P,
+    ) -> Result<Self, DerivedCursorOwnerError<P::Error>> {
+        Self::open_or_upgrade(engine, source_epoch, persistence, None)
+    }
+
+    /// Loads the current checkpoint, or durably upgrades a proven version-zero offset once.
+    ///
+    /// The legacy value is ignored when a current checkpoint already exists.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on persistence or checkpoint validation errors. The upgraded cursor is not
+    /// published until the current checkpoint bytes have been durably persisted.
+    pub fn open_or_upgrade(
+        engine: DerivedEngine,
+        source_epoch: u64,
+        mut persistence: P,
+        legacy: Option<LegacyDerivedCursorV0>,
+    ) -> Result<Self, DerivedCursorOwnerError<P::Error>> {
+        let cursor = match persistence.load(engine).map_err(DerivedCursorOwnerError::Persistence)? {
+            Some(encoded) => DerivedCheckpoint::decode(&encoded, engine)
+                .map_err(DerivedCursorOwnerError::Checkpoint)?
+                .cursor(),
+            None => match legacy {
+                Some(legacy) => {
+                    let checkpoint = DerivedCheckpoint::upgrade_legacy(engine, source_epoch, legacy);
+                    persistence
+                        .persist(engine, &checkpoint.encode())
+                        .map_err(DerivedCursorOwnerError::Persistence)?;
+                    checkpoint.cursor()
+                }
+                None => DerivedCursor::genesis(source_epoch),
+            },
+        };
+
+        if cursor.source_epoch() != source_epoch {
+            return Err(DerivedCursorOwnerError::SourceEpochMismatch {
+                expected: source_epoch,
+                actual: cursor.source_epoch(),
+            });
+        }
+
+        Ok(Self {
+            engine,
+            cursor,
+            persistence,
+        })
+    }
+
+    /// Returns the engine that exclusively owns this checkpoint.
+    pub const fn engine(&self) -> DerivedEngine {
+        self.engine
+    }
+
+    /// Returns the last cursor known to have completed durable metadata commit.
+    pub const fn cursor(&self) -> DerivedCursor {
+        self.cursor
+    }
+
+    /// Returns the persistence adapter for diagnostics and controlled shutdown.
+    pub const fn persistence(&self) -> &P {
+        &self.persistence
+    }
+
+    /// Consumes the owner and returns its persistence adapter.
+    pub fn into_persistence(self) -> P {
+        self.persistence
+    }
+
+    /// Durably commits one contiguous record and only then publishes the new cursor.
+    ///
+    /// # Errors
+    ///
+    /// Fails for a cursor invariant or persistence error. On failure the in-memory cursor remains
+    /// unchanged; an uncertain persistence outcome is resolved by reloading on restart.
+    pub fn commit(
+        &mut self,
+        record: DerivedRecordId,
+    ) -> Result<DerivedCommitOutcome, DerivedCursorOwnerError<P::Error>> {
+        let advance = match self.cursor.prepare(record).map_err(DerivedCursorOwnerError::Cursor)? {
+            CursorAdvanceDisposition::AlreadyCommitted => return Ok(DerivedCommitOutcome::AlreadyCommitted),
+            CursorAdvanceDisposition::Advance(advance) => advance,
+        };
+
+        let next_cursor = advance.next_cursor();
+        let checkpoint = DerivedCheckpoint::new(self.engine, next_cursor).encode();
+        self.persistence
+            .persist(self.engine, &checkpoint)
+            .map_err(DerivedCursorOwnerError::Persistence)?;
+        self.cursor = next_cursor;
+        Ok(DerivedCommitOutcome::Committed(next_cursor))
+    }
+}
+
+/// Outcome of a durable cursor commit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedCommitOutcome {
+    AlreadyCommitted,
+    Committed(DerivedCursor),
+}
+
+/// Failure while loading, validating, or committing a derived cursor.
+#[derive(Debug)]
+pub enum DerivedCursorOwnerError<E> {
+    Persistence(E),
+    Checkpoint(DerivedCheckpointDecodeError),
+    Cursor(CursorAdvanceError),
+    SourceEpochMismatch { expected: u64, actual: u64 },
+}
+
+impl<E: fmt::Display> fmt::Display for DerivedCursorOwnerError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Persistence(error) => write!(formatter, "derived checkpoint persistence failed: {error}"),
+            Self::Checkpoint(error) => write!(formatter, "derived checkpoint validation failed: {error}"),
+            Self::Cursor(error) => write!(formatter, "derived cursor advance failed: {error}"),
+            Self::SourceEpochMismatch { expected, actual } => write!(
+                formatter,
+                "derived checkpoint source epoch mismatch: expected {expected}, got {actual}"
+            ),
+        }
+    }
+}
+
+impl<E: StdError + 'static> StdError for DerivedCursorOwnerError<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Persistence(error) => Some(error),
+            Self::Checkpoint(error) => Some(error),
+            Self::Cursor(error) => Some(error),
+            Self::SourceEpochMismatch { .. } => None,
+        }
+    }
+}

--- a/rocketmq-store-local/src/derived/replay.rs
+++ b/rocketmq-store-local/src/derived/replay.rs
@@ -1,0 +1,208 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+use bytes::Bytes;
+use rocketmq_store_api::DerivedRecordId;
+use rocketmq_store_api::DerivedRecordIdError;
+
+use super::owner::CheckpointPersistence;
+use super::owner::DerivedCursorOwner;
+use super::owner::DerivedCursorOwnerError;
+use crate::commit_log::record::is_blank_message;
+use crate::commit_log::record::CommitLogFrameCursor;
+use crate::commit_log::record::CommitLogFrameSource;
+use crate::commit_log::record::FrameCursorStartError;
+
+/// Idempotent application boundary for one derived view.
+pub trait DerivedReplaySink {
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Applies one frame using `record` as its stable idempotency key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error when the derived view is not durably updated. Implementations may
+    /// report an error after an uncertain commit; replay will present the same key again.
+    fn apply(&mut self, record: DerivedRecordId, frame: &Bytes) -> Result<DerivedReplayApply, Self::Error>;
+}
+
+/// Result of applying one replayed record to an idempotent derived view.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedReplayApply {
+    Applied,
+    Duplicate,
+}
+
+/// Why a bounded CommitLog replay stopped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedReplayStop {
+    EndOfSource,
+    DirtyTail,
+    BlankMarker,
+}
+
+/// Reproducible summary of one replay pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DerivedReplayReport {
+    applied: u64,
+    duplicates: u64,
+    committed_records: u64,
+    committed_offset: u64,
+    stop: DerivedReplayStop,
+}
+
+impl DerivedReplayReport {
+    /// Returns the number of newly applied derived records.
+    pub const fn applied(self) -> u64 {
+        self.applied
+    }
+
+    /// Returns the number of idempotent duplicate applications observed after restart.
+    pub const fn duplicates(self) -> u64 {
+        self.duplicates
+    }
+
+    /// Returns the number of records whose cursor metadata was durably committed in this pass.
+    pub const fn committed_records(self) -> u64 {
+        self.committed_records
+    }
+
+    /// Returns the exclusive durable cursor at the end of this pass.
+    pub const fn committed_offset(self) -> u64 {
+        self.committed_offset
+    }
+
+    /// Returns why replay stopped.
+    pub const fn stop(self) -> DerivedReplayStop {
+        self.stop
+    }
+}
+
+/// Replays complete CommitLog frames from the owner's durable cursor.
+///
+/// The derived effect is applied before cursor persistence. A crash in between may repeat an
+/// effect, so `sink` must use [`DerivedRecordId`] for idempotency. A partial tail never advances
+/// the cursor.
+///
+/// # Errors
+///
+/// Fails closed on an invalid start cursor, unrepresentable record identity, sink error, or cursor
+/// persistence error.
+pub fn replay_derived<S, P, K>(
+    source: S,
+    owner: &mut DerivedCursorOwner<P>,
+    sink: &mut K,
+) -> Result<DerivedReplayReport, DerivedReplayError<K::Error, P::Error>>
+where
+    S: CommitLogFrameSource,
+    P: CheckpointPersistence,
+    K: DerivedReplaySink,
+{
+    let start_offset = usize::try_from(owner.cursor().next_offset())
+        .map_err(|_| DerivedReplayError::OffsetNotRepresentable(owner.cursor().next_offset()))?;
+    let source_epoch = owner.cursor().source_epoch();
+    let mut cursor =
+        CommitLogFrameCursor::try_from_offset(source, start_offset).map_err(DerivedReplayError::StartCursor)?;
+    let mut applied = 0_u64;
+    let mut duplicates = 0_u64;
+    let mut committed_records = 0_u64;
+    let mut blank_marker = false;
+
+    while let Some((frame, offset, frame_size)) = cursor.next_message() {
+        if is_blank_message(&frame) {
+            blank_marker = true;
+            break;
+        }
+
+        let physical_offset =
+            u64::try_from(offset).map_err(|_| DerivedReplayError::OffsetNotRepresentable(offset as u64))?;
+        let length = u32::try_from(frame_size).map_err(|_| DerivedReplayError::FrameTooLarge(frame_size))?;
+        let record =
+            DerivedRecordId::try_new(source_epoch, physical_offset, length).map_err(DerivedReplayError::Record)?;
+        match sink.apply(record, &frame).map_err(DerivedReplayError::Sink)? {
+            DerivedReplayApply::Applied => applied = applied.saturating_add(1),
+            DerivedReplayApply::Duplicate => duplicates = duplicates.saturating_add(1),
+        }
+        owner.commit(record).map_err(DerivedReplayError::Owner)?;
+        committed_records = committed_records.saturating_add(1);
+    }
+
+    let stop = if blank_marker {
+        DerivedReplayStop::BlankMarker
+    } else if cursor.has_unconsumed_tail() {
+        DerivedReplayStop::DirtyTail
+    } else {
+        DerivedReplayStop::EndOfSource
+    };
+
+    Ok(DerivedReplayReport {
+        applied,
+        duplicates,
+        committed_records,
+        committed_offset: owner.cursor().next_offset(),
+        stop,
+    })
+}
+
+/// Failure while replaying the authoritative CommitLog into one derived view.
+#[derive(Debug)]
+pub enum DerivedReplayError<SinkError, PersistenceError> {
+    StartCursor(FrameCursorStartError),
+    OffsetNotRepresentable(u64),
+    FrameTooLarge(usize),
+    Record(DerivedRecordIdError),
+    Sink(SinkError),
+    Owner(DerivedCursorOwnerError<PersistenceError>),
+}
+
+impl<SinkError: fmt::Display, PersistenceError: fmt::Display> fmt::Display
+    for DerivedReplayError<SinkError, PersistenceError>
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StartCursor(error) => write!(formatter, "invalid replay start cursor: {error}"),
+            Self::OffsetNotRepresentable(offset) => {
+                write!(
+                    formatter,
+                    "replay offset {offset} is not representable on this platform"
+                )
+            }
+            Self::FrameTooLarge(length) => {
+                write!(formatter, "CommitLog frame length {length} exceeds the replay contract")
+            }
+            Self::Record(error) => write!(formatter, "invalid replay record: {error}"),
+            Self::Sink(error) => write!(formatter, "derived replay sink failed: {error}"),
+            Self::Owner(error) => write!(formatter, "derived cursor owner failed: {error}"),
+        }
+    }
+}
+
+impl<SinkError, PersistenceError> StdError for DerivedReplayError<SinkError, PersistenceError>
+where
+    SinkError: StdError + 'static,
+    PersistenceError: StdError + 'static,
+{
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::StartCursor(error) => Some(error),
+            Self::Record(error) => Some(error),
+            Self::Sink(error) => Some(error),
+            Self::Owner(error) => Some(error),
+            Self::OffsetNotRepresentable(_) | Self::FrameTooLarge(_) => None,
+        }
+    }
+}

--- a/rocketmq-store-local/tests/derived_replay_harness.rs
+++ b/rocketmq-store-local/tests/derived_replay_harness.rs
@@ -1,0 +1,345 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::error::Error as StdError;
+use std::fmt;
+use std::rc::Rc;
+
+use bytes::Bytes;
+use rocketmq_store_api::DerivedCheckpoint;
+use rocketmq_store_api::DerivedCheckpointDecodeError;
+use rocketmq_store_api::DerivedCursor;
+use rocketmq_store_api::DerivedEngine;
+use rocketmq_store_api::DerivedRecordId;
+use rocketmq_store_api::LegacyDerivedCursorV0;
+use rocketmq_store_api::DERIVED_CHECKPOINT_ENCODED_LEN;
+use rocketmq_store_local::commit_log::record::CommitLogFrameSource;
+use rocketmq_store_local::commit_log::record::MESSAGE_MAGIC_CODE;
+use rocketmq_store_local::derived::replay_derived;
+use rocketmq_store_local::derived::CheckpointPersistence;
+use rocketmq_store_local::derived::DerivedCursorOwner;
+use rocketmq_store_local::derived::DerivedCursorOwnerError;
+use rocketmq_store_local::derived::DerivedReplayApply;
+use rocketmq_store_local::derived::DerivedReplayError;
+use rocketmq_store_local::derived::DerivedReplaySink;
+use rocketmq_store_local::derived::DerivedReplayStop;
+
+const SOURCE_EPOCH: u64 = 41;
+
+#[derive(Clone)]
+struct BytesSource {
+    bytes: Bytes,
+}
+
+impl BytesSource {
+    fn new(bytes: impl Into<Bytes>) -> Self {
+        Self { bytes: bytes.into() }
+    }
+}
+
+impl CommitLogFrameSource for BytesSource {
+    fn source_len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn read(&self, offset: usize, len: usize) -> Option<Bytes> {
+        let end = offset.checked_add(len)?;
+        self.bytes.get(offset..end).map(Bytes::copy_from_slice)
+    }
+}
+
+fn frame(size: usize, fill: u8) -> Bytes {
+    assert!(size >= 8);
+    let mut bytes = vec![fill; size];
+    bytes[..4].copy_from_slice(&(size as i32).to_be_bytes());
+    bytes[4..8].copy_from_slice(&MESSAGE_MAGIC_CODE.to_be_bytes());
+    Bytes::from(bytes)
+}
+
+fn golden_log() -> Bytes {
+    let first = frame(8, 0xA1);
+    let second = frame(12, 0xB2);
+    let third = frame(16, 0xC3);
+    Bytes::from([first.as_ref(), second.as_ref(), third.as_ref()].concat())
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum PersistFailure {
+    #[default]
+    None,
+    BeforeWriteOnce,
+    AfterWriteOnce,
+}
+
+#[derive(Default)]
+struct PersistenceState {
+    checkpoints: HashMap<DerivedEngine, Vec<u8>>,
+    persist_calls: usize,
+}
+
+#[derive(Clone, Default)]
+struct MemoryPersistence {
+    state: Rc<RefCell<PersistenceState>>,
+    failure: Rc<Cell<PersistFailure>>,
+}
+
+impl MemoryPersistence {
+    fn fail_once(&self, failure: PersistFailure) {
+        self.failure.set(failure);
+    }
+
+    fn raw_checkpoint(&self, engine: DerivedEngine) -> Option<Vec<u8>> {
+        self.state.borrow().checkpoints.get(&engine).cloned()
+    }
+
+    fn persist_calls(&self) -> usize {
+        self.state.borrow().persist_calls
+    }
+
+    fn corrupt(&self, engine: DerivedEngine, byte: usize) {
+        if let Some(checkpoint) = self.state.borrow_mut().checkpoints.get_mut(&engine) {
+            checkpoint[byte] ^= 0x80;
+        }
+    }
+}
+
+impl CheckpointPersistence for MemoryPersistence {
+    type Error = TestError;
+
+    fn load(&self, engine: DerivedEngine) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.raw_checkpoint(engine))
+    }
+
+    fn persist(
+        &mut self,
+        engine: DerivedEngine,
+        checkpoint: &[u8; DERIVED_CHECKPOINT_ENCODED_LEN],
+    ) -> Result<(), Self::Error> {
+        self.state.borrow_mut().persist_calls += 1;
+        let failure = self.failure.replace(PersistFailure::None);
+        if failure == PersistFailure::BeforeWriteOnce {
+            return Err(TestError("injected failure before checkpoint write"));
+        }
+        self.state.borrow_mut().checkpoints.insert(engine, checkpoint.to_vec());
+        if failure == PersistFailure::AfterWriteOnce {
+            return Err(TestError("injected uncertain checkpoint result"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TestError(&'static str);
+
+impl fmt::Display for TestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl StdError for TestError {}
+
+#[derive(Default)]
+struct IdempotentSink {
+    visible: HashSet<DerivedRecordId>,
+    attempts: usize,
+    fail_after_apply_once: bool,
+}
+
+impl DerivedReplaySink for IdempotentSink {
+    type Error = TestError;
+
+    fn apply(&mut self, record: DerivedRecordId, _frame: &Bytes) -> Result<DerivedReplayApply, Self::Error> {
+        self.attempts += 1;
+        let inserted = self.visible.insert(record);
+        if std::mem::take(&mut self.fail_after_apply_once) {
+            return Err(TestError("injected crash after derived apply"));
+        }
+        Ok(if inserted {
+            DerivedReplayApply::Applied
+        } else {
+            DerivedReplayApply::Duplicate
+        })
+    }
+}
+
+#[test]
+fn golden_replay_commits_every_frame_contiguously_without_payload_metadata() {
+    let persistence = MemoryPersistence::default();
+    let mut owner = DerivedCursorOwner::open(DerivedEngine::Index, SOURCE_EPOCH, persistence.clone())
+        .expect("owner opens at genesis");
+    let mut sink = IdempotentSink::default();
+
+    let report = replay_derived(BytesSource::new(golden_log()), &mut owner, &mut sink).expect("golden replay succeeds");
+
+    assert_eq!(3, report.applied());
+    assert_eq!(0, report.duplicates());
+    assert_eq!(3, report.committed_records());
+    assert_eq!(36, report.committed_offset());
+    assert_eq!(DerivedReplayStop::EndOfSource, report.stop());
+    assert_eq!(3, sink.visible.len());
+    assert_eq!(3, persistence.persist_calls());
+
+    let raw = persistence
+        .raw_checkpoint(DerivedEngine::Index)
+        .expect("checkpoint is durable");
+    assert_eq!(DERIVED_CHECKPOINT_ENCODED_LEN, raw.len());
+    assert_eq!(
+        DerivedCursor::restore(SOURCE_EPOCH, 36),
+        DerivedCheckpoint::decode(&raw, DerivedEngine::Index)
+            .expect("checkpoint is valid")
+            .cursor()
+    );
+    assert!(!golden_log()
+        .windows(9)
+        .any(|payload| raw.windows(payload.len()).any(|bytes| bytes == payload)));
+}
+
+#[test]
+fn crash_after_apply_replays_the_same_key_idempotently_without_a_hole() {
+    let persistence = MemoryPersistence::default();
+    let mut owner = DerivedCursorOwner::open(DerivedEngine::Tiered, SOURCE_EPOCH, persistence.clone())
+        .expect("owner opens at genesis");
+    let mut sink = IdempotentSink {
+        fail_after_apply_once: true,
+        ..IdempotentSink::default()
+    };
+
+    let error = replay_derived(BytesSource::new(golden_log()), &mut owner, &mut sink)
+        .expect_err("injected crash must stop replay");
+    assert!(matches!(error, DerivedReplayError::Sink(TestError(_))));
+    assert_eq!(0, owner.cursor().next_offset());
+    assert_eq!(1, sink.visible.len());
+
+    let persistence = owner.into_persistence();
+    let mut restarted = DerivedCursorOwner::open(DerivedEngine::Tiered, SOURCE_EPOCH, persistence)
+        .expect("restart reloads genesis cursor");
+    let report = replay_derived(BytesSource::new(golden_log()), &mut restarted, &mut sink).expect("restart catches up");
+
+    assert_eq!(2, report.applied());
+    assert_eq!(1, report.duplicates());
+    assert_eq!(3, report.committed_records());
+    assert_eq!(36, restarted.cursor().next_offset());
+    assert_eq!(3, sink.visible.len());
+    assert_eq!(4, sink.attempts);
+}
+
+#[test]
+fn uncertain_checkpoint_result_is_resolved_by_reload_without_regression() {
+    let persistence = MemoryPersistence::default();
+    persistence.fail_once(PersistFailure::AfterWriteOnce);
+    let mut owner = DerivedCursorOwner::open(DerivedEngine::RocksDb, SOURCE_EPOCH, persistence.clone())
+        .expect("owner opens at genesis");
+    let mut sink = IdempotentSink::default();
+
+    let error = replay_derived(BytesSource::new(golden_log()), &mut owner, &mut sink)
+        .expect_err("uncertain persistence result must stop replay");
+    assert!(matches!(
+        error,
+        DerivedReplayError::Owner(DerivedCursorOwnerError::Persistence(TestError(_)))
+    ));
+    assert_eq!(0, owner.cursor().next_offset());
+
+    let mut restarted = DerivedCursorOwner::open(DerivedEngine::RocksDb, SOURCE_EPOCH, persistence)
+        .expect("restart observes the durable checkpoint");
+    assert_eq!(8, restarted.cursor().next_offset());
+    let report =
+        replay_derived(BytesSource::new(golden_log()), &mut restarted, &mut sink).expect("remaining frames replay");
+    assert_eq!(2, report.applied());
+    assert_eq!(0, report.duplicates());
+    assert_eq!(36, report.committed_offset());
+    assert_eq!(3, sink.visible.len());
+}
+
+#[test]
+fn dirty_tail_stops_at_last_complete_frame_and_resumes_after_repair() {
+    let complete = frame(8, 0x11);
+    let repaired = frame(12, 0x22);
+    let mut partial = repaired.to_vec();
+    partial.truncate(7);
+    let dirty = Bytes::from([complete.as_ref(), partial.as_slice()].concat());
+    let clean = Bytes::from([complete.as_ref(), repaired.as_ref()].concat());
+    let persistence = MemoryPersistence::default();
+    let mut owner = DerivedCursorOwner::open(DerivedEngine::ConsumeQueue, SOURCE_EPOCH, persistence)
+        .expect("owner opens at genesis");
+    let mut sink = IdempotentSink::default();
+
+    let dirty_report =
+        replay_derived(BytesSource::new(dirty), &mut owner, &mut sink).expect("complete prefix is replayable");
+    assert_eq!(DerivedReplayStop::DirtyTail, dirty_report.stop());
+    assert_eq!(8, dirty_report.committed_offset());
+    assert_eq!(1, sink.visible.len());
+
+    let clean_report =
+        replay_derived(BytesSource::new(clean), &mut owner, &mut sink).expect("repaired tail resumes from checkpoint");
+    assert_eq!(DerivedReplayStop::EndOfSource, clean_report.stop());
+    assert_eq!(1, clean_report.applied());
+    assert_eq!(20, clean_report.committed_offset());
+    assert_eq!(2, sink.visible.len());
+}
+
+#[test]
+fn corrupted_checkpoint_fails_closed_without_replaying_from_zero() {
+    let persistence = MemoryPersistence::default();
+    let mut owner = DerivedCursorOwner::open(DerivedEngine::Compaction, SOURCE_EPOCH, persistence.clone())
+        .expect("owner opens at genesis");
+    let first = DerivedRecordId::try_new(SOURCE_EPOCH, 0, 8).expect("record is valid");
+    owner.commit(first).expect("checkpoint commit succeeds");
+    persistence.corrupt(DerivedEngine::Compaction, 20);
+
+    let error = match DerivedCursorOwner::open(DerivedEngine::Compaction, SOURCE_EPOCH, persistence) {
+        Ok(_) => panic!("corruption must fail readiness"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        DerivedCursorOwnerError::Checkpoint(DerivedCheckpointDecodeError::ChecksumMismatch)
+    ));
+}
+
+#[test]
+fn legacy_offset_is_upgraded_durably_before_owner_publication() {
+    let persistence = MemoryPersistence::default();
+    let legacy = LegacyDerivedCursorV0::new(20);
+    let owner =
+        DerivedCursorOwner::open_or_upgrade(DerivedEngine::Index, SOURCE_EPOCH, persistence.clone(), Some(legacy))
+            .expect("legacy cursor upgrades");
+
+    assert_eq!(DerivedCursor::restore(SOURCE_EPOCH, 20), owner.cursor());
+    assert_eq!(1, persistence.persist_calls());
+    let reopened = DerivedCursorOwner::open(DerivedEngine::Index, SOURCE_EPOCH, persistence)
+        .expect("current checkpoint reopens without the legacy input");
+    assert_eq!(owner.cursor(), reopened.cursor());
+}
+
+#[test]
+fn each_engine_owns_an_isolated_checkpoint_namespace() {
+    let persistence = MemoryPersistence::default();
+    let mut index =
+        DerivedCursorOwner::open(DerivedEngine::Index, SOURCE_EPOCH, persistence.clone()).expect("index owner opens");
+    let mut tiered =
+        DerivedCursorOwner::open(DerivedEngine::Tiered, SOURCE_EPOCH, persistence.clone()).expect("tiered owner opens");
+    let first = DerivedRecordId::try_new(SOURCE_EPOCH, 0, 8).expect("record is valid");
+
+    index.commit(first).expect("index checkpoint commits");
+    assert!(persistence.raw_checkpoint(DerivedEngine::Index).is_some());
+    assert!(persistence.raw_checkpoint(DerivedEngine::Tiered).is_none());
+
+    tiered.commit(first).expect("tiered checkpoint commits independently");
+    assert!(persistence.raw_checkpoint(DerivedEngine::Tiered).is_some());
+}

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -26,7 +26,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 50,
       "public_path_sha256": "efb1b554cfdc1275bb621adf4d3dd1ffa51fd50e323e8ced14075251a92644db",
-      "rustdoc_json_sha256": "0ec4076d7c4d8300d3aae0a8947c37eeb62ffe34fae5122491621ec10eb0864b",
+      "rustdoc_json_sha256": "a6244641ffe1163d0f6fc3375b9f358b5b1e3ecac10acbedb94d8714dea43a7d",
       "target": "rocketmq_broker"
     },
     "rocketmq-client-rust": {
@@ -117,7 +117,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 65,
       "public_path_sha256": "a45a59482ae7b3410ade405dc53f2ca4ca2fb66cc1d3feba986f3aa6cf48efda",
-      "rustdoc_json_sha256": "9cdd5f52a3ca6c6beab07df4c7b863ebcd9618d8a393f09adaf6225bb4241230",
+      "rustdoc_json_sha256": "34ae22a9f434791b10c7811f632e1b51e9e3d84fcc5596d5aad4382c92406303",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
@@ -138,7 +138,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 17,
       "public_path_sha256": "3d9e0f9ac569160099d432c85bbb30d17ee1a107e9f665ee636bd4b5898ebc6b",
-      "rustdoc_json_sha256": "d8c1097a1176ee324e78d15ff782efdcecdc1c9978d7f3d8b299a8236172f20a",
+      "rustdoc_json_sha256": "3f48f729375e48c8d0662bbe3adac644e006dc8b26d9e8b3650efb58b5abfcc6",
       "target": "rocketmq_proxy_local"
     },
     "rocketmq-remoting": {
@@ -173,42 +173,42 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "7331d6d305a55b849d19042f9c9398ebb48d57ca8108a75857aebb201f295dfd",
+      "rustdoc_json_sha256": "daab98aa70c1f566ffd60466347abb57b0d5dbeca3d5ac16e698bbdd3dd57e13",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
       "crate_version": "1.0.0",
-      "public_path_count": 86,
-      "public_path_sha256": "373ed7b52892ab8d1131476d01483bda37d52255846e2b15b4dfba6b72a093a2",
-      "rustdoc_json_sha256": "33caa3efef007cc1d45ed4afa195495274cdb87522f70bd79edc851b68550c00",
+      "public_path_count": 118,
+      "public_path_sha256": "d5995bfd455676de80c97a080ab24ea62700a517c8bb2d9f1e5d221975046d67",
+      "rustdoc_json_sha256": "a6eb390148277653210131c930bd4e1de09c9d241a6053f31316a154df0f17d8",
       "target": "rocketmq_store_api"
     },
     "rocketmq-store-inspect": {
       "crate_version": "1.0.0",
       "public_path_count": 7,
       "public_path_sha256": "c7ac03206be85858d3f2805aba968f45fa3284f5c3265fb823a6435f8e2e929e",
-      "rustdoc_json_sha256": "d4d995fc6e20eaa78fb9247d5ef61e1d754a1259e4d4a0ad4fd11aa44e07a641",
+      "rustdoc_json_sha256": "651ac65d0f42310a388387afe73fa3fef34ee1e5f1771dc59d52fa790dfa0abb",
       "target": "rocketmq_store_inspect"
     },
     "rocketmq-store-local": {
       "crate_version": "1.0.0",
-      "public_path_count": 770,
-      "public_path_sha256": "623132a7c5a3d6f08bc8a584e825a6ee3abf605ef574330307fc4b415d7aea85",
-      "rustdoc_json_sha256": "a7024cdd490e8ffa7a251e034da9e3a753ba3082fc56074b1bcb74aea25a59b4",
+      "public_path_count": 799,
+      "public_path_sha256": "b939672270465382a38ac00827a03f49c4b5f14913265da205f777db75342fe2",
+      "rustdoc_json_sha256": "fab74e002577f4dbe53bebc44ffa635f735db38833b6d9e37a2821620e959c9e",
       "target": "rocketmq_store_local"
     },
     "rocketmq-store-rocksdb": {
       "crate_version": "1.0.0",
       "public_path_count": 165,
       "public_path_sha256": "89b9028df0c4643a9e718af49f979144b6e1a03635ce69fde0cdad591fe6701b",
-      "rustdoc_json_sha256": "350497a83a7b707e94721b99e9c3e210ee6654b87e9f50b1c8f3e2c3b8c74902",
+      "rustdoc_json_sha256": "2925f5816f00cfebca6d591a357288ff6eb0a3dfaf0f6b5ff26c5c3e5f3a84db",
       "target": "rocketmq_store_rocksdb"
     },
     "rocketmq-tieredstore": {
       "crate_version": "1.0.0",
       "public_path_count": 105,
       "public_path_sha256": "d081e4002cc88eded04a07ff75116dc5e626b8519d76858bcf2d871003f3399c",
-      "rustdoc_json_sha256": "de0c8f5c8bb006b15eedfdff6501f203bd3a4fac1e35932bfcc7b0918c60f094",
+      "rustdoc_json_sha256": "abc9b3469f7eec82de0e46b04a68ba8418de494c2e0a02b7becc183de2973482",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "490c583e94b31dc7ae1b83c55ed811e2b90d4cce",
+  "source_commit": "1f2a7bb4ae5d6adf271fc34e63c60c956c22606e",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
## Summary
- add a versioned 32-byte per-engine derived checkpoint and contiguous cursor contract
- add durable cursor ownership plus a deterministic CommitLog replay harness
- cover idempotent replay, crash windows, dirty tails, corruption, legacy upgrade, and engine isolation
- update the M10 plan, global checklist, evidence, and reviewed public API snapshot

## Validation
- `cargo test -p rocketmq-store-api --test derived_progress_contracts` (7/7)
- `cargo test -p rocketmq-store-local --test derived_replay_harness` (7/7)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- public API snapshot 31/31 with zero differences after additive review
- architecture dependency, release, ArcMut, runtime, typed-error, RocksDB, and AGENTS routing gates passed

## Known baseline
`cargo test -p rocketmq-store` still reproduces the pre-existing `file_store_vs_rocksdb_behavior_parity_after_restart` fixture failure because its helper instantiates `LocalFileMessageStore` for the RocksDB configuration. The fixture is unchanged by this PR; the exact RocksDB semantics matrix passes.

Closes #8260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable, versioned progress tracking for derived storage engines.
  * Added crash-safe replay from commit logs with idempotent record handling.
  * Added checkpoint validation, corruption detection, legacy cursor upgrades, and isolated engine progress.
  * Added replay reporting for applied, duplicate, committed, and incomplete records.

* **Documentation**
  * Updated migration plans and milestone tracking to reflect completion of the derived cursor and replay work.

* **Tests**
  * Added coverage for replay recovery, dirty tails, persistence failures, checkpoint corruption, and cursor validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->