### PR TITLE
[ISSUE #8351]♻️Replace Lite Pull root lifecycle with safe Arc ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -644,7 +644,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12z Client orderly lock access：Rebalance lock/unlock capability 与 Push/Lite/inner 实现收窄为 `&self`，orderly lock 路径删除 3 个 `mut_from_ref` 并改用 immutable namespace resolution
   - [x] M11-12aa Client Lite Pull config snapshots：实现与 rebalance 配置改用 `ArcSwap` copy-update-publish，不再通过共享引用写配置；兼容 facade 入口保持，内部配置读取只观察完整代际
   - [x] M11-12ab Client Lite Pull facade config snapshots：facade 配置 owner 改为共享 `ArcSwap`，公开 getter 返回 immutable owned `Arc` snapshot，构造边界接收 owned config；builder 与 facade 配置 API 不再暴露 `ArcMut`
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349 与每次真实下降
+  - [x] M11-12ac Client Lite Pull root lifecycle：facade、consumer inner、callback 与 task root 改用标准 `Arc`/`Weak`；专用异步 lifecycle mutex 串行 start/shutdown/订阅控制面，组件槽位使用短锁快照；Rebalance offset store 改为 `ArcSwapOption`
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -673,7 +674,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8345 后实际快照降至 410 production/1,203 occurrence；Client 降至 93/311，orderly service `mut_from_ref` 清零，POP-orderly 仅保留 producer send 可变入口
   - [x] Issue #8347 后 production identity 保持 410，occurrence 降至 1,169；Client 为 93/277，Lite Pull 实现与 rebalance 配置 owner 的 34 个共享可变 occurrence 退出
   - [x] Issue #8349 后实际快照降至 408 production/1,129 occurrence；Client 降至 91/237，Lite Pull facade config 与 builder 的 2 个 production identity、40 个 occurrence 退出
-  - [ ] M11-12ac 及后续：Lite Pull root lifecycle、Client 其余 MQClientInstance/Producer/Push owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8351 后实际快照降至 402 production/1,102 occurrence；Client crate 降至 85/210，Lite Pull root lifecycle 的 6 个 production identity、27 个 production occurrence 与 5 个 test identity、15 个 test occurrence 退出
+  - [ ] M11-12ad 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -354,6 +354,11 @@ Client Lite Pull facade config snapshots 随 Issue #8349 将 facade 的 client/c
 `DefaultLitePullConsumer` 路径、builder、Java-compatible 方法名、namespace/TLS/trace/pull/offset 行为保持。实际快照降至
 408 production/1,129 occurrence，Client 降至 91/237；剩余为 Broker 190/568、Client 91/237 与 Store 127/324，
 总进度仍为 75/82，下一子切片处理 Lite Pull root lifecycle，M11-12 父工作包与最终目标 Gate 均未完成。
+Client Lite Pull root lifecycle 随 Issue #8351 将 facade、consumer inner、rebalance listener、metadata/pull task 的
+根 owner 改为标准 `Arc`/`Weak`，以专用异步 lifecycle mutex 串行 start/shutdown 与订阅控制面；同步状态和组件槽位只在
+短锁内发布或克隆快照，锁外执行 await。Rebalance offset store 改为 `ArcSwapOption`，consumer 注册与订阅表写入收窄为
+`&self`，未新增 shared-mutation occurrence。实际快照降至 402 production/1,102 occurrence，Client crate 降至
+85/210；剩余为 Broker 190/568、Client 85/210 与 Store 127/324，总进度仍为 75/82，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -366,6 +366,12 @@ owned `Arc` snapshot，consumer group 返回 owned value，构造边界接收 ow
 方法名与 namespace/TLS/trace/pull/offset 行为保持。实际快照降至 408 production/1,129 occurrences，Client 降至
 91/237；Lite Pull root lifecycle、其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12ac 已将 Lite Pull facade、consumer inner、callback 与 task 的根 owner 改为标准 `Arc`/`Weak`；专用异步
+lifecycle mutex 串行 start/shutdown 与订阅控制面，同步状态和组件槽位只在短锁内发布/克隆并在 await 前释放。
+Rebalance offset store 使用 `ArcSwapOption` 快照，consumer 注册与订阅表写入收窄为 `&self`。实际快照降至
+402 production/1,102 occurrences，Client crate 降至 85/210；其余 Client/Broker/Store、compatibility 与完整候选
+快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -793,6 +793,33 @@ lifecycle 保留 occurrence 仅因相邻 config 字段/constructor input 改为 
 relocation，逐条按 ADR-013 临时审核且 approval 不提交。tracked baseline 与 reviewed output 的
 identity/id/fingerprint/item 语义集合 1,838/1,838 一致，没有新增或替代 shared-mutation wrapper。
 
+## M11-12ac Client Lite Pull root lifecycle
+
+| 目标 | 实现与证据 |
+|---|---|
+| root owner | facade `OnceCell`、`MQConsumerInnerImplKind::LitePull`、rebalance listener 与 metadata/pull task 使用标准 `Arc<DefaultLitePullConsumerImpl>` / `Weak`，删除 `ArcMut`/`WeakArcMut` 根 owner 和强 self-cycle |
+| lifecycle transition | 专用 Tokio mutex 串行 start/shutdown、subscribe/assign/unsubscribe 与 assign-expression 控制面；start 在状态写锁内原子执行 `CreateJust→StartFailed` 预占，避免同步配置检查后被启动穿插 |
+| component publication | service state、client/pull/offset/RPC/hook 与 task-handle 槽位使用短时标准锁或 `ArcSwapOption`，只在锁内 clone/take/publish，所有 I/O、task wait、offset persistence 与 client shutdown 均在锁外 await |
+| child boundary | Rebalance 构造时发布 group/model/strategy 初值，subscription `DashMap` 写入和 consumer 注册收窄为 `&self`；Rebalance offset store 改为 `ArcSwapOption`，不为 root 迁移新增 `mut_from_ref` |
+| regression evidence | 86 项 Lite Pull 定向测试通过；新增并发 shutdown 串行化与 weak self-reference 无保活环测试，既有 namespace/trace/pull/offset/heartbeat 行为保持 |
+
+M11-12ac 后实际快照为 657 个条目：production 402、test 241、compatibility 14；occurrence 精确为
+production 1,102、test 654、compatibility 40。相对 M11-12ab 真实删除 6 个 production identity、27 个 production
+occurrence 和 5 个 test identity、15 个 test occurrence；相对初始快照累计删除 358 个 production 条目和 1,023 个
+production occurrence。`rocketmq-client` crate production 债务从 91/237 降至 85/210（owner 分组为 client 84/209、
+proxy 1/1）。剩余 production 债务为：
+
+| crate | 条目 | occurrence |
+|---|---:|---:|
+| `rocketmq-broker` | 190 | 568 |
+| `rocketmq-client` | 85 | 210 |
+| `rocketmq-store` | 127 | 324 |
+
+reviewed baseline 从 668→657、occurrences 从 1,838→1,796。42 个 occurrence 真实删除；40 个保留的 child owner 或
+test fixture occurrence 仅因同 item 内 root lifecycle 字段、控制面和测试重排发生 fingerprint relocation，逐条按
+ADR-013 临时审核且 approval 不提交。tracked baseline 与 reviewed output 的 identity/id/fingerprint/item 语义集合
+1,796/1,796 一致，没有新增 shared-mutation occurrence 或替代 wrapper。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1367,9 +1394,29 @@ M11-12ab 追加验证：
 | Lite Pull config ArcMut 定向扫描 | facade、builder、implementation constructor 的 config ArcMut/type/getter/`mut_from_ref` 零匹配；仅保留 root lifecycle owner 给 M11-12ac |
 | `git diff --check` | 通过 |
 
+M11-12ac 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；标准 `Arc` root、shared receiver 与全部 test/integration target 编译通过 |
+| `cargo test -p rocketmq-client-rust default_lite_pull_consumer --lib --all-features` | 86/86 通过；新增 concurrent shutdown lifecycle 与 weak-root 无保活环回归 |
+| `cargo test -p rocketmq-client-rust --test public_api_exports_test crate_root_exports_modern_client_facades_and_traits --all-features` | 1/1 通过；crate-root Lite Pull facade 与 owned config snapshot API 保持 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 969/969，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline reduction（临时 ADR-013 approval） | 6 个 production identity/27 个 production occurrence 与 5 个 test identity/15 个 test occurrence 真实删除；40 个同 item relocation 逐条审核，未配对新增为零；baseline 668/1,838→657/1,796 |
+| `python scripts/arc_mut_guard.py` | 通过；production 402/1,102，Client crate 85/210，tracked/reviewed semantic set 1,796/1,796 一致 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；同步槽位仅短时 clone/take/publish，lifecycle Tokio mutex 是显式 control-plane transition owner |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Lite Pull root ArcMut 定向扫描 | `ArcMut<DefaultLitePullConsumerImpl>`、`WeakArcMut<DefaultLitePullConsumerImpl>`、root constructor 与 root `mut_from_ref` 零匹配；child Rebalance/Pull/MQClient owner 保留给后续切片 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client Lite Pull root lifecycle 与其余 MQClientInstance、Producer、Push owner（91/237）。
+1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（85/210）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -20,7 +20,10 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::OnceLock;
 use std::sync::RwLock as StdRwLock;
+use std::sync::Weak;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -45,7 +48,6 @@ use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
-use rocketmq_rust::WeakArcMut;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
@@ -184,7 +186,7 @@ async fn sleep_or_cancel(shutdown_signal: &Arc<AtomicBool>, cancelled: &Arc<Atom
 
 /// Internal rebalance listener that mirrors Java LitePull's default MessageQueueListenerImpl.
 struct LitePullRebalanceListener {
-    consumer_impl: WeakArcMut<DefaultLitePullConsumerImpl>,
+    consumer_impl: Weak<DefaultLitePullConsumerImpl>,
     user_listener: Arc<StdRwLock<Option<ArcMessageQueueListener>>>,
     task_tracker: TaskTracker,
     shutdown_token: CancellationToken,
@@ -451,16 +453,17 @@ pub struct DefaultLitePullConsumerImpl {
     consumer_config: ArcSwap<LitePullConsumerConfig>,
 
     // Lifecycle state
-    service_state: ArcMut<ServiceState>,
+    lifecycle_transition: Mutex<()>,
+    service_state: StdRwLock<ServiceState>,
     subscription_type: Arc<RwLock<SubscriptionType>>,
     consumer_start_timestamp: AtomicI64,
 
     // Core components
-    client_instance: Option<ArcMut<MQClientInstance>>,
+    client_instance: StdRwLock<Option<ArcMut<MQClientInstance>>>,
     rebalance_impl: ArcMut<RebalanceLitePullImpl>,
-    pull_api_wrapper: Option<ArcMut<PullAPIWrapper>>,
-    offset_store: Option<Arc<OffsetStore>>,
-    rpc_hook: Option<Arc<dyn RPCHook>>,
+    pull_api_wrapper: StdRwLock<Option<ArcMut<PullAPIWrapper>>>,
+    offset_store: StdRwLock<Option<Arc<OffsetStore>>>,
+    rpc_hook: StdRwLock<Option<Arc<dyn RPCHook>>>,
 
     // Queue management
     assigned_message_queue: Arc<AssignedMessageQueue>,
@@ -486,8 +489,8 @@ pub struct DefaultLitePullConsumerImpl {
     next_auto_commit_deadline: Arc<AtomicI64>,
 
     // Hooks
-    consume_message_hook_list: Vec<Arc<dyn ConsumeMessageHook + Send + Sync>>,
-    filter_message_hook_list: Vec<Arc<dyn FilterMessageHook + Send + Sync>>,
+    consume_message_hook_list: StdRwLock<Vec<Arc<dyn ConsumeMessageHook + Send + Sync>>>,
+    filter_message_hook_list: StdRwLock<Vec<Arc<dyn FilterMessageHook + Send + Sync>>>,
 
     // Topic change listeners
     topic_message_queue_change_listener_map:
@@ -497,12 +500,12 @@ pub struct DefaultLitePullConsumerImpl {
 
     // Shutdown coordination
     shutdown_signal: Arc<AtomicBool>,
-    topic_metadata_check_task_handle: Option<LitePullTaskHandle>,
+    topic_metadata_check_task_handle: StdMutex<Option<LitePullTaskHandle>>,
     rebalance_listener_tasks: TaskTracker,
     rebalance_listener_shutdown: CancellationToken,
 
     // Self-reference (for callbacks)
-    default_lite_pull_consumer_impl: Option<ArcMut<DefaultLitePullConsumerImpl>>,
+    self_reference: OnceLock<Weak<DefaultLitePullConsumerImpl>>,
 }
 
 impl DefaultLitePullConsumerImpl {
@@ -520,14 +523,15 @@ impl DefaultLitePullConsumerImpl {
         let mut this = Self {
             client_config: ArcSwap::from_pointee(client_config),
             consumer_config: ArcSwap::from_pointee(consumer_config),
-            service_state: ArcMut::new(ServiceState::CreateJust),
+            lifecycle_transition: Mutex::new(()),
+            service_state: StdRwLock::new(ServiceState::CreateJust),
             subscription_type: Arc::new(RwLock::new(SubscriptionType::None)),
             consumer_start_timestamp: AtomicI64::new(current_millis() as i64),
-            client_instance: None,
+            client_instance: StdRwLock::new(None),
             rebalance_impl: ArcMut::new(RebalanceLitePullImpl::new(rebalance_config)),
-            pull_api_wrapper: None,
-            offset_store: None,
-            rpc_hook: None,
+            pull_api_wrapper: StdRwLock::new(None),
+            offset_store: StdRwLock::new(None),
+            rpc_hook: StdRwLock::new(None),
             assigned_message_queue: Arc::new(AssignedMessageQueue::new()),
             message_queue_locks: Arc::new(RwLock::new(HashMap::new())),
             task_handles: Arc::new(RwLock::new(HashMap::new())),
@@ -539,16 +543,16 @@ impl DefaultLitePullConsumerImpl {
             queue_flow_control_times: Arc::new(AtomicU64::new(0)),
             queue_max_span_flow_control_times: Arc::new(AtomicU64::new(0)),
             next_auto_commit_deadline: Arc::new(AtomicI64::new(0)),
-            consume_message_hook_list: Vec::new(),
-            filter_message_hook_list: Vec::new(),
+            consume_message_hook_list: StdRwLock::new(Vec::new()),
+            filter_message_hook_list: StdRwLock::new(Vec::new()),
             topic_message_queue_change_listener_map: Arc::new(RwLock::new(HashMap::new())),
             message_queues_for_topic: Arc::new(RwLock::new(HashMap::new())),
             user_message_queue_listener: Arc::new(StdRwLock::new(None)),
             shutdown_signal: Arc::new(AtomicBool::new(false)),
-            topic_metadata_check_task_handle: None,
+            topic_metadata_check_task_handle: StdMutex::new(None),
             rebalance_listener_tasks: TaskTracker::new(),
             rebalance_listener_shutdown: CancellationToken::new(),
-            default_lite_pull_consumer_impl: None,
+            self_reference: OnceLock::new(),
         };
         let wrapper = ArcMut::downgrade(&this.rebalance_impl);
         this.rebalance_impl.set_rebalance_impl(wrapper);
@@ -579,32 +583,32 @@ impl DefaultLitePullConsumerImpl {
         self.update_client_config(|config| config.set_use_tls(use_tls));
     }
 
-    /// Sets the self-reference for callbacks.
-    pub fn set_default_lite_pull_consumer_impl(
-        &mut self,
-        default_lite_pull_consumer_impl: ArcMut<DefaultLitePullConsumerImpl>,
-    ) {
-        self.rebalance_impl
-            .set_message_queue_listener(Some(Arc::new(LitePullRebalanceListener {
-                consumer_impl: ArcMut::downgrade(&default_lite_pull_consumer_impl),
-                user_listener: self.user_message_queue_listener.clone(),
-                task_tracker: self.rebalance_listener_tasks.clone(),
-                shutdown_token: self.rebalance_listener_shutdown.clone(),
-            })));
-        self.default_lite_pull_consumer_impl = Some(default_lite_pull_consumer_impl);
+    /// Binds the weak self-reference used by callbacks exactly once.
+    pub(crate) fn bind_self(self: &Arc<Self>) {
+        let self_reference = Arc::downgrade(self);
+        if self.self_reference.set(self_reference.clone()).is_ok() {
+            self.rebalance_impl
+                .set_message_queue_listener(Some(Arc::new(LitePullRebalanceListener {
+                    consumer_impl: self_reference,
+                    user_listener: self.user_message_queue_listener.clone(),
+                    task_tracker: self.rebalance_listener_tasks.clone(),
+                    shutdown_token: self.rebalance_listener_shutdown.clone(),
+                })));
+        }
     }
 
-    pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<dyn RPCHook>>) {
-        self.rpc_hook = rpc_hook;
+    pub fn set_rpc_hook(&self, rpc_hook: Option<Arc<dyn RPCHook>>) {
+        *self.rpc_hook.write().unwrap_or_else(|poisoned| poisoned.into_inner()) = rpc_hook;
     }
 
     /// Validates service state is Running.
     #[inline]
     fn make_sure_state_ok(&self) -> RocketMQResult<()> {
-        if *self.service_state != ServiceState::Running {
+        let service_state = self.service_state();
+        if service_state != ServiceState::Running {
             return Err(crate::mq_client_err!(format!(
                 "The lite pull consumer service state not OK, {:?}, {}",
-                *self.service_state,
+                service_state,
                 rocketmq_common::common::FAQUrl::suggest_todo(rocketmq_common::common::FAQUrl::CLIENT_SERVICE_NOT_OK)
             )));
         }
@@ -613,7 +617,45 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the current service state.
     pub fn service_state(&self) -> ServiceState {
-        *self.service_state
+        *self
+            .service_state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn set_service_state(&self, service_state: ServiceState) {
+        *self
+            .service_state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = service_state;
+    }
+
+    fn component_snapshot<T: Clone>(&self, component: &StdRwLock<Option<T>>) -> Option<T> {
+        component
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn rpc_hook_snapshot(&self) -> Option<Arc<dyn RPCHook>> {
+        self.rpc_hook
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn consume_message_hooks_snapshot(&self) -> Vec<Arc<dyn ConsumeMessageHook + Send + Sync>> {
+        self.consume_message_hook_list
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn filter_message_hooks_snapshot(&self) -> Vec<Arc<dyn FilterMessageHook + Send + Sync>> {
+        self.filter_message_hook_list
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     /// Returns the configured consumer group.
@@ -623,7 +665,11 @@ impl DefaultLitePullConsumerImpl {
 
     /// Updates the consumer group before startup and keeps rebalance config in sync.
     pub fn set_consumer_group(&self, consumer_group: CheetahString) -> RocketMQResult<()> {
-        if *self.service_state != ServiceState::CreateJust {
+        let service_state = self
+            .service_state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *service_state != ServiceState::CreateJust {
             return Err(crate::mq_client_err!(
                 "consumerGroup can not be changed after the lite pull consumer has started."
             ));
@@ -641,34 +687,43 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the active or preconfigured offset store.
     pub fn offset_store(&self) -> Option<Arc<OffsetStore>> {
-        self.offset_store.clone()
+        self.offset_store
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     /// Updates the offset store before startup and keeps rebalance state in sync.
-    pub fn set_offset_store(&mut self, offset_store: Option<Arc<OffsetStore>>) -> RocketMQResult<()> {
-        if *self.service_state != ServiceState::CreateJust {
+    pub fn set_offset_store(&self, offset_store: Option<Arc<OffsetStore>>) -> RocketMQResult<()> {
+        let service_state = self
+            .service_state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *service_state != ServiceState::CreateJust {
             return Err(crate::mq_client_err!(
                 "offsetStore can not be changed after the lite pull consumer has started."
             ));
         }
 
-        self.offset_store = offset_store.clone();
-        if let Some(offset_store) = offset_store {
-            self.rebalance_impl.set_offset_store(offset_store);
-        } else {
-            self.rebalance_impl.offset_store = None;
-        }
+        *self
+            .offset_store
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = offset_store.clone();
+        self.rebalance_impl.set_offset_store(offset_store);
         Ok(())
     }
 
     #[cfg(test)]
     pub(crate) fn rebalance_has_offset_store(&self) -> bool {
-        self.rebalance_impl.offset_store.is_some()
+        self.rebalance_impl.offset_store.load().is_some()
     }
 
     #[cfg(test)]
     pub(crate) fn has_rpc_hook(&self) -> bool {
-        self.rpc_hook.is_some()
+        self.rpc_hook
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
     }
 
     /// Validates configuration before starting.
@@ -732,11 +787,12 @@ impl DefaultLitePullConsumerImpl {
     }
 
     async fn subscribe_inner(
-        &mut self,
+        &self,
         topic: impl Into<CheetahString>,
         sub_expression: impl Into<CheetahString>,
         message_queue_listener: Option<ArcMessageQueueListener>,
     ) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         let topic = topic.into();
         let sub_expression = sub_expression.into();
 
@@ -754,8 +810,8 @@ impl DefaultLitePullConsumerImpl {
             self.set_message_queue_listener(Some(listener));
         }
 
-        if *self.service_state == ServiceState::Running {
-            if let Some(ref client_instance) = self.client_instance {
+        if self.service_state() == ServiceState::Running {
+            if let Some(client_instance) = self.component_snapshot(&self.client_instance) {
                 client_instance.send_heartbeat_to_all_broker_with_lock().await;
                 self.update_topic_subscribe_info_when_subscription_changed().await?;
             }
@@ -766,7 +822,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Subscribes to a topic with optional tag expression filter.
     pub async fn subscribe(
-        &mut self,
+        &self,
         topic: impl Into<CheetahString>,
         sub_expression: impl Into<CheetahString>,
     ) -> RocketMQResult<()> {
@@ -774,7 +830,8 @@ impl DefaultLitePullConsumerImpl {
     }
 
     /// Manually assigns specific message queues (ASSIGN mode).
-    pub async fn assign(&mut self, message_queues: Vec<MessageQueue>) -> RocketMQResult<()> {
+    pub async fn assign(&self, message_queues: Vec<MessageQueue>) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         if message_queues.is_empty() {
             return Err(crate::mq_client_err!("Message queues can not be null or empty."));
         }
@@ -783,7 +840,7 @@ impl DefaultLitePullConsumerImpl {
 
         self.update_assigned_message_queue_for_assign(&message_queues).await;
 
-        if *self.service_state == ServiceState::Running {
+        if self.service_state() == ServiceState::Running {
             self.update_pull_task_for_assign(&message_queues).await?;
         }
 
@@ -881,7 +938,7 @@ impl DefaultLitePullConsumerImpl {
     }
 
     /// Updates topic subscription info when subscription changes (SUBSCRIBE mode).
-    async fn update_topic_subscribe_info_when_subscription_changed(&mut self) -> RocketMQResult<()> {
+    async fn update_topic_subscribe_info_when_subscription_changed(&self) -> RocketMQResult<()> {
         let topics: Vec<CheetahString> = self
             .rebalance_impl
             .get_subscription_inner()
@@ -889,7 +946,7 @@ impl DefaultLitePullConsumerImpl {
             .map(|entry| entry.key().clone())
             .collect();
 
-        if let Some(ref mut client_instance) = self.client_instance {
+        if let Some(client_instance) = self.component_snapshot(&self.client_instance) {
             for topic in &topics {
                 client_instance
                     .update_topic_route_info_from_name_server_topic(topic)
@@ -937,16 +994,27 @@ impl DefaultLitePullConsumerImpl {
     }
 
     /// Starts the lite pull consumer.
-    pub async fn start(&mut self) -> RocketMQResult<()> {
-        match *self.service_state {
+    pub async fn start(&self) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
+        let previous_state = {
+            let mut service_state = self
+                .service_state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_state = *service_state;
+            if previous_state == ServiceState::CreateJust {
+                *service_state = ServiceState::StartFailed;
+            }
+            previous_state
+        };
+
+        match previous_state {
             ServiceState::CreateJust => {
                 let consumer_config = self.consumer_config_snapshot();
                 info!(
                     "DefaultLitePullConsumerImpl [{}] starting. message_model={:?}",
                     consumer_config.consumer_group, consumer_config.message_model
                 );
-
-                *self.service_state = ServiceState::StartFailed;
 
                 self.check_config()?;
 
@@ -956,17 +1024,20 @@ impl DefaultLitePullConsumerImpl {
 
                 let client_config = self.client_config.load_full();
                 let client_instance = MQClientManager::get_instance()
-                    .get_or_create_mq_client_instance(client_config.as_ref().clone(), self.rpc_hook.clone());
-                self.client_instance = Some(client_instance.clone());
+                    .get_or_create_mq_client_instance(client_config.as_ref().clone(), self.rpc_hook_snapshot());
+                *self
+                    .client_instance
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client_instance.clone());
 
-                self.rebalance_impl
-                    .set_consumer_group(consumer_config.consumer_group.clone());
-                self.rebalance_impl.set_message_model(consumer_config.message_model);
-                self.rebalance_impl
-                    .set_allocate_message_queue_strategy(consumer_config.allocate_message_queue_strategy.clone());
-                self.rebalance_impl.set_mq_client_factory(client_instance.clone());
+                self.rebalance_impl.mut_from_ref().set_mq_client_factory(
+                    consumer_config.consumer_group.clone(),
+                    consumer_config.message_model,
+                    consumer_config.allocate_message_queue_strategy.clone(),
+                    client_instance.clone(),
+                );
 
-                if self.pull_api_wrapper.is_none() {
+                if self.component_snapshot(&self.pull_api_wrapper).is_none() {
                     let mut pull_api_wrapper = PullAPIWrapper::new(
                         client_instance.clone(),
                         consumer_config.consumer_group.clone(),
@@ -974,11 +1045,14 @@ impl DefaultLitePullConsumerImpl {
                     );
                     pull_api_wrapper.set_connect_broker_by_user(consumer_config.connect_broker_by_user);
                     pull_api_wrapper.set_default_broker_id(consumer_config.default_broker_id);
-                    pull_api_wrapper.register_filter_message_hook(self.filter_message_hook_list.clone());
-                    self.pull_api_wrapper = Some(ArcMut::new(pull_api_wrapper));
+                    pull_api_wrapper.register_filter_message_hook(self.filter_message_hooks_snapshot());
+                    *self
+                        .pull_api_wrapper
+                        .write()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(ArcMut::new(pull_api_wrapper));
                 }
 
-                let offset_store = self.offset_store.clone().unwrap_or_else(|| {
+                let offset_store = self.offset_store().unwrap_or_else(|| {
                     Arc::new(match consumer_config.message_model {
                         MessageModel::Broadcasting => OffsetStore::new_with_local(LocalFileOffsetStore::new(
                             client_instance.clone(),
@@ -993,23 +1067,26 @@ impl DefaultLitePullConsumerImpl {
 
                 offset_store.load().await?;
 
-                self.rebalance_impl.set_offset_store(offset_store.clone());
+                self.rebalance_impl.set_offset_store(Some(offset_store.clone()));
 
-                self.offset_store = Some(offset_store);
+                *self
+                    .offset_store
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(offset_store);
 
                 let default_lite_pull_consumer_impl = self
-                    .default_lite_pull_consumer_impl
-                    .clone()
+                    .self_reference
+                    .get()
+                    .and_then(Weak::upgrade)
                     .ok_or_else(|| crate::mq_client_err!("default_lite_pull_consumer_impl is not initialized"))?;
                 let register_ok = client_instance
-                    .mut_from_ref()
                     .register_consumer(
                         &consumer_config.consumer_group,
                         MQConsumerInnerImpl::from_lite_pull(default_lite_pull_consumer_impl),
                     )
                     .await;
                 if !register_ok {
-                    *self.service_state = ServiceState::CreateJust;
+                    self.set_service_state(ServiceState::CreateJust);
                     return Err(crate::mq_client_err!(format!(
                         "The consumer group[{}] has been created before, specify another name please.{}",
                         consumer_config.consumer_group,
@@ -1022,7 +1099,7 @@ impl DefaultLitePullConsumerImpl {
                 let client_instance_clone = client_instance.clone();
                 client_instance.mut_from_ref().start(client_instance_clone).await?;
 
-                *self.service_state = ServiceState::Running;
+                self.set_service_state(ServiceState::Running);
 
                 self.start_topic_metadata_check_task()?;
 
@@ -1032,7 +1109,7 @@ impl DefaultLitePullConsumerImpl {
                 );
 
                 if let Err(error) = self.operate_after_running().await {
-                    let _ = self.shutdown().await;
+                    let _ = self.shutdown_transition().await;
                     return Err(error);
                 }
 
@@ -1042,7 +1119,7 @@ impl DefaultLitePullConsumerImpl {
             ServiceState::ShutdownAlready => Err(crate::mq_client_err!("The lite pull consumer has been shutdown")),
             ServiceState::StartFailed => Err(crate::mq_client_err!(format!(
                 "The lite pull consumer start failed, current state: {:?}",
-                *self.service_state
+                self.service_state()
             ))),
         }
     }
@@ -1051,7 +1128,7 @@ impl DefaultLitePullConsumerImpl {
     ///
     /// This mirrors Java's `operateAfterRunning`: subscriptions made before `start`
     /// need topic route refresh, and assignments made before `start` need pull tasks.
-    async fn operate_after_running(&mut self) -> RocketMQResult<()> {
+    async fn operate_after_running(&self) -> RocketMQResult<()> {
         let subscription_type = *self.subscription_type.read().await;
         match subscription_type {
             SubscriptionType::Subscribe => {
@@ -1067,55 +1144,61 @@ impl DefaultLitePullConsumerImpl {
 
         self.refresh_registered_topic_message_queue_snapshots().await?;
 
-        let client_instance = self
-            .client_instance
-            .as_mut()
+        let mut client_instance = self
+            .component_snapshot(&self.client_instance)
             .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
         client_instance.check_client_in_broker().await
     }
 
-    fn start_topic_metadata_check_task(&mut self) -> RocketMQResult<()> {
-        if self.topic_metadata_check_task_handle.is_some() {
+    fn start_topic_metadata_check_task(&self) -> RocketMQResult<()> {
+        if self
+            .topic_metadata_check_task_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+        {
             return Ok(());
         }
 
-        let consumer_impl = self
-            .default_lite_pull_consumer_impl
-            .as_ref()
+        let weak_consumer_impl = self
+            .self_reference
+            .get()
+            .cloned()
             .ok_or_else(|| crate::mq_client_err!("default_lite_pull_consumer_impl is not initialized"))?;
-        let weak_consumer_impl = ArcMut::downgrade(consumer_impl);
         let shutdown_signal = self.shutdown_signal.clone();
         let task_cancelled = Arc::new(AtomicBool::new(false));
         let task_cancelled_for_task = task_cancelled.clone();
         let check_interval =
             Duration::from_millis(self.consumer_config.load().topic_metadata_check_interval_millis.max(1));
 
-        self.topic_metadata_check_task_handle = Some(
-            spawn_lite_pull_task("rocketmq-client-lite-pull-topic-metadata", task_cancelled, async move {
-                if !sleep_or_cancel(&shutdown_signal, &task_cancelled_for_task, Duration::from_secs(10)).await {
-                    return;
+        let handle = spawn_lite_pull_task("rocketmq-client-lite-pull-topic-metadata", task_cancelled, async move {
+            if !sleep_or_cancel(&shutdown_signal, &task_cancelled_for_task, Duration::from_secs(10)).await {
+                return;
+            }
+
+            loop {
+                if shutdown_signal.load(Ordering::Acquire) || task_cancelled_for_task.load(Ordering::Acquire) {
+                    break;
                 }
 
-                loop {
-                    if shutdown_signal.load(Ordering::Acquire) || task_cancelled_for_task.load(Ordering::Acquire) {
-                        break;
-                    }
+                let Some(consumer_impl) = weak_consumer_impl.upgrade() else {
+                    break;
+                };
 
-                    let Some(consumer_impl) = weak_consumer_impl.upgrade() else {
-                        break;
-                    };
-
-                    if let Err(error) = consumer_impl.fetch_topic_message_queues_and_compare().await {
-                        warn!("Scheduled fetchTopicMessageQueuesAndCompare exception: {}", error);
-                    }
-
-                    if !sleep_or_cancel(&shutdown_signal, &task_cancelled_for_task, check_interval).await {
-                        break;
-                    }
+                if let Err(error) = consumer_impl.fetch_topic_message_queues_and_compare().await {
+                    warn!("Scheduled fetchTopicMessageQueuesAndCompare exception: {}", error);
                 }
-            })
-            .map_err(|error| crate::mq_client_err!(format!("failed to spawn topic metadata check task: {error}")))?,
-        );
+
+                if !sleep_or_cancel(&shutdown_signal, &task_cancelled_for_task, check_interval).await {
+                    break;
+                }
+            }
+        })
+        .map_err(|error| crate::mq_client_err!(format!("failed to spawn topic metadata check task: {error}")))?;
+        *self
+            .topic_metadata_check_task_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(handle);
 
         Ok(())
     }
@@ -1201,8 +1284,13 @@ impl DefaultLitePullConsumerImpl {
     }
 
     /// Shuts down the lite pull consumer gracefully.
-    pub async fn shutdown(&mut self) -> RocketMQResult<()> {
-        match *self.service_state {
+    pub async fn shutdown(&self) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
+        self.shutdown_transition().await
+    }
+
+    async fn shutdown_transition(&self) -> RocketMQResult<()> {
+        match self.service_state() {
             ServiceState::Running => {
                 let consumer_group = self.consumer_config.load().consumer_group.clone();
                 info!("DefaultLitePullConsumerImpl [{}] shutting down", consumer_group);
@@ -1223,23 +1311,26 @@ impl DefaultLitePullConsumerImpl {
                     );
                 }
 
-                if let Some(handle) = self.topic_metadata_check_task_handle.take() {
+                let metadata_handle = self
+                    .topic_metadata_check_task_handle
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take();
+                if let Some(handle) = metadata_handle {
                     if !handle.wait(Duration::from_secs(1)).await {
                         warn!("Topic metadata check task did not finish in time");
                     }
                 }
 
                 // Wait for all pull tasks to complete (5s timeout)
-                let mut handles = self.task_handles.write().await;
-                for (mq, handle) in handles.drain() {
+                let handles: Vec<_> = self.task_handles.write().await.drain().collect();
+                for (mq, handle) in handles {
                     if !handle.wait(Duration::from_secs(5)).await {
                         warn!("Pull task for {:?} did not finish in time", mq);
                     }
                 }
-                drop(handles);
-
                 self.persist_consumer_offset().await;
-                if let Some(offset_store) = self.offset_store.as_ref() {
+                if let Some(offset_store) = self.offset_store() {
                     if !offset_store.shutdown(OFFSET_STORE_SHUTDOWN_TIMEOUT).await {
                         warn!(
                             "lite pull consumer [{}] offset store did not stop before timeout",
@@ -1248,15 +1339,17 @@ impl DefaultLitePullConsumerImpl {
                     }
                 }
 
-                if let Some(client) = self.client_instance.as_mut() {
+                let client = self
+                    .client_instance
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take();
+                if let Some(mut client) = client {
                     client.unregister_consumer(&consumer_group).await;
-                }
-
-                if let Some(mut client) = self.client_instance.take() {
                     client.shutdown().await;
                 }
 
-                *self.service_state = ServiceState::ShutdownAlready;
+                self.set_service_state(ServiceState::ShutdownAlready);
 
                 info!("DefaultLitePullConsumerImpl [{}] shutdown successfully", consumer_group);
 
@@ -1273,12 +1366,12 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns whether the consumer is currently running.
     pub async fn is_running(&self) -> bool {
-        matches!(*self.service_state, ServiceState::Running)
+        matches!(self.service_state(), ServiceState::Running)
     }
 
     /// Subscribes to a topic with a listener for queue assignment changes.
     pub async fn subscribe_with_listener<L>(
-        &mut self,
+        &self,
         topic: impl Into<CheetahString>,
         sub_expression: impl Into<CheetahString>,
         listener: L,
@@ -1292,7 +1385,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Subscribes to a topic with a shared listener for queue assignment changes.
     pub async fn subscribe_with_listener_arc(
-        &mut self,
+        &self,
         topic: impl Into<CheetahString>,
         sub_expression: impl Into<CheetahString>,
         listener: ArcMessageQueueListener,
@@ -1305,7 +1398,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Subscribes to a topic with a message selector.
     pub async fn subscribe_with_selector(
-        &mut self,
+        &self,
         topic: impl Into<CheetahString>,
         selector: Option<crate::consumer::message_selector::MessageSelector>,
     ) -> RocketMQResult<()> {
@@ -1313,6 +1406,7 @@ impl DefaultLitePullConsumerImpl {
 
         match selector {
             Some(sel) => {
+                let _transition = self.lifecycle_transition.lock().await;
                 if topic.is_empty() {
                     return Err(crate::mq_client_err!("Topic cannot be empty"));
                 }
@@ -1325,8 +1419,8 @@ impl DefaultLitePullConsumerImpl {
 
                 self.rebalance_impl.put_subscription_data(topic, subscription_data);
 
-                if *self.service_state == ServiceState::Running {
-                    if let Some(ref client_instance) = self.client_instance {
+                if self.service_state() == ServiceState::Running {
+                    if let Some(client_instance) = self.component_snapshot(&self.client_instance) {
                         client_instance.send_heartbeat_to_all_broker_with_lock().await;
                         self.update_topic_subscribe_info_when_subscription_changed().await?;
                     }
@@ -1350,7 +1444,7 @@ impl DefaultLitePullConsumerImpl {
             config.set_namesrv_addr(CheetahString::from_string(joined_addr.clone()));
         });
 
-        if let Some(client_instance) = self.client_instance.as_ref() {
+        if let Some(client_instance) = self.component_snapshot(&self.client_instance) {
             if let Some(api_impl) = client_instance.mq_client_api_impl.as_ref() {
                 api_impl.update_name_server_address_list(&joined_addr).await;
             }
@@ -1374,7 +1468,7 @@ impl DefaultLitePullConsumerImpl {
                 topic
             );
         }
-        if *self.service_state == ServiceState::Running {
+        if self.service_state() == ServiceState::Running {
             let message_queues = self.fetch_message_queues(topic.clone()).await?;
             self.message_queues_for_topic
                 .write()
@@ -1390,13 +1484,14 @@ impl DefaultLitePullConsumerImpl {
         topic: impl Into<CheetahString>,
         sub_expression: impl Into<CheetahString>,
     ) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         let topic = topic.into();
         let sub_expression = sub_expression.into();
 
         if sub_expression.as_str().trim().is_empty() {
             return Err(crate::mq_client_err!("subExpression can not be null or empty."));
         }
-        if *self.service_state != ServiceState::CreateJust {
+        if self.service_state() != ServiceState::CreateJust {
             return Err(crate::mq_client_err!("setAssignTag only can be called before start."));
         }
 
@@ -1451,9 +1546,10 @@ impl DefaultLitePullConsumerImpl {
             }
         }
 
-        let default_impl = self
-            .default_lite_pull_consumer_impl
-            .clone()
+        let weak_default_impl = self
+            .self_reference
+            .get()
+            .cloned()
             .ok_or_else(|| crate::mq_client_err!("Consumer self-reference not initialized"))?;
         let shutdown_signal = self.shutdown_signal.clone();
         let task_cancelled = Arc::new(AtomicBool::new(false));
@@ -1466,6 +1562,10 @@ impl DefaultLitePullConsumerImpl {
                 if shutdown_signal.load(Ordering::Acquire) || task_cancelled_for_task.load(Ordering::Acquire) {
                     break;
                 }
+
+                let Some(default_impl) = weak_default_impl.upgrade() else {
+                    break;
+                };
 
                 let pq = match assigned_mq.get_process_queue(&mq_clone).await {
                     Some(pq) if !pq.is_dropped() => pq,
@@ -1570,10 +1670,8 @@ impl DefaultLitePullConsumerImpl {
         let sys_flag = lite_pull_request_sys_flag();
 
         let mut pull_api_wrapper = self
-            .pull_api_wrapper
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("PullAPIWrapper is not initialized"))?
-            .clone();
+            .component_snapshot(&self.pull_api_wrapper)
+            .ok_or_else(|| crate::mq_client_err!("PullAPIWrapper is not initialized"))?;
         let mut pull_result = pull_api_wrapper
             .pull_kernel_impl(
                 mq,
@@ -1730,7 +1828,7 @@ impl DefaultLitePullConsumerImpl {
 
     #[allow(deprecated)]
     async fn compute_initial_pull_offset(&self, mq: &MessageQueue) -> RocketMQResult<i64> {
-        if let Some(offset_store) = &self.offset_store {
+        if let Some(offset_store) = self.offset_store() {
             let stored_offset = offset_store.read_offset(mq, ReadOffsetType::MemoryFirstThenStore).await;
             if stored_offset >= 0 {
                 return Ok(stored_offset);
@@ -1869,7 +1967,8 @@ impl DefaultLitePullConsumerImpl {
             self.reset_topic(&mut messages);
 
             // Execute consume message hooks if registered
-            if !self.consume_message_hook_list.is_empty() {
+            let consume_message_hooks = self.consume_message_hooks_snapshot();
+            if !consume_message_hooks.is_empty() {
                 let consumer_group = self.consumer_config.load().consumer_group.clone();
                 let client_config = self.client_config.load_full();
                 let mut context = ConsumeMessageContext::new(consumer_group, &messages)
@@ -1877,7 +1976,7 @@ impl DefaultLitePullConsumerImpl {
                     .with_namespace(client_config.namespace.clone().unwrap_or_default());
 
                 // Execute hook before with panic protection
-                for hook in &self.consume_message_hook_list {
+                for hook in &consume_message_hooks {
                     if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         hook.consume_message_before(&mut context);
                     })) {
@@ -1895,7 +1994,7 @@ impl DefaultLitePullConsumerImpl {
                 context.access_channel = Some(client_config.access_channel);
 
                 // Execute hook after with panic protection
-                for hook in &self.consume_message_hook_list {
+                for hook in &consume_message_hooks {
                     if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         hook.consume_message_after(&mut context);
                     })) {
@@ -1962,7 +2061,7 @@ impl DefaultLitePullConsumerImpl {
         let updated = self.commit_assigned_message_queue_offset(mq).await?;
 
         if persist && updated {
-            if let Some(ref offset_store) = self.offset_store {
+            if let Some(offset_store) = self.offset_store() {
                 let mut mqs = HashSet::new();
                 mqs.insert(mq.clone());
                 offset_store.persist_all(&mqs).await;
@@ -2007,7 +2106,7 @@ impl DefaultLitePullConsumerImpl {
         }
 
         if persist {
-            if let Some(ref offset_store) = self.offset_store {
+            if let Some(offset_store) = self.offset_store() {
                 offset_store.persist_all(message_queues).await;
             }
         }
@@ -2044,7 +2143,7 @@ impl DefaultLitePullConsumerImpl {
         }
 
         if persist {
-            if let Some(ref offset_store) = self.offset_store {
+            if let Some(offset_store) = self.offset_store() {
                 offset_store.persist_all(&mqs_to_persist).await;
             }
         }
@@ -2054,7 +2153,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Updates the consume offset for a message queue.
     async fn update_consume_offset(&self, mq: &MessageQueue, offset: i64) -> RocketMQResult<()> {
-        if let Some(ref offset_store) = self.offset_store {
+        if let Some(offset_store) = self.offset_store() {
             offset_store.update_offset(mq, offset, false).await;
         }
         Ok(())
@@ -2066,13 +2165,19 @@ impl DefaultLitePullConsumerImpl {
     }
 
     /// Registers a consume message hook for monitoring message consumption.
-    pub fn register_consume_message_hook(&mut self, hook: Arc<dyn ConsumeMessageHook + Send + Sync>) {
-        self.consume_message_hook_list.push(hook);
+    pub fn register_consume_message_hook(&self, hook: Arc<dyn ConsumeMessageHook + Send + Sync>) {
+        self.consume_message_hook_list
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(hook);
     }
 
     #[cfg(test)]
     pub(crate) fn consume_message_hook_count(&self) -> usize {
-        self.consume_message_hook_list.len()
+        self.consume_message_hook_list
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
     }
 
     /// Removes namespace from message topics if namespace is configured.
@@ -2213,7 +2318,7 @@ impl DefaultLitePullConsumerImpl {
     pub async fn committed(&self, message_queue: &MessageQueue) -> RocketMQResult<i64> {
         self.make_sure_state_ok()?;
 
-        if let Some(ref offset_store) = self.offset_store {
+        if let Some(offset_store) = self.offset_store() {
             let offset = offset_store
                 .read_offset(message_queue, ReadOffsetType::MemoryFirstThenStore)
                 .await;
@@ -2235,7 +2340,8 @@ impl DefaultLitePullConsumerImpl {
     /// and clears assigned message queues for the topic.
     ///
     /// This operation can be performed regardless of the consumer state.
-    pub async fn unsubscribe(&mut self, topic: impl Into<CheetahString>) -> RocketMQResult<()> {
+    pub async fn unsubscribe(&self, topic: impl Into<CheetahString>) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         let topic = topic.into();
 
         // Remove from rebalance_impl subscription
@@ -2279,10 +2385,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         client_instance.mq_admin_impl.search_offset(mq, timestamp).await
     }
@@ -2302,10 +2406,8 @@ impl DefaultLitePullConsumerImpl {
 
         let topic = topic.into();
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         // Fetch topic route data from name server
         let topic_route_data = client_instance
@@ -2344,10 +2446,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         client_instance
             .mq_admin_impl
@@ -2367,10 +2467,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         client_instance
             .mq_admin_impl
@@ -2384,10 +2482,8 @@ impl DefaultLitePullConsumerImpl {
 
         let begin = current_millis().saturating_sub(QUERY_UNIQ_KEY_LOOKBACK_MILLIS);
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
         let result = client_instance
             .mq_admin_impl
             .query_message_with_unique_flag(topic, uniq_key, 32, begin, i64::MAX as u64, true)
@@ -2404,10 +2500,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         if message_decoder::decode_message_id(msg_id).is_ok() {
             client_instance.mq_admin_impl.view_message(topic, msg_id).await
@@ -2444,10 +2538,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         client_instance.mq_admin_impl.earliest_msg_store_time(mq).await
     }
@@ -2493,7 +2585,7 @@ impl DefaultLitePullConsumerImpl {
     /// Updates whether the subscription group runs in unit mode.
     pub fn set_unit_mode(&self, unit_mode: bool) {
         self.update_consumer_config(|config| config.unit_mode = unit_mode);
-        if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
+        if let Some(wrapper) = self.component_snapshot(&self.pull_api_wrapper) {
             wrapper.mut_from_ref().set_unit_mode(unit_mode);
         }
         self.rebalance_impl.set_unit_mode(unit_mode);
@@ -2589,7 +2681,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns whether broker selection is controlled by user configuration.
     pub fn is_connect_broker_by_user(&self) -> bool {
-        self.pull_api_wrapper
+        self.component_snapshot(&self.pull_api_wrapper)
             .as_ref()
             .map_or(self.consumer_config.load().connect_broker_by_user, |wrapper| {
                 wrapper.is_connect_broker_by_user()
@@ -2599,7 +2691,7 @@ impl DefaultLitePullConsumerImpl {
     /// Updates whether broker selection is controlled by user configuration.
     pub fn set_connect_broker_by_user(&self, connect_broker_by_user: bool) {
         self.update_consumer_config(|config| config.connect_broker_by_user = connect_broker_by_user);
-        if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
+        if let Some(wrapper) = self.component_snapshot(&self.pull_api_wrapper) {
             wrapper
                 .mut_from_ref()
                 .set_connect_broker_by_user(connect_broker_by_user);
@@ -2608,7 +2700,7 @@ impl DefaultLitePullConsumerImpl {
 
     /// Returns the broker ID used when user-controlled broker selection is enabled.
     pub fn default_broker_id(&self) -> u64 {
-        self.pull_api_wrapper
+        self.component_snapshot(&self.pull_api_wrapper)
             .as_ref()
             .map_or(self.consumer_config.load().default_broker_id, |wrapper| {
                 wrapper.default_broker_id()
@@ -2618,7 +2710,7 @@ impl DefaultLitePullConsumerImpl {
     /// Updates the broker ID used when user-controlled broker selection is enabled.
     pub fn set_default_broker_id(&self, broker_id: u64) {
         self.update_consumer_config(|config| config.default_broker_id = broker_id);
-        if let Some(wrapper) = self.pull_api_wrapper.as_ref() {
+        if let Some(wrapper) = self.component_snapshot(&self.pull_api_wrapper) {
             wrapper.mut_from_ref().set_default_broker_id(broker_id);
         }
     }
@@ -2727,10 +2819,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         let broker_result = client_instance
             .find_broker_address_in_subscribe(message_queue.broker_name(), mix_all::MASTER_ID, true)
@@ -2751,10 +2841,8 @@ impl DefaultLitePullConsumerImpl {
         self.make_sure_state_ok()?;
 
         let client_instance = self
-            .client_instance
-            .as_ref()
-            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?
-            .clone();
+            .component_snapshot(&self.client_instance)
+            .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
 
         let broker_result = client_instance
             .find_broker_address_in_subscribe(message_queue.broker_name(), mix_all::MASTER_ID, true)
@@ -2867,7 +2955,7 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
         };
 
         if !mqs.is_empty() {
-            if let Some(ref offset_store) = self.offset_store {
+            if let Some(offset_store) = self.offset_store() {
                 offset_store.persist_all(&mqs).await;
             }
         }
@@ -2908,7 +2996,7 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
     }
 
     async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>) {
-        let Some(offset_store) = self.offset_store.as_ref() else {
+        let Some(offset_store) = self.offset_store() else {
             warn!(
                 "lite pull reset offset ignored because offset store is not initialized. group={}, topic={}",
                 self.consumer_config.load().consumer_group,
@@ -2925,7 +3013,7 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
     }
 
     async fn consumer_status(&self, topic: &CheetahString) -> HashMap<MessageQueue, i64> {
-        let Some(offset_store) = self.offset_store.as_ref() else {
+        let Some(offset_store) = self.offset_store() else {
             warn!(
                 "lite pull consumer status is empty because offset store is not initialized. group={}, topic={}",
                 self.consumer_config.load().consumer_group,
@@ -2964,7 +3052,7 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
             let Some(process_queue) = self.assigned_message_queue.get_process_queue(&mq).await else {
                 continue;
             };
-            let commit_offset = if let Some(offset_store) = self.offset_store.as_ref() {
+            let commit_offset = if let Some(offset_store) = self.offset_store() {
                 offset_store
                     .read_offset(&mq, ReadOffsetType::MemoryFirstThenStore)
                     .await
@@ -3174,7 +3262,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_in_create_just_keeps_state_like_java_noop() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_shutdown_create_group"),
@@ -3189,14 +3277,14 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_in_start_failed_keeps_state_like_java_default_case() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_shutdown_failed_group"),
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::StartFailed;
+        impl_.set_service_state(ServiceState::StartFailed);
 
         impl_
             .shutdown()
@@ -3207,8 +3295,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_shutdown_calls_share_one_lifecycle_transition() {
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_concurrent_shutdown_group"),
+                ..Default::default()
+            }),
+        ));
+        impl_.bind_self();
+        impl_.set_service_state(ServiceState::Running);
+
+        let (first, second) = tokio::join!(impl_.shutdown(), impl_.shutdown());
+
+        first.expect("first shutdown should complete");
+        second.expect("second shutdown should observe the completed transition");
+        assert_eq!(impl_.service_state(), ServiceState::ShutdownAlready);
+    }
+
+    #[test]
+    fn callback_self_reference_is_weak_and_does_not_keep_root_alive() {
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_weak_root_group"),
+                ..Default::default()
+            }),
+        ));
+        impl_.bind_self();
+        let weak_impl = Arc::downgrade(&impl_);
+
+        drop(impl_);
+
+        assert!(weak_impl.upgrade().is_none());
+    }
+
+    #[tokio::test]
     async fn start_without_self_reference_returns_error_without_panic() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_missing_self_ref_group"),
@@ -3288,7 +3412,7 @@ mod tests {
 
     #[test]
     fn set_consumer_group_updates_rebalance_before_start_and_rejects_running_mutation() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_initial_group"),
@@ -3306,7 +3430,7 @@ mod tests {
             Some("lite_pull_updated_group")
         );
 
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let error = impl_
             .set_consumer_group(CheetahString::from_static_str("lite_pull_late_group"))
@@ -3369,7 +3493,7 @@ mod tests {
 
     #[test]
     fn set_offset_store_updates_rebalance_before_start_and_rejects_running_mutation() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_offset_store_group"),
@@ -3392,7 +3516,7 @@ mod tests {
         assert!(impl_.offset_store().is_none());
         assert!(!impl_.rebalance_has_offset_store());
 
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let error = impl_
             .set_offset_store(Some(Arc::new(OffsetStore::new_test())))
@@ -3405,7 +3529,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_unit_mode_updates_pull_api_wrapper_for_filter_hooks_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_unit_mode_group"),
@@ -3413,7 +3537,7 @@ mod tests {
             }),
         );
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "lite-pull-unit-mode-test", None);
-        impl_.pull_api_wrapper = Some(ArcMut::new(PullAPIWrapper::new(
+        *impl_.pull_api_wrapper.write().expect("pull wrapper lock") = Some(ArcMut::new(PullAPIWrapper::new(
             client_instance,
             CheetahString::from_static_str("lite_pull_unit_mode_group"),
             false,
@@ -3423,7 +3547,7 @@ mod tests {
 
         assert!(impl_.is_unit_mode());
         assert!(impl_
-            .pull_api_wrapper
+            .component_snapshot(&impl_.pull_api_wrapper)
             .as_ref()
             .expect("pull wrapper should be present")
             .unit_mode());
@@ -3455,28 +3579,27 @@ mod tests {
 
     #[tokio::test]
     async fn operate_after_running_starts_preassigned_pull_tasks() {
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_preassigned_group"),
                 ..Default::default()
             }),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         let mq = MessageQueue::from_parts("topic-a", "broker-a", 0);
         impl_
             .assign(vec![mq.clone()])
             .await
             .expect("assign before running should succeed");
-        impl_.client_instance = Some(MQClientInstance::new_arc(
+        *impl_.client_instance.write().expect("client instance lock") = Some(MQClientInstance::new_arc(
             ClientConfig::default(),
             0,
             "lite-pull-operate-after-running-test",
             None,
         ));
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         impl_
             .operate_after_running()
@@ -3555,7 +3678,7 @@ mod tests {
 
     #[tokio::test]
     async fn consumer_running_info_includes_assigned_process_queues() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_running_info_group"),
@@ -3577,14 +3700,14 @@ mod tests {
 
     #[tokio::test]
     async fn update_name_server_address_updates_client_api_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_update_namesrv_group"),
                 ..Default::default()
             }),
         );
-        impl_.client_instance = Some(MQClientInstance::new_arc(
+        *impl_.client_instance.write().expect("client instance lock") = Some(MQClientInstance::new_arc(
             ClientConfig::default(),
             0,
             "lite-pull-update-namesrv-test",
@@ -3599,10 +3722,12 @@ mod tests {
             impl_.client_config.load().namesrv_addr.as_deref(),
             Some("127.0.0.1:9876;127.0.0.2:9876")
         );
-        let api_impl = impl_
-            .client_instance
+        let client_instance = impl_
+            .component_snapshot(&impl_.client_instance)
+            .expect("client instance should be initialized");
+        let api_impl = client_instance
+            .mq_client_api_impl
             .as_ref()
-            .and_then(|client| client.mq_client_api_impl.as_ref())
             .expect("client api should be initialized");
         let mut actual_addresses = api_impl.get_name_server_address_list().to_vec();
         actual_addresses.sort();
@@ -3617,7 +3742,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_with_sql_selector_preserves_expression_type_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_sql_selector_group"),
@@ -3691,14 +3816,14 @@ mod tests {
         );
         drop(map);
 
-        let mut running_impl = DefaultLitePullConsumerImpl::new(
+        let running_impl = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_assign_filter_running_group"),
                 ..Default::default()
             }),
         );
-        *running_impl.service_state = ServiceState::Running;
+        running_impl.set_service_state(ServiceState::Running);
 
         let running_error = running_impl
             .set_sub_expression_for_assign(topic, "TagA")
@@ -3735,14 +3860,14 @@ mod tests {
 
     #[tokio::test]
     async fn seek_rejects_unassigned_queue_before_broker_offset_lookup_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_seek_unassigned_group"),
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let mq = MessageQueue::from_parts("topic-seek-unassigned", "broker-a", 0);
         let error = impl_
@@ -3758,14 +3883,14 @@ mod tests {
     #[tokio::test]
     async fn commit_all_updates_offsets_without_persisting_like_java() {
         let group = CheetahString::from_static_str("lite_pull_commit_all_group");
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: group,
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let mq = MessageQueue::from_parts("topic-commit-all", "broker-a", 0);
         impl_.assigned_message_queue.put(mq.clone()).await;
@@ -3773,7 +3898,7 @@ mod tests {
 
         let offset_store = Arc::new(OffsetStore::new_test());
         offset_store.update_offset(&mq, 5, false).await;
-        impl_.offset_store = Some(offset_store.clone());
+        *impl_.offset_store.write().expect("offset store lock") = Some(offset_store.clone());
 
         impl_.commit_all().await.expect("commit all should update offset store");
 
@@ -3784,14 +3909,14 @@ mod tests {
     #[tokio::test]
     async fn commit_message_queues_uses_assigned_consume_offset_like_java() {
         let group = CheetahString::from_static_str("lite_pull_commit_set_group");
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: group,
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let mq = MessageQueue::from_parts("topic-commit-set", "broker-a", 0);
         impl_.assigned_message_queue.put(mq.clone()).await;
@@ -3799,7 +3924,7 @@ mod tests {
 
         let offset_store = Arc::new(OffsetStore::new_test());
         offset_store.update_offset(&mq, 5, false).await;
-        impl_.offset_store = Some(offset_store.clone());
+        *impl_.offset_store.write().expect("offset store lock") = Some(offset_store.clone());
 
         let queues = HashSet::from([mq.clone()]);
         impl_
@@ -3814,21 +3939,21 @@ mod tests {
     #[tokio::test]
     async fn commit_message_queues_with_persist_calls_persist_all_like_java() {
         let group = CheetahString::from_static_str("lite_pull_commit_set_persist_group");
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: group,
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let mq = MessageQueue::from_parts("topic-commit-set-persist", "broker-a", 0);
         impl_.assigned_message_queue.put(mq.clone()).await;
         impl_.assigned_message_queue.update_consume_offset(&mq, 100).await;
 
         let offset_store = Arc::new(OffsetStore::new_test());
-        impl_.offset_store = Some(offset_store.clone());
+        *impl_.offset_store.write().expect("offset store lock") = Some(offset_store.clone());
 
         let queues = HashSet::from([mq]);
         impl_
@@ -3841,7 +3966,7 @@ mod tests {
 
     #[tokio::test]
     async fn poll_zero_timeout_returns_cached_message_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_zero_timeout_group"),
@@ -3849,7 +3974,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let mq = MessageQueue::from_parts("topic-zero-timeout", "broker-a", 0);
         impl_.assigned_message_queue.put(mq.clone()).await;
@@ -3881,7 +4006,7 @@ mod tests {
 
     #[tokio::test]
     async fn clear_message_queue_in_cache_removes_pending_consume_requests_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_clear_cache_group"),
@@ -3889,7 +4014,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let cleared_mq = MessageQueue::from_parts("topic-clear-cache", "broker-a", 0);
         let retained_mq = MessageQueue::from_parts("topic-clear-cache", "broker-a", 1);
@@ -3954,7 +4079,7 @@ mod tests {
             access_channel: AccessChannel::Cloud,
             ..Default::default()
         };
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(client_config),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_hook_access_channel_group"),
@@ -3962,7 +4087,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
         let hook = Arc::new(CapturingConsumeHook::new());
         impl_.register_consume_message_hook(hook.clone());
 
@@ -4011,7 +4136,7 @@ mod tests {
 
     #[tokio::test]
     async fn poll_refreshes_last_consume_timestamp_after_hooks_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_timestamp_after_hook_group"),
@@ -4019,7 +4144,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
         let after_timestamp = Arc::new(AtomicU64::new(0));
         impl_.register_consume_message_hook(Arc::new(SlowAfterConsumeHook {
             after_timestamp: after_timestamp.clone(),
@@ -4056,7 +4181,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn concurrent_poll_calls_are_serialized_like_java_synchronized_poll() {
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_serialized_poll_group"),
@@ -4064,7 +4189,7 @@ mod tests {
                 ..Default::default()
             }),
         ));
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
 
         let entered_first_after = Arc::new(AtomicBool::new(false));
         let release_first_after = Arc::new(AtomicBool::new(false));
@@ -4151,7 +4276,7 @@ mod tests {
 
     #[tokio::test]
     async fn pull_inner_refreshes_last_pull_timestamp_before_flow_control_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_last_pull_timestamp_group"),
@@ -4160,7 +4285,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        *impl_.service_state = ServiceState::Running;
+        impl_.set_service_state(ServiceState::Running);
         let mq = MessageQueue::from_parts("topic-flow-control", "broker-a", 0);
         let process_queue = Arc::new(crate::consumer::consumer_impl::process_queue::ProcessQueue::new());
         process_queue.set_last_pull_timestamp(1);
@@ -4237,7 +4362,7 @@ mod tests {
 
     #[tokio::test]
     async fn rebalance_update_assigns_divided_queues_and_starts_pull_tasks() {
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_rebalance_update_group"),
@@ -4245,8 +4370,7 @@ mod tests {
                 ..Default::default()
             }),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         let mq0 = MessageQueue::from_parts("topic-a", "broker-a", 0);
         let mq1 = MessageQueue::from_parts("topic-a", "broker-a", 1);
@@ -4297,15 +4421,14 @@ mod tests {
 
     #[tokio::test]
     async fn lite_pull_rebalance_listener_invokes_user_listener() {
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_user_listener_group"),
                 ..Default::default()
             }),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         let calls = Arc::new(AtomicUsize::new(0));
         {
@@ -4317,7 +4440,7 @@ mod tests {
         }
 
         let listener = LitePullRebalanceListener {
-            consumer_impl: ArcMut::downgrade(&impl_),
+            consumer_impl: Arc::downgrade(&impl_),
             user_listener: impl_.user_message_queue_listener.clone(),
             task_tracker: impl_.rebalance_listener_tasks.clone(),
             shutdown_token: impl_.rebalance_listener_shutdown.clone(),
@@ -4358,15 +4481,14 @@ mod tests {
 
     #[tokio::test]
     async fn lite_pull_rebalance_listener_ignores_changes_after_shutdown_token_cancelled() {
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_cancelled_listener_group"),
                 ..Default::default()
             }),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         let calls = Arc::new(AtomicUsize::new(0));
         {
@@ -4379,7 +4501,7 @@ mod tests {
 
         impl_.rebalance_listener_shutdown.cancel();
         let listener = LitePullRebalanceListener {
-            consumer_impl: ArcMut::downgrade(&impl_),
+            consumer_impl: Arc::downgrade(&impl_),
             user_listener: impl_.user_message_queue_listener.clone(),
             task_tracker: impl_.rebalance_listener_tasks.clone(),
             shutdown_token: impl_.rebalance_listener_shutdown.clone(),
@@ -4399,7 +4521,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_with_listener_installs_user_listener_with_subscription_like_java() {
-        let mut impl_ = DefaultLitePullConsumerImpl::new(
+        let impl_ = DefaultLitePullConsumerImpl::new(
             ArcMut::new(ClientConfig::default()),
             ArcMut::new(LitePullConsumerConfig {
                 consumer_group: CheetahString::from_static_str("lite_pull_subscribe_listener_group"),

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
@@ -30,6 +30,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use arc_swap::ArcSwapOption;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
@@ -66,7 +67,7 @@ pub struct RebalanceLitePullImpl {
     /// optional [`MessageQueueListener`][crate::consumer::message_queue_listener::MessageQueueListener].
     consumer_config: ArcSwap<ConsumerConfig>,
     /// The active offset storage backend, injected after the consumer starts.
-    pub(crate) offset_store: Option<Arc<OffsetStore>>,
+    pub(crate) offset_store: ArcSwapOption<OffsetStore>,
 }
 
 impl RebalanceLitePullImpl {
@@ -78,7 +79,7 @@ impl RebalanceLitePullImpl {
         Self {
             consumer_config: ArcSwap::from_pointee(consumer_config),
             rebalance_impl_inner: RebalanceImpl::new(None, None, None, None),
-            offset_store: None,
+            offset_store: ArcSwapOption::empty(),
         }
     }
 
@@ -144,9 +145,23 @@ impl RebalanceLitePullImpl {
         self.update_consumer_config(|config| config.message_queue_listener = listener.clone());
     }
 
-    /// Injects the `MQClientInstance` used for broker communication.
-    pub fn set_mq_client_factory(&mut self, client_instance: ArcMut<MQClientInstance>) {
+    /// Publishes the runtime rebalance inputs immediately before client registration.
+    pub fn set_mq_client_factory(
+        &mut self,
+        consumer_group: CheetahString,
+        message_model: rocketmq_remoting::protocol::heartbeat::message_model::MessageModel,
+        strategy: Arc<dyn crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy>,
+        client_instance: ArcMut<MQClientInstance>,
+    ) {
+        self.rebalance_impl_inner.consumer_group = Some(consumer_group.clone());
+        self.rebalance_impl_inner.message_model = Some(message_model);
+        self.rebalance_impl_inner.allocate_message_queue_strategy = Some(strategy.clone());
         self.rebalance_impl_inner.client_instance = Some(client_instance);
+        self.update_consumer_config(|config| {
+            config.consumer_group = consumer_group.clone();
+            config.message_model = message_model;
+            config.allocate_message_queue_strategy = Some(strategy.clone());
+        });
     }
 
     /// Registers this [`RebalanceLitePullImpl`] as its own sub-rebalance implementation.
@@ -159,15 +174,15 @@ impl RebalanceLitePullImpl {
 
     /// Inserts or replaces a topic subscription.
     #[inline]
-    pub fn put_subscription_data(&mut self, topic: CheetahString, subscription_data: SubscriptionData) {
+    pub fn put_subscription_data(&self, topic: CheetahString, subscription_data: SubscriptionData) {
         self.rebalance_impl_inner
             .subscription_inner
             .insert(topic, subscription_data);
     }
 
     /// Sets the offset store backend used to persist and query per-queue consume offsets.
-    pub fn set_offset_store(&mut self, offset_store: Arc<OffsetStore>) {
-        self.offset_store = Some(offset_store);
+    pub fn set_offset_store(&self, offset_store: Option<Arc<OffsetStore>>) {
+        self.offset_store.store(offset_store);
     }
 }
 
@@ -197,7 +212,7 @@ impl Rebalance for RebalanceLitePullImpl {
     /// LitePull consumers have no ordering lock, so the queue can always be removed immediately.
     /// Returns `true` unconditionally.
     async fn remove_unnecessary_message_queue(&mut self, mq: &MessageQueue, _pq: &ProcessQueue) -> bool {
-        let Some(ref offset_store) = self.offset_store else {
+        let Some(offset_store) = self.offset_store.load_full() else {
             warn!("Offset store not initialised; skipping persist/remove for {}", mq);
             return true;
         };
@@ -215,7 +230,7 @@ impl Rebalance for RebalanceLitePullImpl {
     ///
     /// Called to discard a stale offset before a fresh initial-offset computation.
     async fn remove_dirty_offset(&mut self, mq: &MessageQueue) {
-        let Some(ref offset_store) = self.offset_store else {
+        let Some(offset_store) = self.offset_store.load_full() else {
             warn!("Offset store not initialised; cannot remove dirty offset for {}", mq);
             return;
         };
@@ -242,7 +257,7 @@ impl Rebalance for RebalanceLitePullImpl {
         let consumer_config = self.consumer_config.load_full();
         let consume_from_where = consumer_config.consume_from_where;
 
-        let offset_store = self.offset_store.as_ref().ok_or_else(|| {
+        let offset_store = self.offset_store.load_full().ok_or_else(|| {
             error!("Offset store not initialised for mq: {}", mq);
             mq_client_err!(
                 ResponseCode::SystemError as i32,

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -31,7 +31,6 @@ use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 use tokio::sync::OnceCell;
 use tokio::sync::RwLock;
 
@@ -151,7 +150,7 @@ pub struct DefaultLitePullConsumer {
     consumer_config: Arc<ArcSwap<LitePullConsumerConfig>>,
 
     /// Core implementation (lazy-initialized on start using OnceCell)
-    default_lite_pull_consumer_impl: Arc<OnceCell<ArcMut<DefaultLitePullConsumerImpl>>>,
+    default_lite_pull_consumer_impl: Arc<OnceCell<Arc<DefaultLitePullConsumerImpl>>>,
 
     /// Optional RPC hook for request/response interception
     rpc_hook: Option<Arc<dyn RPCHook>>,
@@ -969,7 +968,7 @@ impl DefaultLitePullConsumer {
     }
 
     /// Initializes the trace dispatcher if message trace is enabled.
-    async fn init_trace_dispatcher_internal(&self, impl_: &ArcMut<DefaultLitePullConsumerImpl>) -> RocketMQResult<()> {
+    async fn init_trace_dispatcher_internal(&self, impl_: &Arc<DefaultLitePullConsumerImpl>) -> RocketMQResult<()> {
         if !self.enable_msg_trace {
             return Ok(());
         }
@@ -1004,7 +1003,7 @@ impl DefaultLitePullConsumer {
         };
 
         let hook = Arc::new(ConsumeMessageTraceHookImpl::new(dispatcher_arc));
-        impl_.mut_from_ref().register_consume_message_hook(hook);
+        impl_.register_consume_message_hook(hook);
 
         Ok(())
     }
@@ -1032,7 +1031,7 @@ impl DefaultLitePullConsumer {
     }
 
     /// Returns a reference to the internal implementation after it has been initialized.
-    fn try_impl_(&self) -> RocketMQResult<&ArcMut<DefaultLitePullConsumerImpl>> {
+    fn try_impl_(&self) -> RocketMQResult<&Arc<DefaultLitePullConsumerImpl>> {
         self.default_lite_pull_consumer_impl
             .get()
             .ok_or_else(|| RocketMQError::not_initialized("DefaultLitePullConsumer not started. Call start() first."))
@@ -1044,15 +1043,14 @@ impl DefaultLitePullConsumer {
     /// `setSubExpressionForAssign` while the implementation is still in
     /// `CREATE_JUST`. Those calls populate local subscription state and only
     /// trigger broker route updates after `start()`.
-    async fn get_or_init_impl(&self) -> RocketMQResult<&ArcMut<DefaultLitePullConsumerImpl>> {
+    async fn get_or_init_impl(&self) -> RocketMQResult<&Arc<DefaultLitePullConsumerImpl>> {
         self.default_lite_pull_consumer_impl
             .get_or_try_init(|| async {
-                let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+                let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
                     self.client_config_snapshot(),
                     self.consumer_config_snapshot(),
                 ));
-                let wrapper = impl_.clone();
-                impl_.set_default_lite_pull_consumer_impl(wrapper);
+                impl_.bind_self();
                 impl_.set_rpc_hook(self.rpc_hook.clone());
                 impl_.set_message_queue_listener(self.current_message_queue_listener());
 
@@ -1062,10 +1060,10 @@ impl DefaultLitePullConsumer {
                 self.set_consumer_group(consumer_group.clone())?;
                 impl_.set_consumer_group(consumer_group)?;
                 if let Some(offset_store) = self.current_offset_store() {
-                    impl_.mut_from_ref().set_offset_store(Some(offset_store))?;
+                    impl_.set_offset_store(Some(offset_store))?;
                 }
 
-                Ok::<ArcMut<DefaultLitePullConsumerImpl>, rocketmq_error::RocketMQError>(impl_)
+                Ok::<Arc<DefaultLitePullConsumerImpl>, rocketmq_error::RocketMQError>(impl_)
             })
             .await
     }
@@ -1101,7 +1099,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
     async fn start(&self) -> RocketMQResult<()> {
         let impl_ = self.get_or_init_impl().await?;
 
-        impl_.mut_from_ref().start().await?;
+        impl_.start().await?;
         self.set_offset_store_local(impl_.offset_store());
         self.start_trace_dispatcher().await;
         Ok(())
@@ -1109,7 +1107,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
 
     async fn shutdown(&self) {
         if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
-            let _ = impl_.mut_from_ref().shutdown().await;
+            let _ = impl_.shutdown().await;
         }
 
         // Shutdown trace dispatcher
@@ -1138,7 +1136,6 @@ impl LitePullConsumer for DefaultLitePullConsumer {
         let wrapped_topic = self.with_namespace(topic);
         self.get_or_init_impl()
             .await?
-            .mut_from_ref()
             .subscribe(wrapped_topic, sub_expression)
             .await
     }
@@ -1151,7 +1148,6 @@ impl LitePullConsumer for DefaultLitePullConsumer {
         let listener: ArcMessageQueueListener = Arc::new(listener);
         self.get_or_init_impl()
             .await?
-            .mut_from_ref()
             .subscribe_with_listener_arc(wrapped_topic, sub_expression, listener.clone())
             .await?;
         self.set_message_queue_listener_local(Some(listener));
@@ -1162,7 +1158,6 @@ impl LitePullConsumer for DefaultLitePullConsumer {
         let wrapped_topic = self.with_namespace(topic);
         self.get_or_init_impl()
             .await?
-            .mut_from_ref()
             .subscribe_with_selector(wrapped_topic, selector)
             .await
     }
@@ -1171,7 +1166,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
         let wrapped_topic = self.with_namespace(topic);
         match self.try_impl_() {
             Ok(impl_) => {
-                if let Err(e) = impl_.mut_from_ref().unsubscribe(wrapped_topic).await {
+                if let Err(e) = impl_.unsubscribe(wrapped_topic).await {
                     tracing::warn!(topic = %topic, error = %e, "unsubscribe failed");
                 }
             }
@@ -1195,11 +1190,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
         // Wrap namespace for all queues
         let wrapped_queues: Vec<_> = message_queues.iter().map(|mq| self.queue_with_namespace(mq)).collect();
 
-        self.get_or_init_impl()
-            .await?
-            .mut_from_ref()
-            .assign(wrapped_queues)
-            .await
+        self.get_or_init_impl().await?.assign(wrapped_queues).await
     }
 
     async fn set_sub_expression_for_assign(&self, topic: &str, sub_expression: &str) -> RocketMQResult<()> {
@@ -1355,7 +1346,7 @@ impl LitePullConsumer for DefaultLitePullConsumer {
 
     async fn set_offset_store(&self, offset_store: Option<Arc<OffsetStore>>) -> RocketMQResult<()> {
         if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
-            impl_.mut_from_ref().set_offset_store(offset_store.clone())?;
+            impl_.set_offset_store(offset_store.clone())?;
         }
         self.set_offset_store_local(offset_store);
         Ok(())
@@ -1849,18 +1840,17 @@ mod tests {
             .expect("builder should create consumer")
     }
 
-    fn new_namespaced_consumer_with_impl() -> (DefaultLitePullConsumer, ArcMut<DefaultLitePullConsumerImpl>) {
+    fn new_namespaced_consumer_with_impl() -> (DefaultLitePullConsumer, Arc<DefaultLitePullConsumerImpl>) {
         let consumer = DefaultLitePullConsumer::builder()
             .consumer_group("lite_pull_namespace_group")
             .namespace("ns")
             .build()
             .expect("builder should create namespaced consumer");
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             consumer.client_config_snapshot(),
             consumer.consumer_config_snapshot(),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
         if consumer.default_lite_pull_consumer_impl.set(impl_.clone()).is_err() {
             panic!("test consumer impl should be set once");
         }
@@ -2668,12 +2658,11 @@ mod tests {
             true,
             None,
         );
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             consumer.client_config_snapshot(),
             consumer.consumer_config_snapshot(),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         consumer
             .init_trace_dispatcher_internal(&impl_)
@@ -2711,12 +2700,11 @@ mod tests {
             true,
             None,
         );
-        let mut impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
             consumer.client_config_snapshot(),
             consumer.consumer_config_snapshot(),
         ));
-        let wrapper = impl_.clone();
-        impl_.set_default_lite_pull_consumer_impl(wrapper);
+        impl_.bind_self();
 
         consumer
             .init_trace_dispatcher_internal(&impl_)

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
@@ -118,7 +119,7 @@ pub struct MQConsumerInnerImpl {
 #[derive(Clone)]
 enum MQConsumerInnerImplKind {
     Push(ArcMut<DefaultMQPushConsumerImpl>),
-    LitePull(ArcMut<DefaultLitePullConsumerImpl>),
+    LitePull(Arc<DefaultLitePullConsumerImpl>),
 }
 
 impl MQConsumerInnerImpl {
@@ -128,7 +129,7 @@ impl MQConsumerInnerImpl {
         }
     }
 
-    pub(crate) fn from_lite_pull(default_lite_pull_consumer_impl: ArcMut<DefaultLitePullConsumerImpl>) -> Self {
+    pub(crate) fn from_lite_pull(default_lite_pull_consumer_impl: Arc<DefaultLitePullConsumerImpl>) -> Self {
         Self {
             inner: MQConsumerInnerImplKind::LitePull(default_lite_pull_consumer_impl),
         }
@@ -325,12 +326,12 @@ mod tests {
     #[test]
     fn lite_pull_wrapper_delegates_heartbeat_fields() {
         let consumer_group = CheetahString::from_static_str("lite_pull_wrapper_group");
-        let consumer_config = ArcMut::new(LitePullConsumerConfig {
+        let consumer_config = Arc::new(LitePullConsumerConfig {
             consumer_group: consumer_group.clone(),
             ..Default::default()
         });
-        let impl_ = ArcMut::new(DefaultLitePullConsumerImpl::new(
-            ArcMut::new(ClientConfig::default()),
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
+            Arc::new(ClientConfig::default()),
             consumer_config,
         ));
         let wrapper = MQConsumerInnerImpl::from_lite_pull(impl_);

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1989,7 +1989,7 @@ impl MQClientInstance {
         heartbeat_data
     }
 
-    pub async fn register_consumer(&mut self, group: &CheetahString, consumer: MQConsumerInnerImpl) -> bool {
+    pub async fn register_consumer(&self, group: &CheetahString, consumer: MQConsumerInnerImpl) -> bool {
         if self.consumer_table.contains_key(group) {
             warn!("the consumer group[{}] exist already.", group);
             return false;
@@ -2880,7 +2880,7 @@ mod tests {
             namesrv_addr: None,
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-apply-test", None);
+        let instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-apply-test", None);
         let topic = CheetahString::from_static_str("route-refresh-topic");
 
         let producer = ArcMut::new(DefaultMQProducerImpl::new(

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8431,7 +8431,7 @@
           "id": "38a4fbdd1f5a735384b2cedb",
           "fingerprint": "f6e4dd790d276067a2bf0fb4",
           "item": "mod tests",
-          "line": 957
+          "line": 955
         }
       ],
       "owner": "client",
@@ -8450,25 +8450,25 @@
           "id": "8ad31a3a92d7e1a176d55d1e",
           "fingerprint": "51172e9f86c50f5863a1c645",
           "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 922
+          "line": 920
         },
         {
           "id": "8322fa3ba1ba104e5e38248c",
           "fingerprint": "e819127ded0a53214243199f",
           "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 923
+          "line": 921
         },
         {
           "id": "ff472046edb7d6a6b054d8b9",
           "fingerprint": "3957c353a9502e4945cf90e2",
           "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 929
+          "line": 927
         },
         {
           "id": "ec44084d51402012db29076f",
           "fingerprint": "e819127ded0a53214243199f",
           "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 930
+          "line": 928
         }
       ],
       "owner": "client",
@@ -8487,37 +8487,37 @@
           "id": "6aada219a42808342d4fbaa9",
           "fingerprint": "eed881129fbed7094c7aeb13",
           "item": "fn new_service",
-          "line": 983
+          "line": 981
         },
         {
           "id": "a63b8d8e4929c8817881b034",
           "fingerprint": "68bc0512d894fd2b48d17044",
           "item": "fn new_service",
-          "line": 984
+          "line": 982
         },
         {
           "id": "9d55ce4f911e3cb2c72dfeed",
           "fingerprint": "9695c16a5581883b671e91ce",
           "item": "fn new_service_with_config",
-          "line": 993
+          "line": 991
         },
         {
           "id": "1db7db161f920819c96f36ef",
           "fingerprint": "fa7158b7744b0768dfb0b62d",
           "item": "fn new_service_with_config",
-          "line": 994
+          "line": 992
         },
         {
           "id": "2e7db1fe25d3001e20084815",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1002
+          "line": 1000
         },
         {
           "id": "8e0f379e11cd82d30e67061f",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1003
+          "line": 1001
         }
       ],
       "owner": "client",
@@ -8591,7 +8591,7 @@
           "id": "067ad5a12dd4960c59b76dc2",
           "fingerprint": "4e36339b4cc3990fc000139a",
           "item": "struct ConsumeRequest",
-          "line": 670
+          "line": 668
         }
       ],
       "owner": "client",
@@ -8610,19 +8610,19 @@
           "id": "70fa4874d8e5bf481afeb85e",
           "fingerprint": "57d8e479867ad2fbe5c79b6d",
           "item": "fn new_service",
-          "line": 981
+          "line": 979
         },
         {
           "id": "23e7c0532a746bf500553e10",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 1001
+          "line": 999
         },
         {
           "id": "853bd6d7d34667b9c5f76a23",
           "fingerprint": "03aa5a8d5e767064d7a2b302",
           "item": "fn consume_request",
-          "line": 1010
+          "line": 1008
         }
       ],
       "owner": "client",
@@ -8641,7 +8641,7 @@
           "id": "52a4c24f2ae2ec846090ed28",
           "fingerprint": "a3fdf495802032fc7f0e0502",
           "item": "mod tests",
-          "line": 1228
+          "line": 1224
         }
       ],
       "owner": "client",
@@ -8660,13 +8660,13 @@
           "id": "55f56820c5fb78e85d207151",
           "fingerprint": "5be3bf7916f77d342447d184",
           "item": "fn run_orderly_lock_periodic_lifecycle_probe",
-          "line": 1176
+          "line": 1172
         },
         {
           "id": "6cc1e5e3486681c6a57a0dd5",
           "fingerprint": "eafeddae152105f084f9c7f5",
           "item": "fn run_orderly_lock_periodic_lifecycle_probe",
-          "line": 1177
+          "line": 1173
         }
       ],
       "owner": "client",
@@ -8685,37 +8685,37 @@
           "id": "9a6409e14bda0667ae737b04",
           "fingerprint": "3c814ca718bf7b3e8e63db40",
           "item": "fn new_service",
-          "line": 1252
+          "line": 1248
         },
         {
           "id": "00ee094afc40eda94ad40d7f",
           "fingerprint": "68bc0512d894fd2b48d17044",
           "item": "fn new_service",
-          "line": 1253
+          "line": 1249
         },
         {
           "id": "c167a03f80e4e27478c325eb",
           "fingerprint": "1ce254da35d4167cfe84e79e",
           "item": "fn new_service_with_config",
-          "line": 1262
+          "line": 1258
         },
         {
           "id": "76e55e8356db619468b61505",
           "fingerprint": "fa7158b7744b0768dfb0b62d",
           "item": "fn new_service_with_config",
-          "line": 1263
+          "line": 1259
         },
         {
           "id": "1a496aa3f91bed37868ef8ad",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1271
+          "line": 1267
         },
         {
           "id": "8f62eaad6c779e9b14de98ba",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1272
+          "line": 1268
         }
       ],
       "owner": "client",
@@ -8789,7 +8789,7 @@
           "id": "b5fc467d3bfb463a29a319a5",
           "fingerprint": "726e3f144280325520e25752",
           "item": "struct ConsumeRequest",
-          "line": 845
+          "line": 841
         }
       ],
       "owner": "client",
@@ -8808,13 +8808,13 @@
           "id": "3b0b14b1f59a4d95ba8c20b4",
           "fingerprint": "6c47d5d90dd2fc455989318b",
           "item": "fn new_service",
-          "line": 1250
+          "line": 1246
         },
         {
           "id": "00166e76656692a1220a9089",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 1270
+          "line": 1266
         }
       ],
       "owner": "client",
@@ -8833,7 +8833,7 @@
           "id": "c6f513cbf08accdf87e2aeac",
           "fingerprint": "29f1ccabf22de8ac0e03b6ed",
           "item": "mod tests",
-          "line": 920
+          "line": 918
         }
       ],
       "owner": "client",
@@ -8852,37 +8852,37 @@
           "id": "764bbb13f697f2cda49f8e9c",
           "fingerprint": "c3fa90ce6e87a410a76d43a4",
           "item": "fn new_service",
-          "line": 939
+          "line": 937
         },
         {
           "id": "8518515c40dcfe994db94922",
           "fingerprint": "68bc0512d894fd2b48d17044",
           "item": "fn new_service",
-          "line": 940
+          "line": 938
         },
         {
           "id": "0fabf48ed981b6b6b0fbbf72",
           "fingerprint": "93e2e547427fcc125b0d19a3",
           "item": "fn new_service_with_config",
-          "line": 949
+          "line": 947
         },
         {
           "id": "3b3d72ba84b4f064a6e65657",
           "fingerprint": "fa7158b7744b0768dfb0b62d",
           "item": "fn new_service_with_config",
-          "line": 950
+          "line": 948
         },
         {
           "id": "3fb465fd60b54bb643f43bb2",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 958
+          "line": 956
         },
         {
           "id": "71d600c9a8f21cf694c043bf",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 959
+          "line": 957
         }
       ],
       "owner": "client",
@@ -8956,13 +8956,13 @@
           "id": "093b490b31f83655f9509336",
           "fingerprint": "641be760c57d9bb56b9a7c92",
           "item": "struct ConsumeRequest",
-          "line": 599
+          "line": 597
         },
         {
           "id": "210903bc3513652458b137b7",
           "fingerprint": "9b045a764e0504bbe6f1c007",
           "item": "fn new",
-          "line": 609
+          "line": 607
         }
       ],
       "owner": "client",
@@ -8981,13 +8981,13 @@
           "id": "e9f85808bec47f2590b7b5c6",
           "fingerprint": "082e1dbdbc6bd3e3644a208b",
           "item": "fn new_service",
-          "line": 937
+          "line": 935
         },
         {
           "id": "f8e51ee2b528fbd96752ca84",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 957
+          "line": 955
         }
       ],
       "owner": "client",
@@ -9006,7 +9006,7 @@
           "id": "e2f1d946f954d510d440b496",
           "fingerprint": "301b22a57756c01fbbe3ea96",
           "item": "mod tests",
-          "line": 1025
+          "line": 1017
         }
       ],
       "owner": "client",
@@ -9025,25 +9025,25 @@
           "id": "0c90a963a7216263aab0c716",
           "fingerprint": "3b6355dbb8eebf4a0c98f41d",
           "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 948
+          "line": 940
         },
         {
           "id": "b406a35e7c961543643bb3ce",
           "fingerprint": "4f6d9f1992841d3e22006a60",
           "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 950
+          "line": 942
         },
         {
           "id": "060c5d4ea57dbd3b21b88572",
           "fingerprint": "bc57a8a3334772e3e5602fa0",
           "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 959
+          "line": 951
         },
         {
           "id": "9d10e6188eb3bf00306b6c46",
           "fingerprint": "1cb62e0a922c1b1b9e1389c9",
           "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 960
+          "line": 952
         }
       ],
       "owner": "client",
@@ -9062,37 +9062,37 @@
           "id": "96dd8ab72348a0d1ab825867",
           "fingerprint": "19460e0e17224b2b99882301",
           "item": "fn new_service",
-          "line": 1043
+          "line": 1035
         },
         {
           "id": "4608f63cde464711ba9a69db",
           "fingerprint": "e819127ded0a53214243199f",
           "item": "fn new_service",
-          "line": 1044
+          "line": 1036
         },
         {
           "id": "c4dc0dee06e594ac63834649",
           "fingerprint": "70d20c8c1320eec80fd06728",
           "item": "fn new_service_with_config",
-          "line": 1053
+          "line": 1045
         },
         {
           "id": "5962452b0149b8e346834cf3",
           "fingerprint": "eafeddae152105f084f9c7f5",
           "item": "fn new_service_with_config",
-          "line": 1054
+          "line": 1046
         },
         {
           "id": "399a0b0d4ea9290a77cb3354",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1062
+          "line": 1054
         },
         {
           "id": "53d1df91c3b973f73a9aaaee",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1063
+          "line": 1055
         }
       ],
       "owner": "client",
@@ -9166,7 +9166,7 @@
           "id": "f50f24409a57670cb02f95b0",
           "fingerprint": "99023035fadfaf67bc7865ff",
           "item": "fn start_lock_refresh_with_schedule",
-          "line": 255
+          "line": 251
         }
       ],
       "owner": "client",
@@ -9185,13 +9185,13 @@
           "id": "13fc2d75de5572b077426811",
           "fingerprint": "1dda839ad9faf9fb9b43d4c0",
           "item": "fn new_service",
-          "line": 1041
+          "line": 1033
         },
         {
           "id": "2732f5a15e918a5c150a4ef1",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 1061
+          "line": 1053
         }
       ],
       "owner": "client",
@@ -9210,7 +9210,7 @@
           "id": "a769e3c9807073f2b536ea6f",
           "fingerprint": "9f1002806ae1463680b9d881",
           "item": "fn send_message_back",
-          "line": 482
+          "line": 477
         }
       ],
       "owner": "client",
@@ -9229,7 +9229,7 @@
           "id": "a1578a8e4532db53800d00f4",
           "fingerprint": "f64ad1e2ea88a903e7f49ef5",
           "item": "mod tests",
-          "line": 2981
+          "line": 3108
         }
       ],
       "owner": "client",
@@ -9248,25 +9248,19 @@
           "id": "126c94c81e0a61ee9b1da2d9",
           "fingerprint": "8e63f64e890a4e18ec5155d0",
           "item": "fn to_consumer_config",
-          "line": 401
+          "line": 404
         },
         {
-          "id": "71a9141eb370ab018efb879d",
-          "fingerprint": "a4ac8a16e1df3f15a8ca29e7",
+          "id": "19983da6a29ced80471c529c",
+          "fingerprint": "91c09c442fee0f8ccff25fc0",
           "item": "fn new",
-          "line": 519
+          "line": 531
         },
         {
-          "id": "a8a19c4481bd2ff772486787",
-          "fingerprint": "71c552ef84889e5992735b91",
-          "item": "fn new",
-          "line": 523
-        },
-        {
-          "id": "42b08c66e10e51585cd0dd92",
-          "fingerprint": "d6702e14eef4c1d9c38dbb73",
+          "id": "cce0d1fe7cc90211bdf50553",
+          "fingerprint": "41de8ca8523a7bf166711f48",
           "item": "fn start",
-          "line": 948
+          "line": 1052
         }
       ],
       "owner": "client",
@@ -9282,448 +9276,418 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "301dc3f49813204e10cf8247",
-          "fingerprint": "17cbb06bafacc0b83956369e",
+          "id": "30da58b9a02f8b2b05b3d0ce",
+          "fingerprint": "972dc31ff5fe51d7b0a2f72d",
           "item": "fn shutdown_in_create_just_keeps_state_like_java_noop",
-          "line": 3143
+          "line": 3266
         },
         {
           "id": "39460d5c82af71f10a7a8ffc",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn shutdown_in_create_just_keeps_state_like_java_noop",
-          "line": 3144
+          "line": 3267
         },
         {
-          "id": "eb9eeb620e0615a2ea1574c0",
-          "fingerprint": "3e6a1ac9463ce3dea02c6ab9",
+          "id": "c02d576ee8abd14854f1ee4c",
+          "fingerprint": "d0ecdcd7156d24c169de1e1c",
           "item": "fn shutdown_in_start_failed_keeps_state_like_java_default_case",
-          "line": 3158
+          "line": 3281
         },
         {
           "id": "9a407de53b79561007622c1b",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn shutdown_in_start_failed_keeps_state_like_java_default_case",
-          "line": 3159
+          "line": 3282
         },
         {
-          "id": "3febc64f9264d54909a58ac2",
-          "fingerprint": "042e02af98dbda1d1d9eaaba",
+          "id": "4033d2d9e6904008ca2bd67b",
+          "fingerprint": "b145c94034077cfabef6b3cd",
           "item": "fn start_without_self_reference_returns_error_without_panic",
-          "line": 3177
+          "line": 3336
         },
         {
           "id": "12ac131928e6b5d8aa8f94ae",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn start_without_self_reference_returns_error_without_panic",
-          "line": 3178
+          "line": 3337
         },
         {
           "id": "40b8953569ce013a4cb9039c",
           "fingerprint": "ed6bfbfdce8f24a35919579d",
           "item": "fn check_config_rejects_unsupported_consume_from_where_like_java_lite_pull",
-          "line": 3198
+          "line": 3357
         },
         {
           "id": "4e83c0798bd1d8bebf3799a5",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn check_config_rejects_unsupported_consume_from_where_like_java_lite_pull",
-          "line": 3199
+          "line": 3358
         },
         {
           "id": "e49915a29503b014f072b808",
           "fingerprint": "a9406c96495777031f213ba2",
           "item": "fn check_config_rejects_default_consumer_group_like_java_lite_pull",
-          "line": 3216
+          "line": 3375
         },
         {
           "id": "9f546cf6e409fe6d20f9602c",
           "fingerprint": "c4e7e3661c30f49939122442",
           "item": "fn check_config_rejects_default_consumer_group_like_java_lite_pull",
-          "line": 3217
+          "line": 3376
         },
         {
           "id": "24f3fe19b696b130405733c0",
           "fingerprint": "51b797c7c578d286d607e940",
           "item": "fn check_config_rejects_consumer_suspend_timeout_below_broker_suspend_like_java",
-          "line": 3235
+          "line": 3394
         },
         {
           "id": "8cbb13f3218ea787248aad3c",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn check_config_rejects_consumer_suspend_timeout_below_broker_suspend_like_java",
-          "line": 3236
+          "line": 3395
         },
         {
-          "id": "7ff2c0804e05c4cd47e97e8e",
-          "fingerprint": "65a20ab1ccbbe159341fbbd3",
+          "id": "9bdbd3a3c79a8973f25fb14b",
+          "fingerprint": "8f7f5c131d08b4f206c21b30",
           "item": "fn set_consumer_group_updates_rebalance_before_start_and_rejects_running_mutation",
-          "line": 3257
+          "line": 3416
         },
         {
           "id": "124efdae1098e60c4492a5fd",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn set_consumer_group_updates_rebalance_before_start_and_rejects_running_mutation",
-          "line": 3258
+          "line": 3417
         },
         {
-          "id": "c16452456131bc65f410d98c",
-          "fingerprint": "1e95ea407d3a794d80e38591",
+          "id": "c49c8e911ded06138cbc64ae",
+          "fingerprint": "9aeee0a70be4d1b619e6ded5",
           "item": "fn set_offset_store_updates_rebalance_before_start_and_rejects_running_mutation",
-          "line": 3289
+          "line": 3497
         },
         {
           "id": "19af49b37389cc9175982426",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn set_offset_store_updates_rebalance_before_start_and_rejects_running_mutation",
-          "line": 3286
+          "line": 3498
         },
         {
-          "id": "f934dab12c4d406ba58ae00a",
-          "fingerprint": "e08e998bcd6edda01b8c4845",
+          "id": "64465500383d125ca451c2b5",
+          "fingerprint": "b96b346dc347e0f58a8e5eb9",
           "item": "fn set_unit_mode_updates_pull_api_wrapper_for_filter_hooks_like_java",
-          "line": 3325
+          "line": 3533
         },
         {
           "id": "e413d3482603390eb8755de4",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn set_unit_mode_updates_pull_api_wrapper_for_filter_hooks_like_java",
-          "line": 3326
+          "line": 3534
         },
         {
-          "id": "73a8edace0c6d99c65c8d828",
-          "fingerprint": "d0daf3766838656c5fff0c2f",
+          "id": "6d0d65c3545c6df174574ca1",
+          "fingerprint": "1128ad988970e8099a8443f0",
           "item": "fn set_unit_mode_updates_pull_api_wrapper_for_filter_hooks_like_java",
-          "line": 3332
+          "line": 3540
         },
         {
-          "id": "6495abfd801b7b129ceb9001",
-          "fingerprint": "91f9e27dd5100e3fcaa8a2d2",
+          "id": "708e6ce2067b019a77b57bb8",
+          "fingerprint": "920114b59e1dbc5222b7b3e4",
           "item": "fn operate_after_running_starts_preassigned_pull_tasks",
-          "line": 3374
-        },
-        {
-          "id": "80424ee13eeea4ddf1647c32",
-          "fingerprint": "8c6b3dcfe78c6a4a2a5debb2",
-          "item": "fn operate_after_running_starts_preassigned_pull_tasks",
-          "line": 3375
+          "line": 3583
         },
         {
           "id": "ac384da8ff0decd82fb9fe2c",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn operate_after_running_starts_preassigned_pull_tasks",
-          "line": 3376
+          "line": 3584
         },
         {
           "id": "731ad29dcf28b207add091b1",
           "fingerprint": "57e855c8b6e771da718c0473",
           "item": "fn drop",
-          "line": 3425
+          "line": 3632
         },
         {
           "id": "6e0c09767b21822cb7496268",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn drop",
-          "line": 3426
+          "line": 3633
         },
         {
-          "id": "e7f21ff349298147a8b778b1",
-          "fingerprint": "6f664641f1782169f3a064bb",
+          "id": "c170a8701f5ffa341d62d9d5",
+          "fingerprint": "ead3d2b3cee1ae7b714490ed",
           "item": "fn consumer_running_info_includes_assigned_process_queues",
-          "line": 3475
+          "line": 3682
         },
         {
           "id": "b318f31f7ab5fc192c57aca4",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn consumer_running_info_includes_assigned_process_queues",
-          "line": 3476
+          "line": 3683
         },
         {
-          "id": "e695ed4fc2b2199b273c28c3",
-          "fingerprint": "b5e47780476a00f6e54f0659",
+          "id": "59b86e436017ed42c24bfc01",
+          "fingerprint": "5f058666927d6041ec24b008",
           "item": "fn update_name_server_address_updates_client_api_like_java",
-          "line": 3497
+          "line": 3704
         },
         {
           "id": "962cac58a82d1a1020858204",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn update_name_server_address_updates_client_api_like_java",
-          "line": 3498
+          "line": 3705
         },
         {
-          "id": "651418815afdb6c8df828841",
-          "fingerprint": "fb51f3149b0fa29f30921dd7",
+          "id": "6c0409371a9265429d377296",
+          "fingerprint": "017411168a3426b55855866a",
           "item": "fn subscribe_with_sql_selector_preserves_expression_type_like_java",
-          "line": 3537
+          "line": 3746
         },
         {
           "id": "9c1cbc0283496574190bfa9b",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn subscribe_with_sql_selector_preserves_expression_type_like_java",
-          "line": 3538
+          "line": 3747
         },
         {
           "id": "bb3f707ad6afbe9d3bb0f2c9",
           "fingerprint": "d1379570b482f9fe9f73410c",
           "item": "fn set_sub_expression_for_assign_matches_java_validation_and_state",
-          "line": 3581
+          "line": 3790
         },
         {
           "id": "9ffd508dc17c60e9429885c9",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn set_sub_expression_for_assign_matches_java_validation_and_state",
-          "line": 3582
+          "line": 3791
         },
         {
-          "id": "f4289d7ba638d09a4bfeb14f",
-          "fingerprint": "dc9f5e8104c463c8c01a7aa7",
+          "id": "d794df561f9dc6299ee19d68",
+          "fingerprint": "bac224b9c1304ff5772b5282",
           "item": "fn set_sub_expression_for_assign_matches_java_validation_and_state",
-          "line": 3611
+          "line": 3820
         },
         {
           "id": "ab6b4e0328f121b2a7ccb12b",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn set_sub_expression_for_assign_matches_java_validation_and_state",
-          "line": 3612
+          "line": 3821
         },
         {
           "id": "c50aa97bac84af7a1d475b73",
           "fingerprint": "aa10463cf5283eb167cd8d82",
           "item": "fn next_pull_offset_applies_seek_to_consume_offset_like_java",
-          "line": 3631
+          "line": 3840
         },
         {
           "id": "c5302568e86a461cdd4ad071",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn next_pull_offset_applies_seek_to_consume_offset_like_java",
-          "line": 3632
+          "line": 3841
         },
         {
-          "id": "8cc34ee26d5e554541134665",
-          "fingerprint": "0374d197ff918e7b5070ea9e",
+          "id": "01407d339a16bc6e1148c075",
+          "fingerprint": "05abab6d6a5db5cbe6827d3a",
           "item": "fn seek_rejects_unassigned_queue_before_broker_offset_lookup_like_java",
-          "line": 3655
+          "line": 3864
         },
         {
           "id": "1543bd418b5c562978a22841",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn seek_rejects_unassigned_queue_before_broker_offset_lookup_like_java",
-          "line": 3656
+          "line": 3865
         },
         {
-          "id": "3c27a242a72d0e5b3ced0616",
-          "fingerprint": "e0cda1586f1e9c9ab253e106",
+          "id": "bcbb136b372e1f8ab29ca040",
+          "fingerprint": "2f629729f668d5a125283c59",
           "item": "fn commit_all_updates_offsets_without_persisting_like_java",
-          "line": 3678
+          "line": 3887
         },
         {
           "id": "aec170a7a876518bad8a0341",
           "fingerprint": "052a04afd7fd7d9337cfaa9c",
           "item": "fn commit_all_updates_offsets_without_persisting_like_java",
-          "line": 3675
+          "line": 3888
         },
         {
-          "id": "b7b7aad51600709c4a325b96",
-          "fingerprint": "e0cda1586f1e9c9ab253e106",
+          "id": "ed558344e37f5de269bf5629",
+          "fingerprint": "2f629729f668d5a125283c59",
           "item": "fn commit_message_queues_uses_assigned_consume_offset_like_java",
-          "line": 3704
+          "line": 3913
         },
         {
           "id": "86b4a57a28cfc0525dbcbbf3",
           "fingerprint": "052a04afd7fd7d9337cfaa9c",
           "item": "fn commit_message_queues_uses_assigned_consume_offset_like_java",
-          "line": 3701
+          "line": 3914
         },
         {
-          "id": "e11766a4dd22f845fcd80409",
-          "fingerprint": "e0cda1586f1e9c9ab253e106",
+          "id": "17ca9d252cb1b8a6ba6c42ce",
+          "fingerprint": "2f629729f668d5a125283c59",
           "item": "fn commit_message_queues_with_persist_calls_persist_all_like_java",
-          "line": 3734
+          "line": 3943
         },
         {
           "id": "fc425d827e49c4593151175a",
           "fingerprint": "052a04afd7fd7d9337cfaa9c",
           "item": "fn commit_message_queues_with_persist_calls_persist_all_like_java",
-          "line": 3731
+          "line": 3944
         },
         {
-          "id": "e429d50cbded2c7c7d2d14f2",
-          "fingerprint": "72612e8c68b605c320f17990",
+          "id": "785bd3ed9ebe0915a53e9cb4",
+          "fingerprint": "a1673165c67ea98fcbb73202",
           "item": "fn poll_zero_timeout_returns_cached_message_like_java",
-          "line": 3761
+          "line": 3970
         },
         {
           "id": "4861921f79d6d2c5d1e990f1",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn poll_zero_timeout_returns_cached_message_like_java",
-          "line": 3762
+          "line": 3971
         },
         {
-          "id": "b7b125a465753d91fac74cb5",
-          "fingerprint": "3f972dc9a7763fad40bdf87b",
+          "id": "a4fd166d5ed961a38865ff8b",
+          "fingerprint": "48f2ab76e73a3357f7385b46",
           "item": "fn clear_message_queue_in_cache_removes_pending_consume_requests_like_java",
-          "line": 3801
+          "line": 4010
         },
         {
           "id": "02cbab2362703cb9987ad09e",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn clear_message_queue_in_cache_removes_pending_consume_requests_like_java",
-          "line": 3802
+          "line": 4011
         },
         {
-          "id": "e253f5cc90941526d60607a8",
-          "fingerprint": "6c4ba5396bf08dea1d50ed50",
+          "id": "81e50deb7fbb2c893cc4c78a",
+          "fingerprint": "ac207920b91ec78e60f7ddd5",
           "item": "fn poll_sets_access_channel_only_for_after_hook_like_java",
-          "line": 3874
+          "line": 4083
         },
         {
           "id": "e9c0e508582e2941441b6541",
           "fingerprint": "172d69f6a58980c38267ddfa",
           "item": "fn poll_sets_access_channel_only_for_after_hook_like_java",
-          "line": 3875
+          "line": 4084
         },
         {
-          "id": "7716aca44e2fb890ed834d29",
-          "fingerprint": "3982c04def239484da163df0",
+          "id": "6d3a3042b53fa7153697c3fd",
+          "fingerprint": "ee0cf08376f991319cce8627",
           "item": "fn poll_refreshes_last_consume_timestamp_after_hooks_like_java",
-          "line": 3931
+          "line": 4140
         },
         {
           "id": "f97996cfb07b0dd7bc0a924e",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn poll_refreshes_last_consume_timestamp_after_hooks_like_java",
-          "line": 3932
+          "line": 4141
         },
         {
-          "id": "da4282a7a801703dca95c029",
-          "fingerprint": "8e8211e9dac731467cd04b35",
+          "id": "3c054cf0d9f08943f4f1ee30",
+          "fingerprint": "920114b59e1dbc5222b7b3e4",
           "item": "fn concurrent_poll_calls_are_serialized_like_java_synchronized_poll",
-          "line": 3975
-        },
-        {
-          "id": "192d4ff8d26db40f5f0e67f7",
-          "fingerprint": "8c6b3dcfe78c6a4a2a5debb2",
-          "item": "fn concurrent_poll_calls_are_serialized_like_java_synchronized_poll",
-          "line": 3976
+          "line": 4185
         },
         {
           "id": "36e328af6483f6c95a6d3503",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn concurrent_poll_calls_are_serialized_like_java_synchronized_poll",
-          "line": 3977
+          "line": 4186
         },
         {
-          "id": "1c0a14b532f0b70284de01f9",
-          "fingerprint": "a1c9f3c1eb76d2d743656457",
+          "id": "d8ea17006020555c315e8c40",
+          "fingerprint": "b10681626f5a4bad6b7d89c4",
           "item": "fn pull_inner_refreshes_last_pull_timestamp_before_flow_control_like_java",
-          "line": 4071
+          "line": 4280
         },
         {
           "id": "341ca152a2e4f7b6eef31c16",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn pull_inner_refreshes_last_pull_timestamp_before_flow_control_like_java",
-          "line": 4072
+          "line": 4281
         },
         {
           "id": "26421017fd2435eadc086912",
           "fingerprint": "42d90dfee07517f4bc1914dd",
           "item": "fn pull_result_does_not_overwrite_pending_seek_offset_like_java",
-          "line": 4101
+          "line": 4310
         },
         {
           "id": "9e997dc3bfbb6030538541a5",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn pull_result_does_not_overwrite_pending_seek_offset_like_java",
-          "line": 4102
+          "line": 4311
         },
         {
           "id": "c9f4d186b936b1cabcc20235",
           "fingerprint": "102f3dbc1f3673b7df7652c8",
           "item": "fn offset_illegal_corrects_pull_offset_without_dropping_queue_like_java_lite_pull",
-          "line": 4132
+          "line": 4341
         },
         {
           "id": "92676d39c345d6828ac06338",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn offset_illegal_corrects_pull_offset_without_dropping_queue_like_java_lite_pull",
-          "line": 4133
+          "line": 4342
         },
         {
-          "id": "d05bfff97d0059d7113668c9",
-          "fingerprint": "df7e850921205698a048d72e",
+          "id": "1700e90c26373d799d03279c",
+          "fingerprint": "920114b59e1dbc5222b7b3e4",
           "item": "fn rebalance_update_assigns_divided_queues_and_starts_pull_tasks",
-          "line": 4156
-        },
-        {
-          "id": "dea9ab1a2df35822553b5dce",
-          "fingerprint": "8c6b3dcfe78c6a4a2a5debb2",
-          "item": "fn rebalance_update_assigns_divided_queues_and_starts_pull_tasks",
-          "line": 4157
+          "line": 4366
         },
         {
           "id": "3874c70d2ac4292a74864716",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn rebalance_update_assigns_divided_queues_and_starts_pull_tasks",
-          "line": 4158
+          "line": 4367
         },
         {
-          "id": "3bffc9e143b171464217df36",
-          "fingerprint": "93027008f7c544cf2c658acd",
+          "id": "dfd0335395c5f0c1df3c7f2b",
+          "fingerprint": "920114b59e1dbc5222b7b3e4",
           "item": "fn lite_pull_rebalance_listener_invokes_user_listener",
-          "line": 4216
-        },
-        {
-          "id": "f66d04b38210590544f37c65",
-          "fingerprint": "8c6b3dcfe78c6a4a2a5debb2",
-          "item": "fn lite_pull_rebalance_listener_invokes_user_listener",
-          "line": 4217
+          "line": 4425
         },
         {
           "id": "5befbea37203b1770d46940c",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn lite_pull_rebalance_listener_invokes_user_listener",
-          "line": 4218
+          "line": 4426
         },
         {
-          "id": "8e4f2ec68bd66d53336e089a",
-          "fingerprint": "b57e6bf50435cd2f032d73e9",
+          "id": "a9ef79e80c47f76c4fe744f1",
+          "fingerprint": "920114b59e1dbc5222b7b3e4",
           "item": "fn lite_pull_rebalance_listener_ignores_changes_after_shutdown_token_cancelled",
-          "line": 4277
-        },
-        {
-          "id": "7144ba82b1dc5ddfa7510ec9",
-          "fingerprint": "8c6b3dcfe78c6a4a2a5debb2",
-          "item": "fn lite_pull_rebalance_listener_ignores_changes_after_shutdown_token_cancelled",
-          "line": 4278
+          "line": 4485
         },
         {
           "id": "2ba08011ddfb689946f99bca",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn lite_pull_rebalance_listener_ignores_changes_after_shutdown_token_cancelled",
-          "line": 4279
+          "line": 4486
         },
         {
-          "id": "dff2cfbac587cdc7420bbc3c",
-          "fingerprint": "4283725abb933d2694169b12",
+          "id": "00763749b3fc0c40fca6a508",
+          "fingerprint": "71733f1953918d1d674ad676",
           "item": "fn subscribe_with_listener_installs_user_listener_with_subscription_like_java",
-          "line": 4319
+          "line": 4525
         },
         {
           "id": "2e0678f3ca7e2fb502d81552",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn subscribe_with_listener_installs_user_listener_with_subscription_like_java",
-          "line": 4320
+          "line": 4526
         },
         {
           "id": "7c2ab5bb3ecd041b81337331",
           "fingerprint": "83ff5408764cfedd210c7335",
           "item": "fn topic_message_queue_change_listener_fires_only_when_snapshot_changes",
-          "line": 4365
+          "line": 4571
         },
         {
           "id": "77a285f5a2d64c7c75a5c1f7",
           "fingerprint": "339869160bd18fb701332ee2",
           "item": "fn topic_message_queue_change_listener_fires_only_when_snapshot_changes",
-          "line": 4366
+          "line": 4572
         }
       ],
       "owner": "client",
@@ -9739,10 +9703,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "3c9dccfede25a8e4f2ef7448",
-          "fingerprint": "649e14eb200bf08b37ff7151",
+          "id": "939ed63ba12930f75b3a20dc",
+          "fingerprint": "fb75c6af9a069ab85723aee3",
           "item": "<module>",
-          "line": 46
+          "line": 50
         }
       ],
       "owner": "client",
@@ -9758,121 +9722,28 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "17b1c5dd8b83b28b71890cca",
-          "fingerprint": "16df077712964707eccad0c6",
+          "id": "b67671d8e98b7ab8ce6dccf7",
+          "fingerprint": "c471f4a226da3185282b928a",
           "item": "struct DefaultLitePullConsumerImpl",
-          "line": 454
+          "line": 462
         },
         {
-          "id": "04c3e622e53a2f539d541853",
-          "fingerprint": "d3e21f2bdb03bba5149e6ce7",
+          "id": "a90157ac28153d06d91243af",
+          "fingerprint": "3c572ed0394cd02a02fdb69a",
           "item": "struct DefaultLitePullConsumerImpl",
-          "line": 458
+          "line": 463
         },
         {
-          "id": "24c3694242eec76eb2a707c0",
-          "fingerprint": "7285f403424d7da089e38ee4",
+          "id": "72c8e91b534f7e35bac29ed3",
+          "fingerprint": "9fea42cec685b3d774ca244b",
           "item": "struct DefaultLitePullConsumerImpl",
-          "line": 459
+          "line": 464
         },
         {
-          "id": "89f473a6fcb2954c8998eb1c",
-          "fingerprint": "68c71be0999d8f6793f4c1f6",
-          "item": "struct DefaultLitePullConsumerImpl",
-          "line": 460
-        },
-        {
-          "id": "6b146058e75de74f02cdb2cb",
-          "fingerprint": "85e79a2ca74e4572452a250d",
-          "item": "struct DefaultLitePullConsumerImpl",
-          "line": 504
-        },
-        {
-          "id": "3f1b9da8b6bbbd4009bc9db0",
-          "fingerprint": "6eec3682a67a414ecf4d804c",
+          "id": "b581537dd861caf67957a04a",
+          "fingerprint": "91ac1d086910c431643d6072",
           "item": "fn new",
-          "line": 545
-        },
-        {
-          "id": "de1cc0528f357887fba0f897",
-          "fingerprint": "24aad6b6450c85ea722741f6",
-          "item": "fn set_default_lite_pull_consumer_impl",
-          "line": 581
-        },
-        {
-          "id": "bd366a62687f833eb7e70e03",
-          "fingerprint": "d8804dbc4a0269ab82d7b4d7",
-          "item": "fn set_default_lite_pull_consumer_impl",
-          "line": 585
-        },
-        {
-          "id": "1d3c2a4229ad0379e5fd407c",
-          "fingerprint": "8afe1871a4c6ece111dce2cb",
-          "item": "fn start_topic_metadata_check_task",
-          "line": 1056
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "ef7b518417afacc50eab1e3d",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "2a2749337dcdffc502f7d12a",
-          "fingerprint": "263642f69b3ac36007b47ba4",
-          "item": "fn lite_pull_rebalance_listener_invokes_user_listener",
-          "line": 4236
-        },
-        {
-          "id": "eabaffe126abe463ee438c72",
-          "fingerprint": "95498fd60ade69ce8142de45",
-          "item": "fn lite_pull_rebalance_listener_ignores_changes_after_shutdown_token_cancelled",
-          "line": 4298
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "7765bb92d6aa3453ec16d1fc",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "WeakArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "c5986d99c4bf57f5beecbe4e",
-          "fingerprint": "2ecdcd391b2992ebfa4466de",
-          "item": "<module>",
-          "line": 47
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6cf3720577ae336b808de4b7",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "WeakArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "994b51f7a37a2bf1d3ae1fd9",
-          "fingerprint": "9d8c09c7d4119d6d1307bf74",
-          "item": "struct LitePullRebalanceListener",
-          "line": 186
+          "line": 557
         }
       ],
       "owner": "client",
@@ -9891,61 +9762,61 @@
           "id": "606d2b8d69b34fd3b3a83622",
           "fingerprint": "5ea45080f99baa90b6372a65",
           "item": "fn set_consumer_group",
-          "line": 629
+          "line": 679
         },
         {
           "id": "e0829e2d450a1b0d791d8482",
           "fingerprint": "324c5cbf856c0fc462aba2d5",
           "item": "fn update_topic_subscribe_info_when_subscription_changed",
-          "line": 873
+          "line": 959
         },
         {
-          "id": "dc96d723ad4439726b412a14",
-          "fingerprint": "aaddb67df9353fff82543d7f",
+          "id": "564523ea807fa99e1d82ae5e",
+          "fingerprint": "a8480e8cb4e91c2c2f5728bb",
           "item": "fn start",
-          "line": 1001
+          "line": 1033
         },
         {
-          "id": "8e9e22455cd071f692265e0b",
-          "fingerprint": "aace51b4766292c5d7c6e589",
+          "id": "edcf7c7e2a826e0b9f9a3f85",
+          "fingerprint": "68c937800a8a73e65960cd67",
           "item": "fn start",
-          "line": 993
+          "line": 1100
         },
         {
-          "id": "bd5435e89a7fad4736e74b39",
-          "fingerprint": "f8b12897695fcc5930c630a7",
+          "id": "828b1680c6737d4ada1cd3eb",
+          "fingerprint": "ee67b1588be5797090051a30",
           "item": "fn set_unit_mode",
-          "line": 2464
+          "line": 2589
         },
         {
           "id": "5566ff3bb5442376dde2e0b4",
           "fingerprint": "98b95a08cc3ff63ea51c343d",
           "item": "fn set_message_model",
-          "line": 2506
+          "line": 2602
         },
         {
           "id": "96b79669398f05183490427f",
           "fingerprint": "2510978f07090f2956646a78",
           "item": "fn set_allocate_message_queue_strategy",
-          "line": 2547
+          "line": 2643
         },
         {
-          "id": "32386991328ff56585aeed83",
-          "fingerprint": "054ba35b99c0efa2f257a07e",
+          "id": "921f1d37bcfa974e13796ea1",
+          "fingerprint": "c03ff0f8b2b1f4487c8e8989",
           "item": "fn set_connect_broker_by_user",
-          "line": 2574
+          "line": 2696
         },
         {
-          "id": "bc4b6c735238f7c26839f037",
-          "fingerprint": "46b1a652e8e255623beaa8e2",
+          "id": "29bb41cea2780446a8cc306f",
+          "fingerprint": "bf62f8d2d5c167f407c9cbcd",
           "item": "fn set_default_broker_id",
-          "line": 2592
+          "line": 2714
         },
         {
           "id": "f0c147aba4fdca670c9e20a4",
           "fingerprint": "f4ef274a5137f7bef66fc3cb",
           "item": "fn do_rebalance",
-          "line": 2795
+          "line": 2917
         }
       ],
       "owner": "client",
@@ -9964,7 +9835,7 @@
           "id": "2e1a28fe9c0918e52bdf56a5",
           "fingerprint": "d715357faf1d89e33d16251a",
           "item": "mod tests",
-          "line": 2170
+          "line": 2163
         }
       ],
       "owner": "client",
@@ -10020,55 +9891,55 @@
           "id": "94dc438e686953c42c2f194c",
           "fingerprint": "1c06f98cf22dbf5b11ff652d",
           "item": "fn new_unstarted_impl",
-          "line": 2178
+          "line": 2171
         },
         {
           "id": "9029403838ad9ee36b96ba5e",
           "fingerprint": "dbec1f2ff53b3c4d1f5978e8",
           "item": "fn new_check_config_consumer",
-          "line": 2205
+          "line": 2198
         },
         {
           "id": "bed96c1972704abacbb50d54",
           "fingerprint": "f2c8ab11b61d8b619ad064f2",
           "item": "fn new_check_config_consumer",
-          "line": 2209
+          "line": 2202
         },
         {
           "id": "4c264cbb71beaa4bf4c605e3",
           "fingerprint": "dbec1f2ff53b3c4d1f5978e8",
           "item": "fn new_startable_push_consumer",
-          "line": 2220
+          "line": 2213
         },
         {
           "id": "c68059f4dfcdd96ba79265bc",
           "fingerprint": "12958be49d7ef666805e01b4",
           "item": "fn new_startable_push_consumer",
-          "line": 2224
+          "line": 2217
         },
         {
           "id": "636e2f5a281e1663e32dd1bd",
           "fingerprint": "6f3d48a79817be1c040a073a",
           "item": "fn new_startable_push_consumer",
-          "line": 2226
+          "line": 2219
         },
         {
           "id": "6ce2a74fbdc815d3daa5e333",
           "fingerprint": "75cd163ada2c71fc9e1b44b3",
           "item": "fn send_message_back_restores_topic_when_retry_fallback_errors_like_java_finally",
-          "line": 2537
+          "line": 2530
         },
         {
           "id": "3b7754c0715f31ce69f43972",
           "fingerprint": "7e868a3beeee278a476a26c6",
           "item": "fn fetch_subscribe_message_queues_prefers_cached_route_like_java",
-          "line": 2582
+          "line": 2575
         },
         {
           "id": "cbb4cac982e2146c24ee895d",
           "fingerprint": "bed922d3f405df26ffbe730e",
           "item": "fn reset_offsets_drops_clears_persists_and_removes_assigned_queue_like_java",
-          "line": 2666
+          "line": 2664
         }
       ],
       "owner": "client",
@@ -10184,7 +10055,7 @@
           "id": "1a5e1ca13cbdb70c79cde622",
           "fingerprint": "ae2aac844ddedbc42eb8a817",
           "item": "fn register_message_listener",
-          "line": 739
+          "line": 734
         }
       ],
       "owner": "client",
@@ -10203,7 +10074,7 @@
           "id": "0f0d044708edfca1ae1d4c67",
           "fingerprint": "86496c78cf33892adc754a67",
           "item": "fn new_startable_push_consumer",
-          "line": 2215
+          "line": 2208
         }
       ],
       "owner": "client",
@@ -10222,19 +10093,19 @@
           "id": "9d26f62019a525168341ca45",
           "fingerprint": "e3987d672ac08e83a36ffd11",
           "item": "fn do_rebalance",
-          "line": 1907
+          "line": 1900
         },
         {
           "id": "5b17b28d8bdeb32d3de2e6df",
           "fingerprint": "6a81898545cbdf5fae40e0b7",
           "item": "fn try_rebalance",
-          "line": 1916
+          "line": 1914
         },
         {
           "id": "394cfb5961273a9eb01c2a2e",
           "fingerprint": "8aa3de4d8cec698b3866a14b",
           "item": "fn reset_offsets",
-          "line": 2027
+          "line": 2020
         }
       ],
       "owner": "client",
@@ -10253,43 +10124,43 @@
           "id": "1b636421d5ecbfe9f697118b",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2289
+          "line": 2282
         },
         {
           "id": "4366210318539c2a7edb2dad",
           "fingerprint": "69343b618ff42492b938e65c",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2307
+          "line": 2300
         },
         {
           "id": "1c3107c6e26e46a083528afa",
           "fingerprint": "330c5301f067e7c751d78eae",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2337
+          "line": 2330
         },
         {
           "id": "860b3bf5713fe264936bc6d1",
           "fingerprint": "dfd6ebf478835de6e623371d",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2344
+          "line": 2337
         },
         {
           "id": "70f393815241dacc87e7422f",
           "fingerprint": "ef56c22737c574751b2011fe",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2356
+          "line": 2349
         },
         {
           "id": "3a80af2c5eb310032f5e64a4",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2370
+          "line": 2363
         },
         {
           "id": "616daffd00e6d2e9b21ad31d",
           "fingerprint": "ea89c3fc97c837d10c858c78",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2375
+          "line": 2368
         }
       ],
       "owner": "client",
@@ -10591,7 +10462,7 @@
           "id": "c0344f3af9451cbbdb6f2000",
           "fingerprint": "9f0f2bf0aa42cf91fbad20fb",
           "item": "<module>",
-          "line": 40
+          "line": 42
         }
       ],
       "owner": "client",
@@ -10607,10 +10478,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "3ff699a1ba1521c8ec8049cb",
-          "fingerprint": "490aeec1231884ed10807dc8",
+          "id": "229ac9daa7def119a890523a",
+          "fingerprint": "767a851c62038d58e3b34dbc",
           "item": "fn set_mq_client_factory",
-          "line": 113
+          "line": 154
         }
       ],
       "owner": "client",
@@ -10629,7 +10500,7 @@
           "id": "28572033882f85cc92630b14",
           "fingerprint": "310c3b2bb473057ad9cdb526",
           "item": "<module>",
-          "line": 41
+          "line": 43
         }
       ],
       "owner": "client",
@@ -10648,7 +10519,7 @@
           "id": "7cfbf7848e6bb3923d3c0240",
           "fingerprint": "6ab465b5f79495f3e47aea0f",
           "item": "fn set_rebalance_impl",
-          "line": 121
+          "line": 171
         }
       ],
       "owner": "client",
@@ -10716,19 +10587,19 @@
           "id": "b5285b7f6c85a4359a1d02e9",
           "fingerprint": "a1646a5f680f703d98e34012",
           "item": "fn build_process_queue_table_by_broker_name",
-          "line": 572
+          "line": 567
         },
         {
           "id": "57ae5b411b2ae52c9a35399a",
           "fingerprint": "0fdba8aa8161e45fff2cff9a",
           "item": "fn lock_all_impl",
-          "line": 591
+          "line": 586
         },
         {
           "id": "ae37eef15f023a2b35bca26c",
           "fingerprint": "283dbe2c1e78bebdff1680ee",
           "item": "fn unlock_all_impl",
-          "line": 663
+          "line": 658
         }
       ],
       "owner": "client",
@@ -10828,229 +10699,6 @@
       ],
       "owner": "client",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "d78a6783259597fb1fe7cfdc",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "0107efa5727dcb6f05cfa7f1",
-          "fingerprint": "9826bc7f2484e61a6aa6eff9",
-          "item": "mod tests",
-          "line": 1745
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "b45dc968963fbf3942a9c797",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "4f71489cfa6f3fdf3f96aabb",
-          "fingerprint": "3c7bbceb60cd3394ff22ef54",
-          "item": "fn get_or_init_impl",
-          "line": 1050
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "72397ab7310c2cb89e3925e7",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "853b9e7c408ad143bfa92467",
-          "fingerprint": "da88f4ae94e3c46934de038a",
-          "item": "fn new_namespaced_consumer_with_impl",
-          "line": 1858
-        },
-        {
-          "id": "f4a20cf83af5356976065f69",
-          "fingerprint": "f5ca98c4826f0ccd77e487dc",
-          "item": "fn trace_init_uses_configured_batch_num_like_java",
-          "line": 2671
-        },
-        {
-          "id": "16a40581fa45906d1564ce31",
-          "fingerprint": "85c5f7fa8486e00a90b9d00d",
-          "item": "fn trace_init_registers_custom_dispatcher_and_starts_with_client_config",
-          "line": 2714
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "27f0f50437bfca976d678fc2",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "cc05b8804a03fa552f3b448c",
-          "fingerprint": "31e3ae5e5a1cab40e337343e",
-          "item": "<module>",
-          "line": 33
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c5438065af193b29faeb596b",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "25c1e20d9b407e5f8186d5e8",
-          "fingerprint": "3e714b60a962d407274bb1cf",
-          "item": "struct DefaultLitePullConsumer",
-          "line": 154
-        },
-        {
-          "id": "efe04b731f64726aeb477696",
-          "fingerprint": "f841b5b614fdabee7c368ec8",
-          "item": "fn init_trace_dispatcher_internal",
-          "line": 936
-        },
-        {
-          "id": "5235194cb26d0719d40c99dd",
-          "fingerprint": "2dc7ca086c29b37c8322c032",
-          "item": "fn try_impl_",
-          "line": 997
-        },
-        {
-          "id": "b399fc2410ab5377377b5556",
-          "fingerprint": "a89ccd41d283ff2050b00755",
-          "item": "fn get_or_init_impl",
-          "line": 1009
-        },
-        {
-          "id": "8ccca8d0f8425d26e4b5d9ff",
-          "fingerprint": "b58f33450ba5ec304cc8761e",
-          "item": "fn get_or_init_impl",
-          "line": 1028
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "523518965b89ea6414dea18d",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "0d9c8fc20abc7d0059212395",
-          "fingerprint": "84eb67fa8bbfb4f5e9df31c7",
-          "item": "fn new_namespaced_consumer_with_impl",
-          "line": 1811
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e5c896671260a0e7cc7239e4",
-      "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "71de0d55300cc11f301c0e60",
-          "fingerprint": "947bfc3da1282aac365c71cd",
-          "item": "fn init_trace_dispatcher_internal",
-          "line": 969
-        },
-        {
-          "id": "4f4ae8e9ccc5b24382afba6f",
-          "fingerprint": "8c7fcd27083e3612b096e637",
-          "item": "fn get_or_init_impl",
-          "line": 1025
-        },
-        {
-          "id": "43cae7de446d51922207387e",
-          "fingerprint": "fddf183411ef1eb015d1a24c",
-          "item": "fn start",
-          "line": 1064
-        },
-        {
-          "id": "1ec654df427c3b9e40445f50",
-          "fingerprint": "c99d991063eed802b196bcc9",
-          "item": "fn shutdown",
-          "line": 1072
-        },
-        {
-          "id": "c5329318b59d234cfc8e7e97",
-          "fingerprint": "6d21d03af30d2d0391f6e4e9",
-          "item": "fn subscribe_with_expression",
-          "line": 1101
-        },
-        {
-          "id": "54dd54bb28aae8529fedfcac",
-          "fingerprint": "c624cb500bf567c232ff01bc",
-          "item": "fn subscribe_with_listener",
-          "line": 1114
-        },
-        {
-          "id": "8ede407e742a0b29bf83d229",
-          "fingerprint": "b83276e3067c844a75e184cf",
-          "item": "fn subscribe_with_selector",
-          "line": 1125
-        },
-        {
-          "id": "b8d29eddd9e4105d3d99cd76",
-          "fingerprint": "2757332727b8f06f1478c2d6",
-          "item": "fn unsubscribe",
-          "line": 1134
-        },
-        {
-          "id": "878870dc5a84190f66deabc0",
-          "fingerprint": "d978f9073289dc202c512809",
-          "item": "fn assign",
-          "line": 1160
-        },
-        {
-          "id": "bf8fa5a78a675857039d9704",
-          "fingerprint": "784d23362f42e08683cf6151",
-          "item": "fn set_offset_store",
-          "line": 1315
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -11344,42 +10992,11 @@
           "id": "57a273c3273e8452396f37e2",
           "fingerprint": "7e68e15a4de40b865650cb5a",
           "item": "mod tests",
-          "line": 321
+          "line": 322
         }
       ],
       "owner": "client",
       "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "40360024531aaf740e1886ff",
-      "path": "rocketmq-client/src/consumer/mq_consumer_inner.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "ff8593b6fcde9610dfa82275",
-          "fingerprint": "5f519a66d56069551985c16d",
-          "item": "fn lite_pull_wrapper_delegates_heartbeat_fields",
-          "line": 328
-        },
-        {
-          "id": "994c3aef90a3ceaeeb26c041",
-          "fingerprint": "07aab205e7898ebf8989d588",
-          "item": "fn lite_pull_wrapper_delegates_heartbeat_fields",
-          "line": 332
-        },
-        {
-          "id": "8a5b9e96e405e27601127d55",
-          "fingerprint": "cef92c39799cd117202470a3",
-          "item": "fn lite_pull_wrapper_delegates_heartbeat_fields",
-          "line": 333
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -11394,7 +11011,7 @@
           "id": "027457c8d9de8a0993502567",
           "fingerprint": "5e5c7ca6443e2ded95921c9f",
           "item": "<module>",
-          "line": 27
+          "line": 28
         }
       ],
       "owner": "client",
@@ -11410,14 +11027,8 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "1aac66621242de14ad736b15",
-          "fingerprint": "f1fc06b9ed7e310b2e5e58c8",
-          "item": "enum MQConsumerInnerImplKind",
-          "line": 120
-        },
-        {
-          "id": "0823b68d5e17911a9de9913b",
-          "fingerprint": "9679a952d821217e49eebac3",
+          "id": "7ccb6ddb8bd16a34620a9c42",
+          "fingerprint": "4ab3ebd56cd2d51b4a965334",
           "item": "enum MQConsumerInnerImplKind",
           "line": 121
         },
@@ -11425,13 +11036,7 @@
           "id": "cf68039290630e3250d55dcf",
           "fingerprint": "91be699aa96ddbd9ebf19f0a",
           "item": "fn from_push",
-          "line": 125
-        },
-        {
-          "id": "41bd38c180b8f95e75d01678",
-          "fingerprint": "39458552378e0b26f7630457",
-          "item": "fn from_lite_pull",
-          "line": 131
+          "line": 126
         }
       ],
       "owner": "client",
@@ -11614,7 +11219,7 @@
           "id": "8aad077f5b625f95681f6f7a",
           "fingerprint": "bcd4673cf3e3e6c6a0abdb23",
           "item": "<module>",
-          "line": 31
+          "line": 32
         }
       ],
       "owner": "client",
@@ -11633,13 +11238,13 @@
           "id": "0d04a2e6dd833ba8a4d8b347",
           "fingerprint": "fb2f13eb48f737b1472c67ca",
           "item": "struct LocalFileOffsetStore",
-          "line": 80
+          "line": 81
         },
         {
           "id": "8cf27eb448946a4201687772",
           "fingerprint": "dd99b06743470ae418eee360",
           "item": "fn new",
-          "line": 206
+          "line": 207
         }
       ],
       "owner": "client",
@@ -11658,7 +11263,7 @@
           "id": "59807c8d6623ca5f3f02d2ae",
           "fingerprint": "c376fa2b00729a66e11e6866",
           "item": "mod tests",
-          "line": 348
+          "line": 344
         }
       ],
       "owner": "client",
@@ -11926,7 +11531,7 @@
           "id": "12323fc53263baaa9cdd8305",
           "fingerprint": "aacbd2b335a7bfd4cb2b9086",
           "item": "mod tests",
-          "line": 553
+          "line": 554
         }
       ],
       "owner": "client",
@@ -11945,7 +11550,7 @@
           "id": "bfe187691def8ad50fc44a62",
           "fingerprint": "cb91994093622f3409dc4661",
           "item": "fn client_with_push_consumer",
-          "line": 572
+          "line": 573
         },
         {
           "id": "0fc9059a0782007d0708c582",
@@ -12014,13 +11619,13 @@
           "id": "e06663e00e66ebec20720888",
           "fingerprint": "3564626651d9270d2dd7c046",
           "item": "fn client_with_push_consumer",
-          "line": 566
+          "line": 567
         },
         {
           "id": "85fb6469382b95c88c8b1d57",
           "fingerprint": "3b072b74264666bd571ab803",
           "item": "fn client_with_push_consumer",
-          "line": 566
+          "line": 567
         }
       ],
       "owner": "client",
@@ -12039,7 +11644,7 @@
           "id": "34a00e6c7ffbed57f563ef44",
           "fingerprint": "d398c79cbb283702319610e0",
           "item": "fn client_with_push_consumer",
-          "line": 583
+          "line": 584
         }
       ],
       "owner": "client",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8351

### Brief Description

- replace the Lite Pull consumer root `ArcMut` ownership with standard `Arc` and `Weak`
- serialize lifecycle and subscription control-plane transitions while keeping synchronous component locks out of await boundaries
- publish the rebalance offset store through `ArcSwapOption` and update the migration evidence/checklist

#### Motivation

The Lite Pull facade, callback, and scheduled-task root still depended on shared mutable compatibility ownership. That left a self-reference cycle and required callers to recover mutable access from shared references, blocking the M11-12 soundness closure target.

#### Solution

- store `Arc<DefaultLitePullConsumerImpl>` in the facade and consumer wrapper
- bind callbacks and pull tasks through `Weak<DefaultLitePullConsumerImpl>`
- add an async lifecycle transition mutex for start, shutdown, subscribe, assign, and unsubscribe transitions
- use short-lived synchronized snapshots for service state and runtime component slots
- preserve delayed rebalance runtime injection and existing public Lite Pull behavior
- reduce the reviewed ArcMut baseline from 668 identities / 1,838 occurrences to 657 identities / 1,796 occurrences

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- `cargo test -p rocketmq-client-rust default_lite_pull_consumer --lib --all-features`
- `cargo test -p rocketmq-client-rust --test public_api_exports_test crate_root_exports_modern_client_facades_and_traits --all-features`
- `cargo test -p rocketmq-client-rust --all-features --quiet`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard`
- `python scripts/arc_mut_guard.py --fixtures`
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- architecture dependency target/baseline, release guard, standalone consumers, and AGENTS routing checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Lite Pull consumer lifecycle management for safer concurrent start, shutdown, subscription, assignment, and hook operations.
  * Enhanced rebalance and offset-store handling for more reliable consumer coordination.

* **Bug Fixes**
  * Reduced lifecycle-related ownership and synchronization issues.
  * Updated internal progress tracking and validation evidence for the architecture migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->