### PR TITLE
[ISSUE #8262]♻️Implement Tiered cursor retry ledger and backpressure

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 60 | 0 | 22 未开始；合计 22 尚未完成 | 82 |
+| PR 级工作包 | 61 | 0 | 21 未开始；合计 21 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 1（M10） | 2（M11–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 22 个未开始工作包分布：M10 为 4 个、M11 为 12 个、M12 为 6 个。
-PR-M10-01 已完成派生 cursor 合同和 replay harness，当前下一工作包为 PR-M10-02。
+剩余 21 个未开始工作包分布：M10 为 3 个、M11 为 12 个、M12 为 6 个。
+PR-M10-02 已完成 Tiered cursor、retry ledger 与背压，当前下一工作包为 PR-M10-03。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -472,7 +472,16 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] public API additive diff 已审核并最终 31/31 零差异；ArcMut/依赖/runtime/error guard 通过
   - [x] [`M10-01 证据`](phase-3-production-readiness/10-derived-cursor-replay-evidence.md) 记录基线失败、验证与回滚
   - [x] 60/82 已完成、22 未完成，下一工作包 PR-M10-02
-- [ ] PR-M10-02：实现 Tiered cursor、retry ledger 与背压
+- [x] PR-M10-02：实现 Tiered cursor、retry ledger 与背压
+  - [x] 顺序读取 CommitLog；channel count/bytes 满时把背压传回 reput，不丢事件
+  - [x] 失败记录与 cursor 原子持久化；ledger 仅保存 offset tuple 与 retry metadata，不复制 payload
+  - [x] count/bytes/age 三类硬上限触发 `readiness=false`，并 pin 最小未解决 WAL segment
+  - [x] provider timeout/partial write/restart/duplicate/ledger full/WAL pin corpus 7/7 通过
+  - [x] retry scheduler 由 `ScheduledTaskGroup` 所有；正常 shutdown 排空，取消释放阻塞 sender
+  - [x] Store 82+9、Broker Rocks 20、POP 4 专项通过；Rocks batch flush 回归已由原测试捕获并修复
+  - [x] public API additive diff 已审核并最终 31/31 零差异；ArcMut/依赖/runtime/error/MCP 门禁通过
+  - [x] [`M10-02 证据`](phase-3-production-readiness/10-tiered-cursor-retry-evidence.md) 记录目标、基线失败、验证与回滚
+  - [x] 61/82 已完成、21 未完成，下一工作包 PR-M10-03
 - [ ] PR-M10-03：优化 CQ、Rocks 与 Tiered 读取
 - [ ] PR-M10-04：实现 Index/Compaction generation
 - [ ] PR-M10-05：完成 benchmark、soak 与性能 Gate

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3，M10-01 已完成，下一工作包为 PR-M10-02）
+> 状态：实施中（Phase 3，M10-02 已完成，下一工作包为 PR-M10-03）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；60/82 工作包完成，剩余 22 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；61/82 工作包完成，剩余 21 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M10-01 已完成，下一工作包 PR-M10-02） |
+| 状态 | 实施中（PR-M10-02 已完成，下一工作包 PR-M10-03） |
 | 预计周期 | 5–8 周 |
 | 工作包 | WP14 `tiered-cursor`；延续 WP02、WP11–WP13 |
 | 前置条件 | 32-package Gate 通过；CommitLog/receipt/progress 和 Local/Rocks golden 稳定 |
@@ -59,13 +59,17 @@
 
 ### PR-M10-02：Tiered cursor、retry ledger 与背压
 
-- [ ] `[DEV]` 顺序读取 CommitLog；channel 满时暂停 reader，不丢事件。
-- [ ] `[DEV]` 失败项先原子持久 `(source_epoch, offset, length, topic, queue, retry_state)`，再允许全局 cursor 越过。
-- [ ] `[DEV]` ledger 不复制 payload，以 offset tuple 幂等；按 count/bytes/age 硬限制并 pin 最小 WAL segment。
-- [ ] `[DEV]` 到上限时停止 reader、readiness=false、告警并施加背压；分区 worker 隔离/退避。
-- [ ] `[TEST]` 覆盖 provider timeout/partial write/restart/重复提交/ledger 满/WAL pin 回收。
-- [ ] `[REV]` 检查 cursor/retry 不参与 Broker ack，无无界“完成但未提交”内存。
-- [ ] 回滚点：停止对应 topic/queue reader、设置 `readiness=false`，冻结已提交 cursor 与 retry ledger并保留/pin WAL；修复后从已验证 checkpoint 重放。不得切换任何未通过同一 cursor/retry/kill-restart corpus 的实现。
+- [x] `[DEV]` 顺序读取 CommitLog；channel 满时暂停 reader，不丢事件。
+- [x] `[DEV]` 失败项先原子持久 `(source_epoch, offset, length, topic, queue, retry_state)`，再允许全局 cursor 越过。
+- [x] `[DEV]` ledger 不复制 payload，以 offset tuple 幂等；按 count/bytes/age 硬限制并 pin 最小 WAL segment。
+- [x] `[DEV]` 到上限时停止 reader、readiness=false、告警并施加背压；分区 worker 隔离/退避。
+- [x] `[TEST]` 覆盖 provider timeout/partial write/restart/重复提交/ledger 满/WAL pin 回收。
+- [x] `[REV]` 检查 cursor/retry 不参与 Broker ack，无无界“完成但未提交”内存。
+- [x] 回滚点：停止对应 topic/queue reader、设置 `readiness=false`，冻结已提交 cursor 与 retry ledger并保留/pin WAL；修复后从已验证 checkpoint 重放。不得切换任何未通过同一 cursor/retry/kill-restart corpus 的实现。
+
+完成证据：[`10-tiered-cursor-retry-evidence.md`](10-tiered-cursor-retry-evidence.md)。候选提交
+`1a5463b143f33a8246d32d82abd05ddacf3b14c6` 将 payload-free retry ledger、原子 cursor、count/bytes/age
+硬上限、WAL pin、分条退避和上游背压接入真实 Tiered reput；61/82 已完成，下一工作包为 PR-M10-03。
 
 ### PR-M10-03：CQ、Rocks 与 Tiered 读取优化
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-tiered-cursor-retry-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-tiered-cursor-retry-evidence.md
@@ -1,0 +1,97 @@
+# M10-02 Tiered cursor、retry ledger 与背压实施证据
+
+## 结果
+
+M10-02 将 M10-01 的派生进度合同接入真实 Tiered 写路径：CommitLog 仍是唯一 WAL，Tiered 仅持久化
+versioned cursor 与不含 payload 的 retry ledger，并通过 count、bytes、age 三类硬上限、WAL pin 和上游背压
+阻止无界堆积。该包完成后架构盘点为 **61/82**，剩余 21 个工作包；M10 剩余 3 个，下一包是
+PR-M10-03。
+
+## 可追溯性
+
+| 字段 | 值 |
+|---|---|
+| 工作包 | `PR-M10-02` |
+| Issue | [#8262](https://github.com/mxsm/rocketmq-rust/issues/8262) |
+| 分支 | `mxsm/architecture-refactor-tiered-cursor-retry-backpressure` |
+| Main 基线 | `e43b19a642badcefacf4e60a8b28d4bff7b69181` |
+| 冻结代码候选 | `1a5463b143f33a8246d32d82abd05ddacf3b14c6` |
+| 运行期证据 | `target/architecture-refactor/M10/tiered-cursor-8262/` |
+
+## 目标与合同结论
+
+- CommitLog 是唯一权威 WAL；retry ledger 只保存
+  `(source_epoch, physical_offset, length, topic, queue, retry_state)`，不复制消息体。
+- `config/tieredDispatchProgress.bin` 使用 magic、version、payload length、JSON 和 CRC32；临时文件写入、
+  sync、原子 rename 后才发布内存状态，损坏或未知版本 fail closed。
+- provider 失败先与 cursor 原子持久化到 ledger，之后全局 cursor 才能越过；重启按
+  `DerivedRecordId` 从 CommitLog 重建 payload 并幂等重试。
+- reader 同时受 channel count 与 byte semaphore 约束；达到 ledger count、bytes 或 age 上限时停止接收、
+  `readiness=false`，把背压传回 reput，而不是丢事件或产生无界“已完成但未提交”状态。
+- retry 按条目退避并隔离失败；调度由 `ScheduledTaskGroup` 所有，shutdown 可取消阻塞发送，正常关闭则排空
+  已跟踪记录。
+- 最小未解决记录对应的 CommitLog segment 被 pin；Local 清理和悬挂文件重试都不能越过该 pin，成功重试后
+  自动释放。
+- primary append receipt、SyncFlush durable watermark 与 Broker ack 不等待 Tiered；派生健康状态独立暴露。
+- provider partial write 必须完整续写后才成功，避免短写被误认为 durable commit。
+
+## 正确性语料
+
+| 语料 | 结果 |
+|---|---|
+| Tiered cursor/retry corpus | 7/7：timeout、partial write、restart、duplicate、ledger full、WAL pin、repair |
+| Tiered package | 56 个 library、1 个 POSIX 与 7 个 cursor/retry 集成测试通过 |
+| Store Tiered adapter | 5/5：真实 reput 写入、读取 fallback、转换与已有行为兼容 |
+| Store Local | 185 个 library 测试及全部 integration/doc-test target 通过，含 pin 生命周期 |
+| Store API | 26/26，通过 `DerivedRecordId` 排序扩展后的合同语料 |
+| RocksDB 专项 | Store 82 foundation、9 semantics；Broker 20 Rocks 与 4 POP 全部通过 |
+
+RocksDB semantics 首次运行暴露 `rocksdb_query_message_after_dispatch` 中 pending index 为 1。原因是异步批量
+默认实现逐条调用 `dispatch_async`，绕过了 RocksDB Index/Timer/Transaction 的 batch flush。修复后默认异步
+批量保留各实现的 `dispatch_batch` 语义，仅 Tiered 显式逐条等待异步背压；原测试恢复为 9/9，Tiered 5/5
+同步复核通过。该失败是本次发现并修复的回归，不计为成功证据。
+
+## 公共 API 审查
+
+初次签名比较没有删除或重命名公共路径：
+
+- `rocketmq-store` 保持 382 个公共路径且 path hash 不变，仅 trait async 默认实现导致 Rustdoc 原始 hash 变化；
+- `rocketmq-store-api` 保持 118 个公共路径且 path hash 不变，仅 `DerivedRecordId` 增加排序派生；
+- `rocketmq-tieredstore` 从 105 增至 116 个公共路径，仅新增 `TieredDispatchHealth`、
+  `TieredDispatchReadiness` 及其 9 个状态 variant；
+- 其余 workspace library 的公共 path count 与 path hash 不变。
+
+基线绑定冻结代码候选 `1a5463b143f33a8246d32d82abd05ddacf3b14c6`。最终提交态比较结果见下方验证记录。
+
+## 验证记录
+
+| 命令/门禁 | 结果 |
+|---|---|
+| Tiered、Store Tiered、Store API、Store Local focused/package tests | 通过 |
+| Store/Broker RocksDB strict Clippy 与规定测试矩阵 | 通过 |
+| affected-crate all-target/all-feature strict Clippy | 通过 |
+| dependency fixtures/target/baseline 与 release guard | 通过：target 35/35，dev-only 3/3 |
+| ArcMut fixtures/direct guard | 通过；5 个异步生命周期 fingerprint 经精确 relocation 审批，identity/occurrence 零增长 |
+| runtime enforcing audit | 通过；retry scheduler 使用 `ScheduledTaskGroup`，无新增裸 Tokio task |
+| typed-error hygiene 与 AGENTS routing | 通过 |
+| MCP consumer check/test/streamable-http strict Clippy/doc | 通过 |
+| 根 `cargo fmt --all -- --check` 与 workspace strict Clippy | 通过 |
+| public API snapshot | 最终 31/31，differences=0 |
+| `git diff --check` | 通过 |
+
+### 已披露的基线失败
+
+`cargo test -p rocketmq-store` **不记录为通过**。单独复跑
+`file_store_vs_rocksdb_behavior_parity_after_restart` 仍失败：fixture 在配置为 `StoreType::RocksDB` 时仍构造
+`LocalFileMessageStore`，因此伪 Rocks 路径没有逻辑队列。`git diff --exit-code origin/main --
+rocketmq-store/tests/commitlog_recovery_tests.rs` 返回零并输出 `BASELINE_FIXTURE_UNCHANGED`，证明该测试及工厂未被
+M10-02 修改。真实 RocksDB foundation/semantics 和 Broker 专项矩阵全部通过；剩余风险仅为该既有测试工厂错误。
+
+## 审查与回滚
+
+`[REV]` 结论：cursor/retry 不参与 Broker ack；ledger 不含 payload；count/bytes/age、队列 bytes 与 WAL pin
+均有硬边界；失败 worker 不阻塞其他条目；无第二 WAL。M10-02 最终 material finding 为 0。
+
+回滚时停止 Tiered reader、设置 `readiness=false`，冻结已提交 cursor 与 retry ledger并保留/pin 对应 WAL。
+不得删除或越过未解决记录；修复后从已验证 checkpoint 重放。只有通过相同 cursor/retry/kill-restart corpus 的
+上一实现才允许受控切换。

--- a/rocketmq-store-api/src/progress.rs
+++ b/rocketmq-store-api/src/progress.rs
@@ -62,7 +62,7 @@ impl DerivedEngine {
 }
 
 /// Stable idempotency key for one record read from the authoritative CommitLog.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DerivedRecordId {
     source_epoch: u64,
     physical_offset: u64,

--- a/rocketmq-store-local/src/mapped_file/queue_lifecycle.rs
+++ b/rocketmq-store-local/src/mapped_file/queue_lifecycle.rs
@@ -92,6 +92,37 @@ pub fn delete_expired_mapped_files_by_time<N>(
     interval_forcibly: i64,
     clean_immediately: bool,
     delete_file_batch_max: i32,
+    now_millis: N,
+) -> MappedFileQueueDeletion
+where
+    N: FnMut() -> i64,
+{
+    delete_expired_mapped_files_by_time_before(
+        files,
+        expired_time,
+        delete_files_interval,
+        interval_forcibly,
+        clean_immediately,
+        delete_file_batch_max,
+        None,
+        now_millis,
+    )
+}
+
+/// Destroys expired mapped files without crossing an optional derived-engine WAL pin.
+#[doc(hidden)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the legacy cleanup policy plus one hard WAL boundary"
+)]
+pub fn delete_expired_mapped_files_by_time_before<N>(
+    files: &[Arc<DefaultMappedFile>],
+    expired_time: i64,
+    delete_files_interval: i32,
+    interval_forcibly: i64,
+    clean_immediately: bool,
+    delete_file_batch_max: i32,
+    pinned_file_offset: Option<u64>,
     mut now_millis: N,
 ) -> MappedFileQueueDeletion
 where
@@ -101,6 +132,9 @@ where
     let mut deleted_files = Vec::new();
 
     for (index, mapped_file) in files.iter().enumerate().take(candidate_count) {
+        if pinned_file_offset.is_some_and(|pinned| mapped_file.get_file_from_offset() >= pinned) {
+            break;
+        }
         let live_max_timestamp = mapped_file.get_last_modified_timestamp() as i64 + expired_time;
         if now_millis() >= live_max_timestamp || clean_immediately {
             if mapped_file.destroy(interval_forcibly as u64) {

--- a/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
+++ b/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_offset;
 use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_time;
+use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_time_before;
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_last_mapped_file;
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::mapped_files_after_removal;
@@ -75,6 +76,23 @@ fn time_deletion_keeps_the_newest_file_and_honors_the_batch_limit() {
     let deleted = deletion.into_mapped_files();
     assert!(Arc::ptr_eq(&deleted[0], &files[0]));
     assert!(files[2].is_available());
+}
+
+#[test]
+fn time_deletion_stops_before_the_pinned_wal_segment() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let files = vec![
+        mapped_file(&temp_dir, 0, 16),
+        mapped_file(&temp_dir, 16, 16),
+        mapped_file(&temp_dir, 32, 16),
+        mapped_file(&temp_dir, 48, 16),
+    ];
+
+    let deletion = delete_expired_mapped_files_by_time_before(&files, 0, 0, 1000, true, 10, Some(16), || 0);
+
+    assert_eq!(deletion.deleted_count(), 1);
+    assert!(!files[0].is_available());
+    assert!(files[1..].iter().all(|file| file.is_available()));
 }
 
 #[test]

--- a/rocketmq-store/src/base/commit_log_dispatcher.rs
+++ b/rocketmq-store/src/base/commit_log_dispatcher.rs
@@ -12,10 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use crate::base::dispatch_request::DispatchRequest;
 
 pub trait CommitLogDispatcher: Send + Sync + 'static {
     fn dispatch(&self, dispatch_request: &mut DispatchRequest);
+
+    /// Dispatches one request while allowing bounded derived sinks to apply backpressure.
+    fn dispatch_async<'a>(
+        &'a self,
+        dispatch_request: &'a mut DispatchRequest,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move { self.dispatch(dispatch_request) })
+    }
 
     /// Dispatch a batch of requests. Default implementation calls dispatch for each request.
     /// Implementers can override this for batch optimizations.
@@ -23,6 +34,14 @@ pub trait CommitLogDispatcher: Send + Sync + 'static {
         for request in dispatch_requests.iter_mut() {
             self.dispatch(request);
         }
+    }
+
+    /// Dispatches a batch without letting a full derived-sink channel drop records.
+    fn dispatch_batch_async<'a>(
+        &'a self,
+        dispatch_requests: &'a mut [DispatchRequest],
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move { self.dispatch_batch(dispatch_requests) })
     }
 
     /// Returns the highest persisted CommitLog offset this dispatcher has already processed.

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -38,7 +38,7 @@ use rocketmq_store_local::mapped_file::queue_io::load_mapped_file_queue_path;
 use rocketmq_store_local::mapped_file::queue_io::MappedFileQueueLoadOutcome;
 use rocketmq_store_local::mapped_file::queue_lifecycle::clean_swapped_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_offset;
-use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_time;
+use rocketmq_store_local::mapped_file::queue_lifecycle::delete_expired_mapped_files_by_time_before;
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_last_mapped_file;
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::mapped_files_after_removal;
@@ -375,16 +375,36 @@ impl MappedFileQueue {
         clean_immediately: bool,
         delete_file_batch_max: i32,
     ) -> i32 {
+        self.delete_expired_file_by_time_before(
+            expired_time,
+            delete_files_interval,
+            interval_forcibly,
+            clean_immediately,
+            delete_file_batch_max,
+            None,
+        )
+    }
+
+    pub fn delete_expired_file_by_time_before(
+        &mut self,
+        expired_time: i64,
+        delete_files_interval: i32,
+        interval_forcibly: i64,
+        clean_immediately: bool,
+        delete_file_batch_max: i32,
+        pinned_file_offset: Option<u64>,
+    ) -> i32 {
         let mfs = (**self.storage.mapped_files().load()).clone();
         // Check before deleting
         self.check_self();
-        let deletion = delete_expired_mapped_files_by_time(
+        let deletion = delete_expired_mapped_files_by_time_before(
             &mfs,
             expired_time,
             delete_files_interval,
             interval_forcibly,
             clean_immediately,
             delete_file_batch_max,
+            pinned_file_offset,
             || current_millis() as i64,
         );
         let delete_count = deletion.deleted_count();

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2438,12 +2438,32 @@ impl CommitLog {
         clean_immediately: bool,
         delete_file_batch_max: i32,
     ) -> i32 {
-        self.mapped_file_queue.delete_expired_file_by_time(
+        self.delete_expired_files_by_time_before(
             expired_time,
             delete_files_interval,
             interval_forcibly,
             clean_immediately,
             delete_file_batch_max,
+            None,
+        )
+    }
+
+    pub fn delete_expired_files_by_time_before(
+        &mut self,
+        expired_time: i64,
+        delete_files_interval: i32,
+        interval_forcibly: i64,
+        clean_immediately: bool,
+        delete_file_batch_max: i32,
+        pinned_file_offset: Option<u64>,
+    ) -> i32 {
+        self.mapped_file_queue.delete_expired_file_by_time_before(
+            expired_time,
+            delete_files_interval,
+            interval_forcibly,
+            clean_immediately,
+            delete_file_batch_max,
+            pinned_file_offset,
         )
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -491,6 +491,13 @@ impl LocalFileMessageStore {
         }
         #[cfg(feature = "tieredstore")]
         let tiered_store = Self::build_tiered_store(message_store_config.clone(), commit_log.clone(), &mut dispatcher)?;
+        #[cfg(feature = "tieredstore")]
+        let minimum_pinned_wal_segment = tiered_store.as_ref().map(|tiered_store| {
+            let tiered_store = tiered_store.clone();
+            Arc::new(move || tiered_store.minimum_pinned_wal_segment()) as Arc<CommitLogWalPin>
+        });
+        #[cfg(not(feature = "tieredstore"))]
+        let minimum_pinned_wal_segment: Option<Arc<CommitLogWalPin>> = None;
 
         ensure_dir_ok(message_store_config.store_path_root_dir.as_str());
         ensure_dir_ok(Self::get_store_path_physic(&message_store_config).as_str());
@@ -545,6 +552,7 @@ impl LocalFileMessageStore {
                 commit_log.clone(),
                 running_flags.clone(),
                 cleanup_policy,
+                minimum_pinned_wal_segment,
             )),
             correct_logic_offset_service: Arc::new(CorrectLogicOffsetService::new(
                 commit_log.clone(),
@@ -3831,6 +3839,28 @@ impl CommitLogDispatcher for CommitLogDispatcherDefault {
             dispatcher.dispatch_batch(dispatch_requests);
         }
     }
+
+    fn dispatch_async<'a>(
+        &'a self,
+        dispatch_request: &'a mut DispatchRequest,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            for dispatcher in &self.dispatcher_vec {
+                dispatcher.dispatch_async(dispatch_request).await;
+            }
+        })
+    }
+
+    fn dispatch_batch_async<'a>(
+        &'a self,
+        dispatch_requests: &'a mut [DispatchRequest],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            for dispatcher in &self.dispatcher_vec {
+                dispatcher.dispatch_batch_async(dispatch_requests).await;
+            }
+        })
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -4474,7 +4504,8 @@ impl ReputMessageService {
                             &message_store,
                             notify_message_arrive_in_batch,
                             &mut batch,
-                        );
+                        )
+                        .await;
                     }
                     _ = shutdown_dispatcher.cancelled() => {
                         // Process remaining messages in channel before shutdown
@@ -4484,7 +4515,8 @@ impl ReputMessageService {
                                 &message_store,
                                 notify_message_arrive_in_batch,
                                 &mut batch,
-                            );
+                            )
+                            .await;
                         }
                         break;
                     }
@@ -4607,7 +4639,7 @@ struct ReputMessageServiceInner {
     message_store: ArcMut<LocalFileMessageStore>,
 }
 
-fn dispatch_reput_batch(
+async fn dispatch_reput_batch(
     dispatcher: &ArcMut<CommitLogDispatcherDefault>,
     message_store: &ArcMut<LocalFileMessageStore>,
     notify_message_arrive_in_batch: bool,
@@ -4615,7 +4647,7 @@ fn dispatch_reput_batch(
 ) {
     let batch_size = dispatch_batch.len();
     let started = Instant::now();
-    dispatcher.dispatch_batch(dispatch_batch);
+    dispatcher.dispatch_batch_async(dispatch_batch).await;
     message_store
         .store_stats_service
         .record_reput_dispatch_batch(batch_size, started.elapsed());
@@ -4717,7 +4749,8 @@ impl ReputMessageServiceInner {
                                     &self.message_store,
                                     self.notify_message_arrive_in_batch,
                                     &mut dispatch_batch,
-                                );
+                                )
+                                .await;
                                 dispatch_batch.clear();
                             }
 
@@ -4756,7 +4789,8 @@ impl ReputMessageServiceInner {
                 &self.message_store,
                 self.notify_message_arrive_in_batch,
                 &mut dispatch_batch,
-            );
+            )
+            .await;
         }
         self.record_dispatch_behind_bytes();
     }
@@ -4960,12 +4994,15 @@ fn store_path_disk_used_ratio(path: &str) -> f64 {
     }
 }
 
+type CommitLogWalPin = dyn Fn() -> Option<u64> + Send + Sync;
+
 struct CleanCommitLogService {
     message_store_config: Arc<MessageStoreConfig>,
     commit_log: ArcMut<CommitLog>,
     running_flags: Arc<RunningFlags>,
     cleanup_policy: LocalCleanupPolicy,
     manual_delete_tracker: ManualDeleteTracker,
+    minimum_pinned_wal_segment: Option<Arc<CommitLogWalPin>>,
     #[cfg(test)]
     disk_clean_decision_override: StdMutex<Option<DiskCleanDecision>>,
 }
@@ -4978,6 +5015,7 @@ impl CleanCommitLogService {
         commit_log: ArcMut<CommitLog>,
         running_flags: Arc<RunningFlags>,
         cleanup_policy: LocalCleanupPolicy,
+        minimum_pinned_wal_segment: Option<Arc<CommitLogWalPin>>,
     ) -> Self {
         Self {
             message_store_config,
@@ -4985,6 +5023,7 @@ impl CleanCommitLogService {
             running_flags,
             cleanup_policy,
             manual_delete_tracker: ManualDeleteTracker::new(Self::MAX_MANUAL_DELETE_FILE_TIMES),
+            minimum_pinned_wal_segment,
             #[cfg(test)]
             disk_clean_decision_override: StdMutex::new(None),
         }
@@ -4999,13 +5038,18 @@ impl CleanCommitLogService {
         let disk_decision = self.is_space_to_delete();
         let is_manual_delete = self.consume_manual_delete_request();
         let clean_at_once = self.cleanup_policy.clean_file_forcibly_enabled() && disk_decision.clean_immediately;
+        let minimum_pinned_wal_segment = self
+            .minimum_pinned_wal_segment
+            .as_ref()
+            .and_then(|minimum_pinned_wal_segment| minimum_pinned_wal_segment());
         let delete_count = if is_time_up || disk_decision.should_delete || is_manual_delete {
-            self.commit_log.mut_from_ref().delete_expired_files_by_time(
+            self.commit_log.mut_from_ref().delete_expired_files_by_time_before(
                 expired_time,
                 self.message_store_config.delete_commit_log_files_interval as i32,
                 self.message_store_config.destroy_mapped_file_interval_forcibly as i64,
                 clean_at_once,
                 self.message_store_config.delete_file_batch_max as i32,
+                minimum_pinned_wal_segment,
             )
         } else {
             0
@@ -5020,10 +5064,14 @@ impl CleanCommitLogService {
             warn!("disk space will be full soon, but delete commitlog file failed");
         }
 
-        let _ = self
-            .commit_log
-            .mut_from_ref()
-            .retry_delete_first_file(self.message_store_config.redelete_hanged_file_interval as i64);
+        let first_file_is_before_pin = minimum_pinned_wal_segment
+            .is_none_or(|pinned| u64::try_from(self.commit_log.get_min_offset()).is_ok_and(|minimum| minimum < pinned));
+        if first_file_is_before_pin {
+            let _ = self
+                .commit_log
+                .mut_from_ref()
+                .retry_delete_first_file(self.message_store_config.redelete_hanged_file_interval as i64);
+        }
     }
 
     fn execute_delete_files_manually(&self) {
@@ -8543,6 +8591,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn clean_commit_log_service_never_crosses_derived_wal_pin() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                mapped_file_size_commit_log: 32,
+                file_reserved_time: 0,
+                delete_commit_log_files_interval: 0,
+                destroy_mapped_file_interval_forcibly: 0,
+                redelete_hanged_file_interval: 0,
+                delete_file_batch_max: 10,
+                delete_when: "99".to_string(),
+                disk_max_used_space_ratio: 95,
+                clean_file_forcibly_enable: false,
+                ..MessageStoreConfig::default()
+            },
+        );
+        store.init().await.expect("init store");
+        for (offset, fill) in [(0_i64, b'A'), (32, b'B'), (64, b'C')] {
+            let data = vec![fill; 32];
+            assert!(store
+                .get_commit_log_mut()
+                .append_data(offset, &data, 0, data.len() as i32)
+                .await
+                .expect("append commitlog file"));
+        }
+        let cleanup_policy =
+            super::LocalCleanupPolicy::new(store.message_store_config.normalized_local_backend_config().cleanup);
+        store.clean_commit_log_service = Arc::new(CleanCommitLogService::new(
+            store.message_store_config.clone(),
+            store.commit_log.clone(),
+            store.running_flags.clone(),
+            cleanup_policy,
+            Some(Arc::new(|| Some(32))),
+        ));
+
+        store.clean_commit_log_service.execute_delete_files_manually();
+        store.clean_commit_log_service.run();
+
+        assert_eq!(store.get_min_phy_offset(), 32);
+        assert_eq!(store.get_last_file_from_offset(), 64);
+    }
+
+    #[tokio::test]
     async fn clean_commit_log_service_run_skips_expired_files_outside_delete_window() {
         let temp_dir = tempdir().unwrap();
         let mut store = new_configured_test_store(
@@ -8641,6 +8733,7 @@ mod tests {
             store.commit_log.clone(),
             store.running_flags.clone(),
             cleanup_policy,
+            None,
         );
 
         let (ratio, selected_path) = service.min_physic_disk_ratio();

--- a/rocketmq-store/src/tieredstore.rs
+++ b/rocketmq-store/src/tieredstore.rs
@@ -17,9 +17,12 @@ use std::sync::Arc;
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::boundary_type::BoundaryType;
+use rocketmq_error::RocketMQError;
 use rocketmq_observability::metrics::tiered_store::TieredStoreMetrics;
+use rocketmq_store_api::DerivedRecordId;
 use rocketmq_tieredstore::dispatcher::DefaultTieredDispatcher;
 use rocketmq_tieredstore::dispatcher::TieredDispatchRequest;
+use rocketmq_tieredstore::dispatcher::TieredDispatcher;
 use rocketmq_tieredstore::fetcher::TieredGetMessageResult;
 use rocketmq_tieredstore::fetcher::TieredGetMessageStatus;
 use rocketmq_tieredstore::fetcher::TieredQueryResult;
@@ -62,7 +65,22 @@ impl TieredStoreDecorator {
     }
 
     pub fn commit_log_dispatcher(&self, body_resolver: Arc<DispatchBodyResolver>) -> Arc<dyn CommitLogDispatcher> {
-        Arc::new(TieredCommitLogDispatcher::new(self.store.dispatcher(), body_resolver))
+        let dispatcher = self.store.dispatcher();
+        let retry_body_resolver = body_resolver.clone();
+        dispatcher.set_retry_payload_resolver(Arc::new(move |physical_offset, length| {
+            let commit_log_offset = i64::try_from(physical_offset).ok()?;
+            let msg_size = i32::try_from(length).ok()?;
+            retry_body_resolver(&DispatchRequest {
+                commit_log_offset,
+                msg_size,
+                ..DispatchRequest::default()
+            })
+        }));
+        Arc::new(TieredCommitLogDispatcher::new_with_source_epoch(
+            dispatcher,
+            body_resolver,
+            self.store.config().source_epoch,
+        ))
     }
 
     pub async fn load(&self) -> Result<(), StoreError> {
@@ -88,6 +106,14 @@ impl TieredStoreDecorator {
 
     pub fn metrics(&self) -> Arc<TieredStoreMetrics> {
         self.store.metrics()
+    }
+
+    pub fn minimum_pinned_wal_segment(&self) -> Option<u64> {
+        self.store.dispatcher().health().minimum_pinned_wal_segment()
+    }
+
+    pub fn is_dispatch_ready(&self) -> bool {
+        self.store.dispatcher().health().is_ready()
     }
 
     pub const fn should_try_get_message(status: GetMessageStatus) -> bool {
@@ -305,6 +331,7 @@ where
 {
     dispatcher: Arc<DefaultTieredDispatcher<P>>,
     body_resolver: Arc<DispatchBodyResolver>,
+    source_epoch: u64,
 }
 
 impl<P> TieredCommitLogDispatcher<P>
@@ -312,10 +339,28 @@ where
     P: TieredStoreProvider,
 {
     pub fn new(dispatcher: Arc<DefaultTieredDispatcher<P>>, body_resolver: Arc<DispatchBodyResolver>) -> Self {
+        Self::new_with_source_epoch(dispatcher, body_resolver, 0)
+    }
+
+    pub fn new_with_source_epoch(
+        dispatcher: Arc<DefaultTieredDispatcher<P>>,
+        body_resolver: Arc<DispatchBodyResolver>,
+        source_epoch: u64,
+    ) -> Self {
         Self {
             dispatcher,
             body_resolver,
+            source_epoch,
         }
+    }
+
+    fn derived_record(&self, request: &DispatchRequest) -> Result<DerivedRecordId, RocketMQError> {
+        let physical_offset = u64::try_from(request.commit_log_offset)
+            .map_err(|_| RocketMQError::illegal_argument("tiered CommitLog offset must not be negative"))?;
+        let length = u32::try_from(request.msg_size)
+            .map_err(|_| RocketMQError::illegal_argument("tiered CommitLog length must be positive"))?;
+        DerivedRecordId::try_new(self.source_epoch, physical_offset, length)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
     }
 }
 
@@ -339,7 +384,10 @@ where
         };
 
         let request = to_tiered_dispatch_request(dispatch_request, body);
-        if let Err(error) = self.dispatcher.try_dispatch(request) {
+        let result = self
+            .derived_record(dispatch_request)
+            .and_then(|record| self.dispatcher.try_dispatch_derived(record, request));
+        if let Err(error) = result {
             warn!(
                 topic = %dispatch_request.topic,
                 queue_id = dispatch_request.queue_id,
@@ -348,6 +396,76 @@ where
                 "failed to enqueue tieredstore dispatch request"
             );
         }
+    }
+
+    fn dispatch_async<'a>(
+        &'a self,
+        dispatch_request: &'a mut DispatchRequest,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if !dispatch_request.success {
+                return;
+            }
+            let record = match self.derived_record(dispatch_request) {
+                Ok(record) => record,
+                Err(error) => {
+                    warn!(error = %error, "reject invalid tieredstore CommitLog identity");
+                    return;
+                }
+            };
+            let body = loop {
+                if self.dispatcher.is_shutdown() {
+                    return;
+                }
+                if let Some(body) = (self.body_resolver)(dispatch_request) {
+                    break body;
+                }
+                debug!(
+                    topic = %dispatch_request.topic,
+                    queue_id = dispatch_request.queue_id,
+                    queue_offset = dispatch_request.consume_queue_offset,
+                    "pause tieredstore derived reader because CommitLog body is unavailable"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            };
+            let request = to_tiered_dispatch_request(dispatch_request, body);
+            loop {
+                if self.dispatcher.is_shutdown() {
+                    return;
+                }
+                match self.dispatcher.dispatch_derived(record, request.clone()).await {
+                    Ok(()) => break,
+                    Err(error) => {
+                        warn!(
+                            topic = %dispatch_request.topic,
+                            queue_id = dispatch_request.queue_id,
+                            queue_offset = dispatch_request.consume_queue_offset,
+                            error = %error,
+                            "pause tieredstore derived reader after dispatch failure"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                }
+            }
+        })
+    }
+
+    fn dispatch_batch_async<'a>(
+        &'a self,
+        dispatch_requests: &'a mut [DispatchRequest],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            for request in dispatch_requests.iter_mut() {
+                self.dispatch_async(request).await;
+            }
+        })
+    }
+
+    fn dispatch_progress_offset(&self, _commit_log_min_offset: i64) -> Option<i64> {
+        self.dispatcher
+            .health()
+            .cursor()
+            .and_then(|cursor| i64::try_from(cursor.next_offset()).ok())
     }
 }
 

--- a/rocketmq-tieredstore/Cargo.toml
+++ b/rocketmq-tieredstore/Cargo.toml
@@ -35,7 +35,7 @@ rust-version.workspace = true
 default = ["posix-provider", "memory-provider", "serde"]
 posix-provider = []
 memory-provider = []
-serde = ["dep:serde", "dep:serde_json"]
+serde = []
 rocketmq-store-integration = []
 otel-metrics = ["rocketmq-observability/otel-metrics"]
 
@@ -49,8 +49,8 @@ rocketmq-store-api = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
-serde = { workspace = true, optional = true, features = ["derive"] }
-serde_json = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/rocketmq-tieredstore/src/config.rs
+++ b/rocketmq-tieredstore/src/config.rs
@@ -61,6 +61,22 @@ pub struct TieredStoreConfig {
     pub group_commit_size: usize,
     pub max_group_commit_count: usize,
     pub max_pending_tasks: usize,
+    /// CommitLog epoch used to distinguish reused physical offset namespaces.
+    pub source_epoch: u64,
+    /// Maximum encoded message bytes admitted to the bounded dispatch channel.
+    pub max_pending_bytes: usize,
+    /// Maximum failed records retained in the payload-free retry ledger.
+    pub retry_ledger_max_entries: usize,
+    /// Maximum source-WAL bytes represented by retry ledger records.
+    pub retry_ledger_max_bytes: u64,
+    /// Maximum age of the oldest retry before Tiered readiness fails closed.
+    pub retry_ledger_max_age: Duration,
+    /// Initial per-partition retry delay.
+    pub retry_backoff_initial: Duration,
+    /// Maximum per-partition retry delay.
+    pub retry_backoff_max: Duration,
+    /// Source CommitLog segment size used to expose the minimum WAL pin.
+    pub source_wal_segment_size: u64,
     pub read_ahead_cache_enable: bool,
     pub read_ahead_message_count: usize,
     pub read_ahead_message_size: usize,
@@ -91,6 +107,14 @@ impl Default for TieredStoreConfig {
             group_commit_size: 4 * 1024 * 1024,
             max_group_commit_count: 10_000,
             max_pending_tasks: 10_000,
+            source_epoch: 0,
+            max_pending_bytes: 64 * 1024 * 1024,
+            retry_ledger_max_entries: 10_000,
+            retry_ledger_max_bytes: 256 * 1024 * 1024,
+            retry_ledger_max_age: Duration::from_secs(24 * 60 * 60),
+            retry_backoff_initial: Duration::from_millis(100),
+            retry_backoff_max: Duration::from_secs(30),
+            source_wal_segment_size: 1024 * 1024 * 1024,
             read_ahead_cache_enable: true,
             read_ahead_message_count: 4096,
             read_ahead_message_size: 16 * 1024 * 1024,
@@ -133,6 +157,14 @@ mod tests {
         assert_eq!(config.group_commit_size, 4 * 1024 * 1024);
         assert_eq!(config.max_group_commit_count, 10_000);
         assert_eq!(config.max_pending_tasks, 10_000);
+        assert_eq!(config.source_epoch, 0);
+        assert_eq!(config.max_pending_bytes, 64 * 1024 * 1024);
+        assert_eq!(config.retry_ledger_max_entries, 10_000);
+        assert_eq!(config.retry_ledger_max_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.retry_ledger_max_age, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(config.retry_backoff_initial, Duration::from_millis(100));
+        assert_eq!(config.retry_backoff_max, Duration::from_secs(30));
+        assert_eq!(config.source_wal_segment_size, 1024 * 1024 * 1024);
         assert!(config.read_ahead_cache_enable);
         assert_eq!(config.read_ahead_message_count, 4096);
         assert_eq!(config.read_ahead_message_size, 16 * 1024 * 1024);

--- a/rocketmq-tieredstore/src/dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher.rs
@@ -13,8 +13,12 @@
 // limitations under the License.
 
 pub mod dispatch_request;
+mod progress;
+mod progress_persistence;
 pub mod tiered_dispatcher;
 
 pub use dispatch_request::TieredDispatchRequest;
 pub use tiered_dispatcher::DefaultTieredDispatcher;
+pub use tiered_dispatcher::TieredDispatchHealth;
+pub use tiered_dispatcher::TieredDispatchReadiness;
 pub use tiered_dispatcher::TieredDispatcher;

--- a/rocketmq-tieredstore/src/dispatcher/progress.rs
+++ b/rocketmq-tieredstore/src/dispatcher/progress.rs
@@ -1,0 +1,584 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
+use rocketmq_store_api::CursorAdvanceDisposition;
+use rocketmq_store_api::DerivedCheckpoint;
+use rocketmq_store_api::DerivedCursor;
+use rocketmq_store_api::DerivedEngine;
+use rocketmq_store_api::DerivedRecordId;
+use tokio::sync::Mutex;
+
+use super::progress_persistence::PersistedTieredProgress;
+use super::progress_persistence::TieredProgressPersistence;
+use crate::config::TieredStoreConfig;
+use crate::dispatcher::TieredDispatchRequest;
+
+/// Readiness state of the Tiered CommitLog-derived delivery path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TieredDispatchReadiness {
+    Healthy,
+    RetryLedgerFull,
+    RetryLedgerBytesExceeded,
+    RetryLedgerExpired,
+    ProgressPersistenceFailed,
+    RetryPayloadUnavailable,
+    CursorInvariantViolated,
+    DispatcherFailed,
+    Shutdown,
+}
+
+/// Bounded progress and WAL-pin snapshot exposed to readiness and alert owners.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TieredDispatchHealth {
+    readiness: TieredDispatchReadiness,
+    cursor: Option<DerivedCursor>,
+    retry_count: usize,
+    retry_source_bytes: u64,
+    oldest_retry_age: Duration,
+    minimum_pinned_offset: Option<u64>,
+    minimum_pinned_wal_segment: Option<u64>,
+}
+
+impl TieredDispatchHealth {
+    pub(crate) const fn initial() -> Self {
+        Self {
+            readiness: TieredDispatchReadiness::Healthy,
+            cursor: None,
+            retry_count: 0,
+            retry_source_bytes: 0,
+            oldest_retry_age: Duration::ZERO,
+            minimum_pinned_offset: None,
+            minimum_pinned_wal_segment: None,
+        }
+    }
+
+    /// Returns whether intake may continue without violating a hard retry bound.
+    pub const fn is_ready(&self) -> bool {
+        matches!(self.readiness, TieredDispatchReadiness::Healthy)
+    }
+
+    /// Returns the stable readiness/alert reason.
+    pub const fn readiness(&self) -> TieredDispatchReadiness {
+        self.readiness
+    }
+
+    /// Returns the last atomically persisted global Tiered cursor.
+    pub const fn cursor(&self) -> Option<DerivedCursor> {
+        self.cursor
+    }
+
+    /// Returns the number of payload-free retry records.
+    pub const fn retry_count(&self) -> usize {
+        self.retry_count
+    }
+
+    /// Returns the source CommitLog bytes represented by retry records.
+    pub const fn retry_source_bytes(&self) -> u64 {
+        self.retry_source_bytes
+    }
+
+    /// Returns the age of the oldest retry record.
+    pub const fn oldest_retry_age(&self) -> Duration {
+        self.oldest_retry_age
+    }
+
+    /// Returns the minimum physical offset that must remain available for retry.
+    pub const fn minimum_pinned_offset(&self) -> Option<u64> {
+        self.minimum_pinned_offset
+    }
+
+    /// Returns the base offset of the minimum source WAL segment that must remain pinned.
+    pub const fn minimum_pinned_wal_segment(&self) -> Option<u64> {
+        self.minimum_pinned_wal_segment
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct TieredRetryEntry {
+    source_epoch: u64,
+    physical_offset: u64,
+    length: u32,
+    topic: String,
+    queue_id: i32,
+    queue_offset: i64,
+    message_size: i32,
+    tags_code: i64,
+    store_timestamp: i64,
+    keys: Option<String>,
+    uniq_key: Option<String>,
+    offset_id: Option<String>,
+    sys_flag: i32,
+    attempts: u32,
+    first_failed_at_millis: u64,
+    next_attempt_at_millis: u64,
+}
+
+impl TieredRetryEntry {
+    fn new(
+        record: DerivedRecordId,
+        request: &TieredDispatchRequest,
+        now_millis: u64,
+        initial_backoff: Duration,
+    ) -> Self {
+        Self {
+            source_epoch: record.source_epoch(),
+            physical_offset: record.physical_offset(),
+            length: record.length(),
+            topic: request.topic.clone(),
+            queue_id: request.queue_id,
+            queue_offset: request.queue_offset,
+            message_size: request.message_size,
+            tags_code: request.tags_code,
+            store_timestamp: request.store_timestamp,
+            keys: request.keys.clone(),
+            uniq_key: request.uniq_key.clone(),
+            offset_id: request.offset_id.clone(),
+            sys_flag: request.sys_flag,
+            attempts: 1,
+            first_failed_at_millis: now_millis,
+            next_attempt_at_millis: now_millis.saturating_add(duration_millis(initial_backoff)),
+        }
+    }
+
+    pub(crate) fn record(&self) -> Result<DerivedRecordId, RocketMQError> {
+        DerivedRecordId::try_new(self.source_epoch, self.physical_offset, self.length)
+            .map_err(|error| crate::error::storage_corrupted(format!("tiered retry record: {error}")))
+    }
+
+    pub(crate) fn request_with_body(&self, body: Bytes) -> TieredDispatchRequest {
+        TieredDispatchRequest {
+            topic: self.topic.clone(),
+            queue_id: self.queue_id,
+            queue_offset: self.queue_offset,
+            commit_log_offset: i64::try_from(self.physical_offset).unwrap_or(i64::MAX),
+            message_size: self.message_size,
+            tags_code: self.tags_code,
+            store_timestamp: self.store_timestamp,
+            keys: self.keys.clone(),
+            uniq_key: self.uniq_key.clone(),
+            offset_id: self.offset_id.clone(),
+            sys_flag: self.sys_flag,
+            body: Some(body),
+        }
+    }
+
+    pub(crate) const fn next_attempt_at_millis(&self) -> u64 {
+        self.next_attempt_at_millis
+    }
+
+    fn bump(&mut self, now_millis: u64, initial: Duration, maximum: Duration) {
+        self.attempts = self.attempts.saturating_add(1);
+        let exponent = self.attempts.saturating_sub(1).min(31);
+        let delay = duration_millis(initial)
+            .saturating_mul(1_u64 << exponent)
+            .min(duration_millis(maximum));
+        self.next_attempt_at_millis = now_millis.saturating_add(delay);
+    }
+}
+
+#[derive(Clone, Default)]
+struct TieredProgressState {
+    cursor: Option<DerivedCursor>,
+    retries: BTreeMap<DerivedRecordId, TieredRetryEntry>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RecordDisposition {
+    Deliver,
+    RetryPending,
+    AlreadyCommitted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FailureRecordOutcome {
+    Recorded,
+    AlreadyCommitted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetryCapacityError {
+    Entries,
+    Bytes,
+    Age,
+}
+
+pub(crate) struct TieredProgressTracker {
+    source_epoch: u64,
+    retry_max_entries: usize,
+    retry_max_bytes: u64,
+    retry_max_age: Duration,
+    retry_backoff_initial: Duration,
+    retry_backoff_max: Duration,
+    source_wal_segment_size: u64,
+    persistence: TieredProgressPersistence,
+    state: Mutex<TieredProgressState>,
+    health: Arc<RwLock<TieredDispatchHealth>>,
+    loaded: AtomicBool,
+}
+
+impl TieredProgressTracker {
+    pub(crate) fn new(config: &TieredStoreConfig, health: Arc<RwLock<TieredDispatchHealth>>) -> Self {
+        Self {
+            source_epoch: config.source_epoch,
+            retry_max_entries: config.retry_ledger_max_entries.max(1),
+            retry_max_bytes: config.retry_ledger_max_bytes.max(1),
+            retry_max_age: config.retry_ledger_max_age,
+            retry_backoff_initial: config.retry_backoff_initial.max(Duration::from_millis(1)),
+            retry_backoff_max: config.retry_backoff_max.max(config.retry_backoff_initial),
+            source_wal_segment_size: config.source_wal_segment_size.max(1),
+            persistence: TieredProgressPersistence::new(config.store_path_root_dir.clone()),
+            state: Mutex::new(TieredProgressState::default()),
+            health,
+            loaded: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) async fn load(&self, now_millis: u64) -> Result<(), RocketMQError> {
+        if self
+            .loaded
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Ok(());
+        }
+        let result = self.load_inner(now_millis).await;
+        if result.is_err() {
+            self.loaded.store(false, Ordering::Release);
+        }
+        result
+    }
+
+    async fn load_inner(&self, now_millis: u64) -> Result<(), RocketMQError> {
+        let Some(persisted) = self.persistence.load().await? else {
+            self.refresh_health(&TieredProgressState::default(), now_millis, None);
+            return Ok(());
+        };
+        let checkpoint = DerivedCheckpoint::decode(&persisted.checkpoint, DerivedEngine::Tiered)
+            .map_err(|error| crate::error::storage_corrupted(format!("tiered progress checkpoint: {error}")))?;
+        let cursor = checkpoint.cursor();
+        if cursor.source_epoch() != self.source_epoch {
+            return Err(crate::error::storage_corrupted(format!(
+                "tiered progress source epoch mismatch: expected {}, got {}",
+                self.source_epoch,
+                cursor.source_epoch()
+            )));
+        }
+
+        let mut retries = BTreeMap::new();
+        for entry in persisted.retries {
+            let record = entry.record()?;
+            if record.source_epoch() != self.source_epoch || record.end_offset() > cursor.next_offset() {
+                return Err(crate::error::storage_corrupted(
+                    "tiered retry record is outside the persisted cursor prefix",
+                ));
+            }
+            if retries.insert(record, entry).is_some() {
+                return Err(crate::error::storage_corrupted(
+                    "tiered retry ledger contains duplicate record identity",
+                ));
+            }
+        }
+        let state = TieredProgressState {
+            cursor: Some(cursor),
+            retries,
+        };
+        let readiness = self.health_readiness(&state, now_millis);
+        self.refresh_health(&state, now_millis, readiness);
+        *self.state.lock().await = state;
+        Ok(())
+    }
+
+    pub(crate) async fn destroy(&self) -> Result<(), RocketMQError> {
+        self.persistence.destroy().await?;
+        let state = TieredProgressState::default();
+        *self.state.lock().await = state.clone();
+        self.refresh_health(&state, 0, None);
+        self.loaded.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    pub(crate) const fn retry_poll_interval(&self) -> Duration {
+        self.retry_backoff_initial
+    }
+
+    pub(crate) async fn classify(&self, record: DerivedRecordId) -> Result<RecordDisposition, RocketMQError> {
+        self.validate_epoch(record)?;
+        let state = self.state.lock().await;
+        if state.retries.contains_key(&record) {
+            return Ok(RecordDisposition::RetryPending);
+        }
+        let Some(cursor) = state.cursor else {
+            return Ok(RecordDisposition::Deliver);
+        };
+        match cursor
+            .prepare(record)
+            .map_err(|error| RocketMQError::illegal_argument(format!("tiered cursor invariant: {error}")))?
+        {
+            CursorAdvanceDisposition::AlreadyCommitted => Ok(RecordDisposition::AlreadyCommitted),
+            CursorAdvanceDisposition::Advance(_) => Ok(RecordDisposition::Deliver),
+        }
+    }
+
+    pub(crate) async fn record_success(&self, record: DerivedRecordId, now_millis: u64) -> Result<(), RocketMQError> {
+        self.validate_epoch(record)?;
+        let mut state_guard = self.state.lock().await;
+        let mut candidate = state_guard.clone();
+        let current = candidate
+            .cursor
+            .unwrap_or_else(|| DerivedCursor::restore(record.source_epoch(), record.physical_offset()));
+        match current
+            .prepare(record)
+            .map_err(|error| RocketMQError::illegal_argument(format!("tiered cursor invariant: {error}")))?
+        {
+            CursorAdvanceDisposition::AlreadyCommitted => {
+                if candidate.retries.remove(&record).is_none() {
+                    return Ok(());
+                }
+            }
+            CursorAdvanceDisposition::Advance(advance) => {
+                candidate.cursor = Some(advance.next_cursor());
+                candidate.retries.remove(&record);
+            }
+        }
+        self.persist_candidate(&candidate).await?;
+        *state_guard = candidate.clone();
+        self.refresh_health(&candidate, now_millis, self.health_readiness(&candidate, now_millis));
+        Ok(())
+    }
+
+    pub(crate) async fn record_failure(
+        &self,
+        record: DerivedRecordId,
+        request: &TieredDispatchRequest,
+        now_millis: u64,
+    ) -> Result<Result<FailureRecordOutcome, RetryCapacityError>, RocketMQError> {
+        self.validate_epoch(record)?;
+        let mut state_guard = self.state.lock().await;
+        let mut candidate = state_guard.clone();
+        let current = candidate
+            .cursor
+            .unwrap_or_else(|| DerivedCursor::restore(record.source_epoch(), record.physical_offset()));
+        let advance = match current
+            .prepare(record)
+            .map_err(|error| RocketMQError::illegal_argument(format!("tiered cursor invariant: {error}")))?
+        {
+            CursorAdvanceDisposition::AlreadyCommitted => {
+                if !candidate.retries.contains_key(&record) {
+                    return Ok(Ok(FailureRecordOutcome::AlreadyCommitted));
+                }
+                None
+            }
+            CursorAdvanceDisposition::Advance(advance) => Some(advance),
+        };
+
+        match candidate.retries.get_mut(&record) {
+            Some(entry) => entry.bump(now_millis, self.retry_backoff_initial, self.retry_backoff_max),
+            None => {
+                candidate.retries.insert(
+                    record,
+                    TieredRetryEntry::new(record, request, now_millis, self.retry_backoff_initial),
+                );
+            }
+        }
+        if let Some(advance) = advance {
+            candidate.cursor = Some(advance.next_cursor());
+        }
+        if let Some(readiness) = self.capacity_violation(&candidate, now_millis) {
+            let capacity = match readiness {
+                TieredDispatchReadiness::RetryLedgerFull => RetryCapacityError::Entries,
+                TieredDispatchReadiness::RetryLedgerBytesExceeded => RetryCapacityError::Bytes,
+                TieredDispatchReadiness::RetryLedgerExpired => RetryCapacityError::Age,
+                _ => unreachable!("only hard retry limits are returned here"),
+            };
+            self.refresh_health(
+                &state_guard,
+                now_millis,
+                self.health_readiness(&state_guard, now_millis),
+            );
+            return Ok(Err(capacity));
+        }
+
+        self.persist_candidate(&candidate).await?;
+        *state_guard = candidate.clone();
+        self.refresh_health(&candidate, now_millis, self.health_readiness(&candidate, now_millis));
+        Ok(Ok(FailureRecordOutcome::Recorded))
+    }
+
+    pub(crate) async fn due_retries(&self, now_millis: u64) -> Vec<TieredRetryEntry> {
+        let state = self.state.lock().await;
+        let mut due = state
+            .retries
+            .values()
+            .filter(|entry| entry.next_attempt_at_millis() <= now_millis)
+            .cloned()
+            .collect::<Vec<_>>();
+        due.sort_by_key(|entry| (entry.next_attempt_at_millis, entry.topic.clone(), entry.queue_id));
+        due
+    }
+
+    pub(crate) async fn record_retry_failure(
+        &self,
+        record: DerivedRecordId,
+        now_millis: u64,
+    ) -> Result<(), RocketMQError> {
+        let mut state_guard = self.state.lock().await;
+        let Some(_) = state_guard.retries.get(&record) else {
+            return Ok(());
+        };
+        let mut candidate = state_guard.clone();
+        if let Some(entry) = candidate.retries.get_mut(&record) {
+            entry.bump(now_millis, self.retry_backoff_initial, self.retry_backoff_max);
+        }
+        self.persist_candidate(&candidate).await?;
+        *state_guard = candidate.clone();
+        self.refresh_health(&candidate, now_millis, self.health_readiness(&candidate, now_millis));
+        Ok(())
+    }
+
+    pub(crate) async fn record_retry_success(
+        &self,
+        record: DerivedRecordId,
+        now_millis: u64,
+    ) -> Result<(), RocketMQError> {
+        let mut state_guard = self.state.lock().await;
+        if !state_guard.retries.contains_key(&record) {
+            return Ok(());
+        }
+        let mut candidate = state_guard.clone();
+        candidate.retries.remove(&record);
+        self.persist_candidate(&candidate).await?;
+        *state_guard = candidate.clone();
+        self.refresh_health(&candidate, now_millis, self.health_readiness(&candidate, now_millis));
+        Ok(())
+    }
+
+    pub(crate) fn mark_unready(&self, readiness: TieredDispatchReadiness) {
+        self.health.write().readiness = readiness;
+    }
+
+    pub(crate) fn mark_unready_if_healthy(&self, readiness: TieredDispatchReadiness) {
+        let mut health = self.health.write();
+        if health.readiness == TieredDispatchReadiness::Healthy {
+            health.readiness = readiness;
+        }
+    }
+
+    pub(crate) fn hard_backpressure(&self) -> bool {
+        matches!(
+            self.health.read().readiness,
+            TieredDispatchReadiness::RetryLedgerFull
+                | TieredDispatchReadiness::RetryLedgerBytesExceeded
+                | TieredDispatchReadiness::RetryLedgerExpired
+        )
+    }
+
+    async fn persist_candidate(&self, candidate: &TieredProgressState) -> Result<(), RocketMQError> {
+        let Some(cursor) = candidate.cursor else {
+            return Ok(());
+        };
+        let persisted = PersistedTieredProgress {
+            checkpoint: DerivedCheckpoint::new(DerivedEngine::Tiered, cursor).encode().to_vec(),
+            retries: candidate.retries.values().cloned().collect(),
+        };
+        if let Err(error) = self.persistence.persist(&persisted).await {
+            self.mark_unready(TieredDispatchReadiness::ProgressPersistenceFailed);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn validate_epoch(&self, record: DerivedRecordId) -> Result<(), RocketMQError> {
+        if record.source_epoch() == self.source_epoch {
+            return Ok(());
+        }
+        self.mark_unready(TieredDispatchReadiness::CursorInvariantViolated);
+        Err(RocketMQError::illegal_argument(format!(
+            "tiered source epoch mismatch: expected {}, got {}",
+            self.source_epoch,
+            record.source_epoch()
+        )))
+    }
+
+    fn capacity_violation(&self, state: &TieredProgressState, now_millis: u64) -> Option<TieredDispatchReadiness> {
+        if state.retries.len() > self.retry_max_entries {
+            return Some(TieredDispatchReadiness::RetryLedgerFull);
+        }
+        if retry_source_bytes(&state.retries) > self.retry_max_bytes {
+            return Some(TieredDispatchReadiness::RetryLedgerBytesExceeded);
+        }
+        let oldest_age = oldest_retry_age(&state.retries, now_millis);
+        if oldest_age > self.retry_max_age {
+            return Some(TieredDispatchReadiness::RetryLedgerExpired);
+        }
+        None
+    }
+
+    fn health_readiness(&self, state: &TieredProgressState, now_millis: u64) -> Option<TieredDispatchReadiness> {
+        if state.retries.len() >= self.retry_max_entries {
+            return Some(TieredDispatchReadiness::RetryLedgerFull);
+        }
+        if retry_source_bytes(&state.retries) >= self.retry_max_bytes {
+            return Some(TieredDispatchReadiness::RetryLedgerBytesExceeded);
+        }
+        let oldest_age = oldest_retry_age(&state.retries, now_millis);
+        if oldest_age > self.retry_max_age {
+            return Some(TieredDispatchReadiness::RetryLedgerExpired);
+        }
+        None
+    }
+
+    fn refresh_health(&self, state: &TieredProgressState, now_millis: u64, readiness: Option<TieredDispatchReadiness>) {
+        let minimum_pinned_offset = state.retries.keys().map(|record| record.physical_offset()).min();
+        let minimum_pinned_wal_segment =
+            minimum_pinned_offset.map(|offset| offset / self.source_wal_segment_size * self.source_wal_segment_size);
+        *self.health.write() = TieredDispatchHealth {
+            readiness: readiness.unwrap_or(TieredDispatchReadiness::Healthy),
+            cursor: state.cursor,
+            retry_count: state.retries.len(),
+            retry_source_bytes: retry_source_bytes(&state.retries),
+            oldest_retry_age: oldest_retry_age(&state.retries, now_millis),
+            minimum_pinned_offset,
+            minimum_pinned_wal_segment,
+        };
+    }
+}
+
+fn retry_source_bytes(retries: &BTreeMap<DerivedRecordId, TieredRetryEntry>) -> u64 {
+    retries
+        .keys()
+        .map(|record| u64::from(record.length()))
+        .fold(0_u64, u64::saturating_add)
+}
+
+fn oldest_retry_age(retries: &BTreeMap<DerivedRecordId, TieredRetryEntry>, now_millis: u64) -> Duration {
+    retries
+        .values()
+        .map(|entry| now_millis.saturating_sub(entry.first_failed_at_millis))
+        .max()
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::ZERO)
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}

--- a/rocketmq-tieredstore/src/dispatcher/progress_persistence.rs
+++ b/rocketmq-tieredstore/src/dispatcher/progress_persistence.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use rocketmq_error::RocketMQError;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use super::progress::TieredRetryEntry;
+
+const PROGRESS_MAGIC: [u8; 8] = *b"RMQTPRG\0";
+const PROGRESS_VERSION: u16 = 1;
+const HEADER_LEN: usize = 20;
+const CHECKSUM_LEN: usize = 4;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct PersistedTieredProgress {
+    pub(crate) checkpoint: Vec<u8>,
+    pub(crate) retries: Vec<TieredRetryEntry>,
+}
+
+pub(crate) struct TieredProgressPersistence {
+    path: PathBuf,
+    persist_lock: tokio::sync::Mutex<()>,
+}
+
+impl TieredProgressPersistence {
+    pub(crate) fn new(root: PathBuf) -> Self {
+        Self {
+            path: root.join("config").join("tieredDispatchProgress.bin"),
+            persist_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    pub(crate) async fn load(&self) -> Result<Option<PersistedTieredProgress>, RocketMQError> {
+        let encoded = match fs::read(&self.path).await {
+            Ok(encoded) => encoded,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(read_failed(&self.path, error)),
+        };
+        decode(&encoded, &self.path).map(Some)
+    }
+
+    pub(crate) async fn persist(&self, progress: &PersistedTieredProgress) -> Result<(), RocketMQError> {
+        let _guard = self.persist_lock.lock().await;
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| RocketMQError::storage_write_failed(path_string(&self.path), "missing parent directory"))?;
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|error| write_failed(parent, error))?;
+        let encoded = encode(progress)?;
+        let temporary = self.path.with_extension("bin.tmp");
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temporary)
+            .await
+            .map_err(|error| write_failed(&temporary, error))?;
+        file.write_all(&encoded)
+            .await
+            .map_err(|error| write_failed(&temporary, error))?;
+        file.sync_all().await.map_err(|error| write_failed(&temporary, error))?;
+        drop(file);
+        fs::rename(&temporary, &self.path)
+            .await
+            .map_err(|error| write_failed(&self.path, error))?;
+        sync_parent_directory(parent).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn destroy(&self) -> Result<(), RocketMQError> {
+        match fs::remove_file(&self.path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(write_failed(&self.path, error)),
+        }
+    }
+}
+
+fn encode(progress: &PersistedTieredProgress) -> Result<Vec<u8>, RocketMQError> {
+    let payload = serde_json::to_vec(progress)
+        .map_err(|error| RocketMQError::storage_write_failed("tiered progress", error.to_string()))?;
+    let payload_len = u64::try_from(payload.len())
+        .map_err(|_| RocketMQError::storage_write_failed("tiered progress", "payload length overflow"))?;
+    let mut encoded = Vec::with_capacity(HEADER_LEN + payload.len() + CHECKSUM_LEN);
+    encoded.extend_from_slice(&PROGRESS_MAGIC);
+    encoded.extend_from_slice(&PROGRESS_VERSION.to_be_bytes());
+    encoded.extend_from_slice(&0_u16.to_be_bytes());
+    encoded.extend_from_slice(&payload_len.to_be_bytes());
+    encoded.extend_from_slice(&payload);
+    encoded.extend_from_slice(&crc32(&encoded).to_be_bytes());
+    Ok(encoded)
+}
+
+fn decode(encoded: &[u8], path: &Path) -> Result<PersistedTieredProgress, RocketMQError> {
+    if encoded.len() < HEADER_LEN + CHECKSUM_LEN || encoded[..8] != PROGRESS_MAGIC {
+        return Err(corrupted(path));
+    }
+    let version = u16::from_be_bytes([encoded[8], encoded[9]]);
+    let reserved = u16::from_be_bytes([encoded[10], encoded[11]]);
+    if version != PROGRESS_VERSION || reserved != 0 {
+        return Err(corrupted(path));
+    }
+    let payload_len = u64::from_be_bytes([
+        encoded[12],
+        encoded[13],
+        encoded[14],
+        encoded[15],
+        encoded[16],
+        encoded[17],
+        encoded[18],
+        encoded[19],
+    ]);
+    let payload_len = usize::try_from(payload_len).map_err(|_| corrupted(path))?;
+    let expected_len = HEADER_LEN
+        .checked_add(payload_len)
+        .and_then(|length| length.checked_add(CHECKSUM_LEN))
+        .ok_or_else(|| corrupted(path))?;
+    if encoded.len() != expected_len {
+        return Err(corrupted(path));
+    }
+    let checksum_offset = expected_len - CHECKSUM_LEN;
+    let expected_checksum = u32::from_be_bytes([
+        encoded[checksum_offset],
+        encoded[checksum_offset + 1],
+        encoded[checksum_offset + 2],
+        encoded[checksum_offset + 3],
+    ]);
+    if crc32(&encoded[..checksum_offset]) != expected_checksum {
+        return Err(corrupted(path));
+    }
+    serde_json::from_slice(&encoded[HEADER_LEN..checksum_offset]).map_err(|_| corrupted(path))
+}
+
+#[cfg(unix)]
+async fn sync_parent_directory(parent: &Path) -> Result<(), RocketMQError> {
+    fs::File::open(parent)
+        .await
+        .map_err(|error| write_failed(parent, error))?
+        .sync_all()
+        .await
+        .map_err(|error| write_failed(parent, error))
+}
+
+#[cfg(not(unix))]
+async fn sync_parent_directory(_parent: &Path) -> Result<(), RocketMQError> {
+    // The temporary file is synced before the atomic replacement. Windows does not expose a
+    // portable async directory handle through Tokio; rename durability follows the volume's
+    // metadata guarantees.
+    Ok(())
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = 0_u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+fn corrupted(path: &Path) -> RocketMQError {
+    crate::error::storage_corrupted(path_string(path))
+}
+
+fn read_failed(path: &Path, error: std::io::Error) -> RocketMQError {
+    RocketMQError::storage_read_failed(path_string(path), error.to_string())
+}
+
+fn write_failed(path: &Path, error: std::io::Error) -> RocketMQError {
+    RocketMQError::storage_write_failed(path_string(path), error.to_string())
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
@@ -13,17 +13,29 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
+use bytes::Bytes;
+use parking_lot::RwLock;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::UnifiedServiceError;
+use rocketmq_store_api::DerivedRecordId;
 use tokio::sync::mpsc;
+use tokio::sync::Notify;
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 
 use crate::config::TieredStoreConfig;
+use crate::dispatcher::progress::FailureRecordOutcome;
+use crate::dispatcher::progress::RecordDisposition;
+use crate::dispatcher::progress::TieredProgressTracker;
 use crate::dispatcher::TieredDispatchRequest;
 use crate::file::ConsumeQueueUnit;
 use crate::file::TieredFlatFileStore;
@@ -31,11 +43,31 @@ use crate::provider::TieredStoreProvider;
 use crate::runtime;
 use rocketmq_observability::metrics::tiered_store::TieredStoreMetrics;
 
+pub use crate::dispatcher::progress::TieredDispatchHealth;
+pub use crate::dispatcher::progress::TieredDispatchReadiness;
+
 type DispatcherTaskErrorSlot = Arc<tokio::sync::Mutex<Option<RocketMQError>>>;
+type RetryPayloadResolver = dyn Fn(u64, u32) -> Option<Bytes> + Send + Sync;
+
+struct QueuedDispatch {
+    request: TieredDispatchRequest,
+    record: Option<DerivedRecordId>,
+    _byte_permit: OwnedSemaphorePermit,
+}
 
 #[allow(async_fn_in_trait)]
 pub trait TieredDispatcher: Send + Sync {
     async fn dispatch(&self, request: TieredDispatchRequest) -> Result<(), RocketMQError>;
+
+    /// Dispatches one record with its authoritative CommitLog idempotency key.
+    async fn dispatch_derived(
+        &self,
+        record: DerivedRecordId,
+        request: TieredDispatchRequest,
+    ) -> Result<(), RocketMQError> {
+        let _ = record;
+        self.dispatch(request).await
+    }
 
     async fn start(&self) -> Result<(), RocketMQError>;
 
@@ -48,14 +80,19 @@ where
 {
     config: Arc<TieredStoreConfig>,
     flat_file_store: Arc<TieredFlatFileStore<P>>,
-    sender: mpsc::Sender<TieredDispatchRequest>,
-    receiver: tokio::sync::Mutex<Option<mpsc::Receiver<TieredDispatchRequest>>>,
+    sender: mpsc::Sender<QueuedDispatch>,
+    receiver: tokio::sync::Mutex<Option<mpsc::Receiver<QueuedDispatch>>>,
+    pending_bytes: Arc<Semaphore>,
+    pending_byte_capacity: u32,
     permits: Arc<Semaphore>,
     shutdown: CancellationToken,
     task_group: tokio::sync::Mutex<Option<rocketmq_runtime::TaskGroup>>,
     parent_task_group: Option<TaskGroup>,
     task_error: DispatcherTaskErrorSlot,
     metrics: Arc<TieredStoreMetrics>,
+    progress: Arc<TieredProgressTracker>,
+    progress_health: Arc<RwLock<TieredDispatchHealth>>,
+    retry_payload_resolver: Arc<RwLock<Option<Arc<RetryPayloadResolver>>>>,
 }
 
 impl<P> DefaultTieredDispatcher<P>
@@ -120,20 +157,57 @@ where
         metrics: Arc<TieredStoreMetrics>,
         parent_task_group: Option<TaskGroup>,
     ) -> Self {
-        let (sender, receiver) = mpsc::channel(config.max_pending_tasks);
+        let (sender, receiver) = mpsc::channel(config.max_pending_tasks.max(1));
         let permits = Arc::new(Semaphore::new((config.max_pending_tasks / 4).max(1)));
+        let pending_byte_capacity = config
+            .max_pending_bytes
+            .clamp(1, Semaphore::MAX_PERMITS)
+            .min(u32::MAX as usize) as u32;
+        let pending_bytes = Arc::new(Semaphore::new(pending_byte_capacity as usize));
+        let progress_health = Arc::new(RwLock::new(TieredDispatchHealth::initial()));
+        let progress = Arc::new(TieredProgressTracker::new(&config, progress_health.clone()));
         Self {
             config,
             flat_file_store,
             sender,
             receiver: tokio::sync::Mutex::new(Some(receiver)),
+            pending_bytes,
+            pending_byte_capacity,
             permits,
             shutdown,
             task_group: tokio::sync::Mutex::new(None),
             parent_task_group,
             task_error: Arc::new(tokio::sync::Mutex::new(None)),
             metrics,
+            progress,
+            progress_health,
+            retry_payload_resolver: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Configures the CommitLog reader used to reconstruct payload for durable retry records.
+    pub fn set_retry_payload_resolver(&self, resolver: Arc<RetryPayloadResolver>) {
+        *self.retry_payload_resolver.write() = Some(resolver);
+    }
+
+    /// Loads and validates the durable Tiered cursor/retry snapshot.
+    pub async fn load_progress(&self) -> Result<(), RocketMQError> {
+        self.progress.load(current_time_millis()).await
+    }
+
+    /// Removes the independently versioned Tiered cursor/retry metadata.
+    pub async fn destroy_progress(&self) -> Result<(), RocketMQError> {
+        self.progress.destroy().await
+    }
+
+    /// Returns a bounded readiness, retry, and source-WAL pin snapshot.
+    pub fn health(&self) -> TieredDispatchHealth {
+        self.progress_health.read().clone()
+    }
+
+    /// Returns whether the lifecycle owner has cancelled this dispatcher.
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown.is_cancelled()
     }
 
     pub fn metrics(&self) -> Arc<TieredStoreMetrics> {
@@ -167,33 +241,298 @@ where
         if !self.config.storage_level.enabled() || !request.is_valid() {
             return Ok(());
         }
+        if self.is_shutdown() {
+            return Err(RocketMQError::Service(UnifiedServiceError::Interrupted));
+        }
+        let byte_permit = self.try_acquire_bytes(&request)?;
         self.sender
-            .try_send(request)
+            .try_send(QueuedDispatch {
+                request,
+                record: None,
+                _byte_permit: byte_permit,
+            })
             .map_err(|err| RocketMQError::storage_write_failed("tiered_dispatch_queue", err.to_string()))?;
         rocketmq_observability::metrics::tiered_store::record_dispatch_queued(&self.metrics);
         Ok(())
     }
 
+    /// Attempts to enqueue one CommitLog-derived record without dropping its identity.
+    pub fn try_dispatch_derived(
+        &self,
+        record: DerivedRecordId,
+        request: TieredDispatchRequest,
+    ) -> Result<(), RocketMQError> {
+        if !self.config.storage_level.enabled() || !request.is_valid() {
+            return Ok(());
+        }
+        if self.is_shutdown() {
+            return Err(RocketMQError::Service(UnifiedServiceError::Interrupted));
+        }
+        self.validate_record(record, &request)?;
+        let byte_permit = self.try_acquire_bytes(&request)?;
+        self.sender
+            .try_send(QueuedDispatch {
+                request,
+                record: Some(record),
+                _byte_permit: byte_permit,
+            })
+            .map_err(|err| RocketMQError::storage_write_failed("tiered_dispatch_queue", err.to_string()))?;
+        rocketmq_observability::metrics::tiered_store::record_dispatch_queued(&self.metrics);
+        Ok(())
+    }
+
+    fn validate_record(&self, record: DerivedRecordId, request: &TieredDispatchRequest) -> Result<(), RocketMQError> {
+        let request_offset = u64::try_from(request.commit_log_offset)
+            .map_err(|_| RocketMQError::illegal_argument("tiered CommitLog offset must not be negative"))?;
+        let request_length = u32::try_from(request.message_size)
+            .map_err(|_| RocketMQError::illegal_argument("tiered CommitLog length must be positive"))?;
+        if record.source_epoch() != self.config.source_epoch
+            || record.physical_offset() != request_offset
+            || record.length() != request_length
+        {
+            return Err(RocketMQError::illegal_argument(
+                "tiered dispatch record does not match configured source epoch, offset, or length",
+            ));
+        }
+        Ok(())
+    }
+
+    fn request_byte_count(request: &TieredDispatchRequest) -> Result<u32, RocketMQError> {
+        let bytes = request.body.as_ref().map_or(0, Bytes::len);
+        u32::try_from(bytes).map_err(|_| {
+            RocketMQError::storage_write_failed("tiered_dispatch_queue", "message exceeds byte permit range")
+        })
+    }
+
+    fn try_acquire_bytes(&self, request: &TieredDispatchRequest) -> Result<OwnedSemaphorePermit, RocketMQError> {
+        let bytes = Self::request_byte_count(request)?;
+        if bytes > self.pending_byte_capacity {
+            return Err(RocketMQError::storage_write_failed(
+                "tiered_dispatch_queue",
+                "message exceeds bounded pending byte capacity",
+            ));
+        }
+        self.pending_bytes.clone().try_acquire_many_owned(bytes).map_err(|_| {
+            RocketMQError::storage_write_failed("tiered_dispatch_queue", "bounded pending byte capacity reached")
+        })
+    }
+
+    async fn acquire_bytes(&self, request: &TieredDispatchRequest) -> Result<OwnedSemaphorePermit, RocketMQError> {
+        let bytes = Self::request_byte_count(request)?;
+        if bytes > self.pending_byte_capacity {
+            return Err(RocketMQError::storage_write_failed(
+                "tiered_dispatch_queue",
+                "message exceeds bounded pending byte capacity",
+            ));
+        }
+        tokio::select! {
+            biased;
+            _ = self.shutdown.cancelled() => Err(RocketMQError::Service(UnifiedServiceError::Interrupted)),
+            permit = self.pending_bytes.clone().acquire_many_owned(bytes) => {
+                permit.map_err(|_| RocketMQError::Service(UnifiedServiceError::Interrupted))
+            }
+        }
+    }
+
+    async fn enqueue(&self, queued: QueuedDispatch) -> Result<(), RocketMQError> {
+        tokio::select! {
+            biased;
+            _ = self.shutdown.cancelled() => Err(RocketMQError::Service(UnifiedServiceError::Interrupted)),
+            result = self.sender.send(queued) => {
+                result.map_err(|error| {
+                    RocketMQError::storage_write_failed("tiered_dispatch_queue", error.to_string())
+                })
+            }
+        }
+    }
+
     async fn run(
         flat_file_store: Arc<TieredFlatFileStore<P>>,
-        mut receiver: mpsc::Receiver<TieredDispatchRequest>,
+        mut receiver: mpsc::Receiver<QueuedDispatch>,
         permits: Arc<Semaphore>,
         shutdown: CancellationToken,
         metrics: Arc<TieredStoreMetrics>,
+        progress: Arc<TieredProgressTracker>,
+        retry_payload_resolver: Arc<RwLock<Option<Arc<RetryPayloadResolver>>>>,
+        retry_tick: Arc<Notify>,
     ) -> Result<(), RocketMQError> {
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => {
-                    while let Ok(request) = receiver.try_recv() {
-                        Self::dispatch_one(flat_file_store.clone(), permits.clone(), metrics.clone(), request).await?;
+                    while let Ok(queued) = receiver.try_recv() {
+                        Self::process_queued(
+                            flat_file_store.clone(),
+                            permits.clone(),
+                            metrics.clone(),
+                            progress.clone(),
+                            retry_payload_resolver.clone(),
+                            retry_tick.clone(),
+                            queued,
+                            &shutdown,
+                        )
+                        .await?;
                     }
                     break;
                 }
-                maybe_request = receiver.recv() => {
-                    let Some(request) = maybe_request else {
+                maybe_queued = receiver.recv() => {
+                    let Some(queued) = maybe_queued else {
                         break;
                     };
-                    Self::dispatch_one(flat_file_store.clone(), permits.clone(), metrics.clone(), request).await?;
+                    Self::process_queued(
+                        flat_file_store.clone(),
+                        permits.clone(),
+                        metrics.clone(),
+                        progress.clone(),
+                        retry_payload_resolver.clone(),
+                        retry_tick.clone(),
+                        queued,
+                        &shutdown,
+                    )
+                    .await?;
+                }
+                _ = retry_tick.notified() => {
+                    Self::retry_due(
+                        flat_file_store.clone(),
+                        permits.clone(),
+                        metrics.clone(),
+                        progress.clone(),
+                        retry_payload_resolver.clone(),
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_queued(
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        permits: Arc<Semaphore>,
+        metrics: Arc<TieredStoreMetrics>,
+        progress: Arc<TieredProgressTracker>,
+        retry_payload_resolver: Arc<RwLock<Option<Arc<RetryPayloadResolver>>>>,
+        retry_tick: Arc<Notify>,
+        queued: QueuedDispatch,
+        shutdown: &CancellationToken,
+    ) -> Result<(), RocketMQError> {
+        let Some(record) = queued.record else {
+            return Self::dispatch_one(flat_file_store, permits, metrics, queued.request).await;
+        };
+        let disposition = progress.classify(record).await?;
+        match disposition {
+            RecordDisposition::AlreadyCommitted => return Ok(()),
+            RecordDisposition::Deliver | RecordDisposition::RetryPending => {}
+        }
+
+        while disposition == RecordDisposition::Deliver && progress.hard_backpressure() {
+            Self::retry_due(
+                flat_file_store.clone(),
+                permits.clone(),
+                metrics.clone(),
+                progress.clone(),
+                retry_payload_resolver.clone(),
+            )
+            .await?;
+            if !progress.hard_backpressure() {
+                break;
+            }
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    return Ok(());
+                }
+                _ = retry_tick.notified() => {}
+            }
+        }
+
+        loop {
+            let result = Self::dispatch_one(
+                flat_file_store.clone(),
+                permits.clone(),
+                metrics.clone(),
+                queued.request.clone(),
+            )
+            .await;
+            match result {
+                Ok(()) => {
+                    progress.record_success(record, current_time_millis()).await?;
+                    return Ok(());
+                }
+                Err(error) => {
+                    let now_millis = current_time_millis();
+                    match progress.record_failure(record, &queued.request, now_millis).await? {
+                        Ok(FailureRecordOutcome::Recorded | FailureRecordOutcome::AlreadyCommitted) => {
+                            tracing::warn!(
+                                topic = %queued.request.topic,
+                                queue_id = queued.request.queue_id,
+                                physical_offset = record.physical_offset(),
+                                error = %error,
+                                "tiered delivery failure recorded for bounded retry"
+                            );
+                            return Ok(());
+                        }
+                        Err(capacity) => {
+                            tracing::warn!(
+                                ?capacity,
+                                physical_offset = record.physical_offset(),
+                                "tiered retry ledger bound reached; pausing derived reader"
+                            );
+                            Self::retry_due(
+                                flat_file_store.clone(),
+                                permits.clone(),
+                                metrics.clone(),
+                                progress.clone(),
+                                retry_payload_resolver.clone(),
+                            )
+                            .await?;
+                            if !progress.hard_backpressure() {
+                                continue;
+                            }
+                            tokio::select! {
+                                _ = shutdown.cancelled() => {
+                                    return Ok(());
+                                }
+                                _ = retry_tick.notified() => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn retry_due(
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        permits: Arc<Semaphore>,
+        metrics: Arc<TieredStoreMetrics>,
+        progress: Arc<TieredProgressTracker>,
+        retry_payload_resolver: Arc<RwLock<Option<Arc<RetryPayloadResolver>>>>,
+    ) -> Result<(), RocketMQError> {
+        let now_millis = current_time_millis();
+        let retries = progress.due_retries(now_millis).await;
+        if retries.is_empty() {
+            return Ok(());
+        }
+        let resolver = retry_payload_resolver.read().clone();
+        for retry in retries {
+            let record = retry.record()?;
+            let Some(body) = resolver
+                .as_ref()
+                .and_then(|resolver| resolver(record.physical_offset(), record.length()))
+            else {
+                progress.record_retry_failure(record, now_millis).await?;
+                progress.mark_unready_if_healthy(TieredDispatchReadiness::RetryPayloadUnavailable);
+                continue;
+            };
+            let request = retry.request_with_body(body);
+            match Self::dispatch_one(flat_file_store.clone(), permits.clone(), metrics.clone(), request).await {
+                Ok(()) => progress.record_retry_success(record, current_time_millis()).await?,
+                Err(error) => {
+                    tracing::warn!(
+                        physical_offset = record.physical_offset(),
+                        error = %error,
+                        "tiered retry remains pending"
+                    );
+                    progress.record_retry_failure(record, current_time_millis()).await?;
                 }
             }
         }
@@ -233,11 +572,21 @@ where
         request: &TieredDispatchRequest,
     ) -> Result<(), RocketMQError> {
         let file = flat_file_store.get_or_create(request.topic.clone(), request.queue_id)?;
+        // Complete any provider write that failed after staging bytes. This makes an in-process
+        // partial write retry resume the same destination range instead of appending a duplicate.
+        file.commit().await?;
         let consume_queue_min_offset = file.consume_queue_min_offset();
         let consume_queue_commit_offset = file.consume_queue_commit_offset();
         if consume_queue_commit_offset > consume_queue_min_offset {
             if request.queue_offset < consume_queue_commit_offset {
-                return Ok(());
+                let unit = file
+                    .read_consume_queue_unit(request.queue_offset)
+                    .await?
+                    .ok_or_else(|| crate::error::storage_corrupted("tiered duplicate queue unit is missing"))?;
+                let tiered_offset = u64::try_from(unit.commit_log_offset).map_err(|_| {
+                    crate::error::storage_corrupted("tiered duplicate queue unit contains a negative offset")
+                })?;
+                return flat_file_store.append_index(request, tiered_offset).await;
             }
             if request.queue_offset > consume_queue_commit_offset {
                 return Err(RocketMQError::illegal_argument(format!(
@@ -272,15 +621,39 @@ where
         if !self.config.storage_level.enabled() || !request.is_valid() {
             return Ok(());
         }
-        self.sender
-            .send(request)
-            .await
-            .map_err(|err| RocketMQError::storage_write_failed("tiered_dispatch_queue", err.to_string()))?;
+        let byte_permit = self.acquire_bytes(&request).await?;
+        self.enqueue(QueuedDispatch {
+            request,
+            record: None,
+            _byte_permit: byte_permit,
+        })
+        .await?;
+        rocketmq_observability::metrics::tiered_store::record_dispatch_queued(&self.metrics);
+        Ok(())
+    }
+
+    async fn dispatch_derived(
+        &self,
+        record: DerivedRecordId,
+        request: TieredDispatchRequest,
+    ) -> Result<(), RocketMQError> {
+        if !self.config.storage_level.enabled() || !request.is_valid() {
+            return Ok(());
+        }
+        self.validate_record(record, &request)?;
+        let byte_permit = self.acquire_bytes(&request).await?;
+        self.enqueue(QueuedDispatch {
+            request,
+            record: Some(record),
+            _byte_permit: byte_permit,
+        })
+        .await?;
         rocketmq_observability::metrics::tiered_store::record_dispatch_queued(&self.metrics);
         Ok(())
     }
 
     async fn start(&self) -> Result<(), RocketMQError> {
+        self.load_progress().await?;
         let mut receiver_guard = self.receiver.lock().await;
         let Some(receiver) = receiver_guard.take() else {
             return Ok(());
@@ -296,9 +669,37 @@ where
         let permits = self.permits.clone();
         let shutdown = self.shutdown.clone();
         let metrics = self.metrics.clone();
+        let progress = self.progress.clone();
+        let retry_payload_resolver = self.retry_payload_resolver.clone();
+        let retry_tick = Arc::new(Notify::new());
+        let retry_tick_scheduler = retry_tick.clone();
+        ScheduledTaskGroup::new(task_group.child("scheduled"))
+            .schedule_fixed_rate_no_overlap(
+                ScheduledTaskConfig::fixed_rate_no_overlap(
+                    "tieredstore.dispatcher.retry-ledger",
+                    self.progress.retry_poll_interval(),
+                ),
+                move || {
+                    retry_tick_scheduler.notify_one();
+                    std::future::ready(())
+                },
+            )
+            .map_err(|error| dispatcher_startup_failed("schedule retry ledger", error))?;
         task_group
             .spawn_service("tiered-dispatcher", async move {
-                if let Err(error) = Self::run(flat_file_store, receiver, permits, shutdown, metrics).await {
+                if let Err(error) = Self::run(
+                    flat_file_store,
+                    receiver,
+                    permits,
+                    shutdown,
+                    metrics,
+                    progress.clone(),
+                    retry_payload_resolver,
+                    retry_tick,
+                )
+                .await
+                {
+                    progress.mark_unready(TieredDispatchReadiness::DispatcherFailed);
                     *task_error.lock().await = Some(error);
                 }
             })
@@ -309,7 +710,15 @@ where
 
     async fn shutdown(&self) -> Result<(), RocketMQError> {
         self.shutdown_with_report().await?;
+        self.progress.mark_unready(TieredDispatchReadiness::Shutdown);
         Ok(())
+    }
+}
+
+fn current_time_millis() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+        Err(_) => 0,
     }
 }
 
@@ -327,128 +736,5 @@ fn dispatcher_startup_failed(operation: &'static str, error: impl std::fmt::Disp
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use bytes::Bytes;
-    use rocketmq_error::ErrorKind;
-    use rocketmq_error::RocketMQError;
-    use rocketmq_runtime::RuntimeContext;
-    use tokio_util::sync::CancellationToken;
-
-    use super::*;
-    use crate::config::TieredStoreConfig;
-    use crate::file::TieredFlatFileStore;
-    use crate::metadata::JsonMetadataStore;
-    use crate::provider::MemoryProvider;
-
-    #[test]
-    fn dispatcher_task_result_preserves_original_error_kind() {
-        let error = dispatcher_task_result(Some(RocketMQError::illegal_argument("dispatch offset gap")))
-            .expect_err("dispatcher worker error should be propagated");
-
-        assert_eq!(error.kind(), ErrorKind::IllegalArgument);
-        assert!(error.to_string().contains("dispatch offset gap"));
-    }
-
-    #[test]
-    fn dispatcher_startup_failed_uses_service_error_kind() {
-        let error = dispatcher_startup_failed("spawn test worker", "task group closed");
-
-        assert_eq!(error.kind(), ErrorKind::Service);
-        assert!(error.to_string().contains("tieredstore dispatcher spawn test worker"));
-    }
-
-    #[tokio::test]
-    async fn dispatch_writes_commit_log_and_consume_queue_unit() -> Result<(), RocketMQError> {
-        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
-        let config = Arc::new(TieredStoreConfig {
-            store_path_root_dir: temp_dir.path().to_path_buf(),
-            backend_provider: "memory".to_owned(),
-            max_pending_tasks: 4,
-            ..TieredStoreConfig::default()
-        });
-        let flat_file_store = Arc::new(TieredFlatFileStore::new(
-            config.clone(),
-            Arc::new(JsonMetadataStore::new(config.clone())),
-            MemoryProvider::default(),
-        ));
-        let dispatcher = DefaultTieredDispatcher::new(config, flat_file_store.clone(), CancellationToken::new());
-
-        dispatcher.start().await?;
-        dispatcher
-            .dispatch(TieredDispatchRequest {
-                topic: "TopicA".to_owned(),
-                queue_id: 0,
-                queue_offset: 3,
-                commit_log_offset: 1024,
-                message_size: 4,
-                tags_code: 7,
-                store_timestamp: 100,
-                keys: None,
-                uniq_key: None,
-                offset_id: None,
-                sys_flag: 0,
-                body: Some(Bytes::from_static(b"body")),
-            })
-            .await?;
-        dispatcher.shutdown().await?;
-
-        let flat_file = flat_file_store
-            .get("TopicA", 0)
-            .ok_or_else(|| RocketMQError::Internal("missing dispatched flat file".to_owned()))?;
-        let cq_unit = flat_file
-            .read_consume_queue_unit(3)
-            .await?
-            .ok_or_else(|| RocketMQError::Internal("missing dispatched consume queue unit".to_owned()))?;
-
-        assert_eq!(cq_unit.commit_log_offset, 0);
-        assert_eq!(cq_unit.size, 4);
-        assert_eq!(cq_unit.tags_code, 7);
-        assert_eq!(
-            flat_file.read_message_by_queue_offset(3).await?,
-            Some(Bytes::from_static(b"body"))
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn new_with_task_group_parents_dispatcher_task() -> Result<(), RocketMQError> {
-        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
-        let config = Arc::new(TieredStoreConfig {
-            store_path_root_dir: temp_dir.path().to_path_buf(),
-            backend_provider: "memory".to_owned(),
-            max_pending_tasks: 4,
-            ..TieredStoreConfig::default()
-        });
-        let flat_file_store = Arc::new(TieredFlatFileStore::new(
-            config.clone(),
-            Arc::new(JsonMetadataStore::new(config.clone())),
-            MemoryProvider::default(),
-        ));
-        let context = RuntimeContext::from_current("tieredstore-dispatcher-parent-test");
-        let service = context.service_context("tieredstore-dispatcher");
-        let dispatcher = DefaultTieredDispatcher::new_with_task_group(
-            config,
-            flat_file_store,
-            CancellationToken::new(),
-            service.task_group().clone(),
-        );
-
-        dispatcher.start().await?;
-        dispatcher.shutdown().await?;
-
-        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
-        assert!(
-            report
-                .children
-                .iter()
-                .any(|child| child.name == "rocketmq-tieredstore.dispatcher"),
-            "{}",
-            report.to_json()
-        );
-        assert!(report.is_healthy(), "{}", report.to_json());
-        Ok(())
-    }
-}
+#[path = "tiered_dispatcher_tests.rs"]
+mod tests;

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher_tests.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher_tests.rs
@@ -1,0 +1,186 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::RocketMQError;
+use rocketmq_runtime::RuntimeContext;
+use tokio_util::sync::CancellationToken;
+
+use super::*;
+use crate::config::TieredStoreConfig;
+use crate::file::TieredFlatFileStore;
+use crate::metadata::JsonMetadataStore;
+use crate::provider::MemoryProvider;
+
+#[test]
+fn dispatcher_task_result_preserves_original_error_kind() {
+    let error = dispatcher_task_result(Some(RocketMQError::illegal_argument("dispatch offset gap")))
+        .expect_err("dispatcher worker error should be propagated");
+
+    assert_eq!(error.kind(), ErrorKind::IllegalArgument);
+    assert!(error.to_string().contains("dispatch offset gap"));
+}
+
+#[test]
+fn dispatcher_startup_failed_uses_service_error_kind() {
+    let error = dispatcher_startup_failed("spawn test worker", "task group closed");
+
+    assert_eq!(error.kind(), ErrorKind::Service);
+    assert!(error.to_string().contains("tieredstore dispatcher spawn test worker"));
+}
+
+#[tokio::test]
+async fn dispatch_writes_commit_log_and_consume_queue_unit() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+    let config = Arc::new(TieredStoreConfig {
+        store_path_root_dir: temp_dir.path().to_path_buf(),
+        backend_provider: "memory".to_owned(),
+        max_pending_tasks: 4,
+        ..TieredStoreConfig::default()
+    });
+    let flat_file_store = Arc::new(TieredFlatFileStore::new(
+        config.clone(),
+        Arc::new(JsonMetadataStore::new(config.clone())),
+        MemoryProvider::default(),
+    ));
+    let dispatcher = DefaultTieredDispatcher::new(config, flat_file_store.clone(), CancellationToken::new());
+
+    dispatcher.start().await?;
+    dispatcher
+        .dispatch(TieredDispatchRequest {
+            topic: "TopicA".to_owned(),
+            queue_id: 0,
+            queue_offset: 3,
+            commit_log_offset: 1024,
+            message_size: 4,
+            tags_code: 7,
+            store_timestamp: 100,
+            keys: None,
+            uniq_key: None,
+            offset_id: None,
+            sys_flag: 0,
+            body: Some(Bytes::from_static(b"body")),
+        })
+        .await?;
+    dispatcher.shutdown().await?;
+
+    let flat_file = flat_file_store
+        .get("TopicA", 0)
+        .ok_or_else(|| RocketMQError::Internal("missing dispatched flat file".to_owned()))?;
+    let cq_unit = flat_file
+        .read_consume_queue_unit(3)
+        .await?
+        .ok_or_else(|| RocketMQError::Internal("missing dispatched consume queue unit".to_owned()))?;
+
+    assert_eq!(cq_unit.commit_log_offset, 0);
+    assert_eq!(cq_unit.size, 4);
+    assert_eq!(cq_unit.tags_code, 7);
+    assert_eq!(
+        flat_file.read_message_by_queue_offset(3).await?,
+        Some(Bytes::from_static(b"body"))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn new_with_task_group_parents_dispatcher_task() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+    let config = Arc::new(TieredStoreConfig {
+        store_path_root_dir: temp_dir.path().to_path_buf(),
+        backend_provider: "memory".to_owned(),
+        max_pending_tasks: 4,
+        ..TieredStoreConfig::default()
+    });
+    let flat_file_store = Arc::new(TieredFlatFileStore::new(
+        config.clone(),
+        Arc::new(JsonMetadataStore::new(config.clone())),
+        MemoryProvider::default(),
+    ));
+    let context = RuntimeContext::from_current("tieredstore-dispatcher-parent-test");
+    let service = context.service_context("tieredstore-dispatcher");
+    let dispatcher = DefaultTieredDispatcher::new_with_task_group(
+        config,
+        flat_file_store,
+        CancellationToken::new(),
+        service.task_group().clone(),
+    );
+
+    dispatcher.start().await?;
+    dispatcher.shutdown().await?;
+
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    assert!(
+        report
+            .children
+            .iter()
+            .any(|child| child.name == "rocketmq-tieredstore.dispatcher"),
+        "{}",
+        report.to_json()
+    );
+    assert!(report.is_healthy(), "{}", report.to_json());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cancellation_releases_a_sender_waiting_for_byte_capacity() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let config = Arc::new(TieredStoreConfig {
+        store_path_root_dir: temp_dir.path().to_path_buf(),
+        backend_provider: "memory".to_owned(),
+        max_pending_tasks: 1,
+        max_pending_bytes: 4,
+        ..TieredStoreConfig::default()
+    });
+    let flat_file_store = Arc::new(TieredFlatFileStore::new(
+        config.clone(),
+        Arc::new(JsonMetadataStore::new(config.clone())),
+        MemoryProvider::default(),
+    ));
+    let shutdown = CancellationToken::new();
+    let dispatcher = DefaultTieredDispatcher::new(config, flat_file_store, shutdown.clone());
+    let request = || TieredDispatchRequest {
+        topic: "TopicA".to_owned(),
+        queue_id: 0,
+        queue_offset: 0,
+        commit_log_offset: 0,
+        message_size: 4,
+        tags_code: 0,
+        store_timestamp: 0,
+        keys: None,
+        uniq_key: None,
+        offset_id: None,
+        sys_flag: 0,
+        body: Some(Bytes::from_static(b"body")),
+    };
+
+    dispatcher.dispatch(request()).await?;
+    let blocked = dispatcher.dispatch(request());
+    tokio::pin!(blocked);
+    assert!(tokio::time::timeout(Duration::from_millis(25), &mut blocked)
+        .await
+        .is_err());
+
+    shutdown.cancel();
+    let error = tokio::time::timeout(Duration::from_secs(1), blocked)
+        .await
+        .map_err(|error| RocketMQError::Internal(error.to_string()))?
+        .expect_err("cancelled sender must return an interruption");
+    assert_eq!(error.kind(), ErrorKind::Service);
+    assert!(dispatcher.is_shutdown());
+    Ok(())
+}

--- a/rocketmq-tieredstore/src/file/file_segment.rs
+++ b/rocketmq-tieredstore/src/file/file_segment.rs
@@ -247,6 +247,7 @@ where
 
         let mut position = self.commit_position.load(Ordering::Acquire);
         for (index, buffer) in buffers.iter().cloned().enumerate() {
+            let buffer_len = buffer.len();
             let started = std::time::Instant::now();
             let result = self.provider.write(self.path.clone(), position, buffer).await;
             rocketmq_observability::metrics::tiered_store::record_provider_write(
@@ -256,9 +257,28 @@ where
                 started.elapsed().as_millis() as u64,
             );
             match result {
-                Ok(written) => {
+                Ok(written) if written == buffer_len => {
                     position = position.saturating_add(written as u64);
                     self.commit_position.store(position, Ordering::Release);
+                }
+                Ok(written) if written < buffer_len => {
+                    position = position.saturating_add(written as u64);
+                    self.commit_position.store(position, Ordering::Release);
+                    let mut pending = self.pending.lock();
+                    pending.push(buffers[index].slice(written..));
+                    pending.extend(buffers[index + 1..].iter().cloned());
+                    return Err(error::storage_write_failed(
+                        self.path.clone(),
+                        format!("partial provider write: expected {buffer_len}, wrote {written}"),
+                    ));
+                }
+                Ok(written) => {
+                    let mut pending = self.pending.lock();
+                    pending.extend(buffers[index..].iter().cloned());
+                    return Err(error::storage_write_failed(
+                        self.path.clone(),
+                        format!("invalid provider write length: expected {buffer_len}, wrote {written}"),
+                    ));
                 }
                 Err(error) => {
                     let mut pending = self.pending.lock();

--- a/rocketmq-tieredstore/src/lib.rs
+++ b/rocketmq-tieredstore/src/lib.rs
@@ -27,6 +27,8 @@ pub mod store;
 pub use config::TieredStorageLevel;
 pub use config::TieredStoreConfig;
 pub use dispatcher::DefaultTieredDispatcher;
+pub use dispatcher::TieredDispatchHealth;
+pub use dispatcher::TieredDispatchReadiness;
 pub use dispatcher::TieredDispatchRequest;
 pub use dispatcher::TieredDispatcher;
 pub use fetcher::DefaultTieredMessageFetcher;

--- a/rocketmq-tieredstore/src/store.rs
+++ b/rocketmq-tieredstore/src/store.rs
@@ -113,7 +113,8 @@ where
 {
     async fn load(&self) -> Result<(), RocketMQError> {
         let recover_service = CommitLogRecoverService::new(self.metadata_store.clone(), self.flat_file_store.clone());
-        recover_service.recover().await.map(|_| ())
+        recover_service.recover().await?;
+        self.dispatcher.load_progress().await
     }
 
     async fn start(&self) -> Result<(), RocketMQError> {
@@ -136,7 +137,8 @@ where
 
     async fn destroy(&self) -> Result<(), RocketMQError> {
         self.flat_file_store.destroy().await?;
-        self.metadata_store.destroy().await
+        self.metadata_store.destroy().await?;
+        self.dispatcher.destroy_progress().await
     }
 }
 

--- a/rocketmq-tieredstore/tests/tiered_cursor_retry_tests.rs
+++ b/rocketmq-tieredstore/tests/tiered_cursor_retry_tests.rs
@@ -1,0 +1,488 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use rocketmq_store_api::DerivedRecordId;
+use rocketmq_tieredstore::DefaultTieredDispatcher;
+use rocketmq_tieredstore::FileSegmentType;
+use rocketmq_tieredstore::PosixProvider;
+use rocketmq_tieredstore::TieredDispatchReadiness;
+use rocketmq_tieredstore::TieredDispatchRequest;
+use rocketmq_tieredstore::TieredDispatcher;
+use rocketmq_tieredstore::TieredFileSegment;
+use rocketmq_tieredstore::TieredLifecycle;
+use rocketmq_tieredstore::TieredMessageFetcher;
+use rocketmq_tieredstore::TieredStorageLevel;
+use rocketmq_tieredstore::TieredStore;
+use rocketmq_tieredstore::TieredStoreConfig;
+use rocketmq_tieredstore::TieredStoreProvider;
+
+#[derive(Clone, Default)]
+struct FailureControl {
+    fail_writes: Arc<AtomicUsize>,
+    partial_writes: Arc<AtomicUsize>,
+}
+
+impl FailureControl {
+    fn fail_next(&self, count: usize) {
+        self.fail_writes.store(count, Ordering::Release);
+    }
+
+    fn partial_next(&self, count: usize) {
+        self.partial_writes.store(count, Ordering::Release);
+    }
+
+    fn clear(&self) {
+        self.fail_writes.store(0, Ordering::Release);
+        self.partial_writes.store(0, Ordering::Release);
+    }
+
+    fn take(counter: &AtomicUsize) -> bool {
+        counter
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current > 0).then(|| current - 1)
+            })
+            .is_ok()
+    }
+}
+
+#[derive(Clone)]
+struct ControlledPosixProvider {
+    inner: PosixProvider,
+    control: FailureControl,
+}
+
+impl ControlledPosixProvider {
+    fn new(root: std::path::PathBuf, control: FailureControl) -> Self {
+        Self {
+            inner: PosixProvider::new(root),
+            control,
+        }
+    }
+}
+
+impl TieredStoreProvider for ControlledPosixProvider {
+    async fn create_segment(
+        &self,
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+    ) -> Result<TieredFileSegment<Self>, RocketMQError> {
+        let metadata = rocketmq_tieredstore::FileSegmentMetadata::new(path.clone(), segment_type, base_offset);
+        Ok(TieredFileSegment::new(
+            path,
+            segment_type,
+            base_offset,
+            max_size,
+            metadata,
+            self.clone(),
+        ))
+    }
+
+    async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+        self.inner.segment_size(path).await
+    }
+
+    async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+        self.inner.read(path, position, length).await
+    }
+
+    async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+        if FailureControl::take(&self.control.fail_writes) {
+            return Err(RocketMQError::storage_write_failed(path, "injected provider timeout"));
+        }
+        if FailureControl::take(&self.control.partial_writes) {
+            let partial = (data.len() / 2).max(1).min(data.len());
+            return self.inner.write(path, position, data.slice(..partial)).await;
+        }
+        self.inner.write(path, position, data).await
+    }
+
+    async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+        self.inner.delete(path).await
+    }
+}
+
+fn test_config(root: std::path::PathBuf) -> TieredStoreConfig {
+    TieredStoreConfig {
+        storage_level: TieredStorageLevel::Force,
+        store_path_root_dir: root,
+        backend_provider: "controlled-posix".to_owned(),
+        source_epoch: 7,
+        max_pending_tasks: 4,
+        max_pending_bytes: 1024,
+        retry_ledger_max_entries: 4,
+        retry_ledger_max_bytes: 1024,
+        retry_ledger_max_age: Duration::from_secs(60),
+        retry_backoff_initial: Duration::from_millis(5),
+        retry_backoff_max: Duration::from_millis(20),
+        source_wal_segment_size: 16,
+        commit_log_segment_size: 1024,
+        consume_queue_segment_size: 1024,
+        delete_file_interval: Duration::from_secs(3600),
+        ..TieredStoreConfig::default()
+    }
+}
+
+fn request(offset: u64, queue_offset: i64, body: Bytes) -> TieredDispatchRequest {
+    TieredDispatchRequest {
+        topic: "RetryTopic".to_owned(),
+        queue_id: 0,
+        queue_offset,
+        commit_log_offset: offset as i64,
+        message_size: body.len() as i32,
+        tags_code: queue_offset,
+        store_timestamp: 100 + queue_offset,
+        keys: Some(format!("key-{queue_offset}")),
+        uniq_key: None,
+        offset_id: None,
+        sys_flag: 0,
+        body: Some(body),
+    }
+}
+
+fn record(config: &TieredStoreConfig, offset: u64, length: usize) -> DerivedRecordId {
+    DerivedRecordId::try_new(config.source_epoch, offset, length as u32).expect("valid test record")
+}
+
+async fn wait_for_health<P>(
+    dispatcher: &DefaultTieredDispatcher<P>,
+    predicate: impl Fn(&rocketmq_tieredstore::TieredDispatchHealth) -> bool,
+) where
+    P: TieredStoreProvider,
+{
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let health = dispatcher.health();
+            if predicate(&health) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("tiered dispatch health should reach expected state");
+}
+
+#[tokio::test]
+async fn timeout_ledger_survives_restart_without_payload_and_releases_wal_pin() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let root = temp_dir.path().join("tiered");
+    let provider_root = temp_dir.path().join("provider");
+    let config = test_config(root.clone());
+    let body = Bytes::from_static(b"timeout-source-payload");
+    let source_record = record(&config, 32, body.len());
+    let control = FailureControl::default();
+    control.fail_next(1);
+
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(provider_root.clone(), control),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    store
+        .dispatcher()
+        .dispatch_derived(source_record, request(32, 0, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| health.retry_count() == 1).await;
+
+    let failed_health = store.dispatcher().health();
+    assert_eq!(
+        failed_health.cursor().map(|cursor| cursor.next_offset()),
+        Some(32 + body.len() as u64)
+    );
+    assert_eq!(failed_health.minimum_pinned_offset(), Some(32));
+    assert_eq!(failed_health.minimum_pinned_wal_segment(), Some(32));
+    let progress_bytes = tokio::fs::read(root.join("config").join("tieredDispatchProgress.bin"))
+        .await
+        .map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    assert!(!progress_bytes.windows(body.len()).any(|window| window == body.as_ref()));
+    store.shutdown().await?;
+
+    let restarted = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(provider_root, FailureControl::default()),
+    )?;
+    restarted.load().await?;
+    assert_eq!(restarted.dispatcher().health().retry_count(), 1);
+    let retry_body = body.clone();
+    restarted
+        .dispatcher()
+        .set_retry_payload_resolver(Arc::new(move |offset, length| {
+            (offset == 32 && length as usize == retry_body.len()).then(|| retry_body.clone())
+        }));
+    restarted.start().await?;
+    wait_for_health(restarted.dispatcher().as_ref(), |health| {
+        health.retry_count() == 0 && health.minimum_pinned_offset().is_none()
+    })
+    .await;
+    let fetched = restarted
+        .fetcher()
+        .get_message("RetryTopic".to_owned(), 0, 0, 1)
+        .await?;
+    assert_eq!(fetched.messages, vec![body]);
+    restarted.shutdown().await
+}
+
+#[tokio::test]
+async fn partial_provider_write_resumes_and_duplicate_commit_is_idempotent() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let config = test_config(temp_dir.path().join("tiered"));
+    let body = Bytes::from_static(b"partial-write-body");
+    let source_record = record(&config, 0, body.len());
+    let control = FailureControl::default();
+    control.partial_next(1);
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(temp_dir.path().join("provider"), control.clone()),
+    )?;
+    store.load().await?;
+    let retry_body = body.clone();
+    store
+        .dispatcher()
+        .set_retry_payload_resolver(Arc::new(move |offset, length| {
+            (offset == 0 && length as usize == retry_body.len()).then(|| retry_body.clone())
+        }));
+    store.start().await?;
+    store
+        .dispatcher()
+        .dispatch_derived(source_record, request(0, 0, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| {
+        health.cursor().map(|cursor| cursor.next_offset()) == Some(body.len() as u64) && health.retry_count() == 0
+    })
+    .await;
+    assert_eq!(control.partial_writes.load(Ordering::Acquire), 0);
+
+    store
+        .dispatcher()
+        .dispatch_derived(source_record, request(0, 0, body.clone()))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    let fetched = store.fetcher().get_message("RetryTopic".to_owned(), 0, 0, 2).await?;
+    assert_eq!(fetched.messages, vec![body]);
+    assert_eq!(store.dispatcher().health().retry_count(), 0);
+    assert_eq!(store.dispatcher().health().minimum_pinned_offset(), None);
+    store.shutdown().await
+}
+
+#[tokio::test]
+async fn failed_partition_is_isolated_after_retry_is_durable() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let mut config = test_config(temp_dir.path().join("tiered"));
+    config.retry_backoff_initial = Duration::from_secs(10);
+    config.retry_backoff_max = Duration::from_secs(10);
+    let control = FailureControl::default();
+    control.fail_next(1);
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(temp_dir.path().join("provider"), control),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    let body = Bytes::from_static(b"four");
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 0, 4), request(0, 0, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| health.retry_count() == 1).await;
+
+    let mut isolated = request(4, 0, body.clone());
+    isolated.topic = "HealthyTopic".to_owned();
+    isolated.queue_id = 1;
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 4, 4), isolated)
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| {
+        health.cursor().map(|cursor| cursor.next_offset()) == Some(8) && health.retry_count() == 1
+    })
+    .await;
+    let fetched = store.fetcher().get_message("HealthyTopic".to_owned(), 1, 0, 1).await?;
+    assert_eq!(fetched.messages, vec![body]);
+    assert_eq!(store.dispatcher().health().minimum_pinned_offset(), Some(0));
+    store.shutdown().await
+}
+
+#[tokio::test]
+async fn full_retry_ledger_holds_cursor_and_applies_byte_backpressure() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let mut config = test_config(temp_dir.path().join("tiered"));
+    config.max_pending_tasks = 1;
+    config.max_pending_bytes = 4;
+    config.retry_ledger_max_entries = 1;
+    config.retry_backoff_initial = Duration::from_secs(10);
+    config.retry_backoff_max = Duration::from_secs(10);
+    let control = FailureControl::default();
+    control.fail_next(100);
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(temp_dir.path().join("provider"), control.clone()),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    let body = Bytes::from_static(b"four");
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 0, 4), request(0, 0, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| health.retry_count() == 1).await;
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 4, 4), request(4, 1, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| {
+        health.readiness() == TieredDispatchReadiness::RetryLedgerFull
+    })
+    .await;
+
+    assert_eq!(
+        store.dispatcher().health().cursor().map(|cursor| cursor.next_offset()),
+        Some(4)
+    );
+    assert_eq!(store.dispatcher().health().retry_count(), 1);
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(100),
+        store
+            .dispatcher()
+            .dispatch_derived(record(&config, 8, 4), request(8, 2, body)),
+    )
+    .await;
+    assert!(blocked.is_err(), "third record must wait for bounded byte capacity");
+
+    control.clear();
+    let _ = store.dispatcher().shutdown().await;
+    store.shutdown().await
+}
+
+#[tokio::test]
+async fn retry_source_byte_limit_stops_cursor_before_unrecorded_failure() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let mut config = test_config(temp_dir.path().join("tiered"));
+    config.retry_ledger_max_entries = 4;
+    config.retry_ledger_max_bytes = 4;
+    config.retry_backoff_initial = Duration::from_secs(10);
+    config.retry_backoff_max = Duration::from_secs(10);
+    let control = FailureControl::default();
+    control.fail_next(100);
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(temp_dir.path().join("provider"), control.clone()),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    let body = Bytes::from_static(b"four");
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 0, 4), request(0, 0, body.clone()))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| health.retry_count() == 1).await;
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 4, 4), request(4, 1, body))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| {
+        health.readiness() == TieredDispatchReadiness::RetryLedgerBytesExceeded
+    })
+    .await;
+
+    let health = store.dispatcher().health();
+    assert_eq!(health.cursor().map(|cursor| cursor.next_offset()), Some(4));
+    assert_eq!(health.retry_source_bytes(), 4);
+    assert_eq!(health.minimum_pinned_offset(), Some(0));
+    control.clear();
+    let _ = store.dispatcher().shutdown().await;
+    store.shutdown().await
+}
+
+#[tokio::test]
+async fn retry_age_limit_fails_readiness_without_losing_durable_entry() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let mut config = test_config(temp_dir.path().join("tiered"));
+    config.retry_ledger_max_age = Duration::from_millis(10);
+    config.retry_backoff_initial = Duration::from_millis(5);
+    config.retry_backoff_max = Duration::from_millis(5);
+    let control = FailureControl::default();
+    control.fail_next(1);
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(temp_dir.path().join("provider"), control),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    let body = Bytes::from_static(b"aged");
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 0, body.len()), request(0, 0, body))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| {
+        health.readiness() == TieredDispatchReadiness::RetryLedgerExpired
+    })
+    .await;
+    assert_eq!(store.dispatcher().health().retry_count(), 1);
+    assert!(store.dispatcher().health().oldest_retry_age() >= Duration::from_millis(10));
+    store.shutdown().await
+}
+
+#[tokio::test]
+async fn corrupted_progress_snapshot_fails_restart_closed() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let root = temp_dir.path().join("tiered");
+    let provider_root = temp_dir.path().join("provider");
+    let config = test_config(root.clone());
+    let store = TieredStore::with_provider(
+        config.clone(),
+        ControlledPosixProvider::new(provider_root.clone(), FailureControl::default()),
+    )?;
+    store.load().await?;
+    store.start().await?;
+    let body = Bytes::from_static(b"valid");
+    store
+        .dispatcher()
+        .dispatch_derived(record(&config, 0, body.len()), request(0, 0, body))
+        .await?;
+    wait_for_health(store.dispatcher().as_ref(), |health| health.cursor().is_some()).await;
+    store.shutdown().await?;
+
+    let progress_path = root.join("config").join("tieredDispatchProgress.bin");
+    let mut encoded = tokio::fs::read(&progress_path)
+        .await
+        .map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let last = encoded
+        .last_mut()
+        .ok_or_else(|| RocketMQError::Internal("empty progress snapshot".to_owned()))?;
+    *last ^= 0xFF;
+    tokio::fs::write(&progress_path, encoded)
+        .await
+        .map_err(|error| RocketMQError::Internal(error.to_string()))?;
+
+    let restarted = TieredStore::with_provider(
+        config,
+        ControlledPosixProvider::new(provider_root, FailureControl::default()),
+    )?;
+    let error = restarted
+        .load()
+        .await
+        .expect_err("corrupted progress must fail readiness");
+    assert!(error.to_string().contains("tieredDispatchProgress.bin"));
+    Ok(())
+}

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -30414,16 +30414,16 @@
           "line": 4605
         },
         {
-          "id": "5fec31e144244d68cfe1e516",
-          "fingerprint": "1a5ecb154882b957d5018729",
+          "id": "5225e46ff563c824304d8ab6",
+          "fingerprint": "384947f17b5bac7593610153",
           "item": "struct ReputMessageServiceInner",
-          "line": 4607
+          "line": 4639
         },
         {
-          "id": "d250794d266a1160203f4239",
-          "fingerprint": "6d55657ad493eae437eac3b0",
+          "id": "f8587bafc2ac2f561ea493bb",
+          "fingerprint": "f5b90ca5c266723a95147fa1",
           "item": "fn dispatch_reput_batch",
-          "line": 4611
+          "line": 4643
         },
         {
           "id": "59b6f3a63c8c6592eeac6514",
@@ -30773,10 +30773,10 @@
           "line": 4526
         },
         {
-          "id": "db15efbfcb8ca3dd22f134b6",
-          "fingerprint": "1daaf6b15d24063307cb7f12",
+          "id": "0dd1883d3024e576e97c64a6",
+          "fingerprint": "b675292f3c2244dccaa81c69",
           "item": "struct ReputMessageServiceInner",
-          "line": 4607
+          "line": 4639
         },
         {
           "id": "0084947673da00b358eda490",
@@ -30944,16 +30944,16 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "8104e48e05dd038205b87fe9",
-          "fingerprint": "9ff5fa713aebcdfa30578fd3",
+          "id": "0d94c53f509642321269d6a1",
+          "fingerprint": "47dde9b29fa10781ebc41bb0",
           "item": "fn run",
-          "line": 5003
+          "line": 5046
         },
         {
-          "id": "3868a2990574ade766ffcdc8",
-          "fingerprint": "98b4d8e57654052e46da2da2",
+          "id": "63278d5eba087cd7f1369da9",
+          "fingerprint": "a465cc592854aa5addc3bd2c",
           "item": "fn run",
-          "line": 5025
+          "line": 5072
         }
       ],
       "owner": "store",

--- a/scripts/arc-mut-relocation-approvals.json
+++ b/scripts/arc-mut-relocation-approvals.json
@@ -880,6 +880,36 @@
       "from": "fc0b1529da669ab60ac25323",
       "to": "8e0dc49bc32586bf05ce832e",
       "reason": "Rustfmt reordered the surrounding compatibility imports while preserving the same DefaultMQAdminExt ArcMut import and occurrence count"
+    },
+    {
+      "identity": "3642ffbf2d028a63f43d1340",
+      "from": "5fec31e144244d68cfe1e516",
+      "to": "5225e46ff563c824304d8ab6",
+      "reason": "M10-02 made Reput dispatch await bounded Tiered backpressure, shifting the existing ReputMessageServiceInner ArcMut type reference without adding an occurrence"
+    },
+    {
+      "identity": "3642ffbf2d028a63f43d1340",
+      "from": "d250794d266a1160203f4239",
+      "to": "f8587bafc2ac2f561ea493bb",
+      "reason": "M10-02 made dispatch_reput_batch async so it can await derived sinks, changing the existing ArcMut parameter fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "d73ee824202523f10a8371cb",
+      "from": "db15efbfcb8ca3dd22f134b6",
+      "to": "0dd1883d3024e576e97c64a6",
+      "reason": "M10-02 added bounded Tiered Reput backpressure context around the existing LocalFileMessageStore type reference in ReputMessageServiceInner without adding an occurrence"
+    },
+    {
+      "identity": "6208eeddb838b6b71724bf86",
+      "from": "8104e48e05dd038205b87fe9",
+      "to": "0d94c53f509642321269d6a1",
+      "reason": "M10-02 routed the existing CommitLog cleanup mutation through the WAL-pin-aware deletion entry without adding a mut_from_ref occurrence"
+    },
+    {
+      "identity": "6208eeddb838b6b71724bf86",
+      "from": "3868a2990574ade766ffcdc8",
+      "to": "63278d5eba087cd7f1369da9",
+      "reason": "M10-02 guarded the existing retry-delete mutation with the minimum derived WAL pin without adding a mut_from_ref occurrence"
     }
   ]
 }

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -173,14 +173,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "daab98aa70c1f566ffd60466347abb57b0d5dbeca3d5ac16e698bbdd3dd57e13",
+      "rustdoc_json_sha256": "07ea0e5ef9e47fc9c813dfaf7362e8b8f8ea7a70a5566991c2506006c93a502b",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
       "crate_version": "1.0.0",
       "public_path_count": 118,
       "public_path_sha256": "d5995bfd455676de80c97a080ab24ea62700a517c8bb2d9f1e5d221975046d67",
-      "rustdoc_json_sha256": "a6eb390148277653210131c930bd4e1de09c9d241a6053f31316a154df0f17d8",
+      "rustdoc_json_sha256": "be9d53c8c035381815a61f651cec5ea8bd70c14258ff81eb8da7cabfca19484a",
       "target": "rocketmq_store_api"
     },
     "rocketmq-store-inspect": {
@@ -206,9 +206,9 @@
     },
     "rocketmq-tieredstore": {
       "crate_version": "1.0.0",
-      "public_path_count": 105,
-      "public_path_sha256": "d081e4002cc88eded04a07ff75116dc5e626b8519d76858bcf2d871003f3399c",
-      "rustdoc_json_sha256": "abc9b3469f7eec82de0e46b04a68ba8418de494c2e0a02b7becc183de2973482",
+      "public_path_count": 116,
+      "public_path_sha256": "30e3f19ea359f6f43f2369f0d45ed5cb4a7ed0d6a5fc46ed34b8ea69f02708f3",
+      "rustdoc_json_sha256": "b9d9230034c1413d5a2cb14870f1fab100ab913fcfa0de342c17af6e1092b25c",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "1f2a7bb4ae5d6adf271fc34e63c60c956c22606e",
+  "source_commit": "0577c36cec4f5d66483e0af97e8ac1fe16a88160",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -173,7 +173,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "07ea0e5ef9e47fc9c813dfaf7362e8b8f8ea7a70a5566991c2506006c93a502b",
+      "rustdoc_json_sha256": "8332843aec0a41fa654dceed0cecd0b8eba40f93ac7ae317ea8dbda4b66b706f",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -208,7 +208,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 116,
       "public_path_sha256": "30e3f19ea359f6f43f2369f0d45ed5cb4a7ed0d6a5fc46ed34b8ea69f02708f3",
-      "rustdoc_json_sha256": "b9d9230034c1413d5a2cb14870f1fab100ab913fcfa0de342c17af6e1092b25c",
+      "rustdoc_json_sha256": "7c523ac1a991ae2c5a11b3f5add333bc29b44f53e73292a69d3244919c854c60",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "0577c36cec4f5d66483e0af97e8ac1fe16a88160",
+  "source_commit": "1a5463b143f33a8246d32d82abd05ddacf3b14c6",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
Closes #8262

## Summary
- persist a versioned, payload-free Tiered cursor and retry ledger against the single CommitLog WAL
- enforce count/byte/age bounds, WAL pinning, readiness and reput backpressure with owned retry scheduling
- repair provider partial writes and preserve RocksDB batch flush semantics across async derived dispatch
- record M10-02 evidence and advance the architecture checklist to 61/82

## Validation
- Tiered cursor/retry corpus 7/7; `cargo test -p rocketmq-tieredstore`
- Store Tiered 5/5; Store API and Store Local package suites
- RocksDB Store 82 foundation + 9 semantics; Broker 20 Rocks + 4 POP
- root fmt and workspace all-target/all-feature strict Clippy
- dependency/release/ArcMut/runtime/error/AGENTS guards
- MCP check/test/streamable-http strict Clippy/doc
- public API snapshot 31/31, differences=0

## Baseline disclosure
`cargo test -p rocketmq-store` still reproduces the unchanged `file_store_vs_rocksdb_behavior_parity_after_restart` fixture failure because its Rocks-configured path constructs `LocalFileMessageStore`. The exact real RocksDB matrix is green, and the fixture file is unchanged from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable tiered-dispatch progress tracking with retry recovery across restarts.
  - Added configurable retry limits, backoff behavior, readiness reporting, and byte-based backpressure.
  - Added asynchronous dispatch support for smoother processing under load.
  - Added WAL pinning to prevent cleanup from removing data still needed for retries.

- **Bug Fixes**
  - Improved handling of partial storage writes and corrupted progress data.
  - Preserved pending work during shutdown and recovery.

- **Documentation**
  - Updated production-readiness checklists and evidence for the completed milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->