### PR TITLE
[ISSUE #8347]♻️Replace Lite Pull config mutation with snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
 name = "rocketmq-client-rust"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "criterion",

--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -642,7 +642,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12x Client remote offset read access：`RemoteBrokerOffsetStore` 的 broker lookup、route refresh 与 client API 读取直接使用 immutable `MQClientInstance` access，删除 4 个过时 `mut_from_ref`
   - [x] M11-12y Client Push operational access：pull/pop dispatch、retry namespace reset、POP ack/change-invisible receiver 收窄为 `&self`，RebalancePush heartbeat/dispatch 与 consume service 删除 9 个过时 `mut_from_ref`
   - [x] M11-12z Client orderly lock access：Rebalance lock/unlock capability 与 Push/Lite/inner 实现收窄为 `&self`，orderly lock 路径删除 3 个 `mut_from_ref` 并改用 immutable namespace resolution
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345 与每次真实下降
+  - [x] M11-12aa Client Lite Pull config snapshots：实现与 rebalance 配置改用 `ArcSwap` copy-update-publish，不再通过共享引用写配置；兼容 facade 入口保持，内部配置读取只观察完整代际
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -669,7 +670,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8341 后实际快照降至 414 production/1,215 occurrence；Client 降至 97/323，RemoteBrokerOffsetStore 只读查询路径 `mut_from_ref` 清零
   - [x] Issue #8343 后实际快照降至 411 production/1,206 occurrence；Client 降至 94/314，Push request/POP API/retry reset 只读访问删除 3 个 identity、9 个 occurrence
   - [x] Issue #8345 后实际快照降至 410 production/1,203 occurrence；Client 降至 93/311，orderly service `mut_from_ref` 清零，POP-orderly 仅保留 producer send 可变入口
-  - [ ] M11-12aa 及后续：Client 其余 MQClientInstance/Producer/Push/Lite owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8347 后 production identity 保持 410，occurrence 降至 1,169；Client 为 93/277，Lite Pull 实现与 rebalance 配置 owner 的 34 个共享可变 occurrence 退出
+  - [ ] M11-12ab 及后续：Client 其余 MQClientInstance/Producer/Push/Lite facade/root owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -343,6 +343,11 @@ inner 实现收窄为 `&self`，broker lookup、request body、oneway 与 proces
 orderly namespace reset 使用 immutable resolution，删除 3 个 `mut_from_ref`。实际快照降至 410 production/1,203
 occurrence，Client 降至 93/311；剩余为 Broker 190/568、Client 93/311 与 Store 127/324，总进度仍为 75/82，
 M11-12 父工作包未完成。
+Client Lite Pull config snapshots 随 Issue #8347 将实现与 rebalance 配置改为 `ArcSwap` 不可变快照；同步 setter
+通过 copy-update-publish 串行 CAS 发布完整代际，异步 pull/rebalance/metadata/diagnostics 只持有不可变 `Arc` 快照，
+不跨 await 持有同步锁。兼容 facade 构造与 Java 行为保持，内部配置 owner 删除 34 个 `mut_from_ref`/`ArcMut`
+occurrence。实际快照为 410 production/1,169 occurrence，Client 为 93/277；剩余为 Broker 190/568、Client 93/277
+与 Store 127/324，总进度仍为 75/82，M11-12 父工作包与最终目标 Gate 均未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -355,6 +355,11 @@ orderly namespace reset 使用 immutable resolution，删除 3 个过时 `mut_fr
 410 production/1,203 occurrences，Client 降至 93/311；POP-orderly producer send、Rebalance owner/assignment 与
 其余 Client/Broker/Store、compatibility、完整候选快照 Gate 仍保持开放。
 
+M11-12aa 已将 Lite Pull 实现与 rebalance 配置从共享可变 owner 改为 `ArcSwap` 不可变快照；setter 使用
+copy-update-publish，异步 pull/rebalance/metadata/diagnostics 读取完整代际且不跨 await 持有同步 guard。兼容 facade
+入口、namespace、trace、pull、offset 与 Java 配置同步行为保持。实际快照为 410 production/1,169 occurrences，
+Client 为 93/277；Lite Pull facade/root lifecycle、其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～z 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～aa 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -84,6 +84,9 @@ M11-12y 的 Client Push operational access 由 Issue #8343 跟踪，分支为
 
 M11-12z 的 Client orderly lock access 由 Issue #8345 跟踪，分支为
 `mxsm/architecture-refactor-client-orderly-lock-access`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12aa 的 Client Lite Pull config snapshots 由 Issue #8347 跟踪，分支为
+`mxsm/architecture-refactor-lite-pull-config-snapshots`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -734,6 +737,32 @@ occurrence（合计删除 3 个 occurrence），没有新增或 fingerprint relo
 identity/id/fingerprint/item 语义集合完全一致，因此本切片不使用 relocation approval，也没有新增或替代
 shared-mutation wrapper。
 
+## M11-12aa Client Lite Pull config snapshots
+
+| 目标 | 实现与证据 |
+|---|---|
+| implementation config | `DefaultLitePullConsumerImpl` 的 `ClientConfig` 与 `LitePullConsumerConfig` 使用 `ArcSwap` 不可变快照；兼容 `ArcMut` 构造参数仅在边界复制，不再成为内部 owner |
+| rebalance config | `RebalanceLitePullImpl` 直接持有 `ArcSwap<ConsumerConfig>`；group/model/strategy/unit/timestamp/listener 通过 copy-update-publish 同步完整代际 |
+| async read boundary | start、shutdown、pull、flow control、auto-commit、hook、metadata 与 running-info 在 await 前取得不可变 `Arc` 快照，不持有同步 lock guard |
+| concurrent update | 既有 consumer-group 回归测试追加四路同步配置写入，验证不同字段的并发 accepted update 不丢失 |
+| compatibility | public Lite Pull facade 构造与 setter、namespace group wrapping、TLS、trace、pull、offset 与 Java-compatible getter 行为保持不变 |
+
+M11-12aa 后实际快照仍为 671 个条目：production 410、test 247、compatibility 14；occurrence 精确为
+production 1,169、test 676、compatibility 40。相对 M11-12z 没有删除完整 identity，真实删除 34 个 production
+occurrence；相对初始快照累计删除 350 个 production 条目和 956 个 production occurrence。
+`rocketmq-client` production 债务从 93/311 降至 93/277。剩余 production 债务为：
+
+| crate | 条目 | occurrence |
+|---|---:|---:|
+| `rocketmq-broker` | 190 | 568 |
+| `rocketmq-client` | 93 | 277 |
+| `rocketmq-store` | 127 | 324 |
+
+reviewed baseline 从 671→671、occurrences 从 1,919→1,885。34 个 occurrence 均因内部配置共享可变入口真实删除；
+11 个保留 occurrence 仅因同一函数内相邻字段/初始化变为 `ArcSwap` 而发生 fingerprint 位移，逐条按 ADR-013
+临时审核且 approval 不提交。tracked baseline 与 reviewed output 的 identity/id/fingerprint/item 语义集合一致，
+没有新增或替代 shared-mutation wrapper。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1269,9 +1298,28 @@ M11-12z 追加验证：
 | orderly lock `mut_from_ref` 定向扫描 | orderly 零匹配；POP-orderly 仅保留 producer send，baseline 与 reviewed output 语义集合一致 |
 | `git diff --check` | 通过 |
 
+M11-12aa 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；Lite Pull implementation/rebalance config 使用 `ArcSwap` snapshot，全部 target 编译通过 |
+| `cargo test -p rocketmq-client-rust default_lite_pull_consumer --lib` | 83/83 通过；覆盖 config setter 同步、并发 copy-update-publish、namespace、trace、pull、offset、rebalance 与 lifecycle |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 966/966，其余 integration targets 全部通过（35 项既有外部环境测试忽略） |
+| reviewed baseline reduction（临时 ADR-013 approval） | 34 个 production occurrence 真实删除；11 个同 item 保留 occurrence 的 fingerprint relocation 逐条审核，approval 不提交；baseline 671/1,919→671/1,885 |
+| `python scripts/arc_mut_guard.py` | 通过；production 410/1,169，Client 93/277，tracked/reviewed semantic set 1,885/1,885 一致 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；异步路径只持有 immutable `Arc` config snapshot，不跨 await 持有同步 lock guard |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology |
+| `.\scripts\check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Lite Pull internal config `mut_from_ref` 定向扫描 | implementation 与 rebalance config 零匹配；兼容 facade/root lifecycle 边界保留给后续切片 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client 其余 MQClientInstance、Producer、Push/Lite Consumer owner（93/311）。
+1. Client 其余 MQClientInstance、Producer、Push/Lite facade/root owner（93/277）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -59,6 +59,7 @@ rand          = { workspace = true }
 #log
 tracing.workspace = true
 
+arc-swap    = "1.9"
 parking_lot = { workspace = true }
 bytes       = { workspace = true }
 dashmap     = { workspace = true }

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -24,6 +24,7 @@ use std::sync::RwLock as StdRwLock;
 use std::time::Duration;
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
@@ -389,8 +390,8 @@ impl Default for LitePullConsumerConfig {
 
 impl LitePullConsumerConfig {
     /// Converts LitePullConsumerConfig to ConsumerConfig for rebalance.
-    fn to_consumer_config(&self) -> ArcMut<ConsumerConfig> {
-        ArcMut::new(ConsumerConfig {
+    fn to_consumer_config(&self) -> ConsumerConfig {
+        ConsumerConfig {
             consumer_group: self.consumer_group.clone(),
             topic: CheetahString::from_static_str(""),
             sub_expression: CheetahString::from_static_str("*"),
@@ -426,7 +427,7 @@ impl LitePullConsumerConfig {
             trace_dispatcher: None,
             client_rebalance: false,
             rpc_hook: None,
-        })
+        }
     }
 }
 
@@ -446,8 +447,8 @@ pub enum ServiceState {
 /// Core implementation of lite pull consumer.
 pub struct DefaultLitePullConsumerImpl {
     // Configuration
-    pub(crate) client_config: ArcMut<ClientConfig>,
-    pub(crate) consumer_config: ArcMut<LitePullConsumerConfig>,
+    pub(crate) client_config: ArcSwap<ClientConfig>,
+    consumer_config: ArcSwap<LitePullConsumerConfig>,
 
     // Lifecycle state
     service_state: ArcMut<ServiceState>,
@@ -507,16 +508,19 @@ pub struct DefaultLitePullConsumerImpl {
 impl DefaultLitePullConsumerImpl {
     /// Creates a new lite pull consumer implementation.
     pub fn new(client_config: ArcMut<ClientConfig>, consumer_config: ArcMut<LitePullConsumerConfig>) -> Self {
+        let client_config = client_config.as_ref().clone();
+        let consumer_config = consumer_config.as_ref().clone();
         let (tx, rx) = mpsc::unbounded_channel();
+        let rebalance_config = consumer_config.to_consumer_config();
 
         let mut this = Self {
-            client_config,
-            consumer_config: consumer_config.clone(),
+            client_config: ArcSwap::from_pointee(client_config),
+            consumer_config: ArcSwap::from_pointee(consumer_config),
             service_state: ArcMut::new(ServiceState::CreateJust),
             subscription_type: Arc::new(RwLock::new(SubscriptionType::None)),
             consumer_start_timestamp: AtomicI64::new(current_millis() as i64),
             client_instance: None,
-            rebalance_impl: ArcMut::new(RebalanceLitePullImpl::new(consumer_config.to_consumer_config())),
+            rebalance_impl: ArcMut::new(RebalanceLitePullImpl::new(rebalance_config)),
             pull_api_wrapper: None,
             offset_store: None,
             rpc_hook: None,
@@ -547,17 +551,42 @@ impl DefaultLitePullConsumerImpl {
         this
     }
 
+    fn consumer_config_snapshot(&self) -> Arc<LitePullConsumerConfig> {
+        self.consumer_config.load_full()
+    }
+
+    fn update_consumer_config(&self, update: impl Fn(&mut LitePullConsumerConfig)) {
+        self.consumer_config.rcu(|current| {
+            let mut next = (**current).clone();
+            update(&mut next);
+            Arc::new(next)
+        });
+    }
+
+    fn update_client_config(&self, update: impl Fn(&mut ClientConfig)) {
+        self.client_config.rcu(|current| {
+            let mut next = (**current).clone();
+            update(&mut next);
+            Arc::new(next)
+        });
+    }
+
+    pub(crate) fn set_use_tls(&self, use_tls: bool) {
+        self.update_client_config(|config| config.set_use_tls(use_tls));
+    }
+
     /// Sets the self-reference for callbacks.
     pub fn set_default_lite_pull_consumer_impl(
         &mut self,
         default_lite_pull_consumer_impl: ArcMut<DefaultLitePullConsumerImpl>,
     ) {
-        self.rebalance_impl.consumer_config.message_queue_listener = Some(Arc::new(LitePullRebalanceListener {
-            consumer_impl: ArcMut::downgrade(&default_lite_pull_consumer_impl),
-            user_listener: self.user_message_queue_listener.clone(),
-            task_tracker: self.rebalance_listener_tasks.clone(),
-            shutdown_token: self.rebalance_listener_shutdown.clone(),
-        }));
+        self.rebalance_impl
+            .set_message_queue_listener(Some(Arc::new(LitePullRebalanceListener {
+                consumer_impl: ArcMut::downgrade(&default_lite_pull_consumer_impl),
+                user_listener: self.user_message_queue_listener.clone(),
+                task_tracker: self.rebalance_listener_tasks.clone(),
+                shutdown_token: self.rebalance_listener_shutdown.clone(),
+            })));
         self.default_lite_pull_consumer_impl = Some(default_lite_pull_consumer_impl);
     }
 
@@ -585,7 +614,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the configured consumer group.
     pub fn consumer_group_config(&self) -> CheetahString {
-        self.consumer_config.consumer_group.clone()
+        self.consumer_config.load().consumer_group.clone()
     }
 
     /// Updates the consumer group before startup and keeps rebalance config in sync.
@@ -596,11 +625,8 @@ impl DefaultLitePullConsumerImpl {
             ));
         }
 
-        self.consumer_config.mut_from_ref().consumer_group = consumer_group.clone();
-        self.rebalance_impl
-            .mut_from_ref()
-            .set_consumer_group(consumer_group.clone());
-        self.rebalance_impl.consumer_config.mut_from_ref().consumer_group = consumer_group;
+        self.update_consumer_config(|config| config.consumer_group = consumer_group.clone());
+        self.rebalance_impl.mut_from_ref().set_consumer_group(consumer_group);
         Ok(())
     }
 
@@ -643,11 +669,12 @@ impl DefaultLitePullConsumerImpl {
 
     /// Validates configuration before starting.
     fn check_config(&self) -> RocketMQResult<()> {
-        if self.consumer_config.consumer_group.is_empty() {
+        let config = self.consumer_config_snapshot();
+        if config.consumer_group.is_empty() {
             return Err(crate::mq_client_err!("Consumer group cannot be empty"));
         }
 
-        if self.consumer_config.consumer_group == mix_all::DEFAULT_CONSUMER_GROUP {
+        if config.consumer_group == mix_all::DEFAULT_CONSUMER_GROUP {
             return Err(crate::mq_client_err!(format!(
                 "consumerGroup can not equal {}, please specify another one.{}",
                 mix_all::DEFAULT_CONSUMER_GROUP,
@@ -657,29 +684,27 @@ impl DefaultLitePullConsumerImpl {
             )));
         }
 
-        validate_lite_pull_consume_from_where(self.consumer_config.consume_from_where)?;
+        validate_lite_pull_consume_from_where(config.consume_from_where)?;
 
-        if self.consumer_config.pull_batch_size < 1 || self.consumer_config.pull_batch_size > 1024 {
+        if config.pull_batch_size < 1 || config.pull_batch_size > 1024 {
             return Err(crate::mq_client_err!(format!(
                 "pullBatchSize must be in [1, 1024], current value: {}",
-                self.consumer_config.pull_batch_size
+                config.pull_batch_size
             )));
         }
 
-        if self.consumer_config.pull_threshold_for_queue < 1 || self.consumer_config.pull_threshold_for_queue > 65535 {
+        if config.pull_threshold_for_queue < 1 || config.pull_threshold_for_queue > 65535 {
             return Err(crate::mq_client_err!(format!(
                 "pullThresholdForQueue must be in [1, 65535], current value: {}",
-                self.consumer_config.pull_threshold_for_queue
+                config.pull_threshold_for_queue
             )));
         }
 
-        if self.consumer_config.poll_timeout_millis == 0 {
+        if config.poll_timeout_millis == 0 {
             return Err(crate::mq_client_err!("pollTimeoutMillis cannot be 0"));
         }
 
-        if self.consumer_config.consumer_timeout_millis_when_suspend
-            < self.consumer_config.broker_suspend_max_time_millis
-        {
+        if config.consumer_timeout_millis_when_suspend < config.broker_suspend_max_time_millis {
             return Err(crate::mq_client_err!(
                 "Long polling mode, the consumer consumerTimeoutMillisWhenSuspend must greater than \
                  brokerSuspendMaxTimeMillis"
@@ -799,7 +824,7 @@ impl DefaultLitePullConsumerImpl {
         mq_all: &HashSet<MessageQueue>,
         mq_divided: &HashSet<MessageQueue>,
     ) -> RocketMQResult<()> {
-        let assigned = match self.consumer_config.message_model {
+        let assigned = match self.consumer_config.load().message_model {
             MessageModel::Broadcasting => mq_all,
             MessageModel::Clustering => mq_divided,
         };
@@ -911,52 +936,53 @@ impl DefaultLitePullConsumerImpl {
     pub async fn start(&mut self) -> RocketMQResult<()> {
         match *self.service_state {
             ServiceState::CreateJust => {
+                let consumer_config = self.consumer_config_snapshot();
                 info!(
                     "DefaultLitePullConsumerImpl [{}] starting. message_model={:?}",
-                    self.consumer_config.consumer_group, self.consumer_config.message_model
+                    consumer_config.consumer_group, consumer_config.message_model
                 );
 
                 *self.service_state = ServiceState::StartFailed;
 
                 self.check_config()?;
 
-                if self.consumer_config.message_model == MessageModel::Clustering {
-                    self.client_config.change_instance_name_to_pid();
+                if consumer_config.message_model == MessageModel::Clustering {
+                    self.update_client_config(ClientConfig::change_instance_name_to_pid);
                 }
 
+                let client_config = self.client_config.load_full();
                 let client_instance = MQClientManager::get_instance()
-                    .get_or_create_mq_client_instance(self.client_config.as_ref().clone(), self.rpc_hook.clone());
+                    .get_or_create_mq_client_instance(client_config.as_ref().clone(), self.rpc_hook.clone());
                 self.client_instance = Some(client_instance.clone());
 
                 self.rebalance_impl
-                    .set_consumer_group(self.consumer_config.consumer_group.clone());
+                    .set_consumer_group(consumer_config.consumer_group.clone());
+                self.rebalance_impl.set_message_model(consumer_config.message_model);
                 self.rebalance_impl
-                    .set_message_model(self.consumer_config.message_model);
-                self.rebalance_impl
-                    .set_allocate_message_queue_strategy(self.consumer_config.allocate_message_queue_strategy.clone());
+                    .set_allocate_message_queue_strategy(consumer_config.allocate_message_queue_strategy.clone());
                 self.rebalance_impl.set_mq_client_factory(client_instance.clone());
 
                 if self.pull_api_wrapper.is_none() {
                     let mut pull_api_wrapper = PullAPIWrapper::new(
                         client_instance.clone(),
-                        self.consumer_config.consumer_group.clone(),
-                        self.consumer_config.unit_mode,
+                        consumer_config.consumer_group.clone(),
+                        consumer_config.unit_mode,
                     );
-                    pull_api_wrapper.set_connect_broker_by_user(self.consumer_config.connect_broker_by_user);
-                    pull_api_wrapper.set_default_broker_id(self.consumer_config.default_broker_id);
+                    pull_api_wrapper.set_connect_broker_by_user(consumer_config.connect_broker_by_user);
+                    pull_api_wrapper.set_default_broker_id(consumer_config.default_broker_id);
                     pull_api_wrapper.register_filter_message_hook(self.filter_message_hook_list.clone());
                     self.pull_api_wrapper = Some(ArcMut::new(pull_api_wrapper));
                 }
 
                 let offset_store = self.offset_store.clone().unwrap_or_else(|| {
-                    Arc::new(match self.consumer_config.message_model {
+                    Arc::new(match consumer_config.message_model {
                         MessageModel::Broadcasting => OffsetStore::new_with_local(LocalFileOffsetStore::new(
                             client_instance.clone(),
-                            self.consumer_config.consumer_group.clone(),
+                            consumer_config.consumer_group.clone(),
                         )),
                         MessageModel::Clustering => OffsetStore::new_with_remote(RemoteBrokerOffsetStore::new(
                             client_instance.clone(),
-                            self.consumer_config.consumer_group.clone(),
+                            consumer_config.consumer_group.clone(),
                         )),
                     })
                 });
@@ -974,7 +1000,7 @@ impl DefaultLitePullConsumerImpl {
                 let register_ok = client_instance
                     .mut_from_ref()
                     .register_consumer(
-                        &self.consumer_config.consumer_group,
+                        &consumer_config.consumer_group,
                         MQConsumerInnerImpl::from_lite_pull(default_lite_pull_consumer_impl),
                     )
                     .await;
@@ -982,7 +1008,7 @@ impl DefaultLitePullConsumerImpl {
                     *self.service_state = ServiceState::CreateJust;
                     return Err(crate::mq_client_err!(format!(
                         "The consumer group[{}] has been created before, specify another name please.{}",
-                        self.consumer_config.consumer_group,
+                        consumer_config.consumer_group,
                         rocketmq_common::common::FAQUrl::suggest_todo(
                             rocketmq_common::common::FAQUrl::GROUP_NAME_DUPLICATE_URL
                         )
@@ -998,7 +1024,7 @@ impl DefaultLitePullConsumerImpl {
 
                 info!(
                     "DefaultLitePullConsumerImpl [{}] started successfully",
-                    self.consumer_config.consumer_group
+                    consumer_config.consumer_group
                 );
 
                 if let Err(error) = self.operate_after_running().await {
@@ -1057,7 +1083,8 @@ impl DefaultLitePullConsumerImpl {
         let shutdown_signal = self.shutdown_signal.clone();
         let task_cancelled = Arc::new(AtomicBool::new(false));
         let task_cancelled_for_task = task_cancelled.clone();
-        let check_interval = Duration::from_millis(self.consumer_config.topic_metadata_check_interval_millis.max(1));
+        let check_interval =
+            Duration::from_millis(self.consumer_config.load().topic_metadata_check_interval_millis.max(1));
 
         self.topic_metadata_check_task_handle = Some(
             spawn_lite_pull_task("rocketmq-client-lite-pull-topic-metadata", task_cancelled, async move {
@@ -1173,10 +1200,8 @@ impl DefaultLitePullConsumerImpl {
     pub async fn shutdown(&mut self) -> RocketMQResult<()> {
         match *self.service_state {
             ServiceState::Running => {
-                info!(
-                    "DefaultLitePullConsumerImpl [{}] shutting down",
-                    self.consumer_config.consumer_group
-                );
+                let consumer_group = self.consumer_config.load().consumer_group.clone();
+                info!("DefaultLitePullConsumerImpl [{}] shutting down", consumer_group);
 
                 self.shutdown_signal.store(true, Ordering::Release);
                 self.rebalance_listener_shutdown.cancel();
@@ -1190,7 +1215,7 @@ impl DefaultLitePullConsumerImpl {
                 {
                     warn!(
                         "LitePull rebalance listener tasks did not finish in time. group={}",
-                        self.consumer_config.consumer_group
+                        consumer_group
                     );
                 }
 
@@ -1214,13 +1239,13 @@ impl DefaultLitePullConsumerImpl {
                     if !offset_store.shutdown(OFFSET_STORE_SHUTDOWN_TIMEOUT).await {
                         warn!(
                             "lite pull consumer [{}] offset store did not stop before timeout",
-                            self.consumer_config.consumer_group
+                            consumer_group
                         );
                     }
                 }
 
                 if let Some(client) = self.client_instance.as_mut() {
-                    client.unregister_consumer(&self.consumer_config.consumer_group).await;
+                    client.unregister_consumer(&consumer_group).await;
                 }
 
                 if let Some(mut client) = self.client_instance.take() {
@@ -1229,10 +1254,7 @@ impl DefaultLitePullConsumerImpl {
 
                 *self.service_state = ServiceState::ShutdownAlready;
 
-                info!(
-                    "DefaultLitePullConsumerImpl [{}] shutdown successfully",
-                    self.consumer_config.consumer_group
-                );
+                info!("DefaultLitePullConsumerImpl [{}] shutdown successfully", consumer_group);
 
                 Ok(())
             }
@@ -1320,9 +1342,9 @@ impl DefaultLitePullConsumerImpl {
     /// Updates the name server addresses.
     pub async fn update_name_server_address(&self, addresses: Vec<String>) {
         let joined_addr = addresses.join(";");
-        self.client_config
-            .mut_from_ref()
-            .set_namesrv_addr(CheetahString::from_string(joined_addr.clone()));
+        self.update_client_config(|config| {
+            config.set_namesrv_addr(CheetahString::from_string(joined_addr.clone()));
+        });
 
         if let Some(client_instance) = self.client_instance.as_ref() {
             if let Some(api_impl) = client_instance.mq_client_api_impl.as_ref() {
@@ -1450,7 +1472,12 @@ impl DefaultLitePullConsumerImpl {
                     if !sleep_or_cancel(
                         &shutdown_signal,
                         &task_cancelled_for_task,
-                        Duration::from_millis(default_impl.consumer_config.pull_time_delay_millis_when_exception),
+                        Duration::from_millis(
+                            default_impl
+                                .consumer_config
+                                .load()
+                                .pull_time_delay_millis_when_exception,
+                        ),
                     )
                     .await
                     {
@@ -1477,7 +1504,12 @@ impl DefaultLitePullConsumerImpl {
                         if !sleep_or_cancel(
                             &shutdown_signal,
                             &task_cancelled_for_task,
-                            Duration::from_millis(default_impl.consumer_config.pull_time_delay_millis_when_exception),
+                            Duration::from_millis(
+                                default_impl
+                                    .consumer_config
+                                    .load()
+                                    .pull_time_delay_millis_when_exception,
+                            ),
                         )
                         .await
                         {
@@ -1523,9 +1555,10 @@ impl DefaultLitePullConsumerImpl {
         }
 
         let pull_offset = self.next_pull_offset(mq).await?;
+        let consumer_config = self.consumer_config_snapshot();
 
         if pull_offset < 0 {
-            return Ok(self.consumer_config.pull_time_delay_millis_when_exception);
+            return Ok(consumer_config.pull_time_delay_millis_when_exception);
         }
 
         let subscription_data = self.subscription_data_for_queue(mq).await?;
@@ -1544,12 +1577,12 @@ impl DefaultLitePullConsumerImpl {
                 subscription_data.expression_type.clone(),
                 sub_version,
                 pull_offset,
-                self.consumer_config.pull_batch_size,
+                consumer_config.pull_batch_size,
                 i32::MAX,
                 sys_flag,
                 0,
-                self.consumer_config.broker_suspend_max_time_millis,
-                self.consumer_config.consumer_pull_timeout_millis,
+                consumer_config.broker_suspend_max_time_millis,
+                consumer_config.consumer_pull_timeout_millis,
                 CommunicationMode::Sync,
                 NoopPullCallback,
             )
@@ -1649,7 +1682,7 @@ impl DefaultLitePullConsumerImpl {
         let _guard = lock.lock().await;
         self.update_pull_offset_if_no_pending_seek(mq, next_pull_offset, process_queue)
             .await;
-        self.consumer_config.pull_time_delay_millis_when_exception
+        self.consumer_config.load().pull_time_delay_millis_when_exception
     }
 
     async fn subscription_data_for_queue(&self, mq: &MessageQueue) -> RocketMQResult<SubscriptionData> {
@@ -1700,7 +1733,8 @@ impl DefaultLitePullConsumerImpl {
             }
         }
 
-        match self.consumer_config.consume_from_where {
+        let consumer_config = self.consumer_config_snapshot();
+        match consumer_config.consume_from_where {
             ConsumeFromWhere::ConsumeFromFirstOffset | ConsumeFromWhere::ConsumeFromMinOffset => {
                 self.min_offset(mq).await
             }
@@ -1708,8 +1742,7 @@ impl DefaultLitePullConsumerImpl {
                 if mq.topic_str().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
                     return self.max_offset(mq).await;
                 }
-                let timestamp = self
-                    .consumer_config
+                let timestamp = consumer_config
                     .consume_timestamp
                     .as_deref()
                     .and_then(|value| util_all::parse_date(value, util_all::YYYYMMDDHHMMSS))
@@ -1736,7 +1769,7 @@ impl DefaultLitePullConsumerImpl {
         _mq: &MessageQueue,
         pq: &Arc<crate::consumer::consumer_impl::process_queue::ProcessQueue>,
     ) -> RocketMQResult<Option<u64>> {
-        let config = &self.consumer_config;
+        let config = self.consumer_config_snapshot();
 
         // Global cache flow control
         if config.pull_threshold_for_all > 0 {
@@ -1786,7 +1819,7 @@ impl DefaultLitePullConsumerImpl {
         let _poll_guard = self.poll_lock.lock().await;
         self.make_sure_state_ok()?;
 
-        if self.consumer_config.auto_commit {
+        if self.consumer_config.load().auto_commit {
             self.maybe_auto_commit().await;
         }
 
@@ -1833,9 +1866,11 @@ impl DefaultLitePullConsumerImpl {
 
             // Execute consume message hooks if registered
             if !self.consume_message_hook_list.is_empty() {
-                let mut context = ConsumeMessageContext::new(self.consumer_config.consumer_group.clone(), &messages)
+                let consumer_group = self.consumer_config.load().consumer_group.clone();
+                let client_config = self.client_config.load_full();
+                let mut context = ConsumeMessageContext::new(consumer_group, &messages)
                     .with_mq(request.message_queue.clone())
-                    .with_namespace(self.client_config.namespace.clone().unwrap_or_default());
+                    .with_namespace(client_config.namespace.clone().unwrap_or_default());
 
                 // Execute hook before with panic protection
                 for hook in &self.consume_message_hook_list {
@@ -1853,7 +1888,7 @@ impl DefaultLitePullConsumerImpl {
                 // Update context for successful consumption
                 context.status = CheetahString::from_static_str("CONSUME_SUCCESS");
                 context.success = true;
-                context.access_channel = Some(self.client_config.access_channel);
+                context.access_channel = Some(client_config.access_channel);
 
                 // Execute hook after with panic protection
                 for hook in &self.consume_message_hook_list {
@@ -1881,7 +1916,7 @@ impl DefaultLitePullConsumerImpl {
         let next_deadline = self.next_auto_commit_deadline.load(Ordering::Acquire);
 
         if now >= next_deadline {
-            let new_deadline = now + self.consumer_config.auto_commit_interval_millis as i64;
+            let new_deadline = now + self.consumer_config.load().auto_commit_interval_millis as i64;
 
             // Use CAS to ensure only one thread performs the commit.
             if self
@@ -2042,7 +2077,8 @@ impl DefaultLitePullConsumerImpl {
             return;
         }
 
-        if let Some(namespace) = &self.client_config.namespace {
+        let client_config = self.client_config.load();
+        if let Some(namespace) = &client_config.namespace {
             if !namespace.is_empty() {
                 for msg in messages.iter_mut() {
                     let topic = msg.message.topic().to_string();
@@ -2378,11 +2414,8 @@ impl DefaultLitePullConsumerImpl {
 
     /// Parses message queues by removing namespace from their topic names.
     fn parse_message_queues(&self, queue_set: &HashSet<MessageQueue>) -> RocketMQResult<HashSet<MessageQueue>> {
-        let namespace = self
-            .client_config
-            .get_namespace_v2()
-            .map(|s| s.as_str())
-            .unwrap_or_default();
+        let client_config = self.client_config.load();
+        let namespace = client_config.get_namespace_v2().map(|s| s.as_str()).unwrap_or_default();
 
         let mut result = HashSet::with_capacity(queue_set.len());
         for mq in queue_set {
@@ -2430,77 +2463,76 @@ impl DefaultLitePullConsumerImpl {
     /// Returns whether auto-commit is enabled.
     #[allow(dead_code)]
     pub fn is_auto_commit(&self) -> bool {
-        self.consumer_config.auto_commit
+        self.consumer_config.load().auto_commit
     }
 
     /// Updates whether offsets are automatically committed during poll.
     pub fn set_auto_commit(&self, auto_commit: bool) {
-        self.consumer_config.mut_from_ref().auto_commit = auto_commit;
+        self.update_consumer_config(|config| config.auto_commit = auto_commit);
     }
 
     /// Returns the interval between automatic offset commits.
     pub fn auto_commit_interval_millis(&self) -> u64 {
-        self.consumer_config.auto_commit_interval_millis
+        self.consumer_config.load().auto_commit_interval_millis
     }
 
     /// Updates the interval between automatic offset commits.
     pub fn set_auto_commit_interval_millis(&self, interval_millis: u64) {
-        self.consumer_config.mut_from_ref().auto_commit_interval_millis = interval_millis;
+        self.update_consumer_config(|config| config.auto_commit_interval_millis = interval_millis);
     }
 
     /// Returns whether the subscription group runs in unit mode.
     pub fn is_unit_mode(&self) -> bool {
-        self.consumer_config.unit_mode
+        self.consumer_config.load().unit_mode
     }
 
     /// Updates whether the subscription group runs in unit mode.
     pub fn set_unit_mode(&self, unit_mode: bool) {
-        self.consumer_config.mut_from_ref().unit_mode = unit_mode;
+        self.update_consumer_config(|config| config.unit_mode = unit_mode);
         if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
             wrapper.mut_from_ref().set_unit_mode(unit_mode);
         }
-        self.rebalance_impl.consumer_config.mut_from_ref().unit_mode = unit_mode;
+        self.rebalance_impl.set_unit_mode(unit_mode);
     }
 
     /// Returns the configured message model.
     pub fn message_model_config(&self) -> MessageModel {
-        self.consumer_config.message_model
+        self.consumer_config.load().message_model
     }
 
     /// Updates the configured message model.
     pub fn set_message_model(&self, message_model: MessageModel) {
-        self.consumer_config.mut_from_ref().message_model = message_model;
+        self.update_consumer_config(|config| config.message_model = message_model);
         self.rebalance_impl.mut_from_ref().set_message_model(message_model);
-        self.rebalance_impl.consumer_config.mut_from_ref().message_model = message_model;
     }
 
     /// Returns where consumption starts when no offset exists.
     pub fn consume_from_where_config(&self) -> ConsumeFromWhere {
-        self.consumer_config.consume_from_where
+        self.consumer_config.load().consume_from_where
     }
 
     /// Updates where consumption starts when no offset exists.
     pub fn set_consume_from_where(&self, consume_from_where: ConsumeFromWhere) -> RocketMQResult<()> {
         validate_lite_pull_consume_from_where(consume_from_where)?;
-        self.consumer_config.mut_from_ref().consume_from_where = consume_from_where;
-        self.rebalance_impl.consumer_config.mut_from_ref().consume_from_where = consume_from_where;
+        self.update_consumer_config(|config| config.consume_from_where = consume_from_where);
+        self.rebalance_impl.set_consume_from_where(consume_from_where);
         Ok(())
     }
 
     /// Returns the configured timestamp for ConsumeFromTimestamp.
     pub fn consume_timestamp(&self) -> Option<CheetahString> {
-        self.consumer_config.consume_timestamp.clone()
+        self.consumer_config.load().consume_timestamp.clone()
     }
 
     /// Updates the configured timestamp for ConsumeFromTimestamp.
     pub fn set_consume_timestamp(&self, consume_timestamp: Option<CheetahString>) {
-        self.consumer_config.mut_from_ref().consume_timestamp = consume_timestamp.clone();
-        self.rebalance_impl.consumer_config.mut_from_ref().consume_timestamp = consume_timestamp;
+        self.update_consumer_config(|config| config.consume_timestamp = consume_timestamp.clone());
+        self.rebalance_impl.set_consume_timestamp(consume_timestamp);
     }
 
     /// Returns the queue allocation strategy used during rebalance.
     pub fn allocate_message_queue_strategy(&self) -> Arc<dyn AllocateMessageQueueStrategy + Send + Sync> {
-        self.consumer_config.allocate_message_queue_strategy.clone()
+        self.consumer_config.load().allocate_message_queue_strategy.clone()
     }
 
     /// Updates the queue allocation strategy used during rebalance.
@@ -2508,14 +2540,12 @@ impl DefaultLitePullConsumerImpl {
         &self,
         allocate_message_queue_strategy: Arc<dyn AllocateMessageQueueStrategy + Send + Sync>,
     ) {
-        self.consumer_config.mut_from_ref().allocate_message_queue_strategy = allocate_message_queue_strategy.clone();
+        self.update_consumer_config(|config| {
+            config.allocate_message_queue_strategy = allocate_message_queue_strategy.clone();
+        });
         self.rebalance_impl
             .mut_from_ref()
-            .set_allocate_message_queue_strategy(allocate_message_queue_strategy.clone());
-        self.rebalance_impl
-            .consumer_config
-            .mut_from_ref()
-            .allocate_message_queue_strategy = Some(allocate_message_queue_strategy);
+            .set_allocate_message_queue_strategy(allocate_message_queue_strategy);
     }
 
     #[cfg(test)]
@@ -2545,26 +2575,26 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the topic metadata check interval in milliseconds.
     pub fn topic_metadata_check_interval_millis(&self) -> u64 {
-        self.consumer_config.topic_metadata_check_interval_millis
+        self.consumer_config.load().topic_metadata_check_interval_millis
     }
 
     /// Updates the topic metadata check interval in milliseconds.
     pub fn set_topic_metadata_check_interval_millis(&self, interval_millis: u64) {
-        self.consumer_config.mut_from_ref().topic_metadata_check_interval_millis = interval_millis;
+        self.update_consumer_config(|config| config.topic_metadata_check_interval_millis = interval_millis);
     }
 
     /// Returns whether broker selection is controlled by user configuration.
     pub fn is_connect_broker_by_user(&self) -> bool {
         self.pull_api_wrapper
             .as_ref()
-            .map_or(self.consumer_config.connect_broker_by_user, |wrapper| {
+            .map_or(self.consumer_config.load().connect_broker_by_user, |wrapper| {
                 wrapper.is_connect_broker_by_user()
             })
     }
 
     /// Updates whether broker selection is controlled by user configuration.
     pub fn set_connect_broker_by_user(&self, connect_broker_by_user: bool) {
-        self.consumer_config.mut_from_ref().connect_broker_by_user = connect_broker_by_user;
+        self.update_consumer_config(|config| config.connect_broker_by_user = connect_broker_by_user);
         if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
             wrapper
                 .mut_from_ref()
@@ -2576,14 +2606,14 @@ impl DefaultLitePullConsumerImpl {
     pub fn default_broker_id(&self) -> u64 {
         self.pull_api_wrapper
             .as_ref()
-            .map_or(self.consumer_config.default_broker_id, |wrapper| {
+            .map_or(self.consumer_config.load().default_broker_id, |wrapper| {
                 wrapper.default_broker_id()
             })
     }
 
     /// Updates the broker ID used when user-controlled broker selection is enabled.
     pub fn set_default_broker_id(&self, broker_id: u64) {
-        self.consumer_config.mut_from_ref().default_broker_id = broker_id;
+        self.update_consumer_config(|config| config.default_broker_id = broker_id);
         if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
             wrapper.mut_from_ref().set_default_broker_id(broker_id);
         }
@@ -2591,102 +2621,102 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the default poll timeout in milliseconds.
     pub fn poll_timeout_millis(&self) -> u64 {
-        self.consumer_config.poll_timeout_millis
+        self.consumer_config.load().poll_timeout_millis
     }
 
     /// Updates the default poll timeout in milliseconds.
     pub fn set_poll_timeout_millis(&self, timeout_millis: u64) {
-        self.consumer_config.mut_from_ref().poll_timeout_millis = timeout_millis;
+        self.update_consumer_config(|config| config.poll_timeout_millis = timeout_millis);
     }
 
     /// Returns the maximum time that the broker may suspend a long-poll pull request.
     pub fn broker_suspend_max_time_millis(&self) -> u64 {
-        self.consumer_config.broker_suspend_max_time_millis
+        self.consumer_config.load().broker_suspend_max_time_millis
     }
 
     /// Updates the maximum time that the broker may suspend a long-poll pull request.
     pub fn set_broker_suspend_max_time_millis(&self, timeout_millis: u64) {
-        self.consumer_config.mut_from_ref().broker_suspend_max_time_millis = timeout_millis;
+        self.update_consumer_config(|config| config.broker_suspend_max_time_millis = timeout_millis);
     }
 
     /// Returns the consumer-side timeout for suspended long-poll pull requests.
     pub fn consumer_timeout_millis_when_suspend(&self) -> u64 {
-        self.consumer_config.consumer_timeout_millis_when_suspend
+        self.consumer_config.load().consumer_timeout_millis_when_suspend
     }
 
     /// Updates the consumer-side timeout for suspended long-poll pull requests.
     pub fn set_consumer_timeout_millis_when_suspend(&self, timeout_millis: u64) {
-        self.consumer_config.mut_from_ref().consumer_timeout_millis_when_suspend = timeout_millis;
+        self.update_consumer_config(|config| config.consumer_timeout_millis_when_suspend = timeout_millis);
     }
 
     /// Returns the RPC timeout used for lite pull requests in milliseconds.
     pub fn consumer_pull_timeout_millis(&self) -> u64 {
-        self.consumer_config.consumer_pull_timeout_millis
+        self.consumer_config.load().consumer_pull_timeout_millis
     }
 
     /// Updates the RPC timeout used for lite pull requests in milliseconds.
     pub fn set_consumer_pull_timeout_millis(&self, timeout_millis: u64) {
-        self.consumer_config.mut_from_ref().consumer_pull_timeout_millis = timeout_millis;
+        self.update_consumer_config(|config| config.consumer_pull_timeout_millis = timeout_millis);
     }
 
     /// Returns the maximum number of messages requested in one pull.
     pub fn pull_batch_size(&self) -> i32 {
-        self.consumer_config.pull_batch_size
+        self.consumer_config.load().pull_batch_size
     }
 
     /// Updates the maximum number of messages requested in one pull.
     pub fn set_pull_batch_size(&self, pull_batch_size: i32) {
-        self.consumer_config.mut_from_ref().pull_batch_size = pull_batch_size;
+        self.update_consumer_config(|config| config.pull_batch_size = pull_batch_size);
     }
 
     /// Returns the configured number of pull worker threads.
     pub fn pull_thread_nums(&self) -> usize {
-        self.consumer_config.pull_thread_nums
+        self.consumer_config.load().pull_thread_nums
     }
 
     /// Updates the configured number of pull worker threads.
     pub fn set_pull_thread_nums(&self, pull_thread_nums: usize) {
-        self.consumer_config.mut_from_ref().pull_thread_nums = pull_thread_nums;
+        self.update_consumer_config(|config| config.pull_thread_nums = pull_thread_nums);
     }
 
     /// Returns the total cached-message threshold across all queues.
     pub fn pull_threshold_for_all(&self) -> i64 {
-        self.consumer_config.pull_threshold_for_all
+        self.consumer_config.load().pull_threshold_for_all
     }
 
     /// Updates the total cached-message threshold across all queues.
     pub fn set_pull_threshold_for_all(&self, pull_threshold_for_all: i64) {
-        self.consumer_config.mut_from_ref().pull_threshold_for_all = pull_threshold_for_all;
+        self.update_consumer_config(|config| config.pull_threshold_for_all = pull_threshold_for_all);
     }
 
     /// Returns the cached-message threshold for each queue.
     pub fn pull_threshold_for_queue(&self) -> i64 {
-        self.consumer_config.pull_threshold_for_queue
+        self.consumer_config.load().pull_threshold_for_queue
     }
 
     /// Updates the cached-message threshold for each queue.
     pub fn set_pull_threshold_for_queue(&self, pull_threshold_for_queue: i64) {
-        self.consumer_config.mut_from_ref().pull_threshold_for_queue = pull_threshold_for_queue;
+        self.update_consumer_config(|config| config.pull_threshold_for_queue = pull_threshold_for_queue);
     }
 
     /// Returns the cached-message-size threshold in MiB for each queue.
     pub fn pull_threshold_size_for_queue(&self) -> i32 {
-        self.consumer_config.pull_threshold_size_for_queue
+        self.consumer_config.load().pull_threshold_size_for_queue
     }
 
     /// Updates the cached-message-size threshold in MiB for each queue.
     pub fn set_pull_threshold_size_for_queue(&self, pull_threshold_size_for_queue: i32) {
-        self.consumer_config.mut_from_ref().pull_threshold_size_for_queue = pull_threshold_size_for_queue;
+        self.update_consumer_config(|config| config.pull_threshold_size_for_queue = pull_threshold_size_for_queue);
     }
 
     /// Returns the maximum cached offset span.
     pub fn consume_max_span(&self) -> i64 {
-        self.consumer_config.consume_max_span
+        self.consumer_config.load().consume_max_span
     }
 
     /// Updates the maximum cached offset span.
     pub fn set_consume_max_span(&self, consume_max_span: i64) {
-        self.consumer_config.mut_from_ref().consume_max_span = consume_max_span;
+        self.update_consumer_config(|config| config.consume_max_span = consume_max_span);
     }
 
     async fn max_offset(&self, message_queue: &MessageQueue) -> RocketMQResult<i64> {
@@ -2763,11 +2793,11 @@ impl DefaultLitePullConsumerImpl {
 
 impl MQConsumerInner for DefaultLitePullConsumerImpl {
     fn group_name(&self) -> CheetahString {
-        self.consumer_config.consumer_group.clone()
+        self.consumer_config.load().consumer_group.clone()
     }
 
     fn message_model(&self) -> MessageModel {
-        self.consumer_config.message_model
+        self.consumer_config.load().message_model
     }
 
     fn consume_type(&self) -> ConsumeType {
@@ -2776,7 +2806,7 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
     }
 
     fn consume_from_where(&self) -> ConsumeFromWhere {
-        self.consumer_config.consume_from_where
+        self.consumer_config.load().consume_from_where
     }
 
     fn subscriptions(&self) -> HashSet<SubscriptionData> {
@@ -2796,7 +2826,8 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
             if let Err(error) = self.sync_assigned_queues_from_rebalance(&topics).await {
                 warn!(
                     "LitePull failed to synchronize rebalance assignments for group={}, error={}",
-                    self.consumer_config.consumer_group, error
+                    self.consumer_config.load().consumer_group,
+                    error
                 );
             }
         }
@@ -2869,14 +2900,15 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
     }
 
     fn is_unit_mode(&self) -> bool {
-        self.consumer_config.unit_mode
+        self.consumer_config.load().unit_mode
     }
 
     async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>) {
         let Some(offset_store) = self.offset_store.as_ref() else {
             warn!(
                 "lite pull reset offset ignored because offset store is not initialized. group={}, topic={}",
-                self.consumer_config.consumer_group, topic
+                self.consumer_config.load().consumer_group,
+                topic
             );
             return;
         };
@@ -2892,7 +2924,8 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
         let Some(offset_store) = self.offset_store.as_ref() else {
             warn!(
                 "lite pull consumer status is empty because offset store is not initialized. group={}, topic={}",
-                self.consumer_config.consumer_group, topic
+                self.consumer_config.load().consumer_group,
+                topic
             );
             return HashMap::new();
         };
@@ -2908,13 +2941,14 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
         info.consume_orderly = false;
         info.prop_consumer_start_timestamp = self.consumer_start_timestamp.load(Ordering::Acquire) as u64;
         info.sync_properties_from_derived_fields();
-        info.set_property("consumerGroup", self.consumer_config.consumer_group.to_string());
-        info.set_property("messageModel", format!("{:?}", self.consumer_config.message_model));
-        info.set_property("pullBatchSize", self.consumer_config.pull_batch_size.to_string());
-        info.set_property("autoCommit", self.consumer_config.auto_commit.to_string());
+        let consumer_config = self.consumer_config_snapshot();
+        info.set_property("consumerGroup", consumer_config.consumer_group.to_string());
+        info.set_property("messageModel", format!("{:?}", consumer_config.message_model));
+        info.set_property("pullBatchSize", consumer_config.pull_batch_size.to_string());
+        info.set_property("autoCommit", consumer_config.auto_commit.to_string());
         info.set_property(
             "autoCommitIntervalMillis",
-            self.consumer_config.auto_commit_interval_millis.to_string(),
+            consumer_config.auto_commit_interval_millis.to_string(),
         );
 
         for entry in self.rebalance_impl.get_subscription_inner().iter() {
@@ -2976,6 +3010,7 @@ mod tests {
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering as AtomicOrdering;
+    use std::sync::Barrier;
     use std::sync::Mutex as StdMutex;
 
     use super::*;
@@ -3277,6 +3312,55 @@ mod tests {
             .to_string()
             .contains("consumerGroup can not be changed after the lite pull consumer has started"));
         assert_eq!(impl_.consumer_group_config().as_str(), "lite_pull_updated_group");
+
+        let impl_ = Arc::new(impl_);
+        let barrier = Arc::new(Barrier::new(5));
+
+        let workers = [
+            {
+                let impl_ = impl_.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    impl_.set_auto_commit(false);
+                })
+            },
+            {
+                let impl_ = impl_.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    impl_.set_auto_commit_interval_millis(1234);
+                })
+            },
+            {
+                let impl_ = impl_.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    impl_.set_pull_batch_size(64);
+                })
+            },
+            {
+                let impl_ = impl_.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    impl_.set_pull_threshold_for_all(22_222);
+                })
+            },
+        ];
+
+        barrier.wait();
+        for worker in workers {
+            worker.join().expect("config update worker should finish");
+        }
+
+        let config = impl_.consumer_config_snapshot();
+        assert!(!config.auto_commit);
+        assert_eq!(config.auto_commit_interval_millis, 1234);
+        assert_eq!(config.pull_batch_size, 64);
+        assert_eq!(config.pull_threshold_for_all, 22_222);
     }
 
     #[test]
@@ -3508,7 +3592,7 @@ mod tests {
             .await;
 
         assert_eq!(
-            impl_.client_config.namesrv_addr.as_deref(),
+            impl_.client_config.load().namesrv_addr.as_deref(),
             Some("127.0.0.1:9876;127.0.0.2:9876")
         );
         let api_impl = impl_

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
@@ -29,6 +29,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
@@ -63,7 +64,7 @@ pub struct RebalanceLitePullImpl {
     pub(crate) rebalance_impl_inner: RebalanceImpl<RebalanceLitePullImpl>,
     /// Consumer configuration providing `ConsumeFromWhere`, `ConsumeTimestamp`, and the
     /// optional [`MessageQueueListener`][crate::consumer::message_queue_listener::MessageQueueListener].
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    consumer_config: ArcSwap<ConsumerConfig>,
     /// The active offset storage backend, injected after the consumer starts.
     pub(crate) offset_store: Option<Arc<OffsetStore>>,
 }
@@ -73,12 +74,20 @@ impl RebalanceLitePullImpl {
     ///
     /// The offset store, client instance, and subscription strategy must be set separately
     /// before the first rebalance cycle runs.
-    pub fn new(consumer_config: ArcMut<ConsumerConfig>) -> Self {
+    pub fn new(consumer_config: ConsumerConfig) -> Self {
         Self {
-            consumer_config,
+            consumer_config: ArcSwap::from_pointee(consumer_config),
             rebalance_impl_inner: RebalanceImpl::new(None, None, None, None),
             offset_store: None,
         }
+    }
+
+    fn update_consumer_config(&self, update: impl Fn(&mut ConsumerConfig)) {
+        self.consumer_config.rcu(|current| {
+            let mut next = (**current).clone();
+            update(&mut next);
+            Arc::new(next)
+        });
     }
 }
 
@@ -90,7 +99,8 @@ impl RebalanceLitePullImpl {
 
     /// Sets the consumer group name on the underlying rebalance core.
     pub fn set_consumer_group(&mut self, consumer_group: CheetahString) {
-        self.rebalance_impl_inner.consumer_group = Some(consumer_group);
+        self.rebalance_impl_inner.consumer_group = Some(consumer_group.clone());
+        self.update_consumer_config(|config| config.consumer_group = consumer_group.clone());
     }
 
     /// Sets the message model (Clustering / Broadcasting) on the underlying rebalance core.
@@ -99,6 +109,7 @@ impl RebalanceLitePullImpl {
         message_model: rocketmq_remoting::protocol::heartbeat::message_model::MessageModel,
     ) {
         self.rebalance_impl_inner.message_model = Some(message_model);
+        self.update_consumer_config(|config| config.message_model = message_model);
     }
 
     /// Sets the queue-allocation strategy used during rebalancing.
@@ -106,7 +117,31 @@ impl RebalanceLitePullImpl {
         &mut self,
         strategy: Arc<dyn crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy>,
     ) {
-        self.rebalance_impl_inner.allocate_message_queue_strategy = Some(strategy);
+        self.rebalance_impl_inner.allocate_message_queue_strategy = Some(strategy.clone());
+        self.update_consumer_config(|config| config.allocate_message_queue_strategy = Some(strategy.clone()));
+    }
+
+    /// Updates unit-mode routing in the immutable rebalance configuration snapshot.
+    pub fn set_unit_mode(&self, unit_mode: bool) {
+        self.update_consumer_config(|config| config.unit_mode = unit_mode);
+    }
+
+    /// Updates the initial offset policy in the immutable rebalance configuration snapshot.
+    pub fn set_consume_from_where(&self, consume_from_where: ConsumeFromWhere) {
+        self.update_consumer_config(|config| config.consume_from_where = consume_from_where);
+    }
+
+    /// Updates the timestamp used by `ConsumeFromTimestamp`.
+    pub fn set_consume_timestamp(&self, consume_timestamp: Option<CheetahString>) {
+        self.update_consumer_config(|config| config.consume_timestamp = consume_timestamp.clone());
+    }
+
+    /// Updates the rebalance listener in the immutable configuration snapshot.
+    pub fn set_message_queue_listener(
+        &self,
+        listener: Option<Arc<dyn crate::consumer::message_queue_listener::MessageQueueListener>>,
+    ) {
+        self.update_consumer_config(|config| config.message_queue_listener = listener.clone());
     }
 
     /// Injects the `MQClientInstance` used for broker communication.
@@ -147,7 +182,7 @@ impl Rebalance for RebalanceLitePullImpl {
         mq_all: &HashSet<MessageQueue>,
         mq_divided: &HashSet<MessageQueue>,
     ) {
-        let listener = self.consumer_config.message_queue_listener.clone();
+        let listener = self.consumer_config.load().message_queue_listener.clone();
         if let Some(listener) = listener {
             if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 listener.message_queue_changed(topic, mq_all, mq_divided);
@@ -204,7 +239,8 @@ impl Rebalance for RebalanceLitePullImpl {
         &mut self,
         mq: &MessageQueue,
     ) -> rocketmq_error::RocketMQResult<i64> {
-        let consume_from_where = self.consumer_config.consume_from_where;
+        let consumer_config = self.consumer_config.load_full();
+        let consume_from_where = consumer_config.consume_from_where;
 
         let offset_store = self.offset_store.as_ref().ok_or_else(|| {
             error!("Offset store not initialised for mq: {}", mq);
@@ -267,10 +303,8 @@ impl Rebalance for RebalanceLitePullImpl {
                         })?;
                         client.mq_admin_impl.max_offset(mq).await?
                     } else {
-                        let timestamp = super::parse_consume_timestamp_millis(
-                            self.consumer_config.consume_timestamp.as_deref(),
-                            mq,
-                        )?;
+                        let timestamp =
+                            super::parse_consume_timestamp_millis(consumer_config.consume_timestamp.as_deref(), mq)?;
                         let client = self.rebalance_impl_inner.client_instance.as_mut().ok_or_else(|| {
                             error!("Client instance not initialised for mq: {}", mq);
                             mq_client_err!(

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -815,10 +815,9 @@ impl DefaultLitePullConsumer {
     pub fn set_consumer_group(&self, consumer_group: impl Into<CheetahString>) -> RocketMQResult<()> {
         let consumer_group = consumer_group.into();
         if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
-            impl_.set_consumer_group(consumer_group)?;
-        } else {
-            self.consumer_config.mut_from_ref().consumer_group = consumer_group;
+            impl_.set_consumer_group(consumer_group.clone())?;
         }
+        self.consumer_config.mut_from_ref().consumer_group = consumer_group;
         Ok(())
     }
 
@@ -865,6 +864,9 @@ impl DefaultLitePullConsumer {
     /// Enables or disables TLS on the shared client configuration and trace dispatcher.
     pub async fn set_use_tls(&self, use_tls: bool) {
         self.client_config.mut_from_ref().set_use_tls(use_tls);
+        if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
+            impl_.set_use_tls(use_tls);
+        }
         if let Some(dispatcher) = self.trace_dispatcher.read().await.as_ref().cloned() {
             if let Some(async_dispatcher) = dispatcher.as_any().downcast_ref::<AsyncTraceDispatcher>() {
                 async_dispatcher.set_use_tls(use_tls);
@@ -1020,7 +1022,9 @@ impl DefaultLitePullConsumer {
 
                 self.init_trace_dispatcher_internal(&impl_).await?;
 
-                impl_.set_consumer_group(self.consumer_group_with_namespace())?;
+                let consumer_group = self.consumer_group_with_namespace();
+                self.set_consumer_group(consumer_group.clone())?;
+                impl_.set_consumer_group(consumer_group)?;
                 if let Some(offset_store) = self.current_offset_store() {
                     impl_.mut_from_ref().set_offset_store(Some(offset_store))?;
                 }
@@ -2525,13 +2529,13 @@ mod tests {
         let (consumer, impl_) = new_namespaced_consumer_with_impl();
 
         assert!(!consumer.is_use_tls());
-        assert!(!impl_.client_config.is_use_tls());
+        assert!(!impl_.client_config.load().is_use_tls());
 
         consumer.set_use_tls(true).await;
 
         assert!(consumer.is_use_tls());
         assert!(consumer.client_config().is_use_tls());
-        assert!(impl_.client_config.is_use_tls());
+        assert!(impl_.client_config.load().is_use_tls());
     }
 
     #[tokio::test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -4111,6 +4111,7 @@ dependencies = [
 name = "rocketmq-client-rust"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "dashmap",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
 name = "rocketmq-client-rust"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "dashmap",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
 name = "rocketmq-client-rust"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "dashmap",

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -9245,28 +9245,22 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "77679fcb6039301b3076007c",
-          "fingerprint": "5eb180266308f351cf19093e",
-          "item": "fn to_consumer_config",
-          "line": 393
-        },
-        {
           "id": "126c94c81e0a61ee9b1da2d9",
           "fingerprint": "8e63f64e890a4e18ec5155d0",
           "item": "fn to_consumer_config",
           "line": 401
         },
         {
-          "id": "47b5e6a62d3777dbd73014bb",
-          "fingerprint": "acd5e5884ff6687878e3a3bc",
-          "item": "fn new",
-          "line": 515
-        },
-        {
-          "id": "becc5846316a50620dab3d18",
-          "fingerprint": "47996df2dc5df827e52d660b",
+          "id": "71a9141eb370ab018efb879d",
+          "fingerprint": "a4ac8a16e1df3f15a8ca29e7",
           "item": "fn new",
           "line": 519
+        },
+        {
+          "id": "a8a19c4481bd2ff772486787",
+          "fingerprint": "71c552ef84889e5992735b91",
+          "item": "fn new",
+          "line": 523
         },
         {
           "id": "42b08c66e10e51585cd0dd92",
@@ -9764,28 +9758,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ab713db363cb3e22161bc6f9",
-          "fingerprint": "a8a141f9e9bcef11c4f68a7c",
-          "item": "fn to_consumer_config",
-          "line": 392
-        },
-        {
-          "id": "461230db08feda70c1560eb9",
-          "fingerprint": "6bd29f6b5839abdc40d07438",
+          "id": "17b1c5dd8b83b28b71890cca",
+          "fingerprint": "16df077712964707eccad0c6",
           "item": "struct DefaultLitePullConsumerImpl",
-          "line": 449
-        },
-        {
-          "id": "0151341fa3d129007fe0689c",
-          "fingerprint": "8e93f269a319f354d68646c0",
-          "item": "struct DefaultLitePullConsumerImpl",
-          "line": 450
-        },
-        {
-          "id": "4f80a2a18f132dcdf90bd747",
-          "fingerprint": "f803c7a9abf403d83aee5923",
-          "item": "struct DefaultLitePullConsumerImpl",
-          "line": 453
+          "line": 454
         },
         {
           "id": "04c3e622e53a2f539d541853",
@@ -9818,10 +9794,10 @@
           "line": 509
         },
         {
-          "id": "e622075934ca0e7f2ff13a4f",
-          "fingerprint": "4aa6fb76d88b682b73210641",
+          "id": "2e8cf50213f72a28a03a676d",
+          "fingerprint": "d6b752bc752540f90c6cc4e6",
           "item": "fn new",
-          "line": 509
+          "line": 510
         },
         {
           "id": "3f1b9da8b6bbbd4009bc9db0",
@@ -9830,16 +9806,16 @@
           "line": 545
         },
         {
-          "id": "d32134bc74fcd32dc524e058",
-          "fingerprint": "3f0a797295902e1034a72465",
+          "id": "de1cc0528f357887fba0f897",
+          "fingerprint": "24aad6b6450c85ea722741f6",
           "item": "fn set_default_lite_pull_consumer_impl",
-          "line": 553
+          "line": 581
         },
         {
-          "id": "bacb3dfc4d26b4951f9deadd",
-          "fingerprint": "7a941e2efd7735b6b565540c",
+          "id": "bd366a62687f833eb7e70e03",
+          "fingerprint": "d8804dbc4a0269ab82d7b4d7",
           "item": "fn set_default_lite_pull_consumer_impl",
-          "line": 556
+          "line": 585
         },
         {
           "id": "1d3c2a4229ad0379e5fd407c",
@@ -9924,22 +9900,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "af6c57bcb27366ab2b0708a6",
-          "fingerprint": "cf101f144131cc1174fd1ae6",
+          "id": "606d2b8d69b34fd3b3a83622",
+          "fingerprint": "5ea45080f99baa90b6372a65",
           "item": "fn set_consumer_group",
-          "line": 599
-        },
-        {
-          "id": "925bccf776b861cac6281bb8",
-          "fingerprint": "91df3e46665d485658a3abc8",
-          "item": "fn set_consumer_group",
-          "line": 601
-        },
-        {
-          "id": "a5a9ad8e3aa411bd38fa8f38",
-          "fingerprint": "48323f100dbc0b648a348dc1",
-          "item": "fn set_consumer_group",
-          "line": 603
+          "line": 629
         },
         {
           "id": "e0829e2d450a1b0d791d8482",
@@ -9948,10 +9912,10 @@
           "line": 873
         },
         {
-          "id": "d20fad41197e6f7ba85e4753",
-          "fingerprint": "379b870004fcc6ba374bbf99",
+          "id": "dc96d723ad4439726b412a14",
+          "fingerprint": "aaddb67df9353fff82543d7f",
           "item": "fn start",
-          "line": 975
+          "line": 1001
         },
         {
           "id": "8e9e22455cd071f692265e0b",
@@ -9960,112 +9924,22 @@
           "line": 993
         },
         {
-          "id": "d44016419d888ecaa0ceba77",
-          "fingerprint": "c8be3e34ce08d635038a494e",
-          "item": "fn update_name_server_address",
-          "line": 1324
-        },
-        {
-          "id": "f102182b865c35ffe364e431",
-          "fingerprint": "4e9f5b8c86c4efdee85423e3",
-          "item": "fn set_auto_commit",
-          "line": 2442
-        },
-        {
-          "id": "7892e8d095c9c9f6aac38a94",
-          "fingerprint": "fcf8797586716e7007610b21",
-          "item": "fn set_auto_commit_interval_millis",
-          "line": 2452
-        },
-        {
-          "id": "674af65302811025320c022d",
-          "fingerprint": "0fe63b67ab2b22d0bd24ea96",
-          "item": "fn set_unit_mode",
-          "line": 2462
-        },
-        {
           "id": "bd5435e89a7fad4736e74b39",
           "fingerprint": "f8b12897695fcc5930c630a7",
           "item": "fn set_unit_mode",
           "line": 2464
         },
         {
-          "id": "b268ae754a67e50ad41a9a1c",
-          "fingerprint": "475863235f7be23175967cc8",
-          "item": "fn set_unit_mode",
-          "line": 2466
-        },
-        {
-          "id": "fea8169c5c5da47dca57ed97",
-          "fingerprint": "aa98b8bc7765512b47c1835b",
+          "id": "5566ff3bb5442376dde2e0b4",
+          "fingerprint": "98b95a08cc3ff63ea51c343d",
           "item": "fn set_message_model",
-          "line": 2476
+          "line": 2506
         },
         {
-          "id": "929927efad3c1c0b7dce4083",
-          "fingerprint": "6b3e1a92227f9ab5d3653e03",
-          "item": "fn set_message_model",
-          "line": 2477
-        },
-        {
-          "id": "09fe3bdd2201e215f714b191",
-          "fingerprint": "a9d550462b58da343bb85708",
-          "item": "fn set_message_model",
-          "line": 2478
-        },
-        {
-          "id": "f83d45b272246c121782d8fa",
-          "fingerprint": "1ba9ec522b02296baea41e20",
-          "item": "fn set_consume_from_where",
-          "line": 2489
-        },
-        {
-          "id": "b5cb99a89ffcc4c18d9b75a3",
-          "fingerprint": "e635395c509d927a91df14bf",
-          "item": "fn set_consume_from_where",
-          "line": 2490
-        },
-        {
-          "id": "0f47a4e23be2943827a1f7f1",
-          "fingerprint": "a4a6808de64cb5578cc808b8",
-          "item": "fn set_consume_timestamp",
-          "line": 2501
-        },
-        {
-          "id": "f237120fba6926f28ef9eaaa",
-          "fingerprint": "3bb2ece18ebed4add0f62634",
-          "item": "fn set_consume_timestamp",
-          "line": 2502
-        },
-        {
-          "id": "feab57023cb51a4b1c02427a",
-          "fingerprint": "d917c01ef5d2ea93f701e112",
+          "id": "96b79669398f05183490427f",
+          "fingerprint": "2510978f07090f2956646a78",
           "item": "fn set_allocate_message_queue_strategy",
-          "line": 2515
-        },
-        {
-          "id": "6a2cebf1ecc33b5b283c7a0a",
-          "fingerprint": "d26c7afbe966d2e37558259b",
-          "item": "fn set_allocate_message_queue_strategy",
-          "line": 2517
-        },
-        {
-          "id": "8595e9832484f4f85545d982",
-          "fingerprint": "fe442ee7ae87a9100eaf16ac",
-          "item": "fn set_allocate_message_queue_strategy",
-          "line": 2521
-        },
-        {
-          "id": "476456422ab522bfde51b1fe",
-          "fingerprint": "9105190563819d93904e0bdd",
-          "item": "fn set_topic_metadata_check_interval_millis",
-          "line": 2557
-        },
-        {
-          "id": "ce289a28aae19963b8ae8609",
-          "fingerprint": "cdc7d63a69131f810fd78c1d",
-          "item": "fn set_connect_broker_by_user",
-          "line": 2571
+          "line": 2547
         },
         {
           "id": "32386991328ff56585aeed83",
@@ -10074,76 +9948,10 @@
           "line": 2574
         },
         {
-          "id": "8f2bc1b02f543f079377d67a",
-          "fingerprint": "a9ec325f9229e05a45adfedd",
-          "item": "fn set_default_broker_id",
-          "line": 2590
-        },
-        {
           "id": "bc4b6c735238f7c26839f037",
           "fingerprint": "46b1a652e8e255623beaa8e2",
           "item": "fn set_default_broker_id",
           "line": 2592
-        },
-        {
-          "id": "a6be3f045d92f3545783ba44",
-          "fingerprint": "e56173231cbc4b961b7cdf34",
-          "item": "fn set_poll_timeout_millis",
-          "line": 2603
-        },
-        {
-          "id": "22b7e8de125c2914529ef9f7",
-          "fingerprint": "860abf40f853880b10326026",
-          "item": "fn set_broker_suspend_max_time_millis",
-          "line": 2613
-        },
-        {
-          "id": "7a508c282491ecca82d9b5e9",
-          "fingerprint": "d2048810f0713991b5bfc664",
-          "item": "fn set_consumer_timeout_millis_when_suspend",
-          "line": 2623
-        },
-        {
-          "id": "3cedcb8a21b1e019d07b43e1",
-          "fingerprint": "834a6ced73623181fc1c77d7",
-          "item": "fn set_consumer_pull_timeout_millis",
-          "line": 2633
-        },
-        {
-          "id": "be0e1bebd30c812962635f51",
-          "fingerprint": "54e73c24cbaa7b75457e446b",
-          "item": "fn set_pull_batch_size",
-          "line": 2643
-        },
-        {
-          "id": "b4931a343ff74343757a5fa5",
-          "fingerprint": "970ce4387d044bfa1dbf7107",
-          "item": "fn set_pull_thread_nums",
-          "line": 2653
-        },
-        {
-          "id": "5953602cda4c91cf77ba1072",
-          "fingerprint": "a2e18e7df32dd166a8fb49e5",
-          "item": "fn set_pull_threshold_for_all",
-          "line": 2663
-        },
-        {
-          "id": "90084456ebfb16db179ce32e",
-          "fingerprint": "83d4bc3577c037e6dbef28cc",
-          "item": "fn set_pull_threshold_for_queue",
-          "line": 2673
-        },
-        {
-          "id": "146e23148e12c6f7260094d4",
-          "fingerprint": "5c24059a6dd7f54712d0ae52",
-          "item": "fn set_pull_threshold_size_for_queue",
-          "line": 2683
-        },
-        {
-          "id": "b14e021ca2091fb740c4c3a6",
-          "fingerprint": "c8eb043bbad83d786e4a1187",
-          "item": "fn set_consume_max_span",
-          "line": 2693
         },
         {
           "id": "f0c147aba4fdca670c9e20a4",
@@ -10811,18 +10619,6 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "5dd6e7678284a4c818c780a4",
-          "fingerprint": "1155753798c92698f6b61ba4",
-          "item": "struct RebalanceLitePullImpl",
-          "line": 66
-        },
-        {
-          "id": "25408f42114cb8f4e960edbb",
-          "fingerprint": "cfe378f1285eff2c4058cfd5",
-          "item": "fn new",
-          "line": 76
-        },
-        {
           "id": "3ff699a1ba1521c8ec8049cb",
           "fingerprint": "490aeec1231884ed10807dc8",
           "item": "fn set_mq_client_factory",
@@ -11277,8 +11073,8 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "b831964acf452554f8af2bd6",
-          "fingerprint": "9114f5123b4605af92301d98",
+          "id": "0321d2eba96698c5702e0b35",
+          "fingerprint": "18a459a1087bfb162cf87db2",
           "item": "impl Into",
           "line": 820
         },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8347
- Parent #8292

### Brief Description

- replace the internal Lite Pull client and consumer configuration owners with immutable `ArcSwap` snapshots
- replace the Lite Pull rebalance configuration owner with copy-update-publish snapshots
- preserve the public facade, namespace, trace, pull, offset, and Java-compatible setter behavior
- update the reviewed ArcMut baseline and M11-12 progress evidence

#### Motivation

Lite Pull configuration was still stored in `ArcMut`, so synchronous setters obtained mutable references from shared references while async pull, rebalance, metadata, and diagnostic paths read the same state. This slice introduces an explicit publication boundary where readers observe complete immutable generations and concurrent accepted updates are retained.

#### Implementation

- add `arc-swap` to the Client crate and the affected standalone lockfiles
- copy the compatibility constructor inputs into internal `ArcSwap<ClientConfig>` and `ArcSwap<LitePullConsumerConfig>` owners
- publish configuration mutations with `rcu` copy-update-publish operations
- store `RebalanceLitePullImpl` consumer configuration in `ArcSwap<ConsumerConfig>`
- load immutable `Arc` snapshots before async operations instead of holding synchronous guards across `.await`
- extend the existing Lite Pull configuration regression test with four concurrent field updates

### How Did You Test This Change?

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- `cargo test -p rocketmq-client-rust default_lite_pull_consumer --lib` (83 passed)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (966 library tests passed; all integration targets passed; 35 external-environment tests ignored)
- `python -m unittest scripts.tests.test_arc_mut_guard` (67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24 passed)
- `python scripts/arc_mut_guard.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- standalone Example, Tauri Rust backend, and Web backend format/strict Clippy checks
- Web backend `cargo build --all-targets --all-features`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- architecture dependency target/baseline guards and release guard
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`

#### Architecture progress

The reviewed production snapshot remains at 410 identities and decreases from 1,203 to 1,169 occurrences. Client debt remains at 93 identities and decreases from 311 to 277 occurrences. This is an internal PR-M11-12 slice: overall progress remains 75/82, and Client facade/root lifecycle, Broker, Store/HA, compatibility removal, stable/Miri/Loom/soak/SLO, dynamic cluster, and human gates remain open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lite Pull consumers now use consistent configuration snapshots during asynchronous pulls, rebalancing, metadata updates, and diagnostics.
  * Configuration changes, including consumer groups and TLS settings, are applied more reliably before and after startup.
  * Existing compatibility and Java-aligned behavior remain unchanged.

* **Tests**
  * Added concurrency and runtime validation covering configuration updates, snapshot reads, formatting, and static checks.

* **Documentation**
  * Updated architecture migration and soundness-closure tracking for the completed Lite Pull configuration work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->