### PR TITLE
[ISSUE #8361]♻️Replace Push rebalance config mutation with immutable snapshots

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -649,7 +649,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ae Client Push message listener ownership：facade config、implementation 与 Java-compatible getter/setter 改持标准 `Arc<MessageListener>`，concurrent/orderly 注册与替换不再传播共享可变 wrapper
   - [x] M11-12af Client Push subscription snapshots：deprecated startup subscription map 改持标准 `Arc<HashMap>`，config/builder/Java-compatible getter/setter 返回 immutable owned snapshot；dynamic rebalance table 不变
   - [x] M11-12ag Client Push consume service config snapshots：concurrent/orderly 与 POP concurrent/orderly 服务持有同一启动代的 immutable `Arc<ClientConfig>`/`Arc<ConsumerConfig>`，服务不再暴露配置共享写入口
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359 与每次真实下降
+  - [x] M11-12ah Client Push rebalance config snapshots：RebalancePush 使用 `ArcSwap<ConsumerConfig>` 发布完整不可变代际；相关 facade setter 显式同步，队列数变化只通过 Push implementation owner 回写两个动态 threshold
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -683,7 +684,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8355 后 production identity 保持 402、occurrence 降至 1,086；Client 为 85/194，Push MessageListener 的 9 个 production occurrence 与 3 个 test occurrence 退出，1 个 test identity 删除
   - [x] Issue #8357 后实际快照降至 400 production/1,078 occurrence；Client 降至 83/186，Push startup subscription snapshot 的 2 个 production identity/8 occurrence 与 1 个 test identity/1 occurrence 退出
   - [x] Issue #8359 后实际快照降至 398 production/1,054 occurrence；Client owner 降至 80/161，另有 Proxy 1/1；四类 Push consume service 配置的 2 个 production identity/24 occurrence 与 16 个 test occurrence 退出
-  - [ ] M11-12ah 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8361 后 production identity 保持 398、occurrence 降至 1,052；Client owner 降至 80/159，RebalancePush 的 2 个 `ArcMut<ConsumerConfig>` occurrence 退出且测试/compatibility 不增
+  - [ ] M11-12ai 及后续：Client 其余 MQClientInstance/Producer/Push/Rebalance owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -376,6 +376,11 @@ Client Push consume service config snapshots 随 Issue #8359 将 concurrent/orde
 运行状态的 callback 继续通过 Push implementation owner 访问。实际快照降至 398 production/1,054 occurrence，Client owner
 降至 80/161，另有 Proxy 1/1；剩余为 Broker 190/568、Client 80/161、Proxy 1/1 与 Store 127/324，总进度仍为
 75/82，M11-12 父工作包未完成。
+Client Push rebalance config snapshots 随 Issue #8361 将 RebalancePush 的共享可变 consumer config 改为 `ArcSwap` 完整
+不可变代际；相关 facade setter 显式同步，queue-count 变化只通过 Push implementation owner 回写两个 per-queue threshold，
+listener 与 offset 策略读取不再依赖整份配置的共享写别名。实际快照为 398 production/1,052 occurrence，Client owner
+降至 80/159，另有 Proxy 1/1；剩余为 Broker 190/568、Client 80/159、Proxy 1/1 与 Store 127/324，总进度仍为
+75/82，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -390,6 +390,11 @@ M11-12ag 已将 concurrent/orderly 与 POP concurrent/orderly 四类 Push consum
 实际快照降至 398 production/1,054 occurrences，Client owner 降至 80/161，另有 Proxy 1/1；其余 Client/Broker/Store、
 compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12ah 已将 RebalancePush consumer config 改为 `ArcSwap` 完整不可变代际；相关 facade setter 显式发布新快照，
+queue-count 变化只通过 Push implementation owner 回写两个动态 threshold。实际快照为 398 production/1,052
+occurrences，Client owner 降至 80/159，另有 Proxy 1/1；其余 Client/Broker/Store、compatibility 与完整候选快照 Gate
+仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -1490,9 +1490,28 @@ M11-12ag 追加验证：
 | Push service config ArcMut 定向扫描 | 四个服务的 `ArcMut<ClientConfig>`/`ArcMut<ConsumerConfig>` 字段与 constructor 参数零匹配；实时 Push implementation owner 保留给后续切片 |
 | `git diff --check` | 通过 |
 
+M11-12ah 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；RebalancePush `ArcSwap` config generation、facade 同步与全部 target 编译通过 |
+| Push rebalance config focused tests | immutable 初始代际、threshold 重算、listener 新代际、owner threshold 回写与 facade setter 同步共 5/5 通过 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 978/978，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline reduction（临时 ADR-013 approval） | 2 个 production/Client occurrence 真实删除；2 个同 path/symbol/kind/item 的保留 occurrence relocation 逐条审核，approval 不提交；baseline 651/1,727→651/1,725 |
+| `python scripts/arc_mut_guard.py` | 通过；production 398/1,052，Client owner 80/159，Proxy 1/1，tracked/reviewed semantic set 1,725/1,725 一致 |
+| `python -m unittest scripts.tests.test_arc_mut_guard` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；ArcSwap 只发布 owned generation，异步 rebalance 路径持有 owned `Arc` 而非同步 guard |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Push rebalance config ArcMut 定向扫描 | `RebalancePushImpl` 中 `ArcMut<ConsumerConfig>` 字段与 constructor 参数零匹配；Push root、MQClientInstance 与 Rebalance owner 保留给后续切片 |
+| `git diff --check` | 通过 |
+
 ## 剩余切片与 Gate
 
-1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（Client owner 80/161，另有 Proxy 1/1）。
+1. Client 其余 MQClientInstance、Producer、Push 与 Rebalance child owner（Client owner 80/159，另有 Proxy 1/1）。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -145,12 +145,13 @@ impl DefaultMQPushConsumerImpl {
         consumer_config: ArcMut<ConsumerConfig>,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
+        let rebalance_consumer_config = consumer_config.as_ref().clone();
         let mut this = Self {
             global_lock: Arc::new(Default::default()),
             pull_time_delay_mills_when_exception: 3_000,
             client_config: ArcMut::new(client_config.clone()),
             consumer_config: consumer_config.clone(),
-            rebalance_impl: ArcMut::new(RebalancePushImpl::new(client_config, consumer_config)),
+            rebalance_impl: ArcMut::new(RebalancePushImpl::new(client_config, rebalance_consumer_config)),
             filter_message_hook_list: vec![],
             consume_message_hook_list: vec![],
             rpc_hook,
@@ -227,6 +228,23 @@ impl DefaultMQPushConsumerImpl {
 
     pub fn set_offset_store(&mut self, offset_store: Option<Arc<OffsetStore>>) {
         self.offset_store = offset_store;
+    }
+
+    pub(crate) fn sync_rebalance_consumer_config(&self, consumer_config: ConsumerConfig) {
+        self.rebalance_impl.replace_consumer_config(consumer_config);
+    }
+
+    pub(crate) fn update_pull_thresholds_from_rebalance(
+        &mut self,
+        pull_threshold_for_queue: Option<u32>,
+        pull_threshold_size_for_queue: Option<u32>,
+    ) {
+        if let Some(value) = pull_threshold_for_queue {
+            self.consumer_config.pull_threshold_for_queue = value;
+        }
+        if let Some(value) = pull_threshold_size_for_queue {
+            self.consumer_config.pull_threshold_size_for_queue = value;
+        }
     }
 }
 
@@ -2224,6 +2242,16 @@ mod tests {
         let wrapper = consumer.clone();
         consumer.set_default_mqpush_consumer_impl(wrapper);
         consumer
+    }
+
+    #[test]
+    fn rebalance_threshold_updates_publish_to_owner_config() {
+        let mut consumer = new_unstarted_impl();
+
+        consumer.update_pull_thresholds_from_rebalance(Some(25), Some(10));
+
+        assert_eq!(consumer.consumer_config.pull_threshold_for_queue, 25);
+        assert_eq!(consumer.consumer_config.pull_threshold_size_for_queue, 10);
     }
 
     fn message_queue() -> MessageQueue {

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::constant::consume_init_mode::ConsumeInitMode;
@@ -59,19 +60,31 @@ static UNLOCK_DELAY_TIME_MILLS: LazyLock<u64> = LazyLock::new(|| {
 
 pub struct RebalancePushImpl {
     pub(crate) client_config: ClientConfig,
-    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) consumer_config: ArcSwap<ConsumerConfig>,
     pub(crate) rebalance_impl_inner: RebalanceImpl<RebalancePushImpl>,
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
 }
 
 impl RebalancePushImpl {
-    pub fn new(client_config: ClientConfig, consumer_config: ArcMut<ConsumerConfig>) -> Self {
+    pub fn new(client_config: ClientConfig, consumer_config: ConsumerConfig) -> Self {
         RebalancePushImpl {
             client_config,
-            consumer_config,
+            consumer_config: ArcSwap::from_pointee(consumer_config),
             rebalance_impl_inner: RebalanceImpl::new(None, None, None, None),
             default_mqpush_consumer_impl: None,
         }
+    }
+
+    pub(crate) fn replace_consumer_config(&self, consumer_config: ConsumerConfig) {
+        self.consumer_config.store(Arc::new(consumer_config));
+    }
+
+    fn update_consumer_config(&self, update: impl Fn(&mut ConsumerConfig)) {
+        self.consumer_config.rcu(|current| {
+            let mut next = (**current).clone();
+            update(&mut next);
+            Arc::new(next)
+        });
     }
 }
 
@@ -159,6 +172,7 @@ impl Rebalance for RebalancePushImpl {
         mq_all: &HashSet<MessageQueue>,
         mq_divided: &HashSet<MessageQueue>,
     ) {
+        let consumer_config = self.consumer_config.load_full();
         {
             let Some(mut subscription_data) = self.rebalance_impl_inner.subscription_inner.get_mut(topic) else {
                 warn!("Subscription data not found for topic: {}", topic);
@@ -177,23 +191,39 @@ impl Rebalance for RebalancePushImpl {
             process_queue_table.len()
         };
         if current_queue_count != 0 {
-            let pull_threshold_for_topic = self.consumer_config.pull_threshold_for_topic;
+            let mut pull_threshold_for_queue = None;
+            let mut pull_threshold_size_for_queue = None;
+            let pull_threshold_for_topic = consumer_config.pull_threshold_for_topic;
             if pull_threshold_for_topic != -1 {
                 let new_val = 1.max(pull_threshold_for_topic / current_queue_count as i32);
                 info!(
                     "The pullThresholdForQueue is changed from {} to {}",
-                    self.consumer_config.pull_threshold_for_queue, new_val
+                    consumer_config.pull_threshold_for_queue, new_val
                 );
-                self.consumer_config.pull_threshold_for_queue = new_val as u32;
+                pull_threshold_for_queue = Some(new_val as u32);
             }
-            let pull_threshold_size_for_topic = self.consumer_config.pull_threshold_size_for_topic;
+            let pull_threshold_size_for_topic = consumer_config.pull_threshold_size_for_topic;
             if pull_threshold_size_for_topic != -1 {
                 let new_val = 1.max(pull_threshold_size_for_topic / current_queue_count as i32);
                 info!(
                     "The pullThresholdSizeForQueue is changed from {} to {}",
-                    self.consumer_config.pull_threshold_size_for_queue, new_val
+                    consumer_config.pull_threshold_size_for_queue, new_val
                 );
-                self.consumer_config.pull_threshold_size_for_queue = new_val as u32;
+                pull_threshold_size_for_queue = Some(new_val as u32);
+            }
+            if pull_threshold_for_queue.is_some() || pull_threshold_size_for_queue.is_some() {
+                self.update_consumer_config(|config| {
+                    if let Some(value) = pull_threshold_for_queue {
+                        config.pull_threshold_for_queue = value;
+                    }
+                    if let Some(value) = pull_threshold_size_for_queue {
+                        config.pull_threshold_size_for_queue = value;
+                    }
+                });
+                if let Some(mut consumer_impl) = self.default_mqpush_consumer_impl.as_ref().cloned() {
+                    consumer_impl
+                        .update_pull_thresholds_from_rebalance(pull_threshold_for_queue, pull_threshold_size_for_queue);
+                }
             }
         }
 
@@ -201,12 +231,13 @@ impl Rebalance for RebalancePushImpl {
         if let Some(client_instance) = self.rebalance_impl_inner.client_instance.as_ref() {
             let _ = client_instance.send_heartbeat_to_all_broker_with_lock_v2(true).await;
         }
-        if let Some(ref message_queue_listener) = self.consumer_config.message_queue_listener {
+        if let Some(ref message_queue_listener) = consumer_config.message_queue_listener {
             message_queue_listener.message_queue_changed(topic, mq_all, mq_divided);
         }
     }
 
     async fn remove_unnecessary_message_queue(&mut self, mq: &MessageQueue, pq: &ProcessQueue) -> bool {
+        let consumer_config = self.consumer_config.load_full();
         let Some(ref default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl else {
             error!("DefaultMQPushConsumerImpl not initialized");
             return false;
@@ -218,7 +249,7 @@ impl Rebalance for RebalancePushImpl {
         };
         let offset_store = offset_store;
 
-        if consume_orderly && MessageModel::Clustering == self.consumer_config.message_model {
+        if consume_orderly && MessageModel::Clustering == consumer_config.message_model {
             offset_store.persist(mq).await;
             self.try_remove_order_message_queue(mq, pq).await
         } else {
@@ -252,7 +283,8 @@ impl Rebalance for RebalancePushImpl {
         &mut self,
         mq: &MessageQueue,
     ) -> rocketmq_error::RocketMQResult<i64> {
-        let consume_from_where = self.consumer_config.consume_from_where;
+        let consumer_config = self.consumer_config.load_full();
+        let consume_from_where = consumer_config.consume_from_where;
         let default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.as_ref().ok_or_else(|| {
             error!("DefaultMQPushConsumerImpl not initialized for mq: {}", mq);
             mq_client_err!(
@@ -332,10 +364,8 @@ impl Rebalance for RebalancePushImpl {
                                 format!("Client instance not initialized for mq: {}", mq)
                             ));
                         };
-                        let timestamp = super::parse_consume_timestamp_millis(
-                            self.consumer_config.consume_timestamp.as_deref(),
-                            mq,
-                        )?;
+                        let timestamp =
+                            super::parse_consume_timestamp_millis(consumer_config.consume_timestamp.as_deref(), mq)?;
                         client_instance.mq_admin_impl.search_offset(mq, timestamp).await?
                     }
                 } else {
@@ -368,7 +398,7 @@ impl Rebalance for RebalancePushImpl {
     }
 
     fn get_consume_init_mode(&self) -> i32 {
-        let consume_from_where = self.consumer_config.consume_from_where;
+        let consume_from_where = self.consumer_config.load_full().consume_from_where;
         if consume_from_where == ConsumeFromWhere::ConsumeFromFirstOffset {
             ConsumeInitMode::MIN
         } else {
@@ -525,7 +555,7 @@ impl Rebalance for RebalancePushImpl {
     fn client_rebalance(&mut self, topic: &str) -> bool {
         //Pop message mode, order message consumer not implement, it's use
         // ConsumeMessageOrderlyService to consume
-        self.consumer_config.client_rebalance
+        self.consumer_config.load_full().client_rebalance
             || self.rebalance_impl_inner.message_model == Some(MessageModel::Broadcasting)
             || self
                 .default_mqpush_consumer_impl
@@ -712,4 +742,110 @@ async fn unlock_all_impl(
         })
         .collect::<Vec<_>>();
     futures::future::join_all(map).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
+    use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+
+    use super::RebalancePushImpl;
+    use crate::base::client_config::ClientConfig;
+    use crate::consumer::consumer_impl::process_queue::ProcessQueue;
+    use crate::consumer::consumer_impl::re_balance::Rebalance;
+    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+    use crate::consumer::message_queue_listener::MessageQueueListener;
+
+    struct CountingMessageQueueListener(Arc<AtomicUsize>);
+
+    impl MessageQueueListener for CountingMessageQueueListener {
+        fn message_queue_changed(
+            &self,
+            _topic: &str,
+            _mq_all: &HashSet<MessageQueue>,
+            _mq_assigned: &HashSet<MessageQueue>,
+        ) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn constructor_keeps_an_immutable_config_generation() {
+        let mut source = ConsumerConfig {
+            client_rebalance: false,
+            ..Default::default()
+        };
+        let rebalance = RebalancePushImpl::new(ClientConfig::default(), source.clone());
+
+        source.client_rebalance = true;
+
+        assert!(!rebalance.consumer_config.load_full().client_rebalance);
+    }
+
+    #[tokio::test]
+    async fn queue_change_publishes_recomputed_threshold_snapshot() {
+        let topic = CheetahString::from_static_str("topic-a");
+        let config = ConsumerConfig {
+            pull_threshold_for_topic: 100,
+            pull_threshold_size_for_topic: 40,
+            pull_threshold_for_queue: 1_000,
+            pull_threshold_size_for_queue: 100,
+            ..Default::default()
+        };
+        let mut rebalance = RebalancePushImpl::new(ClientConfig::default(), config);
+        rebalance
+            .rebalance_impl_inner
+            .subscription_inner
+            .insert(topic.clone(), SubscriptionData::default());
+        let mut queues = HashSet::new();
+        {
+            let mut process_queues = rebalance.rebalance_impl_inner.process_queue_table.write().await;
+            for queue_id in 0..4 {
+                let mq = MessageQueue::from_parts(topic.clone(), "broker-a", queue_id);
+                queues.insert(mq.clone());
+                process_queues.insert(mq, Arc::new(ProcessQueue::new()));
+            }
+        }
+
+        rebalance.message_queue_changed(topic.as_str(), &queues, &queues).await;
+
+        let published = rebalance.consumer_config.load_full();
+        assert_eq!(published.pull_threshold_for_queue, 25);
+        assert_eq!(published.pull_threshold_size_for_queue, 10);
+    }
+
+    #[tokio::test]
+    async fn replaced_config_generation_drives_listener_callback() {
+        let topic = CheetahString::from_static_str("topic-a");
+        let old_calls = Arc::new(AtomicUsize::new(0));
+        let new_calls = Arc::new(AtomicUsize::new(0));
+        let mut rebalance = RebalancePushImpl::new(
+            ClientConfig::default(),
+            ConsumerConfig {
+                message_queue_listener: Some(Arc::new(CountingMessageQueueListener(old_calls.clone()))),
+                ..Default::default()
+            },
+        );
+        rebalance
+            .rebalance_impl_inner
+            .subscription_inner
+            .insert(topic.clone(), SubscriptionData::default());
+        rebalance.replace_consumer_config(ConsumerConfig {
+            message_queue_listener: Some(Arc::new(CountingMessageQueueListener(new_calls.clone()))),
+            ..Default::default()
+        });
+
+        rebalance
+            .message_queue_changed(topic.as_str(), &HashSet::new(), &HashSet::new())
+            .await;
+
+        assert_eq!(old_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(new_calls.load(Ordering::Relaxed), 1);
+    }
 }

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -987,6 +987,7 @@ impl DefaultMQPushConsumer {
 
     pub fn set_consume_from_where(&mut self, consume_from_where: ConsumeFromWhere) {
         self.consumer_config.set_consume_from_where(consume_from_where);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn consume_message_batch_max_size(&self) -> u32 {
@@ -1053,6 +1054,7 @@ impl DefaultMQPushConsumer {
 
     pub fn set_message_model(&mut self, message_model: MessageModel) {
         self.consumer_config.set_message_model(message_model);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn pull_batch_size(&self) -> u32 {
@@ -1090,6 +1092,7 @@ impl DefaultMQPushConsumer {
     pub fn set_pull_threshold_for_queue(&mut self, pull_threshold_for_queue: u32) {
         self.consumer_config
             .set_pull_threshold_for_queue(pull_threshold_for_queue);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn pop_threshold_for_queue(&self) -> u32 {
@@ -1116,6 +1119,7 @@ impl DefaultMQPushConsumer {
     pub fn set_pull_threshold_for_topic(&mut self, pull_threshold_for_topic: i32) {
         self.consumer_config
             .set_pull_threshold_for_topic(pull_threshold_for_topic);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn pull_threshold_size_for_queue(&self) -> u32 {
@@ -1129,6 +1133,7 @@ impl DefaultMQPushConsumer {
     pub fn set_pull_threshold_size_for_queue(&mut self, pull_threshold_size_for_queue: u32) {
         self.consumer_config
             .set_pull_threshold_size_for_queue(pull_threshold_size_for_queue);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn pull_threshold_size_for_topic(&self) -> i32 {
@@ -1142,6 +1147,7 @@ impl DefaultMQPushConsumer {
     pub fn set_pull_threshold_size_for_topic(&mut self, pull_threshold_size_for_topic: i32) {
         self.consumer_config
             .set_pull_threshold_size_for_topic(pull_threshold_size_for_topic);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn consume_timestamp(&self) -> Option<CheetahString> {
@@ -1155,10 +1161,12 @@ impl DefaultMQPushConsumer {
     pub fn set_consume_timestamp(&mut self, consume_timestamp: impl Into<CheetahString>) {
         self.consumer_config
             .set_consume_timestamp(Some(consume_timestamp.into()));
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn clear_consume_timestamp(&mut self) {
         self.consumer_config.set_consume_timestamp(None);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn is_post_subscription_when_pull(&self) -> bool {
@@ -1328,6 +1336,7 @@ impl DefaultMQPushConsumer {
 
     pub fn set_client_rebalance(&mut self, client_rebalance: bool) {
         self.consumer_config.set_client_rebalance(client_rebalance);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn message_queue_listener(&self) -> Option<ArcMessageQueueListener> {
@@ -1340,10 +1349,18 @@ impl DefaultMQPushConsumer {
 
     pub fn set_message_queue_listener(&mut self, message_queue_listener: Option<ArcMessageQueueListener>) {
         self.consumer_config.set_message_queue_listener(message_queue_listener);
+        self.sync_rebalance_consumer_config();
     }
 
     pub fn apply_tuning_profile(&mut self, profile: ConsumerTuningProfile) {
         self.consumer_config.mut_from_ref().apply_tuning_profile(profile);
+        self.sync_rebalance_consumer_config();
+    }
+
+    fn sync_rebalance_consumer_config(&self) {
+        if let Some(consumer_impl) = self.default_mqpush_consumer_impl.as_ref() {
+            consumer_impl.sync_rebalance_consumer_config(self.consumer_config.as_ref().clone());
+        }
     }
 
     pub fn new(client_config: ClientConfig, consumer_config: ConsumerConfig) -> DefaultMQPushConsumer {
@@ -1909,8 +1926,40 @@ mod tests {
         assert!(!impl_config.client_rebalance);
         assert!(impl_config.message_queue_listener.is_some());
 
+        let rebalance_config = consumer
+            .default_mqpush_consumer_impl
+            .as_ref()
+            .expect("push consumer impl should exist")
+            .rebalance_impl
+            .consumer_config
+            .load_full();
+        assert_eq!(
+            rebalance_config.consume_from_where,
+            ConsumeFromWhere::ConsumeFromFirstOffset
+        );
+        assert_eq!(rebalance_config.message_model, MessageModel::Broadcasting);
+        assert_eq!(rebalance_config.pull_threshold_for_queue, 2048);
+        assert_eq!(rebalance_config.pull_threshold_for_topic, 4096);
+        assert_eq!(rebalance_config.pull_threshold_size_for_queue, 256);
+        assert_eq!(rebalance_config.pull_threshold_size_for_topic, 512);
+        assert_eq!(
+            rebalance_config.consume_timestamp.as_ref().map(CheetahString::as_str),
+            Some("20260610101010")
+        );
+        assert!(!rebalance_config.client_rebalance);
+        assert!(rebalance_config.message_queue_listener.is_some());
+
         consumer.clear_consume_timestamp();
         assert!(consumer.consume_timestamp().is_none());
+        assert!(consumer
+            .default_mqpush_consumer_impl
+            .as_ref()
+            .expect("push consumer impl should exist")
+            .rebalance_impl
+            .consumer_config
+            .load_full()
+            .consume_timestamp
+            .is_none());
     }
 
     #[test]

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -9527,7 +9527,7 @@
           "id": "2e1a28fe9c0918e52bdf56a5",
           "fingerprint": "d715357faf1d89e33d16251a",
           "item": "mod tests",
-          "line": 2165
+          "line": 2183
         }
       ],
       "owner": "client",
@@ -9546,19 +9546,19 @@
           "id": "ac48842a72ce3b93b2caa41f",
           "fingerprint": "5e557a7df4c287f0047afbc7",
           "item": "fn new",
-          "line": 151
+          "line": 152
         },
         {
-          "id": "2525e402bad638eb45f98eef",
-          "fingerprint": "8becd99a2bfae29e9ab4e0c5",
+          "id": "30c25dd436f4edff591e28e0",
+          "fingerprint": "ba5893640c237abb38a22baf",
           "item": "fn new",
-          "line": 153
+          "line": 154
         },
         {
           "id": "9d8683f94805a42c955b3ff8",
           "fingerprint": "c9a9484e7fcafaf098dd24d7",
           "item": "fn new",
-          "line": 157
+          "line": 158
         }
       ],
       "owner": "client",
@@ -9577,43 +9577,43 @@
           "id": "94dc438e686953c42c2f194c",
           "fingerprint": "1c06f98cf22dbf5b11ff652d",
           "item": "fn new_unstarted_impl",
-          "line": 2173
+          "line": 2191
         },
         {
           "id": "bed96c1972704abacbb50d54",
           "fingerprint": "f2c8ab11b61d8b619ad064f2",
           "item": "fn new_check_config_consumer",
-          "line": 2204
+          "line": 2222
         },
         {
           "id": "c68059f4dfcdd96ba79265bc",
           "fingerprint": "12958be49d7ef666805e01b4",
           "item": "fn new_startable_push_consumer",
-          "line": 2219
+          "line": 2237
         },
         {
           "id": "636e2f5a281e1663e32dd1bd",
           "fingerprint": "6f3d48a79817be1c040a073a",
           "item": "fn new_startable_push_consumer",
-          "line": 2221
+          "line": 2239
         },
         {
           "id": "6ce2a74fbdc815d3daa5e333",
           "fingerprint": "75cd163ada2c71fc9e1b44b3",
           "item": "fn send_message_back_restores_topic_when_retry_fallback_errors_like_java_finally",
-          "line": 2532
+          "line": 2560
         },
         {
           "id": "3b7754c0715f31ce69f43972",
           "fingerprint": "7e868a3beeee278a476a26c6",
           "item": "fn fetch_subscribe_message_queues_prefers_cached_route_like_java",
-          "line": 2577
+          "line": 2605
         },
         {
           "id": "cbb4cac982e2146c24ee895d",
           "fingerprint": "bed922d3f405df26ffbe730e",
           "item": "fn reset_offsets_drops_clears_persists_and_removes_assigned_queue_like_java",
-          "line": 2666
+          "line": 2694
         }
       ],
       "owner": "client",
@@ -9693,25 +9693,25 @@
           "id": "6bde2bb69a82a456377d874e",
           "fingerprint": "324398df6442d6680f5d10e3",
           "item": "fn new",
-          "line": 174
+          "line": 175
         },
         {
           "id": "2bc609e8de95d82d434aa84b",
           "fingerprint": "6337932804b5ac18b4e50e3e",
           "item": "fn set_default_mqpush_consumer_impl",
-          "line": 181
+          "line": 182
         },
         {
           "id": "24fa17371eb2663627047926",
           "fingerprint": "c3923db59875c44ba57d8139",
           "item": "fn get_mq_client_factory",
-          "line": 193
+          "line": 194
         },
         {
           "id": "e8f37285186cca9c332a73da",
           "fingerprint": "6ea020e77dd8adced283cd03",
           "item": "fn set_mq_client_factory",
-          "line": 204
+          "line": 205
         }
       ],
       "owner": "client",
@@ -9730,7 +9730,7 @@
           "id": "0f0d044708edfca1ae1d4c67",
           "fingerprint": "86496c78cf33892adc754a67",
           "item": "fn new_startable_push_consumer",
-          "line": 2210
+          "line": 2228
         }
       ],
       "owner": "client",
@@ -9749,19 +9749,19 @@
           "id": "9d26f62019a525168341ca45",
           "fingerprint": "e3987d672ac08e83a36ffd11",
           "item": "fn do_rebalance",
-          "line": 1902
+          "line": 1920
         },
         {
           "id": "5b17b28d8bdeb32d3de2e6df",
           "fingerprint": "6a81898545cbdf5fae40e0b7",
           "item": "fn try_rebalance",
-          "line": 1916
+          "line": 1934
         },
         {
           "id": "394cfb5961273a9eb01c2a2e",
           "fingerprint": "8aa3de4d8cec698b3866a14b",
           "item": "fn reset_offsets",
-          "line": 2022
+          "line": 2040
         }
       ],
       "owner": "client",
@@ -9780,43 +9780,43 @@
           "id": "1b636421d5ecbfe9f697118b",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2284
+          "line": 2312
         },
         {
           "id": "4366210318539c2a7edb2dad",
           "fingerprint": "69343b618ff42492b938e65c",
           "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2302
+          "line": 2330
         },
         {
           "id": "1c3107c6e26e46a083528afa",
           "fingerprint": "330c5301f067e7c751d78eae",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2332
+          "line": 2360
         },
         {
           "id": "860b3bf5713fe264936bc6d1",
           "fingerprint": "dfd6ebf478835de6e623371d",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2339
+          "line": 2367
         },
         {
           "id": "70f393815241dacc87e7422f",
           "fingerprint": "ef56c22737c574751b2011fe",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2351
+          "line": 2379
         },
         {
           "id": "3a80af2c5eb310032f5e64a4",
           "fingerprint": "ed934938abbd94ebf3ebbef8",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2365
+          "line": 2393
         },
         {
           "id": "616daffd00e6d2e9b21ad31d",
           "fingerprint": "ea89c3fc97c837d10c858c78",
           "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2370
+          "line": 2398
         }
       ],
       "owner": "client",
@@ -10194,7 +10194,7 @@
           "id": "5ce1ac35d371431c3141b45e",
           "fingerprint": "3102db85cd77738b347a2dce",
           "item": "<module>",
-          "line": 32
+          "line": 33
         }
       ],
       "owner": "client",
@@ -10210,52 +10210,40 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "552843eaf5693118af49ea88",
-          "fingerprint": "3ed55bb9622ad9506c4b5f87",
-          "item": "struct RebalancePushImpl",
-          "line": 62
-        },
-        {
           "id": "966cdadf732cb9a9129a53e0",
           "fingerprint": "1c5fb6f2d1db8071d1b621d3",
           "item": "struct RebalancePushImpl",
-          "line": 64
-        },
-        {
-          "id": "387af4621327924d8d945d38",
-          "fingerprint": "9a1290a5e81f4b293fcceb36",
-          "item": "fn new",
-          "line": 68
+          "line": 65
         },
         {
           "id": "64d6dcb35a7607f27b604811",
           "fingerprint": "3f18fd64fbee357501ba0646",
           "item": "fn set_default_mqpush_consumer_impl",
-          "line": 85
+          "line": 98
         },
         {
           "id": "1e7b3dcb6016848d7213b8f5",
           "fingerprint": "490aeec1231884ed10807dc8",
           "item": "fn set_mq_client_factory",
-          "line": 105
+          "line": 118
         },
         {
           "id": "b5285b7f6c85a4359a1d02e9",
           "fingerprint": "a1646a5f680f703d98e34012",
           "item": "fn build_process_queue_table_by_broker_name",
-          "line": 567
+          "line": 597
         },
         {
           "id": "57ae5b411b2ae52c9a35399a",
           "fingerprint": "0fdba8aa8161e45fff2cff9a",
           "item": "fn lock_all_impl",
-          "line": 586
+          "line": 616
         },
         {
           "id": "ae37eef15f023a2b35bca26c",
           "fingerprint": "283dbe2c1e78bebdff1680ee",
           "item": "fn unlock_all_impl",
-          "line": 658
+          "line": 794
         }
       ],
       "owner": "client",
@@ -10274,7 +10262,7 @@
           "id": "357c73f00c681f8d36f002d6",
           "fingerprint": "66a075fa50c8e0cfef3f523c",
           "item": "<module>",
-          "line": 33
+          "line": 34
         }
       ],
       "owner": "client",
@@ -10293,7 +10281,7 @@
           "id": "fbae69f300996293d31d9908",
           "fingerprint": "4fc19a14536b9dc10e65af05",
           "item": "fn set_rebalance_impl",
-          "line": 116
+          "line": 129
         }
       ],
       "owner": "client",
@@ -10369,7 +10357,7 @@
           "id": "4bd3be26494abb96bc9e260f",
           "fingerprint": "9826bc7f2484e61a6aa6eff9",
           "item": "mod tests",
-          "line": 1382
+          "line": 1399
         }
       ],
       "owner": "client",
@@ -10388,13 +10376,13 @@
           "id": "193975bf1b4d9fc7783cbb1a",
           "fingerprint": "ea3b5033b309243a6ce382c7",
           "item": "fn new",
-          "line": 1350
+          "line": 1367
         },
         {
           "id": "29d9f3c04da2d0fe1f257605",
           "fingerprint": "72b089cf1222118e8b971ce6",
           "item": "fn new",
-          "line": 1351
+          "line": 1368
         }
       ],
       "owner": "client",
@@ -10478,10 +10466,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "f6c9b70bcfec6b2a6fb3751e",
-          "fingerprint": "9917c687cec0f810ea80cc6b",
+          "id": "7a488b3e40a99ff4155c2b43",
+          "fingerprint": "5eaa37068f371800913cdf8a",
           "item": "fn apply_tuning_profile",
-          "line": 1346
+          "line": 1356
         }
       ],
       "owner": "client",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8361

### Brief Description

- Replace `RebalancePushImpl`'s shared mutable `ConsumerConfig` alias with atomically published immutable generations.
- Synchronize relevant Push facade setter updates into the rebalance snapshot.
- Route queue-count-derived per-queue threshold updates through the owning Push implementation while preserving listener and offset-policy behavior.
- Reduce the reviewed ArcMut baseline from 651 identities/1,727 occurrences to 651/1,725 and update the migration checklist without closing the overall 75/82 goal.

### How Did You Test This Change?

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- Five focused immutable-generation, threshold, listener, owner-publication, and facade-synchronization regressions
- `cargo test -p rocketmq-client-rust --all-features --quiet` (978 library tests plus all integration targets; 35 environment-dependent tests ignored)
- Client package and root workspace strict Clippy
- ArcMut guard tests/fixtures/default baseline, architecture dependency/release guards, runtime audit, and AGENTS routing guard
- Standalone Example, Tauri backend, and Web backend validation, including the Web backend all-target/all-feature build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved consumer configuration consistency during runtime updates and rebalancing.
  - Configuration changes now propagate reliably across consumption settings, timestamps, message models, and tuning profiles.
  - Queue-based pull thresholds are updated consistently when message queues change.
  - Rebalancing now uses stable configuration snapshots, improving predictable listener and consumption behavior.

- **Documentation**
  - Updated architecture migration and production-readiness progress records.
  - Added validation results and refreshed milestone, evidence, and remaining-gate tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->