### PR TITLE
[ISSUE #8317]♻️Replace Client latency fault detector ArcMut ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -627,7 +627,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12i NameServer V1 tables：六张 `ArcMut<HashMap>` 改为 manager 独占普通 `HashMap`，由既有 `Mutex<RouteInfoManager>` wrapper 提供唯一写边界；所有变更入口恢复 `&mut self`，删除冗余内部锁与全部可变逃逸
   - [x] M11-12j Remoting protocol compatibility：删除固定 `ArcMut` header/mapping-detail facade，topic-config wire DTO 直接 re-export Protocol canonical `HashMap` owner；Broker/NameServer 构造端发布 owned protocol value
   - [x] M11-12k Client ProduceAccumulator owner：Manager/Producer 改用安全 `Arc`；批大小/延时配置使用原子状态，sync/async guard task handle 与 schedule sender 收入显式 lifecycle mutex；异步关闭先取出 handle 再 await
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315 与每次真实下降
+  - [x] M11-12l Client latency fault detector：trait/strategy/filter/task capture 改用安全 `Arc`；detector 配置原子发布，resolver/service detector 使用短 `RwLock` 的 `Arc` 快照，单一 lifecycle mutex 串行 task 发布/关闭并排除 shutdown 期间 restart
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -639,7 +640,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8311 后实际快照降至 472 production/1,515 occurrence；NameServer production 债务清零，reviewed baseline 仅删除 V1 tables 的 16 条/44 occurrence，无 relocation
   - [x] Issue #8313 后实际快照降至 466 production/1,505 occurrence；Remoting production 债务清零，Broker wire-wrapper occurrence 同步减少 1 次
   - [x] Issue #8315 后实际快照降至 463 production/1,495 occurrence；Client 降至 143/589，ProduceAccumulator 共享 owner 退出 `ArcMut`
-  - [ ] M11-12l 及后续：Client MQClientInstance/Producer/Admin/Push/Lite owner、Broker、Store/HA、Tools/compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8317 后实际快照降至 454 production/1,481 occurrence；Client 降至 134/575，latency fault detector production 债务清零
+  - [ ] M11-12m 及后续：Client MQClientInstance/Producer/Admin/Push/Lite owner、Broker、Store/HA、Tools/compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -282,6 +282,10 @@ Client ProduceAccumulator owner 随 Issue #8315 从 Manager/Producer 传播的 `
 原子状态发布，guard task handle/schedule sender 由显式 lifecycle mutex 串行且异步关闭不跨同步锁 await；实际快照
 降至 463 production/1,495 occurrence，Client 降至 143/589。剩余为 Broker 190/568、Client 143/589、Store
 127/324 与 Tools 3/14；总进度仍为 75/82，M11-12 父工作包未完成。
+Client latency fault detector 随 Issue #8317 将 trait、strategy、queue filter 与 scheduled task capture 全部改为安全
+`Arc`；配置由原子状态发布，resolver/service detector 只经短 `RwLock` 取得 `Arc` 快照，task lifecycle 在单一 mutex
+内串行并排除 shutdown 期间 restart。实际快照降至 454 production/1,481 occurrence，Client 降至 134/575；
+剩余为 Broker 190/568、Client 134/575、Store 127/324 与 Tools 3/14，总进度仍为 75/82。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -275,6 +275,11 @@ M11-12k 已把 Client ProduceAccumulator 的 Manager/Producer 共享 owner 从 `
 await 前取出 owned handle。实际快照累计降至 463 production/1,495 occurrences，Client 降至 143/589；其余
 Client owner、Broker/Store、Tools/compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12l 已把 Client latency fault detector 的 trait/strategy/filter/task capture 改为安全 `Arc`；detector 配置原子
+发布，resolver/service detector 通过短 `RwLock` 克隆 `Arc` 快照后再执行网络 await，task 发布与关闭由单一
+lifecycle mutex 串行。实际快照累计降至 454 production/1,481 occurrences，Client 降至 134/575；其余 Client
+owner、Broker/Store、Tools/compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～k 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～l 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -39,6 +39,9 @@ M11-12j 的 Remoting protocol compatibility 由 Issue #8313 跟踪，分支为
 
 M11-12k 的 Client ProduceAccumulator owner 由 Issue #8315 跟踪，分支为
 `mxsm/architecture-refactor-client-produce-accumulator`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12l 的 Client latency fault detector owner 由 Issue #8317 跟踪，分支为
+`mxsm/architecture-refactor-client-latency-fault`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -305,6 +308,32 @@ M11-12k 后实际快照为 744 个条目：production 463、test 267、compatibi
 reviewed baseline 只删除源码真实消失的 3 个 identity/10 个 occurrence，不需要 relocation approval；baseline
 747→744、occurrences 2,301→2,291，分类精确为 production 463/1,495、test 267/756、compatibility 14/40。
 
+## M11-12l Client latency fault detector owner
+
+| 目标 | 实现与证据 |
+|---|---|
+| 安全共享 owner | `LatencyFaultTolerance::start_detector`、实现、`MQFaultStrategy`、available/reachable filters、probe 与 tests 全部使用标准 `Arc`，latency production 不再传播共享可变 facade |
+| 原子 detector 配置 | detect timeout、interval 与 enabled flag 使用 acquire/release 原子 load/store；Java-compatible 默认值和 constructor/runtime setter 语义保持 |
+| 依赖快照 | resolver 与 service detector 以 `RwLock<Option<Arc<_>>>` 发布；每轮检测只在短临界区克隆快照，网络 resolve/detect await 不持配置锁 |
+| 单一 task lifecycle | start 的既有 task 检查与新 scheduled task 发布合并到同一 lifecycle mutex；stopping 状态排除 shutdown 期间 restart，取消安全 reset 恢复后续可启动状态 |
+| 行为合同 | 8 路并发 start 只发布一个 owned scheduled task；同步 abort、异步 deadline shutdown、probe schedule metrics、broker availability/reachability 与 config copy 合同保持通过 |
+
+M11-12l 后实际快照为 732 个条目：production 454、test 264、compatibility 14；production occurrence 为
+1,481。相对 M11-12k 删除 9 个 production 条目/14 个 production occurrence，以及 3 个 test 条目/4 个
+test occurrence；相对初始快照累计删除 306 个 production 条目和 644 个 production occurrence。
+`rocketmq-client` production 债务从 143/589 降至 134/575；latency production 债务清零。剩余 production 债务为：
+
+| crate | 条目 | occurrence |
+|---|---:|---:|
+| `rocketmq-broker` | 190 | 568 |
+| `rocketmq-client` | 134 | 575 |
+| `rocketmq-store` | 127 | 324 |
+| `rocketmq-tools` | 3 | 14 |
+
+reviewed baseline 只删除三个 latency 文件中真实消失的 12 个 identity/18 个 occurrence，不需要 relocation
+approval；baseline 744→732、occurrences 2,291→2,273，分类精确为 production 454/1,481、test 264/752、
+compatibility 14/40。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -545,9 +574,28 @@ M11-12k 追加验证：
 | `.\scripts\check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
 | `git diff --check` | 通过 |
 
+M11-12l 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过 |
+| `cargo test -p rocketmq-client-rust latency --lib` | 11/11 通过；包含依赖/config 快照、8 路并发 start 单 task、同步/异步 shutdown 与 lifecycle probe |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 全部通过；library 958/958，其余 integration targets 全部通过（35 项既有外部环境测试忽略） |
+| `python scripts/arc_mut_guard.py --bootstrap target/m11-12l-final-after.json` | 实际 732 条；production 454/1,481、test 264/752、compatibility 14/40 occurrences |
+| reviewed baseline reduction | 无 relocation approval；只删除三个 latency 文件中的真实消失债务，baseline 744→732、occurrences 2,291→2,273 |
+| `python scripts/arc_mut_guard.py` | 通过 |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；detector scheduled task 继续由 Client runtime owner 跟踪，lifecycle 锁不跨网络或 shutdown await |
+| `rocketmq-example`: `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` | standalone 消费者通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology |
+| `.\scripts\check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client MQClientInstance、Producer/Admin、Push/Lite Consumer owner（143/589）。
+1. Client MQClientInstance、Producer/Admin、Push/Lite Consumer owner（134/575）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. Tools 3/14、compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/latency/latency_fault_tolerance.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_rust::ArcMut;
+use std::sync::Arc;
 
 /// Broker-level fault tolerance abstraction for latency-based routing decisions.
 ///
@@ -68,7 +68,7 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     async fn pick_one_at_least(&self) -> Option<T>;
 
     /// Starts a background task to periodically detect broker reachability.
-    fn start_detector(this: ArcMut<Self>);
+    fn start_detector(this: Arc<Self>);
 
     /// Shuts down the background detector task.
     fn shutdown(&self);
@@ -77,13 +77,13 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     async fn detect_by_one_round(&self);
 
     /// Sets the detect timeout bound in milliseconds.
-    fn set_detect_timeout(&mut self, detect_timeout: u32);
+    fn set_detect_timeout(&self, detect_timeout: u32);
 
     /// Sets the detector's interval for each broker in milliseconds.
-    fn set_detect_interval(&mut self, detect_interval: u32);
+    fn set_detect_interval(&self, detect_interval: u32);
 
     /// Enables or disables the background detector.
-    fn set_start_detector_enable(&mut self, start_detector_enable: bool);
+    fn set_start_detector_enable(&self, start_detector_enable: bool);
 
     /// Returns whether the background detector is enabled.
     fn is_start_detector_enable(&self) -> bool;

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering as AtomicOrdering;
+use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
+use parking_lot::RwLock;
 use rocketmq_runtime::ScheduledTaskSnapshot;
 use serde::Serialize;
 
@@ -32,12 +37,28 @@ const DETECTOR_SCAN_INTERVAL: Duration = Duration::from_secs(3);
 
 pub struct LatencyFaultToleranceImpl<R, S> {
     fault_item_table: DashMap<CheetahString, FaultItem>,
-    detect_timeout: u32,
-    detect_interval: u32,
+    detect_timeout: AtomicU32,
+    detect_interval: AtomicU32,
     start_detector_enable: AtomicBool,
-    resolver: Option<R>,
-    service_detector: Option<S>,
-    detector_task: Mutex<Option<FaultDetectorTaskHandle>>,
+    resolver: RwLock<Option<Arc<R>>>,
+    service_detector: RwLock<Option<Arc<S>>>,
+    detector_lifecycle: Mutex<DetectorLifecycle>,
+}
+
+#[derive(Default)]
+struct DetectorLifecycle {
+    task: Option<FaultDetectorTaskHandle>,
+    stopping: bool,
+}
+
+struct DetectorStoppingReset<'a> {
+    lifecycle: &'a Mutex<DetectorLifecycle>,
+}
+
+impl Drop for DetectorStoppingReset<'_> {
+    fn drop(&mut self) {
+        self.lifecycle.lock().stopping = false;
+    }
 }
 
 struct FaultDetectorTaskHandle {
@@ -88,35 +109,66 @@ pub struct LatencyFaultDetectorLifecycleProbe {
 impl<R, S> LatencyFaultToleranceImpl<R, S> {
     pub fn new() -> Self {
         Self {
-            resolver: None,
-            service_detector: None,
+            resolver: RwLock::new(None),
+            service_detector: RwLock::new(None),
             fault_item_table: Default::default(),
-            detect_timeout: 200,
-            detect_interval: 2000,
+            detect_timeout: AtomicU32::new(200),
+            detect_interval: AtomicU32::new(2000),
             start_detector_enable: AtomicBool::new(false),
-            detector_task: Mutex::new(None),
+            detector_lifecycle: Mutex::new(DetectorLifecycle::default()),
         }
     }
 
-    pub fn set_resolver(&mut self, resolver: R) {
-        self.resolver = Some(resolver);
+    pub fn set_resolver(&self, resolver: R) {
+        *self.resolver.write() = Some(Arc::new(resolver));
     }
 
-    pub fn set_service_detector(&mut self, service_detector: S) {
-        self.service_detector = Some(service_detector);
+    pub fn set_service_detector(&self, service_detector: S) {
+        *self.service_detector.write() = Some(Arc::new(service_detector));
     }
 
     #[cfg(test)]
     pub(crate) fn detector_config_for_test(&self) -> (u32, u32) {
-        (self.detect_interval, self.detect_timeout)
+        (
+            self.detect_interval.load(AtomicOrdering::Acquire),
+            self.detect_timeout.load(AtomicOrdering::Acquire),
+        )
     }
 
     pub async fn shutdown_detector(&self) -> bool {
-        let handle = { self.detector_task.lock().take() };
+        let handle = {
+            let mut lifecycle = self.detector_lifecycle.lock();
+            if lifecycle.stopping {
+                return true;
+            }
+            lifecycle.stopping = true;
+            lifecycle.task.take()
+        };
+        let _stopping_reset = DetectorStoppingReset {
+            lifecycle: &self.detector_lifecycle,
+        };
         match handle {
             Some(handle) => handle.shutdown(DETECTOR_TASK_SHUTDOWN_TIMEOUT).await,
             None => true,
         }
+    }
+
+    fn detector_task_count(&self) -> usize {
+        self.detector_lifecycle
+            .lock()
+            .task
+            .as_ref()
+            .map(FaultDetectorTaskHandle::task_count)
+            .unwrap_or_default()
+    }
+
+    fn detector_schedule_snapshot(&self) -> Vec<ScheduledTaskSnapshot> {
+        self.detector_lifecycle
+            .lock()
+            .task
+            .as_ref()
+            .map(FaultDetectorTaskHandle::schedule_snapshot)
+            .unwrap_or_default()
     }
 }
 
@@ -179,26 +231,42 @@ where
         None
     }
 
-    fn start_detector(this: ArcMut<Self>) {
-        {
-            let guard = this.detector_task.lock();
-            if guard.as_ref().is_some_and(|handle| !handle.is_finished()) {
-                return;
-            }
+    fn start_detector(this: Arc<Self>) {
+        let mut lifecycle = this.detector_lifecycle.lock();
+        if lifecycle.stopping || lifecycle.task.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
         }
 
         if let Some(handle) = spawn_detector_loop(this.clone(), DETECTOR_SCAN_INITIAL_DELAY, DETECTOR_SCAN_INTERVAL) {
-            *this.detector_task.lock() = Some(handle);
+            lifecycle.task = Some(handle);
         }
     }
 
     fn shutdown(&self) {
-        if let Some(handle) = self.detector_task.lock().take() {
+        let handle = {
+            let mut lifecycle = self.detector_lifecycle.lock();
+            if lifecycle.stopping {
+                return;
+            }
+            lifecycle.stopping = true;
+            lifecycle.task.take()
+        };
+        let _stopping_reset = DetectorStoppingReset {
+            lifecycle: &self.detector_lifecycle,
+        };
+        if let Some(handle) = handle {
             handle.abort();
         }
     }
 
     async fn detect_by_one_round(&self) {
+        let resolver = self.resolver.read().clone();
+        let service_detector = self.service_detector.read().clone();
+        let detect_interval = self.detect_interval.load(AtomicOrdering::Acquire);
+        let detect_timeout = self.detect_timeout.load(AtomicOrdering::Acquire);
+        let (Some(resolver), Some(service_detector)) = (resolver, service_detector) else {
+            return;
+        };
         let mut remove_set = HashSet::new();
 
         for entry in self.fault_item_table.iter() {
@@ -208,28 +276,20 @@ where
                 continue;
             }
             fault_item.check_stamp.store(
-                current_millis() + self.detect_interval as u64,
+                current_millis() + detect_interval as u64,
                 std::sync::atomic::Ordering::Release,
             );
 
-            let broker_addr = match self.resolver.as_ref() {
-                Some(resolver) => match resolver.resolve(fault_item.name.as_ref()).await {
-                    Some(addr) => addr,
-                    None => {
-                        remove_set.insert(name.clone());
-                        continue;
-                    }
-                },
-                None => continue,
-            };
-
-            let service_detector = match self.service_detector.as_ref() {
-                Some(d) => d,
-                None => continue,
+            let broker_addr = match resolver.resolve(fault_item.name.as_ref()).await {
+                Some(addr) => addr,
+                None => {
+                    remove_set.insert(name.clone());
+                    continue;
+                }
             };
 
             let service_ok = service_detector
-                .detect(broker_addr.as_str(), self.detect_timeout as u64)
+                .detect(broker_addr.as_str(), detect_timeout as u64)
                 .await;
 
             if service_ok && !fault_item.is_reachable() {
@@ -243,36 +303,33 @@ where
         }
     }
 
-    fn set_detect_timeout(&mut self, detect_timeout: u32) {
-        self.detect_timeout = detect_timeout;
+    fn set_detect_timeout(&self, detect_timeout: u32) {
+        self.detect_timeout.store(detect_timeout, AtomicOrdering::Release);
     }
 
-    fn set_detect_interval(&mut self, detect_interval: u32) {
-        self.detect_interval = detect_interval;
+    fn set_detect_interval(&self, detect_interval: u32) {
+        self.detect_interval.store(detect_interval, AtomicOrdering::Release);
     }
 
-    fn set_start_detector_enable(&mut self, start_detector_enable: bool) {
+    fn set_start_detector_enable(&self, start_detector_enable: bool) {
         self.start_detector_enable
-            .store(start_detector_enable, std::sync::atomic::Ordering::Relaxed);
+            .store(start_detector_enable, AtomicOrdering::Release);
     }
 
     fn is_start_detector_enable(&self) -> bool {
-        self.start_detector_enable.load(std::sync::atomic::Ordering::Acquire)
+        self.start_detector_enable.load(AtomicOrdering::Acquire)
     }
 }
 
-use std::cmp::Ordering;
-use std::hash::Hash;
-use std::sync::atomic::AtomicBool;
-
 use cheetah_string::CheetahString;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_rust::ArcMut;
+use std::cmp::Ordering;
+use std::hash::Hash;
 use tracing::error;
 use tracing::info;
 
 fn spawn_detector_loop<R, S>(
-    this: ArcMut<LatencyFaultToleranceImpl<R, S>>,
+    this: Arc<LatencyFaultToleranceImpl<R, S>>,
     initial_delay: Duration,
     scan_interval: Duration,
 ) -> Option<FaultDetectorTaskHandle>
@@ -307,18 +364,13 @@ where
 
 #[doc(hidden)]
 pub async fn run_latency_fault_detector_lifecycle_probe() -> LatencyFaultDetectorLifecycleProbe {
-    let detector = ArcMut::new(LatencyFaultToleranceImpl::<ProbeResolver, ProbeServiceDetector>::new());
-    detector.mut_from_ref().set_start_detector_enable(true);
+    let detector = Arc::new(LatencyFaultToleranceImpl::<ProbeResolver, ProbeServiceDetector>::new());
+    detector.set_start_detector_enable(true);
     let handle = spawn_detector_loop(detector.clone(), Duration::ZERO, Duration::from_millis(1))
         .expect("latency fault detector probe task should start");
-    *detector.detector_task.lock() = Some(handle);
+    detector.detector_lifecycle.lock().task = Some(handle);
 
-    let mut snapshots = detector
-        .detector_task
-        .lock()
-        .as_ref()
-        .map(FaultDetectorTaskHandle::schedule_snapshot)
-        .unwrap_or_default();
+    let mut snapshots = detector.detector_schedule_snapshot();
     for _ in 0..100 {
         if snapshots
             .iter()
@@ -327,33 +379,18 @@ pub async fn run_latency_fault_detector_lifecycle_probe() -> LatencyFaultDetecto
             break;
         }
         tokio::time::sleep(Duration::from_millis(1)).await;
-        snapshots = detector
-            .detector_task
-            .lock()
-            .as_ref()
-            .map(FaultDetectorTaskHandle::schedule_snapshot)
-            .unwrap_or_default();
+        snapshots = detector.detector_schedule_snapshot();
     }
 
     let scheduled_runs = snapshots.iter().map(|snapshot| snapshot.runs).sum();
     let scheduled_skips = snapshots.iter().map(|snapshot| snapshot.skips).sum();
     let scheduled_overlaps = snapshots.iter().map(|snapshot| snapshot.overlaps).sum();
     let scheduled_failures = snapshots.iter().map(|snapshot| snapshot.failures).sum();
-    let task_count_before_shutdown = detector
-        .detector_task
-        .lock()
-        .as_ref()
-        .map(FaultDetectorTaskHandle::task_count)
-        .unwrap_or_default();
+    let task_count_before_shutdown = detector.detector_task_count();
     let shutdown_started_at = std::time::Instant::now();
     let shutdown_healthy = detector.shutdown_detector().await;
     let shutdown_elapsed_us = shutdown_started_at.elapsed().as_micros();
-    let task_count_after_shutdown = detector
-        .detector_task
-        .lock()
-        .as_ref()
-        .map(FaultDetectorTaskHandle::task_count)
-        .unwrap_or_default();
+    let task_count_after_shutdown = detector.detector_task_count();
     let healthy = shutdown_healthy
         && scheduled_runs > 0
         && scheduled_overlaps == 0
@@ -545,6 +582,7 @@ impl std::fmt::Display for FaultItem {
 mod tests {
     use std::future::pending;
     use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
 
     use super::*;
@@ -573,6 +611,26 @@ mod tests {
         }
     }
 
+    struct StaticResolver;
+
+    impl Resolver for StaticResolver {
+        async fn resolve(&self, _name: &CheetahString) -> Option<CheetahString> {
+            Some(CheetahString::from_static_str("127.0.0.1:10911"))
+        }
+    }
+
+    struct RecordingServiceDetector {
+        timeout_millis: Arc<AtomicU64>,
+    }
+
+    impl ServiceDetector for RecordingServiceDetector {
+        async fn detect(&self, _endpoint: &str, timeout_millis: u64) -> bool {
+            self.timeout_millis
+                .store(timeout_millis, std::sync::atomic::Ordering::Release);
+            true
+        }
+    }
+
     #[test]
     fn fault_item_compare_to_matches_java_comparable_shape() {
         let fast = FaultItem::new(CheetahString::from("fast"));
@@ -585,9 +643,29 @@ mod tests {
         assert_eq!(fast.compare_to(&fast), 0);
     }
 
+    #[tokio::test]
+    async fn shared_detector_dependency_and_config_snapshots_drive_one_round() {
+        let detector = Arc::new(LatencyFaultToleranceImpl::<StaticResolver, RecordingServiceDetector>::new());
+        let timeout_millis = Arc::new(AtomicU64::new(0));
+        detector.set_resolver(StaticResolver);
+        detector.set_service_detector(RecordingServiceDetector {
+            timeout_millis: timeout_millis.clone(),
+        });
+        detector.set_detect_timeout(321);
+        detector.set_detect_interval(12_345);
+        let broker = CheetahString::from_static_str("broker-a");
+        detector.update_fault_item(broker.clone(), 10, 0, false).await;
+
+        detector.detect_by_one_round().await;
+
+        assert!(detector.is_reachable(&broker));
+        assert_eq!(timeout_millis.load(std::sync::atomic::Ordering::Acquire), 321);
+        assert_eq!(detector.detector_config_for_test(), (12_345, 321));
+    }
+
     #[test]
     fn start_detector_without_tokio_runtime_does_not_spawn_panic() {
-        let detector = ArcMut::new(LatencyFaultToleranceImpl::<NoopResolver, NoopServiceDetector>::new());
+        let detector = Arc::new(LatencyFaultToleranceImpl::<NoopResolver, NoopServiceDetector>::new());
 
         LatencyFaultTolerance::start_detector(detector.clone());
         detector.shutdown();
@@ -618,7 +696,7 @@ mod tests {
             },
         )
         .expect("scheduled detector test task should start");
-        *detector.detector_task.lock() = Some(FaultDetectorTaskHandle { handle });
+        detector.detector_lifecycle.lock().task = Some(FaultDetectorTaskHandle { handle });
 
         tokio::time::timeout(Duration::from_secs(1), async {
             while !started.load(std::sync::atomic::Ordering::Acquire) {
@@ -630,7 +708,7 @@ mod tests {
 
         detector.shutdown();
 
-        assert!(detector.detector_task.lock().is_none());
+        assert!(detector.detector_lifecycle.lock().task.is_none());
         tokio::time::timeout(Duration::from_secs(1), async {
             while !dropped.load(std::sync::atomic::Ordering::Acquire) {
                 tokio::task::yield_now().await;
@@ -709,13 +787,34 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_detector_waits_for_started_detector_task() {
-        let detector = ArcMut::new(LatencyFaultToleranceImpl::<NoopResolver, NoopServiceDetector>::new());
+        let detector = Arc::new(LatencyFaultToleranceImpl::<NoopResolver, NoopServiceDetector>::new());
 
         LatencyFaultTolerance::start_detector(detector.clone());
 
-        assert!(detector.detector_task.lock().is_some());
+        assert!(detector.detector_lifecycle.lock().task.is_some());
         assert!(detector.shutdown_detector().await);
-        assert!(detector.detector_task.lock().is_none());
+        assert!(detector.detector_lifecycle.lock().task.is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_detector_start_publishes_one_owned_task() {
+        let detector = Arc::new(LatencyFaultToleranceImpl::<NoopResolver, NoopServiceDetector>::new());
+        let starts = (0..8)
+            .map(|_| {
+                let detector = detector.clone();
+                tokio::spawn(async move {
+                    LatencyFaultTolerance::start_detector(detector);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for start in starts {
+            start.await.expect("detector start task should finish");
+        }
+
+        assert_eq!(detector.detector_task_count(), 1);
+        assert!(detector.shutdown_detector().await);
+        assert_eq!(detector.detector_task_count(), 0);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -14,10 +14,10 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_rust::ArcMut;
 
 use crate::base::client_config::ClientConfig;
 use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
@@ -28,7 +28,7 @@ use crate::producer::producer_impl::queue_filter::QueueFilter;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 
 pub struct MQFaultStrategy {
-    latency_fault_tolerance: ArcMut<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
+    latency_fault_tolerance: Arc<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
     send_latency_fault_enable: AtomicBool,
     start_detector_enable: AtomicBool,
     latency_max: Vec<u64>,
@@ -44,19 +44,19 @@ impl MQFaultStrategy {
     const ISOLATION_LATENCY_MS: u64 = 10_000;
 
     pub fn new(client_config: &ClientConfig) -> Self {
-        let mut tolerance_impl = LatencyFaultToleranceImpl::new();
+        let tolerance_impl = LatencyFaultToleranceImpl::new();
         tolerance_impl.set_detect_interval(client_config.detect_interval);
         tolerance_impl.set_detect_timeout(client_config.detect_timeout);
         tolerance_impl.set_start_detector_enable(client_config.start_detector_enable);
-        let latency_fault_tolerance = ArcMut::new(tolerance_impl);
+        let latency_fault_tolerance = Arc::new(tolerance_impl);
         Self {
-            latency_fault_tolerance: ArcMut::clone(&latency_fault_tolerance),
+            latency_fault_tolerance: Arc::clone(&latency_fault_tolerance),
             send_latency_fault_enable: AtomicBool::new(client_config.send_latency_enable),
             start_detector_enable: AtomicBool::new(client_config.start_detector_enable),
             latency_max: Self::DEFAULT_LATENCY_MAX.to_vec(),
             not_available_duration: Self::DEFAULT_NOT_AVAILABLE_DURATION.to_vec(),
             reachable_filter: Box::new(ReachableFilter {
-                latency_fault_tolerance: ArcMut::clone(&latency_fault_tolerance),
+                latency_fault_tolerance: Arc::clone(&latency_fault_tolerance),
             }),
             available_filter: Box::new(AvailableFilter {
                 latency_fault_tolerance,
@@ -64,23 +64,23 @@ impl MQFaultStrategy {
         }
     }
 
-    pub fn start_detector(&mut self) {
+    pub fn start_detector(&self) {
         LatencyFaultTolerance::start_detector(self.latency_fault_tolerance.clone());
     }
 
-    pub(crate) fn set_resolve(&mut self, resolver: DefaultResolver) {
+    pub(crate) fn set_resolve(&self, resolver: DefaultResolver) {
         self.latency_fault_tolerance.set_resolver(resolver);
     }
 
-    pub(crate) fn set_service_detector(&mut self, service_detector: DefaultServiceDetector) {
+    pub(crate) fn set_service_detector(&self, service_detector: DefaultServiceDetector) {
         self.latency_fault_tolerance.set_service_detector(service_detector);
     }
 
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&self) {
         self.latency_fault_tolerance.shutdown();
     }
 
-    pub async fn shutdown_async(&mut self) -> bool {
+    pub async fn shutdown_async(&self) -> bool {
         self.latency_fault_tolerance.shutdown_detector().await
     }
 
@@ -88,7 +88,7 @@ impl MQFaultStrategy {
         self.start_detector_enable.load(Ordering::Relaxed)
     }
 
-    pub fn set_start_detector_enable(&mut self, start_detector_enable: bool) {
+    pub fn set_start_detector_enable(&self, start_detector_enable: bool) {
         self.start_detector_enable
             .store(start_detector_enable, Ordering::Relaxed);
         self.latency_fault_tolerance
@@ -226,7 +226,7 @@ impl QueueFilter for BrokerFilter {
 }
 
 struct ReachableFilter {
-    latency_fault_tolerance: ArcMut<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
+    latency_fault_tolerance: Arc<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
 }
 
 impl QueueFilter for ReachableFilter {
@@ -236,7 +236,7 @@ impl QueueFilter for ReachableFilter {
 }
 
 struct AvailableFilter {
-    latency_fault_tolerance: ArcMut<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
+    latency_fault_tolerance: Arc<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
 }
 
 impl QueueFilter for AvailableFilter {

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -15190,270 +15190,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "5718ab78bcb44b162f58b8c1",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "ca976a17ca25faacca5296e9",
-          "fingerprint": "0e9555e6f8132c6cfccd202e",
-          "item": "<module>",
-          "line": 15
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c23b74b78385cf5940176999",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "af2c57f9e8781d2f937dce65",
-          "fingerprint": "761fd2ca77657fd880ba9dd3",
-          "item": "fn start_detector",
-          "line": 71
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "2e9e70b661ec12b8b15c6c9d",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "31d209e7d3633fd66a5d010b",
-          "fingerprint": "975ea1e2caebc1ff3113c77b",
-          "item": "mod tests",
-          "line": 550
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "10b4bbb68a01f3869e68b23b",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "431134d9ba97fa0d3b7d8e77",
-          "fingerprint": "287e1871fccb272fe158a358",
-          "item": "fn run_latency_fault_detector_lifecycle_probe",
-          "line": 310
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "477b468d4cadf29dd5e67613",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "fd48e3f42de803145b16f882",
-          "fingerprint": "9d6fbba0739877365a1ecb71",
-          "item": "fn start_detector_without_tokio_runtime_does_not_spawn_panic",
-          "line": 590
-        },
-        {
-          "id": "311b5a3cca59e9888bc583c9",
-          "fingerprint": "81d4900c30470cf55a73a4cd",
-          "item": "fn shutdown_detector_waits_for_started_detector_task",
-          "line": 712
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "14188682088ea4f32a3cea05",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a35e2f636ce64ff96da0d6a7",
-          "fingerprint": "a25746ffcc5649367edf39a8",
-          "item": "fn is_start_detector_enable",
-          "line": 270
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "b60ca9f95c4ff41015253f47",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "3ef87a596ead9131d707ebb6",
-          "fingerprint": "d36ada67eef5de0e8334a613",
-          "item": "fn start_detector",
-          "line": 182
-        },
-        {
-          "id": "385cab7dffba548f04dc2600",
-          "fingerprint": "889c53bacbb35283ca4978d1",
-          "item": "fn spawn_detector_loop",
-          "line": 275
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "813540a56567d1571748136e",
-      "path": "rocketmq-client/src/latency/latency_fault_tolerance_impl.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "44c7c01e167eaa1023002c46",
-          "fingerprint": "5a836ed0661e041b0c44a113",
-          "item": "fn run_latency_fault_detector_lifecycle_probe",
-          "line": 311
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "2e2fdc1fc77b0451a275beac",
-      "path": "rocketmq-client/src/latency/mq_fault_strategy.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "72eacaad8d397c2fedb8ebfe",
-          "fingerprint": "29ef1e1a36758df3341af5be",
-          "item": "mod tests",
-          "line": 250
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "dd49a5f49fb8de10eaf83981",
-      "path": "rocketmq-client/src/latency/mq_fault_strategy.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "f6ca5f7917f6540752816bba",
-          "fingerprint": "c81e8005828c07b9f05bce16",
-          "item": "fn new",
-          "line": 51
-        },
-        {
-          "id": "eb77e9d0e1ce50e6d9a549d7",
-          "fingerprint": "cf3dbf193c577cb7236b655c",
-          "item": "fn new",
-          "line": 53
-        },
-        {
-          "id": "083bed7a705c8acc427c22e9",
-          "fingerprint": "62d1f41e659dd47e515f6ce3",
-          "item": "fn new",
-          "line": 59
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "d5bc2423448896ce28b10660",
-      "path": "rocketmq-client/src/latency/mq_fault_strategy.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "dbb9f3fc60f57a378a90b808",
-          "fingerprint": "46074f8187fb48e27220efe2",
-          "item": "<module>",
-          "line": 20
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a3f7a46927467e81bbbf3bc1",
-      "path": "rocketmq-client/src/latency/mq_fault_strategy.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "5ed895b0c80bf5b43b9cf405",
-          "fingerprint": "6d37ae6328d13ae53e934fd8",
-          "item": "struct MQFaultStrategy",
-          "line": 31
-        },
-        {
-          "id": "77334901e3a72a7639a34785",
-          "fingerprint": "a7eed47054d1bbf842539571",
-          "item": "struct ReachableFilter",
-          "line": 229
-        },
-        {
-          "id": "de055cf5000b961d0bde27d3",
-          "fingerprint": "b4c239d83af84ecc1bd7197c",
-          "item": "struct AvailableFilter",
-          "line": 239
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "eb2cd2ebf89240c3b8d85247",
       "path": "rocketmq-client/src/lib.rs",
       "symbol": "ArcMut",
@@ -15589,7 +15325,7 @@
           "id": "73bb2e72e745e6a2cc767322",
           "fingerprint": "aa682f424d5a28672b55f4aa",
           "item": "mod tests",
-          "line": 788
+          "line": 859
         }
       ],
       "owner": "client",
@@ -15608,13 +15344,13 @@
           "id": "f8d0a78f89aea45513e0e0b6",
           "fingerprint": "02f8e0e910010c48dde9a746",
           "item": "fn get_or_create_sync_send_batch",
-          "line": 431
+          "line": 501
         },
         {
           "id": "1f97eed7451595d264de9699",
           "fingerprint": "02f8e0e910010c48dde9a746",
           "item": "fn get_or_create_async_send_batch",
-          "line": 452
+          "line": 523
         }
       ],
       "owner": "client",
@@ -15633,37 +15369,37 @@
           "id": "7741d349c190499cd9308af9",
           "fingerprint": "e091b6428abb1164534614fa",
           "item": "fn message_accumulation_ready_to_send_requires_size_over_hold_size_like_java",
-          "line": 875
+          "line": 946
         },
         {
           "id": "346b8c7614655eab0799a325",
           "fingerprint": "5fdb8284d4b2c31bd8a1fea2",
           "item": "fn message_accumulation_add_returns_index_and_flush_decision",
-          "line": 891
+          "line": 962
         },
         {
           "id": "9f273799df3b86249aa1beb0",
           "fingerprint": "6fe2af802fdbd5400286c1f3",
           "item": "fn message_accumulation_closing_state_is_claimed_once",
-          "line": 920
+          "line": 991
         },
         {
           "id": "12b4677ecd533d3f37dc6220",
           "fingerprint": "e091b6428abb1164534614fa",
           "item": "fn close_pending_batch_does_not_release_batch_already_claimed_for_send",
-          "line": 934
+          "line": 1005
         },
         {
           "id": "5127636530fb8841003b2e05",
           "fingerprint": "5fdb8284d4b2c31bd8a1fea2",
           "item": "fn message_accumulation_batch_sets_java_accumulator_keys_and_tags",
-          "line": 963
+          "line": 1034
         },
         {
           "id": "6eef4ae336ac267fbf52d3da",
           "fingerprint": "c822c3b790cd1a82b8520e32",
           "item": "fn shutdown_async_releases_pending_async_batch_hold_size_and_callbacks",
-          "line": 1059
+          "line": 1143
         }
       ],
       "owner": "client",
@@ -15682,7 +15418,7 @@
           "id": "1cc7f26c5963c0ea538be3d9",
           "fingerprint": "5db3e7eceb3edd1e119c9238",
           "item": "<module>",
-          "line": 38
+          "line": 42
         }
       ],
       "owner": "client",
@@ -15701,13 +15437,13 @@
           "id": "512c1ca0134ca3002f60f08a",
           "fingerprint": "d80ae723530ed68c55e18ca1",
           "item": "struct MessageAccumulation",
-          "line": 1339
+          "line": 1421
         },
         {
           "id": "0ec63b578f90517708a9c9cb",
           "fingerprint": "01972957344812f94cf1103e",
           "item": "fn new",
-          "line": 1417
+          "line": 1499
         }
       ],
       "owner": "client",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8317

### Brief Description

This M11-12l slice replaces the Client latency fault detector's `ArcMut` ownership across its trait, implementation, `MQFaultStrategy`, queue filters, lifecycle probe, and tests with standard `Arc` ownership.

Detector timeout, interval, and enabled state now use atomics. Resolver and service-detector updates publish `Arc` snapshots behind short `RwLock` critical sections, and each detection round clones those snapshots before any network await. Scheduled task inspection, publication, shutdown, and restart exclusion share one explicit lifecycle state, so concurrent starts publish exactly one task and shutdown cannot race with a new start.

Focused tests cover shared dependency/config snapshots, eight concurrent starts, synchronous abort, asynchronous deadline shutdown, schedule metrics, and existing broker selection behavior. The reviewed baseline removes only twelve resolved identities and eighteen occurrences, with no relocation approval: production falls by 9/14 and test debt by 3/4. The repository inventory is now production 454/1,481 occurrences, test 264/752, and compatibility 14/40; Client production debt falls from 143/589 to 134/575. M11-12 remains open at 75/82 completed work packages.

### How Did You Test This Change?

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- `cargo test -p rocketmq-client-rust latency --lib` (11 passed)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (958 library tests plus all integration targets passed; 35 existing external-environment tests ignored)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `rocketmq-example`: `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard -v` (67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24 passed)
- `python scripts/architecture_dependency_guard.py --mode target`
- `python scripts/architecture_dependency_guard.py --mode baseline`
- `python scripts/architecture_release_guard.py`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved client latency fault detection for concurrent operation and lifecycle management.
  * Configuration updates can now be applied safely while detection is running.
  * Detector startup and shutdown are coordinated to prevent duplicate tasks and unsafe restarts.

* **API Updates**
  * Latency detection controls and shutdown operations can now be used through shared instances without exclusive mutable access.

* **Documentation**
  * Updated Phase 3 progress records, validation evidence, and completion metrics for the latency fault detector work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->