### PR TITLE
[ISSUE #8266]♻️Implement versioned Index and Compaction generations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,6 +4951,7 @@ dependencies = [
  "trait-variant",
  "uuid",
  "windows",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5037,6 +5038,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "trait-variant",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ trait-variant = "0.1.2"
 
 mockall = "0.15.0"
 cfg-if  = "1.0.4"
+windows-sys = "0.61.2"
 
 sysinfo = "0.39.3"
 uuid = { version = "1.23.3", features = [

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,14 +29,14 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 62 | 0 | 20 未开始；合计 20 尚未完成 | 82 |
+| PR 级工作包 | 63 | 0 | 19 未开始；合计 19 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 1（M10） | 2（M11–M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 20 个未开始工作包分布：M10 为 2 个、M11 为 12 个、M12 为 6 个。
-PR-M10-03 已完成 CQ、RocksDB 与 Tiered 读路径优化，当前下一工作包为 PR-M10-04。
+剩余 19 个未开始工作包分布：M10 为 1 个、M11 为 12 个、M12 为 6 个。
+PR-M10-04 已完成 Index 与 Compaction generation，当前下一工作包为 PR-M10-05。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -491,7 +491,16 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] public API additive diff 已审核；ArcMut/依赖/runtime/error/MCP/Rocks 专项门禁通过
   - [x] [`M10-03 证据`](phase-3-production-readiness/10-read-path-optimization-evidence.md) 记录目标、基线失败、验证与回滚
   - [x] 62/82 已完成、20 未完成，下一工作包 PR-M10-04
-- [ ] PR-M10-04：实现 Index/Compaction generation
+- [x] PR-M10-04：实现 Index/Compaction generation
+  - [x] Index/Compaction 使用 versioned `gen-N.tmp`、CRC/条数/边界校验、数据/目录 sync 与原子 CURRENT
+  - [x] reader lease 延迟删除 retired generation；重启清理 tmp/orphan，损坏 current 只回滚到 validated previous
+  - [x] Compaction generation 复制 live record，内存仅保 offset/代内 payload 位置，不依赖旧 CommitLog payload
+  - [x] durable compaction watermark 参与 replay；Recovering/OffsetFoundNull fail closed，不裸扫描 CommitLog
+  - [x] Index 与 Compaction build/sync/rename/CURRENT/cleanup kill/restart corpus 全部通过
+  - [x] Store 486 library、Tiered 66+1+7、Rocks 82+9、Broker 20+4、MCP 与 workspace strict Clippy 通过
+  - [x] public API 31/31 零差异；依赖/ArcMut/runtime/error/release/routing 门禁通过
+  - [x] [`M10-04 证据`](phase-3-production-readiness/10-index-compaction-generation-evidence.md) 记录目标、基线/环境失败、验证与回滚
+  - [x] 63/82 已完成、19 未完成，下一工作包 PR-M10-05
 - [ ] PR-M10-05：完成 benchmark、soak 与性能 Gate
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3，M10-03 已完成，下一工作包为 PR-M10-04）
+> 状态：实施中（Phase 3，M10-04 已完成，下一工作包为 PR-M10-05）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；62/82 工作包完成，剩余 20 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；63/82 工作包完成，剩余 19 个
 
 ## 1. 使用方式
 
@@ -195,7 +195,8 @@ M09-05 发布包索引：[`R0 release notes`](phase-2-core-boundaries/09-r0-rele
 
 ## 8. 全局不变量
 
-- CommitLog 是唯一权威 WAL；CQ、Index、RocksDB、Tiered、Compaction 只持久 cursor/watermark 等派生元数据。
+- CommitLog 是唯一权威 WAL；CQ、Index、RocksDB、Tiered 只持久 cursor/watermark 等派生元数据；Compaction
+  额外持久只含 live record 的可重建 generation，但不承担 WAL、replay source 或主写 ack 职责。
 - SyncFlush 只有在 durable watermark 达标后确认；失败不得推进 watermark。
 - 生产 task/thread/connection/pending request 都有 owner、count+byte budget、绝对 deadline 和完成报告。
 - 基础合同 crate 不通过 feature 引入 Tokio、transport、facade、service 或 native backend。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-durability-and-performance.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M10-03 已完成，下一工作包 PR-M10-04） |
+| 状态 | 实施中（PR-M10-04 已完成，下一工作包 PR-M10-05） |
 | 预计周期 | 5–8 周 |
 | 工作包 | WP14 `tiered-cursor`；延续 WP02、WP11–WP13 |
 | 前置条件 | 32-package Gate 通过；CommitLog/receipt/progress 和 Local/Rocks golden 稳定 |
@@ -14,7 +14,8 @@
 
 ## 目标
 
-- 以 CommitLog 作为唯一 WAL/outbox，让 CQ、Index、RocksDB、Tiered、Compaction 各自持久连续 cursor/watermark。
+- 以 CommitLog 作为唯一 WAL/outbox，让 CQ、Index、RocksDB、Tiered 持久连续 cursor/watermark，Compaction
+  额外发布只含 live record 的可重建 generation。
 - 消除派生事件丢失、裸 CommitLog 回退和无界 retry/queue 状态。
 - 通过 byte backpressure、零/少复制和 I/O 合并改善 RSS、p99 与 amplification。
 - 建立可重复的正确性、故障和性能 Gate，关键指标相对固定基线不恶化超过 5%。
@@ -87,12 +88,17 @@ provider read、热拉为 0。62/82 已完成，下一工作包为 PR-M10-04。
 
 ### PR-M10-04：Index/Compaction generation
 
-- [ ] `[DEV]` 构建 `gen-N.tmp`，校验 CRC/条数/边界，sync 后原子切换 CURRENT，延迟删除旧 generation。
-- [ ] `[DEV]` reader 持 generation lease；旧 generation 在最后 reader 退出后删除。
-- [ ] `[DEV]` compaction 只保 key→latest offset，未追平时返回 Recovering 或经过证明的旧 generation+delta，不裸回退 CommitLog。
-- [ ] `[TEST]` 在 build/sync/rename/CURRENT/cleanup 每个故障点 kill/restart，并验证旧 key 不重新可见。
-- [ ] `[REV]` 检查目录 fsync、lease/epoch、version兼容和回滚到上一 generation。
-- [ ] 回滚点：只有上一 generation 通过同一 CRC/边界/kill-restart/durability corpus 时，才原子将 CURRENT 指回；否则保持 Recovering/readiness=false 并修复当前 generation。
+- [x] `[DEV]` 构建 `gen-N.tmp`，校验 CRC/条数/边界，sync 后原子切换 CURRENT，延迟删除旧 generation。
+- [x] `[DEV]` reader 持 generation lease；旧 generation 在最后 reader 退出后删除。
+- [x] `[DEV]` compaction 只保 key→latest offset/代内 payload 位置，未追平时返回 Recovering 或经过证明的旧 generation+delta，不裸回退 CommitLog。
+- [x] `[TEST]` 在 build/sync/rename/CURRENT/cleanup 每个故障点 kill/restart，并验证旧 key 不重新可见。
+- [x] `[REV]` 检查目录 fsync、lease/epoch、version兼容和回滚到上一 generation。
+- [x] 回滚点：只有上一 generation 通过同一 CRC/边界/kill-restart/durability corpus 时，才原子将 CURRENT 指回；否则保持 Recovering/readiness=false 并修复当前 generation。
+
+完成证据：[`10-index-compaction-generation-evidence.md`](10-index-compaction-generation-evidence.md)。冻结代码候选
+`92608c2962bc6e3f0e226980eb7bbf92ac162c1f` 实现 Index/Compaction 的 versioned generation、原子 CURRENT、
+reader lease、validated rollback 和五故障点恢复；Compaction generation 复制 live record，删除 CommitLog resolver
+并重启后仍可读取。63/82 已完成，下一工作包为 PR-M10-05。
 
 ### PR-M10-05：Benchmark、soak 与性能 Gate
 
@@ -154,10 +160,10 @@ python scripts/architecture_dependency_guard.py --mode target
 
 - [ ] `[TEST]` SyncFlush ack 消息 crash/restart 后 100% 可见。
 - [ ] `[TEST]` 各派生 replay 无 hole/重复，cursor/retry 故障可恢复。
-- [ ] `[REV]` CommitLog 是唯一 WAL，派生 metadata 不含 payload。
+- [x] `[REV]` CommitLog 是唯一 WAL；cursor/retry metadata 不含 payload，Compaction 只复制 live record 到可重建 generation。
 - [ ] `[TEST]` Tiered 满载有界且不丢事件，readiness/alert 正确。
-- [ ] `[TEST]` compaction/index 所有 kill point 可恢复或回到上一 generation。
-- [ ] `[REV]` 不存在裸 CommitLog 语义回退。
+- [x] `[TEST]` compaction/index 所有 kill point 可恢复或回到上一 generation。
+- [x] `[REV]` 不存在裸 CommitLog 语义回退。
 - [ ] `[TEST]` Tiered/派生停止、冻结 cursor、pin WAL、checkpoint 重放和“仅切换已验证上一实现”的回滚演练通过。
 - [ ] `[TEST]` 性能 Gate和报告元数据完整。
 - [ ] `[HUMAN]` 持久格式、性能例外和 M10 Gate 已签署。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-index-compaction-generation-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/10-index-compaction-generation-evidence.md
@@ -1,0 +1,90 @@
+# M10-04 Index/Compaction generation 实施证据
+
+## 结果
+
+M10-04 将 Tiered Index 与 Local Compaction 的发布路径收口为 versioned generation。两条路径都先构建
+`gen-N.tmp`，校验 CRC、条数与 offset/time 边界，完成数据和目录持久化后再原子切换 `CURRENT`；旧代由
+reader lease 延迟回收。Compaction generation 会复制 live record，重启读取不依赖原 CommitLog payload；
+未完成 WAL replay 时保持 `Recovering`，不存在裸 CommitLog 扫描回退。该包完成后架构盘点为 **63/82**，
+剩余 19 个工作包；M10 剩余 1 个，下一包为 PR-M10-05。
+
+## 可追溯性
+
+| 字段 | 值 |
+|---|---|
+| 工作包 | `PR-M10-04` |
+| Issue | [#8266](https://github.com/mxsm/rocketmq-rust/issues/8266) |
+| 分支 | `mxsm/architecture-refactor-index-compaction-generation` |
+| Main 基线 | `4dfbad5667b6bb5b2c85f39e23d3c7342e210f50` |
+| 冻结代码候选 | `92608c2962bc6e3f0e226980eb7bbf92ac162c1f` |
+| 运行期证据 | `target/runtime-audit/` |
+
+## Index generation 合同
+
+- `IndexGenerationManager` 使用带 magic/version/CRC 的固定格式 `CURRENT` 与 generation metadata；metadata
+  同时记录 entry count、最小/最大时间戳和物理 offset，加载与发布前均重新验证。
+- 发布顺序固定为 build → sync → validate → rename → `CURRENT` → cleanup。POSIX 在 rename/replace 后同步
+  parent directory；Windows 使用带 write-through 语义的 `MoveFileExW`/`ReplaceFileW`。
+- `IndexFileSegment` 读取快照持有 generation `Arc` lease；清理只删除 strong count 为 1 的 retired generation。
+  重启会删除 `.tmp`/未引用孤儿代，损坏 current 只回滚到重新校验通过的 previous；瞬态 provider 读错误不触发回滚。
+- Provider 新增的 sync、rename、atomic write、prefix list/delete 能力均有默认实现，已有 provider 实现保持
+  source compatible；Memory/POSIX/ProviderKind 路径分别补齐实际能力。
+
+## Compaction generation 合同
+
+- delta 仅保存 CommitLog 精确位置；compact 时解析 live record 并复制 payload 到新 generation。发布后内存记录
+  只保留 key/queue/source offset 与 generation 文件的 payload position/size，不长期持有完整 payload 或 mmap lease。
+- 测试在 compact 后清空 CommitLog resolver，并在不安装 resolver 的新进程视图中重启，仍从 generation 文件读到
+  live payload，证明 generation 不是旧 CommitLog 的 offset 索引壳。
+- 当前代与 delta 先做 latest-physical-offset 过滤；replay 未达到 durable compaction watermark 时返回稳定的
+  `MessageWasRemoving`（内部 `Recovering`），读取失败返回 `OffsetFoundNull`，不会扫描裸 CommitLog 重新暴露旧 key。
+- Compaction dispatcher 的恢复起点纳入 generation durable watermark。CURRENT 损坏或 current generation 校验失败时，
+  只选择重新验证通过的 previous generation，并继续保持 Recovering 直至 delta replay 完成。
+- build/sync/rename/CURRENT/cleanup 五个故障点均执行 kill/restart corpus；cleanup failure 保留已发布 current，
+  其余 publication failure 保留上一有效代。reader lease 测试证明活跃读者退出前旧代不会删除。
+
+## 兼容性与债务审查
+
+- 既有 CommitLog、CQ、Index entry、RocksDB key/value 格式不变；新增 generation/CURRENT 位于独立 versioned 路径。
+- CommitLog 仍是唯一权威 WAL/outbox；Compaction generation 是可重建的 live-record 派生视图，不参与 append ack，
+  也不具备追加日志或 replay source 语义。
+- ArcMut guard 的 production occurrence 从 3191 降至 3189；Compaction dispatcher 不再长期持有 CommitLog `ArcMut`。
+- 31 个 Rustdoc target 的 public path count/hash 全部不变。生成基线绑定冻结代码候选，并复核为
+  `PUBLIC_API_SNAPSHOT_OK packages=31 differences=0`；变化仅为内部 Rustdoc JSON 实现哈希。
+
+## 验证记录
+
+| 命令/门禁 | 结果 |
+|---|---|
+| Compaction focused tests | 8/8 通过；含五故障点、损坏回滚、reader lease、无 CommitLog payload 重启读取 |
+| Store library | 486/486 通过 |
+| Tiered package | 66 library、1 POSIX、7 cursor/retry 集成测试通过 |
+| Store/Broker RocksDB 专项 | 通过；foundation 82、semantics 9、Broker Rocks 20、POP 4 |
+| affected-crate strict Clippy | Store/Tiered all-target/all-feature 通过 |
+| MCP consumer | check、73 library、兼容/integration、streamable-http strict Clippy、doc 通过；外部集群 e2e 1 项按设计 ignored |
+| dependency/release/ArcMut/AGENTS routing | 通过；target 35/35、dev-only 3/3、32-package release topology、ArcMut 零新增 |
+| runtime enforcing audit 与 typed-error hygiene | 通过 |
+| 根 `cargo fmt --all -- --check` 与 workspace strict Clippy | 通过；workspace Clippy 为 all-target/all-feature、`-D warnings` |
+| public API snapshot | 31/31，differences=0，source commit 为冻结代码候选 |
+| `git diff --check` | 通过 |
+
+### 已披露的基线与环境失败
+
+`cargo test -p rocketmq-store` **不记录为通过**。486 个 library 测试通过后，集成 fixture
+`file_store_vs_rocksdb_behavior_parity_after_restart` 继续复现 main 已知失败：fixture 配置 RocksDB store type，
+但构造路径仍为 LocalFileMessageStore，重启后的伪 Rocks 视图没有逻辑队列。该测试文件相对 Main 基线无差异；
+真实 RocksDB foundation/semantics 与 Broker Rocks/POP 专项全部通过。
+
+Windows 首次 Broker 链接触发 MSVC `LNK1140` PDB 容量上限；按链接器建议使用 `/PDB:NONE` 且 `-j 1`
+重新验证，Broker 与 workspace 门禁通过。并行 MCP 链接曾因多个 linker 争用同一个临时 PDB 触发 `LNK1201`，
+限制为单 job 后 73/73 library 与集成测试通过。期间磁盘不足，按交付约定执行 `cargo clean`，释放 189.2 GiB；
+这些环境处理没有修改仓库配置。
+
+## 审查与回滚
+
+`[REV]` 结论：Index/Compaction 的 incomplete/corrupt generation 不会成为 current，active reader lease 会阻止
+删除，Compaction 不依赖原 CommitLog payload 且不会裸回退扫描；既有持久格式、主写 ack 和公共路径保持不变。
+
+回滚只允许把 `CURRENT` 原子指回重新通过 CRC、条数、边界和相同 kill/restart corpus 的 previous generation。
+若 previous 不存在或验证失败，保持 `Recovering`/readiness=false，保留当前代、delta 与所需 WAL，修复后从 durable
+watermark 幂等 replay；不得重写消息数据，也不得用裸 CommitLog 读取作为降级路径。

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -106,6 +106,7 @@ rayon     = "1.12"
 libc = "0.2.186"
 
 [target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 windows = { version = "0.62.2", features = [
   "Win32_Security",
   "Win32_System_Memory_NonVolatile",

--- a/rocketmq-store/src/kv.rs
+++ b/rocketmq-store/src/kv.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 pub(crate) mod compaction_dispatch;
+pub(crate) mod compaction_generation;
 pub(crate) mod compaction_service;
 pub(crate) mod compaction_store;

--- a/rocketmq-store/src/kv/compaction_dispatch.rs
+++ b/rocketmq-store/src/kv/compaction_dispatch.rs
@@ -25,11 +25,9 @@ use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::kv::compaction_store::CompactionStore;
-use crate::log_file::commit_log::CommitLog;
 
 pub struct CommitLogDispatcherCompaction {
     compaction_store: Arc<CompactionStore>,
-    commit_log: ArcMut<CommitLog>,
     message_store_config: Arc<MessageStoreConfig>,
     topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
 }
@@ -37,13 +35,11 @@ pub struct CommitLogDispatcherCompaction {
 impl CommitLogDispatcherCompaction {
     pub fn new(
         compaction_store: Arc<CompactionStore>,
-        commit_log: ArcMut<CommitLog>,
         message_store_config: Arc<MessageStoreConfig>,
         topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
     ) -> Self {
         Self {
             compaction_store,
-            commit_log,
             message_store_config,
             topic_config_table,
         }
@@ -70,16 +66,12 @@ impl CommitLogDispatcher for CommitLogDispatcherCompaction {
             return;
         }
 
-        let Some(select_result) = self
-            .commit_log
-            .get_message(dispatch_request.commit_log_offset, dispatch_request.msg_size)
-        else {
-            return;
-        };
-        let Some(payload) = select_result.get_bytes() else {
-            return;
-        };
+        self.compaction_store.put_dispatch_message(dispatch_request);
+    }
 
-        self.compaction_store.put_dispatch_message(dispatch_request, payload);
+    fn dispatch_progress_offset(&self, commit_log_min_offset: i64) -> Option<i64> {
+        self.message_store_config
+            .enable_compaction
+            .then(|| self.compaction_store.durable_dispatch_offset(commit_log_min_offset))
     }
 }

--- a/rocketmq-store/src/kv/compaction_generation.rs
+++ b/rocketmq-store/src/kv/compaction_generation.rs
@@ -1,0 +1,750 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::iter;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
+const CURRENT_MAGIC: u32 = 0x4343_5547;
+const GENERATION_MAGIC: u32 = 0x4347_454E;
+const RECORDS_MAGIC: u32 = 0x4347_5253;
+const FORMAT_VERSION: u16 = 1;
+const CURRENT_SIZE: usize = 40;
+const GENERATION_METADATA_SIZE: usize = 64;
+const RECORDS_HEADER_SIZE: usize = 16;
+const RECORD_HEADER_SIZE: usize = 40;
+const NO_GENERATION: u64 = u64::MAX;
+const NO_KEY: u16 = u16::MAX;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct CompactionQueueKey {
+    pub(crate) topic: CheetahString,
+    pub(crate) queue_id: i32,
+}
+
+impl CompactionQueueKey {
+    pub(crate) fn new(topic: &CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic: topic.clone(),
+            queue_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum CompactionPayload {
+    CommitLog,
+    Generation { generation: u64, position: u64, size: i32 },
+    Inline(Bytes),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CompactionRecord {
+    pub(crate) queue_offset: i64,
+    pub(crate) batch_num: i32,
+    pub(crate) key: Option<CheetahString>,
+    pub(crate) source_physical_offset: i64,
+    pub(crate) source_size: i32,
+    pub(crate) payload: CompactionPayload,
+}
+
+impl CompactionRecord {
+    pub(crate) fn physical_offset(&self) -> i64 {
+        self.source_physical_offset
+    }
+
+    pub(crate) fn end_physical_offset(&self) -> i64 {
+        self.source_physical_offset
+            .saturating_add(i64::from(self.source_size.max(0)))
+    }
+}
+
+pub(crate) type CompactionQueues = BTreeMap<CompactionQueueKey, BTreeMap<i64, CompactionRecord>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GenerationMetadata {
+    pub(crate) generation: u64,
+    pub(crate) record_count: u64,
+    pub(crate) min_queue_offset: i64,
+    pub(crate) max_queue_offset: i64,
+    pub(crate) min_physical_offset: i64,
+    pub(crate) max_physical_offset: i64,
+    pub(crate) content_crc: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CurrentPointer {
+    pub(crate) current: u64,
+    pub(crate) previous: Option<u64>,
+    pub(crate) next_generation: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadedGeneration {
+    pub(crate) metadata: GenerationMetadata,
+    pub(crate) queues: CompactionQueues,
+}
+
+pub(crate) fn empty_metadata(generation: u64) -> GenerationMetadata {
+    GenerationMetadata {
+        generation,
+        record_count: 0,
+        min_queue_offset: 0,
+        max_queue_offset: 0,
+        min_physical_offset: 0,
+        max_physical_offset: 0,
+        content_crc: crc32(&encode_records_header(0)),
+    }
+}
+
+pub(crate) fn generation_path(root: &Path, generation: u64) -> PathBuf {
+    root.join("generations").join(format!("gen-{generation}"))
+}
+
+pub(crate) fn temporary_generation_path(root: &Path, generation: u64) -> PathBuf {
+    root.join("generations").join(format!("gen-{generation}.tmp"))
+}
+
+pub(crate) async fn read_current(root: PathBuf) -> Result<Option<CurrentPointer>, RocketMQError> {
+    crate::runtime::spawn_io("compaction-read-current", move || {
+        let path = root.join("CURRENT");
+        match std::fs::read(&path) {
+            Ok(bytes) => decode_current(&bytes, &path).map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(read_error(&path, error)),
+        }
+    })
+    .await?
+}
+
+pub(crate) async fn load_generation(root: PathBuf, generation: u64) -> Result<LoadedGeneration, RocketMQError> {
+    if generation == 0 {
+        return Ok(LoadedGeneration {
+            metadata: empty_metadata(0),
+            queues: CompactionQueues::new(),
+        });
+    }
+    crate::runtime::spawn_io("compaction-load-generation", move || {
+        let directory = generation_path(&root, generation);
+        let metadata_path = directory.join("GENERATION");
+        let records_path = directory.join("records");
+        let metadata_bytes = std::fs::read(&metadata_path).map_err(|error| read_error(&metadata_path, error))?;
+        let metadata = decode_generation_metadata(&metadata_bytes, &metadata_path)?;
+        if metadata.generation != generation {
+            return Err(corrupted(&metadata_path));
+        }
+        let records_bytes = std::fs::read(&records_path).map_err(|error| read_error(&records_path, error))?;
+        if crc32(&records_bytes) != metadata.content_crc {
+            return Err(corrupted(&records_path));
+        }
+        let queues = decode_records(&records_bytes, &records_path, generation)?;
+        let actual = metadata_for(generation, &queues, &records_bytes);
+        if actual != metadata {
+            return Err(corrupted(&metadata_path));
+        }
+        Ok(LoadedGeneration { metadata, queues })
+    })
+    .await?
+}
+
+pub(crate) async fn read_generation_payload(
+    root: PathBuf,
+    generation: u64,
+    position: u64,
+    size: i32,
+) -> Result<Bytes, RocketMQError> {
+    crate::runtime::spawn_io("compaction-read-generation-payload", move || {
+        if generation == 0 || size <= 0 {
+            return Err(corrupted(&generation_path(&root, generation).join("records")));
+        }
+        let path = generation_path(&root, generation).join("records");
+        let mut file = File::open(&path).map_err(|error| read_error(&path, error))?;
+        file.seek(SeekFrom::Start(position))
+            .map_err(|error| read_error(&path, error))?;
+        let mut payload = vec![0_u8; size as usize];
+        file.read_exact(&mut payload)
+            .map_err(|error| read_error(&path, error))?;
+        Ok(Bytes::from(payload))
+    })
+    .await?
+}
+
+pub(crate) async fn write_temporary_generation(
+    root: PathBuf,
+    generation: u64,
+    queues: CompactionQueues,
+) -> Result<GenerationMetadata, RocketMQError> {
+    crate::runtime::spawn_io("compaction-build-generation", move || {
+        let directory = temporary_generation_path(&root, generation);
+        remove_path_if_exists(&directory)?;
+        std::fs::create_dir_all(&directory).map_err(|error| write_error(&directory, error))?;
+        let records = encode_records(&queues, &directory.join("records"))?;
+        let metadata = metadata_for(generation, &queues, &records);
+        write_file(&directory.join("records"), &records)?;
+        write_file(&directory.join("GENERATION"), &encode_generation_metadata(metadata))?;
+        Ok(metadata)
+    })
+    .await?
+}
+
+pub(crate) async fn sync_temporary_generation(root: PathBuf, generation: u64) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-sync-generation", move || {
+        let directory = temporary_generation_path(&root, generation);
+        sync_file(&directory.join("records"))?;
+        sync_file(&directory.join("GENERATION"))?;
+        sync_directory(&directory)
+    })
+    .await?
+}
+
+pub(crate) async fn validate_temporary_generation(
+    root: PathBuf,
+    generation: u64,
+    expected: GenerationMetadata,
+) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-validate-generation", move || {
+        let directory = temporary_generation_path(&root, generation);
+        let metadata_path = directory.join("GENERATION");
+        let records_path = directory.join("records");
+        let metadata_bytes = std::fs::read(&metadata_path).map_err(|error| read_error(&metadata_path, error))?;
+        let metadata = decode_generation_metadata(&metadata_bytes, &metadata_path)?;
+        let records_bytes = std::fs::read(&records_path).map_err(|error| read_error(&records_path, error))?;
+        let queues = decode_records(&records_bytes, &records_path, generation)?;
+        let actual = metadata_for(generation, &queues, &records_bytes);
+        if metadata != expected || actual != expected {
+            return Err(corrupted(&metadata_path));
+        }
+        Ok(())
+    })
+    .await?
+}
+
+pub(crate) async fn rename_generation(root: PathBuf, generation: u64) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-rename-generation", move || {
+        let source = temporary_generation_path(&root, generation);
+        let destination = generation_path(&root, generation);
+        rename_path(&source, &destination).map_err(|error| write_error(&destination, error))?;
+        sync_directory(&root.join("generations"))
+    })
+    .await?
+}
+
+pub(crate) async fn write_current(root: PathBuf, pointer: CurrentPointer) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-write-current", move || {
+        std::fs::create_dir_all(&root).map_err(|error| write_error(&root, error))?;
+        let destination = root.join("CURRENT");
+        let temporary = root.join("CURRENT.atomic.tmp");
+        write_file(&temporary, &encode_current(pointer))?;
+        sync_file(&temporary)?;
+        replace_file(&temporary, &destination).map_err(|error| write_error(&destination, error))?;
+        sync_directory(&root)
+    })
+    .await?
+}
+
+pub(crate) async fn delete_generation(root: PathBuf, generation: u64) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-delete-generation", move || {
+        let path = generation_path(&root, generation);
+        remove_path_if_exists(&path)?;
+        sync_directory(&root.join("generations"))
+    })
+    .await?
+}
+
+pub(crate) async fn cleanup_orphans(root: PathBuf, current: u64, previous: Option<u64>) -> Result<(), RocketMQError> {
+    crate::runtime::spawn_io("compaction-cleanup-orphans", move || {
+        let generations = root.join("generations");
+        let entries = match std::fs::read_dir(&generations) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(read_error(&generations, error)),
+        };
+        for entry in entries {
+            let entry = entry.map_err(|error| read_error(&generations, error))?;
+            let path = entry.path();
+            let keep = parse_generation_id(&path)
+                .is_some_and(|generation| generation == current || Some(generation) == previous);
+            if !keep {
+                remove_path_if_exists(&path)?;
+            }
+        }
+        sync_directory(&generations)
+    })
+    .await?
+}
+
+fn metadata_for(generation: u64, queues: &CompactionQueues, records: &[u8]) -> GenerationMetadata {
+    let mut count = 0_u64;
+    let mut min_queue_offset = i64::MAX;
+    let mut max_queue_offset = i64::MIN;
+    let mut min_physical_offset = i64::MAX;
+    let mut max_physical_offset = i64::MIN;
+    for queue in queues.values() {
+        for record in queue.values() {
+            count = count.saturating_add(1);
+            min_queue_offset = min_queue_offset.min(record.queue_offset);
+            max_queue_offset = max_queue_offset.max(record.queue_offset);
+            min_physical_offset = min_physical_offset.min(record.physical_offset());
+            max_physical_offset = max_physical_offset.max(record.end_physical_offset());
+        }
+    }
+    if count == 0 {
+        min_queue_offset = 0;
+        max_queue_offset = 0;
+        min_physical_offset = 0;
+        max_physical_offset = 0;
+    }
+    GenerationMetadata {
+        generation,
+        record_count: count,
+        min_queue_offset,
+        max_queue_offset,
+        min_physical_offset,
+        max_physical_offset,
+        content_crc: crc32(records),
+    }
+}
+
+fn encode_records(queues: &CompactionQueues, path: &Path) -> Result<Vec<u8>, RocketMQError> {
+    let record_count = queues.values().map(BTreeMap::len).sum::<usize>();
+    let mut bytes = BytesMut::with_capacity(RECORDS_HEADER_SIZE + record_count.saturating_mul(RECORD_HEADER_SIZE));
+    bytes.put_slice(&encode_records_header(record_count as u64));
+    for (queue_key, queue) in queues {
+        let topic = queue_key.topic.as_bytes();
+        let topic_len = u16::try_from(topic.len()).map_err(|_| {
+            RocketMQError::storage_write_failed(path_to_string(path), "compaction topic exceeds u16 format limit")
+        })?;
+        for record in queue.values() {
+            let key_bytes = record.key.as_ref().map(CheetahString::as_bytes);
+            let key_len = match key_bytes {
+                Some(key) => u16::try_from(key.len()).map_err(|_| {
+                    RocketMQError::storage_write_failed(path_to_string(path), "compaction key exceeds u16 format limit")
+                })?,
+                None => NO_KEY,
+            };
+            let CompactionPayload::Inline(payload) = &record.payload else {
+                return Err(RocketMQError::storage_write_failed(
+                    path_to_string(path),
+                    "compaction generation must materialize payload before persistence",
+                ));
+            };
+            if record.source_physical_offset < 0
+                || record.source_size <= 0
+                || payload.len() != record.source_size as usize
+            {
+                return Err(RocketMQError::storage_write_failed(
+                    path_to_string(path),
+                    "compaction payload size does not match source record",
+                ));
+            }
+            bytes.put_u16(topic_len);
+            bytes.put_u16(key_len);
+            bytes.put_i32(queue_key.queue_id);
+            bytes.put_i64(record.queue_offset);
+            bytes.put_i32(record.batch_num);
+            bytes.put_i64(record.source_physical_offset);
+            bytes.put_i32(record.source_size);
+            bytes.put_u32(0);
+            bytes.put_u32(0);
+            bytes.put_slice(topic);
+            if let Some(key) = key_bytes {
+                bytes.put_slice(key);
+            }
+            bytes.put_slice(payload);
+        }
+    }
+    Ok(bytes.to_vec())
+}
+
+fn decode_records(bytes: &[u8], path: &Path, generation: u64) -> Result<CompactionQueues, RocketMQError> {
+    if bytes.len() < RECORDS_HEADER_SIZE {
+        return Err(corrupted(path));
+    }
+    let mut cursor = Bytes::copy_from_slice(bytes);
+    if cursor.get_u32() != RECORDS_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+        return Err(corrupted(path));
+    }
+    let _reserved = cursor.get_u16();
+    let count = cursor.get_u64();
+    let mut queues = CompactionQueues::new();
+    for _ in 0..count {
+        if cursor.remaining() < RECORD_HEADER_SIZE {
+            return Err(corrupted(path));
+        }
+        let topic_len = cursor.get_u16() as usize;
+        let raw_key_len = cursor.get_u16();
+        let key_len = if raw_key_len == NO_KEY { 0 } else { raw_key_len as usize };
+        let queue_id = cursor.get_i32();
+        let queue_offset = cursor.get_i64();
+        let batch_num = cursor.get_i32();
+        let physical_offset = cursor.get_i64();
+        let size = cursor.get_i32();
+        let _reserved = cursor.get_u32();
+        let _reserved = cursor.get_u32();
+        let variable_size = topic_len.saturating_add(key_len).saturating_add(size.max(0) as usize);
+        if queue_offset < 0 || batch_num <= 0 || physical_offset < 0 || size <= 0 || cursor.remaining() < variable_size
+        {
+            return Err(corrupted(path));
+        }
+        let topic = std::str::from_utf8(&cursor.copy_to_bytes(topic_len))
+            .map_err(|_| corrupted(path))?
+            .to_owned();
+        let key = if raw_key_len == NO_KEY {
+            None
+        } else {
+            Some(
+                std::str::from_utf8(&cursor.copy_to_bytes(key_len))
+                    .map_err(|_| corrupted(path))?
+                    .to_owned(),
+            )
+        };
+        let payload_position = bytes.len().saturating_sub(cursor.remaining()) as u64;
+        cursor.advance(size as usize);
+        let queue_key = CompactionQueueKey {
+            topic: CheetahString::from_string(topic),
+            queue_id,
+        };
+        let record = CompactionRecord {
+            queue_offset,
+            batch_num,
+            key: key.map(CheetahString::from_string),
+            source_physical_offset: physical_offset,
+            source_size: size,
+            payload: CompactionPayload::Generation {
+                generation,
+                position: payload_position,
+                size,
+            },
+        };
+        if queues
+            .entry(queue_key)
+            .or_default()
+            .insert(queue_offset, record)
+            .is_some()
+        {
+            return Err(corrupted(path));
+        }
+    }
+    if cursor.has_remaining() {
+        return Err(corrupted(path));
+    }
+    Ok(queues)
+}
+
+fn encode_records_header(record_count: u64) -> [u8; RECORDS_HEADER_SIZE] {
+    let mut bytes = BytesMut::with_capacity(RECORDS_HEADER_SIZE);
+    bytes.put_u32(RECORDS_MAGIC);
+    bytes.put_u16(FORMAT_VERSION);
+    bytes.put_u16(0);
+    bytes.put_u64(record_count);
+    bytes.as_ref().try_into().unwrap_or([0; RECORDS_HEADER_SIZE])
+}
+
+fn encode_generation_metadata(metadata: GenerationMetadata) -> [u8; GENERATION_METADATA_SIZE] {
+    let mut bytes = BytesMut::with_capacity(GENERATION_METADATA_SIZE);
+    bytes.put_u32(GENERATION_MAGIC);
+    bytes.put_u16(FORMAT_VERSION);
+    bytes.put_u16(0);
+    bytes.put_u64(metadata.generation);
+    bytes.put_u64(metadata.record_count);
+    bytes.put_i64(metadata.min_queue_offset);
+    bytes.put_i64(metadata.max_queue_offset);
+    bytes.put_i64(metadata.min_physical_offset);
+    bytes.put_i64(metadata.max_physical_offset);
+    bytes.put_u32(metadata.content_crc);
+    let checksum = crc32(&bytes);
+    bytes.put_u32(checksum);
+    bytes.as_ref().try_into().unwrap_or([0; GENERATION_METADATA_SIZE])
+}
+
+fn decode_generation_metadata(bytes: &[u8], path: &Path) -> Result<GenerationMetadata, RocketMQError> {
+    if bytes.len() != GENERATION_METADATA_SIZE {
+        return Err(corrupted(path));
+    }
+    let expected_crc = u32::from_be_bytes(bytes[GENERATION_METADATA_SIZE - 4..].try_into().unwrap_or_default());
+    if crc32(&bytes[..GENERATION_METADATA_SIZE - 4]) != expected_crc {
+        return Err(corrupted(path));
+    }
+    let mut cursor = Bytes::copy_from_slice(bytes);
+    if cursor.get_u32() != GENERATION_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+        return Err(corrupted(path));
+    }
+    let _reserved = cursor.get_u16();
+    let metadata = GenerationMetadata {
+        generation: cursor.get_u64(),
+        record_count: cursor.get_u64(),
+        min_queue_offset: cursor.get_i64(),
+        max_queue_offset: cursor.get_i64(),
+        min_physical_offset: cursor.get_i64(),
+        max_physical_offset: cursor.get_i64(),
+        content_crc: cursor.get_u32(),
+    };
+    let valid_empty = metadata.record_count == 0
+        && metadata.min_queue_offset == 0
+        && metadata.max_queue_offset == 0
+        && metadata.min_physical_offset == 0
+        && metadata.max_physical_offset == 0;
+    let valid_non_empty = metadata.record_count > 0
+        && metadata.min_queue_offset <= metadata.max_queue_offset
+        && metadata.min_physical_offset <= metadata.max_physical_offset;
+    if !valid_empty && !valid_non_empty {
+        return Err(corrupted(path));
+    }
+    Ok(metadata)
+}
+
+fn encode_current(pointer: CurrentPointer) -> [u8; CURRENT_SIZE] {
+    let mut bytes = BytesMut::with_capacity(CURRENT_SIZE);
+    bytes.put_u32(CURRENT_MAGIC);
+    bytes.put_u16(FORMAT_VERSION);
+    bytes.put_u16(0);
+    bytes.put_u64(pointer.current);
+    bytes.put_u64(pointer.previous.unwrap_or(NO_GENERATION));
+    bytes.put_u64(pointer.next_generation);
+    let checksum = crc32(&bytes);
+    bytes.put_u32(checksum);
+    bytes.put_u32(0);
+    bytes.as_ref().try_into().unwrap_or([0; CURRENT_SIZE])
+}
+
+fn decode_current(bytes: &[u8], path: &Path) -> Result<CurrentPointer, RocketMQError> {
+    if bytes.len() != CURRENT_SIZE {
+        return Err(corrupted(path));
+    }
+    let expected_crc = u32::from_be_bytes(bytes[32..36].try_into().unwrap_or_default());
+    if crc32(&bytes[..32]) != expected_crc {
+        return Err(corrupted(path));
+    }
+    let mut cursor = Bytes::copy_from_slice(bytes);
+    if cursor.get_u32() != CURRENT_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+        return Err(corrupted(path));
+    }
+    let _reserved = cursor.get_u16();
+    let current = cursor.get_u64();
+    let previous = match cursor.get_u64() {
+        NO_GENERATION => None,
+        generation => Some(generation),
+    };
+    let next_generation = cursor.get_u64();
+    if next_generation <= current || previous == Some(current) {
+        return Err(corrupted(path));
+    }
+    Ok(CurrentPointer {
+        current,
+        previous,
+        next_generation,
+    })
+}
+
+fn parse_generation_id(path: &Path) -> Option<u64> {
+    let name = path.file_name()?.to_str()?;
+    if name.ends_with(".tmp") {
+        return None;
+    }
+    name.strip_prefix("gen-")?.parse().ok()
+}
+
+fn write_file(path: &Path, bytes: &[u8]) -> Result<(), RocketMQError> {
+    let mut file = File::create(path).map_err(|error| write_error(path, error))?;
+    file.write_all(bytes).map_err(|error| write_error(path, error))?;
+    file.flush().map_err(|error| write_error(path, error))
+}
+
+fn sync_file(path: &Path) -> Result<(), RocketMQError> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| write_error(path, error))
+}
+
+fn remove_path_if_exists(path: &Path) -> Result<(), RocketMQError> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(write_error(path, error)),
+    };
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path).map_err(|error| write_error(path, error))
+    } else {
+        std::fs::remove_file(path).map_err(|error| write_error(path, error))
+    }
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<(), RocketMQError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| write_error(path, error))
+}
+
+#[cfg(windows)]
+fn sync_directory(_path: &Path) -> Result<(), RocketMQError> {
+    // MoveFileExW/ReplaceFileW with WRITE_THROUGH are the durable Windows metadata boundaries.
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn sync_directory(_path: &Path) -> Result<(), RocketMQError> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn rename_path(source: &Path, destination: &Path) -> std::io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn rename_path(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let destination = wide_path(destination);
+    let source = wide_path(source);
+    // SAFETY: Both UTF-16 buffers are NUL-terminated and remain alive for the duration of MoveFileExW.
+    let renamed = unsafe {
+        windows_sys::Win32::Storage::FileSystem::MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            windows_sys::Win32::Storage::FileSystem::MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if renamed == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if !destination.exists() {
+        return std::fs::rename(source, destination);
+    }
+    let destination = wide_path(destination);
+    let source = wide_path(source);
+    // SAFETY: Both buffers are NUL-terminated and remain alive for the call; optional pointers are
+    // null.
+    let replaced = unsafe {
+        windows_sys::Win32::Storage::FileSystem::ReplaceFileW(
+            destination.as_ptr(),
+            source.as_ptr(),
+            std::ptr::null(),
+            windows_sys::Win32::Storage::FileSystem::REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn wide_path(path: &Path) -> Vec<u16> {
+    OsStr::new(path).encode_wide().chain(iter::once(0)).collect()
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn read_error(path: &Path, error: std::io::Error) -> RocketMQError {
+    RocketMQError::storage_read_failed(path_to_string(path), io_reason(&error))
+}
+
+fn write_error(path: &Path, error: std::io::Error) -> RocketMQError {
+    RocketMQError::storage_write_failed(path_to_string(path), io_reason(&error))
+}
+
+fn io_reason(error: &std::io::Error) -> String {
+    format!("I/O error kind {:?}, OS code {:?}", error.kind(), error.raw_os_error())
+}
+
+fn corrupted(path: &Path) -> RocketMQError {
+    RocketMQError::StorageCorrupted {
+        path: path_to_string(path),
+    }
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFF_u32;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_and_generation_metadata_reject_corruption() {
+        let pointer = CurrentPointer {
+            current: 7,
+            previous: Some(6),
+            next_generation: 8,
+        };
+        let encoded = encode_current(pointer);
+        assert_eq!(decode_current(&encoded, Path::new("CURRENT")).unwrap(), pointer);
+        let mut corrupt = encoded;
+        corrupt[8] ^= 1;
+        assert!(decode_current(&corrupt, Path::new("CURRENT")).is_err());
+
+        let metadata = GenerationMetadata {
+            generation: 7,
+            record_count: 1,
+            min_queue_offset: 3,
+            max_queue_offset: 3,
+            min_physical_offset: 10,
+            max_physical_offset: 20,
+            content_crc: 42,
+        };
+        let encoded = encode_generation_metadata(metadata);
+        assert_eq!(
+            decode_generation_metadata(&encoded, Path::new("GENERATION")).unwrap(),
+            metadata
+        );
+    }
+}

--- a/rocketmq-store/src/kv/compaction_service.rs
+++ b/rocketmq-store/src/kv/compaction_service.rs
@@ -46,9 +46,17 @@ impl CompactionService {
         }
     }
 
-    pub fn load(&mut self, exit_ok: bool) -> bool {
+    pub async fn load(&mut self, exit_ok: bool, required_wal_position: i64) -> bool {
+        if let Err(error) = self.compaction_store.load().await {
+            error!("failed to load compaction generations: {error}");
+            return false;
+        }
+        self.compaction_store.begin_recovery(required_wal_position);
         self.loaded = true;
-        info!("load compaction service, exit ok: {}", exit_ok);
+        info!(
+            "load compaction service, exit ok: {}, required WAL position: {}",
+            exit_ok, required_wal_position
+        );
         true
     }
 
@@ -74,9 +82,14 @@ impl CompactionService {
         if let Err(error) = scheduled_tasks.schedule_fixed_rate_no_overlap(config, move || {
             let compaction_store = compaction_store.clone();
             async move {
-                let removed = compaction_store.compact_once();
-                if removed > 0 {
-                    info!("compaction service removed {} obsolete messages", removed);
+                match compaction_store.compact_once().await {
+                    Ok(removed) if removed > 0 => {
+                        info!("compaction service removed {} obsolete messages", removed);
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        error!("compaction generation failed: {error}");
+                    }
                 }
             }
         }) {
@@ -158,7 +171,8 @@ mod tests {
         compaction_store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"latest-message"));
 
         let mut service = CompactionService::new(compaction_store.clone(), 1);
-        assert!(service.load(true));
+        assert!(service.load(true, 0).await);
+        compaction_store.finish_recovery(0);
         service.start();
         assert!(service.has_worker_handle());
 

--- a/rocketmq-store/src/kv/compaction_store.rs
+++ b/rocketmq-store/src/kv/compaction_store.rs
@@ -14,10 +14,13 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
-use dashmap::DashMap;
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
 
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::get_message_result::GetMessageResult;
@@ -25,34 +28,86 @@ use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::select_result::SelectMappedBufferCacheState;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::select_result::SelectMappedBufferSourceKind;
+use crate::kv::compaction_generation;
+use crate::kv::compaction_generation::CompactionPayload;
+use crate::kv::compaction_generation::CompactionQueueKey;
+use crate::kv::compaction_generation::CompactionQueues;
+use crate::kv::compaction_generation::CompactionRecord;
+use crate::kv::compaction_generation::CurrentPointer;
+use crate::kv::compaction_generation::GenerationMetadata;
 use crate::log_file::mapped_file::MappedFile;
 
-#[derive(Default)]
-pub struct CompactionStore {
-    queues: DashMap<CompactionQueueKey, BTreeMap<i64, CompactionMessage>>,
+type PayloadResolver = dyn Fn(i64, i32) -> Option<Bytes> + Send + Sync;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CompactionReadState {
+    Ready {
+        generation: u64,
+        durable_watermark: i64,
+    },
+    Recovering {
+        generation: u64,
+        durable_watermark: i64,
+        required_wal_position: i64,
+    },
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct CompactionQueueKey {
-    topic: CheetahString,
-    queue_id: i32,
+#[derive(Debug)]
+struct CompactionGeneration {
+    metadata: GenerationMetadata,
+    queues: CompactionQueues,
 }
 
-impl CompactionQueueKey {
-    fn new(topic: &CheetahString, queue_id: i32) -> Self {
+impl CompactionGeneration {
+    fn empty() -> Self {
         Self {
-            topic: topic.clone(),
-            queue_id,
+            metadata: compaction_generation::empty_metadata(0),
+            queues: CompactionQueues::new(),
         }
     }
 }
 
-#[derive(Clone, Debug)]
-struct CompactionMessage {
-    queue_offset: i64,
-    batch_num: i32,
-    key: Option<CheetahString>,
-    payload: Bytes,
+#[derive(Debug)]
+struct CompactionState {
+    current: Arc<CompactionGeneration>,
+    previous: Option<Arc<CompactionGeneration>>,
+    retired: Vec<Arc<CompactionGeneration>>,
+    delta: CompactionQueues,
+    next_generation: u64,
+    read_state: CompactionReadState,
+}
+
+pub struct CompactionStore {
+    root: Option<PathBuf>,
+    state: RwLock<CompactionState>,
+    payload_resolver: RwLock<Option<Arc<PayloadResolver>>>,
+    generation_lock: tokio::sync::Mutex<()>,
+    #[cfg(test)]
+    fault_stage: std::sync::atomic::AtomicU8,
+}
+
+impl Default for CompactionStore {
+    fn default() -> Self {
+        let current = Arc::new(CompactionGeneration::empty());
+        Self {
+            root: None,
+            state: RwLock::new(CompactionState {
+                current,
+                previous: None,
+                retired: Vec::new(),
+                delta: CompactionQueues::new(),
+                next_generation: 1,
+                read_state: CompactionReadState::Ready {
+                    generation: 0,
+                    durable_watermark: 0,
+                },
+            }),
+            payload_resolver: RwLock::new(None),
+            generation_lock: tokio::sync::Mutex::new(()),
+            #[cfg(test)]
+            fault_stage: std::sync::atomic::AtomicU8::new(0),
+        }
+    }
 }
 
 impl CompactionStore {
@@ -60,19 +115,146 @@ impl CompactionStore {
         Self::default()
     }
 
+    pub(crate) fn with_root(root: PathBuf) -> Self {
+        let store = Self {
+            root: Some(root),
+            ..Self::default()
+        };
+        store.state.write().read_state = CompactionReadState::Recovering {
+            generation: 0,
+            durable_watermark: 0,
+            required_wal_position: 0,
+        };
+        store
+    }
+
+    pub(crate) fn set_payload_resolver<F>(&self, resolver: F)
+    where
+        F: Fn(i64, i32) -> Option<Bytes> + Send + Sync + 'static,
+    {
+        *self.payload_resolver.write() = Some(Arc::new(resolver));
+    }
+
+    pub(crate) async fn load(&self) -> Result<(), RocketMQError> {
+        let Some(root) = self.root.clone() else {
+            return Ok(());
+        };
+        let _generation_guard = self.generation_lock.lock().await;
+        let Some(pointer) = compaction_generation::read_current(root.clone()).await? else {
+            compaction_generation::cleanup_orphans(root, 0, None).await?;
+            return Ok(());
+        };
+
+        let (current, previous, effective_pointer) =
+            match compaction_generation::load_generation(root.clone(), pointer.current).await {
+                Ok(current) => {
+                    let previous = match pointer.previous {
+                        Some(generation) => compaction_generation::load_generation(root.clone(), generation)
+                            .await
+                            .ok()
+                            .map(Self::generation_from_loaded),
+                        None => None,
+                    };
+                    let effective_pointer = CurrentPointer {
+                        current: pointer.current,
+                        previous: previous.as_ref().map(|generation| generation.metadata.generation),
+                        next_generation: pointer.next_generation,
+                    };
+                    if effective_pointer != pointer {
+                        compaction_generation::write_current(root.clone(), effective_pointer).await?;
+                    }
+                    (Self::generation_from_loaded(current), previous, effective_pointer)
+                }
+                Err(current_error) => {
+                    let Some(previous_id) = pointer.previous else {
+                        return Err(current_error);
+                    };
+                    let previous = compaction_generation::load_generation(root.clone(), previous_id).await?;
+                    let rollback = CurrentPointer {
+                        current: previous_id,
+                        previous: None,
+                        next_generation: pointer.next_generation,
+                    };
+                    compaction_generation::write_current(root.clone(), rollback).await?;
+                    (Self::generation_from_loaded(previous), None, rollback)
+                }
+            };
+
+        let durable_watermark = current.metadata.max_physical_offset;
+        {
+            let mut state = self.state.write();
+            state.current = current;
+            state.previous = previous;
+            state.retired.clear();
+            state.delta.clear();
+            state.next_generation = effective_pointer
+                .next_generation
+                .max(effective_pointer.current.saturating_add(1));
+            state.read_state = CompactionReadState::Recovering {
+                generation: effective_pointer.current,
+                durable_watermark,
+                required_wal_position: durable_watermark,
+            };
+        }
+        compaction_generation::cleanup_orphans(root, effective_pointer.current, effective_pointer.previous).await
+    }
+
+    pub(crate) fn begin_recovery(&self, required_wal_position: i64) {
+        let mut state = self.state.write();
+        state.read_state = CompactionReadState::Recovering {
+            generation: state.current.metadata.generation,
+            durable_watermark: state.current.metadata.max_physical_offset,
+            required_wal_position: required_wal_position.max(0),
+        };
+    }
+
+    pub(crate) fn finish_recovery(&self, recovered_wal_position: i64) {
+        let mut state = self.state.write();
+        let delta_watermark = state
+            .delta
+            .values()
+            .flat_map(BTreeMap::values)
+            .map(CompactionRecord::end_physical_offset)
+            .max()
+            .unwrap_or_default();
+        state.read_state = CompactionReadState::Ready {
+            generation: state.current.metadata.generation,
+            durable_watermark: state
+                .current
+                .metadata
+                .max_physical_offset
+                .max(delta_watermark)
+                .max(recovered_wal_position.max(0)),
+        };
+    }
+
+    pub(crate) fn read_state(&self) -> CompactionReadState {
+        self.state.read().read_state.clone()
+    }
+
+    pub(crate) fn durable_dispatch_offset(&self, commit_log_min_offset: i64) -> i64 {
+        self.state
+            .read()
+            .current
+            .metadata
+            .max_physical_offset
+            .max(commit_log_min_offset)
+    }
+
     pub fn put_message(&self, topic: &CheetahString, queue_id: i32, queue_offset: i64, batch_num: i32, payload: Bytes) {
         self.put_message_with_key(topic, queue_id, queue_offset, batch_num, None, payload);
     }
 
-    pub(crate) fn put_dispatch_message(&self, dispatch_request: &DispatchRequest, payload: Bytes) {
+    pub(crate) fn put_dispatch_message(&self, dispatch_request: &DispatchRequest) {
         let key = (!dispatch_request.keys.is_empty()).then(|| dispatch_request.keys.clone());
-        self.put_message_with_key(
+        self.put_reference(
             &dispatch_request.topic,
             dispatch_request.queue_id,
             dispatch_request.consume_queue_offset,
             dispatch_request.batch_size as i32,
             key,
-            payload,
+            dispatch_request.commit_log_offset,
+            dispatch_request.msg_size,
         );
     }
 
@@ -88,18 +270,55 @@ impl CompactionStore {
         if queue_offset < 0 || payload.is_empty() {
             return;
         }
-
-        let key = CompactionQueueKey::new(topic, queue_id);
-        let mut queue = self.queues.entry(key).or_default();
-        queue.insert(
-            queue_offset,
-            CompactionMessage {
+        let source_size = payload.len() as i32;
+        self.insert_record(
+            topic,
+            queue_id,
+            CompactionRecord {
                 queue_offset,
                 batch_num: batch_num.max(1),
                 key: message_key,
-                payload,
+                source_physical_offset: queue_offset,
+                source_size,
+                payload: CompactionPayload::Inline(payload),
             },
         );
+    }
+
+    fn put_reference(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        queue_offset: i64,
+        batch_num: i32,
+        message_key: Option<CheetahString>,
+        physical_offset: i64,
+        size: i32,
+    ) {
+        if queue_offset < 0 || physical_offset < 0 || size <= 0 {
+            return;
+        }
+        self.insert_record(
+            topic,
+            queue_id,
+            CompactionRecord {
+                queue_offset,
+                batch_num: batch_num.max(1),
+                key: message_key,
+                source_physical_offset: physical_offset,
+                source_size: size,
+                payload: CompactionPayload::CommitLog,
+            },
+        );
+    }
+
+    fn insert_record(&self, topic: &CheetahString, queue_id: i32, record: CompactionRecord) {
+        let mut state = self.state.write();
+        state
+            .delta
+            .entry(CompactionQueueKey::new(topic, queue_id))
+            .or_default()
+            .insert(record.queue_offset, record);
     }
 
     pub fn dispatch_from_commit_log<MF: MappedFile>(
@@ -114,58 +333,185 @@ impl CompactionStore {
         {
             return false;
         }
-
         let file_from_offset = commit_log_file.get_file_from_offset() as i64;
         if dispatch_request.commit_log_offset < file_from_offset {
             return false;
         }
-
         let pos = (dispatch_request.commit_log_offset - file_from_offset) as usize;
-        let size = dispatch_request.msg_size as usize;
-        let Some(payload) = commit_log_file.get_data(pos, size) else {
+        if commit_log_file
+            .get_data(pos, dispatch_request.msg_size as usize)
+            .is_none()
+        {
             return false;
-        };
-
-        self.put_dispatch_message(dispatch_request, payload);
+        }
+        self.put_dispatch_message(dispatch_request);
         true
     }
 
-    pub fn compact_once(&self) -> usize {
-        let mut removed = 0;
-
-        for mut queue in self.queues.iter_mut() {
-            let mut latest_offset_by_key = HashMap::<CheetahString, i64>::new();
-            for (&queue_offset, message) in queue.iter() {
-                let Some(key) = message.key.as_ref() else {
-                    continue;
-                };
-                latest_offset_by_key
-                    .entry(key.clone())
-                    .and_modify(|latest_offset| *latest_offset = (*latest_offset).max(queue_offset))
-                    .or_insert(queue_offset);
+    pub async fn compact_once(&self) -> Result<usize, RocketMQError> {
+        let _generation_guard = self.generation_lock.lock().await;
+        self.cleanup_retired().await?;
+        let (base_generation, delta_snapshot, merged, generation, before) = {
+            let state = self.state.read();
+            if state.delta.is_empty() {
+                return Ok(0);
             }
+            let source = merged_queues(&state.current.queues, &state.delta);
+            let before = merged_count(&source);
+            (
+                state.current.metadata.generation,
+                state.delta.clone(),
+                compact_queues(source),
+                state.next_generation,
+                before,
+            )
+        };
+        let removed = before.saturating_sub(merged_count(&merged));
 
-            if latest_offset_by_key.is_empty() {
-                continue;
+        self.fail_if(FaultStage::Build)?;
+        let (metadata, published_queues) = if let Some(root) = self.root.clone() {
+            let materialized = self.materialize_queues(&merged).await?;
+            let metadata =
+                compaction_generation::write_temporary_generation(root.clone(), generation, materialized).await?;
+            self.fail_if(FaultStage::Sync)?;
+            compaction_generation::sync_temporary_generation(root.clone(), generation).await?;
+            compaction_generation::validate_temporary_generation(root.clone(), generation, metadata).await?;
+            self.fail_if(FaultStage::Rename)?;
+            compaction_generation::rename_generation(root.clone(), generation).await?;
+            let loaded = compaction_generation::load_generation(root.clone(), generation).await?;
+            self.fail_if(FaultStage::Current)?;
+            compaction_generation::write_current(
+                root,
+                CurrentPointer {
+                    current: generation,
+                    previous: Some(base_generation),
+                    next_generation: generation.saturating_add(1),
+                },
+            )
+            .await?;
+            (loaded.metadata, loaded.queues)
+        } else {
+            (metadata_for_memory(generation, &merged), merged)
+        };
+
+        {
+            let mut state = self.state.write();
+            if state.current.metadata.generation != base_generation {
+                return Err(RocketMQError::storage_write_failed(
+                    self.root_display(),
+                    "compaction generation changed during publication",
+                ));
             }
-
-            let before = queue.len();
-            queue.retain(|queue_offset, message| {
-                let Some(key) = message.key.as_ref() else {
-                    return true;
-                };
-                match latest_offset_by_key.get(key) {
-                    Some(latest_offset) => *latest_offset == *queue_offset,
-                    None => true,
-                }
+            let old_current = state.current.clone();
+            if let Some(old_previous) = state.previous.replace(old_current) {
+                state.retired.push(old_previous);
+            }
+            state.current = Arc::new(CompactionGeneration {
+                metadata,
+                queues: published_queues,
             });
-            removed += before.saturating_sub(queue.len());
+            remove_snapshot_from_delta(&mut state.delta, &delta_snapshot);
+            state.next_generation = generation.saturating_add(1);
+            state.read_state = match state.read_state {
+                CompactionReadState::Ready { durable_watermark, .. } => CompactionReadState::Ready {
+                    generation,
+                    durable_watermark: durable_watermark.max(metadata.max_physical_offset),
+                },
+                CompactionReadState::Recovering {
+                    required_wal_position, ..
+                } => CompactionReadState::Recovering {
+                    generation,
+                    durable_watermark: metadata.max_physical_offset,
+                    required_wal_position,
+                },
+            };
         }
-
-        removed
+        self.fail_if(FaultStage::Cleanup)?;
+        self.cleanup_retired().await?;
+        Ok(removed)
     }
 
-    pub fn get_message(
+    pub(crate) async fn rollback_to_previous_generation(&self) -> Result<bool, RocketMQError> {
+        let _generation_guard = self.generation_lock.lock().await;
+        let (current, previous, next_generation) = {
+            let state = self.state.read();
+            let Some(previous) = state.previous.clone() else {
+                return Ok(false);
+            };
+            (state.current.clone(), previous, state.next_generation)
+        };
+        if let Some(root) = self.root.clone() {
+            compaction_generation::write_current(
+                root,
+                CurrentPointer {
+                    current: previous.metadata.generation,
+                    previous: Some(current.metadata.generation),
+                    next_generation,
+                },
+            )
+            .await?;
+        }
+        let mut state = self.state.write();
+        state.current = previous;
+        state.previous = Some(current);
+        state.read_state = CompactionReadState::Recovering {
+            generation: state.current.metadata.generation,
+            durable_watermark: state.current.metadata.max_physical_offset,
+            required_wal_position: state.current.metadata.max_physical_offset,
+        };
+        Ok(true)
+    }
+
+    async fn materialize_queues(&self, queues: &CompactionQueues) -> Result<CompactionQueues, RocketMQError> {
+        let mut materialized = queues.clone();
+        for queue in materialized.values_mut() {
+            for record in queue.values_mut() {
+                let Some(payload) = self.resolve_payload(record).await? else {
+                    return Err(RocketMQError::storage_read_failed(
+                        self.root_display(),
+                        format!(
+                            "compaction source payload is unavailable at physical offset {}",
+                            record.source_physical_offset
+                        ),
+                    ));
+                };
+                if payload.len() != record.source_size as usize {
+                    return Err(RocketMQError::StorageCorrupted {
+                        path: self.root_display(),
+                    });
+                }
+                record.payload = CompactionPayload::Inline(payload);
+            }
+        }
+        Ok(materialized)
+    }
+
+    async fn cleanup_retired(&self) -> Result<(), RocketMQError> {
+        let deletable = {
+            let state = self.state.read();
+            state
+                .retired
+                .iter()
+                .filter(|generation| Arc::strong_count(generation) == 1)
+                .map(|generation| generation.metadata.generation)
+                .filter(|generation| *generation > 0)
+                .collect::<Vec<_>>()
+        };
+        if let Some(root) = self.root.clone() {
+            for generation in &deletable {
+                compaction_generation::delete_generation(root.clone(), *generation).await?;
+            }
+        }
+        if !deletable.is_empty() {
+            self.state
+                .write()
+                .retired
+                .retain(|generation| !deletable.contains(&generation.metadata.generation));
+        }
+        Ok(())
+    }
+
+    pub async fn get_message(
         &self,
         _group: &CheetahString,
         topic: &CheetahString,
@@ -174,21 +520,36 @@ impl CompactionStore {
         max_msg_nums: i32,
         max_total_msg_size: i32,
     ) -> Option<GetMessageResult> {
-        let key = CompactionQueueKey::new(topic, queue_id);
-        let Some(queue) = self.queues.get(&key) else {
-            return Some(status_result(GetMessageStatus::NoMatchedLogicQueue, 0, 0, 0));
+        let (current_lease, delta, read_state) = {
+            let state = self.state.read();
+            (
+                state.current.clone(),
+                state
+                    .delta
+                    .get(&CompactionQueueKey::new(topic, queue_id))
+                    .cloned()
+                    .unwrap_or_default(),
+                state.read_state.clone(),
+            )
         };
-        if queue.is_empty() {
-            return Some(status_result(GetMessageStatus::NoMessageInQueue, 0, 0, 0));
+        if matches!(read_state, CompactionReadState::Recovering { .. }) {
+            // Preserve the stable Java-compatible public enum while making the internal state explicit.
+            return Some(status_result(GetMessageStatus::MessageWasRemoving, offset, 0, 0));
         }
 
+        let key = CompactionQueueKey::new(topic, queue_id);
+        let mut queue = current_lease.queues.get(&key).cloned().unwrap_or_default();
+        queue.extend(delta);
+        let queue = compact_queue(queue);
+        if queue.is_empty() {
+            return Some(status_result(GetMessageStatus::NoMatchedLogicQueue, 0, 0, 0));
+        }
         let min_offset = *queue.keys().next().unwrap_or(&0);
         let max_offset = queue
             .values()
-            .map(|message| message.queue_offset + message.batch_num as i64)
+            .map(|message| message.queue_offset + i64::from(message.batch_num))
             .max()
             .unwrap_or(min_offset);
-
         if offset < min_offset {
             return Some(status_result(
                 GetMessageStatus::OffsetTooSmall,
@@ -218,34 +579,59 @@ impl CompactionStore {
         let max_msg_nums = max_msg_nums.max(1);
         let max_total_msg_size = max_total_msg_size.max(1);
         let mut next_begin_offset = offset;
-
         for (&queue_offset, message) in queue.range(offset..) {
             if result.message_count() >= max_msg_nums {
                 break;
             }
-
-            let payload_size = message.payload.len() as i32;
+            let payload = match self.resolve_payload(message).await {
+                Ok(Some(payload)) => payload,
+                Ok(None) => {
+                    tracing::warn!(
+                        physical_offset = message.source_physical_offset,
+                        "compaction payload is unavailable at its exact location"
+                    );
+                    return Some(status_result(
+                        GetMessageStatus::OffsetFoundNull,
+                        offset,
+                        min_offset,
+                        max_offset,
+                    ));
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        generation = current_lease.metadata.generation,
+                        "compaction generation payload read failed"
+                    );
+                    return Some(status_result(
+                        GetMessageStatus::OffsetFoundNull,
+                        offset,
+                        min_offset,
+                        max_offset,
+                    ));
+                }
+            };
+            let payload_size = payload.len() as i32;
             if result.buffer_total_size() > 0 && result.buffer_total_size() + payload_size > max_total_msg_size {
                 break;
             }
-
+            let physical_offset = message.physical_offset();
             result.add_message(
                 SelectMappedBufferResult {
-                    start_offset: 0,
-                    bytes: Some(message.payload.clone()),
+                    start_offset: physical_offset.max(0) as u64,
+                    bytes: Some(payload),
                     size: payload_size,
                     mapped_file: None,
                     is_in_cache: true,
                     source_kind: SelectMappedBufferSourceKind::Bytes,
-                    file_offset: 0,
+                    file_offset: physical_offset.max(0) as u64,
                     cache_state: SelectMappedBufferCacheState::Unknown,
                 },
                 queue_offset as u64,
                 message.batch_num,
             );
-            next_begin_offset = message.queue_offset + message.batch_num as i64;
+            next_begin_offset = message.queue_offset + i64::from(message.batch_num);
         }
-
         if result.message_count() == 0 {
             return Some(status_result(
                 GetMessageStatus::NoMatchedMessage,
@@ -254,7 +640,6 @@ impl CompactionStore {
                 max_offset,
             ));
         }
-
         result.set_status(Some(GetMessageStatus::Found));
         result.set_next_begin_offset(next_begin_offset);
         result.set_min_offset(min_offset);
@@ -262,12 +647,198 @@ impl CompactionStore {
         Some(result)
     }
 
-    pub fn message_count(&self, topic: &CheetahString, queue_id: i32) -> usize {
-        self.queues
-            .get(&CompactionQueueKey::new(topic, queue_id))
-            .map(|queue| queue.len())
-            .unwrap_or_default()
+    async fn resolve_payload(&self, message: &CompactionRecord) -> Result<Option<Bytes>, RocketMQError> {
+        match &message.payload {
+            CompactionPayload::Inline(payload) => Ok(Some(payload.clone())),
+            CompactionPayload::CommitLog => Ok(self
+                .payload_resolver
+                .read()
+                .as_ref()
+                .and_then(|resolver| resolver(message.source_physical_offset, message.source_size))),
+            CompactionPayload::Generation {
+                generation,
+                position,
+                size,
+            } => {
+                let Some(root) = self.root.clone() else {
+                    return Ok(None);
+                };
+                compaction_generation::read_generation_payload(root, *generation, *position, *size)
+                    .await
+                    .map(Some)
+            }
+        }
     }
+
+    pub fn message_count(&self, topic: &CheetahString, queue_id: i32) -> usize {
+        let state = self.state.read();
+        let key = CompactionQueueKey::new(topic, queue_id);
+        let mut queue = state.current.queues.get(&key).cloned().unwrap_or_default();
+        if let Some(delta) = state.delta.get(&key) {
+            queue.extend(delta.clone());
+        }
+        compact_queue(queue).len()
+    }
+
+    pub(crate) fn current_generation_id(&self) -> u64 {
+        self.state.read().current.metadata.generation
+    }
+
+    fn generation_from_loaded(loaded: compaction_generation::LoadedGeneration) -> Arc<CompactionGeneration> {
+        Arc::new(CompactionGeneration {
+            metadata: loaded.metadata,
+            queues: loaded.queues,
+        })
+    }
+
+    fn root_display(&self) -> String {
+        self.root
+            .as_ref()
+            .map(|root| root.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "memory-compaction".to_owned())
+    }
+
+    #[cfg(test)]
+    fn set_fault(&self, stage: FaultStage) {
+        self.fault_stage
+            .store(stage as u8, std::sync::atomic::Ordering::Release);
+    }
+
+    #[cfg(test)]
+    fn current_lease(&self) -> Arc<CompactionGeneration> {
+        self.state.read().current.clone()
+    }
+
+    #[cfg(test)]
+    fn fail_if(&self, stage: FaultStage) -> Result<(), RocketMQError> {
+        if self
+            .fault_stage
+            .compare_exchange(
+                stage as u8,
+                0,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            return Err(RocketMQError::storage_write_failed(
+                self.root_display(),
+                format!("injected compaction {stage:?} failure"),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn fail_if(&self, _stage: FaultStage) -> Result<(), RocketMQError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+enum FaultStage {
+    Build = 1,
+    Sync = 2,
+    Rename = 3,
+    Current = 4,
+    Cleanup = 5,
+}
+
+fn merged_queues(current: &CompactionQueues, delta: &CompactionQueues) -> CompactionQueues {
+    let mut merged = current.clone();
+    for (key, queue) in delta {
+        merged.entry(key.clone()).or_default().extend(queue.clone());
+    }
+    merged
+}
+
+fn compact_queues(mut queues: CompactionQueues) -> CompactionQueues {
+    queues.retain(|_, queue| {
+        *queue = compact_queue(std::mem::take(queue));
+        !queue.is_empty()
+    });
+    queues
+}
+
+fn compact_queue(mut queue: BTreeMap<i64, CompactionRecord>) -> BTreeMap<i64, CompactionRecord> {
+    let mut latest = HashMap::<CheetahString, (i64, i64)>::new();
+    for (&queue_offset, record) in &queue {
+        let Some(key) = record.key.as_ref() else {
+            continue;
+        };
+        let candidate = (record.physical_offset(), queue_offset);
+        latest
+            .entry(key.clone())
+            .and_modify(|current| *current = (*current).max(candidate))
+            .or_insert(candidate);
+    }
+    queue.retain(|queue_offset, record| {
+        record.key.as_ref().is_none_or(|key| {
+            latest
+                .get(key)
+                .is_some_and(|latest| *latest == (record.physical_offset(), *queue_offset))
+        })
+    });
+    queue
+}
+
+fn merged_count(queues: &CompactionQueues) -> usize {
+    queues.values().map(BTreeMap::len).sum()
+}
+
+fn remove_snapshot_from_delta(delta: &mut CompactionQueues, snapshot: &CompactionQueues) {
+    delta.retain(|queue_key, queue| {
+        if let Some(included) = snapshot.get(queue_key) {
+            queue.retain(|offset, record| {
+                !included
+                    .get(offset)
+                    .is_some_and(|included| same_record_identity(record, included))
+            });
+        }
+        !queue.is_empty()
+    });
+}
+
+fn same_record_identity(left: &CompactionRecord, right: &CompactionRecord) -> bool {
+    left.queue_offset == right.queue_offset
+        && left.batch_num == right.batch_num
+        && left.key == right.key
+        && left.physical_offset() == right.physical_offset()
+        && left.end_physical_offset() == right.end_physical_offset()
+}
+
+fn metadata_for_memory(generation: u64, queues: &CompactionQueues) -> GenerationMetadata {
+    let mut metadata = compaction_generation::empty_metadata(generation);
+    metadata.record_count = merged_count(queues) as u64;
+    if metadata.record_count == 0 {
+        return metadata;
+    }
+    metadata.min_queue_offset = queues
+        .values()
+        .flat_map(BTreeMap::values)
+        .map(|record| record.queue_offset)
+        .min()
+        .unwrap_or_default();
+    metadata.max_queue_offset = queues
+        .values()
+        .flat_map(BTreeMap::values)
+        .map(|record| record.queue_offset)
+        .max()
+        .unwrap_or_default();
+    metadata.min_physical_offset = queues
+        .values()
+        .flat_map(BTreeMap::values)
+        .map(CompactionRecord::physical_offset)
+        .min()
+        .unwrap_or_default();
+    metadata.max_physical_offset = queues
+        .values()
+        .flat_map(BTreeMap::values)
+        .map(CompactionRecord::end_physical_offset)
+        .max()
+        .unwrap_or_default();
+    metadata
 }
 
 fn status_result(
@@ -286,38 +857,42 @@ fn status_result(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use bytes::Bytes;
     use cheetah_string::CheetahString;
+    use parking_lot::RwLock;
 
+    use super::CompactionReadState;
     use super::CompactionStore;
+    use super::FaultStage;
     use crate::base::message_status_enum::GetMessageStatus;
+    use crate::kv::compaction_generation;
 
-    #[test]
-    fn get_message_returns_java_style_status_for_missing_queue() {
+    #[tokio::test]
+    async fn get_message_returns_java_style_status_for_missing_queue() {
         let store = CompactionStore::new();
         let topic = CheetahString::from_static_str("compaction-missing-topic");
         let group = CheetahString::from_static_str("compaction-missing-group");
-
         let result = store
             .get_message(&group, &topic, 0, 0, 32, 1024)
+            .await
             .expect("compaction store should return a status result");
-
         assert_eq!(result.status(), Some(GetMessageStatus::NoMatchedLogicQueue));
         assert_eq!(result.message_count(), 0);
     }
 
-    #[test]
-    fn put_and_get_message_round_trips_in_compaction_store() {
+    #[tokio::test]
+    async fn put_and_get_message_round_trips_in_compaction_store() {
         let store = CompactionStore::new();
         let topic = CheetahString::from_static_str("compaction-topic");
         let group = CheetahString::from_static_str("compaction-group");
-
         store.put_message(&topic, 0, 7, 1, Bytes::from_static(b"compacted-message"));
-
         let result = store
             .get_message(&group, &topic, 0, 7, 32, 1024)
+            .await
             .expect("compaction result");
-
         assert_eq!(result.status(), Some(GetMessageStatus::Found));
         assert_eq!(result.message_count(), 1);
         assert_eq!(result.next_begin_offset(), 8);
@@ -327,32 +902,216 @@ mod tests {
         );
     }
 
-    #[test]
-    fn compact_once_keeps_latest_message_for_same_key() {
+    #[tokio::test]
+    async fn compact_once_keeps_latest_physical_offset_for_same_key() {
         let store = CompactionStore::new();
         let topic = CheetahString::from_static_str("compaction-topic");
         let group = CheetahString::from_static_str("compaction-group");
         let key = CheetahString::from_static_str("same-key");
-
         store.put_message_with_key(&topic, 0, 0, 1, Some(key.clone()), Bytes::from_static(b"old-message"));
         store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"latest-message"));
-
-        assert_eq!(store.message_count(&topic, 0), 2);
-        assert_eq!(store.compact_once(), 1);
         assert_eq!(store.message_count(&topic, 0), 1);
-
-        let old_result = store
-            .get_message(&group, &topic, 0, 0, 32, 1024)
-            .expect("old offset should return a boundary status");
-        assert_eq!(old_result.status(), Some(GetMessageStatus::OffsetTooSmall));
-
+        assert_eq!(store.compact_once().await.unwrap(), 1);
+        assert_eq!(store.current_generation_id(), 1);
         let latest_result = store
             .get_message(&group, &topic, 0, 1, 32, 1024)
+            .await
             .expect("latest result");
         assert_eq!(latest_result.status(), Some(GetMessageStatus::Found));
         assert_eq!(
             latest_result.message_mapped_list()[0].get_bytes_ref().unwrap(),
             &Bytes::from_static(b"latest-message")
         );
+    }
+
+    #[tokio::test]
+    async fn recovering_state_fails_closed_without_raw_commit_log_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = CompactionStore::with_root(temp.path().join("compaction"));
+        store.begin_recovery(100);
+        let topic = CheetahString::from_static_str("topic");
+        let group = CheetahString::from_static_str("group");
+        let result = store.get_message(&group, &topic, 0, 0, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::MessageWasRemoving));
+        assert!(matches!(store.read_state(), CompactionReadState::Recovering { .. }));
+    }
+
+    #[tokio::test]
+    async fn generation_kill_points_recover_and_never_reexpose_stale_key() {
+        for stage in [
+            FaultStage::Build,
+            FaultStage::Sync,
+            FaultStage::Rename,
+            FaultStage::Current,
+            FaultStage::Cleanup,
+        ] {
+            run_kill_point(stage).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_current_rolls_back_only_to_validated_previous_and_stays_recovering() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("compaction-corrupt-current");
+        let topic = CheetahString::from_static_str("topic");
+        let group = CheetahString::from_static_str("group");
+        let key = CheetahString::from_static_str("key");
+        let payloads = Arc::new(RwLock::new(HashMap::from([
+            (10_i64, Bytes::from_static(b"old")),
+            (20_i64, Bytes::from_static(b"new")),
+        ])));
+
+        let store = CompactionStore::with_root(root.clone());
+        install_resolver(&store, payloads.clone());
+        store.load().await.unwrap();
+        store.finish_recovery(0);
+        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3);
+        store.compact_once().await.unwrap();
+        assert_eq!(store.durable_dispatch_offset(0), 13);
+        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3);
+        store.compact_once().await.unwrap();
+        assert_eq!(store.current_generation_id(), 2);
+        drop(store);
+
+        std::fs::write(
+            compaction_generation::generation_path(&root, 2).join("records"),
+            b"corrupt",
+        )
+        .unwrap();
+        let restarted = CompactionStore::with_root(root);
+        install_resolver(&restarted, payloads);
+        restarted.load().await.unwrap();
+        assert_eq!(restarted.current_generation_id(), 1);
+        assert!(matches!(restarted.read_state(), CompactionReadState::Recovering { .. }));
+        assert_eq!(
+            restarted
+                .get_message(&group, &topic, 0, 0, 32, 1024)
+                .await
+                .unwrap()
+                .status(),
+            Some(GetMessageStatus::MessageWasRemoving)
+        );
+
+        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3);
+        restarted.finish_recovery(23);
+        assert_eq!(
+            restarted
+                .get_message(&group, &topic, 0, 0, 32, 1024)
+                .await
+                .unwrap()
+                .status(),
+            Some(GetMessageStatus::OffsetTooSmall)
+        );
+    }
+
+    #[tokio::test]
+    async fn published_generation_reads_without_commit_log_payload() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("compaction-independent-generation");
+        let topic = CheetahString::from_static_str("topic");
+        let group = CheetahString::from_static_str("group");
+        let payloads = Arc::new(RwLock::new(HashMap::from([(10_i64, Bytes::from_static(b"live"))])));
+
+        let store = CompactionStore::with_root(root.clone());
+        install_resolver(&store, payloads.clone());
+        store.load().await.unwrap();
+        store.finish_recovery(0);
+        store.put_reference(&topic, 0, 0, 1, None, 10, 4);
+        store.compact_once().await.unwrap();
+        payloads.write().clear();
+
+        let result = store.get_message(&group, &topic, 0, 0, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(
+            result.message_mapped_list()[0].get_bytes_ref().unwrap(),
+            &Bytes::from_static(b"live")
+        );
+        drop(store);
+
+        let restarted = CompactionStore::with_root(root);
+        restarted.load().await.unwrap();
+        restarted.finish_recovery(14);
+        let result = restarted.get_message(&group, &topic, 0, 0, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(
+            result.message_mapped_list()[0].get_bytes_ref().unwrap(),
+            &Bytes::from_static(b"live")
+        );
+    }
+
+    async fn run_kill_point(stage: FaultStage) {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join(format!("compaction-{stage:?}"));
+        let topic = CheetahString::from_static_str("topic");
+        let group = CheetahString::from_static_str("group");
+        let key = CheetahString::from_static_str("key");
+        let payloads = Arc::new(RwLock::new(HashMap::from([
+            (10_i64, Bytes::from_static(b"old")),
+            (20_i64, Bytes::from_static(b"new")),
+        ])));
+
+        let store = CompactionStore::with_root(root.clone());
+        install_resolver(&store, payloads.clone());
+        store.load().await.unwrap();
+        store.finish_recovery(0);
+        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3);
+        store.compact_once().await.unwrap();
+        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3);
+        store.set_fault(stage);
+        assert!(store.compact_once().await.is_err());
+        let expected_generation = if matches!(stage, FaultStage::Cleanup) { 2 } else { 1 };
+        assert_eq!(store.current_generation_id(), expected_generation);
+        drop(store);
+
+        let restarted = CompactionStore::with_root(root);
+        install_resolver(&restarted, payloads);
+        restarted.load().await.unwrap();
+        assert!(matches!(restarted.read_state(), CompactionReadState::Recovering { .. }));
+        let recovering = restarted.get_message(&group, &topic, 0, 0, 32, 1024).await.unwrap();
+        assert_eq!(recovering.status(), Some(GetMessageStatus::MessageWasRemoving));
+
+        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3);
+        restarted.finish_recovery(23);
+        let result = restarted.get_message(&group, &topic, 0, 0, 32, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::OffsetTooSmall));
+        let latest = restarted.get_message(&group, &topic, 0, 1, 32, 1024).await.unwrap();
+        assert_eq!(latest.status(), Some(GetMessageStatus::Found));
+        assert_eq!(
+            latest.message_mapped_list()[0].get_bytes_ref().unwrap(),
+            &Bytes::from_static(b"new")
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_lease_delays_retired_generation_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("compaction");
+        let topic = CheetahString::from_static_str("topic");
+        let store = CompactionStore::with_root(root.clone());
+        install_resolver(
+            &store,
+            Arc::new(RwLock::new(HashMap::from([
+                (10_i64, Bytes::from_static(b"one")),
+                (20_i64, Bytes::from_static(b"two")),
+                (30_i64, Bytes::from_static(b"three")),
+            ]))),
+        );
+        store.load().await.unwrap();
+        store.finish_recovery(0);
+        store.put_reference(&topic, 0, 0, 1, None, 10, 3);
+        store.compact_once().await.unwrap();
+        let generation_one_lease = store.current_lease();
+        store.put_reference(&topic, 0, 1, 1, None, 20, 3);
+        store.compact_once().await.unwrap();
+        store.put_reference(&topic, 0, 2, 1, None, 30, 5);
+        store.compact_once().await.unwrap();
+        assert!(compaction_generation::generation_path(&root, 1).exists());
+        drop(generation_one_lease);
+        store.compact_once().await.unwrap();
+        assert!(!compaction_generation::generation_path(&root, 1).exists());
+    }
+
+    fn install_resolver(store: &CompactionStore, payloads: Arc<RwLock<HashMap<i64, Bytes>>>) {
+        store.set_payload_resolver(move |offset, _size| payloads.read().get(&offset).cloned());
     }
 }

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -996,7 +996,8 @@ pub mod bench_support {
         compaction_store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"latest-message"));
 
         let mut service = CompactionService::new(compaction_store.clone(), 1);
-        let _ = service.load(true);
+        let _ = service.load(true, 0).await;
+        compaction_store.finish_recovery(0);
         service.start();
 
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -480,15 +480,22 @@ impl LocalFileMessageStore {
         );
         commit_log.set_store_health_recorder(store_health_recorder.clone());
         let commit_log = ArcMut::new(commit_log);
-        let compaction_store = Arc::new(CompactionStore::new());
+        let compaction_store = Arc::new(CompactionStore::with_root(
+            PathBuf::from(message_store_config.store_path_root_dir.as_str()).join("compaction"),
+        ));
         if message_store_config.enable_compaction {
             dispatcher.add_dispatcher(Arc::new(CommitLogDispatcherCompaction::new(
                 compaction_store.clone(),
-                commit_log.clone(),
                 message_store_config.clone(),
                 topic_config_table.clone(),
             )));
         }
+        let compaction_commit_log = commit_log.clone();
+        compaction_store.set_payload_resolver(move |physical_offset, size| {
+            compaction_commit_log
+                .get_message(physical_offset, size)
+                .and_then(|result| result.get_bytes())
+        });
         #[cfg(feature = "tieredstore")]
         let tiered_store = Self::build_tiered_store(message_store_config.clone(), commit_log.clone(), &mut dispatcher)?;
         #[cfg(feature = "tieredstore")]
@@ -1642,11 +1649,12 @@ impl MessageStore for LocalFileMessageStore {
         result &= self.consume_queue_store.load();
 
         if self.message_store_config.enable_compaction {
+            let required_wal_position = self.commit_log.get_max_offset();
             let Some(compaction_service) = self.compaction_service.as_mut() else {
                 error!("compaction is enabled but compaction service is not initialized");
                 return false;
             };
-            result &= compaction_service.load(last_exit_ok);
+            result &= compaction_service.load(last_exit_ok, required_wal_position).await;
             if !result {
                 return result;
             }
@@ -1672,6 +1680,9 @@ impl MessageStore for LocalFileMessageStore {
 
             //recover commit log and consume queue
             self.recover(last_exit_ok).await;
+            if self.message_store_config.enable_compaction {
+                self.compaction_store.finish_recovery(self.get_max_phy_offset());
+            }
             info!(
                 "message store recover end, and the max phy offset = {}",
                 self.get_max_phy_offset()
@@ -2110,9 +2121,10 @@ impl MessageStore for LocalFileMessageStore {
         let topic_config = self.get_topic_config(topic);
         let policy = get_delete_policy_arc_mut(topic_config.as_ref());
         if policy == CleanupPolicy::COMPACTION && self.message_store_config.enable_compaction {
-            if let Some(result) =
-                self.compaction_store
-                    .get_message(group, topic, queue_id, offset, max_msg_nums, max_total_msg_size)
+            if let Some(result) = self
+                .compaction_store
+                .get_message(group, topic, queue_id, offset, max_msg_nums, max_total_msg_size)
+                .await
             {
                 return Some(result);
             }

--- a/rocketmq-tieredstore/Cargo.toml
+++ b/rocketmq-tieredstore/Cargo.toml
@@ -56,6 +56,9 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 trait-variant = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile  = "3.27.0"

--- a/rocketmq-tieredstore/src/file.rs
+++ b/rocketmq-tieredstore/src/file.rs
@@ -18,6 +18,7 @@ pub mod file_segment;
 pub mod flat_file;
 pub mod flat_file_store;
 pub mod index_file_segment;
+pub(crate) mod index_generation;
 
 pub use commit_log_segment::CommitLogSegment;
 pub use consume_queue_segment::ConsumeQueueSegment;

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -199,7 +199,11 @@ where
 
     async fn compact_index_file(&self, retain_from_timestamp_millis: i64) -> Result<(), RocketMQError> {
         let mut entries = self.index_entries_for_compaction().await?;
+        let original_len = entries.len();
         entries.retain(|entry| entry.store_timestamp >= retain_from_timestamp_millis);
+        if entries.len() == original_len {
+            return Ok(());
+        }
         self.index_file.compact_entries(&entries).await
     }
 

--- a/rocketmq-tieredstore/src/file/index_file_segment.rs
+++ b/rocketmq-tieredstore/src/file/index_file_segment.rs
@@ -12,13 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
+use rocketmq_error::ErrorKind;
 use rocketmq_error::RocketMQError;
 
 use crate::error;
+use crate::file::index_generation::crc32;
+use crate::file::index_generation::encode_generation_metadata;
+use crate::file::index_generation::IndexGenerationLease;
+use crate::file::index_generation::IndexGenerationManager;
+use crate::file::index_generation::IndexGenerationMetadata;
 use crate::provider::TieredStoreProvider;
 
 pub const DEFAULT_INDEX_FILE_PATH: &str = "index/tiered_index_file";
@@ -58,6 +66,10 @@ where
     provider: P,
     hash_slot_count: usize,
     max_index_items: usize,
+    generation_manager: Arc<IndexGenerationManager<P>>,
+    generation_lock: Arc<tokio::sync::RwLock<()>>,
+    validated_generation: Arc<parking_lot::RwLock<Option<u64>>>,
+    raw: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -105,11 +117,16 @@ where
     }
 
     pub fn with_limits(directory: String, provider: P, hash_slot_count: usize, max_index_items: usize) -> Self {
+        let generation_manager = Arc::new(IndexGenerationManager::new(directory.clone(), provider.clone()));
         Self {
             directory,
             provider,
             hash_slot_count: hash_slot_count.max(1),
             max_index_items: max_index_items.max(1),
+            generation_manager,
+            generation_lock: Arc::new(tokio::sync::RwLock::new(())),
+            validated_generation: Arc::new(parking_lot::RwLock::new(None)),
+            raw: false,
         }
     }
 
@@ -146,6 +163,20 @@ where
     }
 
     pub async fn append_entry(&self, entry: &TieredIndexEntry) -> Result<(), RocketMQError> {
+        if self.raw {
+            return self.append_entry_raw(entry).await;
+        }
+        let _guard = self.generation_lock.write().await;
+        let current = self.validated_current().await?;
+        let target = if current.id() == 0 {
+            self.raw_segment(current.path().to_owned())
+        } else {
+            self.raw_segment(self.delta_path())
+        };
+        target.append_entry_raw(entry).await
+    }
+
+    async fn append_entry_raw(&self, entry: &TieredIndexEntry) -> Result<(), RocketMQError> {
         let mut segment_timestamps = self.load_manifest().await?;
         if segment_timestamps.is_empty() {
             let timestamp = entry.store_timestamp.max(0);
@@ -175,6 +206,22 @@ where
     }
 
     pub async fn load_entries(&self) -> Result<Vec<TieredIndexEntry>, RocketMQError> {
+        if self.raw {
+            return self.load_entries_raw().await;
+        }
+        let _guard = self.generation_lock.read().await;
+        let current = self.validated_current().await?;
+        let mut entries = self.raw_segment(current.path().to_owned()).load_entries_raw().await?;
+        if current.id() > 0 {
+            entries.extend(self.raw_segment(self.delta_path()).load_entries_raw().await?);
+        }
+        normalize_entries(&mut entries);
+        drop(current);
+        self.generation_manager.cleanup_retired().await?;
+        Ok(entries)
+    }
+
+    async fn load_entries_raw(&self) -> Result<Vec<TieredIndexEntry>, RocketMQError> {
         let mut entries = Vec::new();
         for timestamp in self.load_manifest().await? {
             let path = self.segment_path(timestamp);
@@ -191,6 +238,43 @@ where
     }
 
     pub async fn query_entries(
+        &self,
+        topic: &str,
+        key: &str,
+        max_count: usize,
+        begin_time: i64,
+        end_time: i64,
+    ) -> Result<Vec<TieredIndexEntry>, RocketMQError> {
+        if self.raw {
+            return self
+                .query_entries_raw(topic, key, max_count, begin_time, end_time)
+                .await;
+        }
+        if max_count == 0 || topic.is_empty() || key.is_empty() || begin_time > end_time {
+            return Ok(Vec::new());
+        }
+
+        let _guard = self.generation_lock.read().await;
+        let current = self.validated_current().await?;
+        let mut result = self
+            .raw_segment(current.path().to_owned())
+            .query_entries_raw(topic, key, max_count, begin_time, end_time)
+            .await?;
+        if current.id() > 0 && result.len() < max_count {
+            result.extend(
+                self.raw_segment(self.delta_path())
+                    .query_entries_raw(topic, key, max_count - result.len(), begin_time, end_time)
+                    .await?,
+            );
+        }
+        normalize_entries(&mut result);
+        result.truncate(max_count);
+        drop(current);
+        self.generation_manager.cleanup_retired().await?;
+        Ok(result)
+    }
+
+    async fn query_entries_raw(
         &self,
         topic: &str,
         key: &str,
@@ -239,23 +323,77 @@ where
     }
 
     pub async fn compact_entries(&self, entries: &[TieredIndexEntry]) -> Result<(), RocketMQError> {
+        if self.raw {
+            return self.replace_entries_raw(entries).await;
+        }
+        let _guard = self.generation_lock.write().await;
+        let _current = self.validated_current().await?;
+        let generation = self.generation_manager.next_generation().await?;
+        let temporary_path = self.generation_manager.temporary_path(generation);
+        let generation_path = self.generation_manager.generation_path(generation);
+        self.provider.delete_prefix(temporary_path.clone()).await?;
+
+        let builder = self.raw_segment(temporary_path.clone());
+        let mut normalized = entries.to_vec();
+        normalize_entries(&mut normalized);
+        for entry in &normalized {
+            builder.append_entry_raw(entry).await?;
+        }
+        // The legacy index format stores timestamps as second deltas from the segment boundary.
+        // Derive generation bounds and CRC from the persisted representation so validation does
+        // not compare sub-second source timestamps with their compatible on-disk projection.
+        let persisted_entries = builder.load_entries_raw().await?;
+        let metadata = generation_metadata(generation, &persisted_entries);
+        let metadata_path = self.generation_manager.metadata_path(&temporary_path);
+        let encoded_metadata = encode_generation_metadata(metadata);
+        let written = self
+            .provider_write(metadata_path.clone(), 0, encoded_metadata.clone())
+            .await?;
+        if written != encoded_metadata.len() {
+            return Err(error::storage_write_failed(
+                metadata_path,
+                "partial index generation metadata write",
+            ));
+        }
+        self.sync_generation(&temporary_path).await?;
+        self.validate_generation_path(&temporary_path, metadata).await?;
+
+        self.provider.rename(temporary_path, generation_path).await?;
+        self.generation_manager.publish(metadata).await?;
+        *self.validated_generation.write() = Some(generation);
+        self.provider.delete_prefix(self.delta_path()).await?;
+        self.generation_manager.cleanup_retired().await
+    }
+
+    pub async fn segment_count(&self) -> Result<usize, RocketMQError> {
+        if self.raw {
+            return self.segment_count_raw().await;
+        }
+        let _guard = self.generation_lock.read().await;
+        let current = self.validated_current().await?;
+        let mut count = self.raw_segment(current.path().to_owned()).segment_count_raw().await?;
+        if current.id() > 0 {
+            count = count.saturating_add(self.raw_segment(self.delta_path()).segment_count_raw().await?);
+        }
+        Ok(count)
+    }
+
+    async fn segment_count_raw(&self) -> Result<usize, RocketMQError> {
+        Ok(self.load_manifest().await?.len())
+    }
+
+    async fn replace_entries_raw(&self, entries: &[TieredIndexEntry]) -> Result<(), RocketMQError> {
         let old_segments = self.load_manifest().await?;
         for timestamp in old_segments {
             self.provider.delete(self.segment_path(timestamp)).await?;
         }
         self.provider.delete(self.manifest_path()).await?;
-
         let mut sorted = entries.to_vec();
-        sorted.sort_by_key(|entry| (entry.store_timestamp, entry.queue_id, entry.queue_offset));
-        sorted.dedup();
+        normalize_entries(&mut sorted);
         for entry in sorted {
-            self.append_entry(&entry).await?;
+            self.append_entry_raw(&entry).await?;
         }
         Ok(())
-    }
-
-    pub async fn segment_count(&self) -> Result<usize, RocketMQError> {
-        Ok(self.load_manifest().await?.len())
     }
 
     async fn try_append_to_segment(
@@ -408,8 +546,7 @@ where
             return Ok(Vec::new());
         }
         let bytes = self.provider_read(path.clone(), 0, size as usize).await?;
-        let text =
-            std::str::from_utf8(&bytes).map_err(|err| error::storage_read_failed(path.clone(), err.to_string()))?;
+        let text = std::str::from_utf8(&bytes).map_err(|_| error::storage_corrupted(path.clone()))?;
         let mut timestamps = Vec::new();
         for line in text.lines() {
             if line.trim().is_empty() {
@@ -418,7 +555,7 @@ where
             let timestamp = line
                 .trim()
                 .parse::<i64>()
-                .map_err(|err| error::storage_read_failed(path.clone(), err.to_string()))?;
+                .map_err(|_| error::storage_corrupted(path.clone()))?;
             timestamps.push(timestamp);
         }
         timestamps.sort_unstable();
@@ -440,12 +577,161 @@ where
         Ok(())
     }
 
+    /// Atomically selects the previously validated generation.
+    ///
+    /// The current delta remains readable so records appended after the previous generation are not
+    /// lost.
+    pub async fn rollback_to_previous_generation(&self) -> Result<bool, RocketMQError> {
+        if self.raw {
+            return Ok(false);
+        }
+        let _guard = self.generation_lock.write().await;
+        let Some(previous) = self.generation_manager.previous().await? else {
+            return Ok(false);
+        };
+        self.validate_generation_lease(&previous).await?;
+        if !self.generation_manager.rollback_to_previous().await? {
+            return Ok(false);
+        }
+        *self.validated_generation.write() = Some(previous.id());
+        Ok(true)
+    }
+
+    pub async fn current_generation_id(&self) -> Result<u64, RocketMQError> {
+        Ok(self.generation_manager.current().await?.id())
+    }
+
+    async fn validated_current(&self) -> Result<IndexGenerationLease, RocketMQError> {
+        let current = self.generation_manager.current().await?;
+        if *self.validated_generation.read() == Some(current.id()) {
+            return Ok(current);
+        }
+        match self.validate_generation_lease(&current).await {
+            Ok(()) => {
+                *self.validated_generation.write() = Some(current.id());
+                Ok(current)
+            }
+            Err(current_error) => {
+                if current_error.kind() != ErrorKind::StorageCorrupted {
+                    return Err(current_error);
+                }
+                let Some(previous) = self.generation_manager.previous().await? else {
+                    return Err(current_error);
+                };
+                self.validate_generation_lease(&previous).await?;
+                if !self.generation_manager.rollback_to_validated_previous().await? {
+                    return Err(current_error);
+                }
+                *self.validated_generation.write() = Some(previous.id());
+                Ok(previous)
+            }
+        }
+    }
+
+    async fn validate_generation_lease(&self, generation: &IndexGenerationLease) -> Result<(), RocketMQError> {
+        let Some(metadata) = generation.metadata() else {
+            self.raw_segment(generation.path().to_owned())
+                .load_entries_raw()
+                .await?;
+            return Ok(());
+        };
+        self.validate_generation_path(generation.path(), metadata).await
+    }
+
+    async fn validate_generation_path(
+        &self,
+        generation_path: &str,
+        expected: IndexGenerationMetadata,
+    ) -> Result<(), RocketMQError> {
+        let entries = self.raw_segment(generation_path.to_owned()).load_entries_raw().await?;
+        let actual = generation_metadata(expected.generation, &entries);
+        if actual != expected {
+            return Err(error::storage_corrupted(
+                self.generation_manager.metadata_path(generation_path),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn sync_generation(&self, generation_path: &str) -> Result<(), RocketMQError> {
+        for path in self.provider.list(generation_path.to_owned()).await? {
+            self.provider.sync(path).await?;
+        }
+        self.provider.sync(generation_path.to_owned()).await
+    }
+
+    fn raw_segment(&self, directory: String) -> Self {
+        Self {
+            generation_manager: Arc::new(IndexGenerationManager::new(directory.clone(), self.provider.clone())),
+            directory,
+            provider: self.provider.clone(),
+            hash_slot_count: self.hash_slot_count,
+            max_index_items: self.max_index_items,
+            generation_lock: Arc::new(tokio::sync::RwLock::new(())),
+            validated_generation: Arc::new(parking_lot::RwLock::new(None)),
+            raw: true,
+        }
+    }
+
+    fn delta_path(&self) -> String {
+        format!("{}/delta", self.directory)
+    }
+
     fn manifest_path(&self) -> String {
         format!("{}/manifest", self.directory)
     }
 
     fn segment_path(&self, timestamp: i64) -> String {
         format!("{}/{timestamp}", self.directory)
+    }
+}
+
+fn normalize_entries(entries: &mut Vec<TieredIndexEntry>) {
+    entries.sort_by(|left, right| {
+        left.topic
+            .cmp(&right.topic)
+            .then(left.key.cmp(&right.key))
+            .then(left.store_timestamp.cmp(&right.store_timestamp))
+            .then(left.queue_id.cmp(&right.queue_id))
+            .then(left.queue_offset.cmp(&right.queue_offset))
+            .then(left.commit_log_offset.cmp(&right.commit_log_offset))
+            .then(left.message_size.cmp(&right.message_size))
+    });
+    entries.dedup();
+}
+
+fn generation_metadata(generation: u64, entries: &[TieredIndexEntry]) -> IndexGenerationMetadata {
+    if entries.is_empty() {
+        return IndexGenerationMetadata::empty(generation);
+    }
+    let mut canonical = BytesMut::new();
+    let mut min_timestamp = i64::MAX;
+    let mut max_timestamp = i64::MIN;
+    let mut min_commit_log_offset = u64::MAX;
+    let mut max_commit_log_offset = 0_u64;
+    for entry in entries {
+        canonical.put_u16(entry.topic.len() as u16);
+        canonical.put_slice(entry.topic.as_bytes());
+        canonical.put_u16(entry.key.len() as u16);
+        canonical.put_slice(entry.key.as_bytes());
+        canonical.put_i32(entry.queue_id);
+        canonical.put_i64(entry.queue_offset);
+        canonical.put_u64(entry.commit_log_offset);
+        canonical.put_u64(entry.message_size as u64);
+        canonical.put_i64(entry.store_timestamp);
+        min_timestamp = min_timestamp.min(entry.store_timestamp);
+        max_timestamp = max_timestamp.max(entry.store_timestamp);
+        min_commit_log_offset = min_commit_log_offset.min(entry.commit_log_offset);
+        max_commit_log_offset = max_commit_log_offset.max(entry.commit_log_offset);
+    }
+    IndexGenerationMetadata {
+        generation,
+        entry_count: entries.len() as u64,
+        min_timestamp,
+        max_timestamp,
+        min_commit_log_offset,
+        max_commit_log_offset,
+        content_crc: crc32(&canonical),
     }
 }
 
@@ -464,18 +750,12 @@ fn encode_header(header: &IndexSegmentHeader) -> Bytes {
 
 fn decode_header(bytes: &Bytes) -> Result<IndexSegmentHeader, RocketMQError> {
     if bytes.len() < HEADER_SIZE {
-        return Err(error::storage_read_failed(
-            DEFAULT_INDEX_FILE_PATH,
-            "tiered index segment header is incomplete",
-        ));
+        return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
     }
     let mut bytes = bytes.clone();
     let magic = bytes.get_u32();
     if magic != BEGIN_MAGIC_CODE {
-        return Err(error::storage_read_failed(
-            DEFAULT_INDEX_FILE_PATH,
-            "tiered index segment magic code mismatch",
-        ));
+        return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
     }
     let begin_timestamp = bytes.get_i64();
     let end_timestamp = bytes.get_i64();
@@ -529,20 +809,14 @@ fn decode_segment_entries(bytes: &Bytes) -> Result<Vec<IndexRecord>, RocketMQErr
     let mut records = Vec::with_capacity(header.item_count as usize);
     while records.len() < header.item_count as usize && position < bytes.len() {
         if bytes.len().saturating_sub(position) < ITEM_HEADER_SIZE {
-            return Err(error::storage_read_failed(
-                DEFAULT_INDEX_FILE_PATH,
-                "tiered index item header is incomplete",
-            ));
+            return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
         }
         let decoded_header = decode_record_header(&bytes.slice(position..position + ITEM_HEADER_SIZE))?;
         position += ITEM_HEADER_SIZE;
 
         let string_len = decoded_header.topic_len.saturating_add(decoded_header.key_len);
         if bytes.len().saturating_sub(position) < string_len {
-            return Err(error::storage_read_failed(
-                DEFAULT_INDEX_FILE_PATH,
-                "tiered index item key payload is incomplete",
-            ));
+            return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
         }
         let payload = bytes.slice(position..position + string_len);
         position += string_len;
@@ -553,10 +827,7 @@ fn decode_segment_entries(bytes: &Bytes) -> Result<Vec<IndexRecord>, RocketMQErr
 
 fn decode_record_header(bytes: &Bytes) -> Result<IndexRecordHeader, RocketMQError> {
     if bytes.len() < ITEM_HEADER_SIZE {
-        return Err(error::storage_read_failed(
-            DEFAULT_INDEX_FILE_PATH,
-            "tiered index item header is incomplete",
-        ));
+        return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
     }
     let mut bytes = bytes.clone();
     let hash_code = bytes.get_u32();
@@ -589,16 +860,13 @@ fn decode_record_payload(
 ) -> Result<IndexRecord, RocketMQError> {
     let string_len = header.topic_len.saturating_add(header.key_len);
     if payload.len() < string_len {
-        return Err(error::storage_read_failed(
-            DEFAULT_INDEX_FILE_PATH,
-            "tiered index item key payload is incomplete",
-        ));
+        return Err(error::storage_corrupted(DEFAULT_INDEX_FILE_PATH));
     }
     let topic = std::str::from_utf8(&payload[..header.topic_len])
-        .map_err(|err| error::storage_read_failed(DEFAULT_INDEX_FILE_PATH, err.to_string()))?
+        .map_err(|_| error::storage_corrupted(DEFAULT_INDEX_FILE_PATH))?
         .to_owned();
     let key = std::str::from_utf8(&payload[header.topic_len..string_len])
-        .map_err(|err| error::storage_read_failed(DEFAULT_INDEX_FILE_PATH, err.to_string()))?
+        .map_err(|_| error::storage_corrupted(DEFAULT_INDEX_FILE_PATH))?
         .to_owned();
 
     Ok(IndexRecord {
@@ -644,10 +912,136 @@ fn java_positive_hash(key: &str) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicU8;
+    use std::sync::atomic::Ordering;
+
+    use bytes::Bytes;
+    use rocketmq_error::ErrorKind;
     use rocketmq_error::RocketMQError;
 
     use super::*;
+    use crate::file::FileSegmentType;
+    use crate::file::TieredFileSegment;
+    use crate::metadata::FileSegmentMetadata;
     use crate::provider::MemoryProvider;
+
+    #[derive(Clone, Copy, Debug)]
+    #[repr(u8)]
+    enum FaultStage {
+        Build = 1,
+        Sync = 2,
+        Rename = 3,
+        Current = 4,
+        Cleanup = 5,
+        Read = 6,
+    }
+
+    #[derive(Clone)]
+    struct FaultProvider {
+        inner: MemoryProvider,
+        fault: Arc<AtomicU8>,
+    }
+
+    impl Default for FaultProvider {
+        fn default() -> Self {
+            Self {
+                inner: MemoryProvider::default(),
+                fault: Arc::new(AtomicU8::new(0)),
+            }
+        }
+    }
+
+    impl FaultProvider {
+        fn set_fault(&self, stage: FaultStage) {
+            self.fault.store(stage as u8, Ordering::Release);
+        }
+
+        fn take_fault(&self, stage: FaultStage) -> bool {
+            self.fault
+                .compare_exchange(stage as u8, 0, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        }
+
+        fn injected(path: String, stage: FaultStage) -> RocketMQError {
+            RocketMQError::storage_write_failed(path, format!("injected index {stage:?} failure"))
+        }
+    }
+
+    impl TieredStoreProvider for FaultProvider {
+        async fn create_segment(
+            &self,
+            path: String,
+            segment_type: FileSegmentType,
+            base_offset: u64,
+            max_size: u64,
+        ) -> Result<TieredFileSegment<Self>, RocketMQError> {
+            let metadata = FileSegmentMetadata::new(path.clone(), segment_type, base_offset);
+            Ok(TieredFileSegment::new(
+                path,
+                segment_type,
+                base_offset,
+                max_size,
+                metadata,
+                self.clone(),
+            ))
+        }
+
+        async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+            self.inner.segment_size(path).await
+        }
+
+        async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+            let generation_data = path.contains("/generations/gen-") && !path.ends_with("/GENERATION");
+            if generation_data && self.take_fault(FaultStage::Read) {
+                return Err(RocketMQError::storage_read_failed(path, "injected provider timeout"));
+            }
+            self.inner.read(path, position, length).await
+        }
+
+        async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+            if path.contains(".tmp/") && self.take_fault(FaultStage::Build) {
+                return Err(Self::injected(path, FaultStage::Build));
+            }
+            self.inner.write(path, position, data).await
+        }
+
+        async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+            self.inner.delete(path).await
+        }
+
+        async fn sync(&self, path: String) -> Result<(), RocketMQError> {
+            if path.contains(".tmp") && self.take_fault(FaultStage::Sync) {
+                return Err(Self::injected(path, FaultStage::Sync));
+            }
+            self.inner.sync(path).await
+        }
+
+        async fn rename(&self, source: String, destination: String) -> Result<(), RocketMQError> {
+            if source.contains(".tmp") && self.take_fault(FaultStage::Rename) {
+                return Err(Self::injected(source, FaultStage::Rename));
+            }
+            self.inner.rename(source, destination).await
+        }
+
+        async fn list(&self, prefix: String) -> Result<Vec<String>, RocketMQError> {
+            self.inner.list(prefix).await
+        }
+
+        async fn delete_prefix(&self, prefix: String) -> Result<(), RocketMQError> {
+            let retired_generation = prefix.contains("/generations/gen-") && !prefix.contains(".tmp");
+            if retired_generation && self.take_fault(FaultStage::Cleanup) {
+                return Err(Self::injected(prefix, FaultStage::Cleanup));
+            }
+            self.inner.delete_prefix(prefix).await
+        }
+
+        async fn atomic_write(&self, path: String, data: Bytes) -> Result<(), RocketMQError> {
+            if path.ends_with("/CURRENT") && self.take_fault(FaultStage::Current) {
+                return Err(Self::injected(path, FaultStage::Current));
+            }
+            self.inner.atomic_write(path, data).await
+        }
+    }
 
     fn entry(key: &str, timestamp: i64) -> TieredIndexEntry {
         TieredIndexEntry {
@@ -710,5 +1104,122 @@ mod tests {
     #[test]
     fn java_hash_matches_known_string_hash() {
         assert_eq!(java_positive_hash("TopicA#keyA"), 641_858_195);
+    }
+
+    #[tokio::test]
+    async fn index_generation_kill_points_recover_without_partial_publication() -> Result<(), RocketMQError> {
+        for stage in [
+            FaultStage::Build,
+            FaultStage::Sync,
+            FaultStage::Rename,
+            FaultStage::Current,
+        ] {
+            let provider = FaultProvider::default();
+            let index = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+            index.append_entry(&entry("old", 100)).await?;
+            compact_current(&index).await?;
+            assert_eq!(index.current_generation_id().await?, 1);
+
+            index.append_entry(&entry("new", 200)).await?;
+            let entries = index.load_entries().await?;
+            provider.set_fault(stage);
+            assert!(index.compact_entries(&entries).await.is_err());
+            drop(index);
+
+            let restarted = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+            assert_eq!(restarted.load_entries().await?.len(), 2, "stage {stage:?}");
+            assert_eq!(restarted.current_generation_id().await?, 1, "stage {stage:?}");
+            let orphan = format!("{DEFAULT_INDEX_FILE_PATH}/generations/gen-2");
+            assert!(
+                provider
+                    .list(orphan.clone())
+                    .await?
+                    .into_iter()
+                    .all(|path| !path.starts_with(&orphan)),
+                "stage {stage:?} left orphan generation"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn index_cleanup_failure_keeps_published_generation_and_restart_cleans_orphan() -> Result<(), RocketMQError> {
+        let provider = FaultProvider::default();
+        let index = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+        index.append_entry(&entry("one", 100)).await?;
+        compact_current(&index).await?;
+        index.append_entry(&entry("two", 200)).await?;
+        compact_current(&index).await?;
+        index.append_entry(&entry("three", 300)).await?;
+        let entries = index.load_entries().await?;
+        provider.set_fault(FaultStage::Cleanup);
+        assert!(index.compact_entries(&entries).await.is_err());
+        assert_eq!(index.current_generation_id().await?, 3);
+        let generation_one = format!("{DEFAULT_INDEX_FILE_PATH}/generations/gen-1");
+        assert!(!provider.list(generation_one.clone()).await?.is_empty());
+        drop(index);
+
+        let restarted = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+        assert_eq!(restarted.load_entries().await?.len(), 3);
+        assert!(provider.list(generation_one.clone()).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn index_reader_lease_delays_retired_generation_deletion() -> Result<(), RocketMQError> {
+        let provider = FaultProvider::default();
+        let index = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+        index.append_entry(&entry("one", 100)).await?;
+        compact_current(&index).await?;
+        let generation_one_lease = index.generation_manager.current().await?;
+        index.append_entry(&entry("two", 200)).await?;
+        compact_current(&index).await?;
+        index.append_entry(&entry("three", 300)).await?;
+        compact_current(&index).await?;
+
+        let generation_one = format!("{DEFAULT_INDEX_FILE_PATH}/generations/gen-1");
+        assert!(!provider.list(generation_one.clone()).await?.is_empty());
+        drop(generation_one_lease);
+        index.generation_manager.cleanup_retired().await?;
+        assert!(provider.list(generation_one).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn index_corruption_rolls_back_but_transient_read_failure_does_not() -> Result<(), RocketMQError> {
+        let provider = FaultProvider::default();
+        let index = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+        index.append_entry(&entry("old", 100)).await?;
+        compact_current(&index).await?;
+        index.append_entry(&entry("new", 200)).await?;
+        compact_current(&index).await?;
+        drop(index);
+
+        let transient = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider.clone(), 8, 8);
+        assert_eq!(transient.current_generation_id().await?, 2);
+        provider.set_fault(FaultStage::Read);
+        let error = transient.load_entries().await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::StorageReadFailed);
+        assert_eq!(transient.current_generation_id().await?, 2);
+        drop(transient);
+
+        let generation_two = format!("{DEFAULT_INDEX_FILE_PATH}/generations/gen-2");
+        let segment = provider
+            .list(generation_two)
+            .await?
+            .into_iter()
+            .find(|path| path.rsplit('/').next().is_some_and(|name| name.parse::<i64>().is_ok()))
+            .ok_or_else(|| RocketMQError::Internal("generation segment not found".to_owned()))?;
+        provider.write(segment, 0, Bytes::from_static(&[0, 0, 0, 0])).await?;
+
+        let corrupt = IndexFileSegment::with_limits(DEFAULT_INDEX_FILE_PATH.to_owned(), provider, 8, 8);
+        assert_eq!(corrupt.load_entries().await?, vec![entry("old", 100)]);
+        assert_eq!(corrupt.current_generation_id().await?, 1);
+        Ok(())
+    }
+
+    async fn compact_current(index: &IndexFileSegment<FaultProvider>) -> Result<(), RocketMQError> {
+        let entries = index.load_entries().await?;
+        index.compact_entries(&entries).await
     }
 }

--- a/rocketmq-tieredstore/src/file/index_generation.rs
+++ b/rocketmq-tieredstore/src/file/index_generation.rs
@@ -1,0 +1,572 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
+use tokio::sync::Mutex;
+
+use crate::error;
+use crate::provider::TieredStoreProvider;
+
+const CURRENT_MAGIC: u32 = 0x5449_4743;
+const GENERATION_MAGIC: u32 = 0x5449_474D;
+const FORMAT_VERSION: u16 = 1;
+const CURRENT_SIZE: usize = 40;
+const GENERATION_METADATA_SIZE: usize = 64;
+const NO_GENERATION: u64 = u64::MAX;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IndexGenerationMetadata {
+    pub(crate) generation: u64,
+    pub(crate) entry_count: u64,
+    pub(crate) min_timestamp: i64,
+    pub(crate) max_timestamp: i64,
+    pub(crate) min_commit_log_offset: u64,
+    pub(crate) max_commit_log_offset: u64,
+    pub(crate) content_crc: u32,
+}
+
+impl IndexGenerationMetadata {
+    pub(crate) fn empty(generation: u64) -> Self {
+        Self {
+            generation,
+            entry_count: 0,
+            min_timestamp: 0,
+            max_timestamp: 0,
+            min_commit_log_offset: 0,
+            max_commit_log_offset: 0,
+            content_crc: crc32(&[]),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IndexGeneration {
+    id: u64,
+    path: String,
+    metadata: Option<IndexGenerationMetadata>,
+}
+
+impl IndexGeneration {
+    pub(crate) fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(crate) fn metadata(&self) -> Option<IndexGenerationMetadata> {
+        self.metadata
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct IndexGenerationLease {
+    generation: Arc<IndexGeneration>,
+}
+
+impl IndexGenerationLease {
+    pub(crate) fn id(&self) -> u64 {
+        self.generation.id()
+    }
+
+    pub(crate) fn path(&self) -> &str {
+        self.generation.path()
+    }
+
+    pub(crate) fn metadata(&self) -> Option<IndexGenerationMetadata> {
+        self.generation.metadata()
+    }
+}
+
+#[derive(Debug)]
+struct IndexGenerationState {
+    initialized: bool,
+    current: Arc<IndexGeneration>,
+    previous: Option<Arc<IndexGeneration>>,
+    retired: Vec<Arc<IndexGeneration>>,
+    next_generation: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct IndexGenerationManager<P>
+where
+    P: TieredStoreProvider,
+{
+    directory: String,
+    provider: P,
+    state: RwLock<IndexGenerationState>,
+    initialize_lock: Mutex<()>,
+}
+
+impl<P> IndexGenerationManager<P>
+where
+    P: TieredStoreProvider,
+{
+    pub(crate) fn new(directory: String, provider: P) -> Self {
+        let legacy = Arc::new(IndexGeneration {
+            id: 0,
+            path: directory.clone(),
+            metadata: None,
+        });
+        Self {
+            directory,
+            provider,
+            state: RwLock::new(IndexGenerationState {
+                initialized: false,
+                current: legacy,
+                previous: None,
+                retired: Vec::new(),
+                next_generation: 1,
+            }),
+            initialize_lock: Mutex::new(()),
+        }
+    }
+
+    pub(crate) async fn current(&self) -> Result<IndexGenerationLease, RocketMQError> {
+        self.ensure_initialized().await?;
+        Ok(IndexGenerationLease {
+            generation: self.state.read().current.clone(),
+        })
+    }
+
+    pub(crate) async fn previous(&self) -> Result<Option<IndexGenerationLease>, RocketMQError> {
+        self.ensure_initialized().await?;
+        Ok(self
+            .state
+            .read()
+            .previous
+            .clone()
+            .map(|generation| IndexGenerationLease { generation }))
+    }
+
+    pub(crate) async fn next_generation(&self) -> Result<u64, RocketMQError> {
+        self.ensure_initialized().await?;
+        Ok(self.state.read().next_generation)
+    }
+
+    pub(crate) fn temporary_path(&self, generation: u64) -> String {
+        format!("{}/generations/gen-{generation}.tmp", self.directory)
+    }
+
+    pub(crate) fn generation_path(&self, generation: u64) -> String {
+        if generation == 0 {
+            self.directory.clone()
+        } else {
+            format!("{}/generations/gen-{generation}", self.directory)
+        }
+    }
+
+    pub(crate) fn metadata_path(&self, generation_path: &str) -> String {
+        format!("{generation_path}/GENERATION")
+    }
+
+    pub(crate) async fn publish(&self, metadata: IndexGenerationMetadata) -> Result<(), RocketMQError> {
+        self.ensure_initialized().await?;
+        let (old_current_id, next_generation) = {
+            let state = self.state.read();
+            if metadata.generation != state.next_generation {
+                return Err(error::storage_write_failed(
+                    self.current_path(),
+                    format!(
+                        "generation publication out of order: expected {}, got {}",
+                        state.next_generation, metadata.generation
+                    ),
+                ));
+            }
+            (state.current.id(), state.next_generation.saturating_add(1))
+        };
+        let pointer = CurrentPointer {
+            current: metadata.generation,
+            previous: Some(old_current_id),
+            next_generation,
+        };
+        self.provider
+            .atomic_write(self.current_path(), encode_current(pointer))
+            .await?;
+
+        let mut state = self.state.write();
+        let old_current = state.current.clone();
+        if let Some(old_previous) = state.previous.replace(old_current) {
+            state.retired.push(old_previous);
+        }
+        state.current = Arc::new(IndexGeneration {
+            id: metadata.generation,
+            path: self.generation_path(metadata.generation),
+            metadata: Some(metadata),
+        });
+        state.next_generation = next_generation;
+        Ok(())
+    }
+
+    pub(crate) async fn rollback_to_previous(&self) -> Result<bool, RocketMQError> {
+        self.ensure_initialized().await?;
+        let (current, previous, next_generation) = {
+            let state = self.state.read();
+            let Some(previous) = state.previous.clone() else {
+                return Ok(false);
+            };
+            (state.current.clone(), previous, state.next_generation)
+        };
+        self.provider
+            .atomic_write(
+                self.current_path(),
+                encode_current(CurrentPointer {
+                    current: previous.id(),
+                    previous: Some(current.id()),
+                    next_generation,
+                }),
+            )
+            .await?;
+        let mut state = self.state.write();
+        state.current = previous;
+        state.previous = Some(current);
+        Ok(true)
+    }
+
+    pub(crate) async fn rollback_to_validated_previous(&self) -> Result<bool, RocketMQError> {
+        self.ensure_initialized().await?;
+        let (current, previous, next_generation) = {
+            let state = self.state.read();
+            let Some(previous) = state.previous.clone() else {
+                return Ok(false);
+            };
+            (state.current.clone(), previous, state.next_generation)
+        };
+        self.provider
+            .atomic_write(
+                self.current_path(),
+                encode_current(CurrentPointer {
+                    current: previous.id(),
+                    previous: None,
+                    next_generation,
+                }),
+            )
+            .await?;
+        let mut state = self.state.write();
+        state.current = previous;
+        state.previous = None;
+        state.retired.push(current);
+        Ok(true)
+    }
+
+    pub(crate) async fn cleanup_retired(&self) -> Result<(), RocketMQError> {
+        let deletable = {
+            let mut state = self.state.write();
+            let mut deletable = Vec::new();
+            state.retired.retain(|generation| {
+                if Arc::strong_count(generation) == 1 {
+                    if generation.id() > 0 {
+                        deletable.push(generation.path().to_owned());
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+            deletable
+        };
+        for path in deletable {
+            self.provider.delete_prefix(path).await?;
+        }
+        Ok(())
+    }
+
+    async fn ensure_initialized(&self) -> Result<(), RocketMQError> {
+        if self.state.read().initialized {
+            return Ok(());
+        }
+        let _guard = self.initialize_lock.lock().await;
+        if self.state.read().initialized {
+            return Ok(());
+        }
+
+        let pointer = self.load_current_pointer().await?;
+        let (current, previous, next_generation) = match pointer {
+            Some(pointer) => {
+                let current = self.load_generation(pointer.current).await?;
+                let previous = match pointer.previous {
+                    Some(generation) => Some(self.load_generation(generation).await?),
+                    None => None,
+                };
+                (current, previous, pointer.next_generation)
+            }
+            None => (
+                Arc::new(IndexGeneration {
+                    id: 0,
+                    path: self.directory.clone(),
+                    metadata: None,
+                }),
+                None,
+                1,
+            ),
+        };
+        {
+            let mut state = self.state.write();
+            state.current = current;
+            state.previous = previous;
+            state.next_generation = next_generation.max(1);
+            state.initialized = true;
+        }
+        self.cleanup_orphans_after_restart().await
+    }
+
+    async fn load_current_pointer(&self) -> Result<Option<CurrentPointer>, RocketMQError> {
+        let path = self.current_path();
+        let size = self.provider.segment_size(path.clone()).await?;
+        if size == 0 {
+            return Ok(None);
+        }
+        let bytes = self.provider.read(path.clone(), 0, size as usize).await?;
+        decode_current(&bytes, &path).map(Some)
+    }
+
+    async fn load_generation(&self, generation: u64) -> Result<Arc<IndexGeneration>, RocketMQError> {
+        if generation == 0 {
+            return Ok(Arc::new(IndexGeneration {
+                id: 0,
+                path: self.directory.clone(),
+                metadata: None,
+            }));
+        }
+        let path = self.generation_path(generation);
+        let metadata_path = self.metadata_path(&path);
+        let size = self.provider.segment_size(metadata_path.clone()).await?;
+        if size != GENERATION_METADATA_SIZE as u64 {
+            return Err(error::storage_corrupted(metadata_path));
+        }
+        let bytes = self.provider.read(metadata_path.clone(), 0, size as usize).await?;
+        let metadata = decode_generation_metadata(&bytes, &metadata_path)?;
+        if metadata.generation != generation {
+            return Err(error::storage_corrupted(metadata_path));
+        }
+        Ok(Arc::new(IndexGeneration {
+            id: generation,
+            path,
+            metadata: Some(metadata),
+        }))
+    }
+
+    async fn cleanup_orphans_after_restart(&self) -> Result<(), RocketMQError> {
+        let prefix = format!("{}/generations", self.directory);
+        let paths = self.provider.list(prefix.clone()).await?;
+        if paths.is_empty() {
+            return Ok(());
+        }
+        let (current, previous) = {
+            let state = self.state.read();
+            (
+                state.current.id(),
+                state.previous.as_ref().map(|generation| generation.id()),
+            )
+        };
+        let mut generation_roots = BTreeSet::new();
+        let marker = format!("{prefix}/");
+        for path in paths {
+            let Some(relative) = path.strip_prefix(&marker) else {
+                continue;
+            };
+            let Some(component) = relative.split('/').next() else {
+                continue;
+            };
+            if component.starts_with("gen-") {
+                generation_roots.insert(format!("{prefix}/{component}"));
+            }
+        }
+        for root in generation_roots {
+            let keep = parse_generation_id(&root)
+                .is_some_and(|generation| generation == current || Some(generation) == previous);
+            if !keep {
+                self.provider.delete_prefix(root).await?;
+            }
+        }
+        Ok(())
+    }
+
+    fn current_path(&self) -> String {
+        format!("{}/CURRENT", self.directory)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CurrentPointer {
+    current: u64,
+    previous: Option<u64>,
+    next_generation: u64,
+}
+
+pub(crate) fn encode_generation_metadata(metadata: IndexGenerationMetadata) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(GENERATION_METADATA_SIZE);
+    bytes.put_u32(GENERATION_MAGIC);
+    bytes.put_u16(FORMAT_VERSION);
+    bytes.put_u16(0);
+    bytes.put_u64(metadata.generation);
+    bytes.put_u64(metadata.entry_count);
+    bytes.put_i64(metadata.min_timestamp);
+    bytes.put_i64(metadata.max_timestamp);
+    bytes.put_u64(metadata.min_commit_log_offset);
+    bytes.put_u64(metadata.max_commit_log_offset);
+    bytes.put_u32(metadata.content_crc);
+    let checksum = crc32(&bytes);
+    bytes.put_u32(checksum);
+    bytes.freeze()
+}
+
+pub(crate) fn decode_generation_metadata(bytes: &Bytes, path: &str) -> Result<IndexGenerationMetadata, RocketMQError> {
+    if bytes.len() != GENERATION_METADATA_SIZE {
+        return Err(error::storage_corrupted(path));
+    }
+    let expected_checksum = u32::from_be_bytes(bytes[GENERATION_METADATA_SIZE - 4..].try_into().unwrap_or_default());
+    if crc32(&bytes[..GENERATION_METADATA_SIZE - 4]) != expected_checksum {
+        return Err(error::storage_corrupted(path));
+    }
+    let mut cursor = bytes.clone();
+    if cursor.get_u32() != GENERATION_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+        return Err(error::storage_corrupted(path));
+    }
+    let _reserved = cursor.get_u16();
+    let metadata = IndexGenerationMetadata {
+        generation: cursor.get_u64(),
+        entry_count: cursor.get_u64(),
+        min_timestamp: cursor.get_i64(),
+        max_timestamp: cursor.get_i64(),
+        min_commit_log_offset: cursor.get_u64(),
+        max_commit_log_offset: cursor.get_u64(),
+        content_crc: cursor.get_u32(),
+    };
+    if metadata.entry_count == 0 {
+        if metadata.min_timestamp != 0
+            || metadata.max_timestamp != 0
+            || metadata.min_commit_log_offset != 0
+            || metadata.max_commit_log_offset != 0
+        {
+            return Err(error::storage_corrupted(path));
+        }
+    } else if metadata.min_timestamp > metadata.max_timestamp
+        || metadata.min_commit_log_offset > metadata.max_commit_log_offset
+    {
+        return Err(error::storage_corrupted(path));
+    }
+    Ok(metadata)
+}
+
+fn encode_current(pointer: CurrentPointer) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(CURRENT_SIZE);
+    bytes.put_u32(CURRENT_MAGIC);
+    bytes.put_u16(FORMAT_VERSION);
+    bytes.put_u16(0);
+    bytes.put_u64(pointer.current);
+    bytes.put_u64(pointer.previous.unwrap_or(NO_GENERATION));
+    bytes.put_u64(pointer.next_generation);
+    let checksum = crc32(&bytes);
+    bytes.put_u32(checksum);
+    bytes.put_u32(0);
+    bytes.freeze()
+}
+
+fn decode_current(bytes: &Bytes, path: &str) -> Result<CurrentPointer, RocketMQError> {
+    if bytes.len() != CURRENT_SIZE {
+        return Err(error::storage_corrupted(path));
+    }
+    let expected_checksum = u32::from_be_bytes(bytes[32..36].try_into().unwrap_or_default());
+    if crc32(&bytes[..32]) != expected_checksum {
+        return Err(error::storage_corrupted(path));
+    }
+    let mut cursor = bytes.clone();
+    if cursor.get_u32() != CURRENT_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+        return Err(error::storage_corrupted(path));
+    }
+    let _reserved = cursor.get_u16();
+    let current = cursor.get_u64();
+    let previous = match cursor.get_u64() {
+        NO_GENERATION => None,
+        generation => Some(generation),
+    };
+    let next_generation = cursor.get_u64();
+    if next_generation <= current || previous == Some(current) {
+        return Err(error::storage_corrupted(path));
+    }
+    Ok(CurrentPointer {
+        current,
+        previous,
+        next_generation,
+    })
+}
+
+fn parse_generation_id(path: &str) -> Option<u64> {
+    let component = path.rsplit('/').next()?;
+    if component.ends_with(".tmp") {
+        return None;
+    }
+    component.strip_prefix("gen-")?.parse().ok()
+}
+
+pub(crate) fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFF_u32;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_metadata_round_trips_and_rejects_corruption() {
+        let metadata = IndexGenerationMetadata {
+            generation: 7,
+            entry_count: 3,
+            min_timestamp: 10,
+            max_timestamp: 30,
+            min_commit_log_offset: 100,
+            max_commit_log_offset: 300,
+            content_crc: 42,
+        };
+        let encoded = encode_generation_metadata(metadata);
+        assert_eq!(decode_generation_metadata(&encoded, "GENERATION").unwrap(), metadata);
+
+        let mut corrupted = encoded.to_vec();
+        corrupted[24] ^= 1;
+        assert!(decode_generation_metadata(&Bytes::from(corrupted), "GENERATION").is_err());
+    }
+
+    #[test]
+    fn current_pointer_round_trips_and_rejects_corruption() {
+        let pointer = CurrentPointer {
+            current: 8,
+            previous: Some(7),
+            next_generation: 9,
+        };
+        let encoded = encode_current(pointer);
+        assert_eq!(decode_current(&encoded, "CURRENT").unwrap(), pointer);
+
+        let mut corrupted = encoded.to_vec();
+        corrupted[8] ^= 1;
+        assert!(decode_current(&Bytes::from(corrupted), "CURRENT").is_err());
+    }
+}

--- a/rocketmq-tieredstore/src/provider.rs
+++ b/rocketmq-tieredstore/src/provider.rs
@@ -16,6 +16,8 @@ pub mod memory_file_segment;
 pub mod posix_file_segment;
 pub mod provider_impl;
 
+use std::future::Future;
+
 use bytes::Bytes;
 use rocketmq_error::RocketMQError;
 
@@ -45,4 +47,54 @@ pub trait TieredStoreProviderInner: Sync + Clone + 'static {
     async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError>;
 
     async fn delete(&self, path: String) -> Result<(), RocketMQError>;
+
+    /// Makes prior writes to `path` durable when the backend exposes an explicit sync operation.
+    ///
+    /// Remote providers whose successful write is already durable may keep the default no-op.
+    fn sync(&self, _path: String) -> impl Future<Output = Result<(), RocketMQError>> {
+        async { Ok(()) }
+    }
+
+    /// Renames one file or directory prefix without exposing a partially copied destination.
+    fn rename(&self, source: String, _destination: String) -> impl Future<Output = Result<(), RocketMQError>> {
+        async move {
+            Err(RocketMQError::storage_write_failed(
+                source,
+                "tiered provider does not support atomic rename",
+            ))
+        }
+    }
+
+    /// Lists provider paths rooted at `prefix`.
+    fn list(&self, _prefix: String) -> impl Future<Output = Result<Vec<String>, RocketMQError>> {
+        async { Ok(Vec::new()) }
+    }
+
+    /// Deletes a file or directory prefix and all paths below it.
+    fn delete_prefix(&self, prefix: String) -> impl Future<Output = Result<(), RocketMQError>> {
+        async move {
+            for path in self.list(prefix.clone()).await? {
+                self.delete(path).await?;
+            }
+            self.delete(prefix).await
+        }
+    }
+
+    /// Publishes a small metadata file with atomic replacement semantics.
+    fn atomic_write(&self, path: String, data: Bytes) -> impl Future<Output = Result<(), RocketMQError>> {
+        async move {
+            let temporary = format!("{path}.tmp");
+            self.delete_prefix(temporary.clone()).await?;
+            let expected = data.len();
+            let written = self.write(temporary.clone(), 0, data).await?;
+            if written != expected {
+                return Err(RocketMQError::storage_write_failed(
+                    temporary,
+                    format!("partial metadata write: expected {expected}, wrote {written}"),
+                ));
+            }
+            self.sync(temporary.clone()).await?;
+            self.rename(temporary, path).await
+        }
+    }
 }

--- a/rocketmq-tieredstore/src/provider/memory_file_segment.rs
+++ b/rocketmq-tieredstore/src/provider/memory_file_segment.rs
@@ -89,6 +89,55 @@ impl TieredStoreProvider for MemoryProvider {
         self.files.write().remove(&path);
         Ok(())
     }
+
+    async fn rename(&self, source: String, destination: String) -> Result<(), RocketMQError> {
+        let mut files = self.files.write();
+        let source_prefix = format!("{source}/");
+        let mut replacements = files
+            .keys()
+            .filter(|path| **path == source || path.starts_with(&source_prefix))
+            .cloned()
+            .collect::<Vec<_>>();
+        replacements.sort();
+        if replacements.is_empty() {
+            return Err(RocketMQError::storage_write_failed(
+                source,
+                "source path does not exist",
+            ));
+        }
+
+        let destination_prefix = format!("{destination}/");
+        files.retain(|path, _| *path != destination && !path.starts_with(&destination_prefix));
+        for source_path in replacements {
+            let Some(bytes) = files.remove(&source_path) else {
+                continue;
+            };
+            let suffix = source_path.strip_prefix(&source).unwrap_or_default();
+            files.insert(format!("{destination}{suffix}"), bytes);
+        }
+        Ok(())
+    }
+
+    async fn list(&self, prefix: String) -> Result<Vec<String>, RocketMQError> {
+        let prefix_with_separator = format!("{prefix}/");
+        let mut paths = self
+            .files
+            .read()
+            .keys()
+            .filter(|path| **path == prefix || path.starts_with(&prefix_with_separator))
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.sort();
+        Ok(paths)
+    }
+
+    async fn delete_prefix(&self, prefix: String) -> Result<(), RocketMQError> {
+        let prefix_with_separator = format!("{prefix}/");
+        self.files
+            .write()
+            .retain(|path, _| *path != prefix && !path.starts_with(&prefix_with_separator));
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/rocketmq-tieredstore/src/provider/posix_file_segment.rs
+++ b/rocketmq-tieredstore/src/provider/posix_file_segment.rs
@@ -16,6 +16,13 @@ use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::iter;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
 use bytes::Bytes;
 use rocketmq_error::RocketMQError;
 use tokio::fs::OpenOptions;
@@ -85,10 +92,17 @@ impl TieredStoreProvider for PosixProvider {
             .await
             .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
         let mut buffer = vec![0_u8; length];
-        let read = file
-            .read(&mut buffer)
-            .await
-            .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
+        let mut read = 0;
+        while read < length {
+            let chunk = file
+                .read(&mut buffer[read..])
+                .await
+                .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
+            if chunk == 0 {
+                break;
+            }
+            read += chunk;
+        }
         buffer.truncate(read);
         Ok(Bytes::from(buffer))
     }
@@ -127,10 +141,228 @@ impl TieredStoreProvider for PosixProvider {
             Err(err) => Err(error::storage_write_failed(path_to_string(&full_path), err.to_string())),
         }
     }
+
+    async fn sync(&self, path: String) -> Result<(), RocketMQError> {
+        let full_path = self.resolve(&path);
+        let metadata = match tokio::fs::metadata(&full_path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(error::storage_write_failed(path_to_string(&full_path), err.to_string())),
+        };
+        if metadata.is_dir() {
+            return sync_directory(&full_path).await;
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&full_path)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))?;
+        file.sync_all()
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))
+    }
+
+    async fn rename(&self, source: String, destination: String) -> Result<(), RocketMQError> {
+        let source_path = self.resolve(&source);
+        let destination_path = self.resolve(&destination);
+        if let Some(parent) = destination_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|err| error::storage_write_failed(path_to_string(parent), err.to_string()))?;
+        }
+        rename_path(&source_path, &destination_path)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&destination_path), err.to_string()))?;
+        if let Some(parent) = destination_path.parent() {
+            sync_directory(parent).await?;
+        }
+        Ok(())
+    }
+
+    async fn list(&self, prefix: String) -> Result<Vec<String>, RocketMQError> {
+        let root = self.resolve(&prefix);
+        let metadata = match tokio::fs::metadata(&root).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(error::storage_read_failed(path_to_string(&root), err.to_string())),
+        };
+        if metadata.is_file() {
+            return Ok(vec![prefix]);
+        }
+
+        let mut directories = vec![root];
+        let mut paths = Vec::new();
+        while let Some(directory) = directories.pop() {
+            let mut entries = tokio::fs::read_dir(&directory)
+                .await
+                .map_err(|err| error::storage_read_failed(path_to_string(&directory), err.to_string()))?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|err| error::storage_read_failed(path_to_string(&directory), err.to_string()))?
+            {
+                let path = entry.path();
+                let file_type = entry
+                    .file_type()
+                    .await
+                    .map_err(|err| error::storage_read_failed(path_to_string(&path), err.to_string()))?;
+                if file_type.is_dir() {
+                    directories.push(path);
+                } else if file_type.is_file() {
+                    paths.push(relative_provider_path(&self.root, &path)?);
+                }
+            }
+        }
+        paths.sort();
+        Ok(paths)
+    }
+
+    async fn delete_prefix(&self, prefix: String) -> Result<(), RocketMQError> {
+        let full_path = self.resolve(&prefix);
+        let metadata = match tokio::fs::metadata(&full_path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(error::storage_write_failed(path_to_string(&full_path), err.to_string())),
+        };
+        let result = if metadata.is_dir() {
+            tokio::fs::remove_dir_all(&full_path).await
+        } else {
+            tokio::fs::remove_file(&full_path).await
+        };
+        result.map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))
+    }
+
+    async fn atomic_write(&self, path: String, data: Bytes) -> Result<(), RocketMQError> {
+        let destination = self.resolve(&path);
+        let temporary = destination.with_extension("atomic.tmp");
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|err| error::storage_write_failed(path_to_string(parent), err.to_string()))?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temporary)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&temporary), err.to_string()))?;
+        file.write_all(&data)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&temporary), err.to_string()))?;
+        file.sync_all()
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&temporary), err.to_string()))?;
+        drop(file);
+
+        replace_file(&temporary, &destination)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&destination), err.to_string()))?;
+        if let Some(parent) = destination.parent() {
+            sync_directory(parent).await?;
+        }
+        Ok(())
+    }
 }
 
 fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
+}
+
+fn relative_provider_path(root: &Path, path: &Path) -> Result<String, RocketMQError> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|err| error::storage_read_failed(path_to_string(path), err.to_string()))?;
+    Ok(relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
+#[cfg(unix)]
+async fn sync_directory(path: &Path) -> Result<(), RocketMQError> {
+    let directory = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .await
+        .map_err(|err| error::storage_write_failed(path_to_string(path), err.to_string()))?;
+    directory
+        .sync_all()
+        .await
+        .map_err(|err| error::storage_write_failed(path_to_string(path), err.to_string()))
+}
+
+#[cfg(windows)]
+async fn sync_directory(_path: &Path) -> Result<(), RocketMQError> {
+    // MoveFileExW/ReplaceFileW with WRITE_THROUGH provide the Windows metadata durability boundary.
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+async fn sync_directory(_path: &Path) -> Result<(), RocketMQError> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
+async fn rename_path(source: &Path, destination: &Path) -> std::io::Result<()> {
+    tokio::fs::rename(source, destination).await
+}
+
+#[cfg(windows)]
+async fn rename_path(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let destination = wide_path(destination);
+    let source = wide_path(source);
+    // SAFETY: Both UTF-16 buffers are NUL-terminated and remain alive for the duration of MoveFileExW.
+    let renamed = unsafe {
+        windows_sys::Win32::Storage::FileSystem::MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            windows_sys::Win32::Storage::FileSystem::MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if renamed == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+async fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    tokio::fs::rename(source, destination).await
+}
+
+#[cfg(windows)]
+async fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if !tokio::fs::try_exists(destination).await? {
+        return tokio::fs::rename(source, destination).await;
+    }
+    let destination = wide_path(destination);
+    let source = wide_path(source);
+    // SAFETY: Both UTF-16 buffers are NUL-terminated and remain alive for the duration of the call;
+    // backup/exclude/reserved pointers are intentionally null as allowed by ReplaceFileW.
+    let replaced = unsafe {
+        windows_sys::Win32::Storage::FileSystem::ReplaceFileW(
+            destination.as_ptr(),
+            source.as_ptr(),
+            std::ptr::null(),
+            windows_sys::Win32::Storage::FileSystem::REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn wide_path(path: &Path) -> Vec<u16> {
+    OsStr::new(path).encode_wide().chain(iter::once(0)).collect()
 }
 
 #[cfg(test)]

--- a/rocketmq-tieredstore/src/provider/provider_impl.rs
+++ b/rocketmq-tieredstore/src/provider/provider_impl.rs
@@ -89,4 +89,39 @@ impl TieredStoreProvider for ProviderKind {
             Self::Memory(provider) => provider.delete(path).await,
         }
     }
+
+    async fn sync(&self, path: String) -> Result<(), RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.sync(path).await,
+            Self::Memory(provider) => provider.sync(path).await,
+        }
+    }
+
+    async fn rename(&self, source: String, destination: String) -> Result<(), RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.rename(source, destination).await,
+            Self::Memory(provider) => provider.rename(source, destination).await,
+        }
+    }
+
+    async fn list(&self, prefix: String) -> Result<Vec<String>, RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.list(prefix).await,
+            Self::Memory(provider) => provider.list(prefix).await,
+        }
+    }
+
+    async fn delete_prefix(&self, prefix: String) -> Result<(), RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.delete_prefix(prefix).await,
+            Self::Memory(provider) => provider.delete_prefix(prefix).await,
+        }
+    }
+
+    async fn atomic_write(&self, path: String, data: Bytes) -> Result<(), RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.atomic_write(path, data).await,
+            Self::Memory(provider) => provider.atomic_write(path, data).await,
+        }
+    }
 }

--- a/rocketmq-tieredstore/tests/tiered_cursor_retry_tests.rs
+++ b/rocketmq-tieredstore/tests/tiered_cursor_retry_tests.rs
@@ -119,6 +119,26 @@ impl TieredStoreProvider for ControlledPosixProvider {
     async fn delete(&self, path: String) -> Result<(), RocketMQError> {
         self.inner.delete(path).await
     }
+
+    async fn sync(&self, path: String) -> Result<(), RocketMQError> {
+        self.inner.sync(path).await
+    }
+
+    async fn rename(&self, source: String, destination: String) -> Result<(), RocketMQError> {
+        self.inner.rename(source, destination).await
+    }
+
+    async fn list(&self, prefix: String) -> Result<Vec<String>, RocketMQError> {
+        self.inner.list(prefix).await
+    }
+
+    async fn delete_prefix(&self, prefix: String) -> Result<(), RocketMQError> {
+        self.inner.delete_prefix(prefix).await
+    }
+
+    async fn atomic_write(&self, path: String, data: Bytes) -> Result<(), RocketMQError> {
+        self.inner.atomic_write(path, data).await
+    }
 }
 
 fn test_config(root: std::path::PathBuf) -> TieredStoreConfig {
@@ -483,6 +503,9 @@ async fn corrupted_progress_snapshot_fails_restart_closed() -> Result<(), Rocket
         .load()
         .await
         .expect_err("corrupted progress must fail readiness");
-    assert!(error.to_string().contains("tieredDispatchProgress.bin"));
+    assert!(
+        error.to_string().contains("tieredDispatchProgress.bin"),
+        "unexpected restart error: {error}"
+    );
     Ok(())
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -18100,7 +18100,7 @@
           "id": "9cbe2d507037ccc178f23eb8",
           "fingerprint": "d26a6e9d75c77b5c7069d839",
           "item": "mod tests",
-          "line": 2669
+          "line": 2675
         }
       ],
       "owner": "client",
@@ -18155,7 +18155,7 @@
           "id": "859c354e5e3e6c42e71cbfc7",
           "fingerprint": "df837d5c59f6a54188a3d9c7",
           "item": "fn on_exception",
-          "line": 1319
+          "line": 1325
         }
       ],
       "owner": "client",
@@ -18174,19 +18174,19 @@
           "id": "3537a7f5e9f85fea0a9ca95a",
           "fingerprint": "1e1dd2485b87b679d56fce30",
           "item": "fn apply_route_refresh_updates_producer_and_consumer_views",
-          "line": 2887
+          "line": 2893
         },
         {
           "id": "a88e0cd463d27dc0b3e0d37a",
           "fingerprint": "6ee6af86f91a5447266fe14a",
           "item": "fn apply_route_refresh_updates_producer_and_consumer_views",
-          "line": 2903
+          "line": 2909
         },
         {
           "id": "954bf9f99136644e81c88b1c",
           "fingerprint": "6448cd2aa913551fd4d328c0",
           "item": "fn apply_route_refresh_updates_producer_and_consumer_views",
-          "line": 2905
+          "line": 2911
         }
       ],
       "owner": "client",
@@ -18272,13 +18272,13 @@
           "id": "19229b23cd4be4f5ed4b8fa7",
           "fingerprint": "601870d525a9d7fa55d52273",
           "item": "fn start_scheduled_task",
-          "line": 713
+          "line": 719
         },
         {
           "id": "2eb723a5fa37aea763cefc10",
           "fingerprint": "a257d1fbfb0d07f9b5701185",
           "item": "fn get_mq_client_api_impl",
-          "line": 1277
+          "line": 1283
         }
       ],
       "owner": "client",
@@ -18341,13 +18341,13 @@
           "id": "1a0b0fbc78abb02216825dd8",
           "fingerprint": "849cca6d45fc8601d5ec19c9",
           "item": "fn send_heartbeat_to_all_broker_concurrently",
-          "line": 1689
+          "line": 1695
         },
         {
           "id": "6c837b9baff5a33bb9b7ae7a",
           "fingerprint": "76ea1402c1e48bd63cda20ec",
           "item": "fn send_heartbeat_to_broker_inner",
-          "line": 1915
+          "line": 1921
         }
       ],
       "owner": "client",
@@ -19710,7 +19710,7 @@
           "id": "b1a22a9e0fa5d9ecfa852526",
           "fingerprint": "d140ff4ac2a0ea79a857088b",
           "item": "mod tests",
-          "line": 3620
+          "line": 3656
         }
       ],
       "owner": "client",
@@ -19748,7 +19748,7 @@
           "id": "67b0046e6072159c90695c24",
           "fingerprint": "356398455444fa281e36bc8b",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3651
+          "line": 3687
         }
       ],
       "owner": "client",
@@ -19810,13 +19810,13 @@
           "id": "f4f791ad0cc15215ab5f9f9a",
           "fingerprint": "f0e256b31aba61aae79c3c48",
           "item": "struct DefaultServiceDetector",
-          "line": 3515
+          "line": 3551
         },
         {
           "id": "b1f91ffc3439d3410d7dee6b",
           "fingerprint": "2d53d4eadb152009da2a1127",
           "item": "struct DefaultResolver",
-          "line": 3604
+          "line": 3640
         }
       ],
       "owner": "client",
@@ -19835,13 +19835,13 @@
           "id": "d9a05be2d5e4ad25924e45a9",
           "fingerprint": "e921f953fdb474ebfdf78609",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3650
+          "line": 3686
         },
         {
           "id": "47d45638c009526c0a6964ce",
           "fingerprint": "c4ea98db295aea5d035405e0",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3654
+          "line": 3690
         }
       ],
       "owner": "client",
@@ -20013,25 +20013,25 @@
           "id": "aba9ca5334cb9554b5016b9b",
           "fingerprint": "a51632360baadbb0bc486192",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3653
+          "line": 3689
         },
         {
           "id": "16e189d4577b6391b57c80e4",
           "fingerprint": "8b150fb7bba37b260fdd92e9",
           "item": "fn async_send_to_queue_validates_message_before_kernel_like_java",
-          "line": 4128
+          "line": 4181
         },
         {
           "id": "e443a78aa00d5c904edc6f25",
           "fingerprint": "8b150fb7bba37b260fdd92e9",
           "item": "fn async_send_to_queue_topic_mismatch_uses_java_callback_error_message",
-          "line": 4164
+          "line": 4217
         },
         {
           "id": "8d72eb9eab5bdfe75d28666f",
           "fingerprint": "683fb6d123596cb2a5c150af",
           "item": "fn async_send_with_callback_reports_kernel_error_to_callback",
-          "line": 4205
+          "line": 4258
         }
       ],
       "owner": "client",
@@ -29394,28 +29394,16 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "1a8dca9ae2a1fc3bdc24a62f",
-          "fingerprint": "02b7dc82d03626e8af1f70bd",
-          "item": "struct CommitLogDispatcherCompaction",
-          "line": 32
-        },
-        {
           "id": "a10a40cfc96b7b2fcaabfc7d",
           "fingerprint": "71d8feeadd7a389e415ddd4f",
           "item": "struct CommitLogDispatcherCompaction",
-          "line": 34
-        },
-        {
-          "id": "3507f71369e1658286bd6515",
-          "fingerprint": "e13b824155ffa87f01e7fce9",
-          "item": "fn new",
-          "line": 40
+          "line": 32
         },
         {
           "id": "6e0cae205b7868dd7c36a35b",
           "fingerprint": "fc937ce34af84ef786a6e09d",
           "item": "fn new",
-          "line": 42
+          "line": 39
         }
       ],
       "owner": "store",
@@ -29434,7 +29422,7 @@
           "id": "b871300ee7ca8786bbc26b35",
           "fingerprint": "60663fd942af19d6f9199b24",
           "item": "fn run_store_local_file_scheduled_lifecycle_probe",
-          "line": 1173
+          "line": 1175
         }
       ],
       "owner": "store",
@@ -29453,7 +29441,7 @@
           "id": "f8b0ea22c86e0bc6cb92ffea",
           "fingerprint": "1e252acb0c5593b57e0095a1",
           "item": "mod bench_support",
-          "line": 86
+          "line": 87
         }
       ],
       "owner": "store",
@@ -29472,7 +29460,7 @@
           "id": "a42c1622746f302febbeff19",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn run_store_local_file_scheduled_lifecycle_probe",
-          "line": 1176
+          "line": 1178
         }
       ],
       "owner": "store",
@@ -29491,7 +29479,7 @@
           "id": "f348cf8c3d1bbc140f438bb6",
           "fingerprint": "e059b52786cec435681ca0e9",
           "item": "fn run_store_local_file_scheduled_lifecycle_probe",
-          "line": 1173
+          "line": 1175
         }
       ],
       "owner": "store",
@@ -29510,7 +29498,7 @@
           "id": "ff5cb8579b356fbd4d66fab8",
           "fingerprint": "1f5ae028a080b73b6ea8f67b",
           "item": "mod bench_support",
-          "line": 104
+          "line": 105
         }
       ],
       "owner": "store",
@@ -29529,7 +29517,7 @@
           "id": "3f32578d02aba781f727e927",
           "fingerprint": "63916379c0ab7a205c23b321",
           "item": "mod tests",
-          "line": 2959
+          "line": 2979
         }
       ],
       "owner": "store",
@@ -29573,7 +29561,7 @@
           "id": "7265980ec78de765711160b9",
           "fingerprint": "c7fde3d9b289d1ecd7941a05",
           "item": "fn new_test_message_store_with_config",
-          "line": 3024
+          "line": 3044
         }
       ],
       "owner": "store",
@@ -29695,7 +29683,7 @@
           "id": "7d50f4c4fbd25dc571276dc0",
           "fingerprint": "2bc31f44c5cd16da510f2fe2",
           "item": "fn set_local_file_message_store",
-          "line": 2624
+          "line": 2644
         }
       ],
       "owner": "store",
@@ -29714,19 +29702,19 @@
           "id": "da8ccd189d2844b2e870193c",
           "fingerprint": "8a0d7e5c51594fee80b63b61",
           "item": "fn new_test_message_store",
-          "line": 2998
+          "line": 3018
         },
         {
           "id": "f12d31cdccaebfaa4cc42cd6",
           "fingerprint": "453a5926ef6a46236add2f7a",
           "item": "fn new_test_message_store_with_config",
-          "line": 3012
+          "line": 3032
         },
         {
           "id": "706a410d8231e6134ff660c8",
           "fingerprint": "db4993cd6e602d126ae6cf86",
           "item": "fn new_test_message_store_with_config",
-          "line": 3023
+          "line": 3043
         }
       ],
       "owner": "store",
@@ -29745,7 +29733,7 @@
           "id": "0c7f006a8cf1bf0f03fbaa4f",
           "fingerprint": "a236422f00598205b2ff717d",
           "item": "fn new_test_message_store_with_config",
-          "line": 3024
+          "line": 3044
         }
       ],
       "owner": "store",
@@ -29783,7 +29771,7 @@
           "id": "b8bade14a233134bdbf671f0",
           "fingerprint": "95f1bf9079030c415e36ad1d",
           "item": "mod tests",
-          "line": 2966
+          "line": 2986
         }
       ],
       "owner": "store",
@@ -29832,7 +29820,7 @@
           "id": "98382aa3b1702f6fe382573d",
           "fingerprint": "76ad9de840a1761bb227056d",
           "item": "fn set_local_file_message_store",
-          "line": 2624
+          "line": 2644
         }
       ],
       "owner": "store",
@@ -29851,13 +29839,13 @@
           "id": "6fb1f9cbc0eb0c4c291900bb",
           "fingerprint": "08f62297165ccb9ba5b90f31",
           "item": "fn new_test_message_store",
-          "line": 2998
+          "line": 3018
         },
         {
           "id": "9886a9ac3ad22da55b510088",
           "fingerprint": "c9876221ef5ecc4c67a7b873",
           "item": "fn new_test_message_store_with_config",
-          "line": 3012
+          "line": 3032
         }
       ],
       "owner": "store",
@@ -30100,13 +30088,13 @@
           "id": "41cfbce8951a575089c25d86",
           "fingerprint": "1db69a6201259e16b3e3de6d",
           "item": "fn get_consume_queue",
-          "line": 3353
+          "line": 3373
         },
         {
           "id": "fb117dcbd6c98f3fc8307c10",
           "fingerprint": "eac0977e97367bb08379fd51",
           "item": "fn find_consume_queue",
-          "line": 3360
+          "line": 3380
         }
       ],
       "owner": "store",
@@ -30137,19 +30125,19 @@
           "id": "89c232cf45deec0689d095b3",
           "fingerprint": "8f05858b4f69cb3c851df1f8",
           "item": "fn try_new",
-          "line": 578
+          "line": 593
         },
         {
           "id": "57e135a427ffb2ea551225b9",
           "fingerprint": "457380e7781ba11f1a1c1b8b",
           "item": "fn init",
-          "line": 1816
+          "line": 1835
         },
         {
           "id": "5dcf15358cca2af960647d6d",
           "fingerprint": "795137858435605e6055c3bb",
           "item": "fn init",
-          "line": 1822
+          "line": 1841
         }
       ],
       "owner": "store",
@@ -30168,67 +30156,67 @@
           "id": "fe6ed215f742b0b7382f046f",
           "fingerprint": "3228e710dd3b2f82289ce6e0",
           "item": "fn new_configured_test_store_with_broker",
-          "line": 5538
+          "line": 5598
         },
         {
           "id": "a784257a9eea3ca2888a65d6",
           "fingerprint": "730edc6c382a5095a5566f80",
           "item": "fn new_unwired_test_store",
-          "line": 5576
+          "line": 5636
         },
         {
           "id": "ea80384d3d04734ae9e31340",
           "fingerprint": "bc019fd36449638f708552dc",
           "item": "fn set_message_store_arc_initializes_timer_message_store_when_timer_wheel_enabled",
-          "line": 5856
+          "line": 5916
         },
         {
           "id": "c10b456359e577355ad93172",
           "fingerprint": "a8128514745e5b5b0f573a04",
           "item": "fn compaction_topic_dispatches_and_reads_from_compaction_store",
-          "line": 6252
+          "line": 6312
         },
         {
           "id": "1e66c7b54d88ce1b95508c4c",
           "fingerprint": "a8128514745e5b5b0f573a04",
           "item": "fn rocksdb_store_type_with_rocksdb_cq_topic_uses_compat_local_queue_path",
-          "line": 6298
+          "line": 6358
         },
         {
           "id": "6eca838ea25456a66bfe1e87",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn sync_broker_role_in_controller_mode_refreshes_confirm_offset_for_master",
-          "line": 7165
+          "line": 7225
         },
         {
           "id": "7ad9c617a9ab2369224ba894",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk",
-          "line": 7510
+          "line": 7570
         },
         {
           "id": "a90459da038304a8d37b178a",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn do_recheck_reput_offset_from_dispatchers_rewinds_to_dispatched_commitlog_offset",
-          "line": 8061
+          "line": 8122
         },
         {
           "id": "4bf08ba5d315432b007618ef",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn do_recheck_reput_offset_from_dispatchers_uses_minimum_progress_across_cq_and_index",
-          "line": 8111
+          "line": 8172
         },
         {
           "id": "6d4ec8cb2eb76b205899a719",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn get_dispatch_recovery_offset_respects_controller_epoch_start_offset",
-          "line": 8172
+          "line": 8233
         },
         {
           "id": "f55a020f1bb78baf0d9c9841",
           "fingerprint": "c5e5f216d6f09ac7bc48c9e3",
           "item": "fn do_recheck_reput_offset_from_dispatchers_respects_controller_epoch_start_offset_floor",
-          "line": 8197
+          "line": 8258
         }
       ],
       "owner": "store",
@@ -30266,7 +30254,7 @@
           "id": "73d704c7294a4ad3c853d582",
           "fingerprint": "2140089977a37314c7c94030",
           "item": "mod tests",
-          "line": 5437
+          "line": 5497
         }
       ],
       "owner": "store",
@@ -30327,139 +30315,139 @@
           "id": "9ea4eaf9af63b82283fca422",
           "fingerprint": "afe97e447680f873317b8ab8",
           "item": "fn build_tiered_store",
-          "line": 593
+          "line": 608
         },
         {
           "id": "3306ff378264125e46889d33",
           "fingerprint": "e5109240ce1534636584aa25",
           "item": "fn set_message_store_arc",
-          "line": 656
+          "line": 671
         },
         {
           "id": "10e4f234ee2565c31b36a2f7",
           "fingerprint": "53471ebe8974aca32fdab54d",
           "item": "fn delay_level_table",
-          "line": 667
+          "line": 682
         },
         {
           "id": "55d711651af016482f79bc31",
           "fingerprint": "f989223aeed8f2b3eb1a48fc",
           "item": "fn message_store_arc_or_error",
-          "line": 755
+          "line": 770
         },
         {
           "id": "f5fac3db5be9035b514f23eb",
           "fingerprint": "c33b43872bc8c2b497c48d58",
           "item": "fn get_topic_config",
-          "line": 853
+          "line": 868
         },
         {
           "id": "fe18a5aea3534e4ebfc6a76c",
           "fingerprint": "69a8d585bf49df024e8d71a4",
           "item": "fn start",
-          "line": 4019
+          "line": 4061
         },
         {
           "id": "0e882c172d4250fa64b76ab0",
           "fingerprint": "e040ac0df878d7a0f9be8577",
           "item": "struct BackgroundIndexRebuildWorker",
-          "line": 4113
+          "line": 4155
         },
         {
           "id": "4582701031e93158c6d3eff9",
           "fingerprint": "1c93f8e3f0ced7d79afddcc8",
           "item": "fn start",
-          "line": 4349
+          "line": 4391
         },
         {
           "id": "3041a4b81382e6207f108fdf",
           "fingerprint": "e3fa09bd49504f076da1a918",
           "item": "fn start",
-          "line": 4352
+          "line": 4394
         },
         {
           "id": "f7fa186b77201d41b312b3ac",
           "fingerprint": "25308b92853a7656193b065e",
           "item": "fn start",
-          "line": 4354
+          "line": 4396
         },
         {
           "id": "66b95ed4a446ae74aa052cc7",
           "fingerprint": "96c1f62b398174e21a5554b8",
           "item": "fn run_once",
-          "line": 4521
+          "line": 4565
         },
         {
           "id": "d3d641e8d0b6ae2a13fbe2ad",
           "fingerprint": "e3fa09bd49504f076da1a918",
           "item": "fn run_once",
-          "line": 4524
+          "line": 4568
         },
         {
           "id": "fab45978fcb0c29d61780058",
           "fingerprint": "5c304b2651587cadb336e9a6",
           "item": "fn run_once",
-          "line": 4526
+          "line": 4570
         },
         {
           "id": "b34a21bf98770e31f4a165b4",
           "fingerprint": "6456002e767075c2a111a438",
           "item": "struct ReputMessageServiceInner",
-          "line": 4602
+          "line": 4646
         },
         {
           "id": "e0683262788f978bff01a307",
           "fingerprint": "e3fa09bd49504f076da1a918",
           "item": "struct ReputMessageServiceInner",
-          "line": 4605
+          "line": 4649
         },
         {
           "id": "5225e46ff563c824304d8ab6",
           "fingerprint": "384947f17b5bac7593610153",
           "item": "struct ReputMessageServiceInner",
-          "line": 4639
+          "line": 4651
         },
         {
           "id": "f8587bafc2ac2f561ea493bb",
           "fingerprint": "f5b90ca5c266723a95147fa1",
           "item": "fn dispatch_reput_batch",
-          "line": 4643
+          "line": 4655
         },
         {
           "id": "59b6f3a63c8c6592eeac6514",
           "fingerprint": "05a30ded732ed2c1c89ad3f3",
           "item": "fn dispatch_reput_batch",
-          "line": 4612
+          "line": 4656
         },
         {
           "id": "d8037a2bd068cdcd2c5f00db",
           "fingerprint": "545c9b46ab33535af90503fe",
           "item": "struct CleanCommitLogService",
-          "line": 4965
+          "line": 5013
         },
         {
           "id": "d583a5819be1a1a66fc207ab",
           "fingerprint": "eb5c006d884d32a8e0b5e9b8",
           "item": "struct CleanConsumeQueueService",
-          "line": 5172
+          "line": 5232
         },
         {
           "id": "95946ce5d0633d5bb0eb512b",
           "fingerprint": "2d17eb4b45a953b52bfc11a9",
           "item": "fn new",
-          "line": 5178
+          "line": 5238
         },
         {
           "id": "61cc2f3dbf65ad4e6a3025ec",
           "fingerprint": "2ff84019b2e3a42a1d431022",
           "item": "struct CorrectLogicOffsetService",
-          "line": 5212
+          "line": 5272
         },
         {
           "id": "b5b3d3b4a047150fa61686c4",
           "fingerprint": "ac08876c41b7c0d7270e69a9",
           "item": "fn new",
-          "line": 5217
+          "line": 5277
         }
       ],
       "owner": "store",
@@ -30478,115 +30466,115 @@
           "id": "0272eb6f065fcadde2433cc9",
           "fingerprint": "07f48c3f324369a987bcd9ed",
           "item": "fn new",
-          "line": 4978
+          "line": 5027
         },
         {
           "id": "818e23254f48bf96c011502d",
           "fingerprint": "06808e60c57a588d963a39d1",
           "item": "fn new_test_store",
-          "line": 5494
+          "line": 5554
         },
         {
           "id": "bd75d2fc21441146137a1fa7",
           "fingerprint": "2c50adbb8bb3601aa9696f99",
           "item": "fn new_configured_test_store",
-          "line": 5528
+          "line": 5588
         },
         {
           "id": "a4565850138c33457cb4503f",
           "fingerprint": "ddaaf51b7e9e8a6d5a7fa862",
           "item": "fn new_configured_test_store_with_broker",
-          "line": 5536
+          "line": 5596
         },
         {
           "id": "82ea5c873c16992c9150a787",
           "fingerprint": "a59864eb9429d10129008663",
           "item": "fn new_configured_test_store_with_broker",
-          "line": 5541
+          "line": 5601
         },
         {
           "id": "e300821df2b0dcc5a7ec4518",
           "fingerprint": "1240b98bd3ace44c67fb31a5",
           "item": "fn new_unwired_test_store",
-          "line": 5571
+          "line": 5631
         },
         {
           "id": "03de0f2c94675977dc93bc33",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn new_unwired_test_store",
-          "line": 5579
+          "line": 5639
         },
         {
           "id": "f405d52da628e924dba63dd5",
           "fingerprint": "9594ea63f3c6dfc2a4f8dadb",
           "item": "fn reput_inner_for_store",
-          "line": 5637
+          "line": 5697
         },
         {
           "id": "2bc785020cffc531f67851d5",
           "fingerprint": "65fc444d08793f252677b512",
           "item": "fn new_async_flush_test_store",
-          "line": 5735
+          "line": 5795
         },
         {
           "id": "d3c97c8726298454fce74c15",
           "fingerprint": "7666f2a4683b6bb72bf1c3ee",
           "item": "fn append_encoded_test_message",
-          "line": 5786
+          "line": 5846
         },
         {
           "id": "f82cfea3d0ea6119b10efdb0",
           "fingerprint": "09110b2e53b7eb82a0456a37",
           "item": "fn append_encoded_test_message_with_key",
-          "line": 5796
+          "line": 5856
         },
         {
           "id": "12312895c95000e25723ccbe",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn set_message_store_arc_initializes_timer_message_store_when_timer_wheel_enabled",
-          "line": 5859
+          "line": 5919
         },
         {
           "id": "9b6981b75d6d8201e9a8365d",
           "fingerprint": "30e084e32d538c30720ff9b6",
           "item": "fn sync_broker_role_in_controller_mode_refreshes_confirm_offset_for_master",
-          "line": 7176
+          "line": 7236
         },
         {
           "id": "a8e3d703ddc770393aa8d072",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn master_store_in_process_round_trips_concrete_store_reference",
-          "line": 7215
+          "line": 7275
         },
         {
           "id": "832e44c796a4cee0ae67a7dd",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk",
-          "line": 7518
+          "line": 7578
         },
         {
           "id": "189e90157c3a3241f6b72456",
           "fingerprint": "30e084e32d538c30720ff9b6",
           "item": "fn do_recheck_reput_offset_from_dispatchers_rewinds_to_dispatched_commitlog_offset",
-          "line": 8071
+          "line": 8132
         },
         {
           "id": "7b87fd1be059d112aaa2ecc3",
           "fingerprint": "30e084e32d538c30720ff9b6",
           "item": "fn do_recheck_reput_offset_from_dispatchers_uses_minimum_progress_across_cq_and_index",
-          "line": 8121
+          "line": 8182
         },
         {
           "id": "e0986b3022b078d47dfc7fdc",
           "fingerprint": "30e084e32d538c30720ff9b6",
           "item": "fn get_dispatch_recovery_offset_respects_controller_epoch_start_offset",
-          "line": 8182
+          "line": 8243
         },
         {
           "id": "dbd3ad2b6d465c9f58ff2af5",
           "fingerprint": "30e084e32d538c30720ff9b6",
           "item": "fn do_recheck_reput_offset_from_dispatchers_respects_controller_epoch_start_offset_floor",
-          "line": 8207
+          "line": 8268
         }
       ],
       "owner": "store",
@@ -30605,61 +30593,61 @@
           "id": "72afb08dd84823802eddf156",
           "fingerprint": "7322e8445966d188ee7fd92d",
           "item": "fn new_configured_test_store_with_broker",
-          "line": 5538
+          "line": 5598
         },
         {
           "id": "a4fff833b2fce8cc031cd4c0",
           "fingerprint": "338645fde00ddca9b9407106",
           "item": "fn new_unwired_test_store",
-          "line": 5576
+          "line": 5636
         },
         {
           "id": "0fb3aca56be2c7b8686d0093",
           "fingerprint": "98775f57bdf0972c76ba7d6d",
           "item": "fn set_message_store_arc_initializes_timer_message_store_when_timer_wheel_enabled",
-          "line": 5856
+          "line": 5916
         },
         {
           "id": "7c7647aaebb9f5e60713f098",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn sync_broker_role_in_controller_mode_refreshes_confirm_offset_for_master",
-          "line": 7165
+          "line": 7225
         },
         {
           "id": "532385187ca9a0a1d26b5ad9",
           "fingerprint": "3592b529ab80ca668d418994",
           "item": "fn master_store_in_process_round_trips_concrete_store_reference",
-          "line": 7204
+          "line": 7264
         },
         {
           "id": "c6b0b2d54151b046598a4eac",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk",
-          "line": 7510
+          "line": 7570
         },
         {
           "id": "0ef117a8762354e66adc13ba",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn do_recheck_reput_offset_from_dispatchers_rewinds_to_dispatched_commitlog_offset",
-          "line": 8061
+          "line": 8122
         },
         {
           "id": "ef577de87e7470e8528bf219",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn do_recheck_reput_offset_from_dispatchers_uses_minimum_progress_across_cq_and_index",
-          "line": 8111
+          "line": 8172
         },
         {
           "id": "2e2dbf0ae36fa13c563d8440",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn get_dispatch_recovery_offset_respects_controller_epoch_start_offset",
-          "line": 8172
+          "line": 8233
         },
         {
           "id": "fea9d18dd6124ff2f461ca3f",
           "fingerprint": "c11a0ed2016e5f22d0681b8d",
           "item": "fn do_recheck_reput_offset_from_dispatchers_respects_controller_epoch_start_offset_floor",
-          "line": 8197
+          "line": 8258
         }
       ],
       "owner": "store",
@@ -30678,7 +30666,7 @@
           "id": "3dd2d02171a16f9cda183c72",
           "fingerprint": "0d4bb512c707f673d304374f",
           "item": "mod tests",
-          "line": 5460
+          "line": 5520
         }
       ],
       "owner": "store",
@@ -30734,67 +30722,67 @@
           "id": "1755447c34eba58228ab63ab",
           "fingerprint": "d6c800e84bf0268d938070ca",
           "item": "fn set_message_store_arc",
-          "line": 656
+          "line": 671
         },
         {
           "id": "430536820fef8d2029e0813f",
           "fingerprint": "a82bed77f348e97f3fc18d4a",
           "item": "fn message_store_arc_or_error",
-          "line": 755
+          "line": 770
         },
         {
           "id": "fe864a8e7bb01fdf4839a1ec",
           "fingerprint": "b1e5ab656549d1ea194d5bd3",
           "item": "impl Drop",
-          "line": 842
+          "line": 857
         },
         {
           "id": "9ba3e5e75793e333cc4f7e58",
           "fingerprint": "28b9f90e9d6de0e1c04f40b0",
           "item": "impl LocalFileMessageStore",
-          "line": 851
+          "line": 866
         },
         {
           "id": "7de71a3330daeebfe3e4fcdb",
           "fingerprint": "bc54d1e953e8dc9c4d8b1704",
           "item": "impl MessageStore",
-          "line": 1620
+          "line": 1635
         },
         {
           "id": "dd7d2ca979e7321a0531cad8",
           "fingerprint": "0716072c66ac8246e6711921",
           "item": "fn start",
-          "line": 4354
+          "line": 4396
         },
         {
           "id": "cd8634aab722ed70fbbb60d4",
           "fingerprint": "2ae53147e701a16cb0e446b7",
           "item": "fn run_once",
-          "line": 4526
+          "line": 4570
         },
         {
           "id": "0dd1883d3024e576e97c64a6",
           "fingerprint": "b675292f3c2244dccaa81c69",
           "item": "struct ReputMessageServiceInner",
-          "line": 4639
+          "line": 4651
         },
         {
           "id": "0084947673da00b358eda490",
           "fingerprint": "90fec4925e7650a4d7a58a5d",
           "item": "fn dispatch_reput_batch",
-          "line": 4612
+          "line": 4656
         },
         {
           "id": "17a40d2b55a9ccc512c7286c",
           "fingerprint": "468eb0a73148a232b93b9dbd",
           "item": "fn do_reput",
-          "line": 4745
+          "line": 4790
         },
         {
           "id": "c22cad79c43f8dc4b5793c0c",
           "fingerprint": "ec470e270ac9362bd7c04ed3",
           "item": "fn read_and_parse_batch",
-          "line": 4902
+          "line": 4948
         }
       ],
       "owner": "store",
@@ -30813,85 +30801,85 @@
           "id": "b51abb9cdd4277835643fb3a",
           "fingerprint": "613631996c689785a0c6b2cf",
           "item": "fn is_space_to_delete",
-          "line": 5094
+          "line": 5154
         },
         {
           "id": "6a112e4551e45cd0ec64422b",
           "fingerprint": "e80b3e9ee2dffe26e070244d",
           "item": "fn min_physic_disk_ratio",
-          "line": 5134
+          "line": 5194
         },
         {
           "id": "4170a65b94468400f103d66a",
           "fingerprint": "80a2a65128a715e4690f9234",
           "item": "fn new_test_store",
-          "line": 5494
+          "line": 5554
         },
         {
           "id": "ecef5dc452b331aa59ee2e0c",
           "fingerprint": "65d2f136242a67e39970048c",
           "item": "fn new_configured_test_store",
-          "line": 5528
+          "line": 5588
         },
         {
           "id": "f4167e9cdb317f920eee8481",
           "fingerprint": "09828229447f9c27eca62b69",
           "item": "fn new_configured_test_store_with_broker",
-          "line": 5536
+          "line": 5596
         },
         {
           "id": "e0aa33305e95db168c92764e",
           "fingerprint": "a83fce1e061e676764384245",
           "item": "fn new_unwired_test_store",
-          "line": 5571
+          "line": 5631
         },
         {
           "id": "a5b4a4beeff33840a0fc01c7",
           "fingerprint": "cbc997c17eb8e6ca0bfde016",
           "item": "fn install_recording_arriving_listener",
-          "line": 5627
+          "line": 5687
         },
         {
           "id": "740811ee3ad741abaa452675",
           "fingerprint": "1173b84cce36bf29492ae20f",
           "item": "fn reput_inner_for_store",
-          "line": 5637
+          "line": 5697
         },
         {
           "id": "952561de7f9c1082ab5972bd",
           "fingerprint": "f05584a3e8f30f1765f4faa7",
           "item": "fn new_async_flush_test_store",
-          "line": 5735
+          "line": 5795
         },
         {
           "id": "b6d69ce623a4436bf9946d9b",
           "fingerprint": "1096c9bed13b8b6a0e6add8c",
           "item": "fn encode_tiered_test_message",
-          "line": 5763
+          "line": 5823
         },
         {
           "id": "ebc61622bb5d0eed7de2b3c5",
           "fingerprint": "2be67fb1f1aa0fd31c8d50cb",
           "item": "fn append_encoded_test_message",
-          "line": 5786
+          "line": 5846
         },
         {
           "id": "9a402b7ec18071dc55b33a0b",
           "fingerprint": "b1b766dcf50e538cdd500bc1",
           "item": "fn append_encoded_test_message_with_key",
-          "line": 5796
+          "line": 5856
         },
         {
           "id": "0dab0a2327068f084dad3638",
           "fingerprint": "f705056c61af1cd82f726a9c",
           "item": "fn master_store_in_process_round_trips_concrete_store_reference",
-          "line": 7223
+          "line": 7283
         },
         {
           "id": "57088fa6a3447b30555d062b",
           "fingerprint": "5602f91428927b4c07a845d2",
           "item": "fn clean_commit_log_service_run_deletes_when_disk_usage_is_unavailable",
-          "line": 8671
+          "line": 8777
         }
       ],
       "owner": "store",
@@ -30910,25 +30898,25 @@
           "id": "47767c8e5ca840205a963aeb",
           "fingerprint": "0db97432516266903a225050",
           "item": "fn reset_write_offset",
-          "line": 3290
+          "line": 3310
         },
         {
           "id": "2732429f59b892a7989c9385",
           "fingerprint": "1536b864d3d6678585c2bd31",
           "item": "fn get_commit_log_mut_from_ref",
-          "line": 3422
+          "line": 3442
         },
         {
           "id": "eea893960dd7e04dd261bdd0",
           "fingerprint": "f5378b1857786f892cf9849d",
           "item": "fn truncate_files",
-          "line": 3638
+          "line": 3658
         },
         {
           "id": "3459e3572b6f2b66ed8b8e65",
           "fingerprint": "470c1a7982c2bfa430ed8b87",
           "item": "fn get_last_mapped_file",
-          "line": 3689
+          "line": 3709
         }
       ],
       "owner": "store",
@@ -30947,13 +30935,13 @@
           "id": "0d94c53f509642321269d6a1",
           "fingerprint": "47dde9b29fa10781ebc41bb0",
           "item": "fn run",
-          "line": 5046
+          "line": 5058
         },
         {
           "id": "63278d5eba087cd7f1369da9",
           "fingerprint": "a465cc592854aa5addc3bd2c",
           "item": "fn run",
-          "line": 5072
+          "line": 5084
         }
       ],
       "owner": "store",
@@ -32124,7 +32112,7 @@
           "id": "4b9e90dd8bc6e42dd9cb53e6",
           "fingerprint": "c7fea6c6e4b67ae3a13fd45b",
           "item": "fn new_configured_test_store",
-          "line": 1038
+          "line": 1049
         }
       ],
       "owner": "store",
@@ -32162,7 +32150,7 @@
           "id": "8b955667e5eeaf85721cca1a",
           "fingerprint": "392812b135cb91d518125ce6",
           "item": "mod tests",
-          "line": 1010
+          "line": 1021
         }
       ],
       "owner": "store",
@@ -32206,19 +32194,19 @@
           "id": "13cc2ebf1d4f8de73a0b5795",
           "fingerprint": "969bec7cef9b5744b6ab4fe0",
           "item": "fn new_test_store",
-          "line": 1023
+          "line": 1034
         },
         {
           "id": "99f05e2e748906d9bbaefd14",
           "fingerprint": "944459752d615c7b8def8330",
           "item": "fn new_configured_test_store",
-          "line": 1036
+          "line": 1047
         },
         {
           "id": "11d332c6f80277b72c570224",
           "fingerprint": "4409877677a2ab1aa08a3793",
           "item": "fn new_configured_test_store",
-          "line": 1041
+          "line": 1052
         }
       ],
       "owner": "store",
@@ -32237,7 +32225,7 @@
           "id": "145af9647bc44e52cb6de2bf",
           "fingerprint": "5b7c7626609baabda1c4c8fe",
           "item": "fn new_configured_test_store",
-          "line": 1038
+          "line": 1049
         }
       ],
       "owner": "store",
@@ -32256,7 +32244,7 @@
           "id": "600fab6771f8509cbd698121",
           "fingerprint": "117aa1e982b7efb9e22bd674",
           "item": "mod tests",
-          "line": 1016
+          "line": 1027
         }
       ],
       "owner": "store",
@@ -32275,25 +32263,25 @@
           "id": "ab1d13ee688ed95a6d6e2908",
           "fingerprint": "1205c4bda7cf9a0283f6e1cb",
           "item": "fn new_test_store",
-          "line": 1023
+          "line": 1034
         },
         {
           "id": "4c1a1af8c0a2151d25f80eee",
           "fingerprint": "05366a86ed16017d11544a2d",
           "item": "fn new_configured_test_store",
-          "line": 1036
+          "line": 1047
         },
         {
           "id": "958e00d1a66be8ac723efedf",
           "fingerprint": "51c76c8c9a204046921e1e6b",
           "item": "fn new_test_consume_queue",
-          "line": 1054
+          "line": 1065
         },
         {
           "id": "7eaffce78acc9682c23a8883",
           "fingerprint": "74fbc936e4cf96ed2d78cb3a",
           "item": "fn new_configured_test_consume_queue",
-          "line": 1071
+          "line": 1082
         }
       ],
       "owner": "store",
@@ -33622,25 +33610,25 @@
           "id": "c128e6d73c99006121337546",
           "fingerprint": "345eeacedbefe410da564105",
           "item": "fn rocksdb_message_store_dispatcher_dual_writes_commitlog_dispatch_to_rocksdb_cq",
-          "line": 2960
+          "line": 2967
         },
         {
           "id": "8415872b9be46376e1c855c6",
           "fingerprint": "345eeacedbefe410da564105",
           "item": "fn rocksdb_message_store_delete_topics_removes_rocksdb_consume_queue_state",
-          "line": 3167
+          "line": 3174
         },
         {
           "id": "a95e6c06467cc9af9a9bc414",
           "fingerprint": "345eeacedbefe410da564105",
           "item": "fn rocksdb_message_store_truncate_dirty_logic_files_corrects_rocksdb_consume_queue_offsets",
-          "line": 3195
+          "line": 3202
         },
         {
           "id": "5183e601ef006c645be1b41f",
           "fingerprint": "345eeacedbefe410da564105",
           "item": "fn rocksdb_message_store_clean_expired_consumer_queue_triggers_background_rocksdb_compaction",
-          "line": 3228
+          "line": 3235
         }
       ],
       "owner": "store",
@@ -33708,49 +33696,49 @@
           "id": "79e94ab57f96914f5c3bff84",
           "fingerprint": "88e2a164a1575ea0e8052e06",
           "item": "fn rocksdb_message_store_dispatcher_dual_writes_commitlog_dispatch_to_rocksdb_cq",
-          "line": 2961
+          "line": 2968
         },
         {
           "id": "336592262ef564217d8373c4",
           "fingerprint": "3bd706e8557f21b3048a3f4a",
           "item": "fn rocksdb_message_store_registers_trans_dispatcher_when_enabled",
-          "line": 3040
+          "line": 3047
         },
         {
           "id": "9dae001e5543b9ebebe3d3f6",
           "fingerprint": "3bd706e8557f21b3048a3f4a",
           "item": "fn rocksdb_message_store_keeps_trans_service_disabled_by_default",
-          "line": 3082
+          "line": 3089
         },
         {
           "id": "952e6a0e7f187a17042ff195",
           "fingerprint": "3bd706e8557f21b3048a3f4a",
           "item": "fn rocksdb_message_store_registers_timer_dispatcher_when_enabled",
-          "line": 3104
+          "line": 3111
         },
         {
           "id": "2b70e0018614e44f6481c3b4",
           "fingerprint": "3bd706e8557f21b3048a3f4a",
           "item": "fn rocksdb_message_store_keeps_timer_service_disabled_by_default",
-          "line": 3145
+          "line": 3152
         },
         {
           "id": "e4235dd61bcddcd10ef8a262",
           "fingerprint": "88e2a164a1575ea0e8052e06",
           "item": "fn rocksdb_message_store_delete_topics_removes_rocksdb_consume_queue_state",
-          "line": 3168
+          "line": 3175
         },
         {
           "id": "7e40997fb5f1adfab5fc114b",
           "fingerprint": "88e2a164a1575ea0e8052e06",
           "item": "fn rocksdb_message_store_truncate_dirty_logic_files_corrects_rocksdb_consume_queue_offsets",
-          "line": 3196
+          "line": 3203
         },
         {
           "id": "86a488911395528f4bc911e0",
           "fingerprint": "88e2a164a1575ea0e8052e06",
           "item": "fn rocksdb_message_store_clean_expired_consumer_queue_triggers_background_rocksdb_compaction",
-          "line": 3229
+          "line": 3236
         }
       ],
       "owner": "store",

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -26,7 +26,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 50,
       "public_path_sha256": "efb1b554cfdc1275bb621adf4d3dd1ffa51fd50e323e8ced14075251a92644db",
-      "rustdoc_json_sha256": "a6244641ffe1163d0f6fc3375b9f358b5b1e3ecac10acbedb94d8714dea43a7d",
+      "rustdoc_json_sha256": "27379b546d683f45dc0722e0f2ed1e8356e3a2bbb5c2cb43748d4c532c4b1086",
       "target": "rocketmq_broker"
     },
     "rocketmq-client-rust": {
@@ -117,7 +117,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 65,
       "public_path_sha256": "a45a59482ae7b3410ade405dc53f2ca4ca2fb66cc1d3feba986f3aa6cf48efda",
-      "rustdoc_json_sha256": "34ae22a9f434791b10c7811f632e1b51e9e3d84fcc5596d5aad4382c92406303",
+      "rustdoc_json_sha256": "5e1999fcb6dfc5668bfd16561e0c761797ec3145d1914c987abf3cfe00a4ffa8",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
@@ -138,7 +138,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 17,
       "public_path_sha256": "3d9e0f9ac569160099d432c85bbb30d17ee1a107e9f665ee636bd4b5898ebc6b",
-      "rustdoc_json_sha256": "3f48f729375e48c8d0662bbe3adac644e006dc8b26d9e8b3650efb58b5abfcc6",
+      "rustdoc_json_sha256": "b865923896a09001d4c6a5d839ed736d8d8c7334bfe57dddc31079b37e2d632a",
       "target": "rocketmq_proxy_local"
     },
     "rocketmq-remoting": {
@@ -173,7 +173,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "4e25ec493c6e5c3f9742348d16118fceace634e702574c6aff766d87ce9a4b52",
+      "rustdoc_json_sha256": "6a070d0dc965ff831729d7a5c40ffecb2cb2713cc21bd5b4e189f3398534a70d",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -187,7 +187,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 7,
       "public_path_sha256": "c7ac03206be85858d3f2805aba968f45fa3284f5c3265fb823a6435f8e2e929e",
-      "rustdoc_json_sha256": "651ac65d0f42310a388387afe73fa3fef34ee1e5f1771dc59d52fa790dfa0abb",
+      "rustdoc_json_sha256": "4748b20cfb746b096d77eec660400a7216084788e86bceb263b7bef6c082a72b",
       "target": "rocketmq_store_inspect"
     },
     "rocketmq-store-local": {
@@ -208,7 +208,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 116,
       "public_path_sha256": "30e3f19ea359f6f43f2369f0d45ed5cb4a7ed0d6a5fc46ed34b8ea69f02708f3",
-      "rustdoc_json_sha256": "44a9df71bd22b5c8c221e4e94d4dd4be2c9cb31d09d3ce75c007ca3f47e5eb6c",
+      "rustdoc_json_sha256": "ee785965c0030c5f9e0cdb13ff17c7fe7872b2767e9b349226262683bba354a8",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "e3ef67282f420334a4f2bccc7fa01c81facbd60a",
+  "source_commit": "4dfbad5667b6bb5b2c85f39e23d3c7342e210f50",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -5,49 +5,49 @@
       "crate_version": "1.0.0",
       "public_path_count": 294,
       "public_path_sha256": "15df468d980ab0dbcfbfff8c4179604bde17fe67b25519d7c8de0e4eae8093ec",
-      "rustdoc_json_sha256": "2220dfc60bfc6f52895f59d82b9f9d087027b86d36f3e042ffd858389aec6f7b",
+      "rustdoc_json_sha256": "bb0d91560428dbbd5a4426a1aeeb96eb2bb851adda2109c140a69c464f118dd3",
       "target": "rocketmq_admin_cli"
     },
     "rocketmq-admin-core": {
       "crate_version": "1.0.0",
       "public_path_count": 186,
       "public_path_sha256": "427678ac85d4f76728993ad32b402626d24f41eaeb293c9fa5994ab9cc6bfa0d",
-      "rustdoc_json_sha256": "11a3365595a7cdaeceb539c30d12f7fa3e8049abdc1a5cce8889d990f1b30e78",
+      "rustdoc_json_sha256": "cf70098edca232ad9710c6f34dee9a9aafaf6f43b0fccf22b84bfdd374168e5c",
       "target": "rocketmq_admin_core"
     },
     "rocketmq-auth": {
       "crate_version": "1.0.0",
       "public_path_count": 199,
       "public_path_sha256": "3e919362f222f5a4ae299f5e860d10934105feae4f410a985e729643d31952c1",
-      "rustdoc_json_sha256": "d82fb38fea1babe0275e867d7f17e445ae9146637154ac8487c4e6a58b9537b6",
+      "rustdoc_json_sha256": "af0534f2612ded4f0e3a2c691338211d1f73284264c115df0d3ee65fb79f6112",
       "target": "rocketmq_auth"
     },
     "rocketmq-broker": {
       "crate_version": "1.0.0",
       "public_path_count": 50,
       "public_path_sha256": "efb1b554cfdc1275bb621adf4d3dd1ffa51fd50e323e8ced14075251a92644db",
-      "rustdoc_json_sha256": "27379b546d683f45dc0722e0f2ed1e8356e3a2bbb5c2cb43748d4c532c4b1086",
+      "rustdoc_json_sha256": "940f7f84dffdb56e5facb564360bda798f61d887fa5efef2a84ecae77edfb1ca",
       "target": "rocketmq_broker"
     },
     "rocketmq-client-rust": {
       "crate_version": "1.0.0",
       "public_path_count": 386,
       "public_path_sha256": "421f3b97ff6e9b48202f5e9b51f5d0cc98dfaf61d4f60c9dce15ecaad4f86d81",
-      "rustdoc_json_sha256": "60ed1c14fdf8356b6cb7da1209d07b397ff9cd5ebd3c6b11be4f6e7fa576335a",
+      "rustdoc_json_sha256": "9561a668be69cc81006e0de17e655a2cf43dd3efcd5498a53a0759a412d615e5",
       "target": "rocketmq_client_rust"
     },
     "rocketmq-common": {
       "crate_version": "1.0.0",
       "public_path_count": 620,
       "public_path_sha256": "21cb8a8a110ebfb2dab0bdc82c6a8c1e32d7faf62b0c60be2849b6972ada8447",
-      "rustdoc_json_sha256": "589a828ac0ac50334ece7e67c6fe3fab691ee58b405b1f261635fcef81da8de3",
+      "rustdoc_json_sha256": "268b0fe3b8e29d9c076c44d294ba0e726102b954ed720c389d0c08457bb34ff4",
       "target": "rocketmq_common"
     },
     "rocketmq-controller": {
       "crate_version": "1.0.0",
       "public_path_count": 250,
       "public_path_sha256": "c3bcca468f5d744ccd6a5f4ad23d6970f905e6fee605acb246d1198a397e9d05",
-      "rustdoc_json_sha256": "66fdb5987ed71fcb877734f14954d42972b5c5bf706526d4dd89b6cd83ba1b73",
+      "rustdoc_json_sha256": "6fb4997a8c44a4da19559932f6e2acf39a14878f6fc72ebc8c3b35d3f8fdb33a",
       "target": "rocketmq_controller"
     },
     "rocketmq-dashboard-common": {
@@ -82,7 +82,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 209,
       "public_path_sha256": "60186348b7385948d4018e3ef8cac323084981e7cd18b1ed527b3ec32af85758",
-      "rustdoc_json_sha256": "3efc409afb41a28e4521b9be84f27df31c890817a1e828de73d0055ef2e00de4",
+      "rustdoc_json_sha256": "59e6aa043b9f675c8eb4b3938b81f560e54555c26c8a5fc38abf9af95a920115",
       "target": "rocketmq_mcp"
     },
     "rocketmq-model": {
@@ -96,7 +96,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 55,
       "public_path_sha256": "b9d02df04a02dbe99e0931f0b9e2c006993f1663a836bbce532cc59566b3fb31",
-      "rustdoc_json_sha256": "127803026599e91d9a9b6aa6d56930703cb3d1a5c7b89705abbad69e502396a5",
+      "rustdoc_json_sha256": "5d656ef01e567eefb604fb1d58d6328d64c573d34849187995420569d1c8fd6d",
       "target": "rocketmq_namesrv"
     },
     "rocketmq-observability": {
@@ -117,14 +117,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 65,
       "public_path_sha256": "a45a59482ae7b3410ade405dc53f2ca4ca2fb66cc1d3feba986f3aa6cf48efda",
-      "rustdoc_json_sha256": "5e1999fcb6dfc5668bfd16561e0c761797ec3145d1914c987abf3cfe00a4ffa8",
+      "rustdoc_json_sha256": "232fc90bb8d71bceaf1c9d305893acce45e090a800043dbce7caea89b7c858fe",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
       "crate_version": "1.0.0",
       "public_path_count": 16,
       "public_path_sha256": "a54347aa28148322afe3d20aaf05915c76060a2c32efb7809271c063296e32b2",
-      "rustdoc_json_sha256": "222b0b3c5b041d9b64ad73f24c071d22b59e4a31ed04f3db3ca698a54bb63e80",
+      "rustdoc_json_sha256": "69e3d7866c2bf7dd28bcb353331be025b7b5d06faf1025618681de422a27ef02",
       "target": "rocketmq_proxy_cluster"
     },
     "rocketmq-proxy-core": {
@@ -138,14 +138,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 17,
       "public_path_sha256": "3d9e0f9ac569160099d432c85bbb30d17ee1a107e9f665ee636bd4b5898ebc6b",
-      "rustdoc_json_sha256": "b865923896a09001d4c6a5d839ed736d8d8c7334bfe57dddc31079b37e2d632a",
+      "rustdoc_json_sha256": "f3f342e15749ed1b959033ed84328934fb5f6a9b2862f5944702a62cb04a6c36",
       "target": "rocketmq_proxy_local"
     },
     "rocketmq-remoting": {
       "crate_version": "1.0.0",
       "public_path_count": 207,
       "public_path_sha256": "4b537a17b7eee97f26fed4a5a18c503250f401cd964bc723697301f0d237d7c9",
-      "rustdoc_json_sha256": "e87abfd148dcf4232f493b3aa50c97a17a46bdd01f60243c2f158e0766b5b249",
+      "rustdoc_json_sha256": "2dcc4317956137711b2f87ec2b234dfe9b95c7128eaef163d69b9900b60a4040",
       "target": "rocketmq_remoting"
     },
     "rocketmq-runtime": {
@@ -173,7 +173,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "6a070d0dc965ff831729d7a5c40ffecb2cb2713cc21bd5b4e189f3398534a70d",
+      "rustdoc_json_sha256": "ae3737ce8e657dea6c9aa755f2b1c731a1139b46d3854b3a5f6dd7c317d18968",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -187,7 +187,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 7,
       "public_path_sha256": "c7ac03206be85858d3f2805aba968f45fa3284f5c3265fb823a6435f8e2e929e",
-      "rustdoc_json_sha256": "4748b20cfb746b096d77eec660400a7216084788e86bceb263b7bef6c082a72b",
+      "rustdoc_json_sha256": "aef12755a2e19c8bff5851ca495d213e21cd01ba017c30a8138fe4f7c6a2d0ad",
       "target": "rocketmq_store_inspect"
     },
     "rocketmq-store-local": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "4dfbad5667b6bb5b2c85f39e23d3c7342e210f50",
+  "source_commit": "92608c2962bc6e3f0e226980eb7bbf92ac162c1f",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
## Summary

- publish Tiered Index and Local Compaction through versioned, CRC-validated generations and atomic `CURRENT` pointers
- retain validated previous generations with reader leases, durable directory operations, restart orphan cleanup, and deterministic rollback
- copy live Compaction records into each generation, replay from a durable watermark, and fail closed without raw CommitLog scans
- update M10-04 evidence/checklists to 63/82 complete with M10-05 next

## Validation

- `cargo test -p rocketmq-store --lib` (486 passed)
- `cargo test -p rocketmq-tieredstore` (66 library + 1 POSIX + 7 integration passed)
- Store/Broker RocksDB matrix (82 + 9 + 20 + 4 passed)
- affected-crate and workspace all-target/all-feature strict Clippy
- MCP check/test/streamable-http strict Clippy/doc
- runtime, typed-error, dependency, ArcMut, release, routing, public API (31/31), fmt, and diff guards

## Disclosed baseline/environment findings

- full `cargo test -p rocketmq-store` still reproduces the unchanged `file_store_vs_rocksdb_behavior_parity_after_restart` baseline fixture failure; real RocksDB suites pass
- Windows PDB limits required `/PDB:NONE` with a single Cargo job; no repository configuration was changed

Closes #8266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable, versioned compaction and index generations that persist across restarts.
  - Improved recovery with validated generation loading, rollback support, and controlled recovery states.
  - Added atomic publication, integrity validation, and delayed cleanup of retired generations.
  - Enhanced storage compatibility across Windows, POSIX, memory, and tiered backends.

- **Bug Fixes**
  - Improved handling of partial file reads and corrupted generation metadata.
  - Avoided unnecessary index compaction when no entries require removal.

- **Documentation**
  - Updated migration progress, architecture requirements, and implementation evidence for generation-based storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->