### PR TITLE
[ISSUE #8305]♻️Correct NameServer ArcMut debt breakdown

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -627,7 +627,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
   - [x] Issue #8301 后实际快照降至 688 production/1,959 occurrence；Controller 降至 8 条/24 occurrence，request processor wrapper 已退出 `ArcMut`
-  - [x] Issue #8303 后实际快照降至 669 production/1,918 occurrence；NameServer 降至 28 条/58 occurrence，runtime/KV/V2 route/batch/housekeeping/request-processor owner 已退出 `ArcMut`
+  - [x] Issue #8303 后实际快照降至 669 production/1,918 occurrence；NameServer 降至 28 条/58 occurrence（V1 tables 16/44、remoting client 4/5、Context 8/9），runtime/KV/V2 route/batch/housekeeping/request-processor owner 已退出 `ArcMut`
+  - [x] Issue #8305 按实际快照校正 NameServer 子类别分配；28 条/58 occurrence 总量与 reviewed baseline 不变
   - [ ] M11-12g～i：Remoting Channel/Context owner、Controller/NameServer remoting-client 与 NameServer V1 tables、Client、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -259,7 +259,7 @@ request processor owner 随 Issue #8301 将业务 handler 收窄为共享 receiv
 688 production/1,959 occurrence，Controller 降至 8 条/24 occurrence；总进度仍为 75/82。
 NameServer runtime/processor owner 随 Issue #8303 改为安全 `Arc` 根、`Weak` child handle、`ArcSwap` 配置快照和
 内部同步 batch/KV/V1 wrapper 后，实际快照降至 669 production/1,918 occurrence，NameServer 降至 28 条/58
-occurrence。剩余 NameServer 债务精确为 V1 tables 16/44、remoting client 4/7 和 `ConnectionHandlerContext` 8/7；
+occurrence。剩余 NameServer 债务精确为 V1 tables 16/44、remoting client 4/5 和 `ConnectionHandlerContext` 8/9；
 总进度仍为 75/82，M11-12 父工作包未完成。
 
 ### 9.3 证据目录

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -141,8 +141,8 @@ receiver 收窄和 1 个相邻 import token context 的一对一 relocation，ap
 M11-12f 后实际快照为 1,008 个条目：production 669、test 325、compatibility 14；production occurrence 为
 1,918。相对 M11-12e 删除 19 个 production 条目和 41 个 production occurrence；相对初始快照累计删除
 91 个 production 条目和 207 个 production occurrence。`rocketmq-namesrv` production 债务由 47 条/99 occurrence
-降至 28 条/58 occurrence；剩余项精确为 V1 tables 16/44、remoting client 4/7 和
-`ConnectionHandlerContext` boundary 8/7。
+降至 28 条/58 occurrence；剩余项精确为 V1 tables 16/44、remoting client 4/5 和
+`ConnectionHandlerContext` boundary 8/9。Issue #8305 只校正该子类别分配，不改变总量或 reviewed baseline。
 
 reviewed baseline 为 1,008 条、production 669/1,921 occurrences。临时 ADR-013 approval 只批准 9 条同 item
 一对一 relocation，approval 不提交；baseline 1,029→1,008、occurrence 2,942→2,899。默认 guard 仍精确失败切片前


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8305

### Brief Description

- Correct the M11-12f NameServer debt split to legacy V1 tables 16 entries/44 occurrences, remoting client 4 entries/5 occurrences, and `ConnectionHandlerContext` 8 entries/9 occurrences.
- Keep the verified NameServer total at 28 entries/58 occurrences and the workspace production total at 669 entries/1,918 occurrences.
- Record the evidence correction in the migration checklist and progress handoff.

### How Did You Test This Change?

- Recomputed the three NameServer categories from `target/m11-12f-namesrv-runtime-after.json` and verified that they sum to 28 entries/58 occurrences.
- Searched the migration documents to confirm that the incorrect 4/7 and 8/7 split no longer remains.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture migration progress reports with corrected NameServer dependency and debt breakdowns.
  * Clarified that subcategory allocations were revised while overall totals and reviewed baselines remain unchanged.
  * Added supporting status evidence for ongoing runtime and processor ownership work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->