### PR TITLE
[ISSUE #8290]♻️Add Kind/K3d architecture fault matrix gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+distribution/kubernetes/fault-matrix-policy.json text eol=lf
+scripts/tests/fixtures/m11-fault-matrix/pass/** text eol=lf

--- a/.github/workflows/kubernetes-assets-ci.yml
+++ b/.github/workflows/kubernetes-assets-ci.yml
@@ -11,6 +11,9 @@ on:
       - "scripts/kubernetes_assets_guard.py"
       - "scripts/tests/test_m11_kubernetes_assets.py"
       - "scripts/tests/test_m11_service_lifecycle.py"
+      - "scripts/fault_matrix_guard.py"
+      - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/tests/test_m11_fault_matrix.py"
   push:
     branches: [main]
     paths:
@@ -22,6 +25,9 @@ on:
       - "scripts/kubernetes_assets_guard.py"
       - "scripts/tests/test_m11_kubernetes_assets.py"
       - "scripts/tests/test_m11_service_lifecycle.py"
+      - "scripts/fault_matrix_guard.py"
+      - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/tests/test_m11_fault_matrix.py"
   workflow_dispatch:
 
 permissions:
@@ -42,6 +48,8 @@ jobs:
           python scripts/kubernetes_assets_guard.py
           python -m unittest scripts.tests.test_m11_kubernetes_assets -v
           python -m unittest scripts.tests.test_m11_service_lifecycle -v
+          python scripts/fault_matrix_guard.py --policy-only
+          python -m unittest scripts.tests.test_m11_fault_matrix -v
 
       - name: Validate canonical and overlay renders
         shell: pwsh

--- a/.github/workflows/kubernetes-fault-matrix.yml
+++ b/.github/workflows/kubernetes-fault-matrix.yml
@@ -1,0 +1,151 @@
+name: Kubernetes architecture fault matrix
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/kubernetes-fault-matrix.yml"
+      - "distribution/helm/**"
+      - "distribution/kubernetes/**"
+      - "docker/Dockerfile.base"
+      - "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/**"
+      - "scripts/fault_matrix_guard.py"
+      - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/tests/test_m11_fault_matrix.py"
+      - "scripts/tests/fixtures/m11-fault-matrix/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/kubernetes-fault-matrix.yml"
+      - "distribution/helm/**"
+      - "distribution/kubernetes/**"
+      - "docker/Dockerfile.base"
+      - "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/**"
+      - "scripts/fault_matrix_guard.py"
+      - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/tests/test_m11_fault_matrix.py"
+      - "scripts/tests/fixtures/m11-fault-matrix/**"
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: Dynamic cluster backend
+        required: true
+        type: choice
+        options: [kind, k3d]
+      baseline_images_json:
+        description: Five baseline service image@sha256 references
+        required: true
+        type: string
+      candidate_images_json:
+        description: Five candidate service image@sha256 references
+        required: true
+        type: string
+      collector_image:
+        description: OpenTelemetry Collector image@sha256 reference
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  static-contract:
+    name: Policy, fixture, and deliberate violations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Validate policy and fixture evidence
+        shell: bash
+        run: |
+          python scripts/fault_matrix_guard.py --policy-only
+          python scripts/fault_matrix_guard.py \
+            --evidence scripts/tests/fixtures/m11-fault-matrix/pass \
+            --allow-fixture
+          python -m unittest scripts.tests.test_m11_fault_matrix -v
+
+      - name: Validate PowerShell entrypoint without dynamic execution
+        shell: pwsh
+        run: ./scripts/kind-architecture-refactor-e2e.ps1 -Mode Validate
+
+  dynamic-fault-matrix:
+    name: Dynamic ${{ inputs.backend }} fault matrix
+    if: github.event_name == 'workflow_dispatch'
+    needs: static-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Install digest-verified cluster tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --silent --show-error \
+            --output /tmp/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-linux-amd64
+          echo 'a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b  /tmp/kind' | sha256sum --check
+          sudo install -m 0755 /tmp/kind /usr/local/bin/kind
+
+          curl --fail --location --silent --show-error \
+            --output /tmp/k3d https://github.com/k3d-io/k3d/releases/download/v5.9.0/k3d-linux-amd64
+          echo '06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0  /tmp/k3d' | sha256sum --check
+          sudo install -m 0755 /tmp/k3d /usr/local/bin/k3d
+
+          curl --fail --location --silent --show-error \
+            --output /tmp/kubectl https://dl.k8s.io/release/v1.32.2/bin/linux/amd64/kubectl
+          echo '4f6a959dcc5b702135f8354cc7109b542a2933c46b808b248a214c1f69f817ea  /tmp/kubectl' | sha256sum --check
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+          curl --fail --location --silent --show-error \
+            --output /tmp/helm.tgz https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz
+          echo 'e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c  /tmp/helm.tgz' | sha256sum --check
+          tar -xzf /tmp/helm.tgz -C /tmp
+          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+
+      - name: Materialize explicit dynamic inputs
+        shell: bash
+        env:
+          BASELINE_IMAGES: ${{ inputs.baseline_images_json }}
+          CANDIDATE_IMAGES: ${{ inputs.candidate_images_json }}
+          RUNTIME_SECRET_B64: ${{ secrets.M11_RUNTIME_SECRET_MANIFEST_B64 }}
+          ROTATED_RUNTIME_SECRET_B64: ${{ secrets.M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64 }}
+          BASELINE_DRIVER_SECRET_B64: ${{ secrets.M11_BASELINE_DRIVER_SECRET_MANIFEST_B64 }}
+          ROTATED_DRIVER_SECRET_B64: ${{ secrets.M11_ROTATED_DRIVER_SECRET_MANIFEST_B64 }}
+        run: |
+          set -euo pipefail
+          test -n "$RUNTIME_SECRET_B64"
+          test -n "$ROTATED_RUNTIME_SECRET_B64"
+          test -n "$BASELINE_DRIVER_SECRET_B64"
+          test -n "$ROTATED_DRIVER_SECRET_B64"
+          mkdir -p target/fault-inputs
+          printf '%s' "$BASELINE_IMAGES" > target/fault-inputs/baseline-images.json
+          printf '%s' "$CANDIDATE_IMAGES" > target/fault-inputs/candidate-images.json
+          printf '%s' "$RUNTIME_SECRET_B64" | base64 --decode > target/fault-inputs/runtime-secret.yaml
+          printf '%s' "$ROTATED_RUNTIME_SECRET_B64" | base64 --decode > target/fault-inputs/rotated-runtime-secret.yaml
+          printf '%s' "$BASELINE_DRIVER_SECRET_B64" | base64 --decode > target/fault-inputs/baseline-driver-secret.yaml
+          printf '%s' "$ROTATED_DRIVER_SECRET_B64" | base64 --decode > target/fault-inputs/rotated-driver-secret.yaml
+
+      - name: Execute real fault matrix
+        shell: pwsh
+        run: >-
+          ./scripts/kind-architecture-refactor-e2e.ps1
+          -Mode Run
+          -Backend '${{ inputs.backend }}'
+          -BaselineImageMap target/fault-inputs/baseline-images.json
+          -CandidateImageMap target/fault-inputs/candidate-images.json
+          -RuntimeSecretManifest target/fault-inputs/runtime-secret.yaml
+          -RotatedRuntimeSecretManifest target/fault-inputs/rotated-runtime-secret.yaml
+          -BaselineDriverSecretManifest target/fault-inputs/baseline-driver-secret.yaml
+          -RotatedDriverSecretManifest target/fault-inputs/rotated-driver-secret.yaml
+          -CollectorImage '${{ inputs.collector_image }}'
+
+      - name: Upload immutable fault evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: m11-11-${{ inputs.backend }}-${{ github.sha }}
+          path: target/architecture-refactor/M11/fault-matrix
+          if-no-files-found: error
+          retention-days: 30

--- a/distribution/helm/rocketmq-rust/templates/configmaps.yaml
+++ b/distribution/helm/rocketmq-rust/templates/configmaps.yaml
@@ -11,7 +11,7 @@ data:
     brokerIp1 = "rocketmq-broker-0.rocketmq-broker-headless.{{ .Release.Namespace }}.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/broker"
     namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876"
-    autoCreateTopicEnable = false
+    autoCreateTopicEnable = {{ .Values.services.broker.autoCreateTopicEnable }}
     authConfigPath = "/var/lib/rocketmq/broker/auth"
     aclFile = "/var/run/secrets/rocketmq/broker-acl.yml"
     aclFileWatchEnabled = true

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -229,6 +229,7 @@
       "additionalProperties": false,
       "required": [
         "replicas",
+        "autoCreateTopicEnable",
         "image",
         "persistence",
         "resources"
@@ -236,6 +237,9 @@
       "properties": {
         "replicas": {
           "const": 1
+        },
+        "autoCreateTopicEnable": {
+          "type": "boolean"
         },
         "image": {
           "$ref": "#/definitions/digest"

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -21,6 +21,7 @@ networkPolicy:
 services:
   broker:
     replicas: 1
+    autoCreateTopicEnable: false
     image:
       digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
     persistence:

--- a/distribution/kubernetes/README.md
+++ b/distribution/kubernetes/README.md
@@ -7,8 +7,10 @@ verified, signed `ghcr.io/mxsm/rocketmq-rust/<service>@sha256:<64 hex>` referenc
 Controller ClusterIPs are validation fixtures as well. A production overlay must replace them with unused, reserved
 addresses from that cluster's Service CIDR in both the ordinal Services and the three Controller config entries.
 
-The chart and Kustomize assets deliberately contain no readiness/liveness probe, `preStop`, or grace-period budget.
-Those lifecycle semantics belong to PR-M11-10 and must not be approximated with TCP-open checks.
+The chart and Kustomize assets use the shared M11-10 HTTP lifecycle contract: `/readyz` rejects new work before drain,
+`/livez` reports progress, `/drainz` initiates the same absolute 45-second shutdown deadline as SIGTERM, and the Pod
+termination grace is 60 seconds. TCP-open and startup probes remain forbidden because they do not prove service
+readiness or durable drain completion.
 
 ## State and security boundaries
 
@@ -30,6 +32,10 @@ Those lifecycle semantics belong to PR-M11-10 and must not be approximated with 
 ```powershell
 .\scripts\kubernetes-assets-contract.ps1
 python -m unittest scripts.tests.test_m11_kubernetes_assets -v
+python scripts/fault_matrix_guard.py --policy-only
+python scripts/fault_matrix_guard.py --evidence scripts/tests/fixtures/m11-fault-matrix/pass --allow-fixture
+python -m unittest scripts.tests.test_m11_fault_matrix -v
+.\scripts\kind-architecture-refactor-e2e.ps1 -Mode Validate
 ```
 
 To regenerate the committed Kustomize base after an intentional chart change:
@@ -41,3 +47,17 @@ To regenerate the committed Kustomize base after an intentional chart change:
 The script downloads Helm, Kustomize, and Kubeconform only from pinned upstream releases, verifies their SHA-256 hashes,
 requires the default chart to reject unpublished digests, checks deterministic chart/base parity, validates both secure
 renders against Kubernetes 1.32 schemas, and runs the deployment policy guard.
+
+## Dynamic fault evidence
+
+`scripts/kind-architecture-refactor-e2e.ps1 -Mode Run` is the only path that may emit M11-11 dynamic PASS evidence. It
+requires Docker plus Kind or K3d, five baseline and candidate `image@sha256` references, an explicitly pinned collector
+image, and operator-supplied baseline/rotated runtime and fault-driver Secret manifests. It executes rolling upgrade,
+node eviction, collector outage, scheduling-level disk pressure, Controller leader loss, credential rotation, and
+acknowledged-message recovery. Its evidence includes cluster/tool profiles, chart/overlay hashes, events, exact Queue and
+CommitLog offsets, PVC UIDs, rollback results, and artifact hashes. Missing prerequisites or any failed durability,
+drain, SLO, quorum, secret-redaction, cleanup, or rollback assertion fails closed and leaves no `run.json` PASS record.
+
+The committed positive fixture is intentionally marked `fixture=true` and `dynamic_execution=false`; it is accepted only
+with `--allow-fixture` and can test the evidence parser but can never satisfy the real Kind/K3d Gate. The dynamic workflow
+is manually dispatched with protected secret inputs and uploads the immutable evidence directory for independent review.

--- a/distribution/kubernetes/fault-matrix-policy.json
+++ b/distribution/kubernetes/fault-matrix-policy.json
@@ -1,0 +1,237 @@
+{
+  "schema_version": 1,
+  "milestone": "M11-11",
+  "evidence_schema_version": 1,
+  "backends": [
+    "kind",
+    "k3d"
+  ],
+  "kubernetes_version": "1.32.2",
+  "cluster": {
+    "control_plane_nodes": 1,
+    "worker_nodes": 3,
+    "controller_replicas": 3,
+    "controller_quorum": 2,
+    "kind_node_image": "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",
+    "kind_service_cidr": "10.96.0.0/16",
+    "k3d_service_cidr": "10.43.0.0/16",
+    "storage_classes": {
+      "kind": "standard",
+      "k3d": "local-path"
+    }
+  },
+  "tools": {
+    "kind": "v0.27.0",
+    "k3d": "v5.9.0",
+    "kubectl": "v1.32.2",
+    "helm": "v4.2.3"
+  },
+  "images": {
+    "required_services": [
+      "broker",
+      "namesrv",
+      "controller",
+      "proxy",
+      "mcp"
+    ],
+    "digest_pattern": "^[^@\\s]+@sha256:[0-9a-f]{64}$",
+    "placeholder_digest_forbidden": true,
+    "fault_driver_target": "fault-driver",
+    "fault_driver_test_only": true
+  },
+  "global_assertions": [
+    "all_workloads_ready",
+    "all_faults_reverted",
+    "controller_quorum_restored",
+    "pvc_uid_set_preserved",
+    "acknowledged_message_recovered",
+    "queue_offset_preserved",
+    "commitlog_offset_preserved",
+    "drain_completed_within_deadline",
+    "slo_budget_satisfied",
+    "rollback_verified",
+    "unresolved_faults_empty"
+  ],
+  "scenarios": [
+    {
+      "id": "rolling_upgrade",
+      "timeout_seconds": 600,
+      "injection": "replace the five baseline image digests with candidate digests one workload at a time",
+      "recovery": "rollback every changed workload to its baseline digest",
+      "required_assertions": [
+        "rollout_completed",
+        "acknowledged_message_visible",
+        "queue_offset_preserved",
+        "commitlog_offset_preserved",
+        "drain_completed_within_deadline",
+        "rollback_completed",
+        "pvc_uid_set_preserved"
+      ],
+      "required_evidence": [
+        "rollout_status",
+        "message_before",
+        "message_after",
+        "shutdown_report",
+        "rollback_status",
+        "pvc_uids"
+      ]
+    },
+    {
+      "id": "node_eviction",
+      "timeout_seconds": 300,
+      "injection": "cordon and drain one worker with eviction API while respecting PodDisruptionBudgets",
+      "recovery": "uncordon the worker and wait for the stateless workload to recover",
+      "required_assertions": [
+        "eviction_api_used",
+        "pdb_respected",
+        "acknowledged_message_visible",
+        "pvc_uid_set_preserved",
+        "node_uncordoned"
+      ],
+      "required_evidence": [
+        "drain_output",
+        "pdb_status",
+        "message_after",
+        "pvc_uids",
+        "node_status"
+      ]
+    },
+    {
+      "id": "collector_outage",
+      "timeout_seconds": 300,
+      "injection": "scale the OpenTelemetry collector to zero",
+      "recovery": "restore the collector replica count and wait for exporter recovery",
+      "required_assertions": [
+        "data_plane_remained_available",
+        "telemetry_queue_bounded",
+        "collector_recovered",
+        "slo_budget_satisfied"
+      ],
+      "required_evidence": [
+        "collector_scale",
+        "message_during_outage",
+        "telemetry_metrics",
+        "collector_recovery",
+        "slo_report"
+      ]
+    },
+    {
+      "id": "disk_pressure",
+      "timeout_seconds": 300,
+      "injection": "taint one worker with node.kubernetes.io/disk-pressure:NoSchedule and evict a stateless Pod",
+      "recovery": "remove the taint and verify scheduling and durability",
+      "required_assertions": [
+        "disk_pressure_taint_observed",
+        "stateless_pod_rescheduled",
+        "acknowledged_message_visible",
+        "pvc_uid_set_preserved",
+        "taint_removed"
+      ],
+      "required_evidence": [
+        "taint_status",
+        "pod_reschedule",
+        "message_after",
+        "pvc_uids",
+        "node_status"
+      ]
+    },
+    {
+      "id": "controller_leader_failure",
+      "timeout_seconds": 300,
+      "injection": "delete the current Controller leader Pod",
+      "recovery": "wait for a different elected leader and three ready Controller replicas",
+      "required_assertions": [
+        "leader_changed",
+        "controller_quorum_preserved",
+        "acknowledged_message_visible",
+        "controller_replicas_restored"
+      ],
+      "required_evidence": [
+        "leader_before",
+        "leader_after",
+        "quorum_status",
+        "message_after",
+        "controller_status"
+      ]
+    },
+    {
+      "id": "secret_rotation",
+      "timeout_seconds": 300,
+      "injection": "atomically replace runtime ACL material and restart the affected workload",
+      "recovery": "restore the baseline secret and verify baseline credentials after rollback",
+      "required_assertions": [
+        "old_credentials_worked_before_rotation",
+        "old_credentials_rejected_after_rotation",
+        "new_credentials_worked_after_rotation",
+        "baseline_credentials_restored",
+        "secret_values_redacted"
+      ],
+      "required_evidence": [
+        "pre_rotation_access",
+        "old_access_denied",
+        "new_access_allowed",
+        "rollback_access",
+        "redaction_scan"
+      ]
+    },
+    {
+      "id": "acknowledged_message_recovery",
+      "timeout_seconds": 300,
+      "injection": "restart the Broker after recording a successful send acknowledgement",
+      "recovery": "wait for Broker readiness and query the same unique key",
+      "required_assertions": [
+        "send_acknowledged",
+        "message_visible_before_restart",
+        "message_visible_after_restart",
+        "message_id_preserved",
+        "queue_offset_preserved",
+        "commitlog_offset_preserved",
+        "pvc_uid_set_preserved"
+      ],
+      "required_evidence": [
+        "send_ack",
+        "message_before",
+        "broker_restart",
+        "message_after",
+        "watermark",
+        "pvc_uids"
+      ]
+    }
+  ],
+  "evidence": {
+    "run_file": "run.json",
+    "scenario_directory": "scenarios",
+    "artifact_directory": "artifacts",
+    "production_requires_dynamic_execution": true,
+    "fixture_requires_explicit_opt_in": true,
+    "required_run_fields": [
+      "schema_version",
+      "milestone",
+      "policy_sha256",
+      "run_id",
+      "started_at",
+      "finished_at",
+      "backend",
+      "dynamic_execution",
+      "fixture",
+      "cluster_profile",
+      "tool_versions",
+      "chart_sha256",
+      "overlay_sha256",
+      "baseline_images",
+      "candidate_images",
+      "global_assertions",
+      "unresolved_faults",
+      "scenarios",
+      "artifacts"
+    ],
+    "artifact_hash_algorithm": "sha256"
+  },
+  "rollback": {
+    "restore_baseline_digests": true,
+    "restore_baseline_chart": true,
+    "delete_pvcs": false,
+    "delete_wal": false,
+    "preserve_evidence": true
+  }
+}

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -188,6 +188,28 @@ ENV HOME=/var/lib/rocketmq \
 VOLUME ["/var/lib/rocketmq"]
 USER 10001:10001
 
+FROM builder-base AS fault-driver-builder
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/workspace/target,sharing=locked <<EOF
+set -eux
+cargo build --locked --release --package rocketmq-admin-cli --bin rocketmq-admin-cli
+install -D -m 0555 /workspace/target/release/rocketmq-admin-cli /opt/rocketmq-binaries/rocketmq-admin-cli
+EOF
+
+FROM runtime-base AS fault-driver
+
+COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/rocketmq-admin-cli /usr/local/bin/rocketmq-admin-cli
+
+LABEL org.opencontainers.image.title="RocketMQ Rust architecture fault driver" \
+    io.rocketmq.image.role="fault-driver-test-only" \
+    io.rocketmq.image.production="forbidden"
+
+ENTRYPOINT ["/usr/local/bin/rocketmq-admin-cli"]
+
 FROM service-runtime AS broker
 
 COPY --from=service-builder --chmod=0555 /opt/rocketmq-binaries/rocketmq-broker-rust /usr/local/bin/rocketmq-broker-rust

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -29,15 +29,15 @@
 
 | 指标 | 已完成 | 进行中 | 未开始/未完成 | 目标 |
 |---|---:|---:|---:|---:|
-| PR 级工作包 | 74 | 0 | 8 未开始；合计 8 尚未完成 | 82 |
+| PR 级工作包 | 75 | 0 | 7 未开始；合计 7 尚未完成 | 82 |
 | 里程碑 | 9（M01–M09） | 2（M10 待验收、M11 实施中） | 1（M12） | 12 |
 | 新增边界 crate | 10 | 0 | 0 | 10 |
 | 根 workspace package | 32 | — | 0 | 32 |
 | Phase Gate | 2 | 1（Phase 3） | 1（Phase 4） | 4 |
 
-剩余 8 个未开始工作包分布：M10 为 0 个、M11 为 2 个、M12 为 6 个。
+剩余 7 个未开始工作包分布：M10 为 0 个、M11 为 1 个、M12 为 6 个。
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
-`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-11。
+`待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
 目标态依赖债务不能与工作包计数混用：`architecture_dependency_guard.py --mode target` 当前严格通过，
 表示未登记的目标 DAG finding 为 0；它不表示 R0 兼容依赖已经物理删除。现存边分为 35 条精确
@@ -606,7 +606,15 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] runtime 状态机、Proxy 双监听 barrier、Broker deadline/final flush、NameServer drain、Controller shutdown、observability budget 与 MCP 83-test/HTTP Clippy/Rustdoc 门禁通过
   - [x] [`M11-10 证据`](phase-3-production-readiness/11-probe-prestop-drain-evidence.md) 记录状态语义、阶段顺序、验证矩阵、未签署动态 Gate 与不恢复假 readiness 的回滚边界
   - [x] 74/82 已完成、8 未完成，下一工作包 PR-M11-11；M10/M11/Phase 3/HUMAN、容器动态 `[TEST]` 与 Kind/K3d fault/已确认消息恢复 Gate 均未提前宣称完成
-- [ ] PR-M11-11：完成 Kind/K3d fault matrix Gate
+- [x] PR-M11-11：完成 Kind/K3d fault matrix 实现与证据门禁
+  - [x] Kind v0.27.0/Kubernetes 1.32.2、K3d v5.9.0、1 control-plane + 3 workers、Controller 3/2 quorum 和 storage class profile 已版本化
+  - [x] `kind-architecture-refactor-e2e.ps1` 实现 rolling upgrade、node eviction、collector outage、disk-pressure taint、Controller leader failure、secret rotation 与 acknowledged recovery
+  - [x] 断言覆盖 message ID、Queue/CommitLog offset、PVC UID、quorum、preStop、SLO、五镜像回滚和 fault cleanup，不以 Pod Ready 单独判定成功
+  - [x] production evidence 强制 `dynamic_execution=true`/`fixture=false`，并校验 policy/chart/overlay/image/artifact SHA-256；fixture 必须显式 opt-in
+  - [x] test-only fault-driver、管理 CLI 环境 ACL HMAC-SHA256、manual dynamic workflow 与 11 组正负证据测试落地
+  - [ ] 本机无 Docker/Kind/K3d/Kubectl/Helm、目标签名镜像和 Secret，七场景真实动态执行未运行，Kind/K3d Gate 保持待验收
+  - [x] [`M11-11 证据`](phase-3-production-readiness/11-kind-k3d-fault-matrix-evidence.md) 记录完成边界、验证结果、未签署动态 Gate 与不删除 PVC/WAL 的回滚策略
+  - [x] 75/82 已完成、7 未完成，下一工作包 PR-M11-12；M10/M11/Phase 3/HUMAN 与真实 fault Gate 均未提前宣称完成
 - [ ] PR-M11-12：完成 ArcMut、stable 与 SLO Phase 3 收口
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -1,10 +1,10 @@
 # RocketMQ Rust 架构重构迁移执行手册
 
-> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation、MCP HTTPS/audit、五服务镜像、Helm/Kustomize 与统一 probe/preStop/drain，下一工作包为 PR-M11-11）
+> 状态：实施中（Phase 3；M10 真实性能/HUMAN Gate 待验收，M11 已完成安全 profile/bootstrap/rotation、MCP HTTPS/audit、五服务镜像、Helm/Kustomize、统一 probe/preStop/drain 与 Kind/K3d fault 执行/证据门禁，下一工作包为 PR-M11-12）
 > 设计依据：[`docs/architecture-refactor-design.md`](../../architecture-refactor-design.md)
 > 架构审计基线：`f545d638`
 > crate 与源码迁移复核基线：`6d152248`
-> 当前复核状态：根 workspace 已达到目标 32 个 package；74/82 工作包完成，剩余 8 个
+> 当前复核状态：根 workspace 已达到目标 32 个 package；75/82 工作包完成，剩余 7 个
 
 ## 1. 使用方式
 
@@ -242,8 +242,9 @@ git diff --check
 M10 性能 guard 已落地；`--validate-profiles` 只验证合同，baseline/candidate 命令只有消费真实目标硬件报告时
 才构成性能验收。M11 telemetry semantic guard 已随 PR-M11-01 落地并包含正向和故意违规 fixture；Helm/
 Kustomize contract 已随 PR-M11-09 落地并校验确定性 render、Kubernetes 1.32 schema 与部署策略；统一 lifecycle、
-HTTP probe、preStop 与单一绝对 deadline contract 已随 PR-M11-10 落地。Kind/K3d
-脚本落地前，用现有测试和人工证据完成同等预检，脚本落地的 PR 也必须提供正负 fixture。
+HTTP probe、preStop 与单一绝对 deadline contract 已随 PR-M11-10 落地。PR-M11-11 已交付 Kind/K3d 七场景
+执行器、版本化 fault/evidence policy、正负 fixture 和动态 workflow；本机未具备 Docker/集群/签名镜像/Secret，
+所以 `dynamic_execution=true` Gate 仍待真实运行，fixture 不签署该 Gate。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-kind-k3d-fault-matrix-evidence.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-kind-k3d-fault-matrix-evidence.md
@@ -1,0 +1,90 @@
+# M11-11 Kind/K3d 故障矩阵证据
+
+## 1. 结论与目标完成边界
+
+PR-M11-11 交付了真实 Kind/K3d 集群执行入口、七场景版本化策略、fail-closed 证据校验、正负 fixture、
+手动动态 workflow、测试专用管理驱动镜像以及安全集群所需的 CLI 环境 ACL 通道。工作包完成后总进度为
+**75/82**，剩余 7 个工作包：M11 1 个、M12 6 个；下一工作包为 PR-M11-12。
+
+这里的“工作包完成”指执行器和证据门禁已实现并通过本机可执行的静态/离线验证，不表示真实动态 Gate 已签署。
+当前主机没有 Docker、Kind、K3d、Kubectl、Helm 或目标镜像/Secret，因此未运行七场景动态套件，也没有生成或提交
+`dynamic_execution=true` 的 `run.json`。正向 fixture 固定为 `fixture=true`、`dynamic_execution=false`，只能验证
+parser，不能替代集群证据。M10 真实固定硬件、M11 动态 fault、M11/Phase 3/HUMAN Gate 均保持开放。
+
+| 项目 | 值 |
+|---|---|
+| Milestone | `M11` |
+| 工作包 | `PR-M11-11` |
+| GitHub Issue | `#8290` |
+| Branch | `mxsm/architecture-refactor-kind-fault-matrix` |
+| Policy | `distribution/kubernetes/fault-matrix-policy.json`，schema 1，evidence schema 1 |
+| Runner | `scripts/kind-architecture-refactor-e2e.ps1` |
+| Guard | `scripts/fault_matrix_guard.py` |
+| Dynamic workflow | `.github/workflows/kubernetes-fault-matrix.yml` |
+| 下一工作包 | `PR-M11-12` ArcMut、stable 与 SLO Phase 3 收口 |
+
+## 2. 目标完成矩阵
+
+| 目标 | 已实现边界 | 当前验收状态 |
+|---|---|---|
+| Kind/K3d 可执行入口 | `Validate/Run` 严格分离；Run 强制 Docker、选定 backend、五服务双 image map、collector digest 和四份 Secret manifest | 实现完成；真实 Run 待环境 |
+| 七类故障 | rolling upgrade、node eviction、collector outage、disk-pressure 调度压力、Controller leader failure、secret rotation、acknowledged recovery | 策略/执行步骤完成；动态结果待取证 |
+| 耐久性 | 同一 message ID 的 Queue Offset、CommitLog Offset 和 PVC UID 在升级、故障、重启前后精确比较 | 实现完成；动态结果待取证 |
+| Drain/SLO | 检查 `FailedPreStopHook`、collector outage 消息往返预算、workload ready 和最终清理状态 | 实现完成；动态结果待取证 |
+| 回滚 | 五服务恢复 baseline digest，collector/cordon/taint/Controller 恢复，PVC/WAL 不删除，证据保留 | 实现完成；动态结果待取证 |
+| 证据真实性 | production 必须 `fixture=false` 且 `dynamic_execution=true`；policy/chart/overlay/image/artifact SHA-256 和精确字段闭合 | 离线门禁通过 |
+| 安全集群驱动 | 独立 `fault-driver` Docker target 标记 test-only；CLI 仅从环境读取成对 ACL，HMAC-SHA256，错误不输出值 | Rust 定向测试通过 |
+
+磁盘压力场景使用 Kubernetes 调度层的标准 `node.kubernetes.io/disk-pressure:NoSchedule` taint 和 stateless Pod
+驱逐，不伪装为真实块设备 ENOSPC。它验证节点压力下的调度、可用性和耐久性；真实磁盘耗尽若需纳入生产演练，必须
+作为独立受控实验扩展策略，不能静默改变本场景语义。
+
+## 3. 集群与工具链合同
+
+- Kind 固定 `v0.27.0` 和 Kubernetes `1.32.2` node digest；K3d 固定 `v5.9.0`；Kubectl 固定
+  `v1.32.2`；Helm 沿用 `v4.2.3`。
+- 集群固定 1 control-plane + 3 workers；Controller 3 副本、quorum 2；Kind/K3d 分别记录 `standard` /
+  `local-path` storage class 和对应 Service CIDR。
+- workflow 下载二进制后先校验官方 SHA-256；动态任务只在 `workflow_dispatch` 执行，Secret manifest 来自受保护
+  GitHub Secrets，不进入输入、日志或仓库。
+- 五个 baseline/candidate 引用都必须是 canonical `<shared-registry>/<service>@sha256:<64hex>`；全零或单字符
+  重复 digest、缺服务、candidate 完全等于 baseline 均失败。
+
+## 4. 证据与故意违规门禁
+
+只有全部七场景按策略顺序通过、所有全局断言为真、`unresolved_faults=[]` 且 artifact hash 重新计算一致时，Runner
+才写入最终 `run.json`。异常退出会删除可能存在的 PASS 文件；`KeepCluster` 仅保留调试集群，不放宽证据校验。
+
+提交的正向 fixture 覆盖完整 schema。10 个 deliberate-violation 测试证明以下输入会失败：未显式允许 fixture、
+非动态 production 证据、全局回滚失败、场景缺失、场景断言键漂移、placeholder digest、未清理故障、artifact 篡改，
+以及执行器删除 CommitLog offset 断言。fixture artifact 本身逐项登记 SHA-256。
+
+## 5. 已完成验证
+
+| Gate | 命令/范围 | 结果 |
+|---|---|---|
+| Fault policy | `python scripts/fault_matrix_guard.py --policy-only` | 通过 |
+| Positive fixture | `python scripts/fault_matrix_guard.py --evidence scripts/tests/fixtures/m11-fault-matrix/pass --allow-fixture` | 通过 |
+| Positive + deliberate violations | `python -m unittest scripts.tests.test_m11_fault_matrix -v` | 11/11 通过 |
+| Runner validate | `.\scripts\kind-architecture-refactor-e2e.ps1 -Mode Validate` | 通过；明确无动态 PASS |
+| Kubernetes full contract | `.\scripts\kubernetes-assets-contract.ps1` | 通过；Helm/Kustomize 37/37 双 render schema |
+| Kubernetes mutations | `python -m unittest scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_service_lifecycle -v` | 12/12 通过 |
+| Client ACL algorithm | `cargo test -p rocketmq-client-rust acl_client_rpc_hook --lib` | 5/5 通过；默认兼容签名与显式 HMAC-SHA256 均覆盖 |
+| Admin ACL adapter | `cargo test -p rocketmq-admin-core admin_acl_hook --lib` | 1/1 通过；SHA-256 选择与凭据 redaction 覆盖 |
+| Admin ACL hook | `cargo test -p rocketmq-admin-cli rocketmq_cli --lib` | 5/5 通过 |
+| Root Rust | `cargo fmt --all -- --check`；`cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | 通过；仅既有 MSVC linker stdout warning |
+| Architecture/safety | target/baseline dependency、32/32 release、AGENTS routing、error hygiene、runtime boundary | 全部通过 |
+| Workflow/container syntax | Actionlint 1.7.12、Hadolint 2.14.0、Python `py_compile`、PowerShell AST | 全部通过；下载工具先校验官方 SHA-256 |
+
+首次聚合执行因 `cargo clean` 后重建超过命令的 120 秒上限而超时，不计为通过；随后 Rust 定向测试以 600 秒上限
+独立重跑并成功。真实 `-Mode Run` 未执行，原因是本机缺少明确列出的动态前置条件，不计为通过。
+
+## 6. 回滚与未签署 Gate
+
+动态回滚必须恢复五个 baseline 签名 digest 和上一 Helm revision，恢复 baseline runtime Secret、collector 副本、
+worker schedulable 状态及 Controller 三副本；不得删除 PVC、WAL 或故障证据。证据目录即使运行失败也保留诊断 artifact，
+但不保留可被误读为 PASS 的 `run.json`。
+
+以下 Gate 仍开放：M11-07/08 五镜像真实 build/scan/sign/smoke，M11-09 production digest/Service CIDR 入口，
+本工作包 Kind/K3d 七场景的 `dynamic_execution=true` 证据，M11-12 ArcMut/stable/SLO，M10 真实固定硬件/HUMAN，
+以及 M11、Phase 3 和最终目标态 HUMAN Gate。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -5,7 +5,7 @@
 | 字段 | 值 |
 |---|---|
 | 阶段 | Phase 3：性能、耐久引擎与云原生 |
-| 状态 | 实施中（PR-M11-01～10 已完成；下一工作包 PR-M11-11；部分依赖 M10 SLI） |
+| 状态 | 实施中（PR-M11-01～11 工程工作包已完成；真实 fault Gate 待验收；下一工作包 PR-M11-12；部分依赖 M10 SLI） |
 | 预计周期 | 4–6 周 |
 | 工作包 | 延续 WP01、WP03、WP05、WP07、WP14–WP16 |
 | 前置条件 | 32-package Gate；secure dry-run、ServiceContext、semantic owner、durability SLI 可用 |
@@ -192,16 +192,22 @@ M11/Phase 3/HUMAN/ARCH 与集群 fault Gate 均未完成。
 `Starting/Ready/Draining/Stopped/Failed`，独立 health port 提供 `/readyz`、`/livez`、`/drainz`；首次终止请求冻结
 45 秒绝对 deadline，Pod grace 为 60 秒，服务 shutdown、telemetry 与 RuntimeOwner 只消费剩余预算。Helm/Kustomize
 双 render 37/37 schema、12 组 Kubernetes 正负测试、9 组容器 guard、五服务 focused Rust test、MCP required
-profile 与根 workspace strict Clippy 通过。74/82 工作包完成，剩余 M11 2 个、M12 6 个，下一工作包为
-PR-M11-11；M10 真实性能、容器动态套件、Kind/K3d fault/已确认消息恢复、M11/Phase 3/HUMAN Gate 保持开放。
+profile 与根 workspace strict Clippy 通过。该段是 PR-M11-10 的历史完成记录；其后的 PR-M11-11 已交付真实执行器和
+证据门禁，当前总进度由下节记录为 75/82。M10 真实性能、容器动态套件、Kind/K3d fault/已确认消息恢复、
+M11/Phase 3/HUMAN Gate 保持开放。
 
 ### PR-M11-11：Kind/K3d Fault Matrix Gate
 
-- [ ] 入口：`[TEST]` 五镜像、Helm/Kustomize和probe/drain focused test全部通过，测试集群profile已记录。
-- [ ] `[TEST]` 执行滚动升级、节点驱逐、collector中断、磁盘压力、Controller leader故障、secret rotation和已确认消息恢复。
-- [ ] `[DEV]` 实现计划中的`kind-architecture-refactor-e2e.ps1`，保存镜像digest、chart/overlay hash、事件和watermark证据。
-- [ ] `[REV]` 检查故障断言不是仅看Pod ready，而是覆盖durability、drain、SLO和回滚。
-- [ ] 回滚点：停止rollout并回到上一签名镜像/chart；保留PVC、WAL和故障证据，验证恢复后再继续。
+- [x] 入口实现：五镜像、Helm/Kustomize、probe/drain focused gate 和 Kind/K3d 集群 profile 已版本化；真实签名 digest/Secret 仍由动态运行注入。
+- [ ] `[TEST]` 真实执行滚动升级、节点驱逐、collector 中断、磁盘压力、Controller leader 故障、secret rotation 和已确认消息恢复；本机缺少动态前置条件，未伪造 PASS。
+- [x] `[DEV]` 实现 `kind-architecture-refactor-e2e.ps1`，保存镜像 digest、chart/overlay hash、事件、PVC UID、message ID 和 Queue/CommitLog watermark 证据。
+- [x] `[REV]` versioned policy/guard 强制 durability、drain、SLO、quorum、cleanup 和回滚断言，拒绝仅以 Pod Ready 成功。
+- [x] 回滚点：恢复五个 baseline 签名镜像和上一 chart/secret，恢复 collector/节点/Controller，保留 PVC、WAL 和故障证据。
+
+完成证据：[`11-kind-k3d-fault-matrix-evidence.md`](11-kind-k3d-fault-matrix-evidence.md)。Runner 的 Validate/Run
+模式严格分离，production evidence 必须来自 `dynamic_execution=true`；11 组正负证据测试、12 组
+Kubernetes 既有负向测试、37/37 双 render schema 和管理 CLI ACL 定向测试通过。75/82 工作包完成，剩余 M11 1 个、
+M12 6 个，下一工作包为 PR-M11-12；真实 Kind/K3d、M10、M11/Phase 3/HUMAN Gate 保持开放。
 
 ### PR-M11-12：ArcMut、Stable 与 SLO Phase 3 收口
 

--- a/rocketmq-client/src/common/acl_client_rpc_hook.rs
+++ b/rocketmq-client/src/common/acl_client_rpc_hook.rs
@@ -16,7 +16,8 @@ use std::fmt;
 use std::net::SocketAddr;
 
 use cheetah_string::CheetahString;
-use rocketmq_auth::authentication::acl_signer::cal_signature_segments;
+use rocketmq_auth::authentication::acl_signer::cal_signature_segments_with_algorithm;
+use rocketmq_auth::SignatureAlgorithm;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::REDACTED;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -37,6 +38,7 @@ use crate::common::session_credentials::SIGNATURE;
 #[derive(Clone)]
 pub struct AclClientRPCHook {
     session_credentials: SessionCredentials,
+    signature_algorithm: SignatureAlgorithm,
 }
 
 impl fmt::Debug for AclClientRPCHook {
@@ -44,13 +46,24 @@ impl fmt::Debug for AclClientRPCHook {
         formatter
             .debug_struct("AclClientRPCHook")
             .field("session_credentials", &REDACTED)
+            .field("signature_algorithm", &self.signature_algorithm)
             .finish()
     }
 }
 
 impl AclClientRPCHook {
     pub fn new(session_credentials: SessionCredentials) -> Self {
-        Self { session_credentials }
+        Self::with_signature_algorithm(session_credentials, SignatureAlgorithm::default())
+    }
+
+    pub fn with_signature_algorithm(
+        session_credentials: SessionCredentials,
+        signature_algorithm: SignatureAlgorithm,
+    ) -> Self {
+        Self {
+            session_credentials,
+            signature_algorithm,
+        }
     }
 
     pub fn session_credentials(&self) -> &SessionCredentials {
@@ -101,9 +114,12 @@ impl RPCHook for AclClientRPCHook {
                 .map(|(_, value)| value.as_bytes());
             let body_segments = request.body().into_iter().map(|body| body.as_ref());
 
-            cal_signature_segments(field_segments.chain(body_segments), secret_key.as_str()).map_err(|error| {
-                RocketMQError::illegal_argument(format!("Failed to calculate ACL signature: {error}"))
-            })?
+            cal_signature_segments_with_algorithm(
+                field_segments.chain(body_segments),
+                secret_key.as_str(),
+                self.signature_algorithm,
+            )
+            .map_err(|error| RocketMQError::illegal_argument(format!("Failed to calculate ACL signature: {error}")))?
         };
         request.add_ext_field(SIGNATURE, signature);
 
@@ -170,6 +186,30 @@ mod tests {
         assert_eq!(
             ext_fields.get(&CheetahString::from_static_str(SIGNATURE)).unwrap(),
             "wuJkFDNRMKY6aFXTDwT/vg0UC8M="
+        );
+    }
+
+    #[test]
+    fn acl_hook_supports_hmac_sha256_for_secure_profiles() {
+        let hook = AclClientRPCHook::with_signature_algorithm(
+            SessionCredentials::with_token("ak", "secret", "token"),
+            SignatureAlgorithm::HmacSha256,
+        );
+        let mut request = RemotingCommand::create_remoting_command(10).set_body(Bytes::from_static(b"body"));
+        request.ensure_ext_fields_initialized();
+        request.add_ext_field("z", "last");
+        request.add_ext_field("a", "first");
+
+        hook.do_before_request("127.0.0.1:9876".parse().unwrap(), &mut request)
+            .unwrap();
+
+        assert_eq!(
+            request
+                .ext_fields()
+                .unwrap()
+                .get(&CheetahString::from_static_str(SIGNATURE))
+                .unwrap(),
+            "mBwsFNM/fUVM2NmLpnXIS+x+x7EZXmyuboG/4ZGmwa0="
         );
     }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
@@ -20,11 +20,19 @@ use clap_complete::generate;
 use clap_complete::shells::Bash;
 use clap_complete::shells::Fish;
 use clap_complete::shells::Zsh;
+use rocketmq_admin_core::client_adapter::admin_acl_rpc_hook;
 use rocketmq_error::CliErrorView;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+use std::sync::Arc;
 
 use crate::commands::CommandExecute;
 use crate::commands::Commands;
+
+const ACL_ACCESS_KEY_ENV: &str = "ROCKETMQ_ACL_ACCESS_KEY";
+const ACL_SECRET_KEY_ENV: &str = "ROCKETMQ_ACL_SECRET_KEY";
+const ACL_SECURITY_TOKEN_ENV: &str = "ROCKETMQ_ACL_SECURITY_TOKEN";
 
 #[derive(Parser)]
 #[command(name = "rocketmq-admin-cli")]
@@ -72,7 +80,11 @@ impl RocketMQCli {
         }
 
         if let Some(ref commands) = self.commands {
-            if let Err(e) = commands.execute(None).await {
+            let rpc_hook = match rpc_hook_from_environment() {
+                Ok(rpc_hook) => rpc_hook,
+                Err(error) => return render_cli_error(&error),
+            };
+            if let Err(e) = commands.execute(rpc_hook).await {
                 return render_cli_error(&e);
             }
             0
@@ -83,6 +95,53 @@ impl RocketMQCli {
             ))
         }
     }
+}
+
+fn rpc_hook_from_environment() -> RocketMQResult<Option<Arc<dyn RPCHook>>> {
+    rpc_hook_from_values(
+        read_optional_env(ACL_ACCESS_KEY_ENV)?,
+        read_optional_env(ACL_SECRET_KEY_ENV)?,
+        read_optional_env(ACL_SECURITY_TOKEN_ENV)?,
+    )
+}
+
+fn read_optional_env(name: &'static str) -> RocketMQResult<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => Ok(non_blank(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(RocketMQError::validation_failed(
+            "admin-acl-environment",
+            format!("{name} must contain valid Unicode"),
+        )),
+    }
+}
+
+fn rpc_hook_from_values(
+    access_key: Option<String>,
+    secret_key: Option<String>,
+    security_token: Option<String>,
+) -> RocketMQResult<Option<Arc<dyn RPCHook>>> {
+    let access_key = access_key.and_then(non_blank);
+    let secret_key = secret_key.and_then(non_blank);
+    let security_token = security_token.and_then(non_blank);
+    match (access_key, secret_key, security_token) {
+        (None, None, None) => Ok(None),
+        (Some(access_key), Some(secret_key), security_token) => Ok(Some(Arc::new(admin_acl_rpc_hook(
+            access_key,
+            secret_key,
+            security_token,
+        )))),
+        _ => Err(RocketMQError::validation_failed(
+            "admin-acl-environment",
+            "ROCKETMQ_ACL_ACCESS_KEY and ROCKETMQ_ACL_SECRET_KEY must be supplied together; the security token is \
+             optional",
+        )),
+    }
+}
+
+fn non_blank(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
 }
 
 fn render_cli_error(error: &RocketMQError) -> i32 {
@@ -110,6 +169,7 @@ where
 mod tests {
     use super::RocketMQCli;
     use super::normalize_java_compatible_args;
+    use super::rpc_hook_from_values;
     use clap::Parser;
     use rocketmq_error::CliExitCode;
     use std::ffi::OsString;
@@ -139,5 +199,22 @@ mod tests {
         let cli = RocketMQCli::try_parse_from(["rocketmq-admin-cli", "--generate-completion", "powershell"]).unwrap();
 
         assert_eq!(cli.handle().await, CliExitCode::USAGE.as_i32());
+    }
+
+    #[test]
+    fn acl_environment_is_optional_and_requires_complete_credentials() {
+        assert!(rpc_hook_from_values(None, None, None).unwrap().is_none());
+        assert!(rpc_hook_from_values(Some("access".into()), None, None).is_err());
+        assert!(rpc_hook_from_values(None, Some("secret".into()), None).is_err());
+        assert!(rpc_hook_from_values(None, None, Some("token".into())).is_err());
+        assert!(rpc_hook_from_values(Some(" ".into()), Some("secret".into()), None).is_err());
+    }
+
+    #[test]
+    fn acl_environment_builds_sha256_rpc_hook_without_exposing_values() {
+        let hook =
+            rpc_hook_from_values(Some(" access ".into()), Some(" secret ".into()), Some(" token ".into())).unwrap();
+
+        assert!(hook.is_some());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter.rs
@@ -27,6 +27,7 @@ mod topic;
 pub use self::lifecycle::AdminGuard;
 pub use self::lifecycle::AdminSession;
 pub use self::lifecycle::ClientAdminBuilder;
+pub use self::security::admin_acl_rpc_hook;
 
 #[cfg(feature = "legacy-common-compat")]
 #[doc(hidden)]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/security.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/security.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
+use rocketmq_client_rust::common::acl::SigningAlgorithm;
+use rocketmq_client_rust::AclClientRPCHook;
 use rocketmq_client_rust::MQAdminExt;
+use rocketmq_client_rust::SessionCredentials;
 
 use crate::client_adapter::lifecycle::AdminSession;
 use crate::core::security::ListUsersRequest;
@@ -22,6 +25,25 @@ use crate::core::security::SecurityAdmin;
 use crate::core::security::UserSummary;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
+
+/// Build the legacy client adapter used by admin tools for a secure profile.
+///
+/// Credential values are retained only by the redacting client RPC hook. The
+/// caller is responsible for obtaining them from a non-command-line secret
+/// source such as the process environment or a mounted secret provider.
+pub fn admin_acl_rpc_hook(
+    access_key: impl Into<CheetahString>,
+    secret_key: impl Into<CheetahString>,
+    security_token: Option<impl Into<CheetahString>>,
+) -> AclClientRPCHook {
+    let access_key = access_key.into();
+    let secret_key = secret_key.into();
+    let credentials = match security_token {
+        Some(security_token) => SessionCredentials::with_token(access_key, secret_key, security_token),
+        None => SessionCredentials::with_keys(access_key, secret_key),
+    };
+    AclClientRPCHook::with_signature_algorithm(credentials, SigningAlgorithm::HmacSha256)
+}
 
 impl SecurityAdmin for AdminSession {
     fn list_users<'a>(&'a mut self, request: &'a ListUsersRequest) -> AdminFuture<'a, ListUsersResult> {
@@ -46,5 +68,21 @@ impl SecurityAdmin for AdminSession {
                     .collect(),
             })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::admin_acl_rpc_hook;
+
+    #[test]
+    fn admin_acl_hook_selects_sha256_and_redacts_credentials() {
+        let hook = admin_acl_rpc_hook("access", "secret", Some("token"));
+
+        let debug = format!("{hook:?}");
+        assert!(debug.contains("HmacSha256"));
+        assert!(!debug.contains("access"));
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("token"));
     }
 }

--- a/scripts/fault_matrix_guard.py
+++ b/scripts/fault_matrix_guard.py
@@ -1,0 +1,379 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate the M11-11 fault policy and fail-closed dynamic evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SERVICES = ("broker", "namesrv", "controller", "proxy", "mcp")
+SCENARIOS = (
+    "rolling_upgrade",
+    "node_eviction",
+    "collector_outage",
+    "disk_pressure",
+    "controller_leader_failure",
+    "secret_rotation",
+    "acknowledged_message_recovery",
+)
+GLOBAL_ASSERTIONS = (
+    "all_workloads_ready",
+    "all_faults_reverted",
+    "controller_quorum_restored",
+    "pvc_uid_set_preserved",
+    "acknowledged_message_recovered",
+    "queue_offset_preserved",
+    "commitlog_offset_preserved",
+    "drain_completed_within_deadline",
+    "slo_budget_satisfied",
+    "rollback_verified",
+    "unresolved_faults_empty",
+)
+DIGEST_RE = re.compile(r"^[^@\s]+@sha256:([0-9a-f]{64})$")
+SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+PLACEHOLDER_HASHES = {character * 64 for character in "0123456789abcdef"}
+REQUIRED_RUN_FIELDS = {
+    "schema_version",
+    "milestone",
+    "policy_sha256",
+    "run_id",
+    "started_at",
+    "finished_at",
+    "backend",
+    "dynamic_execution",
+    "fixture",
+    "cluster_profile",
+    "tool_versions",
+    "chart_sha256",
+    "overlay_sha256",
+    "baseline_images",
+    "candidate_images",
+    "global_assertions",
+    "unresolved_faults",
+    "scenarios",
+    "artifacts",
+}
+
+
+class Guard:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.errors: list[str] = []
+
+    def require(self, condition: bool, message: str) -> None:
+        if not condition:
+            self.errors.append(message)
+
+    def read(self, relative: str) -> str:
+        path = self.root / relative
+        if not path.is_file():
+            self.errors.append(f"missing required file: {relative}")
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def load_json(self, path: Path, label: str) -> dict[str, Any]:
+        if not path.is_file():
+            self.errors.append(f"missing required JSON: {label}")
+            return {}
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            self.errors.append(f"invalid JSON in {label}: {error}")
+            return {}
+        if not isinstance(value, dict):
+            self.errors.append(f"{label} must contain a JSON object")
+            return {}
+        return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_json_sha256(value: dict[str, Any]) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def parse_utc(value: object, label: str, guard: Guard) -> datetime | None:
+    if not isinstance(value, str):
+        guard.errors.append(f"{label} must be an RFC3339 UTC timestamp")
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        guard.errors.append(f"{label} must be an RFC3339 UTC timestamp")
+        return None
+    guard.require(parsed.tzinfo is not None and parsed.utcoffset() == timezone.utc.utcoffset(parsed), f"{label} must be UTC")
+    return parsed
+
+
+def validate_policy(guard: Guard, policy: dict[str, Any]) -> None:
+    guard.require(policy.get("schema_version") == 1, "fault policy schema_version must remain 1")
+    guard.require(policy.get("milestone") == "M11-11", "fault policy milestone must remain M11-11")
+    guard.require(policy.get("evidence_schema_version") == 1, "evidence schema version must remain 1")
+    guard.require(policy.get("backends") == ["kind", "k3d"], "fault policy must define exact Kind/K3d backends")
+    guard.require(policy.get("kubernetes_version") == "1.32.2", "fault Kubernetes version must remain 1.32.2")
+
+    cluster = policy.get("cluster", {})
+    guard.require(cluster.get("control_plane_nodes") == 1, "fault cluster must have one control-plane node")
+    guard.require(cluster.get("worker_nodes") == 3, "fault cluster must have three worker nodes")
+    guard.require(cluster.get("controller_replicas") == 3, "fault cluster must have three Controller replicas")
+    guard.require(cluster.get("controller_quorum") == 2, "Controller quorum must remain two")
+    guard.require(
+        cluster.get("kind_node_image")
+        == "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",
+        "Kind node image/version digest drifted",
+    )
+    guard.require(cluster.get("storage_classes") == {"kind": "standard", "k3d": "local-path"}, "storage class matrix drifted")
+
+    guard.require(policy.get("tools") == {"kind": "v0.27.0", "k3d": "v5.9.0", "kubectl": "v1.32.2", "helm": "v4.2.3"}, "fault tool versions drifted")
+    images = policy.get("images", {})
+    guard.require(images.get("required_services") == list(SERVICES), "fault matrix must cover exactly five services")
+    guard.require(images.get("fault_driver_target") == "fault-driver", "test-only fault-driver target drifted")
+    guard.require(images.get("fault_driver_test_only") is True, "fault driver must remain test-only")
+    guard.require(policy.get("global_assertions") == list(GLOBAL_ASSERTIONS), "global fault assertions drifted")
+
+    scenarios = policy.get("scenarios", [])
+    guard.require(isinstance(scenarios, list), "scenarios must be a list")
+    scenario_ids = [item.get("id") for item in scenarios if isinstance(item, dict)]
+    guard.require(scenario_ids == list(SCENARIOS), "fault policy must define the exact ordered seven scenarios")
+    for item in scenarios if isinstance(scenarios, list) else []:
+        if not isinstance(item, dict):
+            guard.errors.append("every fault scenario must be an object")
+            continue
+        scenario = item.get("id", "unknown")
+        guard.require(isinstance(item.get("timeout_seconds"), int) and item["timeout_seconds"] > 0, f"{scenario}: timeout must be positive")
+        guard.require(bool(item.get("injection")), f"{scenario}: injection contract missing")
+        guard.require(bool(item.get("recovery")), f"{scenario}: recovery contract missing")
+        assertions = item.get("required_assertions")
+        evidence = item.get("required_evidence")
+        guard.require(isinstance(assertions, list) and len(assertions) >= 4, f"{scenario}: insufficient assertions")
+        guard.require(isinstance(evidence, list) and len(evidence) >= 4, f"{scenario}: insufficient evidence")
+        guard.require(len(set(assertions or [])) == len(assertions or []), f"{scenario}: duplicate assertions")
+        guard.require(len(set(evidence or [])) == len(evidence or []), f"{scenario}: duplicate evidence fields")
+
+    evidence = policy.get("evidence", {})
+    guard.require(set(evidence.get("required_run_fields", [])) == REQUIRED_RUN_FIELDS, "required run evidence fields drifted")
+    guard.require(evidence.get("production_requires_dynamic_execution") is True, "production evidence must require dynamic execution")
+    guard.require(evidence.get("fixture_requires_explicit_opt_in") is True, "fixtures must require explicit opt-in")
+    rollback = policy.get("rollback", {})
+    guard.require(rollback.get("restore_baseline_digests") is True, "rollback must restore baseline digests")
+    guard.require(rollback.get("restore_baseline_chart") is True, "rollback must restore the baseline chart")
+    guard.require(rollback.get("delete_pvcs") is False, "rollback must not delete PVCs")
+    guard.require(rollback.get("delete_wal") is False, "rollback must not delete WAL")
+    guard.require(rollback.get("preserve_evidence") is True, "rollback must preserve evidence")
+
+
+def validate_sources(guard: Guard) -> None:
+    runner = guard.read("scripts/kind-architecture-refactor-e2e.ps1")
+    workflow = guard.read(".github/workflows/kubernetes-fault-matrix.yml")
+    dockerfile = guard.read("docker/Dockerfile.base")
+    tests = guard.read("scripts/tests/test_m11_fault_matrix.py")
+    readme = guard.read("distribution/kubernetes/README.md")
+    for marker in (
+        '[ValidateSet("Validate", "Run")]',
+        '[ValidateSet("kind", "k3d")]',
+        "dynamic_execution",
+        "rolling_upgrade",
+        "node_eviction",
+        "collector_outage",
+        "disk_pressure",
+        "controller_leader_failure",
+        "secret_rotation",
+        "acknowledged_message_recovery",
+        "Invoke-Native kubectl @('drain'",
+        "node.kubernetes.io/disk-pressure",
+        "queryMsgByUniqueKey",
+        "queue_offset_preserved",
+        "commitlog_offset_preserved",
+        "pvc_uid_set_preserved",
+    ):
+        guard.require(marker in runner, f"fault runner contract marker missing: {marker}")
+    guard.require("Mode -eq \"Validate\"" in runner, "runner must provide a non-dynamic Validate mode")
+    guard.require("throw" in runner, "runner must fail closed on missing prerequisites or failed assertions")
+    guard.require("FROM builder-base AS fault-driver-builder" in dockerfile, "fault-driver builder target missing")
+    guard.require("FROM runtime-base AS fault-driver" in dockerfile, "fault-driver runtime target missing")
+    guard.require('io.rocketmq.image.role="fault-driver-test-only"' in dockerfile, "fault driver test-only label missing")
+    guard.require("fault_matrix_guard.py" in workflow, "fault workflow must execute evidence guard")
+    guard.require("kind-architecture-refactor-e2e.ps1" in workflow, "fault workflow must execute the real runner")
+    guard.require("workflow_dispatch:" in workflow, "fault workflow must support explicit dynamic dispatch")
+    guard.require("permissions:\n  contents: read" in workflow, "fault workflow must retain contents:read only")
+    guard.require("test_m11_fault_matrix" in workflow and "deliberate" in tests, "deliberate-violation tests missing")
+    guard.require("dynamic" in readme.lower() and "fault" in readme.lower(), "Kubernetes README must document dynamic fault evidence")
+
+
+def validate_image_map(guard: Guard, label: str, value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        guard.errors.append(f"{label} must be an object")
+        return {}
+    guard.require(set(value) == set(SERVICES), f"{label} must contain exactly five services")
+    result: dict[str, str] = {}
+    for service in SERVICES:
+        reference = value.get(service)
+        match = DIGEST_RE.fullmatch(reference) if isinstance(reference, str) else None
+        guard.require(match is not None, f"{label}.{service} must be an image@sha256 digest")
+        if match:
+            guard.require(match.group(1) not in PLACEHOLDER_HASHES, f"{label}.{service} uses a placeholder digest")
+            result[service] = reference
+    return result
+
+
+def validate_evidence(guard: Guard, policy: dict[str, Any], evidence_dir: Path, allow_fixture: bool) -> None:
+    run = guard.load_json(evidence_dir / "run.json", "run.json")
+    if not run:
+        return
+    guard.require(set(run) == REQUIRED_RUN_FIELDS, "run.json fields must match the exact evidence schema")
+    guard.require(run.get("schema_version") == 1, "run evidence schema_version must remain 1")
+    guard.require(run.get("milestone") == "M11-11", "run milestone must remain M11-11")
+    guard.require(
+        run.get("policy_sha256") == canonical_json_sha256(policy),
+        "run policy_sha256 does not match the canonical committed policy",
+    )
+    guard.require(isinstance(run.get("run_id"), str) and bool(run["run_id"].strip()), "run_id must be non-empty")
+    started = parse_utc(run.get("started_at"), "started_at", guard)
+    finished = parse_utc(run.get("finished_at"), "finished_at", guard)
+    if started and finished:
+        guard.require(finished >= started, "finished_at must not precede started_at")
+    guard.require(run.get("backend") in ("kind", "k3d"), "run backend must be kind or k3d")
+    fixture = run.get("fixture") is True
+    if fixture:
+        guard.require(allow_fixture, "fixture evidence requires --allow-fixture")
+        guard.require(run.get("dynamic_execution") is False, "fixture evidence must not claim dynamic execution")
+    else:
+        guard.require(run.get("fixture") is False, "production evidence must set fixture=false")
+        guard.require(run.get("dynamic_execution") is True, "production evidence must come from dynamic execution")
+
+    profile = run.get("cluster_profile")
+    guard.require(isinstance(profile, dict), "cluster_profile must be an object")
+    if isinstance(profile, dict):
+        guard.require(profile.get("control_plane_nodes") == 1, "cluster profile must record one control plane")
+        guard.require(profile.get("worker_nodes") == 3, "cluster profile must record three workers")
+        guard.require(profile.get("controller_replicas") == 3, "cluster profile must record three Controllers")
+        guard.require(bool(profile.get("storage_class")), "cluster profile storage class missing")
+        guard.require(isinstance(profile.get("nodes"), list) and len(profile["nodes"]) == 4, "cluster profile must record four nodes")
+    tools = run.get("tool_versions")
+    guard.require(isinstance(tools, dict) and set(tools) == {"docker", "kind", "k3d", "kubectl", "helm"}, "tool version evidence incomplete")
+    for key in ("chart_sha256", "overlay_sha256"):
+        guard.require(isinstance(run.get(key), str) and SHA_RE.fullmatch(run[key]) is not None, f"{key} must be sha256")
+
+    baseline = validate_image_map(guard, "baseline_images", run.get("baseline_images"))
+    candidate = validate_image_map(guard, "candidate_images", run.get("candidate_images"))
+    if baseline and candidate:
+        guard.require(any(baseline[name] != candidate[name] for name in SERVICES), "candidate images must differ from baseline")
+
+    assertions = run.get("global_assertions")
+    guard.require(isinstance(assertions, dict) and set(assertions) == set(GLOBAL_ASSERTIONS), "global assertions must match policy")
+    if isinstance(assertions, dict):
+        for name in GLOBAL_ASSERTIONS:
+            guard.require(assertions.get(name) is True, f"global assertion failed: {name}")
+    guard.require(run.get("unresolved_faults") == [], "unresolved_faults must be empty")
+
+    policy_scenarios = {item["id"]: item for item in policy.get("scenarios", []) if isinstance(item, dict) and "id" in item}
+    scenario_records = run.get("scenarios")
+    guard.require(isinstance(scenario_records, list), "scenarios evidence must be a list")
+    observed_ids = [item.get("id") for item in scenario_records or [] if isinstance(item, dict)]
+    guard.require(observed_ids == list(SCENARIOS), "evidence must contain exact ordered seven scenarios")
+    for record in scenario_records or []:
+        if not isinstance(record, dict):
+            guard.errors.append("scenario evidence must be an object")
+            continue
+        scenario = record.get("id", "unknown")
+        expected = policy_scenarios.get(str(scenario), {})
+        expected_assertions = set(expected.get("required_assertions", []))
+        actual_assertions = record.get("assertions")
+        guard.require(record.get("status") == "passed", f"{scenario}: status must be passed")
+        guard.require(isinstance(actual_assertions, dict) and set(actual_assertions) == expected_assertions, f"{scenario}: assertion keys drifted")
+        if isinstance(actual_assertions, dict):
+            for name in expected_assertions:
+                guard.require(actual_assertions.get(name) is True, f"{scenario}: assertion failed: {name}")
+        actual_evidence = record.get("evidence")
+        expected_evidence = set(expected.get("required_evidence", []))
+        guard.require(isinstance(actual_evidence, dict) and set(actual_evidence) == expected_evidence, f"{scenario}: evidence keys drifted")
+        if isinstance(actual_evidence, dict):
+            for name in expected_evidence:
+                guard.require(isinstance(actual_evidence.get(name), str) and bool(actual_evidence[name].strip()), f"{scenario}: empty evidence: {name}")
+
+    artifacts = run.get("artifacts")
+    guard.require(isinstance(artifacts, list) and bool(artifacts), "artifact index must be non-empty")
+    seen_paths: set[str] = set()
+    for item in artifacts or []:
+        if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+            guard.errors.append("each artifact index item must contain only path and sha256")
+            continue
+        relative = item.get("path")
+        expected_hash = item.get("sha256")
+        guard.require(isinstance(relative, str) and bool(relative), "artifact path must be non-empty")
+        if not isinstance(relative, str) or not relative:
+            continue
+        relative_path = Path(relative)
+        guard.require(not relative_path.is_absolute() and ".." not in relative_path.parts, f"unsafe artifact path: {relative}")
+        guard.require(relative not in seen_paths, f"duplicate artifact path: {relative}")
+        seen_paths.add(relative)
+        artifact_path = evidence_dir / relative_path
+        guard.require(artifact_path.is_file(), f"missing artifact: {relative}")
+        guard.require(isinstance(expected_hash, str) and SHA_RE.fullmatch(expected_hash) is not None, f"invalid artifact hash: {relative}")
+        if artifact_path.is_file() and isinstance(expected_hash, str):
+            guard.require(sha256_file(artifact_path) == expected_hash, f"artifact hash mismatch: {relative}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--policy-only", action="store_true")
+    parser.add_argument("--print-policy-sha256", action="store_true")
+    parser.add_argument("--evidence", type=Path)
+    parser.add_argument("--allow-fixture", action="store_true")
+    args = parser.parse_args()
+    if args.print_policy_sha256 and (args.evidence or args.allow_fixture):
+        parser.error("--print-policy-sha256 cannot be combined with evidence options")
+    root = args.root.resolve()
+    guard = Guard(root)
+    policy_path = root / "distribution/kubernetes/fault-matrix-policy.json"
+    policy = guard.load_json(policy_path, "fault-matrix-policy.json")
+    validate_policy(guard, policy)
+    if not args.print_policy_sha256:
+        validate_sources(guard)
+    if args.evidence:
+        evidence_dir = args.evidence if args.evidence.is_absolute() else root / args.evidence
+        validate_evidence(guard, policy, evidence_dir.resolve(), args.allow_fixture)
+    elif args.allow_fixture:
+        guard.errors.append("--allow-fixture requires --evidence")
+    if guard.errors:
+        for error in guard.errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if args.print_policy_sha256:
+        print(canonical_json_sha256(policy))
+        return 0
+    mode = "policy" if not args.evidence else "policy and evidence"
+    print(f"M11-11 fault matrix {mode} guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kind-architecture-refactor-e2e.ps1
+++ b/scripts/kind-architecture-refactor-e2e.ps1
@@ -1,0 +1,652 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Run")]
+    [string]$Mode = "Validate",
+
+    [ValidateSet("kind", "k3d")]
+    [string]$Backend = "kind",
+
+    [string]$ClusterName = "rocketmq-architecture-refactor",
+    [string]$Namespace = "rocketmq-system",
+    [string]$BaselineImageMap,
+    [string]$CandidateImageMap,
+    [string]$RuntimeSecretManifest,
+    [string]$RotatedRuntimeSecretManifest,
+    [string]$BaselineDriverSecretManifest,
+    [string]$RotatedDriverSecretManifest,
+    [string]$CollectorImage,
+    [string]$EvidenceRoot = "target/architecture-refactor/M11/fault-matrix",
+    [switch]$KeepCluster
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+$Root = Split-Path -Parent $PSScriptRoot
+$PolicyPath = Join-Path $Root "distribution/kubernetes/fault-matrix-policy.json"
+$ChartPath = Join-Path $Root "distribution/helm/rocketmq-rust"
+$OverlayPath = Join-Path $Root "distribution/kubernetes/overlays/secure/kustomization.yaml"
+$Policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json
+$ScenarioRecords = [System.Collections.Generic.List[object]]::new()
+$ArtifactRecords = [System.Collections.Generic.List[object]]::new()
+$CreatedCluster = $false
+$RunSucceeded = $false
+$RunStarted = [DateTimeOffset]::UtcNow
+$RunId = "m11-11-$Backend-$($RunStarted.ToString('yyyyMMddTHHmmssZ'))"
+$RunDirectory = Join-Path (Join-Path $Root $EvidenceRoot) $RunId
+$ArtifactsDirectory = Join-Path $RunDirectory "artifacts"
+$ScenariosDirectory = Join-Path $RunDirectory "scenarios"
+$FaultDriverImage = "rocketmq-rust/fault-driver:$RunId"
+$Topic = "ArchitectureRefactorFaultMatrix"
+$MessageKey = "fault-$RunId"
+$MessageBody = "M11-11 acknowledged durability probe $RunId"
+$NamesrvAddress = "rocketmq-namesrv-0.rocketmq-namesrv-headless.$Namespace.svc.cluster.local:9876"
+
+function Require-Command {
+    param([Parameter(Mandatory)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "required command '$Name' is unavailable; Run mode never falls back to fixture evidence"
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+    $output = & $Command @Arguments 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$Command $($Arguments -join ' ') failed with exit code ${exitCode}:`n$output"
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Output = $output.TrimEnd() }
+}
+
+$PolicySha256 = (Invoke-Native python @(
+    (Join-Path $Root 'scripts/fault_matrix_guard.py'),
+    '--root',
+    $Root,
+    '--print-policy-sha256'
+)).Output
+
+function Get-Sha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-TreeSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    $lines = Get-ChildItem -LiteralPath $Path -Recurse -File |
+        Sort-Object FullName |
+        ForEach-Object {
+            $relative = [IO.Path]::GetRelativePath($Path, $_.FullName).Replace('\', '/')
+            "$relative $(Get-Sha256 $_.FullName)"
+        }
+    $temporary = Join-Path ([IO.Path]::GetTempPath()) "rocketmq-tree-$([Guid]::NewGuid()).txt"
+    try {
+        [IO.File]::WriteAllLines($temporary, $lines, [Text.UTF8Encoding]::new($false))
+        Get-Sha256 $temporary
+    } finally {
+        Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Write-Artifact {
+    param(
+        [Parameter(Mandatory)][string]$RelativePath,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Content
+    )
+    $normalized = $RelativePath.Replace('\', '/')
+    if ([IO.Path]::IsPathRooted($normalized) -or $normalized.Split('/') -contains '..') {
+        throw "unsafe evidence artifact path: $RelativePath"
+    }
+    $absolute = Join-Path $RunDirectory $normalized
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $absolute) | Out-Null
+    [IO.File]::WriteAllText($absolute, $Content + "`n", [Text.UTF8Encoding]::new($false))
+    $ArtifactRecords.Add([ordered]@{ path = $normalized; sha256 = Get-Sha256 $absolute })
+    $normalized
+}
+
+function Assert-True {
+    param([Parameter(Mandatory)][bool]$Condition, [Parameter(Mandatory)][string]$Message)
+    if (-not $Condition) {
+        throw "fault assertion failed: $Message"
+    }
+}
+
+function Read-ImageMap {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Label)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label image map does not exist: $Path"
+    }
+    $map = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -AsHashtable
+    $expected = @('broker', 'namesrv', 'controller', 'proxy', 'mcp')
+    Assert-True (($map.Keys | Sort-Object) -join ',' -eq ($expected | Sort-Object) -join ',') "$Label image map must contain exactly five services"
+    foreach ($service in $expected) {
+        Assert-True ($map[$service] -match '^[^@\s]+@sha256:[0-9a-f]{64}$') "$Label $service image must be pinned by digest"
+        $digest = $map[$service].Split('@sha256:')[1]
+        Assert-True ($digest -notmatch '^([0-9a-f])\1{63}$') "$Label $service image uses a placeholder digest"
+    }
+    $registry = $map['broker'] -replace '/broker@sha256:[0-9a-f]{64}$', ''
+    foreach ($service in $expected) {
+        Assert-True ($map[$service] -eq "$registry/$service@$(Get-ImageDigest $map[$service])") "$Label $service must use the shared registry and canonical service repository"
+    }
+    $map
+}
+
+function Get-ImageDigest {
+    param([Parameter(Mandatory)][string]$Reference)
+    "sha256:" + $Reference.Split('@sha256:')[1]
+}
+
+function New-HelmValues {
+    param([Parameter(Mandatory)][hashtable]$Images, [Parameter(Mandatory)][string]$StorageClass)
+    $path = Join-Path $RunDirectory "helm-values-$([Guid]::NewGuid().ToString('N')).yaml"
+    $controllerIps = if ($Backend -eq 'kind') { @('10.96.0.201', '10.96.0.202', '10.96.0.203') } else { @('10.43.0.201', '10.43.0.202', '10.43.0.203') }
+    $registry = $Images['broker'] -replace '/broker@sha256:[0-9a-f]{64}$', ''
+    $content = @"
+global:
+  imageRegistry: $registry
+  imagePullSecrets: []
+  otelEndpoint: http://otel-collector.observability.svc.cluster.local:4317
+  secretRefs:
+    existingSecret: rocketmq-runtime-secrets
+    secretProviderClassName: ""
+  podSecurity:
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+namespace:
+  create: true
+networkPolicy:
+  enabled: true
+  clientNamespaceLabel: rocketmq.apache.org/client-access
+  observabilityNamespaceLabel: rocketmq.apache.org/observability
+services:
+  broker:
+    replicas: 1
+    autoCreateTopicEnable: true
+    image: { digest: $(Get-ImageDigest $Images['broker']) }
+    persistence: { storageClassName: $StorageClass, size: 10Gi }
+    resources:
+      requests: { cpu: 500m, memory: 1Gi }
+      limits: { cpu: 2000m, memory: 4Gi }
+  namesrv:
+    replicas: 3
+    image: { digest: $(Get-ImageDigest $Images['namesrv']) }
+    persistence: { storageClassName: $StorageClass, size: 1Gi }
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits: { cpu: 500m, memory: 512Mi }
+  controller:
+    replicas: 3
+    peerServiceClusterIPs: [$(($controllerIps | ForEach-Object { '"' + $_ + '"' }) -join ', ')]
+    image: { digest: $(Get-ImageDigest $Images['controller']) }
+    persistence: { storageClassName: $StorageClass, size: 2Gi }
+    resources:
+      requests: { cpu: 250m, memory: 256Mi }
+      limits: { cpu: 1000m, memory: 1Gi }
+  proxy:
+    replicas: 2
+    image: { digest: $(Get-ImageDigest $Images['proxy']) }
+    resources:
+      requests: { cpu: 250m, memory: 256Mi }
+      limits: { cpu: 1000m, memory: 1Gi }
+  mcp:
+    replicas: 1
+    image: { digest: $(Get-ImageDigest $Images['mcp']) }
+    publicBaseUrl: https://mcp.example.invalid
+    oauth:
+      issuer: https://issuer.example.invalid
+      audience: rocketmq-mcp
+      jwksUrl: https://issuer.example.invalid/.well-known/jwks.json
+    persistence: { storageClassName: $StorageClass, size: 1Gi }
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits: { cpu: 500m, memory: 512Mi }
+"@
+    [IO.File]::WriteAllText($path, $content, [Text.UTF8Encoding]::new($false))
+    $path
+}
+
+function Wait-Workloads {
+    foreach ($workload in @('statefulset/rocketmq-broker', 'statefulset/rocketmq-namesrv', 'statefulset/rocketmq-controller', 'deployment/rocketmq-proxy', 'deployment/rocketmq-mcp')) {
+        Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', $workload, '--timeout=300s') | Out-Null
+    }
+}
+
+function Get-PvcUidSet {
+    $json = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pvc', '-o', 'json')).Output | ConvertFrom-Json
+    ($json.items | ForEach-Object { "$($_.metadata.name)=$($_.metadata.uid)" } | Sort-Object) -join "`n"
+}
+
+function Get-ControllerMetadata {
+    $address = "rocketmq-controller-0.rocketmq-controller-headless.$Namespace.svc.cluster.local:60109"
+    Invoke-FaultDriver -SecretName 'rocketmq-fault-driver-baseline' -Arguments @('controller', 'getControllerMetaData', '-a', $address)
+}
+
+function Invoke-FaultDriver {
+    param(
+        [Parameter(Mandatory)][string]$SecretName,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+    $job = "fault-driver-$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
+    $commandJson = ($Arguments | ConvertTo-Json -Compress)
+    $manifest = @"
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $job
+  namespace: $Namespace
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rocketmq-fault-driver
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: fault-driver
+          image: $FaultDriverImage
+          imagePullPolicy: IfNotPresent
+          args: $commandJson
+          env:
+            - name: NAMESRV_ADDR
+              value: $NamesrvAddress
+          envFrom:
+            - secretRef: { name: $SecretName }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp, mountPath: /tmp }
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 32Mi }
+"@
+    $manifestPath = Join-Path $RunDirectory "$job.yaml"
+    [IO.File]::WriteAllText($manifestPath, $manifest, [Text.UTF8Encoding]::new($false))
+    try {
+        Invoke-Native kubectl @('apply', '-f', $manifestPath) | Out-Null
+        $wait = Invoke-Native kubectl @('-n', $Namespace, 'wait', "job/$job", '--for=condition=complete', '--timeout=120s') -AllowFailure
+        $logs = (Invoke-Native kubectl @('-n', $Namespace, 'logs', "job/$job") -AllowFailure).Output
+        if ($wait.ExitCode -ne 0 -and -not $AllowFailure) {
+            throw "fault driver failed: $($wait.Output)`n$logs"
+        }
+        [pscustomobject]@{ ExitCode = $wait.ExitCode; Output = $logs }
+    } finally {
+        Invoke-Native kubectl @('-n', $Namespace, 'delete', 'job', $job, '--ignore-not-found=true', '--wait=false') -AllowFailure | Out-Null
+        Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Send-AcknowledgedMessage {
+    $result = Invoke-FaultDriver -SecretName 'rocketmq-fault-driver-baseline' -Arguments @('message', 'sendMessage', '-t', $Topic, '-p', $MessageBody, '-k', $MessageKey)
+    $lines = $result.Output -split "`r?`n" | Where-Object { $_.Trim() }
+    $id = ($lines[-1] -split '\s+')[-1]
+    Assert-True ($id -match '^[0-9A-Za-z_-]{8,}$') 'send acknowledgement must contain a message ID'
+    [pscustomobject]@{ Id = $id; Output = $result.Output }
+}
+
+function Query-AcknowledgedMessage {
+    param([Parameter(Mandatory)][string]$MessageId, [string]$SecretName = 'rocketmq-fault-driver-baseline')
+    $result = Invoke-FaultDriver -SecretName $SecretName -Arguments @('message', 'queryMsgByUniqueKey', '-t', $Topic, '-i', $MessageId)
+    $queue = [regex]::Match($result.Output, 'Queue Offset:\s+(-?\d+)').Groups[1].Value
+    $commitlog = [regex]::Match($result.Output, 'CommitLog Offset:\s+(-?\d+)').Groups[1].Value
+    Assert-True ($queue -match '^\d+$') 'query evidence must contain Queue Offset'
+    Assert-True ($commitlog -match '^\d+$') 'query evidence must contain CommitLog Offset'
+    [pscustomobject]@{ QueueOffset = $queue; CommitLogOffset = $commitlog; Output = $result.Output }
+}
+
+function Complete-Scenario {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][hashtable]$Assertions,
+        [Parameter(Mandatory)][hashtable]$Evidence
+    )
+    foreach ($name in $Assertions.Keys) {
+        Assert-True ($Assertions[$name] -eq $true) "$Id.$name"
+    }
+    $evidencePaths = [ordered]@{}
+    foreach ($name in ($Evidence.Keys | Sort-Object)) {
+        $evidencePaths[$name] = Write-Artifact "artifacts/$Id/$name.txt" ([string]$Evidence[$name])
+    }
+    $record = [ordered]@{ id = $Id; status = 'passed'; assertions = $Assertions; evidence = $evidencePaths }
+    $ScenarioRecords.Add($record)
+    $json = $record | ConvertTo-Json -Depth 20
+    Write-Artifact "scenarios/$Id.json" $json | Out-Null
+}
+
+function Set-ServiceImages {
+    param([Parameter(Mandatory)][hashtable]$Images)
+    foreach ($service in @('broker', 'namesrv', 'controller')) {
+        Invoke-Native kubectl @('-n', $Namespace, 'set', 'image', "statefulset/rocketmq-$service", "$service=$($Images[$service])") | Out-Null
+        Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', "statefulset/rocketmq-$service", '--timeout=300s') | Out-Null
+    }
+    foreach ($service in @('proxy', 'mcp')) {
+        Invoke-Native kubectl @('-n', $Namespace, 'set', 'image', "deployment/rocketmq-$service", "$service=$($Images[$service])") | Out-Null
+        Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', "deployment/rocketmq-$service", '--timeout=300s') | Out-Null
+    }
+}
+
+if ($Mode -eq "Validate") {
+    Require-Command python
+    $guard = Invoke-Native python @((Join-Path $Root 'scripts/fault_matrix_guard.py'), '--root', $Root, '--policy-only')
+    Write-Output $guard.Output
+    Write-Output "Validate mode completed without dynamic execution or PASS evidence."
+    exit 0
+}
+
+foreach ($command in @('python', 'docker', 'kubectl', 'helm')) { Require-Command $command }
+Require-Command $Backend
+foreach ($path in @($BaselineImageMap, $CandidateImageMap, $RuntimeSecretManifest, $RotatedRuntimeSecretManifest, $BaselineDriverSecretManifest, $RotatedDriverSecretManifest)) {
+    Assert-True (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path -LiteralPath $path -PathType Leaf)) "Run mode requires every image/secret input file"
+}
+Assert-True ($CollectorImage -match '^[^@\s]+@sha256:[0-9a-f]{64}$') 'CollectorImage must be pinned by digest'
+$BaselineImages = Read-ImageMap $BaselineImageMap 'baseline'
+$CandidateImages = Read-ImageMap $CandidateImageMap 'candidate'
+Assert-True ((@('broker', 'namesrv', 'controller', 'proxy', 'mcp') | Where-Object { $BaselineImages[$_] -ne $CandidateImages[$_] }).Count -gt 0) 'candidate images must differ from baseline'
+
+New-Item -ItemType Directory -Force -Path $ArtifactsDirectory, $ScenariosDirectory | Out-Null
+try {
+    $dockerInfo = Invoke-Native docker @('info', '--format', '{{json .ServerVersion}}')
+    if ($Backend -eq 'kind') {
+        $kindConfig = Join-Path $RunDirectory 'kind-config.yaml'
+        $kindYaml = @"
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  serviceSubnet: 10.96.0.0/16
+nodes:
+  - role: control-plane
+  - role: worker
+    labels: { topology.kubernetes.io/zone: zone-a }
+  - role: worker
+    labels: { topology.kubernetes.io/zone: zone-b }
+  - role: worker
+    labels: { topology.kubernetes.io/zone: zone-c }
+"@
+        [IO.File]::WriteAllText($kindConfig, $kindYaml, [Text.UTF8Encoding]::new($false))
+        Invoke-Native kind @('create', 'cluster', '--name', $ClusterName, '--image', $Policy.cluster.kind_node_image, '--config', $kindConfig, '--wait', '180s') | Out-Null
+        $CreatedCluster = $true
+        $StorageClass = 'standard'
+    } else {
+        Invoke-Native k3d @('cluster', 'create', $ClusterName, '--servers', '1', '--agents', '3', '--k3s-arg', '--disable=traefik@server:0', '--k3s-arg', '--service-cidr=10.43.0.0/16@server:0', '--wait') | Out-Null
+        $CreatedCluster = $true
+        $StorageClass = 'local-path'
+    }
+
+    $nodes = ((Invoke-Native kubectl @('get', 'nodes', '-o', 'json')).Output | ConvertFrom-Json).items
+    Assert-True ($nodes.Count -eq 4) 'fault cluster must contain exactly four nodes'
+    $workers = @($nodes | Where-Object { -not $_.metadata.labels.'node-role.kubernetes.io/control-plane' })
+    Assert-True ($workers.Count -eq 3) 'fault cluster must contain exactly three workers'
+
+    Invoke-Native docker @('build', '--file', (Join-Path $Root 'docker/Dockerfile.base'), '--target', 'fault-driver', '--tag', $FaultDriverImage, $Root) | Out-Null
+    if ($Backend -eq 'kind') {
+        Invoke-Native kind @('load', 'docker-image', $FaultDriverImage, '--name', $ClusterName) | Out-Null
+    } else {
+        Invoke-Native k3d @('image', 'import', $FaultDriverImage, '--cluster', $ClusterName) | Out-Null
+    }
+
+    $rocketmqNamespacePath = Join-Path $RunDirectory 'rocketmq-namespace.yaml'
+    $observabilityNamespacePath = Join-Path $RunDirectory 'observability-namespace.yaml'
+    [IO.File]::WriteAllText($rocketmqNamespacePath, "apiVersion: v1`nkind: Namespace`nmetadata:`n  name: $Namespace`n", [Text.UTF8Encoding]::new($false))
+    [IO.File]::WriteAllText($observabilityNamespacePath, "apiVersion: v1`nkind: Namespace`nmetadata:`n  name: observability`n", [Text.UTF8Encoding]::new($false))
+    Invoke-Native kubectl @('apply', '-f', $rocketmqNamespacePath) | Out-Null
+    Invoke-Native kubectl @('label', 'namespace', $Namespace, 'rocketmq.apache.org/client-access=true', '--overwrite') | Out-Null
+    Invoke-Native kubectl @('apply', '-f', $observabilityNamespacePath) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'apply', '-f', $RuntimeSecretManifest) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'apply', '-f', $BaselineDriverSecretManifest) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'apply', '-f', $RotatedDriverSecretManifest) | Out-Null
+    foreach ($secret in @('rocketmq-runtime-secrets', 'rocketmq-fault-driver-baseline', 'rocketmq-fault-driver-rotated')) {
+        Invoke-Native kubectl @('-n', $Namespace, 'get', 'secret', $secret) | Out-Null
+    }
+    Invoke-Native kubectl @('label', 'namespace', 'observability', 'rocketmq.apache.org/observability=true', '--overwrite') | Out-Null
+    $collectorManifest = @"
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: otel-collector-config, namespace: observability }
+data:
+  config.yaml: |
+    receivers: { otlp: { protocols: { grpc: { endpoint: 0.0.0.0:4317 } } } }
+    exporters: { debug: {} }
+    service: { pipelines: { metrics: { receivers: [otlp], exporters: [debug] }, traces: { receivers: [otlp], exporters: [debug] }, logs: { receivers: [otlp], exporters: [debug] } } }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: otel-collector, namespace: observability }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: otel-collector } }
+  template:
+    metadata: { labels: { app: otel-collector } }
+    spec:
+      containers:
+        - name: collector
+          image: $CollectorImage
+          args: ["--config=/etc/otelcol/config.yaml"]
+          ports: [{ name: otlp, containerPort: 4317 }]
+          volumeMounts: [{ name: config, mountPath: /etc/otelcol }]
+      volumes: [{ name: config, configMap: { name: otel-collector-config } }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: otel-collector, namespace: observability }
+spec: { selector: { app: otel-collector }, ports: [{ name: otlp, port: 4317, targetPort: otlp }] }
+"@
+    $collectorPath = Join-Path $RunDirectory 'collector.yaml'
+    [IO.File]::WriteAllText($collectorPath, $collectorManifest, [Text.UTF8Encoding]::new($false))
+    Invoke-Native kubectl @('apply', '-f', $collectorPath) | Out-Null
+    Invoke-Native kubectl @('-n', 'observability', 'rollout', 'status', 'deployment/otel-collector', '--timeout=180s') | Out-Null
+
+    $baselineValues = New-HelmValues $BaselineImages $StorageClass
+    Invoke-Native helm @('upgrade', '--install', 'rocketmq', $ChartPath, '--namespace', $Namespace, '--create-namespace', '--values', $baselineValues, '--wait', '--timeout', '10m') | Out-Null
+    Wait-Workloads
+    $InitialPvcUids = Get-PvcUidSet
+    Assert-True (-not [string]::IsNullOrWhiteSpace($InitialPvcUids)) 'PVC UID evidence must not be empty'
+    $ack = Send-AcknowledgedMessage
+    $before = Query-AcknowledgedMessage $ack.Id
+
+    $rolloutTimer = [Diagnostics.Stopwatch]::StartNew()
+    Set-ServiceImages $CandidateImages
+    $afterUpgrade = Query-AcknowledgedMessage $ack.Id
+    Set-ServiceImages $BaselineImages
+    $rolloutTimer.Stop()
+    $afterRollback = Query-AcknowledgedMessage $ack.Id
+    $pvcAfterUpgrade = Get-PvcUidSet
+    $preStopFailures = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'events', '--field-selector=reason=FailedPreStopHook', '-o', 'name') -AllowFailure).Output
+    Complete-Scenario 'rolling_upgrade' ([ordered]@{
+        rollout_completed = $true; acknowledged_message_visible = $true
+        queue_offset_preserved = $before.QueueOffset -eq $afterUpgrade.QueueOffset
+        commitlog_offset_preserved = $before.CommitLogOffset -eq $afterUpgrade.CommitLogOffset
+        drain_completed_within_deadline = [string]::IsNullOrWhiteSpace($preStopFailures); rollback_completed = $true
+        pvc_uid_set_preserved = $InitialPvcUids -eq $pvcAfterUpgrade
+    }) ([ordered]@{
+        rollout_status = 'candidate and baseline rollouts completed'; message_before = $before.Output
+        message_after = $afterUpgrade.Output; shutdown_report = "failedPreStopHooks=$preStopFailures rolloutSeconds=$($rolloutTimer.Elapsed.TotalSeconds)"
+        rollback_status = $afterRollback.Output; pvc_uids = $pvcAfterUpgrade
+    })
+
+    $evictionNode = ($workers | Select-Object -First 1).metadata.name
+    $drain = Invoke-Native kubectl @('drain', $evictionNode, '--pod-selector=app.kubernetes.io/component=proxy', '--ignore-daemonsets', '--delete-emptydir-data', '--timeout=180s')
+    Wait-Workloads
+    $afterEviction = Query-AcknowledgedMessage $ack.Id
+    $pdb = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pdb', '-o', 'wide')).Output
+    Invoke-Native kubectl @('uncordon', $evictionNode) | Out-Null
+    $nodeStatus = (Invoke-Native kubectl @('get', 'node', $evictionNode, '-o', 'json')).Output
+    Complete-Scenario 'node_eviction' ([ordered]@{
+        eviction_api_used = $drain.Output -match 'drain'; pdb_respected = $pdb -match 'rocketmq-proxy'
+        acknowledged_message_visible = $true; pvc_uid_set_preserved = $InitialPvcUids -eq (Get-PvcUidSet)
+        node_uncordoned = $nodeStatus -notmatch 'Unschedulable.*true'
+    }) ([ordered]@{ drain_output = $drain.Output; pdb_status = $pdb; message_after = $afterEviction.Output; pvc_uids = Get-PvcUidSet; node_status = $nodeStatus })
+
+    $collectorDown = Invoke-Native kubectl @('-n', 'observability', 'scale', 'deployment/otel-collector', '--replicas=0')
+    $outageStart = [Diagnostics.Stopwatch]::StartNew()
+    $duringOutageAck = Send-AcknowledgedMessage
+    $duringOutage = Query-AcknowledgedMessage $duringOutageAck.Id
+    $outageStart.Stop()
+    $telemetryLogs = (Invoke-Native kubectl @('-n', $Namespace, 'logs', 'statefulset/rocketmq-broker', '--tail=300') -AllowFailure).Output
+    Invoke-Native kubectl @('-n', 'observability', 'scale', 'deployment/otel-collector', '--replicas=1') | Out-Null
+    $collectorRecovery = Invoke-Native kubectl @('-n', 'observability', 'rollout', 'status', 'deployment/otel-collector', '--timeout=180s')
+    Complete-Scenario 'collector_outage' ([ordered]@{
+        data_plane_remained_available = $true; telemetry_queue_bounded = $telemetryLogs -notmatch 'unbounded'
+        collector_recovered = $collectorRecovery.ExitCode -eq 0; slo_budget_satisfied = $outageStart.Elapsed.TotalSeconds -lt 30
+    }) ([ordered]@{ collector_scale = $collectorDown.Output; message_during_outage = $duringOutage.Output; telemetry_metrics = $telemetryLogs; collector_recovery = $collectorRecovery.Output; slo_report = "message query seconds=$($outageStart.Elapsed.TotalSeconds) budget=30" })
+
+    $pressureNode = ($workers | Select-Object -Last 1).metadata.name
+    $taint = Invoke-Native kubectl @('taint', 'node', $pressureNode, 'node.kubernetes.io/disk-pressure=true:NoSchedule', '--overwrite')
+    $proxyPod = ((Invoke-Native kubectl @('-n', $Namespace, 'get', 'pods', '-l', 'app.kubernetes.io/component=proxy', '-o', 'json')).Output | ConvertFrom-Json).items | Where-Object { $_.spec.nodeName -eq $pressureNode } | Select-Object -First 1
+    if ($proxyPod) { Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $proxyPod.metadata.name, '--wait=false') | Out-Null }
+    Wait-Workloads
+    $podPlacement = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pods', '-l', 'app.kubernetes.io/component=proxy', '-o', 'wide')).Output
+    $afterPressure = Query-AcknowledgedMessage $ack.Id
+    Invoke-Native kubectl @('taint', 'node', $pressureNode, 'node.kubernetes.io/disk-pressure:NoSchedule-') | Out-Null
+    $pressureStatus = (Invoke-Native kubectl @('get', 'node', $pressureNode, '-o', 'json')).Output
+    Complete-Scenario 'disk_pressure' ([ordered]@{
+        disk_pressure_taint_observed = $taint.Output -match 'tainted'; stateless_pod_rescheduled = $podPlacement -notmatch "$pressureNode.*Terminating"
+        acknowledged_message_visible = $true; pvc_uid_set_preserved = $InitialPvcUids -eq (Get-PvcUidSet); taint_removed = $pressureStatus -notmatch 'node.kubernetes.io/disk-pressure'
+    }) ([ordered]@{ taint_status = $taint.Output; pod_reschedule = $podPlacement; message_after = $afterPressure.Output; pvc_uids = Get-PvcUidSet; node_status = $pressureStatus })
+
+    $leaderBefore = Get-ControllerMetadata
+    $leaderPodMatch = [regex]::Match($leaderBefore.Output, 'rocketmq-controller-(\d+)')
+    Assert-True $leaderPodMatch.Success 'Controller metadata must identify leader ordinal'
+    $leaderPod = "rocketmq-controller-$($leaderPodMatch.Groups[1].Value)"
+    Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $leaderPod, '--wait=false') | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', 'statefulset/rocketmq-controller', '--timeout=180s') | Out-Null
+    $leaderAfter = Get-ControllerMetadata
+    $controllerStatus = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pods', '-l', 'app.kubernetes.io/component=controller', '-o', 'wide')).Output
+    $controllerState = ((Invoke-Native kubectl @('-n', $Namespace, 'get', 'statefulset/rocketmq-controller', '-o', 'json')).Output | ConvertFrom-Json).status
+    $afterLeader = Query-AcknowledgedMessage $ack.Id
+    Complete-Scenario 'controller_leader_failure' ([ordered]@{
+        leader_changed = $leaderAfter.Output -ne $leaderBefore.Output; controller_quorum_preserved = $controllerState.readyReplicas -ge 2
+        acknowledged_message_visible = $true; controller_replicas_restored = $controllerState.readyReplicas -eq 3
+    }) ([ordered]@{ leader_before = $leaderBefore.Output; leader_after = $leaderAfter.Output; quorum_status = $controllerStatus; message_after = $afterLeader.Output; controller_status = $controllerStatus })
+
+    $preRotation = Query-AcknowledgedMessage $ack.Id
+    Invoke-Native kubectl @('-n', $Namespace, 'apply', '-f', $RotatedRuntimeSecretManifest) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'restart', 'statefulset/rocketmq-broker') | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', 'statefulset/rocketmq-broker', '--timeout=180s') | Out-Null
+    $oldDenied = Invoke-FaultDriver -SecretName 'rocketmq-fault-driver-baseline' -Arguments @('message', 'queryMsgByUniqueKey', '-t', $Topic, '-i', $ack.Id) -AllowFailure
+    $newAllowed = Query-AcknowledgedMessage $ack.Id 'rocketmq-fault-driver-rotated'
+    Invoke-Native kubectl @('-n', $Namespace, 'apply', '-f', $RuntimeSecretManifest) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'restart', 'statefulset/rocketmq-broker') | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', 'statefulset/rocketmq-broker', '--timeout=180s') | Out-Null
+    $restored = Query-AcknowledgedMessage $ack.Id
+    $redactionText = "$($oldDenied.Output)`n$($newAllowed.Output)"
+    Complete-Scenario 'secret_rotation' ([ordered]@{
+        old_credentials_worked_before_rotation = $preRotation.QueueOffset -eq $before.QueueOffset
+        old_credentials_rejected_after_rotation = $oldDenied.ExitCode -ne 0
+        new_credentials_worked_after_rotation = $newAllowed.QueueOffset -eq $before.QueueOffset
+        baseline_credentials_restored = $restored.QueueOffset -eq $before.QueueOffset
+        secret_values_redacted = $redactionText -notmatch '(?i)secret[_-]?key\s*[=:]\s*\S+'
+    }) ([ordered]@{ pre_rotation_access = $preRotation.Output; old_access_denied = "exit=$($oldDenied.ExitCode)"; new_access_allowed = $newAllowed.Output; rollback_access = $restored.Output; redaction_scan = 'no secret value pattern present' })
+
+    $pvcBeforeRestart = Get-PvcUidSet
+    $brokerRestart = Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', 'rocketmq-broker-0', '--wait=false')
+    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', 'statefulset/rocketmq-broker', '--timeout=180s') | Out-Null
+    $afterRestart = Query-AcknowledgedMessage $ack.Id
+    $pvcAfterRestart = Get-PvcUidSet
+    Complete-Scenario 'acknowledged_message_recovery' ([ordered]@{
+        send_acknowledged = $true; message_visible_before_restart = $true; message_visible_after_restart = $true
+        message_id_preserved = $afterRestart.Output -match [regex]::Escape($ack.Id)
+        queue_offset_preserved = $before.QueueOffset -eq $afterRestart.QueueOffset
+        commitlog_offset_preserved = $before.CommitLogOffset -eq $afterRestart.CommitLogOffset
+        pvc_uid_set_preserved = $pvcBeforeRestart -eq $pvcAfterRestart
+    }) ([ordered]@{ send_ack = $ack.Output; message_before = $before.Output; broker_restart = $brokerRestart.Output; message_after = $afterRestart.Output; watermark = "queue=$($afterRestart.QueueOffset) commitlog=$($afterRestart.CommitLogOffset)"; pvc_uids = $pvcAfterRestart })
+
+    Assert-True (($ScenarioRecords | ForEach-Object { $_.id }) -join ',' -eq ($Policy.scenarios | ForEach-Object { $_.id }) -join ',') 'all seven scenarios must execute in policy order'
+    Wait-Workloads
+    $FinalPvcUids = Get-PvcUidSet
+    $finalController = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'statefulset/rocketmq-controller', '-o', 'json')).Output | ConvertFrom-Json
+    $finalPods = ((Invoke-Native kubectl @('-n', $Namespace, 'get', 'pods', '-l', 'app.kubernetes.io/name=rocketmq-rust', '-o', 'json')).Output | ConvertFrom-Json).items
+    $allPodsReady = $finalPods.Count -eq 10 -and @($finalPods | Where-Object { ($_.status.conditions | Where-Object { $_.type -eq 'Ready' -and $_.status -eq 'True' }).Count -eq 1 }).Count -eq 10
+    $finalNodes = ((Invoke-Native kubectl @('get', 'nodes', '-o', 'json')).Output | ConvertFrom-Json).items
+    $nodesClean = @($finalNodes | Where-Object { $_.spec.unschedulable -eq $true -or ($_.spec.taints | Where-Object { $_.key -eq 'node.kubernetes.io/disk-pressure' }) }).Count -eq 0
+    $collectorReady = ((Invoke-Native kubectl @('-n', 'observability', 'get', 'deployment/otel-collector', '-o', 'json')).Output | ConvertFrom-Json).status.readyReplicas -eq 1
+    $baselineImagesRestored = $true
+    foreach ($service in @('broker', 'namesrv', 'controller')) {
+        $actualImage = (Invoke-Native kubectl @('-n', $Namespace, 'get', "statefulset/rocketmq-$service", '-o', "jsonpath={.spec.template.spec.containers[?(@.name=='$service')].image}")).Output
+        $baselineImagesRestored = $baselineImagesRestored -and $actualImage -eq $BaselineImages[$service]
+    }
+    foreach ($service in @('proxy', 'mcp')) {
+        $actualImage = (Invoke-Native kubectl @('-n', $Namespace, 'get', "deployment/rocketmq-$service", '-o', "jsonpath={.spec.template.spec.containers[?(@.name=='$service')].image}")).Output
+        $baselineImagesRestored = $baselineImagesRestored -and $actualImage -eq $BaselineImages[$service]
+    }
+    $unresolvedFaults = [System.Collections.Generic.List[string]]::new()
+    if (-not $nodesClean) { $unresolvedFaults.Add('node-cordon-or-disk-pressure-taint') }
+    if (-not $collectorReady) { $unresolvedFaults.Add('collector-not-restored') }
+    if (-not $baselineImagesRestored) { $unresolvedFaults.Add('baseline-images-not-restored') }
+    if ($finalController.status.readyReplicas -ne 3) { $unresolvedFaults.Add('controller-quorum-not-restored') }
+    $clusterProfile = [ordered]@{
+        control_plane_nodes = 1; worker_nodes = 3; controller_replicas = 3; storage_class = $StorageClass
+        nodes = @($nodes | ForEach-Object { $_.metadata.name })
+    }
+    $toolVersions = [ordered]@{
+        docker = $dockerInfo.Output
+        kind = if (Get-Command kind -ErrorAction SilentlyContinue) { (Invoke-Native kind @('version')).Output } else { 'not-installed' }
+        k3d = if (Get-Command k3d -ErrorAction SilentlyContinue) { (Invoke-Native k3d @('version')).Output } else { 'not-installed' }
+        kubectl = (Invoke-Native kubectl @('version', '--client', '--output=json')).Output
+        helm = (Invoke-Native helm @('version', '--short')).Output
+    }
+    $globalAssertions = [ordered]@{
+        all_workloads_ready = $allPodsReady; all_faults_reverted = $unresolvedFaults.Count -eq 0
+        controller_quorum_restored = $finalController.status.readyReplicas -eq 3
+        pvc_uid_set_preserved = $InitialPvcUids -eq $FinalPvcUids
+        acknowledged_message_recovered = $afterRestart.QueueOffset -eq $before.QueueOffset
+        queue_offset_preserved = $afterRestart.QueueOffset -eq $before.QueueOffset
+        commitlog_offset_preserved = $afterRestart.CommitLogOffset -eq $before.CommitLogOffset
+        drain_completed_within_deadline = [string]::IsNullOrWhiteSpace($preStopFailures)
+        slo_budget_satisfied = $outageStart.Elapsed.TotalSeconds -lt 30
+        rollback_verified = $baselineImagesRestored
+        unresolved_faults_empty = $unresolvedFaults.Count -eq 0
+    }
+    foreach ($assertion in $globalAssertions.Keys) { Assert-True $globalAssertions[$assertion] "global.$assertion" }
+    $run = [ordered]@{
+        schema_version = 1; milestone = 'M11-11'; policy_sha256 = $PolicySha256; run_id = $RunId
+        started_at = $RunStarted.ToString('o'); finished_at = [DateTimeOffset]::UtcNow.ToString('o'); backend = $Backend
+        dynamic_execution = $true; fixture = $false; cluster_profile = $clusterProfile; tool_versions = $toolVersions
+        chart_sha256 = Get-TreeSha256 $ChartPath; overlay_sha256 = Get-Sha256 $OverlayPath
+        baseline_images = $BaselineImages; candidate_images = $CandidateImages; global_assertions = $globalAssertions
+        unresolved_faults = @($unresolvedFaults); scenarios = @($ScenarioRecords); artifacts = @($ArtifactRecords)
+    }
+    $runPath = Join-Path $RunDirectory 'run.json'
+    [IO.File]::WriteAllText($runPath, ($run | ConvertTo-Json -Depth 30), [Text.UTF8Encoding]::new($false))
+    Invoke-Native python @((Join-Path $Root 'scripts/fault_matrix_guard.py'), '--root', $Root, '--evidence', $RunDirectory) | Out-Null
+    $RunSucceeded = $true
+    Write-Output "M11-11 dynamic fault matrix passed: $RunDirectory"
+} finally {
+    if ($CreatedCluster -and -not $KeepCluster) {
+        if ($Backend -eq 'kind') {
+            Invoke-Native kind @('delete', 'cluster', '--name', $ClusterName) -AllowFailure | Out-Null
+        } else {
+            Invoke-Native k3d @('cluster', 'delete', $ClusterName) -AllowFailure | Out-Null
+        }
+    }
+    if (-not $RunSucceeded -and (Test-Path -LiteralPath (Join-Path $RunDirectory 'run.json'))) {
+        Remove-Item -LiteralPath (Join-Path $RunDirectory 'run.json') -Force
+    }
+}

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/acknowledged_message_recovery.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/acknowledged_message_recovery.txt
@@ -1,0 +1,1 @@
+fixture: broker restart retained message ID, queue offset, commitlog offset, and PVC identity

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/collector_outage.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/collector_outage.txt
@@ -1,0 +1,1 @@
+fixture: collector outage retained bounded telemetry behavior and data-plane availability within the SLO budget

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/controller_leader_failure.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/controller_leader_failure.txt
@@ -1,0 +1,1 @@
+fixture: Controller leader changed while quorum, replicas, and acknowledged-message visibility were preserved

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/disk_pressure.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/disk_pressure.txt
@@ -1,0 +1,1 @@
+fixture: scheduling pressure taint was observed and removed without changing PVC identity or message visibility

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/node_eviction.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/node_eviction.txt
@@ -1,0 +1,1 @@
+fixture: eviction API respected the proxy PDB and PVC identity while the acknowledged message remained visible

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/rolling_upgrade.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/rolling_upgrade.txt
@@ -1,0 +1,1 @@
+fixture: rolling upgrade preserved acknowledgement, offsets, PVCs, drain deadline, and rollback

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/secret_rotation.txt
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/artifacts/secret_rotation.txt
@@ -1,0 +1,1 @@
+fixture: old credentials failed only after rotation, new credentials worked, rollback worked, and values stayed redacted

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/run.json
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/run.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": 1,
+  "milestone": "M11-11",
+  "policy_sha256": "72dd08e26ca0d5454cfe9ff79465de53dca8155ab7bf967dddc8683663c7f22f",
+  "run_id": "fixture-m11-11-positive",
+  "started_at": "2026-07-17T01:00:00Z",
+  "finished_at": "2026-07-17T01:07:00Z",
+  "backend": "kind",
+  "dynamic_execution": false,
+  "fixture": true,
+  "cluster_profile": {
+    "control_plane_nodes": 1,
+    "worker_nodes": 3,
+    "controller_replicas": 3,
+    "storage_class": "fixture-standard",
+    "nodes": [
+      "fixture-control-plane",
+      "fixture-worker-a",
+      "fixture-worker-b",
+      "fixture-worker-c"
+    ]
+  },
+  "tool_versions": {
+    "docker": "fixture",
+    "kind": "v0.27.0-fixture",
+    "k3d": "not-used-fixture",
+    "kubectl": "v1.32.2-fixture",
+    "helm": "v4.2.3-fixture"
+  },
+  "chart_sha256": "e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c",
+  "overlay_sha256": "029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d",
+  "baseline_images": {
+    "broker": "example.invalid/broker@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777",
+    "namesrv": "example.invalid/namesrv@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
+    "controller": "example.invalid/controller@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",
+    "proxy": "example.invalid/proxy@sha256:a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b",
+    "mcp": "example.invalid/mcp@sha256:06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0"
+  },
+  "candidate_images": {
+    "broker": "example.invalid/broker@sha256:3a88693bc57dd4c3d5f37e2acb1dc7e35daa0e578ca6c8538ed3fc4534de4373",
+    "namesrv": "example.invalid/namesrv@sha256:536532dedeeed56d3f086f49bfb898babf09e36f7d5ac1ee5efc374e59ff7688",
+    "controller": "example.invalid/controller@sha256:d7ac38651c788f9e8745b1a183b894aa4f5acd428ea4a2cebdf31c5c18352e5d",
+    "proxy": "example.invalid/proxy@sha256:9e29c84a61a63655bff5c10fd9ff3153336b16caa0ed5c149950c06a349d72c1",
+    "mcp": "example.invalid/mcp@sha256:4df393a882f7367f20eb8e91411e9f31df2aecef2b57e4748b2879ea4f1fd9c7"
+  },
+  "global_assertions": {
+    "all_workloads_ready": true,
+    "all_faults_reverted": true,
+    "controller_quorum_restored": true,
+    "pvc_uid_set_preserved": true,
+    "acknowledged_message_recovered": true,
+    "queue_offset_preserved": true,
+    "commitlog_offset_preserved": true,
+    "drain_completed_within_deadline": true,
+    "slo_budget_satisfied": true,
+    "rollback_verified": true,
+    "unresolved_faults_empty": true
+  },
+  "unresolved_faults": [],
+  "scenarios": [
+    {
+      "id": "rolling_upgrade",
+      "status": "passed",
+      "assertions": {
+        "rollout_completed": true,
+        "acknowledged_message_visible": true,
+        "queue_offset_preserved": true,
+        "commitlog_offset_preserved": true,
+        "drain_completed_within_deadline": true,
+        "rollback_completed": true,
+        "pvc_uid_set_preserved": true
+      },
+      "evidence": {
+        "rollout_status": "artifacts/rolling_upgrade.txt",
+        "message_before": "artifacts/rolling_upgrade.txt",
+        "message_after": "artifacts/rolling_upgrade.txt",
+        "shutdown_report": "artifacts/rolling_upgrade.txt",
+        "rollback_status": "artifacts/rolling_upgrade.txt",
+        "pvc_uids": "artifacts/rolling_upgrade.txt"
+      }
+    },
+    {
+      "id": "node_eviction",
+      "status": "passed",
+      "assertions": {
+        "eviction_api_used": true,
+        "pdb_respected": true,
+        "acknowledged_message_visible": true,
+        "pvc_uid_set_preserved": true,
+        "node_uncordoned": true
+      },
+      "evidence": {
+        "drain_output": "artifacts/node_eviction.txt",
+        "pdb_status": "artifacts/node_eviction.txt",
+        "message_after": "artifacts/node_eviction.txt",
+        "pvc_uids": "artifacts/node_eviction.txt",
+        "node_status": "artifacts/node_eviction.txt"
+      }
+    },
+    {
+      "id": "collector_outage",
+      "status": "passed",
+      "assertions": {
+        "data_plane_remained_available": true,
+        "telemetry_queue_bounded": true,
+        "collector_recovered": true,
+        "slo_budget_satisfied": true
+      },
+      "evidence": {
+        "collector_scale": "artifacts/collector_outage.txt",
+        "message_during_outage": "artifacts/collector_outage.txt",
+        "telemetry_metrics": "artifacts/collector_outage.txt",
+        "collector_recovery": "artifacts/collector_outage.txt",
+        "slo_report": "artifacts/collector_outage.txt"
+      }
+    },
+    {
+      "id": "disk_pressure",
+      "status": "passed",
+      "assertions": {
+        "disk_pressure_taint_observed": true,
+        "stateless_pod_rescheduled": true,
+        "acknowledged_message_visible": true,
+        "pvc_uid_set_preserved": true,
+        "taint_removed": true
+      },
+      "evidence": {
+        "taint_status": "artifacts/disk_pressure.txt",
+        "pod_reschedule": "artifacts/disk_pressure.txt",
+        "message_after": "artifacts/disk_pressure.txt",
+        "pvc_uids": "artifacts/disk_pressure.txt",
+        "node_status": "artifacts/disk_pressure.txt"
+      }
+    },
+    {
+      "id": "controller_leader_failure",
+      "status": "passed",
+      "assertions": {
+        "leader_changed": true,
+        "controller_quorum_preserved": true,
+        "acknowledged_message_visible": true,
+        "controller_replicas_restored": true
+      },
+      "evidence": {
+        "leader_before": "artifacts/controller_leader_failure.txt",
+        "leader_after": "artifacts/controller_leader_failure.txt",
+        "quorum_status": "artifacts/controller_leader_failure.txt",
+        "message_after": "artifacts/controller_leader_failure.txt",
+        "controller_status": "artifacts/controller_leader_failure.txt"
+      }
+    },
+    {
+      "id": "secret_rotation",
+      "status": "passed",
+      "assertions": {
+        "old_credentials_worked_before_rotation": true,
+        "old_credentials_rejected_after_rotation": true,
+        "new_credentials_worked_after_rotation": true,
+        "baseline_credentials_restored": true,
+        "secret_values_redacted": true
+      },
+      "evidence": {
+        "pre_rotation_access": "artifacts/secret_rotation.txt",
+        "old_access_denied": "artifacts/secret_rotation.txt",
+        "new_access_allowed": "artifacts/secret_rotation.txt",
+        "rollback_access": "artifacts/secret_rotation.txt",
+        "redaction_scan": "artifacts/secret_rotation.txt"
+      }
+    },
+    {
+      "id": "acknowledged_message_recovery",
+      "status": "passed",
+      "assertions": {
+        "send_acknowledged": true,
+        "message_visible_before_restart": true,
+        "message_visible_after_restart": true,
+        "message_id_preserved": true,
+        "queue_offset_preserved": true,
+        "commitlog_offset_preserved": true,
+        "pvc_uid_set_preserved": true
+      },
+      "evidence": {
+        "send_ack": "artifacts/acknowledged_message_recovery.txt",
+        "message_before": "artifacts/acknowledged_message_recovery.txt",
+        "broker_restart": "artifacts/acknowledged_message_recovery.txt",
+        "message_after": "artifacts/acknowledged_message_recovery.txt",
+        "watermark": "artifacts/acknowledged_message_recovery.txt",
+        "pvc_uids": "artifacts/acknowledged_message_recovery.txt"
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "artifacts/rolling_upgrade.txt",
+      "sha256": "3a88693bc57dd4c3d5f37e2acb1dc7e35daa0e578ca6c8538ed3fc4534de4373"
+    },
+    {
+      "path": "artifacts/node_eviction.txt",
+      "sha256": "536532dedeeed56d3f086f49bfb898babf09e36f7d5ac1ee5efc374e59ff7688"
+    },
+    {
+      "path": "artifacts/collector_outage.txt",
+      "sha256": "bd82089b896f1cb98c14954d293c5a761b88bfca7ea8341ab8739c1d2c4db1c6"
+    },
+    {
+      "path": "artifacts/disk_pressure.txt",
+      "sha256": "9e29c84a61a63655bff5c10fd9ff3153336b16caa0ed5c149950c06a349d72c1"
+    },
+    {
+      "path": "artifacts/controller_leader_failure.txt",
+      "sha256": "d7ac38651c788f9e8745b1a183b894aa4f5acd428ea4a2cebdf31c5c18352e5d"
+    },
+    {
+      "path": "artifacts/secret_rotation.txt",
+      "sha256": "4df393a882f7367f20eb8e91411e9f31df2aecef2b57e4748b2879ea4f1fd9c7"
+    },
+    {
+      "path": "artifacts/acknowledged_message_recovery.txt",
+      "sha256": "b4874c779023eedf707a81589cb97e3cf5d481f2b6aac39ac6bbbc6972a89b12"
+    }
+  ]
+}

--- a/scripts/tests/test_m11_fault_matrix.py
+++ b/scripts/tests/test_m11_fault_matrix.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Positive-fixture and deliberate-violation tests for M11-11 evidence."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts" / "fault_matrix_guard.py"
+FIXTURE = Path("scripts/tests/fixtures/m11-fault-matrix/pass")
+
+
+class FaultMatrixGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="m11-fault-matrix-")
+        self.root = Path(self.temporary.name)
+        shutil.copytree(REPO_ROOT / "distribution", self.root / "distribution")
+        (self.root / "docker").mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / "docker" / "Dockerfile.base", self.root / "docker" / "Dockerfile.base")
+        (self.root / "scripts" / "tests" / "fixtures" / "m11-fault-matrix").mkdir(parents=True)
+        shutil.copy2(
+            REPO_ROOT / "scripts" / "kind-architecture-refactor-e2e.ps1",
+            self.root / "scripts" / "kind-architecture-refactor-e2e.ps1",
+        )
+        shutil.copy2(
+            REPO_ROOT / "scripts" / "tests" / "test_m11_fault_matrix.py",
+            self.root / "scripts" / "tests" / "test_m11_fault_matrix.py",
+        )
+        shutil.copytree(
+            REPO_ROOT / FIXTURE,
+            self.root / FIXTURE,
+        )
+        (self.root / ".github" / "workflows").mkdir(parents=True)
+        shutil.copy2(
+            REPO_ROOT / ".github" / "workflows" / "kubernetes-fault-matrix.yml",
+            self.root / ".github" / "workflows" / "kubernetes-fault-matrix.yml",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @property
+    def run_path(self) -> Path:
+        return self.root / FIXTURE / "run.json"
+
+    def run_guard(self, *arguments: str, expect_success: bool) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [sys.executable, str(GUARD), "--root", str(self.root), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        if expect_success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("guard passed", result.stdout)
+        else:
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("ERROR:", result.stderr)
+        return result
+
+    def mutate_run(self, mutation) -> None:  # type: ignore[no-untyped-def]
+        run = json.loads(self.run_path.read_text(encoding="utf-8"))
+        mutation(run)
+        self.run_path.write_text(json.dumps(run, indent=2) + "\n", encoding="utf-8")
+
+    def test_policy_and_positive_fixture_pass(self) -> None:
+        self.run_guard("--policy-only", expect_success=True)
+        self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=True)
+
+    def test_policy_hash_ignores_line_endings(self) -> None:
+        policy = self.root / "distribution" / "kubernetes" / "fault-matrix-policy.json"
+        policy.write_bytes(policy.read_bytes().replace(b"\n", b"\r\n"))
+        self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=True)
+
+    def test_fixture_requires_explicit_opt_in(self) -> None:
+        result = self.run_guard("--evidence", str(FIXTURE), expect_success=False)
+        self.assertIn("--allow-fixture", result.stderr)
+
+    def test_non_dynamic_production_evidence_is_rejected(self) -> None:
+        self.mutate_run(lambda run: run.update(fixture=False))
+        result = self.run_guard("--evidence", str(FIXTURE), expect_success=False)
+        self.assertIn("dynamic execution", result.stderr)
+
+    def test_failed_global_assertion_is_rejected(self) -> None:
+        self.mutate_run(lambda run: run["global_assertions"].update(rollback_verified=False))
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("rollback_verified", result.stderr)
+
+    def test_missing_scenario_is_rejected(self) -> None:
+        self.mutate_run(lambda run: run["scenarios"].pop())
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("exact ordered seven scenarios", result.stderr)
+
+    def test_scenario_assertion_key_drift_is_rejected(self) -> None:
+        self.mutate_run(lambda run: run["scenarios"][0]["assertions"].pop("queue_offset_preserved"))
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("rolling_upgrade: assertion keys drifted", result.stderr)
+
+    def test_placeholder_image_digest_is_rejected(self) -> None:
+        self.mutate_run(
+            lambda run: run["candidate_images"].update(
+                broker="example.invalid/broker@sha256:" + "0" * 64
+            )
+        )
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("placeholder digest", result.stderr)
+
+    def test_unresolved_fault_is_rejected(self) -> None:
+        self.mutate_run(lambda run: run.update(unresolved_faults=["worker-remains-cordoned"]))
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("unresolved_faults", result.stderr)
+
+    def test_artifact_hash_mismatch_is_rejected(self) -> None:
+        artifact = self.root / FIXTURE / "artifacts" / "rolling_upgrade.txt"
+        artifact.write_text("tampered\n", encoding="utf-8")
+        result = self.run_guard("--evidence", str(FIXTURE), "--allow-fixture", expect_success=False)
+        self.assertIn("artifact hash mismatch", result.stderr)
+
+    def test_runner_that_drops_durability_marker_is_rejected(self) -> None:
+        runner = self.root / "scripts" / "kind-architecture-refactor-e2e.ps1"
+        source = runner.read_text(encoding="utf-8")
+        self.assertIn("commitlog_offset_preserved", source)
+        runner.write_text(source.replace("commitlog_offset_preserved", "offset_not_checked"), encoding="utf-8")
+        result = self.run_guard("--policy-only", expect_success=False)
+        self.assertIn("commitlog_offset_preserved", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8290

### Brief Description

Adds the fail-closed M11-11 Kind/K3d architecture fault-matrix contract and execution path for rolling upgrades, node eviction, collector outage, scheduling disk pressure, Controller leader failure, secret rotation, and acknowledged-message recovery.

The change versions the cluster and evidence policy, adds a test-only fault driver and a manual dynamic workflow, validates signed image and artifact digests, and records durability, quorum, drain, SLO, rollback, and fault-cleanup assertions. It also adds HMAC-SHA256 ACL injection for the admin fault driver without exposing secrets, and updates the architecture migration checklist to 75/82 completed work packages.

Fixture evidence remains explicitly non-dynamic and cannot satisfy the production gate. The real seven-scenario Kind/K3d run remains open until a host provides Docker, the pinned cluster tools, signed image digests, and runtime secret manifests.

### How Did You Test This Change?

- `python scripts/fault_matrix_guard.py --policy-only` (passed)
- `python scripts/fault_matrix_guard.py --evidence scripts/tests/fixtures/m11-fault-matrix/pass --allow-fixture` (passed)
- `python -m unittest scripts.tests.test_m11_fault_matrix -v` (11/11 passed)
- `scripts/kind-architecture-refactor-e2e.ps1 -Mode Validate` (passed; no dynamic execution or PASS evidence)
- `python scripts/kubernetes_assets_guard.py` (passed)
- `python -m unittest scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_service_lifecycle -v` (12/12 passed)
- `scripts/kubernetes-assets-contract.ps1` (Helm and Kustomize 37/37 schema, lint, and parity checks passed)
- `python scripts/container_image_guard.py` and the container foundation mutation tests (9/9 passed)
- `cargo test -p rocketmq-client-rust acl_client_rpc_hook --lib` (5/5 passed)
- `cargo test -p rocketmq-admin-cli rocketmq_cli --lib` (5/5 passed)
- `cargo test -p rocketmq-admin-core admin_acl_hook --lib` (1/1 passed)
- `python scripts/architecture_dependency_guard.py --mode target` and `--mode baseline` (passed)
- `python scripts/architecture_release_guard.py` (passed)
- `scripts/check-agents-routing.ps1`, `scripts/check-error-hygiene.ps1`, and `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` (passed)
- `cargo fmt --all -- --check` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- Actionlint 1.7.12 and Hadolint 2.14.0 (passed)

The dynamic Kind/K3d `Run` mode was not executed because the required local cluster runtime, signed images, and secrets were unavailable. No fixture is reported as production evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm deployments can configure broker topic auto-creation, disabled by default.
  * Admin CLI supports optional ACL credentials, security tokens, and HMAC-SHA256 request signing.
  * Added Kubernetes fault-matrix validation and dynamic recovery testing for upgrades, failures, secret rotation, telemetry outages, and message durability.
  * Added a test-only fault-driver container for automated scenarios.

* **Documentation**
  * Documented lifecycle probes, shutdown behavior, validation commands, fault evidence, and rollback requirements.

* **Bug Fixes**
  * Improved validation of fault evidence, artifact integrity, image references, and recovery assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->