### PR TITLE
[ISSUE #8272]♻️Establish SecretProvider contract and local adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,11 +1141,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1103,6 +1158,15 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf 0.11.3",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1320,7 +1384,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1824,6 +1888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3565,6 +3647,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4468,7 @@ dependencies = [
 name = "rocketmq-auth"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "base64",
  "cheetah-string",
  "chrono",
@@ -4909,6 +5003,7 @@ version = "1.0.0"
 dependencies = [
  "cheetah-string",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -6516,6 +6611,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7443,9 +7548,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ serde_json_any_key = "2.1.0"
 anyhow             = "1.0.102"
 bytes              = "1.11.1"
 rand               = "0.10.1"
+zeroize            = "1.9.0"
 num_cpus           = "1.17"
 
 config = "0.15.23"

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -526,7 +526,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] observability 精确 7 组 feature matrix 的 workspace check、strict Clippy 和 package test 全部通过
   - [x] [`M11-01 证据`](phase-3-production-readiness/11-telemetry-semantic-registry-evidence.md) 记录 API、验证、失败修复与回滚边界
   - [x] 65/82 已完成、17 未完成，下一工作包 PR-M11-02；M10/M11/Phase 3 Gate 均未提前宣称完成
-- [ ] PR-M11-02：实现 SecretProvider 基础合同与本地 adapter
+- [x] PR-M11-02：实现 SecretProvider 基础合同与本地 adapter
+  - [x] `rocketmq-security-api` 冻结同步、运行时中立的 provider/name/version/capability/error 合同
+  - [x] `SecretMaterial` 禁止空值、Debug 恒定 redaction，并在显式 zeroize 与 Drop 时清零底层字节
+  - [x] `rocketmq-auth` 提供无全局单例的显式 registry；缺失与重复 provider 均 fail closed
+  - [x] 环境 adapter 只读取显式 logical-name→env allowlist，保持只读且不输出变量名/值
+  - [x] 本地文件 adapter 使用 AES-256-GCM、name+version AAD、owner-only 权限、不可覆盖版本和原子发布
+  - [x] Windows 在没有 owner-only ACL verifier 前拒绝启用；WSL/Linux 真实权限、加密、tamper、版本冲突测试通过
+  - [x] [`M11-02 证据`](phase-3-production-readiness/11-secret-provider-evidence.md) 记录合同、平台测试、API 增量和回滚边界
+  - [x] 66/82 已完成、16 未完成，下一工作包 PR-M11-03；安全默认值、M10/M11/Phase 3 Gate 均未提前宣称完成
 - [ ] PR-M11-03：实现 Secure Profile 与一次性 bootstrap
 - [ ] PR-M11-04：实现 credential/certificate rotation 与原子 reload
 - [ ] PR-M11-05：完成 MCP HTTPS、JWKS 与 Principal 传播

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已启动，下一工作包为 PR-M11-02）
+> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已推进至 SecretProvider，下一工作包为 PR-M11-03）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；65/82 工作包完成，剩余 17 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；66/82 工作包完成，剩余 16 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-secret-provider-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-secret-provider-evidence.md
@@ -1,0 +1,106 @@
+# M11-02 SecretProvider 基础合同与本地 Adapter 实施证据
+
+## 1. 目标完成结论
+
+PR-M11-02 已冻结 runtime-neutral `SecretProvider` 合同，并在 `rocketmq-auth` 交付显式 registry、白名单环境
+adapter 与受限加密文件 adapter。工作包完成后总进度为 **66/82**，剩余 16 个工作包：M11 10 个、M12
+6 个；下一工作包为 PR-M11-03。
+
+这里的“工作包完成”不等于 secure profile 或 M11 完成。安全默认值、一次性 bootstrap、rotation/reload、
+MCP HTTPS/audit、镜像、Helm/Kustomize、Kind/K3d fault matrix 和 ArcMut/stable/SLO 收口仍属于
+PR-M11-03～12。M10 的真实固定硬件 baseline/candidate 与 `[HUMAN]` Gate 也仍待验收。
+
+| 项目 | 值 |
+|---|---|
+| 工作包 | `PR-M11-02` |
+| Issue | `#8272` |
+| Branch | `mxsm/architecture-refactor-secret-provider-contract` |
+| API candidate snapshot | `77416b46bd9627b73201705459d3c39a6c57e084` |
+| 日期 | 2026-07-18 |
+| 合同 owner | `rocketmq-security-api/src/secret_provider.rs` |
+| adapter owner | `rocketmq-auth/src/secret_provider/` |
+
+## 2. 合同与依赖边界
+
+`rocketmq-security-api` 只新增 `zeroize` 这一个内存卫生依赖，没有 AES、文件 adapter、Tokio、网络客户端或
+生产 provider 实现依赖。公共边界保持同步、object-safe 且由 composition root 注入：
+
+| 合同 | 冻结语义 |
+|---|---|
+| `SecretProviderId` / `SecretName` | 最长 128B，只允许 ASCII 字母数字和 `-_.`；拒绝空值、隐藏名、分隔符与 traversal |
+| `SecretMaterial` | 非空、不可 Clone、Debug 恒为 `[REDACTED]`；显式 `Zeroize` 和 Drop 都清零底层字节 |
+| capability | typed access、persistence、versioning enum，不使用位置布尔值 |
+| `SecretProvider` | `Send + Sync` 同步 trait；read 返回 material+可选版本，write 消费 material 并执行 optimistic version |
+| error | 不包含 secret、logical name、环境变量名或路径；缺失 provider、权限、冲突、envelope 和平台均 fail closed |
+| registry | 由 composition root 持有的显式 `BTreeMap`；无全局单例、无默认 fallback、重复 ID 不替换 |
+
+保留原有泛型 `Secret<T>` 以维持已有签名 API 的类型兼容；新的字节材料使用专用 `SecretMaterial`，没有给旧
+泛型增加 `Zeroize` trait bound。生产 Vault/KMS/Kubernetes Secret/OS credential provider 不进入本工作包，
+未来只能通过相同 trait 显式注入。
+
+## 3. 本地 Adapter 与文件语义
+
+环境 adapter 构造时必须提供 logical name 到环境变量名的完整 allowlist；未映射 logical name 返回
+`NotFound`，write 恒定返回 `ReadOnly`。Debug 只显示 provider ID 和映射数量，不显示环境变量名或值，也
+不存在把任意 secret name 直接转换为环境变量查询的路径。
+
+Unix 文件 adapter 的持久化合同如下：
+
+- provider root 和每个 secret 目录必须为 owner-only，现有宽权限目录或 symlink fail closed；
+- key 必须为 32B，material 最大 1 MiB；envelope 使用 AES-256-GCM 和随机 96-bit nonce；
+- AAD 绑定 schema、logical name 和 `u64` version，换名、换版本或修改 ciphertext 都无法通过认证；
+- envelope 为固定 magic + nonce + ciphertext length + ciphertext 的紧凑二进制，不写 pretty JSON 或明文；
+- `None` expected version 仅允许创建；更新必须提交当前版本，旧版本产生 `VersionConflict`；
+- 每个版本写入 owner-only 临时文件、`sync_all`、改为只读后，以同目录 hard-link no-replace 原子发布；
+- 版本文件按 20 位十进制编号且不覆盖，reader 只选择已发布最大版本，崩溃遗留 `.tmp` 不可见；
+- Windows 在没有可证明 owner-only 的 ACL verifier 前，构造 adapter 即返回 `UnsupportedPlatform`。
+
+文件 adapter 是开发/本地受限实现，不是生产 secure profile 默认。PR-M11-03 仍需单独完成安全 profile、
+bootstrap material/readiness 和部署迁移决策。
+
+## 4. 失败注入与公共兼容面
+
+Windows focused tests 直接验证文件 adapter fail closed；WSL/Ubuntu 24.04 使用独立 target 实际执行 Unix
+权限与文件系统语义，覆盖 0755 root 拒绝、0600/0400 owner-only、两次原子版本发布、旧版本冲突、磁盘无
+明文和 ciphertext tamper 拒绝。平台无关测试还覆盖 name/version AAD、logical name traversal、Debug
+redaction、显式 zeroize、provider 缺失/重复、环境 allowlist 和只读写拒绝。
+
+默认特性 public API 快照审查显示：
+
+- `rocketmq-auth` 公共路径从 199 增至 203，只增加 `secret_provider` 模块和三个 facade re-export；
+- `rocketmq-security-api` 公共路径从 58 增至 94，只增加 provider 合同及根级精确 re-export；
+- 其余 29 个 package 的公共路径数量和路径指纹不变；没有删除、重命名或改变现有 public item；
+- 依赖图加入 AES/zeroize 后 Rustdoc 内部 crate ID 使部分 raw JSON hash 改变，已与路径指纹变化分开审查。
+
+## 5. 验证矩阵
+
+| Gate | 命令/范围 | 结果 |
+|---|---|---|
+| Security contract | `cargo test -p rocketmq-security-api` | 3 个新合同测试 + 7 个既有安全合同测试通过 |
+| Auth full | `cargo test -p rocketmq-auth --all-features` | 348 library + 9 Java alignment + 3 SecretProvider + 1 identity，通过；59 doctest ignored |
+| Windows focused | `cargo test -p rocketmq-auth --test secret_provider_contract` | 3/3 通过，包含 ACL 未验证 fail closed |
+| Linux focused | WSL/Ubuntu 独立 target 执行同一测试 | 4/4 通过，包含真实 owner-only/atomic/tamper 测试 |
+| Package Clippy | security-api/auth all-target/all-feature `--no-deps -D warnings` | 通过 |
+| Public API | 31 包默认特性快照重新生成并审查 | 仅 auth +4、security-api +36 additive；最终基线复核 differences=0 |
+| Dependency | `architecture_dependency_guard.py --mode target` | 通过，security-api 保持 contract leaf |
+| Root final | `cargo fmt --all -- --check`；workspace all-target/all-feature strict Clippy | 32 package 通过 |
+| MCP | check、73+1+2 tests、streamable-http strict Clippy、doc | 全部通过；1 个外部集群 E2E 按合同 ignored |
+| Standalone | example、Tauri、Web backend fmt/strict Clippy；Web all-target build | 全部通过 |
+| Error/redaction | `check-error-hygiene.ps1`、`error_architecture_guard.py` | 初次捕获 Debug field 命名，修复后全部通过 |
+| Dependency baseline | target + baseline guard | 全部通过，security-api 保持 contract leaf |
+| Routing | `check-agents-routing.ps1` | `AGENTS_ROUTING_CHECK_OK` |
+| Text | `git diff --check` | 通过 |
+
+Windows/MSVC 既有 linker message 与 `proc-macro-error2` future-incompatibility note 不受本变更影响；strict
+Clippy 退出码为 0，未通过 allow 或 baseline 扩张掩盖。Linux 测试使用 WSL 独立 target，未复用 Windows
+测试二进制。
+
+## 6. 回滚与剩余风险
+
+回滚应停止在 composition root 注册新 provider，并同时回滚 auth adapter、security-api additive 合同、依赖和
+API 基线；原有 secure dry-run、泛型 `Secret<T>` redaction 与受限 secret file 检查继续保留。不得回滚为
+pretty JSON、明文文件、宽松权限、任意环境变量查询或缺失 provider 时的静默 fallback。
+
+本地文件 adapter 只承诺单机文件系统和进程内 writer 序列化；跨主机生产一致性、KMS/Vault 身份、rotation、
+审计和自动 reload 尚未交付。AES-GCM 随机 nonce 受每 key 调用上限约束，生产 provider 必须提供独立的密钥与
+rotation 策略，不能把本地 adapter 当作无限生命周期的生产 secret store。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M11-01 已完成；下一工作包 PR-M11-02；部分依赖 M10 SLI） |
+| 状态 | 实施中（PR-M11-01～02 已完成；下一工作包 PR-M11-03；部分依赖 M10 SLI） |
 | 预计周期 | 4–6 周 |
 | 工作包 | 延续 WP01、WP03、WP05、WP07、WP14–WP16 |
 | 前置条件 | 32-package Gate；secure dry-run、ServiceContext、semantic owner、durability SLI 可用 |
@@ -61,11 +61,16 @@
 
 ### PR-M11-02：SecretProvider 基础合同与本地 Adapter
 
-- [ ] 入口：`[ARCH]` SecretProvider capability、secret wrapper、permission和redaction合同已冻结，不切换安全profile默认值。
-- [ ] `[DEV]` 实现provider contract、显式registry及开发用环境/受限文件adapter；生产provider只通过注入接入。
-- [ ] `[TEST]` focused test：owner-only permission、encrypted envelope、atomic read/write、redacted Debug、zeroize和provider缺失。
-- [ ] `[REV]` 检查secret不进入CLI/env dump/log/config snapshot，security-api不依赖provider实现。
-- [ ] 回滚点：停止注册新provider，保留dry-run与redaction；不得回滚为pretty JSON或宽松权限。
+- [x] 入口：`[ARCH]` SecretProvider capability、secret wrapper、permission和redaction合同已冻结，不切换安全profile默认值。
+- [x] `[DEV]` 实现provider contract、显式registry及开发用环境/受限文件adapter；生产provider只通过注入接入。
+- [x] `[TEST]` focused test：owner-only permission、encrypted envelope、atomic read/write、redacted Debug、zeroize和provider缺失。
+- [x] `[REV]` 检查secret不进入CLI/env dump/log/config snapshot，security-api不依赖provider实现。
+- [x] 回滚点：停止注册新provider，保留dry-run与redaction；不得回滚为pretty JSON或宽松权限。
+
+完成证据：[`11-secret-provider-evidence.md`](11-secret-provider-evidence.md)。合同保持同步且 runtime-neutral；环境
+adapter 只接受显式映射，本地文件 adapter 在 Unix 使用 owner-only AES-256-GCM immutable version，并在
+Windows ACL 未验证时 fail closed。66/82 工作包完成，剩余 M11 10 个、M12 6 个，下一工作包为
+PR-M11-03；本工作包没有切换安全 profile 默认值，也不提前宣称 M10、M11 或 Phase 3 Gate 完成。
 
 ### PR-M11-03：Secure Profile 与一次性 Bootstrap
 

--- a/rocketmq-auth/Cargo.toml
+++ b/rocketmq-auth/Cargo.toml
@@ -56,6 +56,7 @@ hex    = "0.4"
 base64 = "0.22.1"
 
 # Cryptographic operations
+aes-gcm = { version = "0.11.0", features = ["zeroize"] }
 hmac  = "0.13.0"
 md-5  = "0.11"
 sha1  = "0.11"

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 pub mod migration;
 pub mod permission;
 pub mod runtime;
+pub mod secret_provider;
 /// Runtime-neutral contracts implemented by authentication and authorization providers.
 pub mod security_api {
     pub use rocketmq_security_api::*;
@@ -52,6 +53,9 @@ pub use runtime::AuthRuntimeBuilder;
 pub use runtime::AuthenticationService;
 pub use runtime::AuthorizationService;
 pub use runtime::ProviderRegistry;
+pub use secret_provider::EncryptedFileSecretProvider;
+pub use secret_provider::EnvironmentSecretProvider;
+pub use secret_provider::SecretProviderRegistry;
 
 #[doc(hidden)]
 pub mod bench_support {

--- a/rocketmq-auth/src/secret_provider.rs
+++ b/rocketmq-auth/src/secret_provider.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Explicit registry and local development adapters for secret providers.
+
+mod encrypted_file;
+mod environment;
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use rocketmq_security_api::SecretProvider;
+use rocketmq_security_api::SecretProviderError;
+use rocketmq_security_api::SecretProviderId;
+
+pub use encrypted_file::EncryptedFileSecretProvider;
+pub use environment::EnvironmentSecretProvider;
+
+/// Explicit, composition-root-owned provider registry. It deliberately has no global singleton.
+#[derive(Default)]
+pub struct SecretProviderRegistry {
+    providers: BTreeMap<SecretProviderId, Arc<dyn SecretProvider>>,
+}
+
+impl SecretProviderRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers one injected provider and rejects identifier replacement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretProviderError::DuplicateProvider`] when the identifier is already present.
+    pub fn register(&mut self, provider: Arc<dyn SecretProvider>) -> Result<(), SecretProviderError> {
+        let id = provider.id().clone();
+        if self.providers.contains_key(&id) {
+            return Err(SecretProviderError::DuplicateProvider);
+        }
+        self.providers.insert(id, provider);
+        Ok(())
+    }
+
+    /// Resolves an explicitly selected provider without falling back to another implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretProviderError::ProviderNotRegistered`] when no exact identifier is present.
+    pub fn provider(&self, id: &SecretProviderId) -> Result<&Arc<dyn SecretProvider>, SecretProviderError> {
+        self.providers.get(id).ok_or(SecretProviderError::ProviderNotRegistered)
+    }
+
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+impl fmt::Debug for SecretProviderRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretProviderRegistry")
+            .field("provider_ids", &self.providers.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}

--- a/rocketmq-auth/src/secret_provider/encrypted_file.rs
+++ b/rocketmq-auth/src/secret_provider/encrypted_file.rs
@@ -1,0 +1,443 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use aes_gcm::aead::Aead;
+use aes_gcm::aead::Generate;
+use aes_gcm::aead::KeyInit;
+use aes_gcm::aead::Nonce;
+use aes_gcm::aead::Payload;
+use aes_gcm::Aes256Gcm;
+use rocketmq_security_api::SecretAccess;
+use rocketmq_security_api::SecretMaterial;
+use rocketmq_security_api::SecretName;
+use rocketmq_security_api::SecretPersistence;
+use rocketmq_security_api::SecretProvider;
+use rocketmq_security_api::SecretProviderCapabilities;
+use rocketmq_security_api::SecretProviderError;
+use rocketmq_security_api::SecretProviderId;
+use rocketmq_security_api::SecretVersion;
+use rocketmq_security_api::SecretVersioning;
+use rocketmq_security_api::VersionedSecret;
+
+const ENVELOPE_MAGIC: &[u8; 8] = b"RMQSEC01";
+const NONCE_LENGTH: usize = 12;
+const LENGTH_FIELD: usize = 8;
+const ENVELOPE_PREFIX_LENGTH: usize = ENVELOPE_MAGIC.len() + NONCE_LENGTH + LENGTH_FIELD;
+const MAX_SECRET_LENGTH: usize = 1024 * 1024;
+const AUTH_TAG_LENGTH: usize = 16;
+
+/// AES-256-GCM local development adapter with owner-only, immutable version files.
+pub struct EncryptedFileSecretProvider {
+    id: SecretProviderId,
+    root: PathBuf,
+    key: SecretMaterial,
+    write_lock: Mutex<()>,
+}
+
+impl EncryptedFileSecretProvider {
+    /// Opens or creates an owner-only provider root. Windows remains fail-closed until an ACL
+    /// verifier can prove the same owner-only contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns a redacted provider error for invalid keys, permissions, paths, or unsupported ACLs.
+    pub fn new(
+        id: SecretProviderId,
+        root: impl Into<PathBuf>,
+        key: SecretMaterial,
+    ) -> Result<Self, SecretProviderError> {
+        if key.len() != 32 {
+            return Err(SecretProviderError::InvalidMaterial);
+        }
+        let root = root.into();
+        prepare_root(&root)?;
+        Ok(Self {
+            id,
+            root,
+            key,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    #[cfg(unix)]
+    fn read_version(&self, name: &SecretName, version: SecretVersion) -> Result<VersionedSecret, SecretProviderError> {
+        let path = version_path(&self.root.join(name.as_str()), version);
+        let envelope = read_restricted_file(&path)?;
+        let plaintext = decrypt_envelope(&self.key, name, version, &envelope)?;
+        let material = SecretMaterial::new(plaintext).map_err(|_| SecretProviderError::InvalidEnvelope)?;
+        Ok(VersionedSecret::new(material, Some(version)))
+    }
+
+    #[cfg(unix)]
+    fn write_version(
+        &self,
+        name: &SecretName,
+        material: &SecretMaterial,
+        expected_version: Option<SecretVersion>,
+    ) -> Result<SecretVersion, SecretProviderError> {
+        if material.len() > MAX_SECRET_LENGTH {
+            return Err(SecretProviderError::InvalidMaterial);
+        }
+        let directory = self.root.join(name.as_str());
+        prepare_secret_directory(&directory)?;
+        let current = latest_version(&directory)?;
+        let next = match (current, expected_version) {
+            (None, None) => SecretVersion::new(1),
+            (Some(current), Some(expected)) if current == expected => SecretVersion::new(
+                current
+                    .get()
+                    .checked_add(1)
+                    .ok_or(SecretProviderError::VersionConflict)?,
+            ),
+            _ => return Err(SecretProviderError::VersionConflict),
+        };
+        let envelope = encrypt_envelope(&self.key, name, next, material.expose_secret())?;
+        publish_version(&directory, next, &envelope)?;
+        Ok(next)
+    }
+}
+
+impl fmt::Debug for EncryptedFileSecretProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedFileSecretProvider")
+            .field("id", &self.id)
+            .field("root", &"[REDACTED]")
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl SecretProvider for EncryptedFileSecretProvider {
+    fn id(&self) -> &SecretProviderId {
+        &self.id
+    }
+
+    fn capabilities(&self) -> SecretProviderCapabilities {
+        SecretProviderCapabilities::new(
+            SecretAccess::ReadWrite,
+            SecretPersistence::EncryptedLocalStorage,
+            SecretVersioning::Optimistic,
+        )
+    }
+
+    fn read(&self, name: &SecretName) -> Result<VersionedSecret, SecretProviderError> {
+        #[cfg(windows)]
+        {
+            let _ = name;
+            Err(SecretProviderError::UnsupportedPlatform)
+        }
+        #[cfg(unix)]
+        {
+            let directory = self.root.join(name.as_str());
+            check_restricted_directory(&directory)?;
+            let version = latest_version(&directory)?.ok_or(SecretProviderError::NotFound)?;
+            self.read_version(name, version)
+        }
+    }
+
+    fn write(
+        &self,
+        name: &SecretName,
+        material: SecretMaterial,
+        expected_version: Option<SecretVersion>,
+    ) -> Result<SecretVersion, SecretProviderError> {
+        #[cfg(windows)]
+        {
+            let _ = (name, material, expected_version);
+            Err(SecretProviderError::UnsupportedPlatform)
+        }
+        #[cfg(unix)]
+        {
+            let _guard = self.write_lock.lock().map_err(|_| SecretProviderError::Unavailable)?;
+            self.write_version(name, &material, expected_version)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn prepare_root(_root: &Path) -> Result<(), SecretProviderError> {
+    Err(SecretProviderError::UnsupportedPlatform)
+}
+
+#[cfg(unix)]
+fn prepare_root(root: &Path) -> Result<(), SecretProviderError> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    if !root.exists() {
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(root).map_err(|_| SecretProviderError::Unavailable)?;
+    }
+    check_restricted_directory(root)
+}
+
+#[cfg(unix)]
+fn prepare_secret_directory(directory: &Path) -> Result<(), SecretProviderError> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    if !directory.exists() {
+        let mut builder = fs::DirBuilder::new();
+        builder.mode(0o700);
+        match builder.create(directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(_) => return Err(SecretProviderError::Unavailable),
+        }
+    }
+    check_restricted_directory(directory)
+}
+
+#[cfg(unix)]
+fn check_restricted_directory(path: &Path) -> Result<(), SecretProviderError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = fs::symlink_metadata(path).map_err(|_| SecretProviderError::NotFound)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(SecretProviderError::InsecurePermissions);
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(SecretProviderError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn latest_version(directory: &Path) -> Result<Option<SecretVersion>, SecretProviderError> {
+    let entries = fs::read_dir(directory).map_err(|_| SecretProviderError::NotFound)?;
+    let mut latest = None;
+    for entry in entries {
+        let entry = entry.map_err(|_| SecretProviderError::Unavailable)?;
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            return Err(SecretProviderError::InvalidEnvelope);
+        };
+        let Some(raw_version) = file_name.strip_suffix(".secret") else {
+            if file_name.ends_with(".tmp") {
+                continue;
+            }
+            return Err(SecretProviderError::InvalidEnvelope);
+        };
+        if raw_version.len() != 20 || !raw_version.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(SecretProviderError::InvalidEnvelope);
+        }
+        let version = raw_version
+            .parse::<u64>()
+            .map_err(|_| SecretProviderError::InvalidEnvelope)?;
+        if version == 0 {
+            return Err(SecretProviderError::InvalidEnvelope);
+        }
+        let metadata = entry.metadata().map_err(|_| SecretProviderError::Unavailable)?;
+        if !metadata.is_file() {
+            return Err(SecretProviderError::InvalidEnvelope);
+        }
+        let version = SecretVersion::new(version);
+        latest = Some(latest.map_or(version, |current: SecretVersion| current.max(version)));
+    }
+    Ok(latest)
+}
+
+#[cfg(unix)]
+fn version_path(directory: &Path, version: SecretVersion) -> PathBuf {
+    directory.join(format!("{:020}.secret", version.get()))
+}
+
+#[cfg(unix)]
+fn read_restricted_file(path: &Path) -> Result<Vec<u8>, SecretProviderError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let link_metadata = fs::symlink_metadata(path).map_err(|_| SecretProviderError::NotFound)?;
+    if link_metadata.file_type().is_symlink() {
+        return Err(SecretProviderError::InsecurePermissions);
+    }
+    let mut file = File::open(path).map_err(|_| SecretProviderError::Unavailable)?;
+    let metadata = file.metadata().map_err(|_| SecretProviderError::Unavailable)?;
+    if !metadata.is_file() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(SecretProviderError::InsecurePermissions);
+    }
+    let maximum = ENVELOPE_PREFIX_LENGTH + MAX_SECRET_LENGTH + AUTH_TAG_LENGTH;
+    if metadata.len() > maximum as u64 {
+        return Err(SecretProviderError::InvalidEnvelope);
+    }
+    let mut envelope = Vec::with_capacity(metadata.len() as usize);
+    (&mut file)
+        .take(maximum as u64 + 1)
+        .read_to_end(&mut envelope)
+        .map_err(|_| SecretProviderError::Unavailable)?;
+    if envelope.len() > maximum {
+        return Err(SecretProviderError::InvalidEnvelope);
+    }
+    Ok(envelope)
+}
+
+fn associated_data(name: &SecretName, version: SecretVersion) -> Vec<u8> {
+    let mut data = Vec::with_capacity(32 + name.as_str().len());
+    data.extend_from_slice(b"rocketmq-secret-envelope-v1\0");
+    data.extend_from_slice(name.as_str().as_bytes());
+    data.push(0);
+    data.extend_from_slice(&version.get().to_be_bytes());
+    data
+}
+
+fn encrypt_envelope(
+    key: &SecretMaterial,
+    name: &SecretName,
+    version: SecretVersion,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, SecretProviderError> {
+    let cipher = Aes256Gcm::new_from_slice(key.expose_secret()).map_err(|_| SecretProviderError::InvalidMaterial)?;
+    let nonce = Nonce::<Aes256Gcm>::generate();
+    let aad = associated_data(name, version);
+    let ciphertext = cipher
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: plaintext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| SecretProviderError::Unavailable)?;
+    let mut envelope = Vec::with_capacity(ENVELOPE_PREFIX_LENGTH + ciphertext.len());
+    envelope.extend_from_slice(ENVELOPE_MAGIC);
+    envelope.extend_from_slice(&nonce);
+    envelope.extend_from_slice(&(ciphertext.len() as u64).to_be_bytes());
+    envelope.extend_from_slice(&ciphertext);
+    Ok(envelope)
+}
+
+fn decrypt_envelope(
+    key: &SecretMaterial,
+    name: &SecretName,
+    version: SecretVersion,
+    envelope: &[u8],
+) -> Result<Vec<u8>, SecretProviderError> {
+    if envelope.len() < ENVELOPE_PREFIX_LENGTH + AUTH_TAG_LENGTH || &envelope[..ENVELOPE_MAGIC.len()] != ENVELOPE_MAGIC
+    {
+        return Err(SecretProviderError::InvalidEnvelope);
+    }
+    let nonce_start = ENVELOPE_MAGIC.len();
+    let nonce_end = nonce_start + NONCE_LENGTH;
+    let length_end = nonce_end + LENGTH_FIELD;
+    let nonce = Nonce::<Aes256Gcm>::try_from(&envelope[nonce_start..nonce_end])
+        .map_err(|_| SecretProviderError::InvalidEnvelope)?;
+    let encoded_length = u64::from_be_bytes(
+        envelope[nonce_end..length_end]
+            .try_into()
+            .map_err(|_| SecretProviderError::InvalidEnvelope)?,
+    );
+    let ciphertext = &envelope[length_end..];
+    if encoded_length != ciphertext.len() as u64 || ciphertext.len() > MAX_SECRET_LENGTH + AUTH_TAG_LENGTH {
+        return Err(SecretProviderError::InvalidEnvelope);
+    }
+    let cipher = Aes256Gcm::new_from_slice(key.expose_secret()).map_err(|_| SecretProviderError::InvalidMaterial)?;
+    let aad = associated_data(name, version);
+    cipher
+        .decrypt(
+            &nonce,
+            Payload {
+                msg: ciphertext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| SecretProviderError::InvalidEnvelope)
+}
+
+#[cfg(unix)]
+fn publish_version(directory: &Path, version: SecretVersion, envelope: &[u8]) -> Result<(), SecretProviderError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let nonce_start = ENVELOPE_MAGIC.len();
+    let nonce_end = nonce_start + NONCE_LENGTH;
+    let temporary_path = directory.join(format!(
+        ".{:020}-{}.tmp",
+        version.get(),
+        hex::encode(&envelope[nonce_start..nonce_end])
+    ));
+    let final_path = version_path(directory, version);
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true).mode(0o600);
+    let mut file = options
+        .open(&temporary_path)
+        .map_err(|_| SecretProviderError::Unavailable)?;
+    let write_result = (|| {
+        file.write_all(envelope).map_err(|_| SecretProviderError::Unavailable)?;
+        file.sync_all().map_err(|_| SecretProviderError::Unavailable)?;
+        file.set_permissions(fs::Permissions::from_mode(0o400))
+            .map_err(|_| SecretProviderError::Unavailable)?;
+        fs::hard_link(&temporary_path, &final_path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                SecretProviderError::VersionConflict
+            } else {
+                SecretProviderError::Unavailable
+            }
+        })?;
+        sync_directory(directory)
+    })();
+    drop(file);
+    let _ = fs::remove_file(&temporary_path);
+    write_result
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> Result<(), SecretProviderError> {
+    File::open(directory)
+        .and_then(|file| file.sync_all())
+        .map_err(|_| SecretProviderError::Unavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn material(bytes: &[u8]) -> SecretMaterial {
+        SecretMaterial::new(bytes.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn envelope_authenticates_name_version_and_ciphertext() {
+        let key = material(&[9; 32]);
+        let name = SecretName::new("broker-admin-key").unwrap();
+        let version = SecretVersion::new(7);
+        let mut envelope = encrypt_envelope(&key, &name, version, b"not-written-in-clear").unwrap();
+        assert!(!envelope.windows(20).any(|window| window == b"not-written-in-clear"));
+        assert_eq!(
+            decrypt_envelope(&key, &name, version, &envelope).unwrap(),
+            b"not-written-in-clear"
+        );
+
+        envelope[ENVELOPE_PREFIX_LENGTH] ^= 1;
+        assert_eq!(
+            decrypt_envelope(&key, &name, version, &envelope).unwrap_err(),
+            SecretProviderError::InvalidEnvelope
+        );
+        let other_name = SecretName::new("other-key").unwrap();
+        assert_eq!(
+            decrypt_envelope(&key, &other_name, version, &envelope).unwrap_err(),
+            SecretProviderError::InvalidEnvelope
+        );
+    }
+}

--- a/rocketmq-auth/src/secret_provider/environment.rs
+++ b/rocketmq-auth/src/secret_provider/environment.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use rocketmq_security_api::SecretAccess;
+use rocketmq_security_api::SecretMaterial;
+use rocketmq_security_api::SecretName;
+use rocketmq_security_api::SecretPersistence;
+use rocketmq_security_api::SecretProvider;
+use rocketmq_security_api::SecretProviderCapabilities;
+use rocketmq_security_api::SecretProviderError;
+use rocketmq_security_api::SecretProviderId;
+use rocketmq_security_api::SecretVersion;
+use rocketmq_security_api::SecretVersioning;
+use rocketmq_security_api::VersionedSecret;
+
+/// Read-only development adapter that maps logical names to an explicit environment allowlist.
+pub struct EnvironmentSecretProvider {
+    id: SecretProviderId,
+    variables: BTreeMap<SecretName, String>,
+}
+
+impl EnvironmentSecretProvider {
+    /// Creates an adapter from an explicit logical-name to environment-variable mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretProviderError::InvalidConfiguration`] for invalid or duplicate mappings.
+    pub fn new(
+        id: SecretProviderId,
+        mappings: impl IntoIterator<Item = (SecretName, String)>,
+    ) -> Result<Self, SecretProviderError> {
+        let mut variables = BTreeMap::new();
+        for (name, variable) in mappings {
+            if variable.is_empty() || variable.contains(['\0', '=']) || variables.insert(name, variable).is_some() {
+                return Err(SecretProviderError::InvalidConfiguration);
+            }
+        }
+        if variables.is_empty() {
+            return Err(SecretProviderError::InvalidConfiguration);
+        }
+        Ok(Self { id, variables })
+    }
+}
+
+impl fmt::Debug for EnvironmentSecretProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EnvironmentSecretProvider")
+            .field("id", &self.id)
+            .field("mapped_name_count", &self.variables.len())
+            .finish()
+    }
+}
+
+impl SecretProvider for EnvironmentSecretProvider {
+    fn id(&self) -> &SecretProviderId {
+        &self.id
+    }
+
+    fn capabilities(&self) -> SecretProviderCapabilities {
+        SecretProviderCapabilities::new(
+            SecretAccess::ReadOnly,
+            SecretPersistence::ProcessEnvironment,
+            SecretVersioning::Unversioned,
+        )
+    }
+
+    fn read(&self, name: &SecretName) -> Result<VersionedSecret, SecretProviderError> {
+        let variable = self.variables.get(name).ok_or(SecretProviderError::NotFound)?;
+        let value = std::env::var(variable).map_err(|_| SecretProviderError::NotFound)?;
+        let material = SecretMaterial::new(value.into_bytes()).map_err(|_| SecretProviderError::InvalidMaterial)?;
+        Ok(VersionedSecret::new(material, None))
+    }
+
+    fn write(
+        &self,
+        _name: &SecretName,
+        _material: SecretMaterial,
+        _expected_version: Option<SecretVersion>,
+    ) -> Result<SecretVersion, SecretProviderError> {
+        Err(SecretProviderError::ReadOnly)
+    }
+}

--- a/rocketmq-auth/tests/secret_provider_contract.rs
+++ b/rocketmq-auth/tests/secret_provider_contract.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_auth::EncryptedFileSecretProvider;
+use rocketmq_auth::EnvironmentSecretProvider;
+use rocketmq_auth::SecretProviderRegistry;
+use rocketmq_security_api::SecretAccess;
+use rocketmq_security_api::SecretMaterial;
+use rocketmq_security_api::SecretName;
+use rocketmq_security_api::SecretProvider;
+use rocketmq_security_api::SecretProviderError;
+use rocketmq_security_api::SecretProviderId;
+#[cfg(unix)]
+use rocketmq_security_api::SecretVersion;
+
+fn provider_id(value: &str) -> SecretProviderId {
+    SecretProviderId::new(value).unwrap()
+}
+
+fn secret_name(value: &str) -> SecretName {
+    SecretName::new(value).unwrap()
+}
+
+fn material(value: &[u8]) -> SecretMaterial {
+    SecretMaterial::new(value.to_vec()).unwrap()
+}
+
+#[test]
+fn registry_requires_exact_explicit_provider() {
+    let id = provider_id("environment-local");
+    let provider = Arc::new(
+        EnvironmentSecretProvider::new(id.clone(), [(secret_name("process-path"), "PATH".to_owned())]).unwrap(),
+    );
+    let mut registry = SecretProviderRegistry::new();
+
+    assert_eq!(
+        registry.provider(&id).err(),
+        Some(SecretProviderError::ProviderNotRegistered)
+    );
+    registry.register(provider.clone()).unwrap();
+    assert_eq!(registry.len(), 1);
+    assert_eq!(registry.provider(&id).unwrap().id(), &id);
+    assert_eq!(
+        registry.register(provider).unwrap_err(),
+        SecretProviderError::DuplicateProvider
+    );
+}
+
+#[test]
+fn environment_adapter_uses_only_mapped_names_and_is_read_only() {
+    let mapped_name = secret_name("process-path");
+    let provider = EnvironmentSecretProvider::new(
+        provider_id("environment-local"),
+        [(mapped_name.clone(), "PATH".to_owned())],
+    )
+    .unwrap();
+
+    assert_eq!(provider.capabilities().access(), SecretAccess::ReadOnly);
+    let value = provider.read(&mapped_name).unwrap();
+    assert!(!value.material().is_empty());
+    assert_eq!(value.version(), None);
+    assert_eq!(
+        provider.read(&secret_name("unmapped-name")).unwrap_err(),
+        SecretProviderError::NotFound
+    );
+    assert_eq!(
+        provider
+            .write(&mapped_name, material(b"must-be-dropped"), None)
+            .unwrap_err(),
+        SecretProviderError::ReadOnly
+    );
+    let debug = format!("{provider:?}");
+    assert!(!debug.contains("PATH"));
+}
+
+#[cfg(windows)]
+#[test]
+fn encrypted_file_adapter_fails_closed_without_acl_verification() {
+    let directory = tempfile::tempdir().unwrap();
+    let error = EncryptedFileSecretProvider::new(provider_id("encrypted-local"), directory.path(), material(&[3; 32]))
+        .unwrap_err();
+    assert_eq!(error, SecretProviderError::UnsupportedPlatform);
+}
+
+#[cfg(unix)]
+#[test]
+fn encrypted_file_adapter_enforces_permissions_encryption_atomicity_and_versions() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("secrets");
+    let provider = EncryptedFileSecretProvider::new(provider_id("encrypted-local"), &root, material(&[3; 32])).unwrap();
+    let name = secret_name("broker-admin-key");
+    let first_plaintext = b"first-plaintext-must-not-appear";
+    let first_version = provider.write(&name, material(first_plaintext), None).unwrap();
+    assert_eq!(first_version, SecretVersion::new(1));
+    let first = provider.read(&name).unwrap();
+    assert_eq!(first.material().expose_secret(), first_plaintext);
+    assert_eq!(first.version(), Some(first_version));
+
+    let second_plaintext = b"second-plaintext-must-not-appear";
+    let second_version = provider
+        .write(&name, material(second_plaintext), Some(first_version))
+        .unwrap();
+    assert_eq!(second_version, SecretVersion::new(2));
+    assert_eq!(
+        provider
+            .write(&name, material(b"stale-update"), Some(first_version))
+            .unwrap_err(),
+        SecretProviderError::VersionConflict
+    );
+
+    let secret_directory = root.join(name.as_str());
+    let mut versions = fs::read_dir(&secret_directory)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+    versions.sort();
+    assert_eq!(versions.len(), 2);
+    for path in &versions {
+        let bytes = fs::read(path).unwrap();
+        assert!(!bytes
+            .windows(first_plaintext.len())
+            .any(|window| window == first_plaintext));
+        assert!(!bytes
+            .windows(second_plaintext.len())
+            .any(|window| window == second_plaintext));
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o077, 0);
+    }
+    assert_eq!(
+        provider.read(&name).unwrap().material().expose_secret(),
+        second_plaintext
+    );
+
+    let latest = versions.last().unwrap();
+    fs::set_permissions(latest, fs::Permissions::from_mode(0o600)).unwrap();
+    let mut tampered = fs::read(latest).unwrap();
+    *tampered.last_mut().unwrap() ^= 1;
+    fs::write(latest, tampered).unwrap();
+    fs::set_permissions(latest, fs::Permissions::from_mode(0o400)).unwrap();
+    assert_eq!(provider.read(&name).unwrap_err(), SecretProviderError::InvalidEnvelope);
+}
+
+#[cfg(unix)]
+#[test]
+fn encrypted_file_adapter_rejects_broad_root_permissions() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().join("insecure");
+    fs::create_dir(&root).unwrap();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(
+        EncryptedFileSecretProvider::new(provider_id("encrypted-local"), root, material(&[4; 32])).unwrap_err(),
+        SecretProviderError::InsecurePermissions
+    );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -9,6 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,7 +876,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -861,6 +916,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1667,6 +1731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3407,6 +3489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,6 +4080,7 @@ dependencies = [
 name = "rocketmq-auth"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "base64 0.22.1",
  "cheetah-string",
  "chrono",
@@ -4259,6 +4353,7 @@ version = "1.0.0"
 dependencies = [
  "cheetah-string",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -5970,6 +6065,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7106,9 +7211,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -9,6 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,7 +593,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1014,6 +1078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1464,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1983,6 +2065,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2429,7 @@ dependencies = [
 name = "rocketmq-auth"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "base64",
  "cheetah-string",
  "chrono",
@@ -2606,6 +2700,7 @@ version = "1.0.0"
 dependencies = [
  "cheetah-string",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -3571,6 +3666,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -9,6 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,7 +535,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.1",
  "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -944,6 +1008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1365,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1845,6 +1927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2301,7 @@ dependencies = [
 name = "rocketmq-auth"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "base64",
  "cheetah-string",
  "chrono",
@@ -2464,6 +2558,7 @@ version = "1.0.0"
 dependencies = [
  "cheetah-string",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -3369,6 +3464,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/rocketmq-security-api/Cargo.toml
+++ b/rocketmq-security-api/Cargo.toml
@@ -30,3 +30,4 @@ default = []
 [dependencies]
 cheetah-string.workspace = true
 thiserror.workspace = true
+zeroize.workspace = true

--- a/rocketmq-security-api/src/lib.rs
+++ b/rocketmq-security-api/src/lib.rs
@@ -14,6 +14,22 @@
 
 //! Runtime-neutral security contracts.
 
+pub mod secret_provider;
+
+pub use secret_provider::SecretAccess;
+pub use secret_provider::SecretIdentifierError;
+pub use secret_provider::SecretMaterial;
+pub use secret_provider::SecretMaterialError;
+pub use secret_provider::SecretName;
+pub use secret_provider::SecretPersistence;
+pub use secret_provider::SecretProvider;
+pub use secret_provider::SecretProviderCapabilities;
+pub use secret_provider::SecretProviderError;
+pub use secret_provider::SecretProviderId;
+pub use secret_provider::SecretVersion;
+pub use secret_provider::SecretVersioning;
+pub use secret_provider::VersionedSecret;
+
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;

--- a/rocketmq-security-api/src/secret_provider.rs
+++ b/rocketmq-security-api/src/secret_provider.rs
@@ -1,0 +1,334 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime-neutral contracts for injected secret providers.
+
+use std::fmt;
+
+use cheetah_string::CheetahString;
+use thiserror::Error;
+use zeroize::Zeroize;
+
+/// Stable identifier for an explicitly registered secret provider.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SecretProviderId(CheetahString);
+
+impl SecretProviderId {
+    /// Validates and creates a provider identifier.
+    pub fn new(value: impl Into<CheetahString>) -> Result<Self, SecretIdentifierError> {
+        let value = value.into();
+        validate_identifier(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretProviderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SecretProviderId").field(&self.0).finish()
+    }
+}
+
+/// Validated logical secret name. The name cannot contain path separators or traversal segments.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SecretName(CheetahString);
+
+impl SecretName {
+    /// Validates and creates a secret name.
+    pub fn new(value: impl Into<CheetahString>) -> Result<Self, SecretIdentifierError> {
+        let value = value.into();
+        validate_identifier(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretName([REDACTED])")
+    }
+}
+
+/// Validation failure for provider identifiers and logical secret names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum SecretIdentifierError {
+    #[error("secret identifier is empty")]
+    Empty,
+    #[error("secret identifier exceeds 128 bytes")]
+    TooLong,
+    #[error("secret identifier contains unsupported characters")]
+    UnsupportedCharacter,
+}
+
+fn validate_identifier(value: &str) -> Result<(), SecretIdentifierError> {
+    if value.is_empty() {
+        return Err(SecretIdentifierError::Empty);
+    }
+    if value.len() > 128 {
+        return Err(SecretIdentifierError::TooLong);
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        || value == "."
+        || value == ".."
+        || value.starts_with('.')
+    {
+        return Err(SecretIdentifierError::UnsupportedCharacter);
+    }
+    Ok(())
+}
+
+/// Sensitive byte material that is redacted and zeroized when dropped.
+pub struct SecretMaterial(Vec<u8>);
+
+impl SecretMaterial {
+    /// Creates non-empty secret material.
+    pub fn new(value: Vec<u8>) -> Result<Self, SecretMaterialError> {
+        if value.is_empty() {
+            return Err(SecretMaterialError::Empty);
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrows the material for the shortest practical operation scope.
+    pub fn expose_secret(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for SecretMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl Zeroize for SecretMaterial {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl Drop for SecretMaterial {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// Failure to construct valid secret material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum SecretMaterialError {
+    #[error("secret material is empty")]
+    Empty,
+}
+
+/// Version assigned by a provider supporting optimistic updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SecretVersion(u64);
+
+impl SecretVersion {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Secret value returned together with its optional provider version.
+pub struct VersionedSecret {
+    material: SecretMaterial,
+    version: Option<SecretVersion>,
+}
+
+impl VersionedSecret {
+    pub fn new(material: SecretMaterial, version: Option<SecretVersion>) -> Self {
+        Self { material, version }
+    }
+
+    pub fn material(&self) -> &SecretMaterial {
+        &self.material
+    }
+
+    pub fn into_material(self) -> SecretMaterial {
+        self.material
+    }
+
+    pub const fn version(&self) -> Option<SecretVersion> {
+        self.version
+    }
+}
+
+impl fmt::Debug for VersionedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VersionedSecret")
+            .field("material", &"[REDACTED]")
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+/// Mutation support declared by a provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// Storage class declared by a provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretPersistence {
+    ProcessEnvironment,
+    EncryptedLocalStorage,
+    ExternalService,
+}
+
+/// Concurrency contract declared by a provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretVersioning {
+    Unversioned,
+    Optimistic,
+}
+
+/// Typed capabilities exposed before a provider is selected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecretProviderCapabilities {
+    access: SecretAccess,
+    persistence: SecretPersistence,
+    versioning: SecretVersioning,
+}
+
+impl SecretProviderCapabilities {
+    pub const fn new(access: SecretAccess, persistence: SecretPersistence, versioning: SecretVersioning) -> Self {
+        Self {
+            access,
+            persistence,
+            versioning,
+        }
+    }
+
+    pub const fn access(self) -> SecretAccess {
+        self.access
+    }
+
+    pub const fn persistence(self) -> SecretPersistence {
+        self.persistence
+    }
+
+    pub const fn versioning(self) -> SecretVersioning {
+        self.versioning
+    }
+}
+
+/// Fail-closed error surface shared by provider implementations and registries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum SecretProviderError {
+    #[error("secret provider is not registered")]
+    ProviderNotRegistered,
+    #[error("secret provider is already registered")]
+    DuplicateProvider,
+    #[error("secret material was not found")]
+    NotFound,
+    #[error("secret provider is read-only")]
+    ReadOnly,
+    #[error("secret material is invalid")]
+    InvalidMaterial,
+    #[error("secret provider configuration is invalid")]
+    InvalidConfiguration,
+    #[error("secret storage permissions are not owner-only")]
+    InsecurePermissions,
+    #[error("secret version conflict")]
+    VersionConflict,
+    #[error("secret envelope is invalid or authentication failed")]
+    InvalidEnvelope,
+    #[error("secret provider is unavailable")]
+    Unavailable,
+    #[error("secret provider is unsupported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// Synchronous, runtime-neutral boundary implemented by injected providers.
+pub trait SecretProvider: Send + Sync {
+    fn id(&self) -> &SecretProviderId;
+
+    fn capabilities(&self) -> SecretProviderCapabilities;
+
+    /// Reads a secret without exposing provider implementation types.
+    ///
+    /// # Errors
+    ///
+    /// Returns a redacted [`SecretProviderError`] when the material cannot be obtained safely.
+    fn read(&self, name: &SecretName) -> Result<VersionedSecret, SecretProviderError>;
+
+    /// Creates or atomically updates a secret. `None` is create-only; an existing secret requires
+    /// its current version to prevent lost updates.
+    ///
+    /// # Errors
+    ///
+    /// Returns a redacted [`SecretProviderError`] when persistence or version validation fails.
+    fn write(
+        &self,
+        name: &SecretName,
+        material: SecretMaterial,
+        expected_version: Option<SecretVersion>,
+    ) -> Result<SecretVersion, SecretProviderError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use zeroize::Zeroize;
+
+    use super::*;
+
+    #[test]
+    fn identifiers_reject_traversal_and_separators() {
+        for value in ["", ".", "..", ".hidden", "a/b", "a\\b", "a:b", "a b"] {
+            assert!(SecretName::new(value).is_err(), "accepted {value:?}");
+        }
+        assert_eq!(
+            SecretName::new("broker-admin_key.1").unwrap().as_str(),
+            "broker-admin_key.1"
+        );
+    }
+
+    #[test]
+    fn material_and_name_debug_are_redacted() {
+        let material = SecretMaterial::new(b"visible-only-through-explicit-access".to_vec()).unwrap();
+        let name = SecretName::new("cluster-private-key").unwrap();
+        assert_eq!(format!("{material:?}"), "[REDACTED]");
+        assert_eq!(format!("{name:?}"), "SecretName([REDACTED])");
+    }
+
+    #[test]
+    fn explicit_zeroize_clears_material() {
+        let mut material = SecretMaterial::new(vec![7; 32]).unwrap();
+        material.zeroize();
+        assert!(material.is_empty());
+    }
+}

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -5,49 +5,49 @@
       "crate_version": "1.0.0",
       "public_path_count": 294,
       "public_path_sha256": "15df468d980ab0dbcfbfff8c4179604bde17fe67b25519d7c8de0e4eae8093ec",
-      "rustdoc_json_sha256": "b1abb9382d08238992d00de8094a3f4080305c87d6c07687e8467603f3a49522",
+      "rustdoc_json_sha256": "f963dd6fd6cc8f0b7cb663b40d9a0923021818e16dbfbd446069734a69ac2329",
       "target": "rocketmq_admin_cli"
     },
     "rocketmq-admin-core": {
       "crate_version": "1.0.0",
       "public_path_count": 186,
       "public_path_sha256": "427678ac85d4f76728993ad32b402626d24f41eaeb293c9fa5994ab9cc6bfa0d",
-      "rustdoc_json_sha256": "e2afb635501bba200fa8a70009eda1f048751b911db8c36fabfbc3dbe3be4437",
+      "rustdoc_json_sha256": "51d4f3b35c9bb54c5fb9e77b3a0ebe671611fef915819b7d2b15089921cf505a",
       "target": "rocketmq_admin_core"
     },
     "rocketmq-auth": {
       "crate_version": "1.0.0",
-      "public_path_count": 199,
-      "public_path_sha256": "3e919362f222f5a4ae299f5e860d10934105feae4f410a985e729643d31952c1",
-      "rustdoc_json_sha256": "ed1433861e3e61fc5ed90c176a163027c3d6b9a55b14fc74a18b92583dc849ef",
+      "public_path_count": 203,
+      "public_path_sha256": "273d715ed60099bba02ca5407e0839bbefb30bda720020c1a21b881788b14c8a",
+      "rustdoc_json_sha256": "68ea2dbbe0a9570568b1127a5e4a92f3f97f0cffbd13128c9b45c5ef9a329141",
       "target": "rocketmq_auth"
     },
     "rocketmq-broker": {
       "crate_version": "1.0.0",
       "public_path_count": 50,
       "public_path_sha256": "efb1b554cfdc1275bb621adf4d3dd1ffa51fd50e323e8ced14075251a92644db",
-      "rustdoc_json_sha256": "617be435ff3477d0d3e7eff73d0188d15c16d8a85f6c540b0cbdb758d3eecd3c",
+      "rustdoc_json_sha256": "b304466897cf2486db6ac80118f38a9edd37196c9356dc3f18a63e9e0a5fe08e",
       "target": "rocketmq_broker"
     },
     "rocketmq-client-rust": {
       "crate_version": "1.0.0",
       "public_path_count": 386,
       "public_path_sha256": "421f3b97ff6e9b48202f5e9b51f5d0cc98dfaf61d4f60c9dce15ecaad4f86d81",
-      "rustdoc_json_sha256": "3f63d3ffd80d4a8c09f7ba6ca7493ca6ca9f413fad439174f857770eb3ad8ba5",
+      "rustdoc_json_sha256": "e56f26204d9804fe2751f792a24d2a0dc49b9e079ab1075f43ea76373905916e",
       "target": "rocketmq_client_rust"
     },
     "rocketmq-common": {
       "crate_version": "1.0.0",
       "public_path_count": 620,
       "public_path_sha256": "21cb8a8a110ebfb2dab0bdc82c6a8c1e32d7faf62b0c60be2849b6972ada8447",
-      "rustdoc_json_sha256": "268b0fe3b8e29d9c076c44d294ba0e726102b954ed720c389d0c08457bb34ff4",
+      "rustdoc_json_sha256": "11aad5a8b88771d1250c60e56941a487fd0ba60002d9484df169dfcb3acee16f",
       "target": "rocketmq_common"
     },
     "rocketmq-controller": {
       "crate_version": "1.0.0",
       "public_path_count": 250,
       "public_path_sha256": "c3bcca468f5d744ccd6a5f4ad23d6970f905e6fee605acb246d1198a397e9d05",
-      "rustdoc_json_sha256": "a98e23dc6ab22c53224e8841cacec19e913e055824f04caf61d9c57cbb8ea23f",
+      "rustdoc_json_sha256": "54c53f306d2c2563c7d79cbc0b89b3d949b24880e4bc64d9c9c85fcc58989f84",
       "target": "rocketmq_controller"
     },
     "rocketmq-dashboard-common": {
@@ -82,7 +82,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 209,
       "public_path_sha256": "60186348b7385948d4018e3ef8cac323084981e7cd18b1ed527b3ec32af85758",
-      "rustdoc_json_sha256": "092bbb9b7c9a40f88d1dee62fd2d1233b7a2d376597ea340b75f08bb533499fd",
+      "rustdoc_json_sha256": "00535702bb4dc5bb6ad3bdf55dcd73d5da494e0cfd5449465c916b7e9d0fbbbd",
       "target": "rocketmq_mcp"
     },
     "rocketmq-model": {
@@ -96,7 +96,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 55,
       "public_path_sha256": "b9d02df04a02dbe99e0931f0b9e2c006993f1663a836bbce532cc59566b3fb31",
-      "rustdoc_json_sha256": "502e5cf9ce7f284de3ce786f6e55066fc661ae65e12edcfa64611c5422659032",
+      "rustdoc_json_sha256": "080bcf7b0c071d6876584d00b28d974aadb360b1501e37a558d7cdcaf5093cfe",
       "target": "rocketmq_namesrv"
     },
     "rocketmq-observability": {
@@ -117,35 +117,35 @@
       "crate_version": "1.0.0",
       "public_path_count": 65,
       "public_path_sha256": "a45a59482ae7b3410ade405dc53f2ca4ca2fb66cc1d3feba986f3aa6cf48efda",
-      "rustdoc_json_sha256": "6276924ce296730ba8a2d5cd65a0196903048193578d914c978adb75217bf314",
+      "rustdoc_json_sha256": "6c289709a0f1a9edf81a3a3a07193a56a05e8d56331152aad860a2cf9b8b4c2d",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
       "crate_version": "1.0.0",
       "public_path_count": 16,
       "public_path_sha256": "a54347aa28148322afe3d20aaf05915c76060a2c32efb7809271c063296e32b2",
-      "rustdoc_json_sha256": "977b89dc841a50392cd17c0cfc39bd3288aa667a0755fabdb8ec607fbf262e3f",
+      "rustdoc_json_sha256": "5f9df750f172f0fe26b1e9d70bb45915b295e8079cee7fd248e5ac64677c094f",
       "target": "rocketmq_proxy_cluster"
     },
     "rocketmq-proxy-core": {
       "crate_version": "1.0.0",
       "public_path_count": 515,
       "public_path_sha256": "c1954a10d1e67609ab29463cd5bf1a1a08cec7210b86f8127fb90df605d33668",
-      "rustdoc_json_sha256": "63a0bf1ac1e0be86b842ca918bcb31223dfc377ac4a36a61163393ca034ddf78",
+      "rustdoc_json_sha256": "308cac10d6e0528252b04bf438bc84534727a090fd2d61b11898188458516e2c",
       "target": "rocketmq_proxy_core"
     },
     "rocketmq-proxy-local": {
       "crate_version": "1.0.0",
       "public_path_count": 17,
       "public_path_sha256": "3d9e0f9ac569160099d432c85bbb30d17ee1a107e9f665ee636bd4b5898ebc6b",
-      "rustdoc_json_sha256": "065220e5d1ed36daa4313121692a35be0897ffdc1ec3475cf487a592882a0079",
+      "rustdoc_json_sha256": "b871889fcdb751a4ea8d0a99568970bce0f8bdb93a2655697539715fb1515d33",
       "target": "rocketmq_proxy_local"
     },
     "rocketmq-remoting": {
       "crate_version": "1.0.0",
       "public_path_count": 207,
       "public_path_sha256": "4b537a17b7eee97f26fed4a5a18c503250f401cd964bc723697301f0d237d7c9",
-      "rustdoc_json_sha256": "2dcc4317956137711b2f87ec2b234dfe9b95c7128eaef163d69b9900b60a4040",
+      "rustdoc_json_sha256": "9df739c8558a5f4540efc11adee19e7e22cfe316438f52addefbabbbabed154f",
       "target": "rocketmq_remoting"
     },
     "rocketmq-runtime": {
@@ -164,16 +164,16 @@
     },
     "rocketmq-security-api": {
       "crate_version": "1.0.0",
-      "public_path_count": 58,
-      "public_path_sha256": "60870f03e3440f2668e5a52056f508d5d6f450b892ea7770528fc0e5a9de2d8f",
-      "rustdoc_json_sha256": "9c2a1a3c3111ed9172a605b1e37c3575045b388b0dcfd2753ef64c54d71f5f0d",
+      "public_path_count": 94,
+      "public_path_sha256": "bd6dfe3551564c18273f6993a77adbc23bad0bfd00279cae1df280e05991fbe0",
+      "rustdoc_json_sha256": "79f119594d206094729948ae348ce11c3de1faf05a43c64953cff2109f27f31b",
       "target": "rocketmq_security_api"
     },
     "rocketmq-store": {
       "crate_version": "1.0.0",
       "public_path_count": 382,
       "public_path_sha256": "93a543b1cf785538c6ddedc51c70f705824d9a6f425c6169cb7382b48b60b78a",
-      "rustdoc_json_sha256": "adb9c2d0fb23131752bcb064c6c06e2e89136d277e8b52b7eba5fccd8d1a19e8",
+      "rustdoc_json_sha256": "a8f1a32805edc96eba235052ca8a562867c2b340ce0cbf48e1746a473c876393",
       "target": "rocketmq_store"
     },
     "rocketmq-store-api": {
@@ -187,7 +187,7 @@
       "crate_version": "1.0.0",
       "public_path_count": 7,
       "public_path_sha256": "c7ac03206be85858d3f2805aba968f45fa3284f5c3265fb823a6435f8e2e929e",
-      "rustdoc_json_sha256": "a958aa06f39bed9078f75295ec2a6722e0185ddf1fc72856c0e983dfdeaba295",
+      "rustdoc_json_sha256": "ec0e0295769afb21b739de8edc7d71a2fea5a51386cb6778b9296c0125813c6b",
       "target": "rocketmq_store_inspect"
     },
     "rocketmq-store-local": {
@@ -215,12 +215,12 @@
       "crate_version": "1.0.0",
       "public_path_count": 111,
       "public_path_sha256": "e11695741dffe2a835278e4c932b85132df2df6a3db706ec1366aba0b2d71548",
-      "rustdoc_json_sha256": "29a0e9e4150cb674601a7f70cfe3c0b41301351bae0fe3c034dfc50ef7748455",
+      "rustdoc_json_sha256": "389a362d2d47cc86f473484d20ff33729971eb015de05d94e546094eb33c2bff",
       "target": "rocketmq_transport"
     }
   },
   "schema_version": 1,
-  "source_commit": "84e2af503e8908f1ea2b7cbb988d3634300d367e",
+  "source_commit": "77416b46bd9627b73201705459d3c39a6c57e084",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
## Summary

- add a runtime-neutral `SecretProvider` contract with validated identifiers, typed capabilities, optimistic versions, fail-closed errors, and zeroizing redacted secret material
- add an explicit injection-only registry plus allowlisted read-only environment and AES-256-GCM owner-only local-file adapters
- bind encrypted envelopes to logical name and version, publish immutable versions atomically, and keep Windows fail-closed until owner-only ACL verification exists
- update M11 evidence and the completion ledger to 66/82 while leaving secure-default, M10, M11, and Phase 3 HUMAN gates open

## Validation

- `cargo test -p rocketmq-security-api`
- `cargo test -p rocketmq-auth --all-features`
- Windows focused SecretProvider tests: 3/3 passed
- WSL/Ubuntu focused SecretProvider tests: 4/4 passed, including owner-only permissions, atomic versions, encryption, and tamper rejection
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `rocketmq-example`, Tauri backend, and Web backend standalone strict Clippy passed; Web all-target/all-feature build passed
- RocketMQ MCP check, tests, streamable-http strict Clippy, and docs passed
- dependency target/baseline, error hygiene/redaction, routing, and diff guards passed
- public API snapshot: 31/31 packages, differences=0; auth +4 and security-api +36 reviewed as additive

## Compatibility and rollback

- existing generic `Secret<T>`, secure dry-run behavior, public paths, and security profile defaults remain unchanged
- production providers are not bundled and can only enter through explicit trait-object injection
- rollback removes provider registration and the additive adapters/contracts together; it must not restore plaintext JSON, broad permissions, arbitrary environment lookup, or missing-provider fallback

Closes #8272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure secret-provider API with validated identifiers, protected secret material, versioning, and capability reporting.
  * Added explicit provider registration and lookup.
  * Added read-only environment-variable secrets with allowlisted mappings.
  * Added encrypted, versioned local secret storage with permission and tamper checks.

* **Bug Fixes**
  * Added fail-closed behavior for unsupported platforms, insecure permissions, invalid data, and version conflicts.

* **Documentation**
  * Updated production-readiness progress and recorded implementation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->