### PR TITLE
[ISSUE #8357]♻️Replace Push subscription shared mutation with immutable snapshots

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -647,7 +647,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ac Client Lite Pull root lifecycle：facade、consumer inner、callback 与 task root 改用标准 `Arc`/`Weak`；专用异步 lifecycle mutex 串行 start/shutdown/订阅控制面，组件槽位使用短锁快照；Rebalance offset store 改为 `ArcSwapOption`
   - [x] M11-12ad Client PullAPIWrapper immutable access：Lite/Push wrapper owner 改用标准 `Arc`；运行参数使用原子发布、filter hook 使用 `ArcSwap` 整代快照，pull/POP/filter-server receiver 收窄为 `&self`
   - [x] M11-12ae Client Push message listener ownership：facade config、implementation 与 Java-compatible getter/setter 改持标准 `Arc<MessageListener>`，concurrent/orderly 注册与替换不再传播共享可变 wrapper
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355 与每次真实下降
+  - [x] M11-12af Client Push subscription snapshots：deprecated startup subscription map 改持标准 `Arc<HashMap>`，config/builder/Java-compatible getter/setter 返回 immutable owned snapshot；dynamic rebalance table 不变
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -679,7 +680,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8351 后实际快照降至 402 production/1,102 occurrence；Client crate 降至 85/210，Lite Pull root lifecycle 的 6 个 production identity、27 个 production occurrence 与 5 个 test identity、15 个 test occurrence 退出
   - [x] Issue #8353 后 production identity 保持 402、occurrence 降至 1,095；Client 为 85/203，PullAPIWrapper 的 7 个 production occurrence 与 1 个 test occurrence 退出共享可变边界
   - [x] Issue #8355 后 production identity 保持 402、occurrence 降至 1,086；Client 为 85/194，Push MessageListener 的 9 个 production occurrence 与 3 个 test occurrence 退出，1 个 test identity 删除
-  - [ ] M11-12af 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8357 后实际快照降至 400 production/1,078 occurrence；Client 降至 83/186，Push startup subscription snapshot 的 2 个 production identity/8 occurrence 与 1 个 test identity/1 occurrence 退出
+  - [ ] M11-12ag 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -367,6 +367,10 @@ Client Push message listener ownership 随 Issue #8355 将 facade config、imple
 中的 listener handle 改为标准 `Arc<MessageListener>`；concurrent/orderly 注册、替换和清除语义保持，公开 API 不再暴露
 共享可变 wrapper。实际快照为 402 production/1,086 occurrence，Client 为 85/194；剩余为 Broker 190/568、Client
 85/194 与 Store 127/324，总进度仍为 75/82，M11-12 父工作包未完成。
+Client Push subscription snapshots 随 Issue #8357 将 deprecated startup subscription map 改为标准
+`Arc<HashMap>`；config、builder 和 Java-compatible getter/setter 使用 immutable owned snapshot，启动时只读复制到
+独立 dynamic rebalance table。实际快照降至 400 production/1,078 occurrence，Client 降至 83/186；剩余为 Broker
+190/568、Client 83/186 与 Store 127/324，总进度仍为 75/82，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -381,6 +381,10 @@ M11-12ae 已将 Push facade config、implementation 与 Java-compatible getter/s
 标准 `Arc`；concurrent/orderly 注册、替换与清除语义保持。实际快照为 402 production/1,086 occurrences，Client
 为 85/194；其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12af 已将 Push deprecated startup subscription map 改为标准 `Arc<HashMap>`；config/builder/getter/setter 发布
+immutable owned snapshot，启动时只读复制到独立 dynamic rebalance table。实际快照降至 400 production/1,078
+occurrences，Client 降至 83/186；其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -1452,9 +1452,28 @@ M11-12ae 追加验证：
 | Push MessageListener ArcMut 定向扫描 | `ArcMut<MessageListener>` 与对应 constructor 零匹配；Push config/root 其余 owner 保留给后续切片 |
 | `git diff --check` | 通过 |
 
+M11-12af 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；Push subscription immutable snapshot、Lite compatibility conversion 与全部 target 编译通过 |
+| Push subscription focused tests | facade snapshot identity/旧代际不变与 implementation startup copy 各 1/1 通过 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 973/973，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline reduction | 2 个 production/Client identity/8 occurrence 与 1 个 test identity/1 occurrence 真实删除；无新增和 relocation；baseline 656/1,776→653/1,767 |
+| `python scripts/arc_mut_guard.py` | 通过；production 400/1,078，Client 83/186，tracked/reviewed semantic set 1,767/1,767 一致 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；startup snapshot 只读 clone/iterate，不跨 await 持有同步 guard，未新增 task/runtime/blocking 边界 |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Push subscription ArcMut 定向扫描 | `ArcMut<HashMap<CheetahString, CheetahString>>` 与 subscription constructor 零匹配；dynamic rebalance subscription table 保持独立 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（85/194）。
+1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（83/186）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -401,7 +401,7 @@ impl LitePullConsumerConfig {
             consume_from_where: self.consume_from_where,
             consume_timestamp: self.consume_timestamp.clone(),
             allocate_message_queue_strategy: Some(self.allocate_message_queue_strategy.clone()),
-            subscription: ArcMut::new(HashMap::new()),
+            subscription: Arc::new(HashMap::new()),
             message_listener: None,
             message_queue_listener: None,
             offset_store: None,

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -2706,4 +2706,23 @@ mod tests {
         assert_eq!(offset_store.test_persisted_offset(&mq), Some(321));
         assert_eq!(offset_store.test_persist_all_count(), 2);
     }
+
+    #[tokio::test]
+    async fn copy_subscription_reads_immutable_config_snapshot() {
+        let topic = CheetahString::from_static_str("TopicSnapshotCopy");
+        let expression = CheetahString::from_static_str("TagA || TagB");
+        let mut consumer = new_check_config_consumer(None);
+        consumer.consumer_config.subscription = Arc::new(HashMap::from([(topic.clone(), expression.clone())]));
+
+        consumer
+            .copy_subscription()
+            .await
+            .expect("subscription snapshot should copy into rebalance state");
+
+        let subscriptions = consumer.rebalance_impl.get_subscription_inner();
+        let copied = subscriptions
+            .get(&topic)
+            .expect("configured topic should be present after copy");
+        assert_eq!(copied.sub_string, expression);
+    }
 }

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -67,7 +67,7 @@ pub struct ConsumerConfig {
     pub(crate) consume_timestamp: Option<CheetahString>,
     pub(crate) allocate_message_queue_strategy: Option<Arc<dyn AllocateMessageQueueStrategy>>,
     //this field will be removed in a certain version after April 5, 2020
-    pub(crate) subscription: ArcMut<HashMap<CheetahString, CheetahString>>,
+    pub(crate) subscription: Arc<HashMap<CheetahString, CheetahString>>,
     pub(crate) message_listener: Option<Arc<MessageListener>>,
     pub(crate) message_queue_listener: Option<ArcMessageQueueListener>,
     pub(crate) offset_store: Option<Arc<OffsetStore>>,
@@ -118,8 +118,8 @@ impl ConsumerConfig {
         self.allocate_message_queue_strategy.clone()
     }
 
-    pub fn subscription(&self) -> &ArcMut<HashMap<CheetahString, CheetahString>> {
-        &self.subscription
+    pub fn subscription(&self) -> Arc<HashMap<CheetahString, CheetahString>> {
+        self.subscription.clone()
     }
 
     /*    pub fn message_listener(&self) -> &Option<Arc<MessageListener>> {
@@ -294,7 +294,7 @@ impl ConsumerConfig {
      * This method will be removed in a certain version after April 5, 2020, so please do not
      * use this method.
      */
-    pub fn set_subscription(&mut self, subscription: ArcMut<HashMap<CheetahString, CheetahString>>) {
+    pub fn set_subscription(&mut self, subscription: Arc<HashMap<CheetahString, CheetahString>>) {
         self.subscription = subscription;
     }
 
@@ -422,7 +422,7 @@ impl Default for ConsumerConfig {
                 (current_millis() - (1000 * 60 * 30)) as i64,
             ))),
             allocate_message_queue_strategy: Some(Arc::new(AllocateMessageQueueAveragely)),
-            subscription: ArcMut::new(HashMap::new()),
+            subscription: Arc::new(HashMap::new()),
             message_listener: None,
             message_queue_listener: None,
             offset_store: None,
@@ -1010,8 +1010,8 @@ impl DefaultMQPushConsumer {
         self.consumer_group()
     }
 
-    pub fn get_subscription(&self) -> &ArcMut<HashMap<CheetahString, CheetahString>> {
-        &self.consumer_config.subscription
+    pub fn get_subscription(&self) -> Arc<HashMap<CheetahString, CheetahString>> {
+        self.consumer_config.subscription()
     }
 
     #[inline]
@@ -1632,6 +1632,32 @@ mod tests {
 
         assert!(consumer.message_listener().is_none());
         assert!(consumer.consumer_config.message_listener.is_none());
+    }
+
+    #[test]
+    fn push_subscription_facade_preserves_owned_snapshot_identity() {
+        let mut consumer = DefaultMQPushConsumer::builder()
+            .consumer_group("push_subscription_snapshot_group")
+            .build();
+        let first_snapshot = Arc::new(HashMap::from([(
+            CheetahString::from_static_str("TopicSnapshot"),
+            CheetahString::from_static_str("TagA"),
+        )]));
+
+        consumer.consumer_config.set_subscription(first_snapshot.clone());
+
+        let observed = consumer.get_subscription();
+        assert!(Arc::ptr_eq(&first_snapshot, &observed));
+        assert_eq!(observed.get("TopicSnapshot").map(CheetahString::as_str), Some("TagA"));
+
+        let second_snapshot = Arc::new(HashMap::new());
+        consumer.consumer_config.set_subscription(second_snapshot.clone());
+
+        assert!(Arc::ptr_eq(&second_snapshot, &consumer.get_subscription()));
+        assert_eq!(
+            first_snapshot.get("TopicSnapshot").map(CheetahString::as_str),
+            Some("TagA")
+        );
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
@@ -19,7 +19,6 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
@@ -37,7 +36,7 @@ pub struct DefaultMQPushConsumerBuilder {
     consume_from_where: Option<ConsumeFromWhere>,
     consume_timestamp: Option<CheetahString>,
     allocate_message_queue_strategy: Option<Arc<dyn AllocateMessageQueueStrategy>>,
-    subscription: Option<ArcMut<HashMap<CheetahString, CheetahString>>>,
+    subscription: Option<Arc<HashMap<CheetahString, CheetahString>>>,
 
     message_queue_listener: Option<ArcMessageQueueListener>,
 

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -9245,12 +9245,6 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "126c94c81e0a61ee9b1da2d9",
-          "fingerprint": "8e63f64e890a4e18ec5155d0",
-          "item": "fn to_consumer_config",
-          "line": 404
-        },
-        {
           "id": "19983da6a29ced80471c529c",
           "fingerprint": "91c09c442fee0f8ccff25fc0",
           "item": "fn new",
@@ -10657,12 +10651,6 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "b55454ca12c76495ed769a1d",
-          "fingerprint": "5dd0cf2f350e3a806d87ebf5",
-          "item": "fn default",
-          "line": 425
-        },
-        {
           "id": "193975bf1b4d9fc7783cbb1a",
           "fingerprint": "ea3b5033b309243a6ce382c7",
           "item": "fn new",
@@ -10707,24 +10695,6 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "5c58395a184ac4650e515ad1",
-          "fingerprint": "db40f275e31e87b4ab40da9a",
-          "item": "struct ConsumerConfig",
-          "line": 70
-        },
-        {
-          "id": "8a705a9b473fef5e34f7fee0",
-          "fingerprint": "3f9e056e9c329f84fa2d52ae",
-          "item": "fn subscription",
-          "line": 121
-        },
-        {
-          "id": "db548bccb442ea5423709787",
-          "fingerprint": "4acd9a82716ad04f75fc515e",
-          "item": "fn set_subscription",
-          "line": 297
-        },
-        {
           "id": "8e71dee88535713cc61a8f8f",
           "fingerprint": "6ac2314c35eecc84209c55e1",
           "item": "struct DefaultMQPushConsumer",
@@ -10759,12 +10729,6 @@
           "fingerprint": "cf650ba060bcd7e822754772",
           "item": "fn get_default_mq_push_consumer_impl",
           "line": 928
-        },
-        {
-          "id": "315000fd48a55b2e44f231e8",
-          "fingerprint": "212e374c20456f6e1aa1a2dc",
-          "item": "fn get_subscription",
-          "line": 1013
         }
       ],
       "owner": "client",
@@ -10788,63 +10752,6 @@
       ],
       "owner": "client",
       "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "522d5235db4f255b7517ae30",
-      "path": "rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "2b93456d3501179a753283c6",
-          "fingerprint": "50ff3d9c6e4a7c50a2a55b12",
-          "item": "mod tests",
-          "line": 393
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "0a8f4444cacca1dea958571f",
-      "path": "rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "150b2ed79460ffcb2869cbaf",
-          "fingerprint": "cd821fcf8ab820780f893e90",
-          "item": "<module>",
-          "line": 22
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "d5f9f89e1b820d8ac843e9e3",
-      "path": "rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "360b2665391d5b72a7a961a2",
-          "fingerprint": "e4206814ceac7354d2fcea71",
-          "item": "struct DefaultMQPushConsumerBuilder",
-          "line": 40
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8357

### Brief Description

- replace the deprecated Push startup subscription `ArcMut<HashMap<...>>` with an immutable `Arc<HashMap<...>>` snapshot
- update configuration, builder, getter/setter, and Lite compatibility conversion paths
- keep the dynamic rebalance subscription table and runtime subscribe behavior unchanged
- add regressions for Arc snapshot identity, old-generation stability, and startup copying into rebalance state
- update the M11-12 checklist and reviewed ArcMut baseline without marking the 82-item architecture goal complete

The reviewed baseline drops from 656 identities / 1,776 occurrences to 653 identities / 1,767 occurrences. Production drops from 402 identities / 1,086 occurrences to 400 identities / 1,078 occurrences, and the Client crate drops from 85 identities / 194 occurrences to 83 identities / 186 occurrences.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- focused facade snapshot and implementation startup-copy tests (1 passed each)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (973 library tests and all integration targets passed; 35 existing external-environment tests ignored)
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard` (67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24 passed)
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- architecture dependency target/baseline, release guard, and AGENTS routing checks
- standalone Example and dashboard backends: required format, strict Clippy, and Web backend build checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Subscription configuration now uses immutable snapshots for safer access and consistent state management.
  * Push consumer startup copies subscription settings into its independent runtime state.
  * Subscription getters and builders now preserve configured snapshot values.

* **Tests**
  * Added coverage verifying subscription snapshots are copied correctly and retain their configured contents.

* **Documentation**
  * Updated architecture migration and production-readiness tracking with Issue `#8357` progress and revised completion counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->