### PR TITLE
[ISSUE #8345]♻️Narrow orderly consumer lock access

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -641,7 +641,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12w Client accumulator batch producer owner：`MessageAccumulation` 直接持有 owned `DefaultMQProducer` clone；flush 在 batch mutex 内克隆、锁外发送，删除 accumulator 文件全部 ArcMut 构造、类型与 import
   - [x] M11-12x Client remote offset read access：`RemoteBrokerOffsetStore` 的 broker lookup、route refresh 与 client API 读取直接使用 immutable `MQClientInstance` access，删除 4 个过时 `mut_from_ref`
   - [x] M11-12y Client Push operational access：pull/pop dispatch、retry namespace reset、POP ack/change-invisible receiver 收窄为 `&self`，RebalancePush heartbeat/dispatch 与 consume service 删除 9 个过时 `mut_from_ref`
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343 与每次真实下降
+  - [x] M11-12z Client orderly lock access：Rebalance lock/unlock capability 与 Push/Lite/inner 实现收窄为 `&self`，orderly lock 路径删除 3 个 `mut_from_ref` 并改用 immutable namespace resolution
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -667,7 +668,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8339 后实际快照降至 415 production/1,219 occurrence；Client 降至 98/327，ProduceAccumulator production/test ArcMut 债务清零
   - [x] Issue #8341 后实际快照降至 414 production/1,215 occurrence；Client 降至 97/323，RemoteBrokerOffsetStore 只读查询路径 `mut_from_ref` 清零
   - [x] Issue #8343 后实际快照降至 411 production/1,206 occurrence；Client 降至 94/314，Push request/POP API/retry reset 只读访问删除 3 个 identity、9 个 occurrence
-  - [ ] M11-12z 及后续：Client 其余 MQClientInstance/Producer/Push/Lite owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8345 后实际快照降至 410 production/1,203 occurrence；Client 降至 93/311，orderly service `mut_from_ref` 清零，POP-orderly 仅保留 producer send 可变入口
+  - [ ] M11-12aa 及后续：Client 其余 MQClientInstance/Producer/Push/Lite owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -338,6 +338,11 @@ change-invisible receiver 收窄为 `&self`，并为 lazy namespace 提供不写
 RebalancePush heartbeat/dispatch 与 consume service 共删除 9 个过时 `mut_from_ref`。实际快照降至
 411 production/1,206 occurrence，Client 降至 94/314；剩余为 Broker 190/568、Client 94/314 与 Store 127/324，
 总进度仍为 75/82，M11-12 父工作包未完成。
+Client orderly lock access 随 Issue #8345 将 Rebalance 单队列 unlock、全队列 lock/unlock capability 与 Push/Lite/
+inner 实现收窄为 `&self`，broker lookup、request body、oneway 与 process-queue lock state 语义不变；orderly/POP-
+orderly namespace reset 使用 immutable resolution，删除 3 个 `mut_from_ref`。实际快照降至 410 production/1,203
+occurrence，Client 降至 93/311；剩余为 Broker 190/568、Client 93/311 与 Store 127/324，总进度仍为 75/82，
+M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -349,6 +349,12 @@ RebalancePush heartbeat/dispatch 与 consume service 删除 9 个过时 `mut_fro
 411 production/1,206 occurrences，Client 降至 94/314；真实 rebalance/producer mutation、Push owner 与其余
 Client/Broker/Store、compatibility、完整候选快照 Gate 仍保持开放。
 
+M11-12z 已将 Rebalance 单队列 unlock、全队列 lock/unlock capability 与 Push/Lite/inner 实现收窄为 `&self`；
+broker lookup、lock/unlock request body、oneway 与 process-queue lock state/timestamp 语义不变。orderly 与 POP-
+orderly namespace reset 使用 immutable resolution，删除 3 个过时 `mut_from_ref`。实际快照降至
+410 production/1,203 occurrences，Client 降至 93/311；POP-orderly producer send、Rebalance owner/assignment 与
+其余 Client/Broker/Store、compatibility、完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～y 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～z 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -81,6 +81,9 @@ M11-12x 的 Client remote offset read access 由 Issue #8341 跟踪，分支为
 
 M11-12y 的 Client Push operational access 由 Issue #8343 跟踪，分支为
 `mxsm/architecture-refactor-client-push-operational-access`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12z 的 Client orderly lock access 由 Issue #8345 跟踪，分支为
+`mxsm/architecture-refactor-client-orderly-lock-access`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -705,6 +708,32 @@ occurrence（合计删除 9 个 occurrence），没有新增或 fingerprint relo
 identity/id/fingerprint/item 语义集合完全一致，因此本切片不使用 relocation approval，也没有新增或替代
 shared-mutation wrapper。
 
+## M11-12z Client orderly lock access
+
+| 目标 | 实现与证据 |
+|---|---|
+| trait boundary | Rebalance 单队列 `unlock`、全队列 `lock_all`/`unlock_all` receiver 收窄为 `&self`，Push 与 Lite 实现同步收窄 |
+| inner lock capability | `RebalanceImpl::lock`/`lock_with`/`lock_all`/`unlock_all` 使用 immutable receiver 和 immutable client access；仍通过 process-queue 并发表与原子状态更新锁状态/时间戳 |
+| orderly call sites | orderly lock 路径不再制造 mutable alias；POP-orderly lock/unlock 同样直接调用 immutable capability，producer send 的真实可变入口保留 |
+| namespace | orderly 与 POP-orderly reset 使用 `ClientConfig::resolved_namespace`，不再 clone config 后写共享 lazy-cache flag |
+| compatibility | broker lookup、lock/unlock request body、oneway、periodic scheduling、queue lock state/timestamp 与 namespace stripping 语义保持不变 |
+
+M11-12z 后实际快照为 671 个条目：production 410、test 247、compatibility 14；occurrence 精确为
+production 1,203、test 676、compatibility 40。相对 M11-12y 真实删除 1 个 production identity、3 个 production
+occurrence；相对初始快照累计删除 350 个 production 条目和 922 个 production occurrence。
+`rocketmq-client` production 债务从 94/314 降至 93/311。剩余 production 债务为：
+
+| crate | 条目 | occurrence |
+|---|---:|---:|
+| `rocketmq-broker` | 190 | 568 |
+| `rocketmq-client` | 93 | 311 |
+| `rocketmq-store` | 127 | 324 |
+
+reviewed baseline 从 672→671、occurrences 从 1,922→1,919。guard 报告 1 个完整删除 identity 和 2 个局部删除
+occurrence（合计删除 3 个 occurrence），没有新增或 fingerprint relocation；baseline 与 reviewed output 的
+identity/id/fingerprint/item 语义集合完全一致，因此本切片不使用 relocation approval，也没有新增或替代
+shared-mutation wrapper。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1220,9 +1249,29 @@ M11-12y 追加验证：
 | Push operational `mut_from_ref` 定向扫描 | RebalancePush 零匹配；consume paths 只保留 rebalance lock/unlock 与 producer send 等真实可变入口，baseline 与 reviewed 语义集合一致 |
 | `git diff --check` | 通过 |
 
+M11-12z 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；Rebalance lock/unlock trait、Push/Lite/inner 实现与 orderly call sites 使用 immutable receiver |
+| `cargo test -p rocketmq-client-rust consumer::consumer_impl::consume_message_orderly_service::tests --lib --all-features` | 14/14 通过；覆盖 lock path、namespace reset、periodic lifecycle 与 shutdown |
+| `cargo test -p rocketmq-client-rust consumer::consumer_impl::consume_message_pop_orderly_service::tests --lib --all-features` | 17/17 通过；覆盖 lock refresh、namespace reset、task lifecycle、shutdown 与 retry bounds |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 966/966，其余 integration targets 全部通过（35 项既有外部环境测试忽略） |
+| reviewed baseline reduction | guard 报告 1 个完整删除 identity、2 个局部删除 occurrence，合计删除 3 个 occurrence；无新增和 relocation；baseline 672/1,922→671/1,919 |
+| `python scripts/arc_mut_guard.py` | 通过；production 410/1,203，Client 93/311 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+| `rocketmq-example`: `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` | standalone producer/consumer 通过 |
+| `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；未新增 task/runtime/blocking 边界，periodic lock lifecycle 与 await 边界保持受控 |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology |
+| `.\scripts\check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| orderly lock `mut_from_ref` 定向扫描 | orderly 零匹配；POP-orderly 仅保留 producer send，baseline 与 reviewed output 语义集合一致 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client 其余 MQClientInstance、Producer、Push/Lite Consumer owner（94/314）。
+1. Client 其余 MQClientInstance、Producer、Push/Lite Consumer owner（93/311）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -207,7 +207,7 @@ impl ConsumeMessageOrderlyService {
             return;
         }
 
-        let Some(mut default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.as_ref().cloned() else {
+        let Some(default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.as_ref().cloned() else {
             warn!(
                 "lockMQPeriodically skipped: DefaultMQPushConsumerImpl is not initialized, group={}",
                 self.consumer_group
@@ -270,8 +270,7 @@ impl ConsumeMessageOrderlyService {
     }
 
     pub fn reset_namespace(&self, msgs: &mut [Arc<MessageExt>]) {
-        let mut client_config = self.client_config.clone();
-        let namespace = client_config.get_namespace().unwrap_or_default();
+        let namespace = self.client_config.resolved_namespace().unwrap_or_default();
         if namespace.is_empty() {
             return;
         }
@@ -287,7 +286,7 @@ impl ConsumeMessageOrderlyService {
     pub async fn unlock_all_mq(&self) {
         let lock = self.global_lock.lock().await;
 
-        if let Some(mut default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.as_ref().cloned() {
+        if let Some(default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.as_ref().cloned() {
             default_mqpush_consumer_impl
                 .rebalance_impl
                 .rebalance_impl_inner
@@ -352,7 +351,6 @@ impl ConsumeMessageOrderlyService {
             return false;
         };
         default_mqpush_consumer_impl
-            .mut_from_ref()
             .rebalance_impl
             .rebalance_impl_inner
             .lock(message_queue)

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -242,11 +242,7 @@ impl ConsumeMessagePopOrderlyService {
         };
 
         use crate::consumer::consumer_impl::re_balance::Rebalance;
-        default_mqpush_consumer_impl
-            .rebalance_impl
-            .mut_from_ref()
-            .lock_all()
-            .await;
+        default_mqpush_consumer_impl.rebalance_impl.lock_all().await;
     }
 
     fn start_lock_refresh_with_schedule(&self, initial_delay: Duration, period: Duration) {
@@ -269,7 +265,7 @@ impl ConsumeMessagePopOrderlyService {
                         return ScheduledTaskControl::Stop;
                     }
 
-                    let Some(mut impl_) = default_mqpush_consumer_impl.upgrade() else {
+                    let Some(impl_) = default_mqpush_consumer_impl.upgrade() else {
                         return ScheduledTaskControl::Stop;
                     };
 
@@ -305,8 +301,7 @@ impl ConsumeMessagePopOrderlyService {
     }
 
     pub fn reset_namespace(&self, msgs: &mut [Arc<MessageExt>]) {
-        let mut client_config = self.client_config.clone();
-        let namespace = client_config.get_namespace().unwrap_or_default();
+        let namespace = self.client_config.resolved_namespace().unwrap_or_default();
         if namespace.is_empty() {
             return;
         }
@@ -399,7 +394,7 @@ impl ConsumeMessagePopOrderlyService {
     async fn unlock_all_message_queues(&self) {
         if let Some(ref impl_) = self.default_mqpush_consumer_impl {
             use crate::consumer::consumer_impl::re_balance::Rebalance;
-            impl_.rebalance_impl.mut_from_ref().unlock_all(false).await;
+            impl_.rebalance_impl.unlock_all(false).await;
         }
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
@@ -184,17 +184,17 @@ pub trait RebalanceLocal {
     ///
     /// * `mq` - The message queue to be unlocked.
     /// * `oneway` - A boolean indicating if the unlock should be one-way.
-    async fn unlock(&mut self, mq: &MessageQueue, oneway: bool);
+    async fn unlock(&self, mq: &MessageQueue, oneway: bool);
 
     /// Locks all message queues.
-    async fn lock_all(&mut self);
+    async fn lock_all(&self);
 
     /// Unlocks all message queues.
     ///
     /// # Arguments
     ///
     /// * `oneway` - A boolean indicating if the unlock should be one-way.
-    async fn unlock_all(&mut self, oneway: bool);
+    async fn unlock_all(&self, oneway: bool);
 
     /// Performs rebalancing.
     ///

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -1098,7 +1098,7 @@ where
         queue_set
     }
 
-    pub async fn lock(&mut self, mq: &MessageQueue) -> bool {
+    pub async fn lock(&self, mq: &MessageQueue) -> bool {
         let process_queue_table_ = self.process_queue_table.clone();
         let process_queue_table = process_queue_table_.read().await;
         let table = process_queue_table.deref();
@@ -1106,14 +1106,14 @@ where
     }
 
     pub async fn lock_with(
-        &mut self,
+        &self,
         mq: &MessageQueue,
         process_queue_table: &HashMap<MessageQueue, Arc<ProcessQueue>>,
     ) -> bool {
         let Some(consumer_group) = self.consumer_group_ref("lockWith").cloned() else {
             return false;
         };
-        let Some(client) = self.client_instance.as_mut() else {
+        let Some(client) = self.client_instance.as_ref() else {
             warn!("lockWith skipped: client_instance is not initialized, mq={}", mq);
             return false;
         };
@@ -1157,7 +1157,7 @@ where
         }
     }
 
-    pub async fn lock_all(&mut self) {
+    pub async fn lock_all(&self) {
         let broker_mqs = self.build_process_queue_table_by_broker_name().await;
         let Some(consumer_group) = self.consumer_group.clone() else {
             warn!("lockAll skipped: consumer_group is not initialized");
@@ -1171,25 +1171,24 @@ where
         let map = broker_mqs
             .into_iter()
             .map(|(broker_name, mqs)| {
-                let mut client_instance = client_instance.clone();
+                let client_instance = client_instance.clone();
                 let process_queue_table = self.process_queue_table.clone();
                 let consumer_group = consumer_group.clone();
                 async move {
                     if mqs.is_empty() {
                         return;
                     }
-                    let client = client_instance.as_mut();
-                    let find_broker_result = client
+                    let find_broker_result = client_instance
                         .find_broker_address_in_subscribe(&broker_name, mix_all::MASTER_ID, true)
                         .await;
                     if let Some(find_broker_result) = find_broker_result {
                         let request_body = LockBatchRequestBody {
                             consumer_group: Some(consumer_group.to_owned()),
-                            client_id: Some(client.client_id.clone()),
+                            client_id: Some(client_instance.client_id.clone()),
                             mq_set: mqs.clone(),
                             ..Default::default()
                         };
-                        let Some(mq_client_api_impl) = client.mq_client_api_impl.as_ref() else {
+                        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
                             warn!(
                                 "lockAll skipped broker {}: MQClientAPIImpl is not initialized",
                                 broker_name
@@ -1234,7 +1233,7 @@ where
         futures::future::join_all(map).await;
     }
 
-    pub async fn unlock_all(&mut self, oneway: bool) {
+    pub async fn unlock_all(&self, oneway: bool) {
         let broker_mqs = self.build_process_queue_table_by_broker_name().await;
         let Some(consumer_group) = self.consumer_group.clone() else {
             warn!("unlockAll skipped: consumer_group is not initialized");
@@ -1244,7 +1243,7 @@ where
             if mqs.is_empty() {
                 continue;
             }
-            let Some(client) = self.client_instance.as_mut() else {
+            let Some(client) = self.client_instance.as_ref() else {
                 warn!("unlockAll skipped: client_instance is not initialized");
                 return;
             };

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
@@ -356,17 +356,17 @@ impl Rebalance for RebalanceLitePullImpl {
     ///
     /// LitePull consumers do not hold broker-side distributed queue locks; there is nothing
     /// to unlock.
-    async fn unlock(&mut self, _mq: &MessageQueue, _oneway: bool) {}
+    async fn unlock(&self, _mq: &MessageQueue, _oneway: bool) {}
 
     /// No-op for LitePull consumers.
     ///
     /// Broker-side queue locking is a Push-consumer concept and is not used here.
-    async fn lock_all(&mut self) {}
+    async fn lock_all(&self) {}
 
     /// No-op for LitePull consumers.
     ///
     /// Broker-side queue unlocking is a Push-consumer concept and is not used here.
-    async fn unlock_all(&mut self, _oneway: bool) {}
+    async fn unlock_all(&self, _oneway: bool) {}
 
     /// Drives the rebalance cycle by delegating to the shared [`RebalanceImpl`] core.
     async fn do_rebalance(&mut self, is_order: bool) -> bool {

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -433,8 +433,8 @@ impl Rebalance for RebalancePushImpl {
         }
     }
 
-    async fn unlock(&mut self, mq: &MessageQueue, oneway: bool) {
-        let Some(client) = self.rebalance_impl_inner.client_instance.as_mut() else {
+    async fn unlock(&self, mq: &MessageQueue, oneway: bool) {
+        let Some(client) = self.rebalance_impl_inner.client_instance.as_ref() else {
             warn!("Client instance is not available for unlocking {}", mq);
             return;
         };
@@ -476,7 +476,7 @@ impl Rebalance for RebalancePushImpl {
         }
     }
 
-    async fn lock_all(&mut self) {
+    async fn lock_all(&self) {
         if let Some(default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.as_ref() {
             if default_mqpush_consumer_impl.is_consume_orderly() {
                 let process_queue_table = self.rebalance_impl_inner.process_queue_table.clone();
@@ -492,7 +492,7 @@ impl Rebalance for RebalancePushImpl {
         }
     }
 
-    async fn unlock_all(&mut self, oneway: bool) {
+    async fn unlock_all(&self, oneway: bool) {
         let process_queue_table = self.rebalance_impl_inner.process_queue_table.clone();
         let consumer_group = self.rebalance_impl_inner.consumer_group.clone();
         let client_instance = self.rebalance_impl_inner.client_instance.clone();

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8823,25 +8823,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "9cec0ad2b8a8991648e6cd84",
-      "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "9912bd908304b34754061e60",
-          "fingerprint": "ec847fdc2c5a0177c158c209",
-          "item": "fn lock_one_mq",
-          "line": 355
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "aab8c3c5878736152902dbd4",
       "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs",
       "symbol": "*",
@@ -9225,18 +9206,6 @@
       "kind": "mut_from_ref_call",
       "category": "production",
       "occurrences": [
-        {
-          "id": "a3fad5dad135dd14e2092d72",
-          "fingerprint": "97b58edbb5cff801f5d66031",
-          "item": "fn lock_mq_periodically",
-          "line": 247
-        },
-        {
-          "id": "023db31e0f03d561b4f4a9a3",
-          "fingerprint": "3d2114d8eef652c6d6b32489",
-          "item": "fn unlock_all_message_queues",
-          "line": 402
-        },
         {
           "id": "a769e3c9807073f2b536ea6f",
           "fingerprint": "9f1002806ae1463680b9d881",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8345

### Brief Description

- Narrow Rebalance single-queue unlock and all-queue lock/unlock trait capabilities from `&mut self` to `&self`, including Push, Lite Pull, and generic inner implementations.
- Use immutable `MQClientInstance` access for broker lookup and lock/unlock client API calls while continuing to update process-queue lock state through existing atomic/concurrent structures.
- Remove three stale mutable aliases from orderly and POP-orderly lock/unlock paths; keep the POP-orderly producer-send mutable access because it remains genuinely mutable.
- Resolve namespaces immutably in orderly reset paths, avoiding a cloned config that could update the shared lazy-cache flag without updating the original namespace field.
- Preserve lock/unlock request bodies, one-way behavior, queue lock timestamps/state, periodic scheduling, and namespace stripping.
- Reduce the reviewed shared-mutation baseline from 672 entries / 1,922 occurrences to 671 / 1,919. Production debt drops from 411 / 1,206 to 410 / 1,203, and Client debt drops from 94 / 314 to 93 / 311.
- Update the migration checklist and evidence documents. This is an M11-12 sub-slice: overall progress remains 75/82 and the parent work package stays open.

### How Did You Test This Change?

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- `cargo test -p rocketmq-client-rust consumer::consumer_impl::consume_message_orderly_service::tests --lib --all-features` (14/14 passed)
- `cargo test -p rocketmq-client-rust consumer::consumer_impl::consume_message_pop_orderly_service::tests --lib --all-features` (17/17 passed)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (library 966/966 and all integration targets passed; 35 pre-existing external-environment tests ignored)
- `python -m unittest scripts.tests.test_arc_mut_guard` (67/67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24/24 passed)
- `python scripts/arc_mut_guard.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `python scripts/architecture_dependency_guard.py --mode target`
- `python scripts/architecture_dependency_guard.py --mode baseline`
- `python scripts/architecture_release_guard.py`
- `.\scripts\check-agents-routing.ps1`
- Focused orderly lock `mut_from_ref` scans and reviewed semantic-set comparison
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified orderly and POP-orderly consumer queue lock and unlock operations.
  * Namespace resets now use the resolved namespace consistently.
  * Queue locking APIs no longer require mutable access, while preserving existing request, response, and lock-state behavior.
* **Documentation**
  * Updated architecture migration progress, validation notes, and remaining work tracking for the completed client lock-access milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->