### PR TITLE
[ISSUE #8359]♻️Replace Push consume service config mutation with startup snapshots

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -648,7 +648,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ad Client PullAPIWrapper immutable access：Lite/Push wrapper owner 改用标准 `Arc`；运行参数使用原子发布、filter hook 使用 `ArcSwap` 整代快照，pull/POP/filter-server receiver 收窄为 `&self`
   - [x] M11-12ae Client Push message listener ownership：facade config、implementation 与 Java-compatible getter/setter 改持标准 `Arc<MessageListener>`，concurrent/orderly 注册与替换不再传播共享可变 wrapper
   - [x] M11-12af Client Push subscription snapshots：deprecated startup subscription map 改持标准 `Arc<HashMap>`，config/builder/Java-compatible getter/setter 返回 immutable owned snapshot；dynamic rebalance table 不变
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357 与每次真实下降
+  - [x] M11-12ag Client Push consume service config snapshots：concurrent/orderly 与 POP concurrent/orderly 服务持有同一启动代的 immutable `Arc<ClientConfig>`/`Arc<ConsumerConfig>`，服务不再暴露配置共享写入口
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -681,7 +682,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8353 后 production identity 保持 402、occurrence 降至 1,095；Client 为 85/203，PullAPIWrapper 的 7 个 production occurrence 与 1 个 test occurrence 退出共享可变边界
   - [x] Issue #8355 后 production identity 保持 402、occurrence 降至 1,086；Client 为 85/194，Push MessageListener 的 9 个 production occurrence 与 3 个 test occurrence 退出，1 个 test identity 删除
   - [x] Issue #8357 后实际快照降至 400 production/1,078 occurrence；Client 降至 83/186，Push startup subscription snapshot 的 2 个 production identity/8 occurrence 与 1 个 test identity/1 occurrence 退出
-  - [ ] M11-12ag 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8359 后实际快照降至 398 production/1,054 occurrence；Client owner 降至 80/161，另有 Proxy 1/1；四类 Push consume service 配置的 2 个 production identity/24 occurrence 与 16 个 test occurrence 退出
+  - [ ] M11-12ah 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -371,6 +371,11 @@ Client Push subscription snapshots 随 Issue #8357 将 deprecated startup subscr
 `Arc<HashMap>`；config、builder 和 Java-compatible getter/setter 使用 immutable owned snapshot，启动时只读复制到
 独立 dynamic rebalance table。实际快照降至 400 production/1,078 occurrence，Client 降至 83/186；剩余为 Broker
 190/568、Client 83/186 与 Store 127/324，总进度仍为 75/82，M11-12 父工作包未完成。
+Client Push consume service config snapshots 随 Issue #8359 将 concurrent/orderly 与 POP concurrent/orderly 四类服务的
+`ClientConfig`/`ConsumerConfig` 改为启动时创建并成对注入的 immutable `Arc` 快照；服务内只读使用同一配置代际，仍需实时
+运行状态的 callback 继续通过 Push implementation owner 访问。实际快照降至 398 production/1,054 occurrence，Client owner
+降至 80/161，另有 Proxy 1/1；剩余为 Broker 190/568、Client 80/161、Proxy 1/1 与 Store 127/324，总进度仍为
+75/82，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -385,6 +385,11 @@ M11-12af 已将 Push deprecated startup subscription map 改为标准 `Arc<HashM
 immutable owned snapshot，启动时只读复制到独立 dynamic rebalance table。实际快照降至 400 production/1,078
 occurrences，Client 降至 83/186；其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12ag 已将 concurrent/orderly 与 POP concurrent/orderly 四类 Push consume service 的 client/consumer config 改为
+同一启动代的 immutable `Arc` 快照；服务不再持有配置共享写入口，callback 的实时 Push implementation owner 保持不变。
+实际快照降至 398 production/1,054 occurrences，Client owner 降至 80/161，另有 Proxy 1/1；其余 Client/Broker/Store、
+compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -1471,9 +1471,28 @@ M11-12af 追加验证：
 | Push subscription ArcMut 定向扫描 | `ArcMut<HashMap<CheetahString, CheetahString>>` 与 subscription constructor 零匹配；dynamic rebalance subscription table 保持独立 |
 | `git diff --check` | 通过 |
 
+M11-12ag 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；四类 Push consume service 的 immutable config snapshot 与全部 target 编译通过 |
+| Push consume service config focused tests | 同一启动代 `Arc` identity 1/1、orderly/POP-orderly namespace snapshot 2/2 通过 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 974/974，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline reduction（临时 ADR-013 approval） | 2 个 production identity/24 occurrence 与 16 个 test occurrence 真实删除；4 个同 path/symbol/kind/item 的保留 occurrence relocation 逐条审核，approval 不提交；baseline 653/1,767→651/1,727 |
+| `python scripts/arc_mut_guard.py` | 通过；production 398/1,054，Client owner 80/161，Proxy 1/1，tracked/reviewed semantic set 1,727/1,727 一致 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；启动快照在异步服务创建前完成，未新增 task/runtime/blocking 边界或跨 await 同步 guard |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Push service config ArcMut 定向扫描 | 四个服务的 `ArcMut<ClientConfig>`/`ArcMut<ConsumerConfig>` 字段与 constructor 参数零匹配；实时 Push implementation owner 保留给后续切片 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（83/186）。
+1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（Client owner 80/161，另有 Proxy 1/1）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -59,8 +59,8 @@ use crate::runtime::ClientTrackedTaskHandle;
 
 pub struct ConsumeMessageConcurrentlyService {
     pub(crate) default_mqpush_consumer_impl: RwLock<Option<ArcMut<DefaultMQPushConsumerImpl>>>,
-    pub(crate) client_config: ArcMut<ClientConfig>,
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) client_config: Arc<ClientConfig>,
+    pub(crate) consumer_config: Arc<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcMessageListenerConcurrently,
     /// Semaphore used for two purposes:
@@ -169,8 +169,8 @@ fn spawn_tracked_concurrent_task<F>(
 
 impl ConsumeMessageConcurrentlyService {
     pub fn new(
-        client_config: ArcMut<ClientConfig>,
-        consumer_config: ArcMut<ConsumerConfig>,
+        client_config: Arc<ClientConfig>,
+        consumer_config: Arc<ConsumerConfig>,
         consumer_group: CheetahString,
         message_listener: ArcMessageListenerConcurrently,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -375,7 +375,7 @@ impl ConsumeMessageConcurrentlyService {
 
     pub async fn send_message_back(&self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
         let delay_level = context.delay_level_when_next_consume;
-        let mut client_config = self.client_config.clone();
+        let mut client_config = (*self.client_config).clone();
         msg.set_topic(client_config.with_namespace(msg.topic().as_str()));
 
         let Some(mut default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl.read().clone() else {
@@ -917,15 +917,15 @@ pub async fn run_concurrent_clean_expire_lifecycle_probe() -> ConcurrentCleanExp
             Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
         });
     let service = ConsumeMessageConcurrentlyService::new(
-        ArcMut::new(ClientConfig::default()),
-        ArcMut::new(ConsumerConfig::default()),
+        Arc::new(ClientConfig::default()),
+        Arc::new(ConsumerConfig::default()),
         CheetahString::from_static_str("concurrent-clean-expire-probe"),
         listener.clone(),
         None,
     );
     let this = Arc::new(ConsumeMessageConcurrentlyService::new(
-        ArcMut::new(ClientConfig::default()),
-        ArcMut::new(ConsumerConfig::default()),
+        Arc::new(ClientConfig::default()),
+        Arc::new(ConsumerConfig::default()),
         CheetahString::from_static_str("concurrent-clean-expire-probe"),
         listener,
         None,
@@ -978,8 +978,8 @@ mod tests {
 
     fn new_service(default_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>) -> ConsumeMessageConcurrentlyService {
         ConsumeMessageConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
+            Arc::new(ClientConfig::default()),
+            Arc::new(ConsumerConfig::default()),
             consumer_group(),
             listener(),
             default_impl,
@@ -988,12 +988,28 @@ mod tests {
 
     fn new_service_with_config(consumer_config: ConsumerConfig) -> ConsumeMessageConcurrentlyService {
         ConsumeMessageConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(consumer_config),
+            Arc::new(ClientConfig::default()),
+            Arc::new(consumer_config),
             consumer_group(),
             listener(),
             None,
         )
+    }
+
+    #[test]
+    fn service_keeps_shared_startup_config_generation() {
+        let client_config = Arc::new(ClientConfig::default());
+        let consumer_config = Arc::new(ConsumerConfig::default());
+        let service = ConsumeMessageConcurrentlyService::new(
+            client_config.clone(),
+            consumer_config.clone(),
+            consumer_group(),
+            listener(),
+            None,
+        );
+
+        assert!(Arc::ptr_eq(&client_config, &service.client_config));
+        assert!(Arc::ptr_eq(&consumer_config, &service.consumer_config));
     }
 
     fn new_default_impl() -> ArcMut<DefaultMQPushConsumerImpl> {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -72,8 +72,8 @@ static MAX_TIME_CONSUME_CONTINUOUSLY: LazyLock<u64> = LazyLock::new(|| {
 
 pub struct ConsumeMessageOrderlyService {
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
-    pub(crate) client_config: ArcMut<ClientConfig>,
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) client_config: Arc<ClientConfig>,
+    pub(crate) consumer_config: Arc<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcMessageListenerOrderly,
     pub(crate) stopped: Arc<AtomicBool>,
@@ -161,8 +161,8 @@ fn spawn_tracked_orderly_task<F>(
 
 impl ConsumeMessageOrderlyService {
     pub fn new(
-        client_config: ArcMut<ClientConfig>,
-        consumer_config: ArcMut<ConsumerConfig>,
+        client_config: Arc<ClientConfig>,
+        consumer_config: Arc<ConsumerConfig>,
         consumer_group: CheetahString,
         message_listener: ArcMessageListenerOrderly,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -1169,8 +1169,8 @@ pub async fn run_orderly_lock_periodic_lifecycle_probe() -> OrderlyLockPeriodicL
     let listener: ArcMessageListenerOrderly =
         Arc::new(|_msgs: &[&MessageExt], _context: &mut ConsumeOrderlyContext| Ok(ConsumeOrderlyStatus::Success));
     let service = Arc::new(ConsumeMessageOrderlyService::new(
-        ArcMut::new(ClientConfig::default()),
-        ArcMut::new(consumer_config),
+        Arc::new(ClientConfig::default()),
+        Arc::new(consumer_config),
         CheetahString::from_static_str("orderly_lock_periodic_probe_group"),
         listener,
         None,
@@ -1245,8 +1245,8 @@ mod tests {
 
     fn new_service(default_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>) -> ConsumeMessageOrderlyService {
         ConsumeMessageOrderlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
+            Arc::new(ClientConfig::default()),
+            Arc::new(ConsumerConfig::default()),
             consumer_group(),
             listener(),
             default_impl,
@@ -1255,8 +1255,18 @@ mod tests {
 
     fn new_service_with_config(consumer_config: ConsumerConfig) -> ConsumeMessageOrderlyService {
         ConsumeMessageOrderlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(consumer_config),
+            Arc::new(ClientConfig::default()),
+            Arc::new(consumer_config),
+            consumer_group(),
+            listener(),
+            None,
+        )
+    }
+
+    fn new_service_with_client_config(client_config: ClientConfig) -> ConsumeMessageOrderlyService {
+        ConsumeMessageOrderlyService::new(
+            Arc::new(client_config),
+            Arc::new(ConsumerConfig::default()),
             consumer_group(),
             listener(),
             None,
@@ -1445,10 +1455,9 @@ mod tests {
 
     #[test]
     fn reset_namespace_removes_configured_namespace_like_java() {
-        let mut service = new_service(None);
-        service
-            .client_config
-            .set_namespace(CheetahString::from_static_str("ns"));
+        let mut client_config = ClientConfig::default();
+        client_config.set_namespace(CheetahString::from_static_str("ns"));
+        let service = new_service_with_client_config(client_config);
         let mut msg = MessageExt::default();
         msg.set_topic(CheetahString::from_static_str("ns%topic-a"));
         let mut msgs = vec![Arc::new(msg)];

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -82,8 +82,8 @@ fn spawn_tracked_pop_concurrent_task<F>(
 
 pub struct ConsumeMessagePopConcurrentlyService {
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
-    pub(crate) client_config: ArcMut<ClientConfig>,
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) client_config: Arc<ClientConfig>,
+    pub(crate) consumer_config: Arc<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcMessageListenerConcurrently,
     pub(crate) stopped: Arc<AtomicBool>,
@@ -97,8 +97,8 @@ pub struct ConsumeMessagePopConcurrentlyService {
 
 impl ConsumeMessagePopConcurrentlyService {
     pub fn new(
-        client_config: ArcMut<ClientConfig>,
-        consumer_config: ArcMut<ConsumerConfig>,
+        client_config: Arc<ClientConfig>,
+        consumer_config: Arc<ConsumerConfig>,
         consumer_group: CheetahString,
         message_listener: ArcMessageListenerConcurrently,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -934,8 +934,8 @@ mod tests {
 
     fn new_service(default_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>) -> ConsumeMessagePopConcurrentlyService {
         ConsumeMessagePopConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
+            Arc::new(ClientConfig::default()),
+            Arc::new(ConsumerConfig::default()),
             consumer_group(),
             listener(),
             default_impl,
@@ -944,8 +944,8 @@ mod tests {
 
     fn new_service_with_config(consumer_config: ConsumerConfig) -> ConsumeMessagePopConcurrentlyService {
         ConsumeMessagePopConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(consumer_config),
+            Arc::new(ClientConfig::default()),
+            Arc::new(consumer_config),
             consumer_group(),
             listener(),
             None,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -64,8 +64,8 @@ use crate::runtime::ClientScheduledTaskHandle;
 
 pub struct ConsumeMessagePopOrderlyService {
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
-    pub(crate) client_config: ArcMut<ClientConfig>,
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) client_config: Arc<ClientConfig>,
+    pub(crate) consumer_config: Arc<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcMessageListenerOrderly,
     pub(crate) concurrency_limiter: Arc<Semaphore>,
@@ -198,8 +198,8 @@ fn record_orderly_process_event<E>(
 
 impl ConsumeMessagePopOrderlyService {
     pub fn new(
-        client_config: ArcMut<ClientConfig>,
-        consumer_config: ArcMut<ConsumerConfig>,
+        client_config: Arc<ClientConfig>,
+        consumer_config: Arc<ConsumerConfig>,
         consumer_group: CheetahString,
         message_listener: ArcMessageListenerOrderly,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -948,8 +948,8 @@ pub async fn run_pop_orderly_lock_refresh_lifecycle_probe() -> PopOrderlyLockRef
     let listener: ArcMessageListenerOrderly =
         Arc::new(|_msgs: &[&MessageExt], _context: &mut ConsumeOrderlyContext| Ok(ConsumeOrderlyStatus::Success));
     let service = Arc::new(ConsumeMessagePopOrderlyService::new(
-        ArcMut::new(ClientConfig::default()),
-        ArcMut::new(ConsumerConfig {
+        Arc::new(ClientConfig::default()),
+        Arc::new(ConsumerConfig {
             message_model: MessageModel::Clustering,
             ..Default::default()
         }),
@@ -1032,8 +1032,8 @@ mod tests {
 
     fn new_service(default_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>) -> ConsumeMessagePopOrderlyService {
         ConsumeMessagePopOrderlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
+            Arc::new(ClientConfig::default()),
+            Arc::new(ConsumerConfig::default()),
             CheetahString::from_static_str("group"),
             listener(),
             default_impl,
@@ -1042,8 +1042,18 @@ mod tests {
 
     fn new_service_with_config(consumer_config: ConsumerConfig) -> ConsumeMessagePopOrderlyService {
         ConsumeMessagePopOrderlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(consumer_config),
+            Arc::new(ClientConfig::default()),
+            Arc::new(consumer_config),
+            CheetahString::from_static_str("group"),
+            listener(),
+            None,
+        )
+    }
+
+    fn new_service_with_client_config(client_config: ClientConfig) -> ConsumeMessagePopOrderlyService {
+        ConsumeMessagePopOrderlyService::new(
+            Arc::new(client_config),
+            Arc::new(ConsumerConfig::default()),
             CheetahString::from_static_str("group"),
             listener(),
             None,
@@ -1201,10 +1211,9 @@ mod tests {
 
     #[test]
     fn reset_namespace_removes_configured_namespace_like_java() {
-        let mut service = new_service(None);
-        service
-            .client_config
-            .set_namespace(CheetahString::from_static_str("ns"));
+        let mut client_config = ClientConfig::default();
+        client_config.set_namespace(CheetahString::from_static_str("ns"));
+        let service = new_service_with_client_config(client_config);
         let mut msg = MessageExt::default();
         msg.set_topic(CheetahString::from_static_str("ns%topic-a"));
         let mut msgs = vec![Arc::new(msg)];

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -301,12 +301,14 @@ impl DefaultMQPushConsumerImpl {
                     .await?;
 
                 if let Some(message_listener) = self.message_listener.as_ref() {
+                    let client_config_snapshot = Arc::new(self.client_config.as_ref().clone());
+                    let consumer_config_snapshot = Arc::new(self.consumer_config.as_ref().clone());
                     if let Some(listener) = message_listener.message_listener_concurrently.clone() {
                         self.consume_orderly = false;
                         let consume_message_concurrently_service = Arc::new(ConsumeMessageConcurrentlyService::new(
-                            self.client_config.clone(),
-                            self.consumer_config.clone(),
-                            self.consumer_config.consumer_group.clone(),
+                            client_config_snapshot.clone(),
+                            consumer_config_snapshot.clone(),
+                            consumer_config_snapshot.consumer_group.clone(),
                             listener.clone(),
                             self.default_mqpush_consumer_impl.clone(),
                         ));
@@ -316,9 +318,9 @@ impl DefaultMQPushConsumerImpl {
                         )));
                         let consume_message_pop_concurrently_service =
                             Arc::new(ConsumeMessagePopConcurrentlyService::new(
-                                self.client_config.clone(),
-                                self.consumer_config.clone(),
-                                self.consumer_config.consumer_group.clone(),
+                                client_config_snapshot.clone(),
+                                consumer_config_snapshot.clone(),
+                                consumer_config_snapshot.consumer_group.clone(),
                                 listener.clone(),
                                 self.default_mqpush_consumer_impl.clone(),
                             ));
@@ -330,9 +332,9 @@ impl DefaultMQPushConsumerImpl {
                     } else if let Some(listener) = message_listener.message_listener_orderly.clone() {
                         self.consume_orderly = true;
                         let consume_message_orderly_service = Arc::new(ConsumeMessageOrderlyService::new(
-                            self.client_config.clone(),
-                            self.consumer_config.clone(),
-                            self.consumer_config.consumer_group.clone(),
+                            client_config_snapshot.clone(),
+                            consumer_config_snapshot.clone(),
+                            consumer_config_snapshot.consumer_group.clone(),
                             listener.clone(),
                             self.default_mqpush_consumer_impl.clone(),
                         ));
@@ -342,9 +344,9 @@ impl DefaultMQPushConsumerImpl {
                         )));
 
                         let consume_message_pop_orderly_service = Arc::new(ConsumeMessagePopOrderlyService::new(
-                            self.client_config.clone(),
-                            self.consumer_config.clone(),
-                            self.consumer_config.consumer_group.clone(),
+                            client_config_snapshot,
+                            consumer_config_snapshot.clone(),
+                            consumer_config_snapshot.consumer_group.clone(),
                             listener,
                             self.default_mqpush_consumer_impl.clone(),
                         ));

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8440,43 +8440,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "4e16cfb29966b0bf0c634536",
-      "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8ad31a3a92d7e1a176d55d1e",
-          "fingerprint": "51172e9f86c50f5863a1c645",
-          "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 920
-        },
-        {
-          "id": "8322fa3ba1ba104e5e38248c",
-          "fingerprint": "e819127ded0a53214243199f",
-          "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 921
-        },
-        {
-          "id": "ff472046edb7d6a6b054d8b9",
-          "fingerprint": "3957c353a9502e4945cf90e2",
-          "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 927
-        },
-        {
-          "id": "ec44084d51402012db29076f",
-          "fingerprint": "e819127ded0a53214243199f",
-          "item": "fn run_concurrent_clean_expire_lifecycle_probe",
-          "line": 928
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "c1dfaac6abe8b4630bc1d63c",
       "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs",
       "symbol": "ArcMut",
@@ -8484,40 +8447,16 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "6aada219a42808342d4fbaa9",
-          "fingerprint": "eed881129fbed7094c7aeb13",
-          "item": "fn new_service",
-          "line": 981
-        },
-        {
-          "id": "a63b8d8e4929c8817881b034",
-          "fingerprint": "68bc0512d894fd2b48d17044",
-          "item": "fn new_service",
-          "line": 982
-        },
-        {
-          "id": "9d55ce4f911e3cb2c72dfeed",
-          "fingerprint": "9695c16a5581883b671e91ce",
-          "item": "fn new_service_with_config",
-          "line": 991
-        },
-        {
-          "id": "1db7db161f920819c96f36ef",
-          "fingerprint": "fa7158b7744b0768dfb0b62d",
-          "item": "fn new_service_with_config",
-          "line": 992
-        },
-        {
           "id": "2e7db1fe25d3001e20084815",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1000
+          "line": 1016
         },
         {
           "id": "8e0f379e11cd82d30e67061f",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1001
+          "line": 1017
         }
       ],
       "owner": "client",
@@ -8558,30 +8497,6 @@
           "line": 61
         },
         {
-          "id": "7554b36ec18cd855a5f4eb5f",
-          "fingerprint": "246ae2c35596bf1bc3de9e25",
-          "item": "struct ConsumeMessageConcurrentlyService",
-          "line": 62
-        },
-        {
-          "id": "9f2321397d7fc87879d18a58",
-          "fingerprint": "2915b3e70b8157bbb1bd46fe",
-          "item": "struct ConsumeMessageConcurrentlyService",
-          "line": 63
-        },
-        {
-          "id": "2f952224cae8d943d2fedcb0",
-          "fingerprint": "88aaa77a5afbf17e91f706f4",
-          "item": "fn new",
-          "line": 172
-        },
-        {
-          "id": "2584698360cdacfe849f092f",
-          "fingerprint": "04f7ecd145e06a99478169c6",
-          "item": "fn new",
-          "line": 173
-        },
-        {
           "id": "a35e4b88f4a41117e16a2c1c",
           "fingerprint": "de69f197a63f9b84d00d9039",
           "item": "fn new",
@@ -8613,16 +8528,16 @@
           "line": 979
         },
         {
-          "id": "23e7c0532a746bf500553e10",
-          "fingerprint": "22ba5d0e667e1887b6bfc489",
+          "id": "4efb653e857c11af2acf2a58",
+          "fingerprint": "b53445f0cb22b4e4b0ce5998",
           "item": "fn new_default_impl",
-          "line": 999
+          "line": 1015
         },
         {
           "id": "853bd6d7d34667b9c5f76a23",
           "fingerprint": "03aa5a8d5e767064d7a2b302",
           "item": "fn consume_request",
-          "line": 1008
+          "line": 1024
         }
       ],
       "owner": "client",
@@ -8650,31 +8565,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "04bc4b293076c92fc6c7e5a5",
-      "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "55f56820c5fb78e85d207151",
-          "fingerprint": "5be3bf7916f77d342447d184",
-          "item": "fn run_orderly_lock_periodic_lifecycle_probe",
-          "line": 1172
-        },
-        {
-          "id": "6cc1e5e3486681c6a57a0dd5",
-          "fingerprint": "eafeddae152105f084f9c7f5",
-          "item": "fn run_orderly_lock_periodic_lifecycle_probe",
-          "line": 1173
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "c6304d3d9be4581300d5d3ed",
       "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs",
       "symbol": "ArcMut",
@@ -8682,40 +8572,16 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "9a6409e14bda0667ae737b04",
-          "fingerprint": "3c814ca718bf7b3e8e63db40",
-          "item": "fn new_service",
-          "line": 1248
-        },
-        {
-          "id": "00ee094afc40eda94ad40d7f",
-          "fingerprint": "68bc0512d894fd2b48d17044",
-          "item": "fn new_service",
-          "line": 1249
-        },
-        {
-          "id": "c167a03f80e4e27478c325eb",
-          "fingerprint": "1ce254da35d4167cfe84e79e",
-          "item": "fn new_service_with_config",
-          "line": 1258
-        },
-        {
-          "id": "76e55e8356db619468b61505",
-          "fingerprint": "fa7158b7744b0768dfb0b62d",
-          "item": "fn new_service_with_config",
-          "line": 1259
-        },
-        {
           "id": "1a496aa3f91bed37868ef8ad",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1267
+          "line": 1277
         },
         {
           "id": "8f62eaad6c779e9b14de98ba",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1268
+          "line": 1278
         }
       ],
       "owner": "client",
@@ -8750,34 +8616,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "b984f14f067eecdf57c0ffd0",
-          "fingerprint": "ce3e8cda69f533359d0b6474",
+          "id": "370bb2400b369014030af918",
+          "fingerprint": "79711c16ce8e7f87322f3591",
           "item": "struct ConsumeMessageOrderlyService",
           "line": 74
-        },
-        {
-          "id": "ff9b5e0bad709cbedd13a7c1",
-          "fingerprint": "4348ece83164d36a00cfc201",
-          "item": "struct ConsumeMessageOrderlyService",
-          "line": 75
-        },
-        {
-          "id": "27df449543490c8860abdaf2",
-          "fingerprint": "2915b3e70b8157bbb1bd46fe",
-          "item": "struct ConsumeMessageOrderlyService",
-          "line": 76
-        },
-        {
-          "id": "14eb72c8d93282dd8a8c4278",
-          "fingerprint": "fc0c9d3f24e2219ae9ded675",
-          "item": "fn new",
-          "line": 164
-        },
-        {
-          "id": "09d9802e42e2ef3aa4d590c5",
-          "fingerprint": "c8f1df0179979f3ca5a5a712",
-          "item": "fn new",
-          "line": 165
         },
         {
           "id": "6b014a5281d01d483ce0584f",
@@ -8814,7 +8656,7 @@
           "id": "00166e76656692a1220a9089",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 1266
+          "line": 1276
         }
       ],
       "owner": "client",
@@ -8848,30 +8690,6 @@
       "kind": "constructor",
       "category": "test",
       "occurrences": [
-        {
-          "id": "764bbb13f697f2cda49f8e9c",
-          "fingerprint": "c3fa90ce6e87a410a76d43a4",
-          "item": "fn new_service",
-          "line": 937
-        },
-        {
-          "id": "8518515c40dcfe994db94922",
-          "fingerprint": "68bc0512d894fd2b48d17044",
-          "item": "fn new_service",
-          "line": 938
-        },
-        {
-          "id": "0fabf48ed981b6b6b0fbbf72",
-          "fingerprint": "93e2e547427fcc125b0d19a3",
-          "item": "fn new_service_with_config",
-          "line": 947
-        },
-        {
-          "id": "3b3d72ba84b4f064a6e65657",
-          "fingerprint": "fa7158b7744b0768dfb0b62d",
-          "item": "fn new_service_with_config",
-          "line": 948
-        },
         {
           "id": "3fb465fd60b54bb643f43bb2",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
@@ -8917,34 +8735,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "83f20de569baac6ab3bf9766",
-          "fingerprint": "effbdb10d3e9e4920e39956c",
+          "id": "ac007509c95e381f9bb21e27",
+          "fingerprint": "728632a0d546f5bd6422bb0a",
           "item": "struct ConsumeMessagePopConcurrentlyService",
           "line": 84
-        },
-        {
-          "id": "29ceb5a4f785c57fdcae8572",
-          "fingerprint": "4348ece83164d36a00cfc201",
-          "item": "struct ConsumeMessagePopConcurrentlyService",
-          "line": 85
-        },
-        {
-          "id": "5f0854835a700874b04e9333",
-          "fingerprint": "2915b3e70b8157bbb1bd46fe",
-          "item": "struct ConsumeMessagePopConcurrentlyService",
-          "line": 86
-        },
-        {
-          "id": "3e26ec608e86a67e72027bd8",
-          "fingerprint": "c6cc97ab99b5b3ee203c7dab",
-          "item": "fn new",
-          "line": 100
-        },
-        {
-          "id": "0e89f50770bc2376a31882ad",
-          "fingerprint": "04f7ecd145e06a99478169c6",
-          "item": "fn new",
-          "line": 101
         },
         {
           "id": "1f895e71e3f3ec4897d4a964",
@@ -9032,18 +8826,6 @@
           "fingerprint": "4f6d9f1992841d3e22006a60",
           "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
           "line": 942
-        },
-        {
-          "id": "060c5d4ea57dbd3b21b88572",
-          "fingerprint": "bc57a8a3334772e3e5602fa0",
-          "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 951
-        },
-        {
-          "id": "9d10e6188eb3bf00306b6c46",
-          "fingerprint": "1cb62e0a922c1b1b9e1389c9",
-          "item": "fn run_pop_orderly_lock_refresh_lifecycle_probe",
-          "line": 952
         }
       ],
       "owner": "client",
@@ -9059,40 +8841,16 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "96dd8ab72348a0d1ab825867",
-          "fingerprint": "19460e0e17224b2b99882301",
-          "item": "fn new_service",
-          "line": 1035
-        },
-        {
-          "id": "4608f63cde464711ba9a69db",
-          "fingerprint": "e819127ded0a53214243199f",
-          "item": "fn new_service",
-          "line": 1036
-        },
-        {
-          "id": "c4dc0dee06e594ac63834649",
-          "fingerprint": "70d20c8c1320eec80fd06728",
-          "item": "fn new_service_with_config",
-          "line": 1045
-        },
-        {
-          "id": "5962452b0149b8e346834cf3",
-          "fingerprint": "eafeddae152105f084f9c7f5",
-          "item": "fn new_service_with_config",
-          "line": 1046
-        },
-        {
           "id": "399a0b0d4ea9290a77cb3354",
           "fingerprint": "ccabcb8e108c8f037650d8b0",
           "item": "fn new_default_impl",
-          "line": 1054
+          "line": 1064
         },
         {
           "id": "53d1df91c3b973f73a9aaaee",
           "fingerprint": "e814df7f243d4c035faada56",
           "item": "fn new_default_impl",
-          "line": 1055
+          "line": 1065
         }
       ],
       "owner": "client",
@@ -9127,34 +8885,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "3fa023c3b2b3576f1ee2274d",
-          "fingerprint": "a733ddd87f251b62629ac17f",
+          "id": "4059d71ec8c3f32bbf6a5718",
+          "fingerprint": "b64325a840342b167f92c7bf",
           "item": "struct ConsumeMessagePopOrderlyService",
           "line": 66
-        },
-        {
-          "id": "309caddac8ade1f970067329",
-          "fingerprint": "4348ece83164d36a00cfc201",
-          "item": "struct ConsumeMessagePopOrderlyService",
-          "line": 67
-        },
-        {
-          "id": "162ff9819c17de7ba64ae086",
-          "fingerprint": "2915b3e70b8157bbb1bd46fe",
-          "item": "struct ConsumeMessagePopOrderlyService",
-          "line": 68
-        },
-        {
-          "id": "8f45b358468c915f36fe78e4",
-          "fingerprint": "006181259682df083dbd0ef1",
-          "item": "fn new",
-          "line": 201
-        },
-        {
-          "id": "2efcf082457f1c1eb1eb0c17",
-          "fingerprint": "c8f1df0179979f3ca5a5a712",
-          "item": "fn new",
-          "line": 202
         },
         {
           "id": "826c50cae13382b094d99128",
@@ -9191,7 +8925,7 @@
           "id": "2732f5a15e918a5c150a4ef1",
           "fingerprint": "22ba5d0e667e1887b6bfc489",
           "item": "fn new_default_impl",
-          "line": 1053
+          "line": 1063
         }
       ],
       "owner": "client",
@@ -9793,7 +9527,7 @@
           "id": "2e1a28fe9c0918e52bdf56a5",
           "fingerprint": "d715357faf1d89e33d16251a",
           "item": "mod tests",
-          "line": 2163
+          "line": 2165
         }
       ],
       "owner": "client",
@@ -9843,43 +9577,43 @@
           "id": "94dc438e686953c42c2f194c",
           "fingerprint": "1c06f98cf22dbf5b11ff652d",
           "item": "fn new_unstarted_impl",
-          "line": 2171
+          "line": 2173
         },
         {
           "id": "bed96c1972704abacbb50d54",
           "fingerprint": "f2c8ab11b61d8b619ad064f2",
           "item": "fn new_check_config_consumer",
-          "line": 2202
+          "line": 2204
         },
         {
           "id": "c68059f4dfcdd96ba79265bc",
           "fingerprint": "12958be49d7ef666805e01b4",
           "item": "fn new_startable_push_consumer",
-          "line": 2217
+          "line": 2219
         },
         {
           "id": "636e2f5a281e1663e32dd1bd",
           "fingerprint": "6f3d48a79817be1c040a073a",
           "item": "fn new_startable_push_consumer",
-          "line": 2219
+          "line": 2221
         },
         {
           "id": "6ce2a74fbdc815d3daa5e333",
           "fingerprint": "75cd163ada2c71fc9e1b44b3",
           "item": "fn send_message_back_restores_topic_when_retry_fallback_errors_like_java_finally",
-          "line": 2530
+          "line": 2532
         },
         {
           "id": "3b7754c0715f31ce69f43972",
           "fingerprint": "7e868a3beeee278a476a26c6",
           "item": "fn fetch_subscribe_message_queues_prefers_cached_route_like_java",
-          "line": 2575
+          "line": 2577
         },
         {
           "id": "cbb4cac982e2146c24ee895d",
           "fingerprint": "bed922d3f405df26ffbe730e",
           "item": "fn reset_offsets_drops_clears_persists_and_removes_assigned_queue_like_java",
-          "line": 2664
+          "line": 2666
         }
       ],
       "owner": "client",
@@ -9996,7 +9730,7 @@
           "id": "0f0d044708edfca1ae1d4c67",
           "fingerprint": "86496c78cf33892adc754a67",
           "item": "fn new_startable_push_consumer",
-          "line": 2208
+          "line": 2210
         }
       ],
       "owner": "client",
@@ -10015,19 +9749,19 @@
           "id": "9d26f62019a525168341ca45",
           "fingerprint": "e3987d672ac08e83a36ffd11",
           "item": "fn do_rebalance",
-          "line": 1900
+          "line": 1902
         },
         {
           "id": "5b17b28d8bdeb32d3de2e6df",
           "fingerprint": "6a81898545cbdf5fae40e0b7",
           "item": "fn try_rebalance",
-          "line": 1914
+          "line": 1916
         },
         {
           "id": "394cfb5961273a9eb01c2a2e",
           "fingerprint": "8aa3de4d8cec698b3866a14b",
           "item": "fn reset_offsets",
-          "line": 2020
+          "line": 2022
         }
       ],
       "owner": "client",
@@ -10046,43 +9780,43 @@
           "id": "1b636421d5ecbfe9f697118b",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2282
+          "line": 2284
         },
         {
           "id": "4366210318539c2a7edb2dad",
           "fingerprint": "69343b618ff42492b938e65c",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2300
+          "line": 2302
         },
         {
           "id": "1c3107c6e26e46a083528afa",
           "fingerprint": "330c5301f067e7c751d78eae",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2330
+          "line": 2332
         },
         {
           "id": "860b3bf5713fe264936bc6d1",
           "fingerprint": "dfd6ebf478835de6e623371d",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2337
+          "line": 2339
         },
         {
           "id": "70f393815241dacc87e7422f",
           "fingerprint": "ef56c22737c574751b2011fe",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2349
+          "line": 2351
         },
         {
           "id": "3a80af2c5eb310032f5e64a4",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2363
+          "line": 2365
         },
         {
           "id": "616daffd00e6d2e9b21ad31d",
           "fingerprint": "ea89c3fc97c837d10c858c78",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2368
+          "line": 2370
         }
       ],
       "owner": "client",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8359

### Brief Description

- Replace the four Push consume services' shared mutable client and consumer configs with immutable startup `Arc` snapshots.
- Build one client/consumer snapshot pair during Push startup and share that generation across the concurrent or orderly service pair.
- Preserve live `DefaultMQPushConsumerImpl` access for callbacks that require operational state.
- Reduce the reviewed ArcMut baseline from 653 identities/1,767 occurrences to 651/1,727 and update the migration checklist without closing the overall 75/82 goal.

### How Did You Test This Change?

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- Focused startup-generation and namespace snapshot tests (3/3)
- `cargo test -p rocketmq-client-rust --all-features --quiet` (974 library tests plus all integration targets; 35 environment-dependent tests ignored)
- Client package and root workspace strict Clippy
- ArcMut guard tests/fixtures/default baseline, architecture dependency/release guards, runtime audit, and AGENTS routing guard
- Standalone Example, Tauri backend, and Web backend validation, including the Web backend all-target/all-feature build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consumer services now share immutable configuration snapshots throughout startup and message processing.
  * Push and POP consumption modes consistently use the same startup configuration generation.

* **Bug Fixes**
  * Prevented runtime configuration mutation through shared service configuration.
  * Updated namespace handling to configure services safely during creation.

* **Tests**
  * Added validation that services share the expected configuration snapshot.
  * Updated lifecycle, startup, and configuration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->