### PR TITLE
[ISSUE #8264]♻️Optimize CQ RocksDB and Tiered read paths

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 61 | 0 | 21 未开始；合计 21 尚未完成 | 82 |
+| PR 级工作包 | 62 | 0 | 20 未开始；合计 20 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 1（M10） | 2（M11–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 21 个未开始工作包分布：M10 为 3 个、M11 为 12 个、M12 为 6 个。
-PR-M10-02 已完成 Tiered cursor、retry ledger 与背压，当前下一工作包为 PR-M10-03。
+剩余 20 个未开始工作包分布：M10 为 2 个、M11 为 12 个、M12 为 6 个。
+PR-M10-03 已完成 CQ、RocksDB 与 Tiered 读路径优化，当前下一工作包为 PR-M10-04。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -482,7 +482,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] public API additive diff 已审核并最终 31/31 零差异；ArcMut/依赖/runtime/error/MCP 门禁通过
   - [x] [`M10-02 证据`](phase-3-production-readiness/10-tiered-cursor-retry-evidence.md) 记录目标、基线失败、验证与回滚
   - [x] 61/82 已完成、21 未完成，下一工作包 PR-M10-03
-- [ ] PR-M10-03：优化 CQ、Rocks 与 Tiered 读取
+- [x] PR-M10-03：优化 CQ、Rocks 与 Tiered 读取
+  - [x] Local CQ 直接借用 mmap slice 解码 20B unit，按有界请求预分配结果，不为单元创建临时 buffer
+  - [x] Rocks CQ 使用一次原生 range scan 返回 typed value，移除 typed→Bytes→typed 往返
+  - [x] Tiered 使用全局 byte-bounded、generation-aware block cache，并合并相邻 CQ/CommitLog range
+  - [x] 32 条冷拉精确 2 次 provider read、热拉 0；Rocks 完整拉取精确 2 次 point read + 1 次 scan
+  - [x] cache retained bytes、generation/path 失效与 body lease 生命周期已审查并由测试覆盖
+  - [x] public API additive diff 已审核；ArcMut/依赖/runtime/error/MCP/Rocks 专项门禁通过
+  - [x] [`M10-03 证据`](phase-3-production-readiness/10-read-path-optimization-evidence.md) 记录目标、基线失败、验证与回滚
+  - [x] 62/82 已完成、20 未完成，下一工作包 PR-M10-04
 - [ ] PR-M10-04：实现 Index/Compaction generation
 - [ ] PR-M10-05：完成 benchmark、soak 与性能 Gate
 - [ ] 对应任务文档的 Exit Checklist 全部通过

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3，M10-02 已完成，下一工作包为 PR-M10-03）
+> 状态：实施中（Phase 3，M10-03 已完成，下一工作包为 PR-M10-04）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；61/82 工作包完成，剩余 21 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；62/82 工作包完成，剩余 20 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M10-02 已完成，下一工作包 PR-M10-03） |
+| 状态 | 实施中（PR-M10-03 已完成，下一工作包 PR-M10-04） |
 | 预计周期 | 5–8 周 |
 | 工作包 | WP14 `tiered-cursor`；延续 WP02、WP11–WP13 |
 | 前置条件 | 32-package Gate 通过；CommitLog/receipt/progress 和 Local/Rocks golden 稳定 |
@@ -73,12 +73,17 @@
 
 ### PR-M10-03：CQ、Rocks 与 Tiered 读取优化
 
-- [ ] `[DEV]` CQ 在借用 slice 上解析 20B unit，结果按请求上限预分配。
-- [ ] `[DEV]` Rocks 使用 prefix/range iterator 或 multi-get，直接返回 typed value。
-- [ ] `[DEV]` Tiered 使用按 bytes 限制的 generation-aware block cache并合并相邻 ranges。
-- [ ] `[TEST]` 验证 CQ allocation=0、Rocks native calls≤3、cold pull provider calls≤4、warm=0 的假设；未达假设不影响正确性结论。
-- [ ] `[REV]` 检查 body lease 生命周期、cache key generation 和无额外 decode round-trip。
-- [ ] 回滚点：读取优化可切换到已通过同一读取正确性、generation 和 durability corpus 的上一 read adapter；否则停止受影响读取、保留 cache/generation 证据，不做未验证降级。
+- [x] `[DEV]` CQ 在借用 slice 上解析 20B unit，结果按请求上限预分配。
+- [x] `[DEV]` Rocks 使用 prefix/range iterator 或 multi-get，直接返回 typed value。
+- [x] `[DEV]` Tiered 使用按 bytes 限制的 generation-aware block cache并合并相邻 ranges。
+- [x] `[TEST]` 验证 CQ allocation=0、Rocks native calls≤3、cold pull provider calls≤4、warm=0 的假设；未达假设不影响正确性结论。
+- [x] `[REV]` 检查 body lease 生命周期、cache key generation 和无额外 decode round-trip。
+- [x] 回滚点：读取优化可切换到已通过同一读取正确性、generation 和 durability corpus 的上一 read adapter；否则停止受影响读取、保留 cache/generation 证据，不做未验证降级。
+
+完成证据：[`10-read-path-optimization-evidence.md`](10-read-path-optimization-evidence.md)。候选提交
+`e3ef67282f420334a4f2bccc7fa01c81facbd60a` 保持 Local/Rocks/Tiered 持久格式不变；CQ 单元借用解析的
+每单元临时 allocation 为 0，Rocks 完整拉取为 2 次点读加 1 次 range scan，Tiered 32 条冷拉为 2 次
+provider read、热拉为 0。62/82 已完成，下一工作包为 PR-M10-04。
 
 ### PR-M10-04：Index/Compaction generation
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-read-path-optimization-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-read-path-optimization-evidence.md
@@ -1,0 +1,107 @@
+# M10-03 CQ、RocksDB 与 Tiered 读路径优化实施证据
+
+## 结果
+
+M10-03 在不改变 CommitLog、ConsumeQueue 或 RocksDB 持久格式的前提下收口三条读路径：Local CQ
+从 mmap 借用切片解析，RocksDB CQ 以一次范围扫描返回 typed value，Tiered 以全局 byte budget 管理
+generation-aware block cache 并合并相邻读取。该包完成后架构盘点为 **62/82**，剩余 20 个工作包；
+M10 剩余 2 个，下一包为 PR-M10-04。
+
+## 可追溯性
+
+| 字段 | 值 |
+|---|---|
+| 工作包 | `PR-M10-03` |
+| Issue | [#8264](https://github.com/mxsm/rocketmq-rust/issues/8264) |
+| 分支 | `mxsm/architecture-refactor-read-path-optimization` |
+| Main 基线 | `313b73671ec0cac57e853f67bbfed23b5304070a` |
+| 冻结代码候选 | `e3ef67282f420334a4f2bccc7fa01c81facbd60a` |
+| 运行期证据 | `target/architecture-refactor/M10/read-path-8264/` |
+
+## 目标与合同结论
+
+### Local ConsumeQueue
+
+- `ConsumeQueueIterator` 直接调用 `ConsumeQueueRecord::decode(&mmap[start..end])`；20-byte 单元解析不创建
+  `Bytes`、`Vec` 或其他临时堆 buffer，因此每单元解析的临时 heap allocation 为 0。
+- `iterate_from_with_count` 现在实际执行有界请求，`count <= 0` 返回空迭代器，不再退化为读取整个映射区。
+- `LocalFileMessageStore::get_message` 按 `min(max_msg_nums, max_msgs_num_batch)` 预分配结果，替代固定 100 项容量；
+  测试同时固定请求容量和两条真实派发消息的读取语义。
+
+### RocksDB ConsumeQueue
+
+- CQ key 保持 Java-compatible big-endian 布局；`[start, end)` 只执行一次 native range scan，并逐项校验
+  精确连续 key，遇到第一个 hole 停止。
+- Store root 直接消费 `ConsumeQueueValue`，删除 legacy typed→Bytes→typed round trip；旧 `range_query`
+  兼容 facade 保留，新的 typed API 为 additive。
+- 实测完整拉取为 2 次 offset boundary point read 加 1 次 CQ range scan，总 native calls=3；CQ range
+  本身为 scan=1、point read=0。
+
+### Tiered block cache
+
+- `TieredFlatFileStore` 为所有 topic/queue 共享一个 cache，默认 retained-byte 硬上限 64 MiB；CQ block
+  为 64 KiB，CommitLog block 为 1 MiB，按 byte LRU/TTL 淘汰。
+- cache key 包含 segment path、metadata `create_timestamp` generation、segment type 和 block offset；删除
+  segment 时按 path 失效所有 generation，store destroy 时清空。
+- 32 条连续消息冷拉精确执行 2 次 provider read（一个 CQ block、一个 CommitLog block），满足 ≤4；
+  同范围热拉为 0 次。
+
+## 正确性、边界与 lease 审查
+
+- 旧 `ConsumeQueueUnit::decode(Bytes)` 入口保留，并委托新增借用解码；owned 与 borrowed 入口用同一
+  golden unit 验证，未产生 source compatibility 删除。
+- cache 命中返回 `Bytes::slice`，活跃 pull 可在 cache 淘汰后继续持有 backing block；这属于读取 lease，
+  不计入 cache retained bytes。活跃 lease 仍受 pull message count 和 byte size 上限约束，不形成 cache
+  retained-byte 逃逸。
+- 同 generation 的 append-only segment 若在已缓存 block 后增长，required length 会使短 block miss 并重新
+  读取；旧 generation 不会命中新 generation。
+- 本包不改变消息 body、CQ、CommitLog、Rocks key/value 编码，也不改变 Broker ack、durable watermark、
+  cursor 或 retry ledger 语义。
+
+## 公共 API 审查
+
+31 个 Rustdoc target 全部刷新。初始检查只报告三个 `surface-changed`：
+
+| crate | public path count | public path hash | 审查结论 |
+|---|---:|---|---|
+| `rocketmq-store` | 382 | 不变 | 内部结果容量与借用 iterator 实现变化 |
+| `rocketmq-store-rocksdb` | 165 | 不变 | additive typed range API 与内部直接消费 |
+| `rocketmq-tieredstore` | 116 | 不变 | additive cache byte budget/借用 decode，旧入口保留 |
+
+没有公共路径删除、重命名或 breaking diff；审核后基线绑定冻结代码候选。最终提交态重新刷新并要求
+`PUBLIC_API_SNAPSHOT_OK packages=31 differences=0`。
+
+## 验证记录
+
+| 命令/门禁 | 结果 |
+|---|---|
+| Local CQ/结果容量 focused tests | 通过；borrowed iterator 1/1，真实 get 1/1 |
+| Tiered package | 60 个 library、1 个 POSIX、7 个 cursor/retry 集成测试通过 |
+| Store library | 480/480 通过 |
+| Store/Broker RocksDB strict Clippy 与专项矩阵 | 通过；foundation 82、semantics 9、Broker Rocks 20、POP 4 |
+| affected-crate all-target/all-feature strict Clippy | 通过 |
+| dependency fixtures/target/baseline 与 release guard | 通过：target 35/35，dev-only 3/3 |
+| ArcMut fixtures/direct guard | 通过；零新增、零 baseline 增长 |
+| runtime enforcing audit | 通过；无新增 task/thread/runtime owner |
+| typed-error hygiene 与 AGENTS routing | 通过 |
+| MCP consumer check/test/streamable-http strict Clippy/doc | 通过；73 library，兼容与 integration 语料通过 |
+| 根 `cargo fmt --all -- --check` 与 workspace strict Clippy | 通过 |
+| public API snapshot | 最终 31/31，differences=0 |
+| `git diff --check` | 通过 |
+
+### 已披露的基线失败
+
+`cargo test -p rocketmq-store` **不记录为通过**。单独复跑
+`file_store_vs_rocksdb_behavior_parity_after_restart` 仍失败：fixture 配置 `StoreType::RocksDB`，但构造的仍是
+`LocalFileMessageStore`，伪 Rocks 路径重启后没有逻辑队列。`git diff --exit-code origin/main --
+rocketmq-store/tests/commitlog_recovery_tests.rs` 返回零并输出 `BASELINE_FIXTURE_UNCHANGED`，证明测试和工厂未被
+M10-03 修改。真实 RocksDB foundation/semantics 与 Broker 专项全部通过。
+
+## 审查与回滚
+
+`[REV]` 结论：持久格式、body lease、generation 隔离和 first-hole 语义保持；cache retained bytes 有全局
+硬上限；RocksDB 无额外 decode round trip；M10-03 最终 material finding 为 0。
+
+回滚时先关闭 Tiered read-ahead 配置并清空 cache，Rocks/Local 切回已通过相同读取正确性、generation 与
+durability corpus 的上一 read adapter。若上一实现没有同等证据，则停止受影响读取并保留 cache/generation
+现场，不做未验证降级；回滚不得改变或重写现有 CQ、CommitLog、Rocks 持久数据。

--- a/rocketmq-store-rocksdb/src/consume_queue.rs
+++ b/rocketmq-store-rocksdb/src/consume_queue.rs
@@ -20,6 +20,7 @@ use std::sync::Weak;
 
 use crate::batch::RocksDbWriteBatch;
 use crate::column_family::RocksDbColumnFamily;
+use crate::iterator::RocksDbRangeScanOptions;
 use crate::iterator::RocksDbScanOptions;
 use crate::key::ConsumeQueueKey;
 use crate::key::ConsumeQueueOffsetBoundary;
@@ -281,12 +282,33 @@ impl<'a> RocksDbConsumeQueueBatchWriter<'a> {
         }
 
         let topic = topic.into();
-        let mut values = Vec::with_capacity(num as usize);
-        for offset_delta in 0..num {
-            match self.get_cq_value(topic.clone(), queue_id, start_index + i64::from(offset_delta))? {
-                Some(value) => values.push(value),
-                None => break,
+        let end_index = start_index
+            .checked_add(i64::from(num))
+            .ok_or_else(|| RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.consume_queue.range",
+                value: format!("{start_index}+{num}"),
+                reason: "consume queue range overflowed i64".to_string(),
+            })?;
+        let start = encode_consume_queue_key(&topic, queue_id, start_index)?;
+        let end = encode_consume_queue_key(&topic, queue_id, end_index)?;
+        let items = self.store.range_scan(&RocksDbRangeScanOptions::new(
+            RocksDbColumnFamily::Default.name(),
+            start,
+            end,
+            num as usize,
+        ))?;
+        let mut values = Vec::with_capacity(items.len());
+        for (offset_delta, item) in items.into_iter().enumerate() {
+            let offset_delta = i64::try_from(offset_delta).map_err(|_| RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.consume_queue.range",
+                value: offset_delta.to_string(),
+                reason: "consume queue range index exceeds i64".to_string(),
+            })?;
+            let expected_key = encode_consume_queue_key(&topic, queue_id, start_index + offset_delta)?;
+            if item.key.as_ref() != expected_key.as_slice() {
+                break;
             }
+            values.push(ConsumeQueueValue::decode(item.value.as_ref())?);
         }
         Ok(values)
     }
@@ -433,6 +455,21 @@ impl RocksDbConsumeQueueStore {
             .into_iter()
             .map(encode_consume_queue_value)
             .collect()
+    }
+
+    /// Reads a contiguous ConsumeQueue range as typed values with one native range scan.
+    ///
+    /// The scan stops at the first missing logical offset and never performs the legacy
+    /// typed-to-bytes-to-typed round trip used by the compatibility facade.
+    pub fn range_query_values(
+        &self,
+        topic: impl Into<String>,
+        queue_id: i32,
+        start_index: i64,
+        num: i32,
+    ) -> Result<Vec<ConsumeQueueValue>, RocketMQError> {
+        let writer = RocksDbConsumeQueueBatchWriter::new(self.store.as_ref());
+        writer.range_query_cq_values(topic, queue_id, start_index, num)
     }
 
     pub fn get_max_offset_in_queue(&self, topic: impl Into<String>, queue_id: i32) -> Result<i64, RocketMQError> {
@@ -720,4 +757,15 @@ fn encode_consume_queue_value(value: ConsumeQueueValue) -> Result<Bytes, RocketM
     let mut encoded_value = Vec::with_capacity(ConsumeQueueValue::ENCODED_LEN);
     value.encode(&mut encoded_value)?;
     Ok(Bytes::from(encoded_value))
+}
+
+fn encode_consume_queue_key(topic: &str, queue_id: i32, cq_offset: i64) -> Result<Vec<u8>, RocketMQError> {
+    let key = ConsumeQueueKey {
+        topic: topic.to_owned(),
+        queue_id,
+        cq_offset,
+    };
+    let mut encoded = Vec::with_capacity(key.encoded_len());
+    key.encode(&mut encoded)?;
+    Ok(encoded)
 }

--- a/rocketmq-store-rocksdb/src/message_store.rs
+++ b/rocketmq-store-rocksdb/src/message_store.rs
@@ -464,7 +464,7 @@ impl RocksDbMessageStoreRoot {
             status = GetStatus::NoMatchedMessage;
             let max_pull_size = request.max_total_message_size.clamp(100, request.max_pull_message_size);
             let read_count = request.max_message_count.max(0);
-            let values = self.derived.consume_queue_store.range_query(
+            let values = self.derived.consume_queue_store.range_query_values(
                 request.topic.to_string(),
                 request.queue_id,
                 request.offset,
@@ -474,19 +474,12 @@ impl RocksDbMessageStoreRoot {
                 status = GetStatus::OffsetFoundNull;
                 next_begin_offset = local.correct_queue_offset(request.offset, request.offset.saturating_add(1));
             } else {
-                for (index, encoded_value) in values.into_iter().enumerate() {
+                for (index, value) in values.into_iter().enumerate() {
                     if message_count >= request.max_message_count || buffer_total_size >= max_pull_size {
                         break;
                     }
                     let queue_offset = request.offset + index as i64;
                     next_begin_offset = queue_offset + 1;
-                    let value = match ConsumeQueueValue::decode(encoded_value.as_ref()) {
-                        Ok(value) => value,
-                        Err(_) => {
-                            status = GetStatus::OffsetFoundNull;
-                            break;
-                        }
-                    };
                     if !cq_filter(value.tag_hash_code) {
                         continue;
                     }

--- a/rocketmq-store/src/base/get_message_result.rs
+++ b/rocketmq-store/src/base/get_message_result.rs
@@ -270,6 +270,11 @@ impl GetMessageResult {
         self.message_mapped_list.as_slice()
     }
 
+    #[cfg(test)]
+    pub(crate) fn message_mapped_capacity(&self) -> usize {
+        self.message_mapped_list.capacity()
+    }
+
     #[inline]
     pub fn message_mapped_list_mut(&mut self) -> &mut [SelectMappedBufferResult] {
         self.message_mapped_list.as_mut()

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2124,7 +2124,8 @@ impl MessageStore for LocalFileMessageStore {
         let mut next_begin_offset = offset;
         let mut min_offset = 0;
         let mut max_offset = 0;
-        let mut get_result = GetMessageResult::new();
+        let result_capacity = (max_msg_nums.max(0) as usize).min(self.message_store_config.max_msgs_num_batch.max(1));
+        let mut get_result = GetMessageResult::new_result_size(result_capacity);
         let max_offset_py = self.commit_log.get_max_offset();
         let consume_queue = self.find_consume_queue(topic, queue_id);
         if let Some(consume_queue) = consume_queue {
@@ -7785,6 +7786,7 @@ mod tests {
         assert_eq!(result.min_offset(), 0);
         assert_eq!(result.max_offset(), 2);
         assert_eq!(result.message_mapped_list().len(), 2);
+        assert_eq!(result.message_mapped_capacity(), 32);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -414,7 +414,7 @@ impl RocksDBMessageStore {
                 return None;
             }
         };
-        let mut result = GetMessageResult::new();
+        let mut result = GetMessageResult::new_result_size(read_result.records.len());
         for record in read_result.records {
             result.add_message(record.selection, record.queue_offset, record.batch_count);
         }

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -914,8 +914,8 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
             None => None,
             Some(value) => Some(Box::new(ConsumeQueueIterator {
                 smbr: Some(value),
-                relative_pos: 0,
                 counter: 0,
+                remaining: usize::MAX,
                 consume_queue_ext: self.consume_queue_ext.clone(),
             })),
         }
@@ -924,9 +924,16 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
     fn iterate_from_with_count(
         &self,
         start_index: i64,
-        _count: i32,
+        count: i32,
     ) -> Option<Box<dyn Iterator<Item = CqUnit> + Send + '_>> {
-        self.iterate_from(start_index)
+        self.get_index_buffer(start_index).map(|value| {
+            Box::new(ConsumeQueueIterator {
+                smbr: Some(value),
+                counter: 0,
+                remaining: count.max(0) as usize,
+                consume_queue_ext: self.consume_queue_ext.clone(),
+            }) as Box<dyn Iterator<Item = CqUnit> + Send + '_>
+        })
     }
 
     fn get_offset_in_queue_by_time_with_boundary(&self, timestamp: i64, boundary_type: BoundaryType) -> i64 {
@@ -943,8 +950,8 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
 struct ConsumeQueueIterator {
     smbr: Option<SelectMappedBufferResult>,
-    relative_pos: i32,
     counter: i32,
+    remaining: usize,
     consume_queue_ext: Option<ConsumeQueueExt>,
 }
 
@@ -961,6 +968,9 @@ impl Iterator for ConsumeQueueIterator {
     type Item = CqUnit;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
         match self.smbr.as_ref() {
             None => None,
             Some(value) => {
@@ -972,6 +982,7 @@ impl Iterator for ConsumeQueueIterator {
                 self.counter += 1;
                 let end = start + CQ_STORE_UNIT_SIZE as usize;
                 let record = ConsumeQueueRecord::decode(&mmp[start..end])?;
+                self.remaining = self.remaining.saturating_sub(1);
                 let mut cq_unit = CqUnit {
                     queue_offset: start as i64 / CQ_STORE_UNIT_SIZE as i64,
                     size: record.message_size,
@@ -1171,6 +1182,40 @@ mod tests {
         assert_eq!(cq_ext_unit.tags_code(), 456);
         assert_eq!(cq_ext_unit.msg_store_time(), 7890);
         assert_eq!(cq_ext_unit.filter_bit_map(), Some(bitmap.as_slice()));
+    }
+
+    #[test]
+    fn consume_queue_borrowed_iterator_honors_request_count() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("single-cq-bounded-iterator-topic");
+        let mut consume_queue = new_test_consume_queue(&temp_dir, &topic, (8 * CQ_STORE_UNIT_SIZE) as usize);
+
+        for queue_offset in 0_i64..4 {
+            consume_queue.put_message_position_info_wrapper(&DispatchRequest {
+                topic: topic.clone(),
+                queue_id: 0,
+                commit_log_offset: queue_offset * 32,
+                msg_size: 32,
+                consume_queue_offset: queue_offset,
+                success: true,
+                ..DispatchRequest::default()
+            });
+        }
+
+        let records = consume_queue
+            .iterate_from_with_count(0, 2)
+            .expect("bounded iterator")
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].queue_offset, 0);
+        assert_eq!(records[1].queue_offset, 1);
+        assert_eq!(
+            consume_queue
+                .iterate_from_with_count(0, 0)
+                .expect("empty bounded iterator")
+                .count(),
+            0
+        );
     }
 
     #[test]

--- a/rocketmq-store/tests/rocksdb_foundation_tests.rs
+++ b/rocketmq-store/tests/rocksdb_foundation_tests.rs
@@ -2268,9 +2268,13 @@ fn consume_queue_range_query_returns_contiguous_values_until_first_missing() {
 
     writer.write(&request).expect("seed write should succeed");
 
+    let metrics_before = store.metrics();
     let values = writer
         .range_query_cq_values("TopicA", 3, 0, 3)
         .expect("range query should succeed");
+    let metrics_after = store.metrics();
+    assert_eq!(metrics_after.scan_count - metrics_before.scan_count, 1);
+    assert_eq!(metrics_after.read_count - metrics_before.read_count, 0);
     assert_eq!(
         values,
         vec![ConsumeQueueValue {
@@ -2284,6 +2288,9 @@ fn consume_queue_range_query_returns_contiguous_values_until_first_missing() {
     let values_after_gap = writer
         .range_query_cq_values("TopicA", 3, 2, 3)
         .expect("range query after gap should succeed");
+    let metrics_after_gap = store.metrics();
+    assert_eq!(metrics_after_gap.scan_count - metrics_after.scan_count, 1);
+    assert_eq!(metrics_after_gap.read_count - metrics_after.read_count, 0);
     assert_eq!(
         values_after_gap,
         vec![ConsumeQueueValue {

--- a/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
+++ b/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
@@ -156,10 +156,14 @@ async fn rocksdb_store_load_start_recover_round_trip() {
     assert!(reloaded.load().await, "load reloaded store");
     reloaded.start().await.expect("start reloaded store");
 
+    let metrics_before_pull = reloaded.rocksdb_store().metrics();
     let get_result = reloaded
         .get_message(&group, &topic, 0, 0, 32, None)
         .await
         .expect("get message result");
+    let metrics_after_pull = reloaded.rocksdb_store().metrics();
+    assert_eq!(metrics_after_pull.read_count - metrics_before_pull.read_count, 2);
+    assert_eq!(metrics_after_pull.scan_count - metrics_before_pull.scan_count, 1);
     assert_eq!(get_result.status(), Some(GetMessageStatus::Found));
     assert_eq!(get_result.message_count(), 1);
     assert_eq!(reloaded.get_max_offset_in_queue(&topic, 0), 1);

--- a/rocketmq-tieredstore/src/config.rs
+++ b/rocketmq-tieredstore/src/config.rs
@@ -78,6 +78,8 @@ pub struct TieredStoreConfig {
     /// Source CommitLog segment size used to expose the minimum WAL pin.
     pub source_wal_segment_size: u64,
     pub read_ahead_cache_enable: bool,
+    /// Global byte budget for Tiered ConsumeQueue and CommitLog read-ahead blocks.
+    pub read_ahead_cache_max_bytes: usize,
     pub read_ahead_message_count: usize,
     pub read_ahead_message_size: usize,
     pub read_ahead_cache_expire: Duration,
@@ -116,6 +118,7 @@ impl Default for TieredStoreConfig {
             retry_backoff_max: Duration::from_secs(30),
             source_wal_segment_size: 1024 * 1024 * 1024,
             read_ahead_cache_enable: true,
+            read_ahead_cache_max_bytes: 64 * 1024 * 1024,
             read_ahead_message_count: 4096,
             read_ahead_message_size: 16 * 1024 * 1024,
             read_ahead_cache_expire: Duration::from_secs(15),
@@ -166,6 +169,7 @@ mod tests {
         assert_eq!(config.retry_backoff_max, Duration::from_secs(30));
         assert_eq!(config.source_wal_segment_size, 1024 * 1024 * 1024);
         assert!(config.read_ahead_cache_enable);
+        assert_eq!(config.read_ahead_cache_max_bytes, 64 * 1024 * 1024);
         assert_eq!(config.read_ahead_message_count, 4096);
         assert_eq!(config.read_ahead_message_size, 16 * 1024 * 1024);
         assert_eq!(config.read_ahead_cache_expire, Duration::from_secs(15));

--- a/rocketmq-tieredstore/src/fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod read_ahead_cache;
 pub mod tiered_message_fetcher;
 
 pub use tiered_message_fetcher::DefaultTieredMessageFetcher;

--- a/rocketmq-tieredstore/src/fetcher/read_ahead_cache.rs
+++ b/rocketmq-tieredstore/src/fetcher/read_ahead_cache.rs
@@ -1,0 +1,271 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::ops::Range;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+
+use crate::file::FileSegment;
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+use crate::provider::TieredStoreProvider;
+
+pub(crate) const CONSUME_QUEUE_BLOCK_SIZE: usize = 64 * 1024;
+pub(crate) const COMMIT_LOG_BLOCK_SIZE: usize = 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ReadAheadCacheKey {
+    path: String,
+    generation: i64,
+    segment_type: FileSegmentType,
+    block_offset: u64,
+}
+
+struct ReadAheadCacheEntry {
+    bytes: Bytes,
+    last_access: Instant,
+}
+
+#[derive(Default)]
+struct ReadAheadCacheState {
+    entries: HashMap<ReadAheadCacheKey, ReadAheadCacheEntry>,
+    lru: VecDeque<ReadAheadCacheKey>,
+    bytes: usize,
+}
+
+pub(crate) struct ReadAheadCache {
+    enabled: bool,
+    max_bytes: usize,
+    expire: Duration,
+    state: Mutex<ReadAheadCacheState>,
+}
+
+impl ReadAheadCache {
+    pub(crate) fn new(enabled: bool, max_bytes: usize, expire: Duration) -> Self {
+        Self {
+            enabled: enabled && max_bytes > 0 && !expire.is_zero(),
+            max_bytes,
+            expire,
+            state: Mutex::new(ReadAheadCacheState::default()),
+        }
+    }
+
+    pub(crate) async fn read<P>(
+        &self,
+        segment: &TieredFileSegment<P>,
+        range: Range<u64>,
+        block_size: usize,
+    ) -> Result<Bytes, RocketMQError>
+    where
+        P: TieredStoreProvider,
+    {
+        if !self.enabled || block_size == 0 {
+            return segment.read(range).await;
+        }
+
+        let commit_position = segment.commit_position();
+        if range.start >= commit_position || range.end <= range.start {
+            return segment.read(range).await;
+        }
+        let requested_end = range.end.min(commit_position);
+        let block_size = block_size as u64;
+        let metadata = segment.metadata();
+        let mut chunks = Vec::new();
+        let mut block_offset = range.start / block_size * block_size;
+        while block_offset < requested_end {
+            let block_end = block_offset.saturating_add(block_size).min(commit_position);
+            let key = ReadAheadCacheKey {
+                path: metadata.path.clone(),
+                generation: metadata.create_timestamp,
+                segment_type: metadata.segment_type,
+                block_offset,
+            };
+            let required_len =
+                usize::try_from(requested_end.min(block_end).saturating_sub(block_offset)).unwrap_or(usize::MAX);
+            let block = match self.get(&key, required_len) {
+                Some(bytes) => bytes,
+                None => {
+                    let bytes = segment.read(block_offset..block_end).await?;
+                    self.insert(key, bytes.clone());
+                    bytes
+                }
+            };
+            let slice_start =
+                usize::try_from(range.start.max(block_offset).saturating_sub(block_offset)).unwrap_or(block.len());
+            let slice_end =
+                usize::try_from(requested_end.min(block_end).saturating_sub(block_offset)).unwrap_or(block.len());
+            if slice_start > slice_end || slice_end > block.len() {
+                return Err(RocketMQError::storage_read_failed(
+                    metadata.path.clone(),
+                    "tiered read-ahead block is shorter than the committed range",
+                ));
+            }
+            chunks.push(block.slice(slice_start..slice_end));
+            block_offset = block_end;
+        }
+
+        if chunks.len() == 1 {
+            if let Some(chunk) = chunks.pop() {
+                return Ok(chunk);
+            }
+        }
+        let total_len = chunks.iter().map(Bytes::len).sum();
+        let mut joined = BytesMut::with_capacity(total_len);
+        for chunk in chunks {
+            joined.put(chunk);
+        }
+        Ok(joined.freeze())
+    }
+
+    pub(crate) fn invalidate_path(&self, path: &str) {
+        let mut state = self.state.lock();
+        let keys = state
+            .entries
+            .keys()
+            .filter(|key| key.path == path)
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in keys {
+            Self::remove(&mut state, &key);
+        }
+    }
+
+    pub(crate) fn clear(&self) {
+        *self.state.lock() = ReadAheadCacheState::default();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.state.lock().bytes
+    }
+
+    fn get(&self, key: &ReadAheadCacheKey, required_len: usize) -> Option<Bytes> {
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        let usable = state.entries.get(key).is_some_and(|entry| {
+            now.duration_since(entry.last_access) <= self.expire && entry.bytes.len() >= required_len
+        });
+        if !usable {
+            Self::remove(&mut state, key);
+            return None;
+        }
+        let entry = state.entries.get_mut(key)?;
+        entry.last_access = now;
+        let bytes = entry.bytes.clone();
+        state.lru.retain(|candidate| candidate != key);
+        state.lru.push_back(key.clone());
+        Some(bytes)
+    }
+
+    fn insert(&self, key: ReadAheadCacheKey, bytes: Bytes) {
+        if bytes.is_empty() || bytes.len() > self.max_bytes {
+            return;
+        }
+        let mut state = self.state.lock();
+        Self::remove(&mut state, &key);
+        while state.bytes.saturating_add(bytes.len()) > self.max_bytes {
+            let Some(oldest) = state.lru.pop_front() else {
+                break;
+            };
+            if let Some(entry) = state.entries.remove(&oldest) {
+                state.bytes = state.bytes.saturating_sub(entry.bytes.len());
+            }
+        }
+        state.bytes = state.bytes.saturating_add(bytes.len());
+        state.entries.insert(
+            key.clone(),
+            ReadAheadCacheEntry {
+                bytes,
+                last_access: Instant::now(),
+            },
+        );
+        state.lru.push_back(key);
+    }
+
+    fn remove(state: &mut ReadAheadCacheState, key: &ReadAheadCacheKey) {
+        if let Some(entry) = state.entries.remove(key) {
+            state.bytes = state.bytes.saturating_sub(entry.bytes.len());
+        }
+        state.lru.retain(|candidate| candidate != key);
+    }
+}
+
+pub(crate) const fn block_size(segment_type: FileSegmentType) -> usize {
+    match segment_type {
+        FileSegmentType::CommitLog => COMMIT_LOG_BLOCK_SIZE,
+        FileSegmentType::ConsumeQueue => CONSUME_QUEUE_BLOCK_SIZE,
+        FileSegmentType::Index => CONSUME_QUEUE_BLOCK_SIZE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_evicts_by_total_bytes() {
+        let cache = ReadAheadCache::new(true, 6, Duration::from_secs(10));
+        let first = ReadAheadCacheKey {
+            path: "topic/0/commitlog/0".to_owned(),
+            generation: 1,
+            segment_type: FileSegmentType::CommitLog,
+            block_offset: 0,
+        };
+        let second = ReadAheadCacheKey {
+            path: "topic/0/commitlog/4".to_owned(),
+            generation: 2,
+            segment_type: FileSegmentType::CommitLog,
+            block_offset: 0,
+        };
+
+        cache.insert(first.clone(), Bytes::from_static(b"abcd"));
+        cache.insert(second.clone(), Bytes::from_static(b"efgh"));
+
+        assert!(cache.get(&first, 4).is_none());
+        assert_eq!(cache.get(&second, 4), Some(Bytes::from_static(b"efgh")));
+        assert_eq!(cache.retained_bytes(), 4);
+    }
+
+    #[test]
+    fn cache_isolates_generations_and_invalidates_the_whole_segment_path() {
+        let cache = ReadAheadCache::new(true, 8, Duration::from_secs(10));
+        let first = ReadAheadCacheKey {
+            path: "topic/0/commitlog/0".to_owned(),
+            generation: 1,
+            segment_type: FileSegmentType::CommitLog,
+            block_offset: 0,
+        };
+        let second = ReadAheadCacheKey {
+            generation: 2,
+            ..first.clone()
+        };
+
+        cache.insert(first.clone(), Bytes::from_static(b"old!"));
+        cache.insert(second.clone(), Bytes::from_static(b"new!"));
+
+        assert_eq!(cache.get(&first, 4), Some(Bytes::from_static(b"old!")));
+        assert_eq!(cache.get(&second, 4), Some(Bytes::from_static(b"new!")));
+        assert_eq!(cache.retained_bytes(), 8);
+        cache.invalidate_path(&first.path);
+        assert_eq!(cache.retained_bytes(), 0);
+    }
+}

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -382,6 +382,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -392,10 +394,66 @@ mod tests {
     use crate::config::TieredStoreConfig;
     use crate::dispatcher::TieredDispatchRequest;
     use crate::file::ConsumeQueueUnit;
+    use crate::file::FileSegmentType;
+    use crate::file::TieredFileSegment;
     use crate::file::TieredFlatFileStore;
+    use crate::metadata::FileSegmentMetadata;
     use crate::metadata::JsonMetadataStore;
     use crate::metadata::TieredMetadataStore;
     use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
+
+    #[derive(Clone, Default)]
+    struct CountingProvider {
+        inner: MemoryProvider,
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl CountingProvider {
+        fn reset_reads(&self) {
+            self.reads.store(0, Ordering::Release);
+        }
+
+        fn read_count(&self) -> usize {
+            self.reads.load(Ordering::Acquire)
+        }
+    }
+
+    impl TieredStoreProvider for CountingProvider {
+        async fn create_segment(
+            &self,
+            path: String,
+            segment_type: FileSegmentType,
+            base_offset: u64,
+            max_size: u64,
+        ) -> Result<TieredFileSegment<Self>, RocketMQError> {
+            Ok(TieredFileSegment::new(
+                path.clone(),
+                segment_type,
+                base_offset,
+                max_size,
+                FileSegmentMetadata::new(path, segment_type, base_offset),
+                self.clone(),
+            ))
+        }
+
+        async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+            self.inner.segment_size(path).await
+        }
+
+        async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+            self.reads.fetch_add(1, Ordering::AcqRel);
+            self.inner.read(path, position, length).await
+        }
+
+        async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+            self.inner.write(path, position, data).await
+        }
+
+        async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+            self.inner.delete(path).await
+        }
+    }
 
     async fn build_fetcher() -> Result<DefaultTieredMessageFetcher<MemoryProvider>, RocketMQError> {
         let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
@@ -589,6 +647,62 @@ mod tests {
         assert_eq!(result.status, TieredGetMessageStatus::Found);
         assert_eq!(result.messages, vec![Bytes::from_static(b"first")]);
         assert_eq!(result.next_begin_offset, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read_ahead_cache_coalesces_cold_pull_and_eliminates_warm_provider_reads() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            commit_log_segment_size: 1024 * 1024,
+            consume_queue_segment_size: 64 * 1024,
+            read_ahead_cache_enable: true,
+            read_ahead_cache_max_bytes: 4 * 1024 * 1024,
+            read_ahead_message_count: 32,
+            read_ahead_message_size: 32 * 64,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = CountingProvider::default();
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config.clone(),
+            metadata_store,
+            provider.clone(),
+        ));
+        let flat_file = flat_file_store.get_or_create("TopicA".to_owned(), 0)?;
+        for queue_offset in 0_i64..32 {
+            let message = Bytes::from(vec![queue_offset as u8; 64]);
+            let commit_log_offset = flat_file.append_commit_log(message.clone(), queue_offset).await?;
+            flat_file
+                .append_consume_queue(
+                    queue_offset,
+                    ConsumeQueueUnit {
+                        commit_log_offset: commit_log_offset as i64,
+                        size: message.len() as i32,
+                        tags_code: queue_offset,
+                    },
+                    queue_offset,
+                )
+                .await?;
+        }
+        flat_file.commit().await?;
+        let fetcher = DefaultTieredMessageFetcher::new(config, flat_file_store);
+
+        provider.reset_reads();
+        let cold = fetcher.get_message("TopicA".to_owned(), 0, 0, 32).await?;
+        assert_eq!(cold.messages.len(), 32);
+        assert_eq!(
+            provider.read_count(),
+            2,
+            "cold pull must coalesce CQ and CommitLog reads"
+        );
+
+        provider.reset_reads();
+        let warm = fetcher.get_message("TopicA".to_owned(), 0, 0, 32).await?;
+        assert_eq!(warm.messages, cold.messages);
+        assert_eq!(provider.read_count(), 0);
         Ok(())
     }
 

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -24,6 +23,8 @@ use rocketmq_model::boundary_type::BoundaryType;
 
 use crate::config::TieredStoreConfig;
 use crate::error;
+use crate::fetcher::read_ahead_cache::block_size;
+use crate::fetcher::read_ahead_cache::ReadAheadCache;
 use crate::file::FileSegment;
 use crate::file::FileSegmentStatus;
 use crate::file::FileSegmentType;
@@ -52,17 +53,28 @@ impl ConsumeQueueUnit {
         bytes.freeze()
     }
 
-    pub fn decode(mut bytes: Bytes) -> Result<Self, RocketMQError> {
+    pub fn decode(bytes: Bytes) -> Result<Self, RocketMQError> {
+        Self::decode_slice(bytes.as_ref())
+    }
+
+    /// Decodes one borrowed ConsumeQueue unit without allocating a temporary buffer.
+    pub fn decode_slice(bytes: &[u8]) -> Result<Self, RocketMQError> {
         if bytes.len() != CONSUME_QUEUE_UNIT_SIZE {
             return Err(error::illegal_argument(format!(
                 "tiered consume queue unit must be {CONSUME_QUEUE_UNIT_SIZE} bytes, got {}",
                 bytes.len()
             )));
         }
+        let mut commit_log_offset = [0_u8; 8];
+        commit_log_offset.copy_from_slice(&bytes[..8]);
+        let mut size = [0_u8; 4];
+        size.copy_from_slice(&bytes[8..12]);
+        let mut tags_code = [0_u8; 8];
+        tags_code.copy_from_slice(&bytes[12..20]);
         Ok(Self {
-            commit_log_offset: bytes.get_i64(),
-            size: bytes.get_i32(),
-            tags_code: bytes.get_i64(),
+            commit_log_offset: i64::from_be_bytes(commit_log_offset),
+            size: i32::from_be_bytes(size),
+            tags_code: i64::from_be_bytes(tags_code),
         })
     }
 }
@@ -76,6 +88,7 @@ where
     config: Arc<TieredStoreConfig>,
     metadata_store: Arc<JsonMetadataStore>,
     provider: P,
+    read_ahead_cache: Arc<ReadAheadCache>,
     commit_log_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
     consume_queue_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
 }
@@ -91,12 +104,29 @@ where
         metadata_store: Arc<JsonMetadataStore>,
         provider: P,
     ) -> Self {
+        let read_ahead_cache = Arc::new(ReadAheadCache::new(
+            config.read_ahead_cache_enable,
+            config.read_ahead_cache_max_bytes,
+            config.read_ahead_cache_expire,
+        ));
+        Self::new_with_read_ahead_cache(topic, queue_id, config, metadata_store, provider, read_ahead_cache)
+    }
+
+    pub(crate) fn new_with_read_ahead_cache(
+        topic: String,
+        queue_id: i32,
+        config: Arc<TieredStoreConfig>,
+        metadata_store: Arc<JsonMetadataStore>,
+        provider: P,
+        read_ahead_cache: Arc<ReadAheadCache>,
+    ) -> Self {
         Self {
             topic,
             queue_id,
             config,
             metadata_store,
             provider,
+            read_ahead_cache,
             commit_log_segments: Mutex::new(Vec::new()),
             consume_queue_segments: Mutex::new(Vec::new()),
         }
@@ -300,7 +330,7 @@ where
         else {
             return Ok(None);
         };
-        ConsumeQueueUnit::decode(bytes).map(Some)
+        ConsumeQueueUnit::decode_slice(bytes.as_ref()).map(Some)
     }
 
     pub async fn read_message_by_queue_offset(&self, queue_offset: i64) -> Result<Option<Bytes>, RocketMQError> {
@@ -522,6 +552,7 @@ where
             .await?;
         segment.mark_deleted();
         self.provider.delete(metadata.path.clone()).await?;
+        self.read_ahead_cache.invalidate_path(&metadata.path);
         self.remove_segment(metadata.segment_type, metadata.base_offset, &metadata.path);
         Ok(())
     }
@@ -551,7 +582,15 @@ where
             if segment.commit_position() < CONSUME_QUEUE_UNIT_SIZE as u64 {
                 continue;
             }
-            let unit = ConsumeQueueUnit::decode(segment.read(0..CONSUME_QUEUE_UNIT_SIZE as u64).await?)?;
+            let bytes = self
+                .read_ahead_cache
+                .read(
+                    &segment,
+                    0..CONSUME_QUEUE_UNIT_SIZE as u64,
+                    block_size(segment.segment_type()),
+                )
+                .await?;
+            let unit = ConsumeQueueUnit::decode_slice(bytes.as_ref())?;
             if unit.commit_log_offset < 0 {
                 continue;
             }
@@ -599,8 +638,13 @@ where
             return Ok(None);
         };
         let relative_offset = absolute_offset.saturating_sub(segment.base_offset());
-        let bytes = segment
-            .read(relative_offset..relative_offset.saturating_add(length as u64))
+        let bytes = self
+            .read_ahead_cache
+            .read(
+                &segment,
+                relative_offset..relative_offset.saturating_add(length as u64),
+                block_size(segment_type),
+            )
             .await?;
         Ok(Some(bytes))
     }
@@ -689,6 +733,20 @@ mod tests {
             .copy_from_slice(&store_timestamp.to_be_bytes());
         bytes.extend_from_slice(body);
         bytes.freeze()
+    }
+
+    #[test]
+    fn consume_queue_unit_supports_owned_and_borrowed_decode() -> Result<(), RocketMQError> {
+        let unit = ConsumeQueueUnit {
+            commit_log_offset: 42,
+            size: 128,
+            tags_code: 7,
+        };
+        let encoded = unit.encode();
+
+        assert_eq!(ConsumeQueueUnit::decode(encoded.clone())?, unit);
+        assert_eq!(ConsumeQueueUnit::decode_slice(encoded.as_ref())?, unit);
+        Ok(())
     }
 
     #[tokio::test]

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -19,6 +19,7 @@ use rocketmq_error::RocketMQError;
 
 use crate::config::TieredStoreConfig;
 use crate::dispatcher::TieredDispatchRequest;
+use crate::fetcher::read_ahead_cache::ReadAheadCache;
 use crate::file::FileSegmentStatus;
 use crate::file::FileSegmentType;
 use crate::file::IndexFileSegment;
@@ -41,6 +42,7 @@ where
     config: Arc<TieredStoreConfig>,
     metadata_store: Arc<JsonMetadataStore>,
     provider: P,
+    read_ahead_cache: Arc<ReadAheadCache>,
     files: DashMap<FlatFileKey, Arc<TieredFlatFile<P>>>,
     index_file: IndexFileSegment<P>,
 }
@@ -50,6 +52,11 @@ where
     P: TieredStoreProvider,
 {
     pub fn new(config: Arc<TieredStoreConfig>, metadata_store: Arc<JsonMetadataStore>, provider: P) -> Self {
+        let read_ahead_cache = Arc::new(ReadAheadCache::new(
+            config.read_ahead_cache_enable,
+            config.read_ahead_cache_max_bytes,
+            config.read_ahead_cache_expire,
+        ));
         let index_file = IndexFileSegment::with_limits(
             IndexFileSegment::<P>::default_path().to_owned(),
             provider.clone(),
@@ -60,6 +67,7 @@ where
             config,
             metadata_store,
             provider,
+            read_ahead_cache,
             files: DashMap::new(),
             index_file,
         }
@@ -97,12 +105,13 @@ where
             queue_id,
         };
         let entry = self.files.entry(key).or_insert_with(|| {
-            Arc::new(TieredFlatFile::new(
+            Arc::new(TieredFlatFile::new_with_read_ahead_cache(
                 topic,
                 queue_id,
                 self.config.clone(),
                 self.metadata_store.clone(),
                 self.provider.clone(),
+                self.read_ahead_cache.clone(),
             ))
         });
         Ok(entry.value().clone())
@@ -128,6 +137,7 @@ where
 
     pub async fn destroy(&self) -> Result<(), RocketMQError> {
         self.files.clear();
+        self.read_ahead_cache.clear();
         Ok(())
     }
 

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -173,7 +173,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "8332843aec0a41fa654dceed0cecd0b8eba40f93ac7ae317ea8dbda4b66b706f",
+      "rustdoc_json_sha256": "4e25ec493c6e5c3f9742348d16118fceace634e702574c6aff766d87ce9a4b52",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -201,14 +201,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 165,
       "public_path_sha256": "89b9028df0c4643a9e718af49f979144b6e1a03635ce69fde0cdad591fe6701b",
-      "rustdoc_json_sha256": "2925f5816f00cfebca6d591a357288ff6eb0a3dfaf0f6b5ff26c5c3e5f3a84db",
+      "rustdoc_json_sha256": "2b1d1df74915ee10e7910ee83499221a4d1b5d8b3a899e4a2c79074b7b4357b4",
       "target": "rocketmq_store_rocksdb"
     },
     "rocketmq-tieredstore": {
       "crate_version": "1.0.0",
       "public_path_count": 116,
       "public_path_sha256": "30e3f19ea359f6f43f2369f0d45ed5cb4a7ed0d6a5fc46ed34b8ea69f02708f3",
-      "rustdoc_json_sha256": "7c523ac1a991ae2c5a11b3f5add333bc29b44f53e73292a69d3244919c854c60",
+      "rustdoc_json_sha256": "44a9df71bd22b5c8c221e4e94d4dd4be2c9cb31d09d3ce75c007ca3f47e5eb6c",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "1a5463b143f33a8246d32d82abd05ddacf3b14c6",
+  "source_commit": "e3ef67282f420334a4f2bccc7fa01c81facbd60a",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
Closes #8264

Implements bounded Local CQ parsing, typed RocksDB range reads, and generation-aware Tiered block caching. Validation and baseline disclosure are recorded in the M10-03 evidence document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message retrieval across local, RocksDB, and tiered storage.
  * Added configurable tiered-storage read-ahead caching with byte limits and expiry controls.
  * Added typed range-query support for more efficient contiguous reads.
* **Performance**
  * Reduced redundant storage reads and improved cache reuse on repeated requests.
  * Improved result-buffer sizing and bounded consume-queue iteration.
* **Bug Fixes**
  * Corrected requested-count handling, including zero-item requests.
  * Added cache invalidation when tiered segments are removed.
* **Documentation**
  * Updated production-readiness progress and added evidence for read-path optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->