### PR TITLE
[ISSUE #8327]♻️Replace Client fault strategy shared mutation

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -632,7 +632,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12n Client consume service lifecycle：通用分发器与四类 Push/Pop concurrent/orderly service 改用标准 `Arc`/`Weak` owner；start/shutdown/request task 只经 `&self`，Pop orderly lock-refresh handle 以 lifecycle mutex 发布并在 await 前取出
   - [x] M11-12o Client send hook/trace context owner：异步 after-hook 只持有不可变 hook 快照，`SendMessageContext` 删除 Producer owner；trace dispatcher 只保存启动后解析出的 client id，不再持有 host Producer/Consumer 实现
   - [x] M11-12p Client Admin facade self owner：Client 与 admin-core facade 直接拥有实现和单一 ClientConfig；ClientInstance Admin group 注册值收窄为 owner-free marker，删除无读取用途的 self `ArcMut` 保活环，Tools production 债务清零
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325 与每次真实下降
+  - [x] M11-12q Client Producer fault strategy owner：Producer 直接拥有策略，异步发送回调克隆阈值快照并只共享 detector/原子开关，删除 `ArcMut<MQFaultStrategy>`
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -649,7 +650,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8321 后实际快照降至 436 production/1,337 occurrence；Client 降至 116/431，consume service lifecycle owner 与 task capture 退出 `ArcMut`
   - [x] Issue #8323 后实际快照降至 432 production/1,329 occurrence；Client 降至 112/423，send hook/trace context 不再反向持有 Producer/Consumer owner
   - [x] Issue #8325 后实际快照降至 424 production/1,295 occurrence；Client 降至 107/403、Tools production 清零，Admin facade/config/registration self owner 退出 `ArcMut`
-  - [ ] M11-12q 及后续：Client MQClientInstance/Producer/Admin API/Push/Lite owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8327 后实际快照降至 423 production/1,292 occurrence；Client 降至 106/400，Producer fault strategy owner 退出 `ArcMut`
+  - [ ] M11-12r 及后续：Client MQClientInstance/Producer/Admin API/Push/Lite owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -302,6 +302,9 @@ Client Admin facade self owner 随 Issue #8325 改为 Client 与 admin-core faca
 `ClientConfig`；ClientInstance 的 Admin group 注册值收窄为 owner-free marker，不再通过无读取用途的 self
 `ArcMut` 保活完整 Admin 实现。实际快照降至 424 production/1,295 occurrence，Client 降至 107/403 且 Tools
 production 债务清零；剩余为 Broker 190/568、Client 107/403 与 Store 127/324，总进度仍为 75/82。
+Client Producer fault strategy 随 Issue #8327 改为 Producer 直接拥有；异步发送回调克隆延迟阈值快照，只共享
+concurrency-safe detector 和原子运行时开关，不再共享可变策略 owner。实际快照降至 423 production/1,292
+occurrence，Client 降至 106/400；剩余为 Broker 190/568、Client 106/400 与 Store 127/324，总进度仍为 75/82。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -303,6 +303,11 @@ owner-free marker，不再保活完整 Admin 实现。实际快照累计降至 4
 降至 107/403 且 Tools production 债务清零；其余 Client Instance/API/Producer/Consumer owner、Broker/Store、
 compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12q 已删除 Client Producer fault strategy 的 `ArcMut` owner：Producer 直接拥有策略，异步发送回调按发送时刻
+克隆延迟阈值快照，只共享 concurrency-safe detector 与原子运行时开关。实际快照累计降至 423
+production/1,292 occurrences，Client 降至 106/400；其余 Client Instance/API/Producer/Consumer owner、
+Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～p 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～q 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -54,6 +54,9 @@ M11-12o 的 Client send hook/trace context owner 由 Issue #8323 跟踪，分支
 
 M11-12p 的 Client Admin facade self owner 由 Issue #8325 跟踪，分支为
 `mxsm/architecture-refactor-client-admin-facade-owner`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12q 的 Client Producer fault strategy owner 由 Issue #8327 跟踪，分支为
+`mxsm/architecture-refactor-client-fault-strategy-owner`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -453,6 +456,31 @@ production 债务从 3/14 清零。剩余 production
 reviewed baseline 从 698→688、occurrences 从 2,065→2,029。10 个 identity 和 36 个 occurrence 均因源码
 真实删除而下降；没有新增、relocation approval 或替代 shared-mutation wrapper。
 
+## M11-12q Client Producer fault strategy owner
+
+| 目标 | 实现与证据 |
+|---|---|
+| Producer 独占 owner | `DefaultMQProducerImpl` 直接拥有 `MQFaultStrategy`，同步发送与配置 API 继续通过普通引用访问 |
+| async send 快照 | 异步发送回调接收普通 `MQFaultStrategy` clone；延迟阈值与不可用时长表按发送时刻复制，不再传播 shared-mutation capability |
+| 共享运行态 | clone 仅共享 concurrency-safe latency detector 与两个 `Arc<AtomicBool>` 运行时开关；启停和 fault update 无同步锁跨 await |
+| queue filter | available/reachable filter 在选择时从共享 detector 构造轻量只读 view，不保留可变策略反向引用 |
+| compatibility | Producer latency getter/setter、异步 retry queue selection、detector lifecycle 与 fault update 语义保持不变 |
+
+M11-12q 后实际快照为 687 个条目：production 423、test 250、compatibility 14；occurrence 精确为
+production 1,292、test 694、compatibility 40。相对 M11-12p 删除 1 个 production identity/3 个 production
+occurrence；相对初始快照累计删除 337 个 production 条目和 833 个 production occurrence。
+`rocketmq-client` production 债务从 107/403 降至 106/400。剩余 production 债务为：
+
+| crate | 条目 | occurrence |
+|---|---:|---:|
+| `rocketmq-broker` | 190 | 568 |
+| `rocketmq-client` | 106 | 400 |
+| `rocketmq-store` | 127 | 324 |
+
+reviewed baseline 从 688→687、occurrences 从 2,029→2,026。`DefaultMQProducerImpl` 同 item 中未改动的
+`MQClientInstance` 字段因相邻 fault-strategy 字段删除发生 1 条一对一 fingerprint relocation，按 ADR-013
+临时审核且 approval 不提交；除此之外只删除真实消失的 3 个 occurrence，没有新增或替代 shared-mutation wrapper。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -792,9 +820,30 @@ M11-12p 追加验证：
 | Admin self-owner 定向扫描 | 零匹配；`ArcMut<ClientConfig>`、`ArcMut<DefaultMQAdminExtImpl>`、`set_inner` 与冗余 inner `as_ref`/`as_mut` 均已删除 |
 | `git diff --check` | 通过 |
 
+M11-12q 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过 |
+| `cargo test -p rocketmq-client-rust fault_strategy --lib` | 3/3 通过；clone 共享运行时开关并保留发送时阈值快照 |
+| `cargo test -p rocketmq-client-rust producer_java_facade_accessors_sync_impl_without_panic --lib` | 1/1 通过；Producer latency getter/setter 合同保持 |
+| `cargo test -p rocketmq-client-rust async_retry_queue --lib` | 2/2 通过；异步 retry 队列选择保持 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 全部通过；library 963/963，其余 integration targets 全部通过（35 项既有外部环境测试忽略） |
+| reviewed baseline reduction（临时 ADR-013 approval） | 仅批准 1 条同 item 相邻字段 fingerprint relocation，删除 1 个 identity/3 个 occurrence；baseline 688→687、occurrences 2,029→2,026；approval 不提交 |
+| `python scripts/arc_mut_guard.py` | 通过；`ArcMut<MQFaultStrategy>` 定向扫描为零，Client production 降至 106/400 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+| `rocketmq-example`: `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` | standalone Producer 使用新的 owned/snapshot fault strategy API 通过 |
+| `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；async send 只捕获普通策略快照，未新增 detached task、运行时或跨 await 同步 guard |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology |
+| `.\scripts\check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| `ArcMut<MQFaultStrategy>` 定向扫描 | 零匹配 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client MQClientInstance、Producer、Push/Lite Consumer 与 Admin ClientInstance/API owner（107/403）。
+1. Client MQClientInstance、Producer、Push/Lite Consumer 与 Admin ClientInstance/API owner（106/400）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2578,7 +2578,7 @@ impl MQClientAPIImpl {
     async fn send_message_async_impl(
         remoting_client: Arc<RocketmqDefaultClient<ClientRemotingProcessor>>,
         client_config: Arc<ClientConfig>,
-        mq_fault_strategy: ArcMut<MQFaultStrategy>,
+        mq_fault_strategy: MQFaultStrategy,
         mut current_addr: CheetahString,
         mut current_broker_name: CheetahString,
         msg_topic: CheetahString,

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -27,14 +27,13 @@ use crate::producer::producer_impl::default_mq_producer_impl::DefaultServiceDete
 use crate::producer::producer_impl::queue_filter::QueueFilter;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 
+#[derive(Clone)]
 pub struct MQFaultStrategy {
     latency_fault_tolerance: Arc<LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>>,
-    send_latency_fault_enable: AtomicBool,
-    start_detector_enable: AtomicBool,
+    send_latency_fault_enable: Arc<AtomicBool>,
+    start_detector_enable: Arc<AtomicBool>,
     latency_max: Vec<u64>,
     not_available_duration: Vec<u64>,
-    reachable_filter: Box<dyn QueueFilter>,
-    available_filter: Box<dyn QueueFilter>,
 }
 
 impl MQFaultStrategy {
@@ -51,16 +50,10 @@ impl MQFaultStrategy {
         let latency_fault_tolerance = Arc::new(tolerance_impl);
         Self {
             latency_fault_tolerance: Arc::clone(&latency_fault_tolerance),
-            send_latency_fault_enable: AtomicBool::new(client_config.send_latency_enable),
-            start_detector_enable: AtomicBool::new(client_config.start_detector_enable),
+            send_latency_fault_enable: Arc::new(AtomicBool::new(client_config.send_latency_enable)),
+            start_detector_enable: Arc::new(AtomicBool::new(client_config.start_detector_enable)),
             latency_max: Self::DEFAULT_LATENCY_MAX.to_vec(),
             not_available_duration: Self::DEFAULT_NOT_AVAILABLE_DURATION.to_vec(),
-            reachable_filter: Box::new(ReachableFilter {
-                latency_fault_tolerance: Arc::clone(&latency_fault_tolerance),
-            }),
-            available_filter: Box::new(AvailableFilter {
-                latency_fault_tolerance,
-            }),
         }
     }
 
@@ -112,12 +105,24 @@ impl MQFaultStrategy {
                 tp_info.reset_index();
             }
 
-            let filter = &[self.available_filter.as_ref(), &broker_filter as &dyn QueueFilter];
+            let available_filter = AvailableFilter {
+                latency_fault_tolerance: Arc::clone(&self.latency_fault_tolerance),
+            };
+            let filter = &[
+                &available_filter as &dyn QueueFilter,
+                &broker_filter as &dyn QueueFilter,
+            ];
             if let Some(mq) = tp_info.select_one_message_queue_filters(filter) {
                 return Some(mq);
             }
 
-            let filter = &[self.reachable_filter.as_ref(), &broker_filter as &dyn QueueFilter];
+            let reachable_filter = ReachableFilter {
+                latency_fault_tolerance: Arc::clone(&self.latency_fault_tolerance),
+            };
+            let filter = &[
+                &reachable_filter as &dyn QueueFilter,
+                &broker_filter as &dyn QueueFilter,
+            ];
             if let Some(mq) = tp_info.select_one_message_queue_filters(filter) {
                 return Some(mq);
             }
@@ -178,7 +183,7 @@ impl MQFaultStrategy {
     }
 
     #[inline]
-    pub fn set_send_latency_fault_enable(&mut self, send_latency_fault_enable: bool) {
+    pub fn set_send_latency_fault_enable(&self, send_latency_fault_enable: bool) {
         self.send_latency_fault_enable
             .store(send_latency_fault_enable, Ordering::Relaxed);
     }
@@ -285,5 +290,26 @@ mod tests {
         assert_eq!(detect_timeout, 321);
         assert!(strategy.is_start_detector_enable());
         assert!(strategy.latency_fault_tolerance.is_start_detector_enable());
+    }
+
+    #[test]
+    fn cloned_strategy_shares_runtime_switches_and_snapshots_thresholds() {
+        let mut strategy = MQFaultStrategy::new(&ClientConfig::default());
+        strategy.set_latency_max(vec![10, 20, 30]);
+        strategy.set_not_available_duration(vec![0, 100, 200]);
+        strategy.set_send_latency_fault_enable(true);
+        strategy.set_start_detector_enable(true);
+
+        let snapshot = strategy.clone();
+
+        strategy.set_latency_max(vec![40, 50, 60]);
+        strategy.set_not_available_duration(vec![300, 400, 500]);
+        strategy.set_send_latency_fault_enable(false);
+        strategy.set_start_detector_enable(false);
+
+        assert_eq!(snapshot.get_latency_max(), &[10, 20, 30]);
+        assert_eq!(snapshot.get_not_available_duration(), &[0, 100, 200]);
+        assert!(!snapshot.is_send_latency_fault_enable());
+        assert!(!snapshot.is_start_detector_enable());
     }
 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -325,7 +325,7 @@ pub struct DefaultMQProducerImpl {
 
     rpc_hook: Option<Arc<dyn RPCHook>>,
     client_instance: Option<ArcMut<MQClientInstance>>,
-    pub(crate) mq_fault_strategy: ArcMut<MQFaultStrategy>,
+    pub(crate) mq_fault_strategy: MQFaultStrategy,
 
     // ===== Backpressure control =====
     semaphore_async_send_num: Arc<Semaphore>,
@@ -376,7 +376,7 @@ impl DefaultMQProducerImpl {
             pending_forbidden_hooks: ParkingLotMutex::new(Some(Vec::new())),
             rpc_hook,
             client_instance: None,
-            mq_fault_strategy: ArcMut::new(MQFaultStrategy::new(&client_config)),
+            mq_fault_strategy: MQFaultStrategy::new(&client_config),
             semaphore_async_send_num: Arc::new(semaphore_async_send_num),
             semaphore_async_send_size: Arc::new(semaphore_async_send_size),
             default_mqproducer_impl_inner: None,

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8424,7 +8424,7 @@
           "id": "359b0af7317c25b2dfab54cc",
           "fingerprint": "fdacb2c5d33b8875b9bb8dff",
           "item": "fn mq_client_api",
-          "line": 595
+          "line": 583
         }
       ],
       "owner": "client",
@@ -13310,12 +13310,6 @@
           "line": 2496
         },
         {
-          "id": "6fdc2ff50a2b8e9051cc8da9",
-          "fingerprint": "5e94ca02aec26acf5f74c523",
-          "item": "fn send_message_async_impl",
-          "line": 2581
-        },
-        {
           "id": "b707cabfb0ac55855f1b0180",
           "fingerprint": "5a67d1e294ce8f269bed92e1",
           "item": "fn send_message_async_impl",
@@ -13728,25 +13722,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "153c434808bb6f950f6105fa",
-      "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "5b17d0645666b0df747d2325",
-          "fingerprint": "7ec3125a183230ee649ace61",
-          "item": "fn new",
-          "line": 379
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "5e670f69aff88a2e2dc94ccb",
       "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
       "symbol": "ArcMut",
@@ -13792,16 +13767,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "d1832cee30378641a5522674",
-          "fingerprint": "c259fed63ecb8f2f9fa7c5d6",
+          "id": "e79256d601200eac98e5068e",
+          "fingerprint": "4d3a3d736cc488c4afc80b45",
           "item": "struct DefaultMQProducerImpl",
           "line": 327
-        },
-        {
-          "id": "1ca351fef3b97903513525ee",
-          "fingerprint": "757bda2cb2924c152e4e31ba",
-          "item": "struct DefaultMQProducerImpl",
-          "line": 328
         },
         {
           "id": "f191254954997718012ea998",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8327

### Brief Description

- Make `DefaultMQProducerImpl` directly own `MQFaultStrategy` instead of wrapping it in `ArcMut`.
- Clone latency threshold tables as immutable per-send snapshots while sharing only the concurrency-safe detector and atomic runtime switches.
- Pass the ordinary strategy snapshot into asynchronous send callbacks without shared-reference mutation.
- Preserve producer latency configuration, retry queue selection, detector lifecycle, and fault update behavior.
- Reduce the reviewed ArcMut baseline from 688 to 687 entries and from 2,029 to 2,026 occurrences; Client production debt is now 106/400 while the overall migration remains 75/82.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust fault_strategy --lib` (3 tests passed)
- `cargo test -p rocketmq-client-rust producer_java_facade_accessors_sync_impl_without_panic --lib`
- `cargo test -p rocketmq-client-rust async_retry_queue --lib` (2 tests passed)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (963 library tests plus all enabled integration targets passed)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`
- ArcMut guard with 67 unit tests and 24 fixtures, runtime audit, architecture guards, and AGENTS routing guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved producer fault-strategy ownership and asynchronous send handling.
  * Runtime fault-detection switches now remain synchronized across cloned strategies.
  * Queue filters are evaluated dynamically, while latency thresholds remain stable snapshots.
  * Fault-strategy configuration can now be updated without exclusive access.

* **Documentation**
  * Updated production-readiness tracking, validation evidence, milestones, and remaining work counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->