### PR TITLE
[ISSUE #8282]♻️Establish reproducible container foundation and supply-chain gates

### DIFF
--- a/.github/workflows/container-foundation-ci.yml
+++ b/.github/workflows/container-foundation-ci.yml
@@ -1,0 +1,74 @@
+name: Container Foundation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docker/**"
+      - "scripts/container_image_guard.py"
+      - "scripts/container-supply-chain.ps1"
+      - "scripts/tests/test_m11_container_foundation.py"
+      - ".github/workflows/container-foundation-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/**"
+      - "scripts/container_image_guard.py"
+      - "scripts/container-supply-chain.ps1"
+      - "scripts/tests/test_m11_container_foundation.py"
+      - ".github/workflows/container-foundation-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-foundation
+  cancel-in-progress: false
+
+jobs:
+  verify-foundation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.48.0
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+          cache: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Verify static container contract
+        run: |
+          python scripts/container_image_guard.py
+          python -m unittest scripts.tests.test_m11_container_foundation
+
+      - name: Build and verify runtime foundation
+        shell: pwsh
+        run: |
+          ./scripts/container-supply-chain.ps1 -OutputDirectory target/container-foundation
+
+      - name: Upload supply-chain evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: container-foundation
+          path: target/container-foundation/
+          if-no-files-found: error
+          retention-days: 14

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,131 @@
+# syntax=docker/dockerfile:1.7
+
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDER_IMAGE=docker.io/library/rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777
+ARG RUNTIME_IMAGE=docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+ARG DEBIAN_SNAPSHOT=20260717T000000Z
+ARG ROCKETMQ_RUST_TOOLCHAIN=nightly-2026-07-05
+
+FROM ${BUILDER_IMAGE} AS builder-base
+
+ARG DEBIAN_SNAPSHOT
+ARG ROCKETMQ_RUST_TOOLCHAIN
+
+# The timestamped Debian snapshot makes package resolution immutable for this foundation revision.
+# hadolint ignore=DL3008
+RUN <<EOF
+set -eux
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources
+cat > /etc/apt/sources.list.d/rocketmq-snapshot.sources <<SOURCES
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+SOURCES
+apt-get -o Acquire::Check-Valid-Until=false update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    git \
+    libclang-dev \
+    libssl-dev \
+    llvm \
+    make \
+    ninja-build \
+    pkg-config \
+    protobuf-compiler
+rm -rf /var/lib/apt/lists/*
+rustup toolchain install "${ROCKETMQ_RUST_TOOLCHAIN}" \
+    --profile minimal \
+    --component clippy,rustfmt
+EOF
+
+ENV CC=clang \
+    CXX=clang++ \
+    RUSTUP_TOOLCHAIN=${ROCKETMQ_RUST_TOOLCHAIN}
+
+WORKDIR /workspace
+
+FROM ${RUNTIME_IMAGE} AS runtime-base
+
+ARG DEBIAN_SNAPSHOT
+ARG SOURCE_REVISION=unknown
+ARG SOURCE_VERSION=0.0.0-dev
+
+# The timestamped Debian snapshot makes package resolution immutable for this foundation revision.
+# hadolint ignore=DL3008
+RUN <<EOF
+set -eux
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources
+cat > /etc/apt/sources.list.d/rocketmq-snapshot.sources <<SOURCES
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+SOURCES
+apt-get -o Acquire::Check-Valid-Until=false update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3
+rm -rf /var/lib/apt/lists/*
+groupadd --gid 10001 rocketmq
+useradd --uid 10001 --gid 10001 --home-dir /home/rocketmq --create-home --shell /usr/sbin/nologin rocketmq
+install -d -o 10001 -g 10001 /opt/rocketmq /var/lib/rocketmq /tmp/rocketmq
+EOF
+
+LABEL org.opencontainers.image.source="https://github.com/mxsm/rocketmq-rust" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.vendor="RocketMQ Rust Authors" \
+    org.opencontainers.image.title="RocketMQ Rust runtime foundation" \
+    org.opencontainers.image.version=${SOURCE_VERSION} \
+    org.opencontainers.image.revision=${SOURCE_REVISION} \
+    io.rocketmq.image.role="runtime-base" \
+    io.rocketmq.runtime.uid="10001" \
+    io.rocketmq.runtime.gid="10001" \
+    io.rocketmq.runtime.read-only-rootfs="required" \
+    io.rocketmq.runtime.data-path="/var/lib/rocketmq" \
+    io.rocketmq.runtime.tmpfs-path="/tmp/rocketmq"
+
+ENV HOME=/home/rocketmq \
+    TMPDIR=/tmp/rocketmq
+
+STOPSIGNAL SIGTERM
+USER 10001:10001
+WORKDIR /opt/rocketmq
+
+FROM runtime-base AS runtime-base-smoke
+
+CMD ["/bin/true"]

--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": 1,
+  "milestone": "M11-07",
+  "foundation_dockerfile": "docker/Dockerfile.base",
+  "base_images": {
+    "builder": {
+      "reference": "docker.io/library/rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777",
+      "source": "https://hub.docker.com/_/rust"
+    },
+    "runtime": {
+      "reference": "docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
+      "source": "https://hub.docker.com/_/debian"
+    }
+  },
+  "build": {
+    "rust_toolchain": "nightly-2026-07-05",
+    "debian_snapshot": "20260717T000000Z",
+    "builder_packages": [
+      "build-essential",
+      "ca-certificates",
+      "clang",
+      "cmake",
+      "git",
+      "libclang-dev",
+      "libssl-dev",
+      "llvm",
+      "make",
+      "ninja-build",
+      "pkg-config",
+      "protobuf-compiler"
+    ],
+    "runtime_packages": [
+      "ca-certificates",
+      "libssl3"
+    ],
+    "builder_target": "builder-base",
+    "runtime_target": "runtime-base",
+    "smoke_target": "runtime-base-smoke"
+  },
+  "runtime": {
+    "uid": 10001,
+    "gid": 10001,
+    "read_only_rootfs_required": true,
+    "writable_data_path": "/var/lib/rocketmq",
+    "tmpfs_path": "/tmp/rocketmq",
+    "default_command": [
+      "/bin/true"
+    ],
+    "required_labels": {
+      "io.rocketmq.image.role": "runtime-base",
+      "io.rocketmq.runtime.uid": "10001",
+      "io.rocketmq.runtime.gid": "10001",
+      "io.rocketmq.runtime.read-only-rootfs": "required",
+      "io.rocketmq.runtime.data-path": "/var/lib/rocketmq",
+      "io.rocketmq.runtime.tmpfs-path": "/tmp/rocketmq"
+    }
+  },
+  "naming": {
+    "repository_prefix": "ghcr.io/mxsm/rocketmq-rust",
+    "services": [
+      "broker",
+      "namesrv",
+      "controller",
+      "proxy",
+      "mcp"
+    ],
+    "immutable_tag_pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9a-f]{12}$",
+    "forbidden_tags": [
+      "latest",
+      "main",
+      "master"
+    ]
+  },
+  "supply_chain": {
+    "syft_version": "v1.48.0",
+    "trivy_version": "v0.72.0",
+    "cosign_version": "v3.1.2",
+    "sbom_format": "cyclonedx-json",
+    "critical_vulnerability_policy": {
+      "severity": "CRITICAL",
+      "maximum_findings": 0,
+      "ignore_unfixed": false
+    },
+    "signature": {
+      "format": "sigstore-bundle",
+      "ephemeral_test_key": true,
+      "private_key_must_be_deleted": true,
+      "published_digest_pattern": "^ghcr\\.io/mxsm/rocketmq-rust/(broker|namesrv|controller|proxy|mcp)@sha256:[0-9a-f]{64}$",
+      "certificate_identity_regexp": "^https://github\\.com/mxsm/rocketmq-rust/\\.github/workflows/[A-Za-z0-9._/-]+@refs/(heads/main|tags/[A-Za-z0-9._-]+)$",
+      "certificate_oidc_issuer": "https://token.actions.githubusercontent.com"
+    }
+  },
+  "workflow": {
+    "path": ".github/workflows/container-foundation-ci.yml",
+    "actions": {
+      "actions/checkout": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "docker/setup-buildx-action": "bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+      "anchore/sbom-action/download-syft": "e22c389904149dbc22b58101806040fa8d37a610",
+      "aquasecurity/setup-trivy": "81e514348e19b6112ce2a7e3ecbafe19c1e1f567",
+      "sigstore/cosign-installer": "6f9f17788090df1f26f669e9d70d6ae9567deba6",
+      "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    }
+  },
+  "compatibility_exceptions": [
+    {
+      "path": "docker/Dockerfile",
+      "expires_at": "M11-08",
+      "reason": "Existing combined service image remains unchanged until five independent service entrypoints are delivered."
+    }
+  ]
+}

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,15 +29,15 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 70 | 0 | 12 未开始；合计 12 尚未完成 | 82 |
+| PR 级工作包 | 71 | 0 | 11 未开始；合计 11 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 2（M10 待验收、M11 实施中） | 1（M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 12 个未开始工作包分布：M10 为 0 个、M11 为 6 个、M12 为 6 个。
+剩余 11 个未开始工作包分布：M10 为 0 个、M11 为 5 个、M12 为 6 个。
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
-`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-07。
+`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-08。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -570,7 +570,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] 默认 82 tests 与 all-features 104 tests 通过；stdio/HTTPS/JWKS/principal 与无副作用 `change-planning` 合同保持不变
   - [x] [`M11-06 证据`](phase-3-production-readiness/11-mcp-audit-drain-evidence.md) 记录实现、API 增量、验证矩阵、回滚和未签署 Gate
   - [x] 70/82 已完成、12 未完成，下一工作包 PR-M11-07；M10/M11/Phase 3/HUMAN/ARCH Gate 均未提前宣称完成
-- [ ] PR-M11-07：建立容器镜像基础
+- [x] PR-M11-07：建立容器镜像基础
+  - [x] 新增独立 `Dockerfile.base`，builder/runtime manifest 使用 reviewed digest，Rust nightly 与 Debian package snapshot 固定日期；旧组合镜像行为不变并登记为 M11-08 到期例外
+  - [x] runtime foundation 只从 pinned Debian runtime stage 构建，固定 UID/GID 10001、read-only rootfs、data volume/tmpfs、SIGTERM 和 OCI label 合同，无 shell/service entrypoint
+  - [x] `container-policy.json` 冻结五服务 GHCR 命名、immutable tag、工具版本、零 CRITICAL、Sigstore bundle 与 digest-only keyless image signature 规则
+  - [x] 静态 guard 与 6 组正向/故意违规测试通过，覆盖 mutable base、root、未固定 action、弱化 scanner/signature、未登记 Dockerfile、过期例外和 snapshot package 漂移
+  - [x] workflow action 全部按 40 位 SHA 固定；PowerShell AST、Actionlint v1.7.12、Hadolint v2.14.0 与 AGENTS routing 检查通过
+  - [x] Ubuntu workflow 已交付 build、non-root/read-only smoke、CycloneDX SBOM、Trivy、Cosign bundle 与 provenance artifact；本机/WSL 缺少容器和供应链工具，未把远端 workflow 写成已执行
+  - [x] [`M11-07 证据`](phase-3-production-readiness/11-container-foundation-evidence.md) 记录 immutable 输入、策略、验证边界、兼容例外与回滚
+  - [x] 71/82 已完成、11 未完成，下一工作包 PR-M11-08；M10/M11/Phase 3/HUMAN/ARCH 及容器动态 `[TEST]` Gate 均未提前宣称完成
 - [ ] PR-M11-08：交付五个服务镜像入口
 - [ ] PR-M11-09：交付 Helm 与 Kustomize 资产
 - [ ] PR-M11-10：统一 Probe、PreStop 与 Drain

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation、MCP HTTPS/JWKS/principal 与 audit drain，下一工作包为 PR-M11-07）
+> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation、MCP HTTPS/audit 与容器基础，下一工作包为 PR-M11-08）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；70/82 工作包完成，剩余 12 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；71/82 工作包完成，剩余 11 个
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-container-foundation-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-container-foundation-evidence.md
@@ -1,0 +1,104 @@
+# M11-07 容器镜像基础与供应链门禁实施证据
+
+## 1. 结论与进度边界
+
+PR-M11-07 已交付与旧组合镜像隔离的 container foundation：builder/runtime 输入按 manifest digest 固定，
+Rust nightly 与 Debian package repository 按日期固定；runtime 约束为数字 non-root、read-only rootfs、仅声明
+data volume 与 tmpfs 可写，并提供 SBOM、零 CRITICAL 漏洞、Sigstore bundle 和 digest-only keyless image
+signature 的执行模板与最小权限 workflow。
+
+工作包完成后总进度为 **71/82**，剩余 11 个工作包：M11 5 个、M12 6 个；下一工作包为 PR-M11-08。
+这里的“工作包完成”表示 foundation、policy、guard、动态验证 workflow 与回滚边界已实现，不表示远端容器
+workflow 已观察成功。当前动态 `[TEST]`、M11 入口 `[ARCH]`、安全默认迁移 `[HUMAN]`、M10 真实固定硬件
+baseline/candidate 与 `[HUMAN]` Gate 均未签署，也不等于 M11、Phase 3 或最终目标态 Gate 完成。
+
+| 项目 | 结果 |
+|---|---|
+| 工作包 | `PR-M11-07` |
+| GitHub Issue | `#8282` |
+| 主要 owner | `docker/Dockerfile.base`、`docker/container-policy.json`、container guard/workflow |
+| 新增依赖边 | 无 Cargo/目标 DAG 边；仅新增容器供应链 workflow |
+| 非目标 | 五服务 binary/entrypoint（M11-08）、Helm/Kustomize（M11-09）、probe/drain（M11-10） |
+
+## 2. 盘点、兼容例外与 immutable 输入
+
+盘点时仓库只有 `docker/Dockerfile`：它使用 mutable `latest-rust-slim`/`trixie-slim`，同时打包多个 binary，
+通过 shell 和 `ROCKETMQ_COMPONENT` 分发。M11-07 不静默改变既有部署，因此保留该文件原样，并在 versioned
+policy 中登记唯一 compatibility exception，强制 `expires_at = M11-08`。任何新增未登记 Dockerfile 或延长例外
+都会使 guard 失败。
+
+foundation 固定以下输入：
+
+| 输入 | 固定值 |
+|---|---|
+| Builder manifest | `rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777` |
+| Runtime manifest | `debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818` |
+| Rust toolchain | `nightly-2026-07-05`；官方 dist manifest 可用 |
+| Debian package snapshot | `20260717T000000Z`；Debian 与 security 的 bookworm Release 可用 |
+| Syft / Trivy / Cosign | `v1.48.0` / `v0.72.0` / `v3.1.2` |
+| GitHub Actions | checkout/buildx/tool installers/upload 均固定完整 40 位 commit SHA |
+
+Builder snapshot 安装 workspace native build 所需 clang/LLVM/CMake/Ninja/protobuf/OpenSSL 工具；runtime 从独立
+pinned Debian stage 开始，只安装同一 snapshot 的 CA 与 `libssl3`，不继承 builder layer，也不复制 repository
+source、编译器或调试产物。Hadolint 的 DL3008 只在两个使用 immutable snapshot 的 RUN 上窄化忽略，并在相邻
+注释记录理由。
+
+## 3. Runtime、命名与供应链合同
+
+- UID/GID 固定为 `10001:10001`，工作目录 `/opt/rocketmq`；基础镜像不提供 service/shell entrypoint，默认
+  command 仅为 `/bin/true`，服务入口由 M11-08 分别拥有。
+- rootfs 必须 read-only；唯一持久可写路径为 `/var/lib/rocketmq` volume，临时写路径为
+  `/tmp/rocketmq` tmpfs。OCI label 固定 role、uid/gid、read-only、data/tmpfs 语义，停止信号为 SIGTERM。
+- 五服务 repository 固定在 `ghcr.io/mxsm/rocketmq-rust/{broker,namesrv,controller,proxy,mcp}`，发布 tag 必须为
+  semantic version 加 12 位 commit；`latest/main/master` 禁止。
+- 本地 foundation 验证生成 CycloneDX JSON、Trivy JSON、Cosign SBOM bundle/public key 与 provenance JSON；
+  ephemeral private key 在 success/failure 路径均删除，不进入 artifact。
+- 生产 image signing 只接受五服务 GHCR `@sha256:` digest，keyless verify 固定 GitHub Actions OIDC issuer 和
+  本仓库 workflow identity regexp；tag 不能进入签名入口。实际 push/sign 由 M11-08 发布 workflow 调用。
+
+## 4. 动态 workflow 与证据边界
+
+`.github/workflows/container-foundation-ci.yml` 只申请 `contents: read`，不使用 `pull_request_target`、package
+write 或 OIDC。workflow 在 Ubuntu 安装固定版本工具，然后执行：
+
+1. 静态 guard 与 6 组故意违规测试；
+2. Buildx 构建 `runtime-base-smoke`，检查 OCI user/label；
+3. `--network none --read-only` 启动，只挂载声明 data volume/tmpfs，并验证 rootfs 写入失败；
+4. Syft 生成 CycloneDX、Trivy 对全部 CRITICAL（含 unfixed）执行 exit-code 1；
+5. Cosign 生成临时 key、签名/验证 SBOM bundle、删除 private key；
+6. 输出 source/image/base/toolchain/snapshot 与三个 artifact SHA-256 的 provenance，并上传 14 天 artifact。
+
+当前 Windows host 与 Ubuntu WSL 均无 Docker/Podman/Buildah/Syft/Trivy/Cosign；没有通过安装系统级容器
+daemon 扩大本工作包权限。因此本地未生成 image ID、SBOM、Trivy report 或 signature bundle，远端 workflow
+也按用户约定不等待完成。M11-08 的入口必须读取同一 source commit 的成功 artifact，否则动态 `[TEST]` 仍未
+满足，不能发布五服务镜像。
+
+## 5. 本地验证矩阵
+
+| Gate | 命令/范围 | 结果 |
+|---|---|---|
+| Container guard | `python scripts/container_image_guard.py` | 通过；2 个 Dockerfile、1 个 M11-08 到期例外 |
+| Positive/negative tests | `python -m unittest scripts.tests.test_m11_container_foundation -v` | 6/6 通过 |
+| Python syntax | `python -m py_compile ...` | 通过 |
+| PowerShell AST | `Parser::ParseFile(scripts/container-supply-chain.ps1)` | 通过 |
+| Workflow syntax | checksum-verified Actionlint `v1.7.12` | 通过 |
+| Dockerfile lint | checksum-verified Hadolint `v2.14.0` | 通过，无 finding |
+| Official input check | Docker Hub manifest API、Debian snapshot Release、Rust dist 与 action input | 通过 |
+| AGENTS routing | `scripts/check-agents-routing.ps1` | 通过：standalone Cargo 4、Node 3、routes 8 |
+| Architecture | target/baseline dependency guard；release guard | 通过：target ledger 35、dev-only 3、release topology 32/32 |
+| Text | `git diff --check` | 通过 |
+| Dynamic image suite | Docker/Syft/Trivy/Cosign workflow | 已交付，当前未观察执行；保持 open `[TEST]` |
+
+本工作包没有修改 Rust、Cargo manifest、公共 API、wire/storage 或运行时代码，因此不触发 Cargo、public API、
+runtime ownership、typed-error 或 RocksDB specialized gate。
+
+## 6. 回滚与剩余目标
+
+回滚必须整体移除 foundation Dockerfile、policy、guard/tests、supply-chain script、workflow 与本证据。旧组合
+Dockerfile 在 M11-07 期间仍是兼容路径；若任何服务已在 M11-08 采用新 foundation，则只能回到上一签名
+image digest，不能恢复 root、可写 rootfs、mutable tag、无 SBOM/scan/signature 或把五服务重新合并。
+
+剩余 M11 目标为：PR-M11-08 五服务镜像入口、M11-09 Helm/Kustomize、M11-10 probe/preStop/drain、
+M11-11 Kind/K3d fault matrix、M11-12 ArcMut/stable/SLO 收口。M12 仍有 6 个 AI Native 工作包。此外，M10
+仍缺真实固定硬件 baseline/candidate、原始数据 hash 与 `[HUMAN]` Gate；M11 入口 `[ARCH]`、安全默认迁移
+`[HUMAN]`、容器动态 `[TEST]`、Phase 3 和最终目标态 Gate 均未签署。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M11-01～06 已完成；下一工作包 PR-M11-07；部分依赖 M10 SLI） |
+| 状态 | 实施中（PR-M11-01～07 已完成；下一工作包 PR-M11-08；部分依赖 M10 SLI） |
 | 预计周期 | 4–6 周 |
 | 工作包 | 延续 WP01、WP03、WP05、WP07、WP14–WP16 |
 | 前置条件 | 32-package Gate；secure dry-run、ServiceContext、semantic owner、durability SLI 可用 |
@@ -133,10 +133,18 @@ runtime shutdown；超时、取消、drop、sink/flush failure 与 pending count
 ### PR-M11-07：容器镜像基础
 
 - [ ] 入口：`[ARCH]` runtime基础镜像、用户/文件系统、供应链和产物命名规则已冻结。
-- [ ] `[DEV]` 建统一多阶段构建、最小runtime、非root、read-only rootfs、SBOM、签名和漏洞扫描模板。
+- [x] `[DEV]` 建统一多阶段构建、最小runtime、非root、read-only rootfs、SBOM、签名和漏洞扫描模板。
 - [ ] `[TEST]` focused test：image build、non-root/read-only启动、SBOM生成、签名验证和critical vulnerability policy。
-- [ ] `[REV]` 检查不包含构建工具、源码、secret或调试产物，镜像可按digest复现。
-- [ ] 回滚点：使用上一签名基础镜像digest；不回滚安全用户/文件系统约束。
+- [x] `[REV]` 静态复核 runtime stage 不依赖 builder、不复制源码/secret/debug，manifest/toolchain/package snapshot/action/tool 均有 immutable 输入。
+- [x] 回滚点：使用上一签名基础镜像digest；不回滚安全用户/文件系统约束。
+
+完成证据：[`11-container-foundation-evidence.md`](11-container-foundation-evidence.md)。新增 foundation 与现有组合镜像
+隔离；builder/runtime manifest digest、Rust nightly 日期和 Debian snapshot 固定，runtime 使用数字非 root 身份与
+声明式 read-only/data/tmpfs contract。guard、负向测试、Actionlint、Hadolint 和 routing gate 均通过；Ubuntu
+workflow 将执行真实 build/smoke/SBOM/Trivy/Cosign/provenance。当前 Windows 与 WSL 无 Docker/Podman/Syft/
+Trivy/Cosign，且按交付约定不等待远端 CI，因此动态 `[TEST]` 保持未签署，必须在 M11-08 消费成功 artifact 后
+才能使用该 foundation 发布服务镜像。71/82 工作包完成，剩余 M11 5 个、M12 6 个，下一工作包为 PR-M11-08；
+M10 真实性能、M11 入口 `[ARCH]`/安全默认 `[HUMAN]`、M11 与 Phase 3 Gate 均未完成。
 
 ### PR-M11-08：五个服务镜像入口
 

--- a/scripts/container-supply-chain.ps1
+++ b/scripts/container-supply-chain.ps1
@@ -1,0 +1,170 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [string]$ImageRef = "rocketmq-rust/runtime-base:verification",
+    [string]$Dockerfile = "docker/Dockerfile.base",
+    [string]$OutputDirectory = "target/container-foundation",
+    [string]$PublishedImageDigest = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command failed with exit code $LASTEXITCODE"
+    }
+}
+
+foreach ($command in @("docker", "syft", "trivy", "cosign", "git")) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+        throw "required command is unavailable: $command"
+    }
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$dockerfilePath = (Resolve-Path (Join-Path $root $Dockerfile)).Path
+$outputPath = Join-Path $root $OutputDirectory
+New-Item -ItemType Directory -Force -Path $outputPath | Out-Null
+
+$policy = Get-Content -Raw -LiteralPath (Join-Path $root "docker/container-policy.json") | ConvertFrom-Json
+$sourceCommit = (& git -C $root rev-parse HEAD).Trim()
+$sourceEpoch = (& git -C $root show -s --format=%ct HEAD).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "failed to resolve source revision"
+}
+$sourceVersion = "1.0.0-$($sourceCommit.Substring(0, 12))"
+$env:SOURCE_DATE_EPOCH = $sourceEpoch
+
+Invoke-Checked docker buildx build --load --file $dockerfilePath --target $policy.build.smoke_target --tag $ImageRef --build-arg "SOURCE_REVISION=$sourceCommit" --build-arg "SOURCE_VERSION=$sourceVersion" $root
+
+$configuredUser = (& docker image inspect --format "{{.Config.User}}" $ImageRef).Trim()
+if ($LASTEXITCODE -ne 0 -or $configuredUser -ne "$($policy.runtime.uid):$($policy.runtime.gid)") {
+    throw "runtime image user mismatch: $configuredUser"
+}
+$labels = (& docker image inspect --format "{{json .Config.Labels}}" $ImageRef) | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0) {
+    throw "failed to inspect runtime image labels"
+}
+foreach ($property in $policy.runtime.required_labels.PSObject.Properties) {
+    $actual = $labels.PSObject.Properties[$property.Name].Value
+    if ($actual -ne $property.Value) {
+        throw "runtime image label mismatch: $($property.Name)"
+    }
+}
+
+$smoke = @(
+    "set -eu",
+    ('test "$(id -u)" = {0}' -f $policy.runtime.uid),
+    ('test "$(id -g)" = {0}' -f $policy.runtime.gid),
+    "! touch /opt/rocketmq/rootfs-must-stay-read-only 2>/dev/null",
+    "touch $($policy.runtime.writable_data_path)/data-write",
+    "touch $($policy.runtime.tmpfs_path)/tmp-write"
+) -join "; "
+Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m" $ImageRef /bin/sh -c $smoke
+
+$sbomPath = Join-Path $outputPath "runtime-base.cdx.json"
+$trivyPath = Join-Path $outputPath "runtime-base.trivy.json"
+$bundlePath = Join-Path $outputPath "runtime-base.sbom.sigstore.json"
+$keyPrefix = Join-Path $outputPath "ephemeral-container-foundation"
+$privateKey = "$keyPrefix.key"
+$publicKey = "$keyPrefix.pub"
+
+Invoke-Checked syft scan "docker:$ImageRef" --scope all-layers --output "cyclonedx-json=$sbomPath"
+Invoke-Checked trivy image --scanners vuln --severity CRITICAL --exit-code 1 --format json --output $trivyPath $ImageRef
+$sbom = Get-Content -Raw -LiteralPath $sbomPath | ConvertFrom-Json
+if ($sbom.bomFormat -ne "CycloneDX") {
+    throw "Syft output is not a CycloneDX SBOM"
+}
+$trivyReport = Get-Content -Raw -LiteralPath $trivyPath | ConvertFrom-Json
+$criticalFindings = @(
+    foreach ($result in @($trivyReport.Results)) {
+        $vulnerabilities = $result.PSObject.Properties["Vulnerabilities"]
+        if ($null -ne $vulnerabilities) {
+            foreach ($vulnerability in @($vulnerabilities.Value)) {
+                if ($vulnerability.Severity -eq "CRITICAL") {
+                    $vulnerability
+                }
+            }
+        }
+    }
+).Count
+if ($criticalFindings -gt $policy.supply_chain.critical_vulnerability_policy.maximum_findings) {
+    throw "critical vulnerability policy failed: $criticalFindings findings"
+}
+
+$oldPassword = $env:COSIGN_PASSWORD
+$randomBytes = New-Object byte[] 32
+$random = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+try {
+    $random.GetBytes($randomBytes)
+    $env:COSIGN_PASSWORD = [Convert]::ToBase64String($randomBytes)
+    Invoke-Checked cosign generate-key-pair --output-key-prefix $keyPrefix
+    Invoke-Checked cosign sign-blob --yes --key $privateKey --bundle $bundlePath $sbomPath
+    Invoke-Checked cosign verify-blob --key $publicKey --bundle $bundlePath $sbomPath
+}
+finally {
+    $random.Dispose()
+    $env:COSIGN_PASSWORD = $oldPassword
+    if (Test-Path -LiteralPath $privateKey) {
+        Remove-Item -LiteralPath $privateKey -Force
+    }
+}
+if (Test-Path -LiteralPath $privateKey) {
+    throw "ephemeral signing private key was not deleted"
+}
+
+$publishedImageVerified = $false
+if ($PublishedImageDigest) {
+    if ($PublishedImageDigest -notmatch $policy.supply_chain.signature.published_digest_pattern) {
+        throw "published image must be an approved GHCR service digest"
+    }
+    Invoke-Checked cosign sign --yes $PublishedImageDigest
+    Invoke-Checked cosign verify --certificate-identity-regexp $policy.supply_chain.signature.certificate_identity_regexp --certificate-oidc-issuer $policy.supply_chain.signature.certificate_oidc_issuer $PublishedImageDigest
+    $publishedImageVerified = $true
+}
+
+$imageId = (& docker image inspect --format "{{.Id}}" $ImageRef).Trim()
+$evidence = [ordered]@{
+    schema_version = 1
+    source_commit = $sourceCommit
+    source_date_epoch = [long]$sourceEpoch
+    image_ref = $ImageRef
+    image_id = $imageId
+    configured_user = $configuredUser
+    builder_image = $policy.base_images.builder.reference
+    runtime_image = $policy.base_images.runtime.reference
+    rust_toolchain = $policy.build.rust_toolchain
+    debian_snapshot = $policy.build.debian_snapshot
+    sbom_format = $sbom.bomFormat
+    critical_vulnerability_findings = $criticalFindings
+    sbom_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $sbomPath).Hash.ToLowerInvariant()
+    trivy_report_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $trivyPath).Hash.ToLowerInvariant()
+    signature_bundle_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $bundlePath).Hash.ToLowerInvariant()
+    private_key_retained = $false
+    published_image_digest = $PublishedImageDigest
+    published_image_verified = $publishedImageVerified
+}
+$evidence | ConvertTo-Json -Depth 8 | Set-Content -Encoding utf8 -LiteralPath (Join-Path $outputPath "provenance.json")
+Write-Host "CONTAINER_SUPPLY_CHAIN_OK image=$ImageRef output=$OutputDirectory"

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -1,0 +1,227 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = ROOT / "docker" / "container-policy.json"
+
+
+def load_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def audit_foundation(
+    policy: dict[str, Any],
+    dockerfile: str,
+    workflow: str,
+    supply_script: str,
+    dockerfiles: set[str],
+) -> list[str]:
+    findings: list[str] = []
+    if policy.get("schema_version") != 1:
+        findings.append("container policy schema_version must be 1")
+    if policy.get("milestone") != "M11-07":
+        findings.append("container policy milestone must be M11-07")
+
+    foundation = policy.get("foundation_dockerfile")
+    exceptions = policy.get("compatibility_exceptions", [])
+    registered = {foundation}
+    for exception in exceptions:
+        path = exception.get("path")
+        registered.add(path)
+        if exception.get("expires_at") != "M11-08":
+            findings.append(f"compatibility exception {path} must expire at M11-08")
+        if not str(exception.get("reason", "")).strip():
+            findings.append(f"compatibility exception {path} requires a reason")
+    for path in sorted(dockerfiles - registered):
+        findings.append(f"unregistered Dockerfile: {path}")
+    for path in sorted(registered - dockerfiles):
+        findings.append(f"registered Dockerfile does not exist: {path}")
+
+    builder_ref = policy["base_images"]["builder"]["reference"]
+    runtime_ref = policy["base_images"]["runtime"]["reference"]
+    for name, reference in (("builder", builder_ref), ("runtime", runtime_ref)):
+        if not re.fullmatch(r"[^\s@]+:[^\s@]+@sha256:[0-9a-f]{64}", reference):
+            findings.append(f"{name} base image must use a tag plus sha256 manifest digest")
+        if ":latest@" in reference:
+            findings.append(f"{name} base image must not use latest")
+    required_dockerfile_fragments = [
+        f"ARG BUILDER_IMAGE={builder_ref}",
+        f"ARG RUNTIME_IMAGE={runtime_ref}",
+        f"ARG DEBIAN_SNAPSHOT={policy['build']['debian_snapshot']}",
+        f"ARG ROCKETMQ_RUST_TOOLCHAIN={policy['build']['rust_toolchain']}",
+        "AS builder-base",
+        "AS runtime-base",
+        "AS runtime-base-smoke",
+        "snapshot.debian.org/archive/debian/",
+        "snapshot.debian.org/archive/debian-security/",
+        "Acquire::Check-Valid-Until=false",
+        f"USER {policy['runtime']['uid']}:{policy['runtime']['gid']}",
+        'CMD ["/bin/true"]',
+        "STOPSIGNAL SIGTERM",
+    ]
+    for fragment in required_dockerfile_fragments:
+        if fragment not in dockerfile:
+            findings.append(f"foundation Dockerfile missing: {fragment}")
+    for package in policy["build"]["builder_packages"] + policy["build"]["runtime_packages"]:
+        if not re.search(rf"(?m)^\s*{re.escape(package)}(?:\s|\\|$)", dockerfile):
+            findings.append(f"foundation Dockerfile missing pinned-snapshot package: {package}")
+    if re.search(r"(?im)^\s*ENTRYPOINT\b", dockerfile):
+        findings.append("foundation Dockerfile must not define a shell or service entrypoint")
+    if re.search(r"(?im)^\s*COPY\s+\.\s", dockerfile):
+        findings.append("foundation runtime must not copy the repository source")
+    if re.search(r"(?i)(?:^|[^a-z])latest(?:[^a-z]|$)", dockerfile):
+        findings.append("foundation Dockerfile contains a mutable latest tag")
+    for label, value in policy["runtime"]["required_labels"].items():
+        if f'{label}="{value}"' not in dockerfile:
+            findings.append(f"foundation Dockerfile missing required label {label}={value}")
+
+    runtime = policy["runtime"]
+    if runtime.get("uid") == 0 or runtime.get("gid") == 0:
+        findings.append("container runtime identity must be non-root")
+    if runtime.get("read_only_rootfs_required") is not True:
+        findings.append("container policy must require a read-only rootfs")
+    if runtime.get("default_command") != ["/bin/true"]:
+        findings.append("container foundation default command must remain /bin/true")
+
+    naming = policy["naming"]
+    if naming.get("repository_prefix") != "ghcr.io/mxsm/rocketmq-rust":
+        findings.append("container repository prefix drifted")
+    if set(naming.get("services", [])) != {"broker", "namesrv", "controller", "proxy", "mcp"}:
+        findings.append("container service naming set must contain the five M11 services")
+    try:
+        tag_pattern = re.compile(naming["immutable_tag_pattern"])
+    except (KeyError, re.error):
+        findings.append("container immutable tag pattern is invalid")
+    else:
+        if not tag_pattern.fullmatch("1.0.0-0123456789ab") or tag_pattern.fullmatch("latest"):
+            findings.append("container immutable tag pattern is not strict")
+    if set(naming.get("forbidden_tags", [])) != {"latest", "main", "master"}:
+        findings.append("container mutable tag deny-list drifted")
+
+    supply_chain = policy["supply_chain"]
+    vulnerability = supply_chain["critical_vulnerability_policy"]
+    if vulnerability != {
+        "severity": "CRITICAL",
+        "maximum_findings": 0,
+        "ignore_unfixed": False,
+    }:
+        findings.append("container critical vulnerability policy was weakened")
+    signature = supply_chain["signature"]
+    if signature.get("format") != "sigstore-bundle" or signature.get("private_key_must_be_deleted") is not True:
+        findings.append("container signature bundle/private-key policy was weakened")
+    expected_digest_pattern = (
+        r"^ghcr\.io/mxsm/rocketmq-rust/(broker|namesrv|controller|proxy|mcp)@sha256:[0-9a-f]{64}$"
+    )
+    if signature.get("published_digest_pattern") != expected_digest_pattern:
+        findings.append("published container signatures must require an approved GHCR service digest")
+    if signature.get("certificate_oidc_issuer") != "https://token.actions.githubusercontent.com":
+        findings.append("published container signatures must require the GitHub Actions OIDC issuer")
+
+    if "pull_request_target:" in workflow:
+        findings.append("container workflow must not use pull_request_target")
+    if "permissions:\n  contents: read" not in workflow:
+        findings.append("container workflow must declare contents: read")
+    for forbidden_permission in ("id-token: write", "packages: write", "contents: write"):
+        if forbidden_permission in workflow:
+            findings.append(f"container foundation workflow must not request {forbidden_permission}")
+    for action, sha in policy["workflow"]["actions"].items():
+        if f"uses: {action}@{sha}" not in workflow:
+            findings.append(f"container workflow must pin {action}@{sha}")
+    for version_key, input_name in (
+        ("syft_version", "syft-version"),
+        ("trivy_version", "version"),
+        ("cosign_version", "cosign-release"),
+    ):
+        version = policy["supply_chain"][version_key]
+        if f"{input_name}: {version}" not in workflow:
+            findings.append(f"container workflow must pin {input_name}: {version}")
+    for fragment in (
+        "python scripts/container_image_guard.py",
+        "scripts/container-supply-chain.ps1",
+        "target/container-foundation",
+    ):
+        if fragment not in workflow:
+            findings.append(f"container workflow missing: {fragment}")
+
+    script_fragments = [
+        "--read-only",
+        "--network",
+        "none",
+        "--tmpfs",
+        "--mount",
+        "$policy.runtime.tmpfs_path",
+        "$policy.runtime.writable_data_path",
+        "cyclonedx-json",
+        "--severity",
+        "CRITICAL",
+        "--exit-code",
+        "cosign",
+        "sign-blob",
+        "verify-blob",
+        "--bundle",
+        "Remove-Item -LiteralPath $privateKey",
+        "cosign sign --yes $PublishedImageDigest",
+        "cosign verify --certificate-identity-regexp",
+        "$policy.supply_chain.signature.published_digest_pattern",
+    ]
+    for fragment in script_fragments:
+        if fragment not in supply_script:
+            findings.append(f"container supply-chain script missing: {fragment}")
+    if "--ignore-unfixed" in supply_script:
+        findings.append("critical vulnerability gate must not ignore unfixed findings")
+    return findings
+
+
+def repository_dockerfiles(root: Path = ROOT) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in (root / "docker").glob("Dockerfile*")
+        if path.is_file()
+    }
+
+
+def main() -> int:
+    try:
+        policy = load_policy()
+        dockerfile = (ROOT / policy["foundation_dockerfile"]).read_text(encoding="utf-8")
+        workflow = (ROOT / policy["workflow"]["path"]).read_text(encoding="utf-8")
+        supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
+        findings = audit_foundation(policy, dockerfile, workflow, supply_script, repository_dockerfiles())
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(f"CONTAINER_IMAGE_GUARD_FAILED {error}", file=sys.stderr)
+        return 2
+    if findings:
+        for finding in findings:
+            print(f"CONTAINER_IMAGE_GUARD_FINDING {finding}", file=sys.stderr)
+        return 1
+    print(
+        "CONTAINER_IMAGE_GUARD_OK "
+        f"dockerfiles={len(repository_dockerfiles())} "
+        f"exceptions={len(policy['compatibility_exceptions'])} "
+        f"milestone={policy['milestone']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -1,0 +1,133 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_guard():
+    path = ROOT / "scripts" / "container_image_guard.py"
+    spec = importlib.util.spec_from_file_location("container_image_guard", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load container_image_guard.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+GUARD = load_guard()
+
+
+class ContainerFoundationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = GUARD.load_policy()
+        cls.dockerfile = (ROOT / cls.policy["foundation_dockerfile"]).read_text(encoding="utf-8")
+        cls.workflow = (ROOT / cls.policy["workflow"]["path"]).read_text(encoding="utf-8")
+        cls.supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
+        cls.dockerfiles = GUARD.repository_dockerfiles()
+
+    def audit(
+        self,
+        *,
+        policy=None,
+        dockerfile=None,
+        workflow=None,
+        supply_script=None,
+        dockerfiles=None,
+    ):
+        return GUARD.audit_foundation(
+            policy or self.policy,
+            dockerfile if dockerfile is not None else self.dockerfile,
+            workflow if workflow is not None else self.workflow,
+            supply_script if supply_script is not None else self.supply_script,
+            dockerfiles if dockerfiles is not None else self.dockerfiles,
+        )
+
+    def test_repository_foundation_contract_passes(self) -> None:
+        self.assertEqual([], self.audit())
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "container_image_guard.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("CONTAINER_IMAGE_GUARD_OK", result.stdout)
+
+    def test_mutable_base_or_root_identity_is_rejected(self) -> None:
+        mutable = self.dockerfile.replace(
+            self.policy["base_images"]["runtime"]["reference"],
+            "docker.io/library/debian:latest",
+        )
+        findings = self.audit(dockerfile=mutable)
+        self.assertTrue(any("ARG RUNTIME_IMAGE=" in finding for finding in findings))
+        self.assertTrue(any("mutable latest" in finding for finding in findings))
+
+        root = self.dockerfile.replace("USER 10001:10001", "USER 0:0")
+        self.assertTrue(any("USER 10001:10001" in finding for finding in self.audit(dockerfile=root)))
+
+    def test_unpinned_action_or_weakened_scanner_is_rejected(self) -> None:
+        checkout_sha = self.policy["workflow"]["actions"]["actions/checkout"]
+        workflow = self.workflow.replace(
+            f"actions/checkout@{checkout_sha}",
+            "actions/checkout@v7",
+        )
+        self.assertTrue(any("actions/checkout" in finding for finding in self.audit(workflow=workflow)))
+
+        weakened = self.supply_script.replace("--severity", "--ignore-unfixed --severity", 1)
+        self.assertTrue(any("must not ignore unfixed" in finding for finding in self.audit(supply_script=weakened)))
+
+    def test_unregistered_dockerfile_or_extended_exception_is_rejected(self) -> None:
+        dockerfiles = set(self.dockerfiles)
+        dockerfiles.add("docker/Dockerfile.unreviewed")
+        self.assertTrue(any("unregistered Dockerfile" in finding for finding in self.audit(dockerfiles=dockerfiles)))
+
+        policy = copy.deepcopy(self.policy)
+        policy["compatibility_exceptions"][0]["expires_at"] = "M11-12"
+        self.assertTrue(any("must expire at M11-08" in finding for finding in self.audit(policy=policy)))
+
+    def test_missing_read_only_or_signature_verification_is_rejected(self) -> None:
+        no_read_only = self.supply_script.replace("--read-only", "--read-write", 1)
+        self.assertTrue(any("--read-only" in finding for finding in self.audit(supply_script=no_read_only)))
+
+        no_verify = self.supply_script.replace("verify-blob", "verify-disabled", 1)
+        self.assertTrue(any("verify-blob" in finding for finding in self.audit(supply_script=no_verify)))
+
+    def test_weakened_policy_or_package_snapshot_is_rejected(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["supply_chain"]["critical_vulnerability_policy"]["maximum_findings"] = 1
+        self.assertTrue(any("vulnerability policy" in finding for finding in self.audit(policy=policy)))
+
+        policy = copy.deepcopy(self.policy)
+        policy["supply_chain"]["signature"]["published_digest_pattern"] = ".*"
+        self.assertTrue(any("GHCR service digest" in finding for finding in self.audit(policy=policy)))
+
+        missing_package = self.dockerfile.replace("    libssl3", "    removed-libssl3", 1)
+        self.assertTrue(any("libssl3" in finding for finding in self.audit(dockerfile=missing_package)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an isolated multi-stage builder/runtime foundation with pinned manifest digests, dated Rust nightly, and immutable Debian package snapshot
- freeze non-root/read-only/data/tmpfs/OCI label and five-service GHCR naming contracts in a versioned policy
- add executable guard and six positive/deliberate-violation tests for mutable inputs, root identity, action/tool pins, scanner/signature weakening, Dockerfile registration, and expiring compatibility
- add a least-privilege Ubuntu workflow for Buildx smoke, CycloneDX SBOM, zero-CRITICAL Trivy, Cosign bundle/provenance, plus optional digest-only keyless image signing for M11-08
- preserve the existing combined Dockerfile as an explicit compatibility exception expiring at M11-08 and update progress to 71/82

## Local validation
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation -v` (6 passed)
- Python compile and PowerShell AST parse
- checksum-verified Actionlint v1.7.12
- checksum-verified Hadolint v2.14.0
- `./scripts/check-agents-routing.ps1`
- target/baseline architecture dependency guards and release guard
- `git diff --check`

## Dynamic validation boundary
Docker/Podman/Buildah/Syft/Trivy/Cosign are unavailable on both the Windows host and WSL. The new Ubuntu workflow owns build, non-root/read-only smoke, SBOM, scan, signature bundle, and provenance artifact generation. Per the project delivery instruction this PR does not wait for CI; no dynamic image result is claimed before observation, and M11-08 must consume a successful same-commit artifact before publishing service images.

## Open gates
M10 performance/HUMAN, M11 ARCH/security-default HUMAN, container dynamic TEST, M11, and Phase 3 gates remain open.

Closes #8282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure, reproducible container foundation for Rust services.
  * Enforced non-root execution, read-only root filesystem support, pinned base images, and required runtime metadata.
  * Added automated image policy checks, vulnerability scanning, SBOM generation, and signature verification.
  * Added CI validation with downloadable supply-chain evidence artifacts.

* **Documentation**
  * Added production-readiness guidance, verification requirements, rollback rules, and updated migration progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->