### PR TITLE
[ISSUE #8270]♻️Establish telemetry semantic registry

### DIFF
--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -83,6 +83,9 @@ jobs:
       - name: Check architecture performance profiles
         run: python scripts/architecture_performance_guard.py --validate-profiles
 
+      - name: Check telemetry semantic registry
+        run: python scripts/telemetry_semantic_guard.py
+
       - name: Check shared-mutation fixtures
         run: python scripts/arc_mut_guard.py --fixtures
 

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,15 +29,15 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 64 | 0 | 18 未开始；合计 18 尚未完成 | 82 |
-| 里程碑 | 9（M01–M09） | 1（M10，工作包完成、Gate 待验收） | 2（M11–M12） | 12 |
+| PR 级工作包 | 65 | 0 | 17 未开始；合计 17 尚未完成 | 82 |
+| 里程碑 | 9（M01–M09） | 2（M10 待验收、M11 实施中） | 1（M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 18 个未开始工作包分布：M10 为 0 个、M11 为 12 个、M12 为 6 个。
+剩余 17 个未开始工作包分布：M10 为 0 个、M11 为 11 个、M12 为 6 个。
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
-`待验收`而非`已完成`。当前下一工作包为 PR-M11-01。
+`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-02。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -518,7 +518,14 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
 
 任务文档：[`11-security-observability-cloud.md`](phase-3-production-readiness/11-security-observability-cloud.md)
 
-- [ ] PR-M11-01：建立 Telemetry semantic registry
+- [x] PR-M11-01：建立 Telemetry semantic registry
+  - [x] 119 个 metric、4 个 span、7 个 stable log event 与 66 个 attribute 进入 versioned registry
+  - [x] guard 与 Rust semantic/catalog/span/event/outage 常量双向同步，拒绝未知信号、隐私/基数/采样/deprecation 漂移
+  - [x] 7 类故意违规 fixture 与 7 个 guard 单测通过；全架构 guard 132/132 通过并接入 Linux/Windows CI
+  - [x] collector outage queue 同时限制 count/bytes/record，`try_enqueue` 不等待并计量 drop；provider 共享绝对关闭预算
+  - [x] observability 精确 7 组 feature matrix 的 workspace check、strict Clippy 和 package test 全部通过
+  - [x] [`M11-01 证据`](phase-3-production-readiness/11-telemetry-semantic-registry-evidence.md) 记录 API、验证、失败修复与回滚边界
+  - [x] 65/82 已完成、17 未完成，下一工作包 PR-M11-02；M10/M11/Phase 3 Gate 均未提前宣称完成
 - [ ] PR-M11-02：实现 SecretProvider 基础合同与本地 adapter
 - [ ] PR-M11-03：实现 Secure Profile 与一次性 bootstrap
 - [ ] PR-M11-04：实现 credential/certificate rotation 与原子 reload

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3；M10 工作包已完成但真实性能/HUMAN Gate 待验收，下一工作包为 PR-M11-01）
+> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已启动，下一工作包为 PR-M11-02）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；64/82 工作包完成，剩余 18 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；65/82 工作包完成，剩余 17 个
 
 ## 1. 使用方式
 
@@ -218,6 +218,7 @@ python scripts/architecture_dependency_guard.py --mode baseline
 python scripts/architecture_release_guard.py
 python scripts/architecture_performance_guard.py --validate-profiles
 python scripts/architecture_performance_guard.py --baseline <baseline.json> --candidate <candidate.json>
+python scripts/telemetry_semantic_guard.py
 python scripts/arc_mut_guard.py
 .\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline
 .\scripts\check-error-hygiene.ps1
@@ -230,16 +231,15 @@ git diff --check
 
 ### 9.2 由里程碑新增后才执行的命令
 
-下列脚本是 M11 的计划交付物，当前不能作为已存在的门禁报告成功：
+下列脚本仍是 M11 后续工作包的计划交付物，当前不能作为已存在的门禁报告成功：
 
 ```powershell
-python scripts/telemetry_semantic_guard.py
 .\scripts\kind-architecture-refactor-e2e.ps1
 ```
 
 M10 性能 guard 已落地；`--validate-profiles` 只验证合同，baseline/candidate 命令只有消费真实目标硬件报告时
-才构成性能验收。M11 脚本落地前，用 `cargo metadata`、`cargo tree`、`rg`、现有测试和人工证据完成同等预检；
-脚本落地的 PR 必须同时提供正向和故意违规的 fixture。
+才构成性能验收。M11 telemetry semantic guard 已随 PR-M11-01 落地并包含正向和故意违规 fixture；Kind/K3d
+脚本落地前，用现有测试和人工证据完成同等预检，脚本落地的 PR 也必须提供正负 fixture。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 已批准，等待 M09；部分依赖 M10 SLI |
+| 状态 | 实施中（PR-M11-01 已完成；下一工作包 PR-M11-02；部分依赖 M10 SLI） |
 | 预计周期 | 4–6 周 |
 | 工作包 | 延续 WP01、WP03、WP05、WP07、WP14–WP16 |
 | 前置条件 | 32-package Gate；secure dry-run、ServiceContext、semantic owner、durability SLI 可用 |
@@ -48,12 +48,16 @@
 
 ### PR-M11-01：Telemetry semantic registry
 
-- [ ] `[ARCH]` 为每个 metric/span/log 声明 owner、unit、stability、attributes、cardinality、privacy、deprecation。
-- [ ] `[DEV]` 实现计划中的 `telemetry_semantic_guard.py` 和违规 fixture，未登记/超预算字段拒绝。
-- [ ] `[DEV]` 登记 request、watermark/lag、connection/bytes、task、recovery/cache、auth/MCP、exporter 信号。
-- [ ] `[TEST]` 覆盖 collector outage：有界队列、可计量 drop、shutdown timeout，数据面不阻塞。
-- [ ] `[REV]` 检查字段低基数、采样明确、无敏感数据和每消息无限 span/event。
-- [ ] 回滚点：registry 可回到上一 version；不得关闭 privacy/cardinality 失败。
+- [x] `[ARCH]` 为每个 metric/span/log 声明 owner、unit、stability、attributes、cardinality、privacy、deprecation。
+- [x] `[DEV]` 实现计划中的 `telemetry_semantic_guard.py` 和违规 fixture，未登记/超预算字段拒绝。
+- [x] `[DEV]` 登记 request、watermark/lag、connection/bytes、task、recovery/cache、auth/MCP、exporter 信号。
+- [x] `[TEST]` 覆盖 collector outage：有界队列、可计量 drop、shutdown timeout，数据面不阻塞。
+- [x] `[REV]` 检查字段低基数、采样明确、无敏感数据和每消息无限 span/event。
+- [x] 回滚点：registry 可回到上一 version；不得关闭 privacy/cardinality 失败。
+
+完成证据：[`11-telemetry-semantic-registry-evidence.md`](11-telemetry-semantic-registry-evidence.md)。注册表覆盖
+119 metric、4 span、7 stable log event 和 66 attribute；65/82 工作包完成，剩余 M11 11 个、M12 6 个，
+下一工作包为 PR-M11-02。本工作包不提前宣称 M10、M11 或 Phase 3 Gate 完成。
 
 ### PR-M11-02：SecretProvider 基础合同与本地 Adapter
 
@@ -184,7 +188,7 @@ python scripts/architecture_dependency_guard.py --mode target
 .\scripts\kind-architecture-refactor-e2e.ps1
 ```
 
-kind E2E、semantic guard只在脚本和fixture实际交付后执行。
+Telemetry semantic guard 已由 PR-M11-01 交付并接入 CI；kind E2E 仍只在后续脚本和 fixture 实际交付后执行。
 
 ## 回滚触发器
 
@@ -197,7 +201,7 @@ kind E2E、semantic guard只在脚本和fixture实际交付后执行。
 
 ## Exit Checklist
 
-- [ ] `[TEST]` semantic/cardinality/privacy guard正负fixture全绿。
+- [x] `[TEST]` semantic/cardinality/privacy guard正负fixture全绿。
 - [ ] `[TEST]` collector/audit outage有界且不阻塞数据面。
 - [ ] `[REV]` secure缺失/过期/unknown均fail closed，secret全链路脱敏。
 - [ ] `[TEST]` MCP HTTP认证、rotation、audit、Plan无副作用合同通过。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-telemetry-semantic-registry-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-telemetry-semantic-registry-evidence.md
@@ -1,0 +1,108 @@
+# M11-01 Telemetry semantic registry 实施证据
+
+## 1. 目标完成结论
+
+PR-M11-01 已建立可生成、可版本化、可与 Rust 源码双向校验的 telemetry semantic registry，并实现
+collector outage 的有界非阻塞队列合同和 provider 共享绝对关闭预算。工作包完成后总进度为 **65/82**，
+剩余 17 个工作包：M11 11 个、M12 6 个；下一工作包为 PR-M11-02。
+
+这里的“工作包完成”不等于 M11 或 Phase 3 Gate 完成。SecretProvider、secure profile、rotation、MCP
+HTTPS/audit、镜像、Helm/Kustomize、Kind/K3d fault matrix、ArcMut/stable/SLO 收口仍属于 PR-M11-02～12。
+M10 的真实固定硬件 baseline/candidate 与 `[HUMAN]` Gate 也仍待验收。
+
+| 项目 | 值 |
+|---|---|
+| 工作包 | `PR-M11-01` |
+| Issue | `#8270` |
+| Branch | `mxsm/architecture-refactor-telemetry-semantic-registry` |
+| API candidate snapshot | `84e2af503e8908f1ea2b7cbb988d3634300d367e` |
+| 日期 | 2026-07-18 |
+| Registry | `scripts/telemetry-semantic-registry.json`，schema 1，registry `1.0.0` |
+| Guard | `scripts/telemetry_semantic_guard.py` |
+| 生成器 | `scripts/generate_telemetry_semantic_registry.py` |
+| 违规样例 | `scripts/telemetry-semantic-guard-violations.json` |
+
+## 2. Semantic registry 与源码闭环
+
+注册表不是手工复制的一份旁路清单。生成器读取 canonical Rust 来源，guard 再独立解析同一来源并执行精确集合校验：
+
+- `semantic.rs` 的 119 个 metric 常量必须与 Java 兼容目录 93 个和 Rust 原生目录 26 个一一对应；
+- `trace/span_names.rs` 的 4 个 span 与 `semantic::events` 的 7 个 stable log event 必须全部登记且不得新增未知项；
+- metric 的 symbol、kind、unit、attribute 顺序、owner 和 Java/Rust catalog provenance 必须与源码一致；
+- 66 个 attribute 全部声明 cardinality、privacy、最大 distinct/value bytes、默认启用与 redaction；
+- request、watermark/lag、connection/bytes、task、recovery/cache、auth/MCP、exporter 七类信号缺一即失败；
+- 删除/重命名必须使用 semantic version 和至少两个 minor 的 deprecation window；
+- 高基数字段默认关闭，敏感字段必须 hash/drop，message body、token、secret、credential 等字段名直接拒绝；
+- span/log 必须声明有限 ratio/rate limit 和每操作 event 上限，不能建立每消息无限 span/event。
+
+CI 在 Linux 与 Windows 的 architecture-guards job 中直接运行 guard；同一 job 的 `test_*guard.py` discovery
+同时运行正向测试和故意违规样例。
+
+## 3. Collector outage 与关闭合同
+
+`TelemetryOutageQueue<T>` 是 exporter adapter 的公共有界 admission 原语：
+
+| 边界 | 默认值/行为 |
+|---|---|
+| queue count | 2,048 records |
+| queue bytes | 8 MiB estimated payload |
+| single record | 64 KiB |
+| export batch | 512 records |
+| scheduled delay | 5,000 ms |
+| exporter timeout | 3,000 ms（OTLP exporter 默认配置） |
+| provider shutdown | 所有 logs/traces/metrics 共享 5,000 ms 总预算 |
+| admission | `try_enqueue`；锁竞争、关闭、count/byte/record 超限时立即 drop，不等待数据面 |
+| measurement | accepted/drained/dropped items+bytes、queued items+bytes，并由 outcome 暴露 drop reason |
+
+OTLP trace/log processor 的 count/batch/delay 上限已从依赖默认值改为显式配置；SDK processor 本身使用
+non-blocking bounded channel。自定义 exporter adapter 使用本次的 count+byte queue，不得退回无界 channel。
+`TelemetryGuard::shutdown_with_timeout` 从一次调用开始计算共享预算，按 logs→traces→metrics 传递剩余时间，
+避免 collector outage 把默认 5 秒按 provider 数量累加。
+
+七个 Rust 单测覆盖 count、bytes、单记录、锁竞争、FIFO batch、deadline drop、正常 drain 和配置拒绝。
+该原语不创建 task/thread/runtime；worker 继续由现有 exporter/provider lifecycle 所有。
+
+## 4. 失败注入与审查结果
+
+提交的七类违规 fixture 均被 fail closed：未知 signal、未声明 attribute、高基数默认开启、event rate
+无上限、deprecation window 过短、数据面阻塞和 byte bound 弱化。额外单测覆盖缺失 signal family、敏感字段
+关闭 redaction 以及 message body 字段。
+
+初次执行精确 feature matrix 时，`observability` 组合在未启用 OTLP 的情况下发现
+`trace_batch_config` dead code，strict Clippy 失败。实现随后把 helper 的 cfg 从 `otel-traces`/`otel-logs`
+收窄为真实消费者 `otlp-traces`/`otlp-logs`，并从失败组合重新执行，最终 7/7 组合通过。初次失败不计为通过。
+
+默认特性 public API 快照审查显示 `rocketmq-observability` 公共路径由 561 增至 598：新增 36 个 outage
+合同路径和一个显式 timeout API，属于本工作包的有意 additive；没有删除或改名。其余快照变化只有 Rustdoc
+JSON 原始 hash，公开路径数量和指纹不变。基线已绑定候选快照 `84e2af503e89…` 重新冻结，并从新生成的
+31 个 Rustdoc JSON 复核为 `PUBLIC_API_SNAPSHOT_OK packages=31 differences=0`。
+
+## 5. 验证矩阵
+
+| Gate | 命令/范围 | 结果 |
+|---|---|---|
+| Guard unit | `python -m unittest discover -s scripts/tests -p "test_*guard.py" -v` | 132/132 通过 |
+| Semantic CLI | `python scripts/telemetry_semantic_guard.py` | PASS：119 metric、4 span、7 log、66 attribute |
+| Rust focused | catalog 4 tests；outage 7 tests | 11/11 通过 |
+| Feature matrix | default、observability、otlp-metrics、otel-metrics+prometheus、otlp-traces、otlp-logs、OTLP+Prometheus | 每组 workspace check、strict Clippy、package test 均通过 |
+| Root final | `cargo fmt --all -- --check`；workspace all-target/all-feature strict Clippy | 通过 |
+| Public API | 31 包默认特性快照重新生成并检查 | 31/31，differences=0；observability 增量已归类 additive |
+| Runtime | `runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过 |
+| Architecture | dependency fixtures/baseline、release、performance profile、ArcMut fixtures/baseline | 全部通过 |
+| Routing | `check-agents-routing.ps1` | `AGENTS_ROUTING_CHECK_OK` |
+| Standalone | `rocketmq-example` fmt 与 all-target strict Clippy | 通过 |
+| Text | `git diff --check` | 通过 |
+
+Windows linker 的既有 `linker stdout` warning 和 `proc-macro-error2` future-incompatibility note 不受本变更影响；
+strict Clippy 退出码为 0，未通过 allow 或 baseline 扩张掩盖。
+
+## 6. 回滚与剩余风险
+
+回滚时必须同时回到上一 registry version、catalog、event 常量、guard/fixture 和 OTLP 配置；不能只删除
+guard 或放宽 privacy/cardinality/deprecation/outage 检查。新增 API 为 additive，不改变已有 `shutdown()`
+调用，其默认语义现在更严格地共享一个 5 秒预算。
+
+当前 OTel SDK 的内置 processor 原生提供 count-bounded non-blocking queue，但不暴露 byte estimator；本次公共
+adapter queue 提供独立的 count+byte/record 硬上限。后续自定义 exporter 必须使用该原语或提供等价可证明
+实现，不能把本次合同解释为允许 SDK 之外的无界队列。真实 collector 长时中断、进程级 RSS 与生产 SLO
+仍需在 PR-M11-11 fault matrix 和 PR-M11-12 SLO 收口中验证。

--- a/rocketmq-observability/src/exporter.rs
+++ b/rocketmq-observability/src/exporter.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 pub mod otlp;
+pub mod outage;
 pub mod prometheus;
 pub mod stdout;

--- a/rocketmq-observability/src/exporter/otlp.rs
+++ b/rocketmq-observability/src/exporter/otlp.rs
@@ -63,6 +63,7 @@ pub fn init_otlp_tracer_provider(
     use opentelemetry_otlp::SpanExporter;
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_otlp::WithTonicConfig;
+    use opentelemetry_sdk::trace::BatchSpanProcessor;
     use opentelemetry_sdk::trace::Sampler;
     use opentelemetry_sdk::trace::SdkTracerProvider;
 
@@ -78,11 +79,14 @@ pub fn init_otlp_tracer_provider(
     let exporter = exporter_builder
         .build()
         .map_err(crate::error::ObservabilityError::traces_init)?;
+    let processor = BatchSpanProcessor::builder(exporter)
+        .with_batch_config(crate::exporter::outage::trace_batch_config())
+        .build();
 
     Ok(SdkTracerProvider::builder()
         .with_resource(crate::resource::build_resource(config))
         .with_sampler(Sampler::TraceIdRatioBased(config.traces.sample_ratio.clamp(0.0, 1.0)))
-        .with_batch_exporter(exporter)
+        .with_span_processor(processor)
         .build())
 }
 
@@ -95,6 +99,7 @@ pub fn init_otlp_logger_provider(
     use opentelemetry_otlp::LogExporter;
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_otlp::WithTonicConfig;
+    use opentelemetry_sdk::logs::BatchLogProcessor;
     use opentelemetry_sdk::logs::SdkLoggerProvider;
 
     let mut exporter_builder = LogExporter::builder()
@@ -109,10 +114,13 @@ pub fn init_otlp_logger_provider(
     let exporter = exporter_builder
         .build()
         .map_err(crate::error::ObservabilityError::logs_init)?;
+    let processor = BatchLogProcessor::builder(exporter)
+        .with_batch_config(crate::exporter::outage::log_batch_config())
+        .build();
 
     Ok(SdkLoggerProvider::builder()
         .with_resource(crate::resource::build_resource(config))
-        .with_batch_exporter(exporter)
+        .with_log_processor(processor)
         .build())
 }
 

--- a/rocketmq-observability/src/exporter/outage.rs
+++ b/rocketmq-observability/src/exporter/outage.rs
@@ -1,0 +1,538 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded admission contract for telemetry exporters during collector outages.
+//!
+//! The data plane uses [`TelemetryOutageQueue::try_enqueue`], which never waits for the exporter
+//! lock. Export workers drain batches on their own owned lifecycle. Shutdown closes admission and
+//! uses one caller-provided absolute deadline; reaching that deadline drops and reports the
+//! remaining telemetry instead of extending the service shutdown budget.
+
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+use std::sync::TryLockError;
+use std::time::Instant;
+
+/// Default maximum number of telemetry records admitted during a collector outage.
+pub const DEFAULT_MAX_QUEUE_ITEMS: usize = 2_048;
+
+/// Default maximum estimated bytes admitted during a collector outage.
+pub const DEFAULT_MAX_QUEUE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Default maximum size of one admitted telemetry record.
+pub const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;
+
+/// Default maximum number of records returned in one exporter batch.
+pub const DEFAULT_MAX_EXPORT_BATCH_ITEMS: usize = 512;
+
+/// Default interval before a partial exporter batch is flushed.
+pub const DEFAULT_SCHEDULED_DELAY_MILLIS: u64 = 5_000;
+
+/// Default maximum duration of one collector export attempt.
+pub const DEFAULT_EXPORT_TIMEOUT_MILLIS: u64 = 3_000;
+
+/// Default total deadline for telemetry provider shutdown.
+pub const DEFAULT_SHUTDOWN_TIMEOUT_MILLIS: u64 = 5_000;
+
+/// Count and byte limits for an exporter outage queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TelemetryQueueLimits {
+    /// Maximum number of queued records.
+    max_items: usize,
+    /// Maximum sum of estimated record bytes.
+    max_bytes: usize,
+    /// Maximum estimated size of one record.
+    max_record_bytes: usize,
+}
+
+impl TelemetryQueueLimits {
+    /// Creates validated non-zero queue limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelemetryQueueConfigError`] when a limit is zero or one record could exceed the
+    /// entire byte budget.
+    pub fn new(max_items: usize, max_bytes: usize, max_record_bytes: usize) -> Result<Self, TelemetryQueueConfigError> {
+        if max_items == 0 {
+            return Err(TelemetryQueueConfigError::ZeroLimit("max_items"));
+        }
+        if max_bytes == 0 {
+            return Err(TelemetryQueueConfigError::ZeroLimit("max_bytes"));
+        }
+        if max_record_bytes == 0 {
+            return Err(TelemetryQueueConfigError::ZeroLimit("max_record_bytes"));
+        }
+        if max_record_bytes > max_bytes {
+            return Err(TelemetryQueueConfigError::RecordExceedsQueue {
+                max_record_bytes,
+                max_queue_bytes: max_bytes,
+            });
+        }
+        Ok(Self {
+            max_items,
+            max_bytes,
+            max_record_bytes,
+        })
+    }
+
+    /// Returns the maximum number of queued records.
+    pub const fn max_items(self) -> usize {
+        self.max_items
+    }
+
+    /// Returns the maximum sum of estimated queued bytes.
+    pub const fn max_bytes(self) -> usize {
+        self.max_bytes
+    }
+
+    /// Returns the maximum estimated size of one record.
+    pub const fn max_record_bytes(self) -> usize {
+        self.max_record_bytes
+    }
+}
+
+impl Default for TelemetryQueueLimits {
+    fn default() -> Self {
+        Self {
+            max_items: DEFAULT_MAX_QUEUE_ITEMS,
+            max_bytes: DEFAULT_MAX_QUEUE_BYTES,
+            max_record_bytes: DEFAULT_MAX_RECORD_BYTES,
+        }
+    }
+}
+
+/// Invalid telemetry outage queue configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TelemetryQueueConfigError {
+    /// A queue limit was configured as zero.
+    #[error("telemetry queue limit {0} must be greater than zero")]
+    ZeroLimit(&'static str),
+    /// The maximum record size exceeds the entire byte budget.
+    #[error("telemetry max_record_bytes {max_record_bytes} exceeds max_queue_bytes {max_queue_bytes}")]
+    RecordExceedsQueue {
+        /// Maximum configured record size.
+        max_record_bytes: usize,
+        /// Maximum configured queue bytes.
+        max_queue_bytes: usize,
+    },
+}
+
+/// Reason a telemetry record was dropped before export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryDropReason {
+    /// The queue has stopped accepting records for shutdown.
+    Closed,
+    /// The queue item limit was reached.
+    ItemLimit,
+    /// The queue byte limit was reached.
+    ByteLimit,
+    /// The individual record exceeded its byte limit.
+    RecordTooLarge,
+    /// The exporter lock was contended or poisoned; the data plane did not wait.
+    LockUnavailable,
+}
+
+/// Result of non-blocking telemetry admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryEnqueueOutcome {
+    /// The record was admitted.
+    Accepted,
+    /// The record was dropped for the supplied reason.
+    Dropped(TelemetryDropReason),
+}
+
+/// Current queue and lifetime counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TelemetryQueueSnapshot {
+    /// Records currently waiting for export.
+    pub queued_items: usize,
+    /// Estimated bytes currently waiting for export.
+    pub queued_bytes: usize,
+    /// Records admitted over the queue lifetime.
+    pub accepted_items: u64,
+    /// Estimated bytes admitted over the queue lifetime.
+    pub accepted_bytes: u64,
+    /// Records removed by exporter workers.
+    pub drained_items: u64,
+    /// Estimated bytes removed by exporter workers.
+    pub drained_bytes: u64,
+    /// Records dropped before export or at the shutdown deadline.
+    pub dropped_items: u64,
+    /// Estimated bytes dropped before export or at the shutdown deadline.
+    pub dropped_bytes: u64,
+    /// Whether new admission is closed.
+    pub closed: bool,
+}
+
+/// Final state produced when an outage queue drains or reaches its absolute deadline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TelemetryOutageShutdownReport {
+    /// Whether the absolute shutdown deadline expired with queued telemetry remaining.
+    pub timed_out: bool,
+    /// Records dropped specifically because the deadline expired.
+    pub deadline_dropped_items: u64,
+    /// Estimated bytes dropped specifically because the deadline expired.
+    pub deadline_dropped_bytes: u64,
+    /// Final queue and lifetime counters.
+    pub snapshot: TelemetryQueueSnapshot,
+}
+
+#[derive(Debug)]
+struct Queued<T> {
+    item: T,
+    estimated_bytes: usize,
+}
+
+#[derive(Debug)]
+struct QueueState<T> {
+    records: VecDeque<Queued<T>>,
+    queued_bytes: usize,
+    closed: bool,
+    shutdown_deadline: Option<Instant>,
+}
+
+impl<T> Default for QueueState<T> {
+    fn default() -> Self {
+        Self {
+            records: VecDeque::new(),
+            queued_bytes: 0,
+            closed: false,
+            shutdown_deadline: None,
+        }
+    }
+}
+
+/// A count-and-byte bounded queue for exporter adapters.
+///
+/// This type does not create a task or thread. The exporter remains owned by the service's
+/// existing lifecycle and calls [`Self::drain_batch`] from that owned worker.
+#[derive(Debug)]
+pub struct TelemetryOutageQueue<T> {
+    limits: TelemetryQueueLimits,
+    state: Mutex<QueueState<T>>,
+    accepted_items: AtomicU64,
+    accepted_bytes: AtomicU64,
+    drained_items: AtomicU64,
+    drained_bytes: AtomicU64,
+    dropped_items: AtomicU64,
+    dropped_bytes: AtomicU64,
+}
+
+impl<T> TelemetryOutageQueue<T> {
+    /// Creates an empty queue with validated limits.
+    pub fn new(limits: TelemetryQueueLimits) -> Self {
+        Self {
+            limits,
+            state: Mutex::new(QueueState::default()),
+            accepted_items: AtomicU64::new(0),
+            accepted_bytes: AtomicU64::new(0),
+            drained_items: AtomicU64::new(0),
+            drained_bytes: AtomicU64::new(0),
+            dropped_items: AtomicU64::new(0),
+            dropped_bytes: AtomicU64::new(0),
+        }
+    }
+
+    /// Attempts to admit a telemetry record without waiting for an exporter lock.
+    ///
+    /// `estimated_bytes` must include the envelope and attribute payload estimate used by the
+    /// owning exporter. A zero estimate is accounted as one byte so the byte budget always moves.
+    pub fn try_enqueue(&self, item: T, estimated_bytes: usize) -> TelemetryEnqueueOutcome {
+        let estimated_bytes = estimated_bytes.max(1);
+        if estimated_bytes > self.limits.max_record_bytes {
+            self.record_drop(estimated_bytes);
+            return TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::RecordTooLarge);
+        }
+
+        let mut state = match self.state.try_lock() {
+            Ok(state) => state,
+            Err(TryLockError::WouldBlock | TryLockError::Poisoned(_)) => {
+                self.record_drop(estimated_bytes);
+                return TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::LockUnavailable);
+            }
+        };
+        if state.closed {
+            self.record_drop(estimated_bytes);
+            return TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::Closed);
+        }
+        if state.records.len() >= self.limits.max_items {
+            self.record_drop(estimated_bytes);
+            return TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::ItemLimit);
+        }
+        if state.queued_bytes.saturating_add(estimated_bytes) > self.limits.max_bytes {
+            self.record_drop(estimated_bytes);
+            return TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::ByteLimit);
+        }
+
+        state.records.push_back(Queued { item, estimated_bytes });
+        state.queued_bytes += estimated_bytes;
+        self.accepted_items.fetch_add(1, Ordering::Relaxed);
+        self.accepted_bytes.fetch_add(estimated_bytes as u64, Ordering::Relaxed);
+        TelemetryEnqueueOutcome::Accepted
+    }
+
+    /// Removes a bounded FIFO batch for an exporter worker.
+    ///
+    /// `max_items` and `max_bytes` are clamped to at least one. One admitted record may exceed
+    /// `max_bytes`; it is still returned alone so a worker can always make progress.
+    pub fn drain_batch(&self, max_items: usize, max_bytes: usize) -> Vec<T> {
+        let mut state = self.lock_state();
+        let mut items = Vec::new();
+        let mut drained_bytes = 0usize;
+        let max_items = max_items.max(1);
+        let max_bytes = max_bytes.max(1);
+        while items.len() < max_items {
+            let Some(front) = state.records.front() else {
+                break;
+            };
+            if !items.is_empty() && drained_bytes.saturating_add(front.estimated_bytes) > max_bytes {
+                break;
+            }
+            let Some(record) = state.records.pop_front() else {
+                break;
+            };
+            state.queued_bytes -= record.estimated_bytes;
+            drained_bytes += record.estimated_bytes;
+            items.push(record.item);
+        }
+        self.drained_items.fetch_add(items.len() as u64, Ordering::Relaxed);
+        self.drained_bytes.fetch_add(drained_bytes as u64, Ordering::Relaxed);
+        items
+    }
+
+    /// Stops new admission and binds shutdown to one absolute deadline.
+    pub fn begin_shutdown(&self, deadline: Instant) {
+        let mut state = self.lock_state();
+        state.closed = true;
+        state.shutdown_deadline = Some(deadline);
+    }
+
+    /// Returns a final report once the queue drains or the absolute deadline expires.
+    ///
+    /// Before the deadline, `None` means the exporter worker should continue draining. At the
+    /// deadline, all remaining records are dropped and included in the report.
+    pub fn poll_shutdown(&self, now: Instant) -> Option<TelemetryOutageShutdownReport> {
+        let mut state = self.lock_state();
+        if !state.closed {
+            return None;
+        }
+        if state.records.is_empty() {
+            return Some(TelemetryOutageShutdownReport {
+                timed_out: false,
+                deadline_dropped_items: 0,
+                deadline_dropped_bytes: 0,
+                snapshot: self.snapshot_from_state(&state),
+            });
+        }
+        let deadline = state.shutdown_deadline?;
+        if now < deadline {
+            return None;
+        }
+
+        let deadline_dropped_items = state.records.len() as u64;
+        let deadline_dropped_bytes = state.queued_bytes as u64;
+        state.records.clear();
+        state.queued_bytes = 0;
+        self.dropped_items.fetch_add(deadline_dropped_items, Ordering::Relaxed);
+        self.dropped_bytes.fetch_add(deadline_dropped_bytes, Ordering::Relaxed);
+        Some(TelemetryOutageShutdownReport {
+            timed_out: true,
+            deadline_dropped_items,
+            deadline_dropped_bytes,
+            snapshot: self.snapshot_from_state(&state),
+        })
+    }
+
+    /// Returns current queue occupancy and lifetime counters.
+    pub fn snapshot(&self) -> TelemetryQueueSnapshot {
+        let state = self.lock_state();
+        self.snapshot_from_state(&state)
+    }
+
+    fn record_drop(&self, estimated_bytes: usize) {
+        self.dropped_items.fetch_add(1, Ordering::Relaxed);
+        self.dropped_bytes.fetch_add(estimated_bytes as u64, Ordering::Relaxed);
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, QueueState<T>> {
+        self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn snapshot_from_state(&self, state: &QueueState<T>) -> TelemetryQueueSnapshot {
+        TelemetryQueueSnapshot {
+            queued_items: state.records.len(),
+            queued_bytes: state.queued_bytes,
+            accepted_items: self.accepted_items.load(Ordering::Relaxed),
+            accepted_bytes: self.accepted_bytes.load(Ordering::Relaxed),
+            drained_items: self.drained_items.load(Ordering::Relaxed),
+            drained_bytes: self.drained_bytes.load(Ordering::Relaxed),
+            dropped_items: self.dropped_items.load(Ordering::Relaxed),
+            dropped_bytes: self.dropped_bytes.load(Ordering::Relaxed),
+            closed: state.closed,
+        }
+    }
+}
+
+impl<T> Default for TelemetryOutageQueue<T> {
+    fn default() -> Self {
+        Self::new(TelemetryQueueLimits::default())
+    }
+}
+
+#[cfg(feature = "otlp-traces")]
+pub(crate) fn trace_batch_config() -> opentelemetry_sdk::trace::BatchConfig {
+    opentelemetry_sdk::trace::BatchConfigBuilder::default()
+        .with_max_queue_size(DEFAULT_MAX_QUEUE_ITEMS)
+        .with_max_export_batch_size(DEFAULT_MAX_EXPORT_BATCH_ITEMS)
+        .with_scheduled_delay(std::time::Duration::from_millis(DEFAULT_SCHEDULED_DELAY_MILLIS))
+        .build()
+}
+
+#[cfg(feature = "otlp-logs")]
+pub(crate) fn log_batch_config() -> opentelemetry_sdk::logs::BatchConfig {
+    opentelemetry_sdk::logs::BatchConfigBuilder::default()
+        .with_max_queue_size(DEFAULT_MAX_QUEUE_ITEMS)
+        .with_max_export_batch_size(DEFAULT_MAX_EXPORT_BATCH_ITEMS)
+        .with_scheduled_delay(std::time::Duration::from_millis(DEFAULT_SCHEDULED_DELAY_MILLIS))
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn queue() -> TelemetryOutageQueue<&'static str> {
+        TelemetryOutageQueue::new(TelemetryQueueLimits::new(2, 8, 6).expect("test limits should be valid"))
+    }
+
+    #[test]
+    fn queue_is_count_and_byte_bounded_and_drops_are_measurable() {
+        let queue = queue();
+
+        assert_eq!(queue.try_enqueue("one", 3), TelemetryEnqueueOutcome::Accepted);
+        assert_eq!(queue.try_enqueue("two", 5), TelemetryEnqueueOutcome::Accepted);
+        assert_eq!(
+            queue.try_enqueue("count-full", 1),
+            TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::ItemLimit)
+        );
+
+        let snapshot = queue.snapshot();
+        assert_eq!(snapshot.queued_items, 2);
+        assert_eq!(snapshot.queued_bytes, 8);
+        assert_eq!(snapshot.accepted_items, 2);
+        assert_eq!(snapshot.dropped_items, 1);
+        assert_eq!(snapshot.dropped_bytes, 1);
+    }
+
+    #[test]
+    fn record_and_byte_limits_fail_closed() {
+        let queue = queue();
+
+        assert_eq!(
+            queue.try_enqueue("oversized", 7),
+            TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::RecordTooLarge)
+        );
+        assert_eq!(queue.try_enqueue("five", 5), TelemetryEnqueueOutcome::Accepted);
+        assert_eq!(
+            queue.try_enqueue("byte-full", 4),
+            TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::ByteLimit)
+        );
+        assert_eq!(queue.snapshot().queued_bytes, 5);
+    }
+
+    #[test]
+    fn data_plane_drops_instead_of_waiting_for_exporter_lock() {
+        let queue = queue();
+        let _exporter_lock = queue.state.lock().expect("test should hold exporter lock");
+
+        assert_eq!(
+            queue.try_enqueue("contended", 2),
+            TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::LockUnavailable)
+        );
+        assert_eq!(queue.dropped_items.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn exporter_drains_fifo_batches_with_bounded_accounting() {
+        let queue = queue();
+        assert_eq!(queue.try_enqueue("one", 3), TelemetryEnqueueOutcome::Accepted);
+        assert_eq!(queue.try_enqueue("two", 5), TelemetryEnqueueOutcome::Accepted);
+
+        assert_eq!(queue.drain_batch(2, 4), vec!["one"]);
+        assert_eq!(queue.drain_batch(2, 8), vec!["two"]);
+        let snapshot = queue.snapshot();
+        assert_eq!(snapshot.queued_items, 0);
+        assert_eq!(snapshot.queued_bytes, 0);
+        assert_eq!(snapshot.drained_items, 2);
+        assert_eq!(snapshot.drained_bytes, 8);
+    }
+
+    #[test]
+    fn absolute_shutdown_deadline_reports_collector_outage() {
+        let queue = queue();
+        assert_eq!(queue.try_enqueue("one", 3), TelemetryEnqueueOutcome::Accepted);
+        assert_eq!(queue.try_enqueue("two", 5), TelemetryEnqueueOutcome::Accepted);
+        let deadline = Instant::now() + Duration::from_millis(10);
+        queue.begin_shutdown(deadline);
+
+        assert_eq!(
+            queue.try_enqueue("closed", 1),
+            TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::Closed)
+        );
+        assert!(queue.poll_shutdown(deadline - Duration::from_millis(1)).is_none());
+        let report = queue
+            .poll_shutdown(deadline)
+            .expect("absolute deadline should finish shutdown");
+
+        assert!(report.timed_out);
+        assert_eq!(report.deadline_dropped_items, 2);
+        assert_eq!(report.deadline_dropped_bytes, 8);
+        assert_eq!(report.snapshot.queued_items, 0);
+        assert_eq!(report.snapshot.dropped_items, 3);
+        assert_eq!(report.snapshot.dropped_bytes, 9);
+    }
+
+    #[test]
+    fn drained_queue_finishes_before_deadline_without_timeout() {
+        let queue = queue();
+        assert_eq!(queue.try_enqueue("one", 3), TelemetryEnqueueOutcome::Accepted);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        queue.begin_shutdown(deadline);
+        assert_eq!(queue.drain_batch(1, 8), vec!["one"]);
+
+        let report = queue.poll_shutdown(Instant::now()).expect("empty queue should finish");
+        assert!(!report.timed_out);
+        assert_eq!(report.deadline_dropped_items, 0);
+        assert_eq!(report.snapshot.drained_items, 1);
+    }
+
+    #[test]
+    fn invalid_limits_are_rejected() {
+        assert_eq!(
+            TelemetryQueueLimits::new(0, 8, 4),
+            Err(TelemetryQueueConfigError::ZeroLimit("max_items"))
+        );
+        assert_eq!(
+            TelemetryQueueLimits::new(1, 4, 5),
+            Err(TelemetryQueueConfigError::RecordExceedsQueue {
+                max_record_bytes: 5,
+                max_queue_bytes: 4,
+            })
+        );
+    }
+}

--- a/rocketmq-observability/src/init.rs
+++ b/rocketmq-observability/src/init.rs
@@ -81,11 +81,28 @@ impl TelemetryGuard {
     }
 
     pub fn shutdown(self) -> Result<(), ObservabilityError> {
-        self.shutdown_with_report().into_result()
+        self.shutdown_with_timeout(std::time::Duration::from_millis(
+            crate::exporter::outage::DEFAULT_SHUTDOWN_TIMEOUT_MILLIS,
+        ))
+    }
+
+    /// Shuts down every telemetry provider within one shared timeout budget.
+    ///
+    /// Later providers receive only the time remaining from the original absolute deadline, so a
+    /// collector outage cannot multiply the shutdown delay by the number of enabled signals.
+    ///
+    /// # Errors
+    ///
+    /// Returns an exporter-specific [`ObservabilityError`] when a provider fails or exhausts the
+    /// shared timeout budget.
+    pub fn shutdown_with_timeout(self, timeout: std::time::Duration) -> Result<(), ObservabilityError> {
+        self.shutdown_inner(timeout).into_result()
     }
 
     pub(crate) fn shutdown_with_report(self) -> TelemetryProviderShutdownReport {
-        self.shutdown_inner()
+        self.shutdown_inner(std::time::Duration::from_millis(
+            crate::exporter::outage::DEFAULT_SHUTDOWN_TIMEOUT_MILLIS,
+        ))
     }
 
     pub fn subscriber_install_status(&self) -> SubscriberInstallStatus {
@@ -97,12 +114,13 @@ impl TelemetryGuard {
     }
 
     #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
-    fn shutdown_inner(mut self) -> TelemetryProviderShutdownReport {
+    fn shutdown_inner(mut self, timeout: std::time::Duration) -> TelemetryProviderShutdownReport {
         let mut report = TelemetryProviderShutdownReport::default();
+        let started_at = std::time::Instant::now();
 
         #[cfg(feature = "otel-logs")]
         if let Some(provider) = self.logger_provider.take() {
-            if let Err(error) = provider.shutdown() {
+            if let Err(error) = provider.shutdown_with_timeout(timeout.saturating_sub(started_at.elapsed())) {
                 report.logs_shutdown_ok = false;
                 report.logs_shutdown_error = Some(error.to_string());
             }
@@ -110,7 +128,7 @@ impl TelemetryGuard {
 
         #[cfg(feature = "otel-traces")]
         if let Some(provider) = self.tracer_provider.take() {
-            if let Err(error) = provider.shutdown() {
+            if let Err(error) = provider.shutdown_with_timeout(timeout.saturating_sub(started_at.elapsed())) {
                 report.traces_shutdown_ok = false;
                 report.traces_shutdown_error = Some(error.to_string());
             }
@@ -118,7 +136,7 @@ impl TelemetryGuard {
 
         #[cfg(feature = "otel-metrics")]
         if let Some(provider) = self.meter_provider.take() {
-            if let Err(error) = provider.shutdown() {
+            if let Err(error) = provider.shutdown_with_timeout(timeout.saturating_sub(started_at.elapsed())) {
                 report.metrics_shutdown_ok = false;
                 report.metrics_shutdown_error = Some(error.to_string());
             }
@@ -133,7 +151,7 @@ impl TelemetryGuard {
     }
 
     #[cfg(not(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs")))]
-    fn shutdown_inner(self) -> TelemetryProviderShutdownReport {
+    fn shutdown_inner(self, _timeout: std::time::Duration) -> TelemetryProviderShutdownReport {
         TelemetryProviderShutdownReport::default()
     }
 
@@ -572,6 +590,13 @@ mod tests {
             }
         );
         guard.shutdown().expect("noop shutdown should succeed");
+    }
+
+    #[test]
+    fn noop_guard_accepts_an_explicit_absolute_shutdown_budget() {
+        TelemetryGuard::noop()
+            .shutdown_with_timeout(std::time::Duration::ZERO)
+            .expect("noop shutdown should not consume a timeout budget");
     }
 
     #[test]

--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -23,9 +23,11 @@ pub enum MetricKind {
     UpDownCounter,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MetricSource {
     Broker,
+    Client,
+    NameServer,
     Pop,
     Remoting,
     Store,
@@ -143,6 +145,7 @@ const CONTROLLER_DLEDGER_LABELS: &[&str] = &[
     labels::DLEDGER_OPERATION_STATUS,
 ];
 const CONTROLLER_ELECTION_LABELS: &[&str] = &[labels::ADDRESS, labels::GROUP, labels::PEER_ID, labels::ELECTION_RESULT];
+const BROKER_LABEL_DROPPED_LABELS: &[&str] = &[labels::CLUSTER, labels::NODE_TYPE, labels::NODE_ID, labels::LABEL_KEY];
 
 pub const JAVA_METRICS: &[MetricDescriptor] = &[
     MetricDescriptor {
@@ -809,8 +812,198 @@ pub const JAVA_METRICS: &[MetricDescriptor] = &[
     },
 ];
 
+/// Rust-native metrics that are not part of the Java compatibility catalog.
+pub const RUST_METRICS: &[MetricDescriptor] = &[
+    MetricDescriptor {
+        name: metrics::SEND_MESSAGE_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: BROKER_TOPIC_LABELS,
+        source: MetricSource::Broker,
+    },
+    MetricDescriptor {
+        name: metrics::METRICS_LABEL_DROPPED_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{label}",
+        labels: BROKER_LABEL_DROPPED_LABELS,
+        source: MetricSource::Broker,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_APPEND_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_FLUSH_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_DISPATCH_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_DISK_USAGE,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::REMOTING_REQUESTS_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{request}",
+        labels: &[],
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::REMOTING_REQUEST_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::REMOTING_NETWORK_BYTES,
+        kind: MetricKind::Counter,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_SEND_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{message}",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_SEND_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_CONSUME_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{message}",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_CONSUME_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_REBALANCE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{event}",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::NAMESRV_ROUTE_REQUEST_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{request}",
+        labels: &[],
+        source: MetricSource::NameServer,
+    },
+    MetricDescriptor {
+        name: metrics::NAMESRV_ROUTE_REQUEST_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::NameServer,
+    },
+    MetricDescriptor {
+        name: metrics::NAMESRV_BROKER_REGISTRATIONS,
+        kind: MetricKind::Counter,
+        unit: "{registration}",
+        labels: &[],
+        source: MetricSource::NameServer,
+    },
+    MetricDescriptor {
+        name: metrics::NAMESRV_ACTIVE_BROKERS,
+        kind: MetricKind::ObservableGauge,
+        unit: "{broker}",
+        labels: &[],
+        source: MetricSource::NameServer,
+    },
+    MetricDescriptor {
+        name: metrics::CONTROLLER_ELECTION_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{election}",
+        labels: &[],
+        source: MetricSource::Controller,
+    },
+    MetricDescriptor {
+        name: metrics::CONTROLLER_ELECTION_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Controller,
+    },
+    MetricDescriptor {
+        name: metrics::CONTROLLER_LEADER_CHANGES_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{change}",
+        labels: &[],
+        source: MetricSource::Controller,
+    },
+    MetricDescriptor {
+        name: metrics::CONTROLLER_ACTIVE_BROKERS,
+        kind: MetricKind::ObservableGauge,
+        unit: "{broker}",
+        labels: &[],
+        source: MetricSource::Controller,
+    },
+    MetricDescriptor {
+        name: metrics::PROXY_GRPC_REQUESTS_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{request}",
+        labels: &[],
+        source: MetricSource::Proxy,
+    },
+    MetricDescriptor {
+        name: metrics::PROXY_GRPC_REQUEST_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Proxy,
+    },
+    MetricDescriptor {
+        name: metrics::PROXY_FORWARD_LATENCY,
+        kind: MetricKind::Histogram,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Proxy,
+    },
+    MetricDescriptor {
+        name: metrics::PROXY_ACTIVE_CONNECTIONS,
+        kind: MetricKind::ObservableGauge,
+        unit: "{connection}",
+        labels: &[],
+        source: MetricSource::Proxy,
+    },
+];
+
 pub const fn java_metrics() -> &'static [MetricDescriptor] {
     JAVA_METRICS
+}
+
+pub const fn rust_metrics() -> &'static [MetricDescriptor] {
+    RUST_METRICS
 }
 
 #[cfg(test)]
@@ -925,6 +1118,35 @@ mod tests {
 
         assert_eq!(actual, expected);
         assert_eq!(JAVA_METRICS.len(), actual.len(), "duplicate metric names in catalog");
+    }
+
+    #[test]
+    fn combined_catalog_contains_every_semantic_metric_once() {
+        let combined = JAVA_METRICS
+            .iter()
+            .chain(RUST_METRICS)
+            .map(|descriptor| descriptor.name)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(JAVA_METRICS.len(), 93);
+        assert_eq!(RUST_METRICS.len(), 26);
+        assert_eq!(combined.len(), 119, "duplicate metric names across catalogs");
+    }
+
+    #[test]
+    fn rust_catalog_covers_native_sources() {
+        let sources = RUST_METRICS
+            .iter()
+            .map(|descriptor| descriptor.source)
+            .collect::<HashSet<_>>();
+
+        assert!(sources.contains(&MetricSource::Broker));
+        assert!(sources.contains(&MetricSource::Client));
+        assert!(sources.contains(&MetricSource::NameServer));
+        assert!(sources.contains(&MetricSource::Remoting));
+        assert!(sources.contains(&MetricSource::Store));
+        assert!(sources.contains(&MetricSource::Proxy));
+        assert!(sources.contains(&MetricSource::Controller));
     }
 
     #[test]

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -181,6 +181,18 @@ pub mod labels {
     pub const DLEDGER_OPERATION: &str = "dledger_operation";
     pub const DLEDGER_OPERATION_STATUS: &str = "dLedger_operation_status";
     pub const ELECTION_RESULT: &str = "election_result";
+    pub const LABEL_KEY: &str = "label_key";
+}
+
+/// Stable event identifiers consumed by structured-log exporters and guards.
+pub mod events {
+    pub const AUTH_DECISION: &str = "rocketmq.auth.decision";
+    pub const AUTH_RELOAD: &str = "rocketmq.auth.reload";
+    pub const MCP_ACTION: &str = "rocketmq.mcp.action";
+    pub const TASK_LIFECYCLE: &str = "rocketmq.task.lifecycle";
+    pub const RECOVERY_STATE: &str = "rocketmq.recovery.state";
+    pub const EXPORTER_DROP: &str = "rocketmq.exporter.drop";
+    pub const EXPORTER_SHUTDOWN: &str = "rocketmq.exporter.shutdown";
 }
 
 pub mod trace {

--- a/scripts/generate_telemetry_semantic_registry.py
+++ b/scripts/generate_telemetry_semantic_registry.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regenerate the checked-in M11 telemetry semantic registry."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import telemetry_semantic_guard as guard
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "scripts" / "telemetry-semantic-registry.json"
+FIXTURE_PATH = ROOT / "scripts" / "telemetry-semantic-guard-violations.json"
+
+HIGH_CARDINALITY_ATTRIBUTES = {
+    "messaging.message.id",
+    "messaging.rocketmq.message.keys",
+}
+PUBLIC_ATTRIBUTES = {
+    "success",
+    "result",
+    "state",
+    "signal_type",
+}
+SPAN_ATTRIBUTES = {
+    "BROKER_RECEIVE_SEND": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "server.address",
+        "messaging.destination.partition.id",
+    ],
+    "STORE_APPEND": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.message.body.size",
+    ],
+    "PRODUCER_SEND": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.message.id",
+        "messaging.message.body.size",
+        "messaging.rocketmq.message.keys",
+    ],
+    "CONSUMER_PROCESS": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.consumer.group.name",
+        "server.address",
+        "messaging.destination.partition.id",
+        "rocketmq.consume.mode",
+        "rocketmq.batch.message_count",
+        "messaging.message.id",
+        "messaging.message.body.size",
+        "messaging.rocketmq.message.keys",
+    ],
+}
+EVENT_CONTRACTS = {
+    "AUTH_DECISION": ("auth-mcp", "security", ["operation", "decision", "result", "reason"]),
+    "AUTH_RELOAD": ("auth-mcp", "security", ["result", "reason"]),
+    "MCP_ACTION": ("auth-mcp", "mcp", ["operation", "result", "reason"]),
+    "TASK_LIFECYCLE": ("task", "runtime", ["task_type", "state", "result", "reason"]),
+    "RECOVERY_STATE": ("recovery-cache", "storage", ["component", "state", "result", "reason"]),
+    "EXPORTER_DROP": ("exporter", "observability", ["reason", "signal_type", "dropped_count"]),
+    "EXPORTER_SHUTDOWN": (
+        "exporter",
+        "observability",
+        ["result", "reason", "queued_items", "queued_bytes", "dropped_count"],
+    ),
+}
+
+
+def metric_family(metric_id: str) -> str:
+    if "metrics_label_dropped" in metric_id:
+        return "exporter"
+    if any(token in metric_id for token in ("watermark", "lag", "behind", "inflight", "ready", "queueing")):
+        return "watermark-lag"
+    if any(token in metric_id for token in ("connection", "bytes", "throughput", "size", "disk_usage")):
+        return "connection-bytes"
+    if any(token in metric_id for token in ("rocksdb", "tiered", "storage", "store_")):
+        return "recovery-cache"
+    return "request"
+
+
+def attribute_contract(attribute_id: str) -> dict[str, Any]:
+    high = attribute_id in HIGH_CARDINALITY_ATTRIBUTES
+    privacy = "sensitive" if high else "public" if attribute_id in PUBLIC_ATTRIBUTES else "operational"
+    return {
+        "id": attribute_id,
+        "cardinality": "high" if high else "bounded",
+        "privacy": privacy,
+        "max_distinct": 1_000 if high else 10_000,
+        "max_value_bytes": 512 if high else 256,
+        "default_enabled": not high,
+        "redaction": "hash" if high else "none",
+    }
+
+
+def deprecation() -> dict[str, Any]:
+    return {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": None,
+        "remove_after": None,
+    }
+
+
+def signal_privacy(attributes: list[str]) -> str:
+    return "sensitive" if HIGH_CARDINALITY_ATTRIBUTES.intersection(attributes) else "operational"
+
+
+def build_registry() -> dict[str, Any]:
+    inventory = guard.build_source_inventory()
+    extra_attributes = {
+        attribute
+        for attributes in SPAN_ATTRIBUTES.values()
+        for attribute in attributes
+    }
+    extra_attributes.update(
+        attribute
+        for _, _, attributes in EVENT_CONTRACTS.values()
+        for attribute in attributes
+    )
+    attribute_ids = set(inventory["labels"].values()) | extra_attributes
+    signals: list[dict[str, Any]] = []
+
+    for metric in inventory["metrics"]:
+        owner = re.sub(r"(?<!^)(?=[A-Z])", "-", metric["source"]).lower()
+        signals.append(
+            {
+                "id": metric["id"],
+                "source_symbol": metric["source_symbol"],
+                "signal_type": "metric",
+                "kind": metric["kind"],
+                "unit": metric["unit"],
+                "owner": owner,
+                "catalog": metric["catalog"],
+                "family": metric_family(metric["id"]),
+                "stability": "stable",
+                "attributes": metric["attributes"],
+                "cardinality_budget": 10_000 if metric["attributes"] else 1,
+                "privacy": signal_privacy(metric["attributes"]),
+                "sampling": {"strategy": "aggregate"},
+                "deprecation": deprecation(),
+            }
+        )
+
+    span_owners = {
+        "BROKER_RECEIVE_SEND": "broker",
+        "STORE_APPEND": "store",
+        "PRODUCER_SEND": "client",
+        "CONSUMER_PROCESS": "client",
+    }
+    for symbol, span_id in inventory["spans"].items():
+        attributes = SPAN_ATTRIBUTES[symbol]
+        signals.append(
+            {
+                "id": span_id,
+                "source_symbol": symbol,
+                "signal_type": "span",
+                "owner": span_owners[symbol],
+                "family": "recovery-cache" if symbol == "STORE_APPEND" else "request",
+                "stability": "stable",
+                "attributes": attributes,
+                "cardinality_budget": 1_000,
+                "privacy": signal_privacy(attributes),
+                "sampling": {
+                    "strategy": "ratio",
+                    "default_ratio": 0.01,
+                    "max_events_per_operation": 0,
+                },
+                "deprecation": deprecation(),
+            }
+        )
+
+    for symbol, event_id in inventory["events"].items():
+        family, owner, attributes = EVENT_CONTRACTS[symbol]
+        signals.append(
+            {
+                "id": event_id,
+                "source_symbol": symbol,
+                "signal_type": "log",
+                "owner": owner,
+                "family": family,
+                "stability": "stable",
+                "attributes": attributes,
+                "cardinality_budget": 1_000,
+                "privacy": signal_privacy(attributes),
+                "sampling": {
+                    "strategy": "rate_limit",
+                    "max_per_second": 100,
+                    "max_events_per_operation": 1,
+                },
+                "deprecation": deprecation(),
+            }
+        )
+
+    outage = {
+        field: inventory["outage"][constant]
+        for constant, field in guard.EXPECTED_OUTAGE_CONSTANTS.items()
+    }
+    outage.update(
+        {
+            "enqueue": "try_enqueue",
+            "overflow": "drop_newest",
+            "shutdown_deadline": "absolute",
+            "data_plane_blocking": False,
+            "drop_signal": "rocketmq.exporter.drop",
+            "shutdown_signal": "rocketmq.exporter.shutdown",
+            "measurements": [
+                "accepted",
+                "drained",
+                "dropped_by_reason",
+                "queued_items",
+                "queued_bytes",
+            ],
+        }
+    )
+    return {
+        "schema_version": 1,
+        "registry_version": "1.0.0",
+        "milestone": "M11-01",
+        "description": "Canonical telemetry semantics and collector-outage behavior for RocketMQ Rust.",
+        "required_families": sorted(guard.REQUIRED_FAMILIES),
+        "attributes": [attribute_contract(item) for item in sorted(attribute_ids)],
+        "signals": signals,
+        "outage_policy": outage,
+    }
+
+
+def build_violation_fixtures(registry: dict[str, Any]) -> dict[str, Any]:
+    high_index = next(
+        index
+        for index, attribute in enumerate(registry["attributes"])
+        if attribute["cardinality"] == "high"
+    )
+    deprecated_index = next(
+        index for index, signal in enumerate(registry["signals"]) if signal["signal_type"] == "log"
+    )
+    return {
+        "schema_version": 1,
+        "registry_version": registry["registry_version"],
+        "fixtures": [
+            {
+                "id": "unknown-signal",
+                "operation": "set",
+                "path": ["signals", 0, "id"],
+                "value": "rocketmq_unknown_metric",
+                "expected": "unknown registry signal",
+            },
+            {
+                "id": "undeclared-attribute",
+                "operation": "set",
+                "path": ["signals", 0, "attributes"],
+                "value": ["undeclared.attribute"],
+                "expected": "undeclared attributes",
+            },
+            {
+                "id": "high-cardinality-default",
+                "operation": "set",
+                "path": ["attributes", high_index, "default_enabled"],
+                "value": True,
+                "expected": "high-cardinality attribute must be disabled by default",
+            },
+            {
+                "id": "unbounded-event-rate",
+                "operation": "delete",
+                "path": ["signals", deprecated_index, "sampling", "max_per_second"],
+                "expected": "rate-limited event requires max_per_second",
+            },
+            {
+                "id": "invalid-deprecation-window",
+                "operation": "set",
+                "path": ["signals", deprecated_index, "deprecation"],
+                "value": {
+                    "status": "deprecated",
+                    "since": "1.0.0",
+                    "replacement": "rocketmq.auth.replacement",
+                    "remove_after": "1.1.0",
+                },
+                "expected": "deprecation window must span at least two minor versions",
+            },
+            {
+                "id": "blocking-outage-enqueue",
+                "operation": "set",
+                "path": ["outage_policy", "data_plane_blocking"],
+                "value": True,
+                "expected": "outage_policy.data_plane_blocking must remain False",
+            },
+            {
+                "id": "weakened-byte-bound",
+                "operation": "set",
+                "path": ["outage_policy", "max_queue_bytes"],
+                "value": 0,
+                "expected": "outage_policy.max_queue_bytes must match Rust constant",
+            },
+        ],
+    }
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    registry = build_registry()
+    findings = guard.validate_registry(registry)
+    if findings:
+        raise SystemExit("refusing to write invalid registry:\n- " + "\n- ".join(findings))
+    write_json(REGISTRY_PATH, registry)
+    write_json(FIXTURE_PATH, build_violation_fixtures(registry))
+    print(
+        f"generated {REGISTRY_PATH.relative_to(ROOT)} with "
+        f"{len(registry['signals'])} signals and {len(registry['attributes'])} attributes"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -5,35 +5,35 @@
       "crate_version": "1.0.0",
       "public_path_count": 294,
       "public_path_sha256": "15df468d980ab0dbcfbfff8c4179604bde17fe67b25519d7c8de0e4eae8093ec",
-      "rustdoc_json_sha256": "bb0d91560428dbbd5a4426a1aeeb96eb2bb851adda2109c140a69c464f118dd3",
+      "rustdoc_json_sha256": "b1abb9382d08238992d00de8094a3f4080305c87d6c07687e8467603f3a49522",
       "target": "rocketmq_admin_cli"
     },
     "rocketmq-admin-core": {
       "crate_version": "1.0.0",
       "public_path_count": 186,
       "public_path_sha256": "427678ac85d4f76728993ad32b402626d24f41eaeb293c9fa5994ab9cc6bfa0d",
-      "rustdoc_json_sha256": "cf70098edca232ad9710c6f34dee9a9aafaf6f43b0fccf22b84bfdd374168e5c",
+      "rustdoc_json_sha256": "e2afb635501bba200fa8a70009eda1f048751b911db8c36fabfbc3dbe3be4437",
       "target": "rocketmq_admin_core"
     },
     "rocketmq-auth": {
       "crate_version": "1.0.0",
       "public_path_count": 199,
       "public_path_sha256": "3e919362f222f5a4ae299f5e860d10934105feae4f410a985e729643d31952c1",
-      "rustdoc_json_sha256": "af0534f2612ded4f0e3a2c691338211d1f73284264c115df0d3ee65fb79f6112",
+      "rustdoc_json_sha256": "ed1433861e3e61fc5ed90c176a163027c3d6b9a55b14fc74a18b92583dc849ef",
       "target": "rocketmq_auth"
     },
     "rocketmq-broker": {
       "crate_version": "1.0.0",
       "public_path_count": 50,
       "public_path_sha256": "efb1b554cfdc1275bb621adf4d3dd1ffa51fd50e323e8ced14075251a92644db",
-      "rustdoc_json_sha256": "940f7f84dffdb56e5facb564360bda798f61d887fa5efef2a84ecae77edfb1ca",
+      "rustdoc_json_sha256": "617be435ff3477d0d3e7eff73d0188d15c16d8a85f6c540b0cbdb758d3eecd3c",
       "target": "rocketmq_broker"
     },
     "rocketmq-client-rust": {
       "crate_version": "1.0.0",
       "public_path_count": 386,
       "public_path_sha256": "421f3b97ff6e9b48202f5e9b51f5d0cc98dfaf61d4f60c9dce15ecaad4f86d81",
-      "rustdoc_json_sha256": "9561a668be69cc81006e0de17e655a2cf43dd3efcd5498a53a0759a412d615e5",
+      "rustdoc_json_sha256": "3f63d3ffd80d4a8c09f7ba6ca7493ca6ca9f413fad439174f857770eb3ad8ba5",
       "target": "rocketmq_client_rust"
     },
     "rocketmq-common": {
@@ -47,7 +47,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 250,
       "public_path_sha256": "c3bcca468f5d744ccd6a5f4ad23d6970f905e6fee605acb246d1198a397e9d05",
-      "rustdoc_json_sha256": "6fb4997a8c44a4da19559932f6e2acf39a14878f6fc72ebc8c3b35d3f8fdb33a",
+      "rustdoc_json_sha256": "a98e23dc6ab22c53224e8841cacec19e913e055824f04caf61d9c57cbb8ea23f",
       "target": "rocketmq_controller"
     },
     "rocketmq-dashboard-common": {
@@ -82,7 +82,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 209,
       "public_path_sha256": "60186348b7385948d4018e3ef8cac323084981e7cd18b1ed527b3ec32af85758",
-      "rustdoc_json_sha256": "59e6aa043b9f675c8eb4b3938b81f560e54555c26c8a5fc38abf9af95a920115",
+      "rustdoc_json_sha256": "092bbb9b7c9a40f88d1dee62fd2d1233b7a2d376597ea340b75f08bb533499fd",
       "target": "rocketmq_mcp"
     },
     "rocketmq-model": {
@@ -96,14 +96,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 55,
       "public_path_sha256": "b9d02df04a02dbe99e0931f0b9e2c006993f1663a836bbce532cc59566b3fb31",
-      "rustdoc_json_sha256": "5d656ef01e567eefb604fb1d58d6328d64c573d34849187995420569d1c8fd6d",
+      "rustdoc_json_sha256": "502e5cf9ce7f284de3ce786f6e55066fc661ae65e12edcfa64611c5422659032",
       "target": "rocketmq_namesrv"
     },
     "rocketmq-observability": {
       "crate_version": "1.0.0",
-      "public_path_count": 561,
-      "public_path_sha256": "cf3c7051fa974110205db2119cc52584e373556c185dcd452535e9b2ea0a55b7",
-      "rustdoc_json_sha256": "34f1a871aa9531209c7c896aa5b3f2c5cff0b738f4935cdef5ea2c075d5ebff0",
+      "public_path_count": 598,
+      "public_path_sha256": "59f8f83703a5b460a42df29ae5484a665619528f5ac8265fcd9e02b078394ec7",
+      "rustdoc_json_sha256": "1189fca74a484d8e763eaa7c937068194bb199f0346fe6c83a8e71c6c65efda2",
       "target": "rocketmq_observability"
     },
     "rocketmq-protocol": {
@@ -117,14 +117,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 65,
       "public_path_sha256": "a45a59482ae7b3410ade405dc53f2ca4ca2fb66cc1d3feba986f3aa6cf48efda",
-      "rustdoc_json_sha256": "232fc90bb8d71bceaf1c9d305893acce45e090a800043dbce7caea89b7c858fe",
+      "rustdoc_json_sha256": "6276924ce296730ba8a2d5cd65a0196903048193578d914c978adb75217bf314",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
       "crate_version": "1.0.0",
       "public_path_count": 16,
       "public_path_sha256": "a54347aa28148322afe3d20aaf05915c76060a2c32efb7809271c063296e32b2",
-      "rustdoc_json_sha256": "69e3d7866c2bf7dd28bcb353331be025b7b5d06faf1025618681de422a27ef02",
+      "rustdoc_json_sha256": "977b89dc841a50392cd17c0cfc39bd3288aa667a0755fabdb8ec607fbf262e3f",
       "target": "rocketmq_proxy_cluster"
     },
     "rocketmq-proxy-core": {
@@ -138,7 +138,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 17,
       "public_path_sha256": "3d9e0f9ac569160099d432c85bbb30d17ee1a107e9f665ee636bd4b5898ebc6b",
-      "rustdoc_json_sha256": "f3f342e15749ed1b959033ed84328934fb5f6a9b2862f5944702a62cb04a6c36",
+      "rustdoc_json_sha256": "065220e5d1ed36daa4313121692a35be0897ffdc1ec3475cf487a592882a0079",
       "target": "rocketmq_proxy_local"
     },
     "rocketmq-remoting": {
@@ -173,7 +173,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "ae3737ce8e657dea6c9aa755f2b1c731a1139b46d3854b3a5f6dd7c317d18968",
+      "rustdoc_json_sha256": "adb9c2d0fb23131752bcb064c6c06e2e89136d277e8b52b7eba5fccd8d1a19e8",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -187,7 +187,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 7,
       "public_path_sha256": "c7ac03206be85858d3f2805aba968f45fa3284f5c3265fb823a6435f8e2e929e",
-      "rustdoc_json_sha256": "aef12755a2e19c8bff5851ca495d213e21cd01ba017c30a8138fe4f7c6a2d0ad",
+      "rustdoc_json_sha256": "a958aa06f39bed9078f75295ec2a6722e0185ddf1fc72856c0e983dfdeaba295",
       "target": "rocketmq_store_inspect"
     },
     "rocketmq-store-local": {
@@ -201,14 +201,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 165,
       "public_path_sha256": "89b9028df0c4643a9e718af49f979144b6e1a03635ce69fde0cdad591fe6701b",
-      "rustdoc_json_sha256": "2b1d1df74915ee10e7910ee83499221a4d1b5d8b3a899e4a2c79074b7b4357b4",
+      "rustdoc_json_sha256": "3a0cd98e23de2c265ba555719e1292f504dfad0139ab4e5051eaaa88026cbb08",
       "target": "rocketmq_store_rocksdb"
     },
     "rocketmq-tieredstore": {
       "crate_version": "1.0.0",
       "public_path_count": 116,
       "public_path_sha256": "30e3f19ea359f6f43f2369f0d45ed5cb4a7ed0d6a5fc46ed34b8ea69f02708f3",
-      "rustdoc_json_sha256": "ee785965c0030c5f9e0cdb13ff17c7fe7872b2767e9b349226262683bba354a8",
+      "rustdoc_json_sha256": "83adf1e528efa9c1c244b18e2d002a3e58ad5050d898e98987a85ad97db6e7ff",
       "target": "rocketmq_tieredstore"
     },
     "rocketmq-transport": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "92608c2962bc6e3f0e226980eb7bbf92ac162c1f",
+  "source_commit": "84e2af503e8908f1ea2b7cbb988d3634300d367e",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",

--- a/scripts/telemetry-semantic-guard-violations.json
+++ b/scripts/telemetry-semantic-guard-violations.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "registry_version": "1.0.0",
+  "fixtures": [
+    {
+      "id": "unknown-signal",
+      "operation": "set",
+      "path": [
+        "signals",
+        0,
+        "id"
+      ],
+      "value": "rocketmq_unknown_metric",
+      "expected": "unknown registry signal"
+    },
+    {
+      "id": "undeclared-attribute",
+      "operation": "set",
+      "path": [
+        "signals",
+        0,
+        "attributes"
+      ],
+      "value": [
+        "undeclared.attribute"
+      ],
+      "expected": "undeclared attributes"
+    },
+    {
+      "id": "high-cardinality-default",
+      "operation": "set",
+      "path": [
+        "attributes",
+        29,
+        "default_enabled"
+      ],
+      "value": true,
+      "expected": "high-cardinality attribute must be disabled by default"
+    },
+    {
+      "id": "unbounded-event-rate",
+      "operation": "delete",
+      "path": [
+        "signals",
+        123,
+        "sampling",
+        "max_per_second"
+      ],
+      "expected": "rate-limited event requires max_per_second"
+    },
+    {
+      "id": "invalid-deprecation-window",
+      "operation": "set",
+      "path": [
+        "signals",
+        123,
+        "deprecation"
+      ],
+      "value": {
+        "status": "deprecated",
+        "since": "1.0.0",
+        "replacement": "rocketmq.auth.replacement",
+        "remove_after": "1.1.0"
+      },
+      "expected": "deprecation window must span at least two minor versions"
+    },
+    {
+      "id": "blocking-outage-enqueue",
+      "operation": "set",
+      "path": [
+        "outage_policy",
+        "data_plane_blocking"
+      ],
+      "value": true,
+      "expected": "outage_policy.data_plane_blocking must remain False"
+    },
+    {
+      "id": "weakened-byte-bound",
+      "operation": "set",
+      "path": [
+        "outage_policy",
+        "max_queue_bytes"
+      ],
+      "value": 0,
+      "expected": "outage_policy.max_queue_bytes must match Rust constant"
+    }
+  ]
+}

--- a/scripts/telemetry-semantic-registry.json
+++ b/scripts/telemetry-semantic-registry.json
@@ -1,0 +1,4068 @@
+{
+  "schema_version": 1,
+  "registry_version": "1.0.0",
+  "milestone": "M11-01",
+  "description": "Canonical telemetry semantics and collector-outage behavior for RocketMQ Rust.",
+  "required_families": [
+    "auth-mcp",
+    "connection-bytes",
+    "exporter",
+    "recovery-cache",
+    "request",
+    "task",
+    "watermark-lag"
+  ],
+  "attributes": [
+    {
+      "id": "address",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "aggregation",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "broker_set",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "category",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "cluster",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "component",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "consume_mode",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "consumer_group",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "dLedger_operation_status",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "decision",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "dledger_operation",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "dropped_count",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "election_result",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "engine",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "errno",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "file_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "from",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "group",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "invocation_status",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "is_long_polling",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "is_retry",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "is_system",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "label_key",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "language",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "message_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.consumer.group.name",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.destination.name",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.destination.partition.id",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.message.body.size",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.message.id",
+      "cardinality": "high",
+      "privacy": "sensitive",
+      "max_distinct": 1000,
+      "max_value_bytes": 512,
+      "default_enabled": false,
+      "redaction": "hash"
+    },
+    {
+      "id": "messaging.operation.name",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "messaging.rocketmq.message.keys",
+      "cardinality": "high",
+      "privacy": "sensitive",
+      "max_distinct": 1000,
+      "max_value_bytes": 512,
+      "default_enabled": false,
+      "redaction": "hash"
+    },
+    {
+      "id": "messaging.system",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "node_id",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "node_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "operation",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "path",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "peer_id",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "processor",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "protocol_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "proxy_mode",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "put_status",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "queue_id",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "queued_bytes",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "queued_items",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "reason",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "request_code",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "request_handle_status",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "request_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "response_code",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "result",
+      "cardinality": "bounded",
+      "privacy": "public",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "revive_message_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "rocketmq.batch.message_count",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "rocketmq.consume.mode",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "server.address",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "signal_type",
+      "cardinality": "bounded",
+      "privacy": "public",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "state",
+      "cardinality": "bounded",
+      "privacy": "public",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "storage_medium",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "storage_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "success",
+      "cardinality": "bounded",
+      "privacy": "public",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "task_type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "timer_bound_s",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "to",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "topic",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "type",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "version",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    }
+  ],
+  "signals": [
+    {
+      "id": "rocketmq_processor_watermark",
+      "source_symbol": "PROCESSOR_WATERMARK",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{request}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "processor"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_broker_permission",
+      "source_symbol": "BROKER_PERMISSION",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "1",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_topic_number",
+      "source_symbol": "TOPIC_NUMBER",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{topic}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_group_number",
+      "source_symbol": "CONSUMER_GROUP_NUMBER",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{consumer_group}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_messages_in_total",
+      "source_symbol": "MESSAGES_IN_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "message_type",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_messages_out_total",
+      "source_symbol": "MESSAGES_OUT_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_throughput_in_total",
+      "source_symbol": "THROUGHPUT_IN_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_throughput_out_total",
+      "source_symbol": "THROUGHPUT_OUT_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_message_size",
+      "source_symbol": "MESSAGE_SIZE",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "By",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "message_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_topic_create_execution_time",
+      "source_symbol": "TOPIC_CREATE_EXECUTION_TIME",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_group_create_execution_time",
+      "source_symbol": "CONSUMER_GROUP_CREATE_EXECUTION_TIME",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_producer_connections",
+      "source_symbol": "PRODUCER_CONNECTIONS",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{connection}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "language",
+        "version",
+        "protocol_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_connections",
+      "source_symbol": "CONSUMER_CONNECTIONS",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{connection}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "consumer_group",
+        "language",
+        "version",
+        "protocol_type",
+        "consume_mode",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_lag_messages",
+      "source_symbol": "CONSUMER_LAG_MESSAGES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_lag_latency",
+      "source_symbol": "CONSUMER_LAG_LATENCY",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_inflight_messages",
+      "source_symbol": "CONSUMER_INFLIGHT_MESSAGES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_queueing_latency",
+      "source_symbol": "CONSUMER_QUEUEING_LATENCY",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_consumer_ready_messages",
+      "source_symbol": "CONSUMER_READY_MESSAGES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_send_to_dlq_messages_total",
+      "source_symbol": "SEND_TO_DLQ_MESSAGES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic",
+        "consumer_group",
+        "is_retry",
+        "is_system"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_commit_messages_total",
+      "source_symbol": "COMMIT_MESSAGES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rollback_messages_total",
+      "source_symbol": "ROLLBACK_MESSAGES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_finish_message_latency",
+      "source_symbol": "FINISH_MESSAGE_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_half_messages",
+      "source_symbol": "HALF_MESSAGES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "broker",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_buffer_scan_time_consume",
+      "source_symbol": "POP_BUFFER_SCAN_TIME_CONSUME",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_revive_in_message_total",
+      "source_symbol": "POP_REVIVE_IN_MESSAGE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "consumer_group",
+        "topic",
+        "revive_message_type",
+        "put_status"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_revive_out_message_total",
+      "source_symbol": "POP_REVIVE_OUT_MESSAGE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "consumer_group",
+        "topic",
+        "queue_id",
+        "revive_message_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_revive_retry_messages_total",
+      "source_symbol": "POP_REVIVE_RETRY_MESSAGES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "consumer_group",
+        "topic",
+        "revive_message_type",
+        "put_status"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_revive_lag",
+      "source_symbol": "POP_REVIVE_LAG",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "queue_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_revive_latency",
+      "source_symbol": "POP_REVIVE_LATENCY",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "queue_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_offset_buffer_size",
+      "source_symbol": "POP_OFFSET_BUFFER_SIZE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{offset}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_pop_checkpoint_buffer_size",
+      "source_symbol": "POP_CHECKPOINT_BUFFER_SIZE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{checkpoint}",
+      "owner": "pop",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rpc_latency",
+      "source_symbol": "RPC_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "remoting",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "protocol_type",
+        "request_code",
+        "response_code",
+        "is_long_polling",
+        "result"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_storage_size",
+      "source_symbol": "STORAGE_SIZE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_storage_flush_behind_bytes",
+      "source_symbol": "STORAGE_FLUSH_BEHIND_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_storage_dispatch_behind_bytes",
+      "source_symbol": "STORAGE_DISPATCH_BEHIND_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_storage_message_reserve_time",
+      "source_symbol": "STORAGE_MESSAGE_RESERVE_TIME",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_delay_message_latency",
+      "source_symbol": "DELAY_MESSAGE_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "seconds",
+      "owner": "store",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_commitlog_segment_lease_active",
+      "source_symbol": "STORE_COMMITLOG_SEGMENT_LEASE_ACTIVE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{lease}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_ha_ack_latency_millis",
+      "source_symbol": "STORE_HA_ACK_LATENCY_MILLIS",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_ha_replication_lag_bytes",
+      "source_symbol": "STORE_HA_REPLICATION_LAG_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_sendfile_bytes_total",
+      "source_symbol": "STORE_LINUX_SENDFILE_BYTES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_mlock_bytes",
+      "source_symbol": "STORE_LINUX_MLOCK_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_mlock_attempt_total",
+      "source_symbol": "STORE_LINUX_MLOCK_ATTEMPT_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "category"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_mlock_success_total",
+      "source_symbol": "STORE_LINUX_MLOCK_SUCCESS_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "category"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_mlock_failure_total",
+      "source_symbol": "STORE_LINUX_MLOCK_FAILURE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "category",
+        "errno"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_mlock_skipped_total",
+      "source_symbol": "STORE_LINUX_MLOCK_SKIPPED_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "category",
+        "reason"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_locked_bytes",
+      "source_symbol": "STORE_LINUX_LOCKED_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "category"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_munlock_failure_total",
+      "source_symbol": "STORE_LINUX_MUNLOCK_FAILURE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "category",
+        "errno"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_page_cache_warmup_millis",
+      "source_symbol": "STORE_LINUX_PAGE_CACHE_WARMUP_MILLIS",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_linux_storage_degradation_total",
+      "source_symbol": "STORE_LINUX_STORAGE_DEGRADATION_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "reason",
+        "errno"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_transfer_batch_total",
+      "source_symbol": "STORE_TRANSFER_BATCH_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{batch}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_transfer_bytes_total",
+      "source_symbol": "STORE_TRANSFER_BYTES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_transfer_engine_total",
+      "source_symbol": "STORE_TRANSFER_ENGINE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{transfer}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "engine"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_transfer_fallback_total",
+      "source_symbol": "STORE_TRANSFER_FALLBACK_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{fallback}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "from",
+        "to",
+        "reason"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_transfer_partial_write_total",
+      "source_symbol": "STORE_TRANSFER_PARTIAL_WRITE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{write}",
+      "owner": "store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_enqueue_lag",
+      "source_symbol": "TIMER_ENQUEUE_LAG",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_enqueue_latency",
+      "source_symbol": "TIMER_ENQUEUE_LATENCY",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_dequeue_lag",
+      "source_symbol": "TIMER_DEQUEUE_LAG",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_dequeue_latency",
+      "source_symbol": "TIMER_DEQUEUE_LATENCY",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "ms",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timing_messages",
+      "source_symbol": "TIMING_MESSAGES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_enqueue_total",
+      "source_symbol": "TIMER_ENQUEUE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_dequeue_total",
+      "source_symbol": "TIMER_DEQUEUE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_timer_message_snapshot",
+      "source_symbol": "TIMER_MESSAGE_SNAPSHOT",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "timer",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "timer_bound_s"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_bytes_written",
+      "source_symbol": "ROCKSDB_BYTES_WRITTEN",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_bytes_read",
+      "source_symbol": "ROCKSDB_BYTES_READ",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_times_written_self",
+      "source_symbol": "ROCKSDB_TIMES_WRITTEN_SELF",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{operation}",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_times_written_other",
+      "source_symbol": "ROCKSDB_TIMES_WRITTEN_OTHER",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{operation}",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_rate_cache_hit",
+      "source_symbol": "ROCKSDB_RATE_CACHE_HIT",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "1",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_times_compressed",
+      "source_symbol": "ROCKSDB_TIMES_COMPRESSED",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{operation}",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_read_amplification_bytes",
+      "source_symbol": "ROCKSDB_READ_AMPLIFICATION_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_rocksdb_times_read",
+      "source_symbol": "ROCKSDB_TIMES_READ",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{operation}",
+      "owner": "rocks-db",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "storage_type",
+        "storage_medium",
+        "type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_messages_dispatch_total",
+      "source_symbol": "TIERED_STORE_MESSAGES_DISPATCH_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "topic",
+        "queue_id",
+        "file_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_messages_out_total",
+      "source_symbol": "TIERED_STORE_MESSAGES_OUT_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "topic",
+        "group"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_get_message_fallback_total",
+      "source_symbol": "TIERED_STORE_GET_MESSAGE_FALLBACK_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{request}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "topic",
+        "group"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_provider_upload_bytes",
+      "source_symbol": "TIERED_STORE_PROVIDER_UPLOAD_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "success",
+        "path"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_provider_download_bytes",
+      "source_symbol": "TIERED_STORE_PROVIDER_DOWNLOAD_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "success",
+        "path"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_provider_rpc_latency",
+      "source_symbol": "TIERED_STORE_PROVIDER_RPC_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "success",
+        "path"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_api_latency",
+      "source_symbol": "TIERED_STORE_API_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "success"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_dispatch_latency",
+      "source_symbol": "TIERED_STORE_DISPATCH_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "topic",
+        "queue_id",
+        "file_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_dispatch_behind",
+      "source_symbol": "TIERED_STORE_DISPATCH_BEHIND",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{message}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "topic",
+        "queue_id",
+        "file_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_read_ahead_cache_count",
+      "source_symbol": "TIERED_STORE_READ_AHEAD_CACHE_COUNT",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{entry}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_read_ahead_cache_bytes",
+      "source_symbol": "TIERED_STORE_READ_AHEAD_CACHE_BYTES",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_read_ahead_cache_access_total",
+      "source_symbol": "TIERED_STORE_READ_AHEAD_CACHE_ACCESS_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{access}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "success"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_tiered_store_read_ahead_cache_hit_total",
+      "source_symbol": "TIERED_STORE_READ_AHEAD_CACHE_HIT_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{hit}",
+      "owner": "tiered-store",
+      "catalog": "java",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "success"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_proxy_up",
+      "source_symbol": "PROXY_UP",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "1",
+      "owner": "proxy",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "node_type",
+        "cluster",
+        "node_id",
+        "proxy_mode"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "role",
+      "source_symbol": "CONTROLLER_ROLE",
+      "signal_type": "metric",
+      "kind": "up_down_counter",
+      "unit": "1",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "dledger_disk_usage",
+      "source_symbol": "CONTROLLER_DLEDGER_DISK_USAGE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "active_broker_num",
+      "source_symbol": "CONTROLLER_ACTIVE_BROKER_NUM",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{broker}",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "request_total",
+      "source_symbol": "CONTROLLER_REQUEST_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{request}",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id",
+        "request_type",
+        "request_handle_status"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "dledger_op_total",
+      "source_symbol": "CONTROLLER_DLEDGER_OP_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{operation}",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id",
+        "dledger_operation",
+        "dLedger_operation_status"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "election_total",
+      "source_symbol": "CONTROLLER_ELECTION_TOTAL_JAVA",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{election}",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id",
+        "election_result"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "request_latency",
+      "source_symbol": "CONTROLLER_REQUEST_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "us",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id",
+        "request_type"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "dledger_op_latency",
+      "source_symbol": "CONTROLLER_DLEDGER_OP_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "us",
+      "owner": "controller",
+      "catalog": "java",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "address",
+        "group",
+        "peer_id",
+        "dledger_operation"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_send_message_latency",
+      "source_symbol": "SEND_MESSAGE_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "broker",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "topic"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_metrics_label_dropped_total",
+      "source_symbol": "METRICS_LABEL_DROPPED_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{label}",
+      "owner": "broker",
+      "catalog": "rust",
+      "family": "exporter",
+      "stability": "stable",
+      "attributes": [
+        "cluster",
+        "node_type",
+        "node_id",
+        "label_key"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_append_latency",
+      "source_symbol": "STORE_APPEND_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "rust",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_flush_latency",
+      "source_symbol": "STORE_FLUSH_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "rust",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_dispatch_latency",
+      "source_symbol": "STORE_DISPATCH_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "store",
+      "catalog": "rust",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_store_disk_usage",
+      "source_symbol": "STORE_DISK_USAGE",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "By",
+      "owner": "store",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_remoting_requests_total",
+      "source_symbol": "REMOTING_REQUESTS_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{request}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_remoting_request_latency",
+      "source_symbol": "REMOTING_REQUEST_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_remoting_network_bytes",
+      "source_symbol": "REMOTING_NETWORK_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_send_total",
+      "source_symbol": "CLIENT_SEND_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_send_latency",
+      "source_symbol": "CLIENT_SEND_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_consume_total",
+      "source_symbol": "CLIENT_CONSUME_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{message}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_consume_latency",
+      "source_symbol": "CLIENT_CONSUME_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_rebalance_total",
+      "source_symbol": "CLIENT_REBALANCE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{event}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_namesrv_route_request_total",
+      "source_symbol": "NAMESRV_ROUTE_REQUEST_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{request}",
+      "owner": "name-server",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_namesrv_route_request_latency",
+      "source_symbol": "NAMESRV_ROUTE_REQUEST_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "name-server",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_namesrv_broker_registrations",
+      "source_symbol": "NAMESRV_BROKER_REGISTRATIONS",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{registration}",
+      "owner": "name-server",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_namesrv_active_brokers",
+      "source_symbol": "NAMESRV_ACTIVE_BROKERS",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{broker}",
+      "owner": "name-server",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_controller_election_total",
+      "source_symbol": "CONTROLLER_ELECTION_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{election}",
+      "owner": "controller",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_controller_election_latency",
+      "source_symbol": "CONTROLLER_ELECTION_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "controller",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_controller_leader_changes_total",
+      "source_symbol": "CONTROLLER_LEADER_CHANGES_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{change}",
+      "owner": "controller",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_controller_active_brokers",
+      "source_symbol": "CONTROLLER_ACTIVE_BROKERS",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{broker}",
+      "owner": "controller",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_proxy_grpc_requests_total",
+      "source_symbol": "PROXY_GRPC_REQUESTS_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{request}",
+      "owner": "proxy",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_proxy_grpc_request_latency",
+      "source_symbol": "PROXY_GRPC_REQUEST_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "proxy",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_proxy_forward_latency",
+      "source_symbol": "PROXY_FORWARD_LATENCY",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "ms",
+      "owner": "proxy",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_proxy_active_connections",
+      "source_symbol": "PROXY_ACTIVE_CONNECTIONS",
+      "signal_type": "metric",
+      "kind": "observable_gauge",
+      "unit": "{connection}",
+      "owner": "proxy",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ BROKER RECEIVE_SEND",
+      "source_symbol": "BROKER_RECEIVE_SEND",
+      "signal_type": "span",
+      "owner": "broker",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "server.address",
+        "messaging.destination.partition.id"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ STORE APPEND",
+      "source_symbol": "STORE_APPEND",
+      "signal_type": "span",
+      "owner": "store",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.message.body.size"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ PRODUCER SEND",
+      "source_symbol": "PRODUCER_SEND",
+      "signal_type": "span",
+      "owner": "client",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.message.id",
+        "messaging.message.body.size",
+        "messaging.rocketmq.message.keys"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "sensitive",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ CONSUMER PROCESS",
+      "source_symbol": "CONSUMER_PROCESS",
+      "signal_type": "span",
+      "owner": "client",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "messaging.system",
+        "messaging.operation.name",
+        "messaging.destination.name",
+        "messaging.consumer.group.name",
+        "server.address",
+        "messaging.destination.partition.id",
+        "rocketmq.consume.mode",
+        "rocketmq.batch.message_count",
+        "messaging.message.id",
+        "messaging.message.body.size",
+        "messaging.rocketmq.message.keys"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "sensitive",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.auth.decision",
+      "source_symbol": "AUTH_DECISION",
+      "signal_type": "log",
+      "owner": "security",
+      "family": "auth-mcp",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "decision",
+        "result",
+        "reason"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.auth.reload",
+      "source_symbol": "AUTH_RELOAD",
+      "signal_type": "log",
+      "owner": "security",
+      "family": "auth-mcp",
+      "stability": "stable",
+      "attributes": [
+        "result",
+        "reason"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.mcp.action",
+      "source_symbol": "MCP_ACTION",
+      "signal_type": "log",
+      "owner": "mcp",
+      "family": "auth-mcp",
+      "stability": "stable",
+      "attributes": [
+        "operation",
+        "result",
+        "reason"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.task.lifecycle",
+      "source_symbol": "TASK_LIFECYCLE",
+      "signal_type": "log",
+      "owner": "runtime",
+      "family": "task",
+      "stability": "stable",
+      "attributes": [
+        "task_type",
+        "state",
+        "result",
+        "reason"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.recovery.state",
+      "source_symbol": "RECOVERY_STATE",
+      "signal_type": "log",
+      "owner": "storage",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "component",
+        "state",
+        "result",
+        "reason"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.exporter.drop",
+      "source_symbol": "EXPORTER_DROP",
+      "signal_type": "log",
+      "owner": "observability",
+      "family": "exporter",
+      "stability": "stable",
+      "attributes": [
+        "reason",
+        "signal_type",
+        "dropped_count"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq.exporter.shutdown",
+      "source_symbol": "EXPORTER_SHUTDOWN",
+      "signal_type": "log",
+      "owner": "observability",
+      "family": "exporter",
+      "stability": "stable",
+      "attributes": [
+        "result",
+        "reason",
+        "queued_items",
+        "queued_bytes",
+        "dropped_count"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "rate_limit",
+        "max_per_second": 100,
+        "max_events_per_operation": 1
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    }
+  ],
+  "outage_policy": {
+    "max_queue_items": 2048,
+    "max_queue_bytes": 8388608,
+    "max_record_bytes": 65536,
+    "max_export_batch_items": 512,
+    "scheduled_delay_millis": 5000,
+    "export_timeout_millis": 3000,
+    "shutdown_timeout_millis": 5000,
+    "enqueue": "try_enqueue",
+    "overflow": "drop_newest",
+    "shutdown_deadline": "absolute",
+    "data_plane_blocking": false,
+    "drop_signal": "rocketmq.exporter.drop",
+    "shutdown_signal": "rocketmq.exporter.shutdown",
+    "measurements": [
+      "accepted",
+      "drained",
+      "dropped_by_reason",
+      "queued_items",
+      "queued_bytes"
+    ]
+  }
+}

--- a/scripts/telemetry_semantic_guard.py
+++ b/scripts/telemetry_semantic_guard.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Enforce the versioned RocketMQ telemetry semantic registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = ROOT / "scripts" / "telemetry-semantic-registry.json"
+SEMANTIC_SOURCE = ROOT / "rocketmq-observability" / "src" / "semantic.rs"
+CATALOG_SOURCE = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog.rs"
+SPAN_SOURCE = ROOT / "rocketmq-observability" / "src" / "trace" / "span_names.rs"
+OUTAGE_SOURCE = ROOT / "rocketmq-observability" / "src" / "exporter" / "outage.rs"
+
+REQUIRED_FAMILIES = {
+    "request",
+    "watermark-lag",
+    "connection-bytes",
+    "task",
+    "recovery-cache",
+    "auth-mcp",
+    "exporter",
+}
+REQUIRED_SIGNAL_FIELDS = {
+    "id",
+    "source_symbol",
+    "signal_type",
+    "owner",
+    "family",
+    "stability",
+    "attributes",
+    "cardinality_budget",
+    "privacy",
+    "sampling",
+    "deprecation",
+}
+EXPECTED_OUTAGE_CONSTANTS = {
+    "DEFAULT_MAX_QUEUE_ITEMS": "max_queue_items",
+    "DEFAULT_MAX_QUEUE_BYTES": "max_queue_bytes",
+    "DEFAULT_MAX_RECORD_BYTES": "max_record_bytes",
+    "DEFAULT_MAX_EXPORT_BATCH_ITEMS": "max_export_batch_items",
+    "DEFAULT_SCHEDULED_DELAY_MILLIS": "scheduled_delay_millis",
+    "DEFAULT_EXPORT_TIMEOUT_MILLIS": "export_timeout_millis",
+    "DEFAULT_SHUTDOWN_TIMEOUT_MILLIS": "shutdown_timeout_millis",
+}
+FORBIDDEN_ATTRIBUTE_RE = re.compile(
+    r"(?:password|passwd|credential|private[._-]?key|access[._-]?key|secret|token|message[._-]?body(?![._-]?size))",
+    re.IGNORECASE,
+)
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+class SourceInventoryError(ValueError):
+    """Raised when the Rust telemetry inventory cannot be parsed exactly."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read JSON {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return value
+
+
+def module_body(source: str, module: str) -> str:
+    match = re.search(rf"pub\s+mod\s+{re.escape(module)}\s*\{{", source)
+    if match is None:
+        raise SourceInventoryError(f"missing module: {module}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise SourceInventoryError(f"unterminated module: {module}")
+    return source[match.end() : cursor - 1]
+
+
+def parse_string_constants(source: str) -> dict[str, str]:
+    return dict(re.findall(r'pub\s+const\s+(\w+)\s*:\s*&str\s*=\s*"([^"]+)"\s*;', source))
+
+
+def catalog_array_body(source: str, name: str) -> str:
+    match = re.search(rf"pub\s+const\s+{re.escape(name)}\s*:.*?=\s*&\[(.*?)\n\];", source, re.DOTALL)
+    if match is None:
+        raise SourceInventoryError(f"missing catalog array: {name}")
+    return match.group(1)
+
+
+def parse_label_sets(source: str, labels: dict[str, str]) -> dict[str, list[str]]:
+    label_sets: dict[str, list[str]] = {}
+    pattern = re.compile(r"const\s+(\w+)\s*:\s*&\[&str\]\s*=\s*&\[(.*?)\];", re.DOTALL)
+    for name, body in pattern.findall(source):
+        symbols = re.findall(r"labels::(\w+)", body)
+        try:
+            label_sets[name] = [labels[symbol] for symbol in symbols]
+        except KeyError as error:
+            raise SourceInventoryError(f"unknown label symbol in {name}: {error.args[0]}") from error
+    return label_sets
+
+
+def parse_catalog(
+    source: str,
+    metrics: dict[str, str],
+    labels: dict[str, str],
+) -> list[dict[str, Any]]:
+    label_sets = parse_label_sets(source, labels)
+    descriptor_re = re.compile(
+        r"MetricDescriptor\s*\{\s*"
+        r"name:\s*metrics::(\w+),\s*"
+        r"kind:\s*MetricKind::(\w+),\s*"
+        r'unit:\s*"([^"]+)",\s*'
+        r"labels:\s*(.*?),\s*"
+        r"source:\s*MetricSource::(\w+),\s*\}",
+        re.DOTALL,
+    )
+    descriptors: list[dict[str, Any]] = []
+    for catalog_name in ("JAVA_METRICS", "RUST_METRICS"):
+        body = catalog_array_body(source, catalog_name)
+        matches = descriptor_re.findall(body)
+        if not matches:
+            raise SourceInventoryError(f"no descriptors parsed from {catalog_name}")
+        for symbol, kind, unit, label_expression, owner in matches:
+            if symbol not in metrics:
+                raise SourceInventoryError(f"catalog references unknown metric symbol: {symbol}")
+            expression = label_expression.strip()
+            if expression.startswith("&["):
+                label_symbols = re.findall(r"labels::(\w+)", expression)
+                try:
+                    attributes = [labels[item] for item in label_symbols]
+                except KeyError as error:
+                    raise SourceInventoryError(
+                        f"catalog metric {symbol} references unknown label: {error.args[0]}"
+                    ) from error
+            else:
+                if expression not in label_sets:
+                    raise SourceInventoryError(f"catalog metric {symbol} uses unknown label set: {expression}")
+                attributes = label_sets[expression]
+            descriptors.append(
+                {
+                    "id": metrics[symbol],
+                    "source_symbol": symbol,
+                    "kind": re.sub(r"(?<!^)(?=[A-Z])", "_", kind).lower(),
+                    "unit": unit,
+                    "attributes": attributes,
+                    "source": owner,
+                    "catalog": "java" if catalog_name == "JAVA_METRICS" else "rust",
+                }
+            )
+    return descriptors
+
+
+def parse_integer_expression(expression: str) -> int:
+    normalized = expression.replace("_", "").strip()
+    if not re.fullmatch(r"[0-9*\s]+", normalized):
+        raise SourceInventoryError(f"unsupported integer expression: {expression}")
+    result = 1
+    for factor in normalized.split("*"):
+        result *= int(factor.strip())
+    return result
+
+
+def parse_outage_constants(source: str) -> dict[str, int]:
+    constants: dict[str, int] = {}
+    for constant in EXPECTED_OUTAGE_CONSTANTS:
+        match = re.search(
+            rf"pub\s+const\s+{re.escape(constant)}\s*:\s*(?:usize|u64)\s*=\s*([^;]+);",
+            source,
+        )
+        if match is None:
+            raise SourceInventoryError(f"missing outage constant: {constant}")
+        constants[constant] = parse_integer_expression(match.group(1))
+    return constants
+
+
+def build_source_inventory() -> dict[str, Any]:
+    semantic_source = SEMANTIC_SOURCE.read_text(encoding="utf-8")
+    metrics = parse_string_constants(module_body(semantic_source, "metrics"))
+    labels = parse_string_constants(module_body(semantic_source, "labels"))
+    events = parse_string_constants(module_body(semantic_source, "events"))
+    catalog = parse_catalog(CATALOG_SOURCE.read_text(encoding="utf-8"), metrics, labels)
+    spans = parse_string_constants(SPAN_SOURCE.read_text(encoding="utf-8"))
+    outage = parse_outage_constants(OUTAGE_SOURCE.read_text(encoding="utf-8"))
+
+    catalog_symbols = {item["source_symbol"] for item in catalog}
+    if catalog_symbols != set(metrics):
+        missing = sorted(set(metrics) - catalog_symbols)
+        unknown = sorted(catalog_symbols - set(metrics))
+        raise SourceInventoryError(f"metric/catalog drift: missing={missing} unknown={unknown}")
+    if len(catalog) != len({item["id"] for item in catalog}):
+        raise SourceInventoryError("duplicate metric identifiers in combined catalog")
+    return {
+        "metrics": catalog,
+        "spans": spans,
+        "events": events,
+        "labels": labels,
+        "outage": outage,
+    }
+
+
+def version_tuple(value: Any) -> tuple[int, int, int] | None:
+    if not isinstance(value, str):
+        return None
+    match = SEMVER_RE.fullmatch(value)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def validate_deprecation(signal: dict[str, Any], findings: list[str]) -> None:
+    signal_id = signal.get("id", "<unknown>")
+    deprecation = signal.get("deprecation")
+    if not isinstance(deprecation, dict):
+        findings.append(f"{signal_id}: deprecation must be an object")
+        return
+    status = deprecation.get("status")
+    since = version_tuple(deprecation.get("since"))
+    if status not in {"active", "deprecated"} or since is None:
+        findings.append(f"{signal_id}: invalid deprecation status or since version")
+        return
+    replacement = deprecation.get("replacement")
+    remove_after = version_tuple(deprecation.get("remove_after"))
+    if status == "active":
+        if replacement is not None or deprecation.get("remove_after") is not None:
+            findings.append(f"{signal_id}: active signal cannot declare replacement or removal")
+        return
+    if not isinstance(replacement, str) or not replacement or remove_after is None:
+        findings.append(f"{signal_id}: deprecated signal requires replacement and remove_after")
+        return
+    since_minor = since[0] * 10_000 + since[1]
+    removal_minor = remove_after[0] * 10_000 + remove_after[1]
+    if removal_minor - since_minor < 2:
+        findings.append(f"{signal_id}: deprecation window must span at least two minor versions")
+
+
+def validate_attributes(registry: dict[str, Any], findings: list[str]) -> dict[str, dict[str, Any]]:
+    raw_attributes = registry.get("attributes")
+    if not isinstance(raw_attributes, list):
+        findings.append("attributes must be a list")
+        return {}
+    attributes: dict[str, dict[str, Any]] = {}
+    for attribute in raw_attributes:
+        if not isinstance(attribute, dict) or not isinstance(attribute.get("id"), str):
+            findings.append("attribute entries must be objects with string ids")
+            continue
+        attribute_id = attribute["id"]
+        if attribute_id in attributes:
+            findings.append(f"duplicate attribute: {attribute_id}")
+            continue
+        attributes[attribute_id] = attribute
+        if FORBIDDEN_ATTRIBUTE_RE.search(attribute_id):
+            findings.append(f"forbidden sensitive attribute identifier: {attribute_id}")
+        cardinality = attribute.get("cardinality")
+        privacy = attribute.get("privacy")
+        if cardinality not in {"low", "bounded", "high"}:
+            findings.append(f"{attribute_id}: invalid cardinality")
+        if privacy not in {"public", "operational", "sensitive"}:
+            findings.append(f"{attribute_id}: invalid privacy")
+        if not isinstance(attribute.get("max_distinct"), int) or attribute.get("max_distinct", 0) <= 0:
+            findings.append(f"{attribute_id}: max_distinct must be positive")
+        if not isinstance(attribute.get("max_value_bytes"), int) or attribute.get("max_value_bytes", 0) <= 0:
+            findings.append(f"{attribute_id}: max_value_bytes must be positive")
+        if cardinality == "high" and attribute.get("default_enabled") is not False:
+            findings.append(f"{attribute_id}: high-cardinality attribute must be disabled by default")
+        if privacy == "sensitive" and attribute.get("redaction") not in {"hash", "drop"}:
+            findings.append(f"{attribute_id}: sensitive attribute requires hash or drop redaction")
+    return attributes
+
+
+def validate_signal_common(
+    signal: Any,
+    attributes: dict[str, dict[str, Any]],
+    findings: list[str],
+) -> None:
+    if not isinstance(signal, dict):
+        findings.append("signal entry must be an object")
+        return
+    signal_id = signal.get("id", "<unknown>")
+    missing_fields = sorted(REQUIRED_SIGNAL_FIELDS - set(signal))
+    if missing_fields:
+        findings.append(f"{signal_id}: missing signal fields {missing_fields}")
+    if signal.get("signal_type") not in {"metric", "span", "log"}:
+        findings.append(f"{signal_id}: invalid signal_type")
+    if signal.get("stability") not in {"stable", "experimental"}:
+        findings.append(f"{signal_id}: invalid stability")
+    if signal.get("privacy") not in {"public", "operational", "sensitive"}:
+        findings.append(f"{signal_id}: invalid privacy")
+    budget = signal.get("cardinality_budget")
+    if not isinstance(budget, int) or isinstance(budget, bool) or budget <= 0:
+        findings.append(f"{signal_id}: cardinality_budget must be a positive integer")
+    signal_attributes = signal.get("attributes")
+    if not isinstance(signal_attributes, list) or len(signal_attributes) != len(set(signal_attributes)):
+        findings.append(f"{signal_id}: attributes must be a unique list")
+    else:
+        unknown = sorted(set(signal_attributes) - set(attributes))
+        if unknown:
+            findings.append(f"{signal_id}: undeclared attributes {unknown}")
+        high = [item for item in signal_attributes if attributes.get(item, {}).get("cardinality") == "high"]
+        if high and signal.get("privacy") != "sensitive":
+            findings.append(f"{signal_id}: high-cardinality attributes require sensitive privacy")
+    sampling = signal.get("sampling")
+    if not isinstance(sampling, dict) or sampling.get("strategy") not in {
+        "aggregate",
+        "ratio",
+        "rate_limit",
+    }:
+        findings.append(f"{signal_id}: invalid sampling policy")
+    elif signal.get("signal_type") in {"span", "log"}:
+        limit = sampling.get("max_events_per_operation")
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0:
+            findings.append(f"{signal_id}: span/log sampling requires a finite per-operation limit")
+        if sampling.get("strategy") == "ratio":
+            ratio = sampling.get("default_ratio")
+            if not isinstance(ratio, (int, float)) or isinstance(ratio, bool) or not 0 <= ratio <= 1:
+                findings.append(f"{signal_id}: ratio sampling must remain between zero and one")
+        if sampling.get("strategy") == "rate_limit":
+            rate = sampling.get("max_per_second")
+            if not isinstance(rate, int) or isinstance(rate, bool) or rate <= 0:
+                findings.append(f"{signal_id}: rate-limited event requires max_per_second")
+    validate_deprecation(signal, findings)
+
+
+def validate_source_sync(
+    signals: list[dict[str, Any]],
+    inventory: dict[str, Any],
+    findings: list[str],
+) -> None:
+    registry_by_key = {
+        (signal.get("signal_type"), signal.get("id")): signal
+        for signal in signals
+        if isinstance(signal, dict)
+    }
+    expected_keys = {
+        *(('metric', item["id"]) for item in inventory["metrics"]),
+        *(("span", value) for value in inventory["spans"].values()),
+        *(("log", value) for value in inventory["events"].values()),
+    }
+    actual_keys = set(registry_by_key)
+    for signal_type, signal_id in sorted(expected_keys - actual_keys):
+        findings.append(f"missing registry signal: {signal_type}:{signal_id}")
+    for signal_type, signal_id in sorted(actual_keys - expected_keys):
+        findings.append(f"unknown registry signal: {signal_type}:{signal_id}")
+
+    for metric in inventory["metrics"]:
+        signal = registry_by_key.get(("metric", metric["id"]))
+        if signal is None:
+            continue
+        for field in ("source_symbol", "kind", "unit", "attributes"):
+            if signal.get(field) != metric[field]:
+                findings.append(
+                    f"{metric['id']}: registry {field}={signal.get(field)!r} "
+                    f"does not match source {metric[field]!r}"
+                )
+        expected_owner = re.sub(r"(?<!^)(?=[A-Z])", "-", metric["source"]).lower()
+        if signal.get("owner") != expected_owner:
+            findings.append(f"{metric['id']}: owner does not match catalog source {expected_owner}")
+        if signal.get("catalog") != metric["catalog"]:
+            findings.append(f"{metric['id']}: catalog provenance does not match source")
+
+    for signal_type, source_key, source_values in (
+        ("span", "spans", inventory["spans"]),
+        ("log", "events", inventory["events"]),
+    ):
+        for symbol, signal_id in source_values.items():
+            signal = registry_by_key.get((signal_type, signal_id))
+            if signal is not None and signal.get("source_symbol") != symbol:
+                findings.append(f"{signal_id}: source_symbol does not match {source_key} source")
+
+
+def validate_outage_policy(
+    registry: dict[str, Any],
+    inventory: dict[str, Any],
+    signal_ids: set[str],
+    findings: list[str],
+) -> None:
+    policy = registry.get("outage_policy")
+    if not isinstance(policy, dict):
+        findings.append("outage_policy must be an object")
+        return
+    for constant, field in EXPECTED_OUTAGE_CONSTANTS.items():
+        expected = inventory["outage"][constant]
+        if policy.get(field) != expected:
+            findings.append(f"outage_policy.{field} must match Rust constant {constant}={expected}")
+    required_values = {
+        "enqueue": "try_enqueue",
+        "overflow": "drop_newest",
+        "shutdown_deadline": "absolute",
+        "data_plane_blocking": False,
+        "drop_signal": "rocketmq.exporter.drop",
+        "shutdown_signal": "rocketmq.exporter.shutdown",
+    }
+    for field, expected in required_values.items():
+        if policy.get(field) != expected:
+            findings.append(f"outage_policy.{field} must remain {expected!r}")
+    for signal_field in ("drop_signal", "shutdown_signal"):
+        if policy.get(signal_field) not in signal_ids:
+            findings.append(f"outage_policy.{signal_field} references an unknown signal")
+    measurements = policy.get("measurements")
+    required_measurements = {
+        "accepted",
+        "drained",
+        "dropped_by_reason",
+        "queued_items",
+        "queued_bytes",
+    }
+    if not isinstance(measurements, list) or not required_measurements.issubset(measurements):
+        findings.append("outage_policy.measurements does not expose every bounded-queue outcome")
+
+
+def validate_registry(registry: dict[str, Any], inventory: dict[str, Any] | None = None) -> list[str]:
+    findings: list[str] = []
+    if registry.get("schema_version") != 1 or registry.get("milestone") != "M11-01":
+        findings.append("registry schema_version or milestone is invalid")
+    if version_tuple(registry.get("registry_version")) is None:
+        findings.append("registry_version must be semantic versioning")
+    attributes = validate_attributes(registry, findings)
+    signals = registry.get("signals")
+    if not isinstance(signals, list):
+        findings.append("signals must be a list")
+        return findings
+    keys: list[tuple[Any, Any]] = []
+    for signal in signals:
+        validate_signal_common(signal, attributes, findings)
+        if isinstance(signal, dict):
+            keys.append((signal.get("signal_type"), signal.get("id")))
+    if len(keys) != len(set(keys)):
+        findings.append("duplicate signal type/id pairs in registry")
+    families = {signal.get("family") for signal in signals if isinstance(signal, dict)}
+    missing_families = sorted(REQUIRED_FAMILIES - families)
+    if missing_families:
+        findings.append(f"registry is missing required families: {missing_families}")
+
+    source_inventory = inventory or build_source_inventory()
+    validate_source_sync(signals, source_inventory, findings)
+    signal_ids = {signal.get("id") for signal in signals if isinstance(signal, dict)}
+    validate_outage_policy(registry, source_inventory, signal_ids, findings)
+    return findings
+
+
+def apply_fixture(document: dict[str, Any], fixture: dict[str, Any]) -> dict[str, Any]:
+    """Apply a deterministic violation fixture used by guard regression tests."""
+
+    result = deepcopy(document)
+    path = fixture.get("path")
+    if not isinstance(path, list) or not path:
+        raise ValueError("fixture path must be a non-empty list")
+    parent: Any = result
+    for component in path[:-1]:
+        parent = parent[component]
+    operation = fixture.get("operation")
+    terminal = path[-1]
+    if operation == "set":
+        parent[terminal] = deepcopy(fixture.get("value"))
+    elif operation == "delete":
+        del parent[terminal]
+    elif operation == "append":
+        parent[terminal].append(deepcopy(fixture.get("value")))
+    else:
+        raise ValueError(f"unsupported fixture operation: {operation}")
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        registry = load_json(args.registry)
+        inventory = build_source_inventory()
+        findings = validate_registry(registry, inventory)
+    except (OSError, ValueError) as error:
+        print(f"telemetry semantic guard: FAIL\n- {error}")
+        return 1
+    if findings:
+        print("telemetry semantic guard: FAIL")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+    signal_counts = {
+        signal_type: sum(1 for signal in registry["signals"] if signal["signal_type"] == signal_type)
+        for signal_type in ("metric", "span", "log")
+    }
+    print(
+        "telemetry semantic guard: PASS "
+        f"version={registry['registry_version']} metrics={signal_counts['metric']} "
+        f"spans={signal_counts['span']} logs={signal_counts['log']} "
+        f"attributes={len(registry['attributes'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_telemetry_semantic_guard.py
+++ b/scripts/tests/test_telemetry_semantic_guard.py
@@ -1,0 +1,122 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import generate_telemetry_semantic_registry as generator  # noqa: E402
+import telemetry_semantic_guard as guard  # noqa: E402
+
+
+class TelemetrySemanticGuardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.registry = guard.load_json(guard.DEFAULT_REGISTRY)
+        cls.inventory = guard.build_source_inventory()
+        cls.fixtures = guard.load_json(
+            SCRIPTS / "telemetry-semantic-guard-violations.json"
+        )["fixtures"]
+
+    def test_live_registry_matches_every_rust_signal(self) -> None:
+        self.assertEqual([], guard.validate_registry(self.registry, self.inventory))
+        self.assertEqual(119, len(self.inventory["metrics"]))
+        self.assertEqual(4, len(self.inventory["spans"]))
+        self.assertEqual(7, len(self.inventory["events"]))
+        self.assertEqual(130, len(self.registry["signals"]))
+
+    def test_generator_is_deterministic(self) -> None:
+        self.assertEqual(self.registry, generator.build_registry())
+
+    def test_cli_reports_registered_inventory(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "telemetry_semantic_guard.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("metrics=119 spans=4 logs=7 attributes=66", result.stdout)
+
+    def test_committed_violation_fixtures_are_rejected(self) -> None:
+        fixture_ids = {fixture["id"] for fixture in self.fixtures}
+        self.assertEqual(
+            {
+                "unknown-signal",
+                "undeclared-attribute",
+                "high-cardinality-default",
+                "unbounded-event-rate",
+                "invalid-deprecation-window",
+                "blocking-outage-enqueue",
+                "weakened-byte-bound",
+            },
+            fixture_ids,
+        )
+        for fixture in self.fixtures:
+            with self.subTest(fixture=fixture["id"]):
+                invalid = guard.apply_fixture(self.registry, fixture)
+                findings = guard.validate_registry(invalid, self.inventory)
+                self.assertTrue(
+                    any(fixture["expected"] in finding for finding in findings),
+                    findings,
+                )
+
+    def test_missing_required_family_is_rejected(self) -> None:
+        invalid = copy.deepcopy(self.registry)
+        for signal in invalid["signals"]:
+            if signal["family"] == "auth-mcp":
+                signal["family"] = "request"
+        findings = guard.validate_registry(invalid, self.inventory)
+        self.assertTrue(any("missing required families" in finding for finding in findings))
+
+    def test_sensitive_attribute_cannot_disable_redaction(self) -> None:
+        invalid = copy.deepcopy(self.registry)
+        attribute = next(
+            item for item in invalid["attributes"] if item["privacy"] == "sensitive"
+        )
+        attribute["redaction"] = "none"
+        findings = guard.validate_registry(invalid, self.inventory)
+        self.assertTrue(any("requires hash or drop redaction" in finding for finding in findings))
+
+    def test_forbidden_payload_attribute_is_rejected(self) -> None:
+        invalid = copy.deepcopy(self.registry)
+        invalid["attributes"].append(
+            {
+                "id": "message.body",
+                "cardinality": "bounded",
+                "privacy": "sensitive",
+                "max_distinct": 1,
+                "max_value_bytes": 64,
+                "default_enabled": False,
+                "redaction": "drop",
+            }
+        )
+        findings = guard.validate_registry(invalid, self.inventory)
+        self.assertTrue(any("forbidden sensitive attribute" in finding for finding in findings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- establish a versioned telemetry semantic registry covering 119 metrics, 4 spans, 7 stable log events, and 66 governed attributes
- add source-synchronized cardinality/privacy/sampling/deprecation and collector-outage guards with positive and violation fixtures
- add a count-and-byte bounded non-blocking exporter queue, explicit OTLP batch bounds, and one shared absolute provider shutdown budget
- update M11 implementation evidence and the global completion ledger to 65/82, while keeping M10 real-performance and Phase 3 HUMAN gates open

## Validation

- `python -m unittest discover -s scripts/tests -p test_*guard.py -v` (132 passed)
- `python scripts/telemetry_semantic_guard.py`
- observability CI feature matrix: all 7 exact profiles passed workspace check, strict Clippy, and package tests
- `cargo test -p rocketmq-observability --all-features`
- `cargo doc -p rocketmq-observability --no-deps --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `rocketmq-example`: fmt and all-target strict Clippy
- runtime audit, dependency target/baseline, release, performance-profile, ArcMut, routing, and diff guards passed
- public API snapshot: 31/31 packages, differences=0; observability additions reviewed as additive

## Compatibility and rollback

- no metric/span/event identifier is removed or renamed
- the public API change is additive; existing `TelemetryGuard::shutdown()` remains available
- rollback must restore the registry, catalog, event constants, guard fixtures, and exporter bounds together; privacy/cardinality failures must not be disabled

Closes #8270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded, non-blocking telemetry outage buffering with drop accounting, batching, and deadline-aware shutdown.
  * Added a versioned telemetry semantic registry covering metrics, traces, logs, privacy, cardinality, and exporter policies.
  * Added public telemetry event identifiers and expanded native metric catalog coverage.
  * Added shared timeout support for telemetry shutdown.

* **Bug Fixes**
  * Improved telemetry export reliability during outages without blocking application data paths.

* **Tests**
  * Added registry generation, validation, negative-fixture, and CI guard coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->