### PR TITLE
[ISSUE #8280]♻️Establish bounded MCP audit writer and shutdown drain

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,15 +29,15 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 69 | 0 | 13 未开始；合计 13 尚未完成 | 82 |
+| PR 级工作包 | 70 | 0 | 12 未开始；合计 12 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 2（M10 待验收、M11 实施中） | 1（M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 13 个未开始工作包分布：M10 为 0 个、M11 为 7 个、M12 为 6 个。
+剩余 12 个未开始工作包分布：M10 为 0 个、M11 为 6 个、M12 为 6 个。
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
-`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-06。
+`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-07。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -561,7 +561,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] 默认 stdio 与 `--all-features` 均通过；`change-planning` 仍只产生 `mutates_cluster: false` 计划，没有 Apply/`dangerous-tools`
   - [x] [`M11-05 证据`](phase-3-production-readiness/11-mcp-https-jwks-evidence.md) 记录 TLS/JWKS/principal、公共 API、验证矩阵和回滚边界
   - [x] 69/82 已完成、13 未完成，下一工作包 PR-M11-06；M10/M11/Phase 3/HUMAN Gate 均未提前宣称完成
-- [ ] PR-M11-06：完成 MCP Audit Writer 与 Shutdown Drain
+- [x] PR-M11-06：完成 MCP Audit Writer 与 Shutdown Drain
+  - [x] audit schema 固定为 `schema_version = 1`，principal/action/outcome/error 等变长字段先脱敏、清理控制字符并按 UTF-8 字节确定性截断
+  - [x] 生产端只使用 `try_acquire_many_owned` + `try_send`；最大单条、队列条数与队列字节分别有界，overflow/oversized/closed 均独立计量
+  - [x] writer 在 `ServiceContext` 下 FIFO 写入；文件创建、append 与 `sync_all` 全部经注入的 `BlockingExecutor`，sink 失败不输出底层路径或 I/O 错误
+  - [x] `shutdown_with_deadline` 按“关闭准入→drain→flush→runtime shutdown”执行，所有阶段复用同一个绝对 `ShutdownDeadline` 并返回 accepted/written/dropped/pending/failure 报告
+  - [x] count/byte overflow、oversized/redaction、FIFO、sink/flush failure、stall/deadline、运行时取消和真实文件 flush 共 7 项 focused test 通过
+  - [x] 默认 82 tests 与 all-features 104 tests 通过；stdio/HTTPS/JWKS/principal 与无副作用 `change-planning` 合同保持不变
+  - [x] [`M11-06 证据`](phase-3-production-readiness/11-mcp-audit-drain-evidence.md) 记录实现、API 增量、验证矩阵、回滚和未签署 Gate
+  - [x] 70/82 已完成、12 未完成，下一工作包 PR-M11-07；M10/M11/Phase 3/HUMAN/ARCH Gate 均未提前宣称完成
 - [ ] PR-M11-07：建立容器镜像基础
 - [ ] PR-M11-08：交付五个服务镜像入口
 - [ ] PR-M11-09：交付 Helm 与 Kustomize 资产

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation 与 MCP HTTPS/JWKS/principal，下一工作包为 PR-M11-06）
+> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation、MCP HTTPS/JWKS/principal 与 audit drain，下一工作包为 PR-M11-07）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；69/82 工作包完成，剩余 13 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；70/82 工作包完成，剩余 12 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-mcp-audit-drain-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-mcp-audit-drain-evidence.md
@@ -1,0 +1,98 @@
+# M11-06 MCP Audit Writer 与 Shutdown Drain 实施证据
+
+## 1. 结论与进度边界
+
+PR-M11-06 已把 MCP audit 从仅有记录条数上限、关闭时被 runtime 直接取消的 writer，收紧为按记录数和
+真实序列化字节双重有界、生产者无等待、可在单一绝对截止时间内 drain/flush 并生成健康报告的生命周期
+组件。文件 sink 的目录创建、append 和 `sync_all` 全部通过注入的 `BlockingExecutor`；writer 仍由
+`ServiceContext` 持有，不新增 detached task、ad-hoc runtime 或数据面等待。
+
+工作包完成后总进度为 **70/82**，剩余 12 个工作包：M11 6 个、M12 6 个；下一工作包为 PR-M11-07。
+这里的“工作包完成”只表示目标实现、复核与工程验证完成，不替代尚未签署的 M11 入口 `[ARCH]`、安全默认
+迁移 `[HUMAN]`、M10 真实固定硬件 baseline/candidate 与 `[HUMAN]` Gate，也不等于 M11、Phase 3 或最终
+目标态 Gate 完成。
+
+| 项目 | 结果 |
+|---|---|
+| 工作包 | `PR-M11-06` |
+| GitHub Issue | `#8280` |
+| 主要 owner | `rocketmq-mcp::guard::audit`；应用生命周期组合位于 `rocketmq-mcp::app` |
+| 新增依赖边 | 无；复用现有 `rocketmq-mcp -> rocketmq-runtime` 注入边界 |
+| 非目标 | M11-07～12 镜像/部署/fault/SLO、M12 Apply/AI Native、M10 真实性能签署 |
+
+## 2. 稳定 schema、脱敏与记录上限
+
+- `AuditRecord` 增加固定 `schema_version = 1`。NDJSON 字段顺序由 Rust struct 定义，构造者传入的版本在准入
+  前统一重置为当前版本，避免伪造或混用版本。
+- `request_id`、principal/operator、client、cluster、tool、arguments hash 与 error 分别设置确定性 UTF-8
+  字节上限。所有字符串先复用敏感 assignment redaction，再把控制字符替换为 U+FFFD，最后只在字符边界
+  截断。
+- 最大单条记录按脱敏后实际 `serde_json` 字节加换行计算；超过 `audit.max_record_bytes` 的记录不进入内存
+  history、queue 或 sink，并增加 `dropped/oversized`。
+- sink 错误只记录稳定事件与计数，不记录路径、底层 I/O 文本、credential、token、请求体或完整配置。
+
+## 3. 双容量无等待准入与 FIFO writer
+
+每个异步记录先用 `Semaphore::try_acquire_many_owned` 取得与实际 NDJSON 字节数一致的 permit，再用
+`mpsc::Sender::try_send` 竞争记录槽位。生产端没有 `.await`；字节满、条数满和关闭分别增加
+`byte_capacity_drops`、`count_capacity_drops`、`closed_drops`。成功入队才增加 `accepted/queued`。
+
+envelope 持有 byte permit 和 pending guard：正常写入、sink 失败、channel 回收、future abort 或 runtime 取消
+都会通过析构释放字节并扣减 `pending_records/pending_bytes`。单 writer 顺序消费 channel，成功记录按 FIFO
+写入 sink 与有界 history；单条写入失败只增加 `sink_failures`，不会阻塞生产者或停止后续记录。
+
+`memory` sink 保持同步、本地且有界的测试/查询语义；`tracing` sink 不改变 stdout，应用 subscriber 仍把日志
+写到 stderr；`file` sink 的所有阻塞文件操作只通过现有 `BlockingExecutor::spawn_io` 执行。
+
+## 4. 单一绝对关闭预算与可观测报告
+
+`AuditLog::close_and_drain(deadline)` 原子取走 sender，拒绝新准入，等待 writer 把已接收记录按 FIFO 写完并
+flush。`McpApp::shutdown_with_deadline` 随后把同一个 `ShutdownDeadline` 传给
+`RuntimeContext::shutdown_tasks_until`，audit 阶段不会为 runtime 重新分配完整 timeout。
+
+`AuditDrainReport` 返回 status、elapsed、accepted、written、各类 drop、sink/flush failure 和 pending
+count/bytes。writer 被截止时间后的 runtime shutdown 中止时，pending guard 仍会归零，但 completion 不会被
+误标为 drained；后续报告保持 `timed_out`。兼容入口 `McpApp::shutdown()` 仍使用十秒预算并记录不健康报告。
+
+## 5. 公共 API 与配置兼容性
+
+默认特性公共 API 快照对 31 个 workspace library 全量重建：
+
+- `rocketmq-mcp` public path 从 210 增至 217。新增路径为 `AUDIT_SCHEMA_VERSION`、`AuditDrainStatus` 及其
+  3 个 variant、`AuditDrainReport`、`McpShutdownReport`；其余 30 个包路径与 fingerprint 不变。
+- `AuditConfig` 新增 `max_record_bytes` 与 `queue_max_bytes`。Serde 均提供默认值，旧 TOML 继续解析；直接使用
+  Rust struct literal 的 embedder 需要补齐两个字段。
+- `AuditRecord` 新增 `schema_version`，`AuditMetrics` 增加 admission/drain 明细字段；直接构造或穷尽解构这些
+  public struct 的 embedder 需要按 v1 schema 迁移。既有 `AuditRecord::new`、`AuditLog::record/records/metrics`
+  与 `McpApp::shutdown` 保留。
+- 更新受管 baseline 后再次全量复核为 31/31 package、`differences=0`。
+
+## 6. 验证矩阵
+
+| Gate | 命令/范围 | 结果 |
+|---|---|---|
+| Audit focused | `cargo test -p rocketmq-mcp guard::audit::tests --lib` | 7/7 通过：count/byte overflow、oversized/redaction、FIFO、sink/flush failure、stall/deadline、runtime cancellation、file flush |
+| MCP default | `cargo check -p rocketmq-mcp`；`cargo test -p rocketmq-mcp` | 通过；82 library、typed boundary 与 2 个本地 integration 通过，1 个外部集群 E2E 按环境合同 ignored |
+| MCP all features | `cargo test -p rocketmq-mcp --all-features` | 104 library、typed boundary 与 2 个本地 integration 通过；`change-planning` 仍无副作用 |
+| MCP strict Clippy | `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings` | 通过 |
+| Rustdoc | `cargo doc -p rocketmq-mcp --no-deps` | 通过 |
+| Runtime ownership | `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 退出码 0，runtime boundary baseline passed，无新 raw spawn/blocking/root 边界 |
+| Dependency/release | target + baseline dependency guard；architecture release guard | 通过；target ledger 35、dev-only 3、release topology 32/32 |
+| Public API | 31 包快照重建、增量分类、baseline 更新后零差异复核 | MCP 210→217 additive；其余 30 包路径不变 |
+| Root final | `cargo fmt --all -- --check`；workspace all-target/all-feature strict Clippy | 通过 |
+| Text | `git diff --check` | 通过 |
+
+Windows/MSVC linker message 与 `proc-macro-error2` future-incompatibility note 是既有工具链输出；严格 Clippy
+退出码为 0，没有新增 `allow` 或降低 lint。外部集群 integration 未配置 Namesrv/topic/group/broker，按既有测试
+合同 ignored；本工作包全部验收项不依赖外部集群。
+
+## 7. 回滚与剩余目标
+
+代码回滚必须同时回滚双容量配置、v1 schema、writer lifecycle、shutdown report、测试、README 与公共 API
+baseline。运行期若 audit writer/sink 不健康，应停止暴露 Streamable HTTP 管理入口并保留 stdio/人工 CLI，
+不得通过改成无界队列、生产端等待、记录敏感底层错误或跳过 drain 来恢复服务。
+
+剩余 M11 目标为：PR-M11-07 容器镜像基础、M11-08 五服务入口、M11-09 Helm/Kustomize、M11-10
+probe/preStop/drain、M11-11 Kind/K3d fault matrix、M11-12 ArcMut/stable/SLO 收口。M12 仍有 6 个 AI Native
+工作包。此外，M10 仍缺真实固定硬件 baseline/candidate、原始数据 hash 与 `[HUMAN]` Gate；M11 入口
+`[ARCH]`、安全默认迁移 `[HUMAN]`、Phase 3 和最终目标态 Gate 均未签署。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M11-01～05 已完成；下一工作包 PR-M11-06；部分依赖 M10 SLI） |
+| 状态 | 实施中（PR-M11-01～06 已完成；下一工作包 PR-M11-07；部分依赖 M10 SLI） |
 | 预计周期 | 4–6 周 |
 | 工作包 | 延续 WP01、WP03、WP05、WP07、WP14–WP16 |
 | 前置条件 | 32-package Gate；secure dry-run、ServiceContext、semantic owner、durability SLI 可用 |
@@ -118,10 +118,17 @@ last-known-good；verified principal 经真实 protocol handler 进入 RBAC/rate
 ### PR-M11-06：MCP Audit Writer 与 Shutdown Drain
 
 - [ ] 入口：`[ARCH]` audit schema、count+byte上限、overflow policy、绝对deadline和flush报告已冻结。
-- [ ] `[DEV]` audit writer按count+bytes有界，记录稳定principal/action/outcome，shutdown在同一deadline内drain/flush并报告未完成项。
-- [ ] `[TEST]` focused test：overflow、sink timeout/failure、进程取消、deadline、redaction和audit ordering。
-- [ ] `[REV]` 检查audit故障不阻塞数据面、敏感字段不落盘、未完成记录可观测。
-- [ ] 回滚点：回到上一通过同一audit corpus的writer；否则关闭HTTP管理入口并保留核心stdio/人工运维。
+- [x] `[DEV]` audit writer按count+bytes有界，记录稳定principal/action/outcome，shutdown在同一deadline内drain/flush并报告未完成项。
+- [x] `[TEST]` focused test：overflow、sink timeout/failure、进程取消、deadline、redaction和audit ordering。
+- [x] `[REV]` 检查audit故障不阻塞数据面、敏感字段不落盘、未完成记录可观测。
+- [x] 回滚点：回到上一通过同一audit corpus的writer；否则关闭HTTP管理入口并保留核心stdio/人工运维。
+
+完成证据：[`11-mcp-audit-drain-evidence.md`](11-mcp-audit-drain-evidence.md)。生产者按已脱敏 NDJSON 的真实
+字节数与记录数分别执行无等待准入，writer 由 `ServiceContext` 持有且所有文件 I/O 只经过
+`BlockingExecutor`。关闭先停止准入，再在同一绝对 deadline 内完成 FIFO drain/flush，随后把剩余预算交给
+runtime shutdown；超时、取消、drop、sink/flush failure 与 pending count/bytes 均进入报告。70/82 工作包完成，
+剩余 M11 6 个、M12 6 个，下一工作包为 PR-M11-07。M11 入口 `[ARCH]`、安全默认 `[HUMAN]`、M10
+真实性能与 `[HUMAN]`、M11 和 Phase 3 Gate 均保持未完成。
 
 ### PR-M11-07：容器镜像基础
 

--- a/rocketmq-tools/rocketmq-mcp/README.md
+++ b/rocketmq-tools/rocketmq-mcp/README.md
@@ -100,7 +100,10 @@ Important fields:
 - `security.max_concurrent_requests_per_cluster`: bounded concurrent Tool and Resource work per configured cluster.
 - `security.rate_limit_per_minute`: per-principal, per-cluster, per-operation limit.
 - `audit.sink`: `memory`, `file`, or `tracing`.
-- `audit.queue_capacity`: bounded audit writer queue. Queue drops and sink failures are emitted as trace metrics.
+- `audit.queue_capacity`: maximum number of accepted records waiting for the asynchronous writer.
+- `audit.max_record_bytes`: maximum serialized NDJSON record size after redaction and deterministic field bounds.
+- `audit.queue_max_bytes`: maximum bytes retained by the writer queue. Record-count and byte admission are enforced
+  independently with non-blocking `try` semantics.
 - `cache.enabled`: enables or bypasses the shared query cache.
 - `cache.max_entries`: maximum number of in-memory entries; it must be greater than zero when caching is enabled.
 - `cache.*_ttl_ms`: per-query-family freshness windows for overview, topic, broker, and consumer-lag data.
@@ -108,6 +111,12 @@ Important fields:
 - `diagnosis.consumer_lag_threshold`: server-owned threshold used by consumer-lag rules.
 
 Cache keys include the schema version, visibility class, query kind, resolved cluster, and normalized query parameters. Failures are not cached. Concurrent misses for the same key are coalesced, and `cache_status` reports `miss`, `hit`, or `bypass`. Embedders can call `McpApp::invalidate_cache()` to clear all entries explicitly. Cumulative hit, miss, bypass, eviction, invalidation, and coalesced-waiter counters are emitted at trace level after Tool and Resource requests.
+
+Audit records use `schema_version = 1`, redact sensitive assignments and control characters before admission, and
+bound every variable-length field. Shutdown closes admission, drains accepted records in FIFO order, flushes the sink,
+and then shuts down runtime tasks against the same absolute deadline. Embedders that need machine-readable lifecycle
+evidence can call `McpApp::shutdown_with_deadline()` and inspect `McpShutdownReport`; `McpApp::shutdown()` retains the
+ten-second compatibility wrapper and logs unhealthy reports.
 
 Command-line overrides:
 
@@ -273,4 +282,6 @@ Cluster and RocketMQ entity names are UTF-8 percent-encoded as URI path or query
 - HTTP `429`: raise `security.rate_limit_per_minute` only after reviewing client retry behavior.
 - Empty or invalid stdio responses: ensure no wrapper script writes logs or banners to stdout.
 - No cluster data: verify `clusters[].namesrv_addr`, local network access, and RocketMQ namesrv availability.
-- Audit file errors: create the audit directory or use `audit.sink = "memory"` for local tests. Check `audit_sink_failures` and `audit_dropped` trace metrics before increasing queue capacity.
+- Audit file errors: create the audit directory or use `audit.sink = "memory"` for local tests. Check accepted/written,
+  count-capacity drops, byte-capacity drops, oversized records, sink/flush failures, and pending records/bytes before
+  changing either queue limit.

--- a/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-tools/rocketmq-mcp/conf/mcp.example.toml
@@ -51,6 +51,8 @@ enabled = true
 sink = "file"
 path = "./logs/rocketmq-mcp-audit.log"
 queue_capacity = 1024
+max_record_bytes = 16384
+queue_max_bytes = 1048576
 
 [cache]
 enabled = true

--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -19,7 +19,31 @@ use crate::adapter::query_facade::QueryFacade;
 use crate::config::Args;
 use crate::config::McpConfig;
 use crate::config::TransportKind;
+use crate::guard::audit::AuditDrainReport;
 use crate::guard::Guard;
+
+#[derive(Debug, Clone)]
+pub struct McpShutdownReport {
+    pub audit: AuditDrainReport,
+    pub runtime: Option<rocketmq_runtime::ShutdownReport>,
+}
+
+impl McpShutdownReport {
+    pub fn is_healthy(&self) -> bool {
+        self.audit.is_healthy()
+            && self
+                .runtime
+                .as_ref()
+                .is_none_or(rocketmq_runtime::ShutdownReport::is_healthy)
+    }
+
+    pub fn log_if_unhealthy(&self) {
+        self.audit.log_if_unhealthy();
+        if let Some(runtime) = &self.runtime {
+            runtime.log_if_unhealthy();
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct McpApp {
@@ -93,8 +117,17 @@ impl McpApp {
             cache_invalidations = metrics.invalidations,
             cache_coalesced_waiters = metrics.coalesced_waiters,
             audit_queued = audit.queued,
+            audit_accepted = audit.accepted,
+            audit_written = audit.written,
             audit_dropped = audit.dropped,
+            audit_oversized = audit.oversized,
+            audit_count_capacity_drops = audit.count_capacity_drops,
+            audit_byte_capacity_drops = audit.byte_capacity_drops,
+            audit_closed_drops = audit.closed_drops,
             audit_sink_failures = audit.sink_failures,
+            audit_flush_failures = audit.flush_failures,
+            audit_pending_records = audit.pending_records,
+            audit_pending_bytes = audit.pending_bytes,
             "rocketmq-mcp cache metrics"
         );
     }
@@ -109,10 +142,26 @@ impl McpApp {
     }
 
     pub async fn shutdown(&self) {
-        if let Some(runtime_context) = &self.runtime_context {
-            let report = runtime_context.shutdown_tasks(std::time::Duration::from_secs(10)).await;
-            report.log_if_unhealthy();
-        }
+        let report = self
+            .shutdown_with_deadline(rocketmq_runtime::ShutdownDeadline::after(
+                std::time::Duration::from_secs(10),
+            ))
+            .await;
+        report.log_if_unhealthy();
+    }
+
+    /// Closes audit admission, drains accepted records, and then shuts down all owned runtime work.
+    ///
+    /// The same absolute `deadline` bounds both phases, so audit draining cannot reset the runtime
+    /// shutdown budget.
+    pub async fn shutdown_with_deadline(&self, deadline: rocketmq_runtime::ShutdownDeadline) -> McpShutdownReport {
+        let audit = self.guard.audit_log().close_and_drain(deadline).await;
+        let runtime = if let Some(runtime_context) = &self.runtime_context {
+            Some(runtime_context.shutdown_tasks_until(deadline).await)
+        } else {
+            None
+        };
+        McpShutdownReport { audit, runtime }
     }
 
     fn start_background_services(&mut self) -> Result<(), crate::error::McpError> {

--- a/rocketmq-tools/rocketmq-mcp/src/config.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/config.rs
@@ -148,6 +148,21 @@ impl McpConfig {
                 "audit.queue_capacity must be greater than zero".to_string(),
             ));
         }
+        if self.audit.max_record_bytes == 0 {
+            return Err(McpError::InvalidConfig(
+                "audit.max_record_bytes must be greater than zero".to_string(),
+            ));
+        }
+        if self.audit.queue_max_bytes < self.audit.max_record_bytes {
+            return Err(McpError::InvalidConfig(
+                "audit.queue_max_bytes must be at least audit.max_record_bytes".to_string(),
+            ));
+        }
+        if self.audit.queue_max_bytes > u32::MAX as usize {
+            return Err(McpError::InvalidConfig(
+                "audit.queue_max_bytes must not exceed u32::MAX".to_string(),
+            ));
+        }
 
         self.server.http.auth.validate()?;
         if self.server.transport == TransportKind::StreamableHttp {
@@ -448,6 +463,18 @@ pub struct AuditConfig {
     pub sink: String,
     pub path: String,
     pub queue_capacity: usize,
+    #[serde(default = "default_audit_max_record_bytes")]
+    pub max_record_bytes: usize,
+    #[serde(default = "default_audit_queue_max_bytes")]
+    pub queue_max_bytes: usize,
+}
+
+const fn default_audit_max_record_bytes() -> usize {
+    16 * 1024
+}
+
+const fn default_audit_queue_max_bytes() -> usize {
+    1024 * 1024
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -531,6 +558,8 @@ mod tests {
         assert_eq!(config.clusters[0].namesrv_addr, "127.0.0.1:9876");
         assert_eq!(config.diagnosis.consumer_lag_policy_profile, "production-default");
         assert_eq!(config.diagnosis.consumer_lag_threshold, 1_000);
+        assert_eq!(config.audit.max_record_bytes, 16 * 1024);
+        assert_eq!(config.audit.queue_max_bytes, 1024 * 1024);
     }
 
     #[test]
@@ -580,6 +609,29 @@ mod tests {
         let error = config.validate().unwrap_err();
 
         assert!(error.to_string().contains("cache.max_entries"));
+    }
+
+    #[test]
+    fn audit_capacity_requires_one_bounded_record_and_u32_byte_accounting() {
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.audit.max_record_bytes = 0;
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("audit.max_record_bytes"));
+
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.audit.queue_max_bytes = config.audit.max_record_bytes - 1;
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("at least audit.max_record_bytes"));
+
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.audit.queue_max_bytes = u32::MAX as usize + 1;
+        assert!(config.validate().unwrap_err().to_string().contains("u32::MAX"));
     }
 
     #[cfg(feature = "streamable-http")]

--- a/rocketmq-tools/rocketmq-mcp/src/guard.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard.rs
@@ -578,6 +578,8 @@ mod tests {
                 sink: "memory".to_string(),
                 path: String::new(),
                 queue_capacity: 16,
+                max_record_bytes: 16 * 1024,
+                queue_max_bytes: 1024 * 1024,
             },
             &[ClusterConfig {
                 name: "local-dev".to_string(),

--- a/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
@@ -15,22 +15,37 @@
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use async_trait::async_trait;
 use serde::Serialize;
 use tokio::sync::mpsc;
+use tokio::sync::Notify;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
 
 use crate::config::AuditConfig;
+use crate::guard::sanitizer::sanitize_text;
 use crate::guard::GuardError;
 use crate::guard::RiskLevel;
 
+pub const AUDIT_SCHEMA_VERSION: u16 = 1;
+
 const MAX_AUDIT_RECORDS: usize = 1024;
+const MAX_REQUEST_ID_BYTES: usize = 128;
+const MAX_IDENTITY_BYTES: usize = 256;
+const MAX_TOOL_BYTES: usize = 256;
+const MAX_ARGUMENTS_HASH_BYTES: usize = 128;
+const MAX_ERROR_BYTES: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -41,6 +56,7 @@ pub enum AuditStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AuditRecord {
+    pub schema_version: u16,
     pub timestamp_unix_ms: u128,
     pub request_id: String,
     pub operator: String,
@@ -72,6 +88,7 @@ impl AuditRecord {
         error: Option<String>,
     ) -> Self {
         Self {
+            schema_version: AUDIT_SCHEMA_VERSION,
             timestamp_unix_ms: now_unix_ms(),
             request_id,
             operator,
@@ -90,21 +107,140 @@ impl AuditRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuditMetrics {
     pub queued: u64,
+    pub accepted: u64,
+    pub written: u64,
     pub dropped: u64,
+    pub oversized: u64,
+    pub count_capacity_drops: u64,
+    pub byte_capacity_drops: u64,
+    pub closed_drops: u64,
     pub sink_failures: u64,
+    pub flush_failures: u64,
+    pub pending_records: u64,
+    pub pending_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditDrainStatus {
+    Disabled,
+    Drained,
+    TimedOut,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuditDrainReport {
+    pub status: AuditDrainStatus,
+    pub elapsed: Duration,
+    pub accepted: u64,
+    pub written: u64,
+    pub dropped: u64,
+    pub oversized: u64,
+    pub count_capacity_drops: u64,
+    pub byte_capacity_drops: u64,
+    pub closed_drops: u64,
+    pub sink_failures: u64,
+    pub flush_failures: u64,
+    pub pending_records: u64,
+    pub pending_bytes: u64,
+}
+
+impl AuditDrainReport {
+    pub fn is_healthy(&self) -> bool {
+        matches!(self.status, AuditDrainStatus::Disabled | AuditDrainStatus::Drained)
+            && self.pending_records == 0
+            && self.pending_bytes == 0
+            && self.dropped == 0
+            && self.sink_failures == 0
+            && self.flush_failures == 0
+    }
+
+    pub fn log_if_unhealthy(&self) {
+        if !self.is_healthy() {
+            tracing::warn!(
+                status = ?self.status,
+                accepted = self.accepted,
+                written = self.written,
+                dropped = self.dropped,
+                oversized = self.oversized,
+                sink_failures = self.sink_failures,
+                flush_failures = self.flush_failures,
+                pending_records = self.pending_records,
+                pending_bytes = self.pending_bytes,
+                "rocketmq-mcp audit drain report is unhealthy"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 struct AuditCounters {
     queued: AtomicU64,
+    accepted: AtomicU64,
+    written: AtomicU64,
     dropped: AtomicU64,
+    oversized: AtomicU64,
+    count_capacity_drops: AtomicU64,
+    byte_capacity_drops: AtomicU64,
+    closed_drops: AtomicU64,
     sink_failures: AtomicU64,
+    flush_failures: AtomicU64,
+    pending_records: AtomicU64,
+    pending_bytes: AtomicU64,
+}
+
+#[derive(Debug)]
+struct WriterCompletion {
+    finished: AtomicBool,
+    drained: AtomicBool,
+    notify: Notify,
+}
+
+impl WriterCompletion {
+    fn new() -> Self {
+        Self {
+            finished: AtomicBool::new(false),
+            drained: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    fn finish(&self, drained: bool) {
+        if drained {
+            self.drained.store(true, Ordering::Release);
+        }
+        self.finished.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+}
+
+struct CompletionGuard(Arc<WriterCompletion>);
+
+impl Drop for CompletionGuard {
+    fn drop(&mut self) {
+        self.0.finish(false);
+    }
+}
+
+#[derive(Debug, Default)]
+enum AuditLifecycle {
+    #[default]
+    Unstarted,
+    Disabled,
+    Memory {
+        closed: bool,
+    },
+    Running {
+        sender: Option<mpsc::Sender<AuditEnvelope>>,
+        byte_budget: Arc<Semaphore>,
+        completion: Arc<WriterCompletion>,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct AuditLog {
     records: Arc<Mutex<VecDeque<AuditRecord>>>,
-    sender: Arc<Mutex<Option<mpsc::Sender<AuditRecord>>>>,
+    lifecycle: Arc<Mutex<AuditLifecycle>>,
     counters: Arc<AuditCounters>,
 }
 
@@ -114,54 +250,90 @@ impl AuditLog {
         config: &AuditConfig,
         service_context: &rocketmq_runtime::ServiceContext,
     ) -> Result<(), GuardError> {
-        if !config.enabled || config.sink == "memory" {
-            return Ok(());
-        }
-        let (sender, receiver) = mpsc::channel(config.queue_capacity);
-        let mut current_sender = self
-            .sender
-            .lock()
-            .map_err(|_| GuardError::InvalidArgument("audit queue state is unavailable".to_string()))?;
-        if current_sender.is_some() {
-            return Ok(());
-        }
-        *current_sender = Some(sender);
-        drop(current_sender);
-
-        let config = config.clone();
-        let counters = self.counters.clone();
-        let blocking = service_context.blocking().clone();
-        service_context
-            .task_group()
-            .spawn_service("rocketmq-mcp-audit-writer", async move {
-                run_audit_writer(receiver, config, blocking, counters).await;
-            })
-            .map_err(|error| GuardError::InvalidArgument(format!("failed to start audit writer: {error}")))?;
-        Ok(())
+        let sink: Box<dyn AuditSink> = match config.sink.as_str() {
+            "file" => Box::new(FileAuditSink {
+                path: PathBuf::from(&config.path),
+                blocking: service_context.blocking().clone(),
+            }),
+            "tracing" => Box::new(TracingAuditSink),
+            "memory" => Box::new(MemoryAuditSink),
+            _ => {
+                return Err(GuardError::InvalidArgument("unsupported audit sink".to_string()));
+            }
+        };
+        self.start_with_sink(config, service_context, sink)
     }
 
     pub fn record(&self, config: &AuditConfig, record: AuditRecord) {
-        self.push(record.clone());
-        if let Some(sender) = self.sender.lock().ok().and_then(|sender| sender.clone()) {
-            match sender.try_send(record) {
-                Ok(()) => {
-                    self.counters.queued.fetch_add(1, Ordering::Relaxed);
-                }
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    self.counters.dropped.fetch_add(1, Ordering::Relaxed);
-                    tracing::warn!("rocketmq-mcp audit queue is full; audit record dropped");
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    self.counters.sink_failures.fetch_add(1, Ordering::Relaxed);
-                    tracing::warn!("rocketmq-mcp audit queue is closed; audit record dropped");
-                }
+        if !config.enabled {
+            return;
+        }
+
+        let Some((record, encoded)) = self.prepare_record(config, record) else {
+            return;
+        };
+
+        if config.sink == "memory" {
+            let is_closed = self
+                .lifecycle
+                .lock()
+                .map(|lifecycle| matches!(*lifecycle, AuditLifecycle::Memory { closed: true }))
+                .unwrap_or(true);
+            if is_closed {
+                self.drop_closed();
+            } else {
+                self.accept_memory(record);
             }
             return;
         }
 
-        if let Err(error) = write_sink(config, &record) {
-            self.counters.sink_failures.fetch_add(1, Ordering::Relaxed);
-            tracing::warn!(?error, "rocketmq-mcp audit sink write failed");
+        let queue = self.lifecycle.lock().ok().and_then(|lifecycle| match &*lifecycle {
+            AuditLifecycle::Running {
+                sender: Some(sender),
+                byte_budget,
+                ..
+            } => Some((sender.clone(), byte_budget.clone())),
+            _ => None,
+        });
+        let Some((sender, byte_budget)) = queue else {
+            self.drop_closed();
+            return;
+        };
+
+        let encoded_len = encoded.len() as u64;
+        let permit = match byte_budget.try_acquire_many_owned(encoded.len() as u32) {
+            Ok(permit) => permit,
+            Err(_) => {
+                self.counters.dropped.fetch_add(1, Ordering::Relaxed);
+                self.counters.byte_capacity_drops.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!("rocketmq-mcp audit byte capacity is full; audit record dropped");
+                return;
+            }
+        };
+
+        self.counters.pending_records.fetch_add(1, Ordering::Relaxed);
+        self.counters.pending_bytes.fetch_add(encoded_len, Ordering::Relaxed);
+        let envelope = AuditEnvelope {
+            record,
+            encoded,
+            _byte_permit: permit,
+            pending: PendingAuditRecord {
+                counters: self.counters.clone(),
+                encoded_len,
+            },
+        };
+
+        match sender.try_send(envelope) {
+            Ok(()) => {
+                self.counters.queued.fetch_add(1, Ordering::Relaxed);
+                self.counters.accepted.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.counters.dropped.fetch_add(1, Ordering::Relaxed);
+                self.counters.count_capacity_drops.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!("rocketmq-mcp audit record capacity is full; audit record dropped");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => self.drop_closed(),
         }
     }
 
@@ -175,84 +347,379 @@ impl AuditLog {
     pub fn metrics(&self) -> AuditMetrics {
         AuditMetrics {
             queued: self.counters.queued.load(Ordering::Relaxed),
+            accepted: self.counters.accepted.load(Ordering::Relaxed),
+            written: self.counters.written.load(Ordering::Relaxed),
             dropped: self.counters.dropped.load(Ordering::Relaxed),
+            oversized: self.counters.oversized.load(Ordering::Relaxed),
+            count_capacity_drops: self.counters.count_capacity_drops.load(Ordering::Relaxed),
+            byte_capacity_drops: self.counters.byte_capacity_drops.load(Ordering::Relaxed),
+            closed_drops: self.counters.closed_drops.load(Ordering::Relaxed),
             sink_failures: self.counters.sink_failures.load(Ordering::Relaxed),
+            flush_failures: self.counters.flush_failures.load(Ordering::Relaxed),
+            pending_records: self.counters.pending_records.load(Ordering::Relaxed),
+            pending_bytes: self.counters.pending_bytes.load(Ordering::Relaxed),
         }
     }
 
-    fn push(&self, record: AuditRecord) {
-        let Ok(mut records) = self.records.lock() else {
-            return;
+    pub async fn close_and_drain(&self, deadline: rocketmq_runtime::ShutdownDeadline) -> AuditDrainReport {
+        let started_at = Instant::now();
+        let completion = {
+            let Ok(mut lifecycle) = self.lifecycle.lock() else {
+                return self.drain_report(AuditDrainStatus::TimedOut, started_at.elapsed());
+            };
+            match &mut *lifecycle {
+                AuditLifecycle::Running { sender, completion, .. } => {
+                    sender.take();
+                    Some(completion.clone())
+                }
+                AuditLifecycle::Memory { closed } => {
+                    *closed = true;
+                    return self.drain_report(AuditDrainStatus::Drained, started_at.elapsed());
+                }
+                AuditLifecycle::Unstarted | AuditLifecycle::Disabled => {
+                    return self.drain_report(AuditDrainStatus::Disabled, started_at.elapsed());
+                }
+            }
         };
-        if records.len() == MAX_AUDIT_RECORDS {
-            records.pop_front();
+
+        let Some(completion) = completion else {
+            return self.drain_report(AuditDrainStatus::TimedOut, started_at.elapsed());
+        };
+        let mut timed_out = false;
+        while !completion.finished.load(Ordering::Acquire) {
+            let notified = completion.notify.notified();
+            if completion.finished.load(Ordering::Acquire) {
+                break;
+            }
+            if deadline.is_expired()
+                || tokio::time::timeout_at(tokio::time::Instant::from_std(deadline.instant()), notified)
+                    .await
+                    .is_err()
+            {
+                timed_out = true;
+                break;
+            }
         }
-        records.push_back(record);
+
+        let metrics = self.metrics();
+        let status = if timed_out
+            || !completion.drained.load(Ordering::Acquire)
+            || metrics.pending_records > 0
+            || metrics.pending_bytes > 0
+        {
+            AuditDrainStatus::TimedOut
+        } else {
+            AuditDrainStatus::Drained
+        };
+        self.drain_report(status, started_at.elapsed())
+    }
+
+    fn start_with_sink(
+        &self,
+        config: &AuditConfig,
+        service_context: &rocketmq_runtime::ServiceContext,
+        sink: Box<dyn AuditSink>,
+    ) -> Result<(), GuardError> {
+        validate_queue_config(config)?;
+        let mut lifecycle = self
+            .lifecycle
+            .lock()
+            .map_err(|_| GuardError::InvalidArgument("audit queue state is unavailable".to_string()))?;
+        if !matches!(*lifecycle, AuditLifecycle::Unstarted) {
+            return Ok(());
+        }
+        if !config.enabled {
+            *lifecycle = AuditLifecycle::Disabled;
+            return Ok(());
+        }
+        if config.sink == "memory" {
+            *lifecycle = AuditLifecycle::Memory { closed: false };
+            return Ok(());
+        }
+
+        let (sender, receiver) = mpsc::channel(config.queue_capacity);
+        let byte_budget = Arc::new(Semaphore::new(config.queue_max_bytes));
+        let completion = Arc::new(WriterCompletion::new());
+        let counters = self.counters.clone();
+        let records = self.records.clone();
+        let writer_completion = completion.clone();
+        service_context
+            .task_group()
+            .spawn_service("rocketmq-mcp-audit-writer", async move {
+                run_audit_writer(receiver, sink, counters, records, writer_completion).await;
+            })
+            .map_err(|error| GuardError::InvalidArgument(format!("failed to start audit writer: {error}")))?;
+        *lifecycle = AuditLifecycle::Running {
+            sender: Some(sender),
+            byte_budget,
+            completion,
+        };
+        Ok(())
+    }
+
+    fn prepare_record(&self, config: &AuditConfig, record: AuditRecord) -> Option<(AuditRecord, Vec<u8>)> {
+        let record = sanitize_record(record);
+        let mut encoded = match serde_json::to_vec(&record) {
+            Ok(encoded) => encoded,
+            Err(_) => {
+                self.counters.dropped.fetch_add(1, Ordering::Relaxed);
+                self.counters.sink_failures.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!("rocketmq-mcp audit record serialization failed");
+                return None;
+            }
+        };
+        encoded.push(b'\n');
+        if encoded.len() > config.max_record_bytes {
+            self.counters.dropped.fetch_add(1, Ordering::Relaxed);
+            self.counters.oversized.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                record_bytes = encoded.len(),
+                max_record_bytes = config.max_record_bytes,
+                "rocketmq-mcp oversized audit record dropped"
+            );
+            return None;
+        }
+        Some((record, encoded))
+    }
+
+    fn accept_memory(&self, record: AuditRecord) {
+        push_record(&self.records, record);
+        self.counters.accepted.fetch_add(1, Ordering::Relaxed);
+        self.counters.written.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn drop_closed(&self) {
+        self.counters.dropped.fetch_add(1, Ordering::Relaxed);
+        self.counters.closed_drops.fetch_add(1, Ordering::Relaxed);
+        tracing::warn!("rocketmq-mcp audit queue is closed; audit record dropped");
+    }
+
+    fn drain_report(&self, status: AuditDrainStatus, elapsed: Duration) -> AuditDrainReport {
+        let metrics = self.metrics();
+        AuditDrainReport {
+            status,
+            elapsed,
+            accepted: metrics.accepted,
+            written: metrics.written,
+            dropped: metrics.dropped,
+            oversized: metrics.oversized,
+            count_capacity_drops: metrics.count_capacity_drops,
+            byte_capacity_drops: metrics.byte_capacity_drops,
+            closed_drops: metrics.closed_drops,
+            sink_failures: metrics.sink_failures,
+            flush_failures: metrics.flush_failures,
+            pending_records: metrics.pending_records,
+            pending_bytes: metrics.pending_bytes,
+        }
+    }
+}
+
+struct PendingAuditRecord {
+    counters: Arc<AuditCounters>,
+    encoded_len: u64,
+}
+
+impl Drop for PendingAuditRecord {
+    fn drop(&mut self) {
+        self.counters.pending_records.fetch_sub(1, Ordering::Relaxed);
+        self.counters
+            .pending_bytes
+            .fetch_sub(self.encoded_len, Ordering::Relaxed);
+    }
+}
+
+struct AuditEnvelope {
+    record: AuditRecord,
+    encoded: Vec<u8>,
+    _byte_permit: OwnedSemaphorePermit,
+    pending: PendingAuditRecord,
+}
+
+#[async_trait]
+trait AuditSink: Send {
+    async fn write(&mut self, record: &AuditRecord, encoded: &[u8]) -> Result<(), ()>;
+    async fn flush(&mut self) -> Result<(), ()>;
+}
+
+struct FileAuditSink {
+    path: PathBuf,
+    blocking: rocketmq_runtime::BlockingExecutor,
+}
+
+#[async_trait]
+impl AuditSink for FileAuditSink {
+    async fn write(&mut self, _record: &AuditRecord, encoded: &[u8]) -> Result<(), ()> {
+        let path = self.path.clone();
+        let encoded = encoded.to_vec();
+        self.blocking
+            .spawn_io("rocketmq-mcp-audit-file-write", move || {
+                write_file_record(path, &encoded)
+            })
+            .await
+            .map_err(|_| ())?
+    }
+
+    async fn flush(&mut self) -> Result<(), ()> {
+        let path = self.path.clone();
+        self.blocking
+            .spawn_io("rocketmq-mcp-audit-file-flush", move || flush_audit_file(path))
+            .await
+            .map_err(|_| ())?
+    }
+}
+
+struct TracingAuditSink;
+
+#[async_trait]
+impl AuditSink for TracingAuditSink {
+    async fn write(&mut self, record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
+        tracing::info!(
+            schema_version = record.schema_version,
+            request_id = %record.request_id,
+            operator = %record.operator,
+            client = ?record.client,
+            cluster = ?record.cluster,
+            tool = %record.tool,
+            risk_level = ?record.risk_level,
+            status = ?record.status,
+            duration_ms = record.duration_ms,
+            "rocketmq-mcp audit record"
+        );
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+struct MemoryAuditSink;
+
+#[async_trait]
+impl AuditSink for MemoryAuditSink {
+    async fn write(&mut self, _record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), ()> {
+        Ok(())
     }
 }
 
 async fn run_audit_writer(
-    mut receiver: mpsc::Receiver<AuditRecord>,
-    config: AuditConfig,
-    blocking: rocketmq_runtime::BlockingExecutor,
+    mut receiver: mpsc::Receiver<AuditEnvelope>,
+    mut sink: Box<dyn AuditSink>,
     counters: Arc<AuditCounters>,
+    records: Arc<Mutex<VecDeque<AuditRecord>>>,
+    completion: Arc<WriterCompletion>,
 ) {
-    while let Some(record) = receiver.recv().await {
-        let config = config.clone();
-        let write_result = match config.sink.as_str() {
-            "file" => {
-                let record = record.clone();
-                blocking
-                    .spawn_io("rocketmq-mcp-audit-file-write", move || {
-                        write_file_record(&config, &record)
-                    })
-                    .await
-                    .map_err(|error| error.to_string())
-                    .and_then(|result| result)
-            }
-            _ => write_sink(&config, &record),
-        };
-        if let Err(error) = write_result {
+    let completion = CompletionGuard(completion);
+    while let Some(envelope) = receiver.recv().await {
+        if sink.write(&envelope.record, &envelope.encoded).await.is_ok() {
+            push_record(&records, envelope.record);
+            counters.written.fetch_add(1, Ordering::Relaxed);
+        } else {
             counters.sink_failures.fetch_add(1, Ordering::Relaxed);
-            tracing::warn!(?error, "rocketmq-mcp asynchronous audit sink write failed");
+            tracing::warn!("rocketmq-mcp asynchronous audit sink write failed");
         }
+        drop(envelope.pending);
     }
+
+    if sink.flush().await.is_err() {
+        counters.flush_failures.fetch_add(1, Ordering::Relaxed);
+        tracing::warn!("rocketmq-mcp audit sink flush failed");
+    }
+    completion.0.finish(true);
 }
 
-fn write_sink(config: &AuditConfig, record: &AuditRecord) -> Result<(), String> {
-    match config.sink.as_str() {
-        "memory" => Ok(()),
-        "file" => write_file_record(config, record),
-        "tracing" => {
-            tracing::info!(
-                request_id = %record.request_id,
-                operator = %record.operator,
-                client = ?record.client,
-                tool = %record.tool,
-                risk_level = ?record.risk_level,
-                status = ?record.status,
-                duration_ms = record.duration_ms,
-                "rocketmq-mcp audit record"
-            );
-            Ok(())
-        }
-        sink => Err(format!("unknown rocketmq-mcp audit sink `{sink}`")),
+fn push_record(records: &Mutex<VecDeque<AuditRecord>>, record: AuditRecord) {
+    let Ok(mut records) = records.lock() else {
+        return;
+    };
+    if records.len() == MAX_AUDIT_RECORDS {
+        records.pop_front();
     }
+    records.push_back(record);
 }
 
-fn write_file_record(config: &AuditConfig, record: &AuditRecord) -> Result<(), String> {
-    let path = Path::new(&config.path);
+fn write_file_record(path: PathBuf, encoded: &[u8]) -> Result<(), ()> {
     if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("failed to create audit directory `{}`: {error}", parent.display()))?;
+        std::fs::create_dir_all(parent).map_err(|_| ())?;
     }
-    let line = serde_json::to_string(record).map_err(|error| format!("failed to serialize audit record: {error}"))?;
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
-        .map_err(|error| format!("failed to open audit file `{}`: {error}", config.path))?;
-    writeln!(file, "{line}").map_err(|error| format!("failed to write audit file `{}`: {error}", config.path))
+        .map_err(|_| ())?;
+    file.write_all(encoded).map_err(|_| ())
+}
+
+fn flush_audit_file(path: PathBuf) -> Result<(), ()> {
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|_| ())?;
+    file.sync_all().map_err(|_| ())
+}
+
+fn sanitize_record(mut record: AuditRecord) -> AuditRecord {
+    record.schema_version = AUDIT_SCHEMA_VERSION;
+    record.request_id = sanitize_field(&record.request_id, MAX_REQUEST_ID_BYTES);
+    record.operator = sanitize_field(&record.operator, MAX_IDENTITY_BYTES);
+    record.client = record
+        .client
+        .as_deref()
+        .map(|value| sanitize_field(value, MAX_IDENTITY_BYTES));
+    record.cluster = record
+        .cluster
+        .as_deref()
+        .map(|value| sanitize_field(value, MAX_IDENTITY_BYTES));
+    record.tool = sanitize_field(&record.tool, MAX_TOOL_BYTES);
+    record.arguments_hash = sanitize_field(&record.arguments_hash, MAX_ARGUMENTS_HASH_BYTES);
+    record.error = record
+        .error
+        .as_deref()
+        .map(|value| sanitize_field(value, MAX_ERROR_BYTES));
+    record
+}
+
+fn sanitize_field(value: &str, max_bytes: usize) -> String {
+    let sanitized = sanitize_text(value)
+        .chars()
+        .map(|character| if character.is_control() { '\u{fffd}' } else { character })
+        .collect::<String>();
+    truncate_utf8(&sanitized, max_bytes).to_string()
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn validate_queue_config(config: &AuditConfig) -> Result<(), GuardError> {
+    if config.queue_capacity == 0 {
+        return Err(GuardError::InvalidArgument(
+            "audit queue capacity must be greater than zero".to_string(),
+        ));
+    }
+    if config.max_record_bytes == 0 || config.queue_max_bytes < config.max_record_bytes {
+        return Err(GuardError::InvalidArgument(
+            "audit byte capacity must cover one non-empty record".to_string(),
+        ));
+    }
+    if config.queue_max_bytes > u32::MAX as usize {
+        return Err(GuardError::InvalidArgument(
+            "audit byte capacity exceeds the supported maximum".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn now_unix_ms() -> u128 {
@@ -261,3 +728,6 @@ fn now_unix_ms() -> u128 {
         .map(|duration| duration.as_millis())
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-tools/rocketmq-mcp/src/guard/audit/tests.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/audit/tests.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+
+use super::*;
+
+struct TestSinkState {
+    attempts: Mutex<Vec<String>>,
+    started: Notify,
+    release: Semaphore,
+    stall_first: AtomicBool,
+    failures_remaining: AtomicU64,
+    fail_flush: AtomicBool,
+}
+
+impl Default for TestSinkState {
+    fn default() -> Self {
+        Self {
+            attempts: Mutex::new(Vec::new()),
+            started: Notify::new(),
+            release: Semaphore::new(0),
+            stall_first: AtomicBool::new(false),
+            failures_remaining: AtomicU64::new(0),
+            fail_flush: AtomicBool::new(false),
+        }
+    }
+}
+
+struct TestAuditSink {
+    state: Arc<TestSinkState>,
+}
+
+#[async_trait]
+impl AuditSink for TestAuditSink {
+    async fn write(&mut self, record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
+        self.state
+            .attempts
+            .lock()
+            .expect("test sink attempts lock")
+            .push(record.request_id.clone());
+        self.state.started.notify_one();
+        if self.state.stall_first.swap(false, Ordering::AcqRel) {
+            let permit = self.state.release.acquire().await.map_err(|_| ())?;
+            drop(permit);
+        }
+        if self
+            .state
+            .failures_remaining
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(());
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), ()> {
+        if self.state.fail_flush.load(Ordering::Acquire) {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test]
+async fn memory_records_are_versioned_redacted_bounded_and_oversized_records_are_dropped() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-memory-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let mut config = test_config("memory");
+    log.start(&config, &service).unwrap();
+    log.record(
+        &config,
+        sample_record("request-1", Some("token=secret\nrequest failed".to_string())),
+    );
+
+    let records = log.records();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].schema_version, AUDIT_SCHEMA_VERSION);
+    let error = records[0].error.as_deref().expect("sanitized error");
+    assert!(!error.contains("secret"));
+    assert!(!error.contains('\n'));
+    assert!(error.contains('\u{fffd}'));
+
+    config.max_record_bytes = 64;
+    log.record(&config, sample_record("request-2", None));
+    let metrics = log.metrics();
+    assert_eq!(metrics.accepted, 1);
+    assert_eq!(metrics.written, 1);
+    assert_eq!(metrics.dropped, 1);
+    assert_eq!(metrics.oversized, 1);
+
+    config.max_record_bytes = 16 * 1024;
+    let report = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(1)))
+        .await;
+    assert_eq!(report.status, AuditDrainStatus::Drained);
+    log.record(&config, sample_record("request-after-close", None));
+    assert_eq!(log.metrics().closed_drops, 1);
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(1)))
+        .await;
+}
+
+#[tokio::test]
+async fn count_capacity_is_non_blocking_and_preserves_fifo_for_accepted_records() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-count-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let mut config = test_config("tracing");
+    config.queue_capacity = 1;
+    let state = Arc::new(TestSinkState::default());
+    state.stall_first.store(true, Ordering::Release);
+    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+        .unwrap();
+
+    log.record(&config, sample_record("request-1", None));
+    tokio::time::timeout(Duration::from_secs(1), state.started.notified())
+        .await
+        .expect("writer started");
+    log.record(&config, sample_record("request-2", None));
+    log.record(&config, sample_record("request-3", None));
+
+    let metrics = log.metrics();
+    assert_eq!(metrics.accepted, 2);
+    assert_eq!(metrics.count_capacity_drops, 1);
+    state.release.add_permits(1);
+    let report = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+    assert_eq!(report.status, AuditDrainStatus::Drained);
+    assert_eq!(report.written, 2);
+    assert_eq!(
+        *state.attempts.lock().unwrap(),
+        vec!["request-1".to_string(), "request-2".to_string()]
+    );
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+}
+
+#[tokio::test]
+async fn byte_capacity_is_non_blocking_independent_of_record_capacity() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-byte-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let mut config = test_config("tracing");
+    let encoded_len = log
+        .prepare_record(&config, sample_record("request-1", None))
+        .unwrap()
+        .1
+        .len();
+    config.max_record_bytes = encoded_len * 2;
+    config.queue_max_bytes = encoded_len * 2;
+    config.queue_capacity = 8;
+    let state = Arc::new(TestSinkState::default());
+    state.stall_first.store(true, Ordering::Release);
+    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+        .unwrap();
+
+    log.record(&config, sample_record("request-1", None));
+    tokio::time::timeout(Duration::from_secs(1), state.started.notified())
+        .await
+        .expect("writer started");
+    log.record(&config, sample_record("request-2", None));
+    log.record(&config, sample_record("request-3", None));
+
+    assert_eq!(log.metrics().accepted, 2);
+    assert_eq!(log.metrics().byte_capacity_drops, 1);
+    state.release.add_permits(1);
+    let report = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+    assert_eq!(report.status, AuditDrainStatus::Drained);
+    assert_eq!(report.pending_bytes, 0);
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+}
+
+#[tokio::test]
+async fn sink_failure_does_not_stop_fifo_writer_and_flush_failure_is_reported() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-failure-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let config = test_config("tracing");
+    let state = Arc::new(TestSinkState::default());
+    state.failures_remaining.store(1, Ordering::Release);
+    state.fail_flush.store(true, Ordering::Release);
+    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+        .unwrap();
+
+    for request_id in ["request-1", "request-2", "request-3"] {
+        log.record(&config, sample_record(request_id, None));
+    }
+    let report = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+
+    assert_eq!(report.status, AuditDrainStatus::Drained);
+    assert_eq!(report.accepted, 3);
+    assert_eq!(report.written, 2);
+    assert_eq!(report.sink_failures, 1);
+    assert_eq!(report.flush_failures, 1);
+    assert_eq!(
+        *state.attempts.lock().unwrap(),
+        vec![
+            "request-1".to_string(),
+            "request-2".to_string(),
+            "request-3".to_string()
+        ]
+    );
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+}
+
+#[tokio::test]
+async fn one_absolute_deadline_reports_stall_then_allows_a_later_drain() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-deadline-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let config = test_config("tracing");
+    let state = Arc::new(TestSinkState::default());
+    state.stall_first.store(true, Ordering::Release);
+    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+        .unwrap();
+    log.record(&config, sample_record("request-1", None));
+    tokio::time::timeout(Duration::from_secs(1), state.started.notified())
+        .await
+        .expect("writer started");
+
+    let timed_out = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_millis(10)))
+        .await;
+    assert_eq!(timed_out.status, AuditDrainStatus::TimedOut);
+    assert_eq!(timed_out.pending_records, 1);
+    log.record(&config, sample_record("request-after-close", None));
+    assert_eq!(log.metrics().closed_drops, 1);
+
+    state.release.add_permits(1);
+    let drained = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+    assert_eq!(drained.status, AuditDrainStatus::Drained);
+    assert_eq!(drained.pending_records, 0);
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+}
+
+#[tokio::test]
+async fn runtime_cancellation_releases_pending_capacity_without_claiming_a_drain() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-cancellation-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let log = AuditLog::default();
+    let config = test_config("tracing");
+    let state = Arc::new(TestSinkState::default());
+    state.stall_first.store(true, Ordering::Release);
+    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+        .unwrap();
+    log.record(&config, sample_record("request-cancelled", None));
+    tokio::time::timeout(Duration::from_secs(1), state.started.notified())
+        .await
+        .expect("writer started");
+
+    let deadline = rocketmq_runtime::ShutdownDeadline::after(Duration::from_millis(10));
+    let audit = log.close_and_drain(deadline).await;
+    assert_eq!(audit.status, AuditDrainStatus::TimedOut);
+    let runtime_report = runtime.shutdown_tasks_until(deadline).await;
+    assert!(!runtime_report.is_healthy());
+
+    let after_cancellation = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(1)))
+        .await;
+    assert_eq!(after_cancellation.status, AuditDrainStatus::TimedOut);
+    assert_eq!(after_cancellation.pending_records, 0);
+    assert_eq!(after_cancellation.pending_bytes, 0);
+}
+
+#[tokio::test]
+async fn file_sink_flushes_ndjson_through_the_blocking_boundary() {
+    let runtime = rocketmq_runtime::RuntimeContext::try_from_current("audit-file-test").unwrap();
+    let service = runtime.service_context("audit-writer");
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("audit.jsonl");
+    let log = AuditLog::default();
+    let mut config = test_config("file");
+    config.path = path.to_string_lossy().into_owned();
+    log.start(&config, &service).unwrap();
+    log.record(&config, sample_record("request-file", None));
+
+    let report = log
+        .close_and_drain(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+    assert_eq!(report.status, AuditDrainStatus::Drained);
+    assert_eq!(report.accepted, 1);
+    assert_eq!(report.written, 1);
+    let contents = std::fs::read_to_string(path).unwrap();
+    let record: serde_json::Value = serde_json::from_str(contents.trim()).unwrap();
+    assert_eq!(record["schema_version"], AUDIT_SCHEMA_VERSION);
+    assert_eq!(record["request_id"], "request-file");
+    runtime
+        .shutdown_tasks_until(rocketmq_runtime::ShutdownDeadline::after(Duration::from_secs(2)))
+        .await;
+}
+
+fn test_config(sink: &str) -> AuditConfig {
+    AuditConfig {
+        enabled: true,
+        sink: sink.to_string(),
+        path: String::new(),
+        queue_capacity: 16,
+        max_record_bytes: 16 * 1024,
+        queue_max_bytes: 1024 * 1024,
+    }
+}
+
+fn sample_record(request_id: &str, error: Option<String>) -> AuditRecord {
+    AuditRecord::new(
+        request_id.to_string(),
+        "operator-a".to_string(),
+        Some("client-a".to_string()),
+        Some("cluster-a".to_string()),
+        "rocketmq_get_cluster_overview".to_string(),
+        "0123456789abcdef".to_string(),
+        RiskLevel::ReadOnly,
+        AuditStatus::Success,
+        7,
+        error,
+    )
+}

--- a/rocketmq-tools/rocketmq-mcp/src/guard/http_auth.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/http_auth.rs
@@ -454,6 +454,8 @@ mod tests {
                 sink: "memory".to_string(),
                 path: String::new(),
                 queue_capacity: 16,
+                max_record_bytes: 16 * 1024,
+                queue_max_bytes: 1024 * 1024,
             },
             &[ClusterConfig {
                 name: "local-dev".to_string(),

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -952,6 +952,8 @@ mod tests {
                 sink: "memory".to_string(),
                 path: String::new(),
                 queue_capacity: 16,
+                max_record_bytes: 16 * 1024,
+                queue_max_bytes: 1024 * 1024,
             },
             &[ClusterConfig {
                 name: "local-dev".to_string(),

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -80,9 +80,9 @@
     },
     "rocketmq-mcp": {
       "crate_version": "1.0.0",
-      "public_path_count": 210,
-      "public_path_sha256": "1adf3bd1edbb5303001350b9b5649471e0a8f50a0acb3a75f094eae91efe3483",
-      "rustdoc_json_sha256": "d598a69858edb4c3622d170067d8c39ae4f64486dd2a093ff7824ce9ee527c7c",
+      "public_path_count": 217,
+      "public_path_sha256": "ec51fdf9aa133bfb1d64e5392f9665693ac0b8776cc4f74eaee6aa17a5f14643",
+      "rustdoc_json_sha256": "5a4627a1214fb0fe8dde7bd971fd63ab62a065e569934d8636fd7971182a9c9a",
       "target": "rocketmq_mcp"
     },
     "rocketmq-model": {
@@ -220,7 +220,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "760986f17312c13b74990b92a20242872cf64e54",
+  "source_commit": "45cfb8c3854613b6c2c42b74590f5e053f2aac84",
   "toolchain": {
     "cargo": "cargo 1.99.0-nightly (2f0e7011e 2026-07-05)",
     "rustc": "rustc 1.99.0-nightly (3659db0d3 2026-07-05)",


### PR DESCRIPTION
## Summary
- introduce versioned, redacted, deterministically bounded MCP audit records
- enforce independent record-count and byte admission with non-blocking producers and FIFO writer ownership under `ServiceContext`
- drain and flush audit before runtime shutdown using one absolute `ShutdownDeadline`, with explicit accepted/written/dropped/pending/failure reporting
- update MCP configuration, public API snapshot, migration checklist, and M11-06 evidence to 70/82

## Validation
- `cargo test -p rocketmq-mcp guard::audit::tests --lib` (7 passed)
- `cargo test -p rocketmq-mcp` (82 library tests plus local integrations passed; external cluster E2E ignored by contract)
- `cargo test -p rocketmq-mcp --all-features` (104 library tests plus local integrations passed)
- `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings`
- `cargo doc -p rocketmq-mcp --no-deps`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- architecture target/baseline dependency guards and release guard
- public API snapshot: 31/31 packages, differences=0 after reviewed MCP 210 -> 217 additive paths
- `git diff --check`

## Compatibility and gates
- old TOML receives defaults for both new byte limits; direct Rust struct literals require the documented additive fields
- default stdio, HTTPS/JWKS/principal propagation, and non-mutating `change-planning` behavior remain unchanged
- M10 performance/HUMAN, M11 ARCH/security-default HUMAN, M11, and Phase 3 gates remain open

Closes #8280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded, non-blocking audit buffering with record-size and byte-capacity limits.
  * Added sanitized, versioned audit records with FIFO writing and configurable sinks.
  * Added shutdown draining with deadlines and health reports.
  * Added audit acceptance, write, drop, overflow, and pending-work metrics.
* **Bug Fixes**
  * Improved handling of audit sink failures, flush failures, oversized records, and shutdown timeouts.
* **Documentation**
  * Updated configuration, troubleshooting, and rollout documentation with the new audit and shutdown behavior.
* **Tests**
  * Expanded coverage for capacity limits, sanitization, ordering, failures, flushing, and deadline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->