### PR TITLE
[ISSUE #8369]♻️Replace MQClientInstance root ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -653,7 +653,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ai Client Push root config snapshots：facade 与 implementation 共享 `Arc<ArcSwap<ConsumerConfig>>`，setter 以 clone-update-publish 发布完整代际；启动、回调、diagnostics 与动态 threshold 更新只读取稳定 immutable `Arc` 快照
   - [x] M11-12aj Client Push implementation root ownership：facade、consumer registry、callback 与 task capture 改用标准 `Arc`，root-owned consume/rebalance 回边改用 `Weak`；start/shutdown 由 lifecycle mutex 串行，组件槽位短锁发布快照，rebalance metadata 使用共享引用安全更新且未新增 production `mut_from_ref`
   - [x] M11-12ak Client Rebalance root ownership：Push/LitePull concrete rebalance root 改用标准 `Arc`，core self-reference 与 concrete setter 改用标准 `Weak`；释放 root 后 weak upgrade 失败的定向测试通过，`MQClientInstance` 兼容 handle 保留给后续切片
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367 与每次真实下降
+  - [x] M11-12al Client MQClientInstance root ownership：Manager/Proxy handle 与 Admin/Producer/Consumer/Rebalance/API/OffsetStore 全链路改用标准 `Arc<MQClientInstance>`；Remoting/Admin 回指改用标准 `Weak`，lifecycle、API slot 与 task handle 显式同步，公开运行路径收窄为共享 receiver
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -691,7 +692,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8363 后实际快照降至 397 production/1,045 occurrence；Client owner 降至 79/152，测试从 47/145 降至 47/132；Push 根 `ConsumerConfig` 的 1 个 identity/20 occurrence 退出
   - [x] Issue #8365 后实际快照降至 376 production/995 occurrence；Client owner 降至 58/102，Client test 降至 25/102；Push implementation root、consume service/callback owner 与过时 rebalance 可变 receiver 共删除 21 个 production identity/50 occurrence、22 个 test identity/30 occurrence
   - [x] Issue #8367 后实际快照降至 368 production/982 occurrence；Client owner 降至 50/89；Push/LitePull Rebalance root 与 standard-weak self reference 共删除 8 个 production identity/13 occurrence，测试/compatibility 不增
-  - [ ] M11-12al 及后续：Client MQClientInstance/Producer owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8369 后实际快照降至 326 production/909 occurrence；Client owner 降至 9/17、Client test 降至 12/83、Proxy production 清零；MQClientInstance root 全链路共删除 42 个 production identity/73 occurrence 与 13 个 test identity/19 occurrence
+  - [ ] M11-12am 及后续：Client Producer/PullMessageService child owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -397,6 +397,12 @@ Client Rebalance root ownership 随 Issue #8367 将 Push/LitePull concrete rebal
 self-reference 不会保活 root。实际快照降至 368 production/982 occurrence，Client owner 降至 50/89；剩余为 Broker
 190/568、Client 50/89、Proxy 1/1 与 Store 127/324，总进度仍为 75/82。下一子切片为 M11-12al Client
 MQClientInstance root ownership，M11-12 父工作包未完成。
+Client MQClientInstance root ownership 随 Issue #8369 将 Manager/Proxy compatibility handle 与
+Admin/Producer/Consumer/Rebalance/API/OffsetStore 持有链统一改为标准 `Arc<MQClientInstance>`，Remoting/Admin
+回指统一为标准 `Weak`；lifecycle transition、API slot 与 connection task handle 使用显式同步，运行路径收窄为共享
+receiver。实际快照降至 326 production/909 occurrence，Client owner 降至 9/17、Client test 降至 12/83，Proxy
+production 债务清零；剩余为 Broker 190/568、Client 9/17 与 Store 127/324，总进度仍为 75/82。下一子切片为
+M11-12am Client Producer root ownership，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -411,6 +411,12 @@ setter 从 `WeakArcMut` 改为标准 `Weak`；不改变 queue assignment、start
 `ArcMut<MQClientInstance>` 的位置明确保留给下一 owner 切片。实际快照降至 368 production/982 occurrences，Client
 owner 降至 50/89，另有 Proxy 1/1；其余 Client/Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12al 已将 MQClientManager/Proxy compatibility handle 与 Admin/Producer/Consumer/Rebalance/API/OffsetStore
+持有的 `MQClientInstance` root 统一改为标准 `Arc`，Remoting/Admin 回指改为标准 `Weak`；lifecycle、API slot 与
+connection task handle 使用显式同步，start/shutdown 与 default producer 兼容入口串行。实际快照降至 326
+production/909 occurrences，Client owner 降至 9/17、Client test 降至 12/83，Proxy production 债务清零；其余
+Client Producer/PullMessageService、Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -105,6 +105,9 @@ M11-12aj 的 Client Push implementation root ownership 由 Issue #8365 跟踪，
 M11-12ak 的 Client Rebalance root ownership 由 Issue #8367 跟踪，分支为
 `mxsm/architecture-refactor-rebalance-root-ownership`；它仍是同一 M11-12 工作包的子切片。
 
+M11-12al 的 Client MQClientInstance root ownership 由 Issue #8369 跟踪，分支为
+`mxsm/architecture-refactor-mq-client-instance-root-ownership`；它仍是同一 M11-12 工作包的子切片。
+
 ## 初始盘点
 
 在 main `86719f1bc77c2e78ff32195262bad820145f271b` 上生成当前源码快照：
@@ -914,6 +917,32 @@ approval 不提交；其余 8 个 identity/13 个 occurrence 为真实删除。r
 `ArcMut<RebalanceLitePullImpl>`、对应 constructor 与 `WeakArcMut` self-reference 已零匹配。下一子切片 M11-12al
 处理 `MQClientInstance` root ownership；75/82 总进度不变。
 
+## M11-12al Client MQClientInstance root ownership
+
+| 目标 | 实现与证据 |
+|---|---|
+| standard root | `MQClientManager`、Proxy compatibility handle 与 Admin/Producer/Consumer/Rebalance/API/OffsetStore 全链路统一持有标准 `Arc<MQClientInstance>`；repository 中目标 root 的 `ArcMut`/`WeakArcMut` 零匹配 |
+| cycle breaking | `ClientRemotingProcessor` 与 `MQAdminImpl` 仅保存标准 `Weak<MQClientInstance>`；构造 API 借用外部 `Arc` 后 downgrade，drop root 后 weak upgrade 返回 `None` |
+| lifecycle publication | `start`/`shutdown` 使用单一异步 transition mutex；service state 使用短 `RwLock`，API slot 使用 `ArcSwapOption`，connection task handle 使用短 `Mutex` 并在 await 前取出 |
+| child compatibility | 尚未迁移的 DefaultProducer/PullMessageService child owner 保留在显式 lifecycle mutex 后；共享 receiver 通过 clone-local child handle 调用，不新增 production `mut_from_ref` |
+| regression evidence | MQClientInstance 30/30、Remoting 22/22、Admin 7/7、Pull 10/10、Rebalance 24/24、Pull integration 28/28 与 typed-error 5/5 定向测试通过；Client 全量 library 984/984 及全部 integration targets 通过 |
+
+M11-12al 后实际快照为 544 个条目：production 326、test 204、compatibility 14；occurrence 精确为 production
+909、test 571、compatibility 40。相对 M11-12ak 删除 42 个 production identity/73 occurrence、13 个 test
+identity/19 occurrence，compatibility 不增加；Client owner 从 50/89 降至 9/17，Client test 从 25/102 降至
+12/83，Proxy production 从 1/1 降至零。剩余 production 债务为：
+
+| owner | 条目 | occurrence |
+|---|---:|---:|
+| Broker | 190 | 568 |
+| Client | 9 | 17 |
+| Store | 127 | 324 |
+
+reviewed baseline 从 599→544、occurrences 从 1,612→1,520。6 个同 identity/same item occurrence 与 2 个
+test-only import identity relocation 逐条按 ADR-013 临时审核且 approval 不提交；其余为真实删除。repository 中
+`ArcMut<MQClientInstance>`、`WeakArcMut<MQClientInstance>`、对应 constructor 与 root `mut_from_ref` 已零匹配。
+下一子切片 M11-12am 处理 DefaultMQProducer root/Weak self owner；75/82 总进度不变。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1660,11 +1689,29 @@ M11-12ak 追加验证：
 | Rebalance root ArcMut 定向扫描 | repository 中 Push/LitePull concrete Rebalance `ArcMut`/constructor 与 `WeakArcMut` self-reference 零匹配 |
 | `git diff --check` | 通过；仅报告工作树 CRLF 转换提示，无 whitespace error |
 
+M11-12al 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；标准 MQClientInstance root 与所有 Client target 编译通过 |
+| MQClientInstance/Remoting/Admin/Pull/Rebalance focused tests | 30/30、22/22、7/7、10/10、24/24 通过；Pull integration 28/28、typed-error 5/5 通过 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 984/984，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline promotion（临时 ADR-013 approval） | 42 个 production identity/73 occurrence、13 个 test identity/19 occurrence 净删除；6 个同 identity occurrence 与 2 个 test import identity relocation 逐条审核，approval 不提交；baseline 599/1,612→544/1,520 |
+| `python scripts/arc_mut_guard.py` | 通过；production 326/909、test 204/571、compatibility 14/40；Client owner 9/17、Client test 12/83，Proxy production 清零；没有新增 production `mut_from_ref` |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；root、Pull/Rebalance service 与 default producer transition 串行，短同步锁不跨 `.await` |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates，guard 单测 49/49 通过 |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| MQClientInstance root ArcMut 定向扫描 | repository 中 `ArcMut<MQClientInstance>` / `WeakArcMut<MQClientInstance>` / 对应 constructor 零匹配；root 文件无 `mut_from_ref` |
+| `git diff --check` | 通过；仅报告工作树 CRLF 转换提示，无 whitespace error |
+
 ## 剩余切片与 Gate
 
-1. Client MQClientInstance root/consumer handles、Producer self owner 与剩余可变 receiver（Client owner 50/89，另有
-   Proxy 1/1）；下一子切片 M11-12al 先统一 MQClientManager、Admin/Producer/Consumer/Rebalance/API/offset store 持有的
-   `MQClientInstance` owner，并收窄其剩余可变 receiver。
+1. Client DefaultMQProducer self owner、PullMessageService child owner 与剩余可变 receiver（Client owner 9/17）；
+   下一子切片 M11-12am 先统一 Producer facade/implementation/registry/callback 的 root 与 standard-weak self owner。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
+++ b/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
@@ -173,8 +173,8 @@ async fn run_sharded_pull_workers(request_count: usize, shard_count: usize) -> S
         pull_message_service_shards: shard_count,
         ..Default::default()
     };
-    let mut instance = MQClientInstance::new_arc(client_config, 0, "client-pull-scheduler-sharded-bench", None);
-    let mut service = PullMessageService::with_capacity_and_shards(request_count.next_power_of_two(), shard_count);
+    let instance = MQClientInstance::new_arc(client_config, 0, "client-pull-scheduler-sharded-bench", None);
+    let service = PullMessageService::with_capacity_and_shards(request_count.next_power_of_two(), shard_count);
     service
         .start(instance.clone())
         .await

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -129,7 +129,6 @@ use rocketmq_remoting::protocol::subscription::group_forbidden::GroupForbidden;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 use tracing::info;
 use tracing::warn;
 
@@ -527,7 +526,7 @@ fn lite_pull_topic_config(
 
 pub struct DefaultMQAdminExtImpl {
     service_state: ServiceState,
-    client_instance: Option<ArcMut<MQClientInstance>>,
+    client_instance: Option<Arc<MQClientInstance>>,
     rpc_hook: Option<Arc<dyn RPCHook>>,
     timeout_millis: Duration,
     kv_namespace_to_delete_list: Vec<CheetahString>,
@@ -935,7 +934,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
                 self.client_instance
                     .as_mut()
                     .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?
-                    .start(arc_mut)
+                    .start()
                     .await?;
                 self.service_state = ServiceState::Running;
                 info!("the adminExt [{}] start OK", self.admin_ext_group);

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -448,7 +448,7 @@ impl ConsumeMessageOrderlyService {
             );
             return false;
         };
-        let Some(mut client_instance) = default_mqpush_consumer_impl.get_mq_client_factory() else {
+        let Some(client_instance) = default_mqpush_consumer_impl.get_mq_client_factory() else {
             warn!(
                 "sendMessageBack skipped: MQClientInstance is not initialized, group={} msg={}",
                 self.consumer_group, msg
@@ -456,7 +456,7 @@ impl ConsumeMessageOrderlyService {
             return false;
         };
 
-        let result = client_instance.default_producer.send(new_msg).await;
+        let result = client_instance.send_with_default_producer(new_msg).await;
         result.is_ok()
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -477,16 +477,12 @@ impl ConsumeMessagePopOrderlyService {
 
         if let Some(impl_) = self.consumer_impl() {
             if let Some(client_factory) = impl_.get_mq_client_factory() {
-                if let Some(producer_impl) = client_factory.default_producer.default_mqproducer_impl.as_ref() {
-                    match producer_impl.mut_from_ref().send(&mut new_msg).await {
-                        Ok(_) => true,
-                        Err(e) => {
-                            error!("sendMessageBack failed: {:?}, msg: {:?}", e, msg);
-                            false
-                        }
+                match client_factory.send_with_default_producer_impl(&mut new_msg).await {
+                    Ok(_) => true,
+                    Err(e) => {
+                        error!("sendMessageBack failed: {:?}, msg: {:?}", e, msg);
+                        false
                     }
-                } else {
-                    false
                 }
             } else {
                 false

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -47,7 +47,6 @@ use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
@@ -459,7 +458,7 @@ pub struct DefaultLitePullConsumerImpl {
     consumer_start_timestamp: AtomicI64,
 
     // Core components
-    client_instance: StdRwLock<Option<ArcMut<MQClientInstance>>>,
+    client_instance: StdRwLock<Option<Arc<MQClientInstance>>>,
     rebalance_impl: Arc<RebalanceLitePullImpl>,
     pull_api_wrapper: StdRwLock<Option<Arc<PullAPIWrapper>>>,
     offset_store: StdRwLock<Option<Arc<OffsetStore>>>,
@@ -1096,8 +1095,7 @@ impl DefaultLitePullConsumerImpl {
                     )));
                 }
 
-                let client_instance_clone = client_instance.clone();
-                client_instance.mut_from_ref().start(client_instance_clone).await?;
+                client_instance.start().await?;
 
                 self.set_service_state(ServiceState::Running);
 
@@ -1144,7 +1142,7 @@ impl DefaultLitePullConsumerImpl {
 
         self.refresh_registered_topic_message_queue_snapshots().await?;
 
-        let mut client_instance = self
+        let client_instance = self
             .component_snapshot(&self.client_instance)
             .ok_or_else(|| crate::mq_client_err!("Client instance not initialized"))?;
         client_instance.check_client_in_broker().await
@@ -1344,7 +1342,7 @@ impl DefaultLitePullConsumerImpl {
                     .write()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .take();
-                if let Some(mut client) = client {
+                if let Some(client) = client {
                     client.unregister_consumer(&consumer_group).await;
                     client.shutdown().await;
                 }
@@ -1445,7 +1443,7 @@ impl DefaultLitePullConsumerImpl {
         });
 
         if let Some(client_instance) = self.component_snapshot(&self.client_instance) {
-            if let Some(api_impl) = client_instance.mq_client_api_impl.as_ref() {
+            if let Some(api_impl) = client_instance.mq_client_api_impl.load_full() {
                 api_impl.update_name_server_address_list(&joined_addr).await;
             }
         }
@@ -2412,7 +2410,7 @@ impl DefaultLitePullConsumerImpl {
         // Fetch topic route data from name server
         let topic_route_data = client_instance
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or_else(|| crate::mq_client_err!("MQClientAPIImpl not initialized"))?
             .get_topic_route_info_from_name_server_detail(topic.as_str(), 3000, true)
             .await?;
@@ -2827,7 +2825,7 @@ impl DefaultLitePullConsumerImpl {
 
         client_instance
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or_else(|| crate::mq_client_err!("MQClientAPIImpl not initialized"))?
             .get_max_offset(broker_result.broker_addr.as_str(), message_queue, 3000)
             .await
@@ -2849,7 +2847,7 @@ impl DefaultLitePullConsumerImpl {
 
         client_instance
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or_else(|| crate::mq_client_err!("MQClientAPIImpl not initialized"))?
             .get_min_offset(broker_result.broker_addr.as_str(), message_queue, 3000)
             .await
@@ -3100,6 +3098,8 @@ mod tests {
     use std::sync::atomic::Ordering as AtomicOrdering;
     use std::sync::Barrier;
     use std::sync::Mutex as StdMutex;
+
+    use rocketmq_rust::ArcMut;
 
     use super::*;
     use crate::base::access_channel::AccessChannel;
@@ -3723,7 +3723,7 @@ mod tests {
             .expect("client instance should be initialized");
         let api_impl = client_instance
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .expect("client api should be initialized");
         let mut actual_addresses = api_impl.get_name_server_address_list().to_vec();
         actual_addresses.sort();

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -57,7 +57,6 @@ use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_remoting::rpc::topic_request_header::TopicRequestHeader;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
@@ -126,7 +125,7 @@ pub struct DefaultMQPushConsumerImpl {
     consume_message_hook_list: StdRwLock<Vec<ConsumeMessageHookArc>>,
     rpc_hook: Option<Arc<dyn RPCHook>>,
     service_state: StdRwLock<ServiceState>,
-    client_instance: StdRwLock<Option<ArcMut<MQClientInstance>>>,
+    client_instance: StdRwLock<Option<Arc<MQClientInstance>>>,
     pull_api_wrapper: StdRwLock<Option<Arc<PullAPIWrapper>>>,
     pause: Arc<AtomicBool>,
     consume_orderly: AtomicBool,
@@ -209,7 +208,7 @@ impl DefaultMQPushConsumerImpl {
         }
     }
 
-    pub fn get_mq_client_factory(&self) -> Option<ArcMut<MQClientInstance>> {
+    pub fn get_mq_client_factory(&self) -> Option<Arc<MQClientInstance>> {
         self.component_snapshot(&self.client_instance)
     }
 
@@ -220,7 +219,7 @@ impl DefaultMQPushConsumerImpl {
             .map(|client_instance| client_instance.client_id.clone())
     }
 
-    pub fn set_mq_client_factory(&self, client_instance: ArcMut<MQClientInstance>) {
+    pub fn set_mq_client_factory(&self, client_instance: Arc<MQClientInstance>) {
         self.rebalance_impl.set_mq_client_factory(client_instance.clone());
         self.set_component(&self.client_instance, Some(client_instance));
     }
@@ -374,7 +373,7 @@ impl DefaultMQPushConsumerImpl {
                     });
                 }
                 let client_config = self.client_config_snapshot();
-                let mut client_instance = MQClientManager::get_instance()
+                let client_instance = MQClientManager::get_instance()
                     .get_or_create_mq_client_instance(client_config.as_ref().clone(), self.rpc_hook.clone());
                 self.set_component(&self.client_instance, Some(client_instance.clone()));
                 self.rebalance_impl
@@ -531,8 +530,7 @@ impl DefaultMQPushConsumerImpl {
                         FAQUrl::suggest_todo(FAQUrl::GROUP_NAME_DUPLICATE_URL)
                     )));
                 }
-                let client_instance_clone = client_instance.clone();
-                client_instance.start(client_instance_clone).await?;
+                client_instance.start().await?;
                 info!(
                     "the consumer [{}] start OK, message_model={}, isUnitMode={}",
                     consumer_config.consumer_group, consumer_config.message_model, consumer_config.unit_mode
@@ -569,7 +567,7 @@ impl DefaultMQPushConsumerImpl {
 
     async fn run_startup_after_running_checks(&self) -> rocketmq_error::RocketMQResult<()> {
         self.update_topic_subscribe_info_when_subscription_changed().await;
-        let mut client_instance = self
+        let client_instance = self
             .get_mq_client_factory()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("MQClientInstance"))?;
         client_instance.check_client_in_broker().await?;
@@ -608,7 +606,7 @@ impl DefaultMQPushConsumerImpl {
                     }
                 }
                 let consumer_group = self.consumer_config_snapshot().consumer_group.clone();
-                if let Some(mut client) = self.get_mq_client_factory() {
+                if let Some(client) = self.get_mq_client_factory() {
                     client.unregister_consumer(consumer_group.as_str()).await;
                     client.shutdown().await;
                 } else {
@@ -1681,7 +1679,7 @@ impl DefaultMQPushConsumerImpl {
             let max_consume_retry_times = self.get_max_reconsume_times();
             let consumer_group = self.consumer_config_snapshot().consumer_group.clone();
             let result = if let Some(client_instance) = self.get_mq_client_factory() {
-                if let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() {
+                if let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() {
                     mq_client_api_impl
                         .consumer_send_message_back(
                             broker_addr.as_str(),
@@ -1754,8 +1752,7 @@ impl DefaultMQPushConsumerImpl {
         let new_msg = self.build_retry_message_for_send_back(msg)?;
         self.get_mq_client_factory()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("MQClientInstance"))?
-            .default_producer
-            .send(new_msg)
+            .send_with_default_producer(new_msg)
             .await?;
         Ok(())
     }
@@ -1863,7 +1860,7 @@ impl DefaultMQPushConsumerImpl {
 
             fn on_exception(&self, _e: rocketmq_error::RocketMQError) {}
         }
-        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
+        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
             error!("ackAsync error: MQClientAPIImpl is not initialized");
             return;
         };
@@ -2460,7 +2457,6 @@ mod tests {
         let existing_consumer = new_startable_push_consumer(client_config.clone(), group.clone());
         assert!(
             client_instance
-                .mut_from_ref()
                 .register_consumer(&group, MQConsumerInnerImpl::from_push(existing_consumer))
                 .await
         );
@@ -2477,7 +2473,7 @@ mod tests {
             .and_then(|service| service.get_consume_message_concurrently_service())
             .is_some_and(|service| service.is_shutdown()));
 
-        client_instance.mut_from_ref().unregister_consumer(group).await;
+        client_instance.unregister_consumer(group).await;
         MQClientManager::get_instance().remove_client_factory(&client_id);
     }
 
@@ -2507,14 +2503,13 @@ mod tests {
             .put_subscription_data(topic.clone(), subscription);
         assert!(
             client_instance
-                .mut_from_ref()
                 .register_consumer(&group, MQConsumerInnerImpl::from_push(consumer.clone()))
                 .await
         );
 
         let mut broker_addrs = HashMap::new();
         broker_addrs.insert(mix_all::MASTER_ID, CheetahString::from_static_str("127.0.0.1:10911"));
-        client_instance.mut_from_ref().topic_route_table.insert(
+        client_instance.topic_route_table.insert(
             topic,
             TopicRouteData {
                 broker_datas: vec![BrokerData::new(
@@ -2526,7 +2521,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        client_instance.mut_from_ref().mq_client_api_impl = None;
+        client_instance.mq_client_api_impl.store(None);
 
         let error = consumer
             .complete_startup_after_running()
@@ -2540,12 +2535,11 @@ mod tests {
         let replacement = new_startable_push_consumer(ClientConfig::default(), group.clone());
         assert!(
             client_instance
-                .mut_from_ref()
                 .register_consumer(&group, MQConsumerInnerImpl::from_push(replacement))
                 .await,
             "shutdown rollback should unregister the failed consumer group"
         );
-        client_instance.mut_from_ref().unregister_consumer(group).await;
+        client_instance.unregister_consumer(group).await;
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -38,7 +38,6 @@ use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageR
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
-use rocketmq_rust::ArcMut;
 
 use crate::consumer::consumer_impl::pull_request_ext::PullResultExt;
 use crate::consumer::pop_callback::PopCallback;
@@ -89,7 +88,7 @@ fn decode_pull_messages(
 }
 
 pub struct PullAPIWrapper {
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
     consumer_group: CheetahString,
     unit_mode: AtomicBool,
     pull_from_which_node_table: Arc<DashMap<MessageQueue, AtomicU64>>,
@@ -99,7 +98,7 @@ pub struct PullAPIWrapper {
 }
 
 impl PullAPIWrapper {
-    pub fn new(mq_client_factory: ArcMut<MQClientInstance>, consumer_group: CheetahString, unit_mode: bool) -> Self {
+    pub fn new(mq_client_factory: Arc<MQClientInstance>, consumer_group: CheetahString, unit_mode: bool) -> Self {
         Self {
             client_instance: mq_client_factory,
             consumer_group,

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::RwLock as StdRwLock;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -31,9 +32,9 @@ use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::UnifiedServiceError;
 use rocketmq_runtime::Shutdown;
-use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use tokio::sync::mpsc;
+use tokio::sync::Mutex;
 use tokio::time::Instant as TokioInstant;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -79,11 +80,13 @@ type MessageRequestSender = tokio::sync::mpsc::Sender<BoxedMessageRequest>;
 /// - Delayed tasks check `is_stopped()` before execution
 #[derive(Clone)]
 pub struct PullMessageService {
+    lifecycle_transition: Arc<Mutex<()>>,
+
     /// Message request channel sender
-    tx: Option<tokio::sync::mpsc::Sender<Box<dyn MessageRequest + Send + 'static>>>,
+    tx: Arc<StdRwLock<Option<MessageRequestSender>>>,
 
     /// Shutdown signal broadcaster
-    tx_shutdown: Option<tokio::sync::broadcast::Sender<()>>,
+    tx_shutdown: Arc<StdRwLock<Option<tokio::sync::broadcast::Sender<()>>>>,
 
     /// Service stopped flag (for fast check)
     stopped: Arc<AtomicBool>,
@@ -485,7 +488,7 @@ async fn run_pull_request_shard_worker(
     index: usize,
     mut rx: mpsc::Receiver<PullRequest>,
     mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
-    mut instance: ArcMut<MQClientInstance>,
+    instance: Arc<MQClientInstance>,
     metrics: Arc<PullRequestShardMetrics>,
 ) {
     info!(shard_index = index, "PullMessageService shard worker started");
@@ -496,7 +499,7 @@ async fn run_pull_request_shard_worker(
                 break;
             }
             Some(request) = rx.recv() => {
-                PullMessageService::pull_message(request, &mut instance).await;
+                PullMessageService::pull_message(request, instance.as_ref()).await;
                 metrics.record_processed();
             }
             else => {
@@ -532,8 +535,9 @@ impl PullMessageService {
             .collect();
 
         PullMessageService {
-            tx: None,
-            tx_shutdown: None,
+            lifecycle_transition: Arc::new(Mutex::new(())),
+            tx: Arc::new(StdRwLock::new(None)),
+            tx_shutdown: Arc::new(StdRwLock::new(None)),
             stopped: Arc::new(AtomicBool::new(false)),
             queue_capacity,
             shard_count,
@@ -579,15 +583,21 @@ impl PullMessageService {
     ///
     /// # Errors
     /// Returns error if service is already started
-    pub async fn start(&mut self, instance: ArcMut<MQClientInstance>) -> Result<(), RocketMQError> {
-        if self.tx.is_some() {
+    pub async fn start(&self, instance: Arc<MQClientInstance>) -> Result<(), RocketMQError> {
+        let _transition = self.lifecycle_transition.lock().await;
+        if self
+            .tx
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+        {
             warn!("{} already started", self.get_service_name());
             return Ok(());
         }
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Box<dyn MessageRequest + Send + 'static>>(self.queue_capacity);
         let (mut shutdown, tx_shutdown) = Shutdown::new(1);
-        let mut pop_instance = instance.clone();
+        let pop_instance = instance.clone();
 
         let handle = spawn_client_tracked_task("rocketmq-client-pull-message-service", async move {
             info!("{} service started", "PullMessageService");
@@ -600,7 +610,7 @@ impl PullMessageService {
                     }
                     Some(request) = rx.recv() => {
                         // Process request with exception handling
-                        if let Err(e) = Self::process_request(request, &mut pop_instance).await {
+                        if let Err(e) = Self::process_request(request, pop_instance.as_ref()).await {
                             error!("{} failed to process request: {:?}", "PullMessageService", e);
                         }
                     }
@@ -643,8 +653,11 @@ impl PullMessageService {
             });
         }
 
-        self.tx = Some(tx);
-        self.tx_shutdown = Some(tx_shutdown);
+        *self.tx.write().unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(tx);
+        *self
+            .tx_shutdown
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(tx_shutdown);
         self.stopped.store(false, Ordering::Release);
         *self.main_task_handle.lock().await = Some(handle);
         *self.pull_shard_task_handles.lock().await = pull_handles;
@@ -768,7 +781,7 @@ impl PullMessageService {
     /// Returns error if request processing fails
     async fn process_request(
         request: Box<dyn MessageRequest + Send + 'static>,
-        instance: &mut MQClientInstance,
+        instance: &MQClientInstance,
     ) -> Result<(), RocketMQError> {
         match request.get_message_request_mode() {
             MessageRequestMode::Pull => {
@@ -792,7 +805,7 @@ impl PullMessageService {
     }
 
     /// Handles pull message request
-    async fn pull_message(request: PullRequest, instance: &mut MQClientInstance) {
+    async fn pull_message(request: PullRequest, instance: &MQClientInstance) {
         if let Some(mut consumer) = instance.select_consumer(request.get_consumer_group()).await {
             consumer.pull_message(request).await;
         } else {
@@ -801,7 +814,7 @@ impl PullMessageService {
     }
 
     /// Handles pop message request
-    async fn pop_message(request: PopRequest, instance: &mut MQClientInstance) {
+    async fn pop_message(request: PopRequest, instance: &MQClientInstance) {
         if let Some(mut consumer) = instance.select_consumer(request.get_consumer_group()).await {
             consumer.pop_message(request).await;
         } else {
@@ -863,7 +876,7 @@ impl PullMessageService {
         self.submit_delayed(
             DelayedSchedulePayload::Pop {
                 request: pop_request,
-                tx: self.tx.clone(),
+                tx: self.tx.read().unwrap_or_else(|poisoned| poisoned.into_inner()).clone(),
             },
             time_delay,
         );
@@ -876,7 +889,8 @@ impl PullMessageService {
             return;
         }
 
-        if let Some(tx) = &self.tx {
+        let tx = self.tx.read().unwrap_or_else(|poisoned| poisoned.into_inner()).clone();
+        if let Some(tx) = tx {
             if let Err(e) = tx.send(Box::new(pop_request)).await {
                 error!(
                     "executePopPullRequestImmediately messageRequestQueue.put error: {:?}",
@@ -936,6 +950,7 @@ impl PullMessageService {
     /// - Cancels all scheduled tasks
     /// - Waits for main loop to finish (with timeout)
     pub async fn shutdown(&self, timeout_ms: u64) -> Result<(), RocketMQError> {
+        let _transition = self.lifecycle_transition.lock().await;
         if self.is_stopped() {
             warn!("{} already stopped", self.get_service_name());
             return Ok(());
@@ -956,7 +971,12 @@ impl PullMessageService {
             .take();
 
         // 2. Send shutdown signal
-        if let Some(tx_shutdown) = &self.tx_shutdown {
+        let tx_shutdown = self
+            .tx_shutdown
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(tx_shutdown) = tx_shutdown {
             tx_shutdown
                 .send(())
                 .map_err(|_| pull_message_service_shutdown_signal_failed())?;
@@ -1018,8 +1038,8 @@ impl Default for PullMessageService {
 
 #[doc(hidden)]
 pub async fn run_pull_message_service_lifecycle_probe() -> PullMessageServiceLifecycleProbe {
-    let mut service = PullMessageService::new();
-    let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "pull-message-service-probe", None);
+    let service = PullMessageService::new();
+    let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "pull-message-service-probe", None);
 
     let start_result = service.start(instance.clone()).await;
     let task_count_before_shutdown = service.main_task_count().await;
@@ -1125,9 +1145,10 @@ mod tests {
     }
 
     async fn process_mismatched_request(mode: MessageRequestMode) -> RocketMQError {
-        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "pull-message-mismatch-test", None);
+        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "pull-message-mismatch-test", None);
 
-        match PullMessageService::process_request(Box::new(MismatchedMessageRequest { mode }), &mut instance).await {
+        match PullMessageService::process_request(Box::new(MismatchedMessageRequest { mode }), instance.as_ref()).await
+        {
             Ok(_) => panic!("mismatched message request should be rejected"),
             Err(error) => error,
         }
@@ -1209,10 +1230,13 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_reports_closed_shutdown_receiver_as_client_invalid_state() {
-        let mut service = PullMessageService::new();
+        let service = PullMessageService::new();
         let (tx_shutdown, rx_shutdown) = tokio::sync::broadcast::channel(1);
         drop(rx_shutdown);
-        service.tx_shutdown = Some(tx_shutdown);
+        *service
+            .tx_shutdown
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(tx_shutdown);
 
         let error = match service.shutdown(100).await {
             Ok(_) => panic!("closed shutdown receiver should be rejected"),

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -34,7 +34,6 @@ use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
-use rocketmq_rust::ArcMut;
 use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
@@ -100,7 +99,7 @@ pub(crate) struct RebalanceImpl<R> {
 
     /// Client transport handle is snapshotted separately so network work never holds the
     /// synchronous metadata lock across an await point.
-    client_instance: StdRwLock<Option<ArcMut<MQClientInstance>>>,
+    client_instance: StdRwLock<Option<Arc<MQClientInstance>>>,
 
     /// Weak reference to the concrete rebalance implementation (e.g., `RebalancePushImpl`),
     /// enabling abstract callbacks without creating reference cycles.
@@ -133,7 +132,7 @@ where
         consumer_group: Option<CheetahString>,
         message_model: Option<MessageModel>,
         allocate_message_queue_strategy: Option<Arc<dyn AllocateMessageQueueStrategy>>,
-        mqclient_instance: Option<ArcMut<MQClientInstance>>,
+        mqclient_instance: Option<Arc<MQClientInstance>>,
     ) -> Self {
         RebalanceImpl {
             process_queue_table: Arc::new(RwLock::new(HashMap::with_capacity(64))),
@@ -162,7 +161,7 @@ where
         self.subscription_inner.remove(topic);
     }
 
-    pub fn get_mq_client_factory(&self) -> Option<ArcMut<MQClientInstance>> {
+    pub fn get_mq_client_factory(&self) -> Option<Arc<MQClientInstance>> {
         self.client_instance
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -173,7 +172,7 @@ where
         self.metadata_snapshot().allocate_message_queue_strategy
     }
 
-    pub fn set_mq_client_factory(&self, client_instance: ArcMut<MQClientInstance>) {
+    pub fn set_mq_client_factory(&self, client_instance: Arc<MQClientInstance>) {
         *self
             .client_instance
             .write()
@@ -318,7 +317,7 @@ where
         let Some(message_model) = self.message_model_value("tryQueryAssignment") else {
             return false;
         };
-        let Some(mut client_instance) = self.get_mq_client_factory() else {
+        let Some(client_instance) = self.get_mq_client_factory() else {
             error!("tryQueryAssignment error: client_instance is None for topic: {}", topic);
             return false;
         };
@@ -461,7 +460,7 @@ where
         let Some(message_model) = self.message_model_value("getRebalanceResultFromBroker") else {
             return false;
         };
-        let Some(mut client_instance) = self.get_mq_client_factory() else {
+        let Some(client_instance) = self.get_mq_client_factory() else {
             error!("get_rebalance_result_from_broker error: client_instance is None.");
             return false;
         };
@@ -760,7 +759,7 @@ where
             }
 
             if !all_mq_locked {
-                if let Some(mut client_instance) = self.get_mq_client_factory() {
+                if let Some(client_instance) = self.get_mq_client_factory() {
                     client_instance.rebalance_later(500);
                 } else {
                     warn!("rebalance_later skipped: client_instance is not initialized");
@@ -955,7 +954,7 @@ where
         }
 
         if !all_mq_locked {
-            if let Some(mut client_instance) = self.get_mq_client_factory() {
+            if let Some(client_instance) = self.get_mq_client_factory() {
                 client_instance.rebalance_later(500);
             } else {
                 warn!("rebalance_later skipped: client_instance is not initialized");
@@ -1006,7 +1005,7 @@ where
                 let Some(consumer_group) = self.consumer_group_ref("rebalanceByTopic") else {
                     return false;
                 };
-                let cid_all = if let Some(mut client_instance) = self.get_mq_client_factory() {
+                let cid_all = if let Some(client_instance) = self.get_mq_client_factory() {
                     client_instance.find_consumer_id_list(topic, &consumer_group).await
                 } else {
                     warn!(
@@ -1149,7 +1148,7 @@ where
                 ..Default::default()
             };
             request_body.mq_set.insert(mq.clone());
-            let Some(mq_client_api_impl) = client.mq_client_api_impl.as_ref() else {
+            let Some(mq_client_api_impl) = client.mq_client_api_impl.load_full() else {
                 warn!("lockWith skipped: MQClientAPIImpl is not initialized, mq={}", mq);
                 return false;
             };
@@ -1209,7 +1208,7 @@ where
                             mq_set: mqs.clone(),
                             ..Default::default()
                         };
-                        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
+                        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
                             warn!(
                                 "lockAll skipped broker {}: MQClientAPIImpl is not initialized",
                                 broker_name
@@ -1278,7 +1277,7 @@ where
                     mq_set: mqs.clone(),
                     ..Default::default()
                 };
-                let Some(mq_client_api_impl) = client.mq_client_api_impl.as_ref() else {
+                let Some(mq_client_api_impl) = client.mq_client_api_impl.load_full() else {
                     warn!(
                         "unlockAll skipped broker {}: MQClientAPIImpl is not initialized",
                         broker_name

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs
@@ -40,7 +40,6 @@ use rocketmq_common::common::mix_all;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
-use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -152,7 +151,7 @@ impl RebalanceLitePullImpl {
         consumer_group: CheetahString,
         message_model: rocketmq_remoting::protocol::heartbeat::message_model::MessageModel,
         strategy: Arc<dyn crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy>,
-        client_instance: ArcMut<MQClientInstance>,
+        client_instance: Arc<MQClientInstance>,
     ) {
         self.rebalance_impl_inner.set_consumer_group(consumer_group.clone());
         self.rebalance_impl_inner.set_message_model(message_model);

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -32,7 +32,6 @@ use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchReq
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
-use rocketmq_rust::ArcMut;
 use std::sync::LazyLock;
 use tokio::sync::RwLock;
 use tracing::error;
@@ -126,7 +125,7 @@ impl RebalancePushImpl {
             .set_allocate_message_queue_strategy(allocate_message_queue_strategy);
     }
 
-    pub fn set_mq_client_factory(&self, client_instance: ArcMut<MQClientInstance>) {
+    pub fn set_mq_client_factory(&self, client_instance: Arc<MQClientInstance>) {
         self.rebalance_impl_inner.set_mq_client_factory(client_instance);
     }
 
@@ -494,7 +493,7 @@ impl Rebalance for RebalancePushImpl {
                 ..Default::default()
             };
             request_body.mq_set.insert(mq.clone());
-            let Some(mq_client_api_impl) = client.mq_client_api_impl.as_ref() else {
+            let Some(mq_client_api_impl) = client.mq_client_api_impl.load_full() else {
                 warn!("unlockBatchMQ skipped: MQClientAPIImpl is not initialized, mq={}", mq);
                 return;
             };
@@ -606,7 +605,7 @@ impl Rebalance for RebalancePushImpl {
 
 async fn build_process_queue_table_by_broker_name(
     process_queue_table: &Arc<RwLock<HashMap<MessageQueue, Arc<ProcessQueue>>>>,
-    client: &ArcMut<MQClientInstance>,
+    client: &Arc<MQClientInstance>,
 ) -> HashMap<CheetahString, HashSet<MessageQueue>> {
     let mut result = HashMap::new();
     let process_queue_table_read = process_queue_table.read().await;
@@ -625,7 +624,7 @@ async fn lock_all_impl(
     broker_mqs: HashMap<CheetahString, HashSet<MessageQueue>>,
     process_queue_table: Arc<RwLock<HashMap<MessageQueue, Arc<ProcessQueue>>>>,
     consumer_group: Option<CheetahString>,
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
 ) {
     use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 
@@ -649,7 +648,7 @@ async fn lock_all_impl(
                         mq_set: mqs.clone(),
                         ..Default::default()
                     };
-                    let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
+                    let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
                         warn!(
                             "lockBatchMQ skipped: MQClientAPIImpl is not initialized for broker {}",
                             broker_name
@@ -697,7 +696,7 @@ async fn unlock_all_impl(
     broker_mqs: HashMap<CheetahString, HashSet<MessageQueue>>,
     process_queue_table: Arc<RwLock<HashMap<MessageQueue, Arc<ProcessQueue>>>>,
     consumer_group: Option<CheetahString>,
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
     oneway: bool,
 ) {
     let map = broker_mqs
@@ -720,7 +719,7 @@ async fn unlock_all_impl(
                         mq_set: mqs.clone(),
                         ..Default::default()
                     };
-                    let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
+                    let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
                         warn!(
                             "unlockBatchMQ skipped: MQClientAPIImpl is not initialized for broker {}",
                             broker_name

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::RwLock as StdRwLock;
 use std::time::Duration;
 
 use rocketmq_common::TimeUtils::current_millis;
@@ -24,9 +25,9 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_error::UnifiedServiceError;
 use rocketmq_runtime::Shutdown;
-use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use tokio::select;
+use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio::time::Instant;
 use tracing::error;
@@ -179,9 +180,10 @@ impl RebalanceConfig {
 #[derive(Clone)]
 pub struct RebalanceService {
     config: RebalanceConfig,
+    lifecycle_transition: Arc<Mutex<()>>,
     notify: Arc<Notify>,
     stopped_notify: Arc<Notify>,
-    tx_shutdown: Option<tokio::sync::broadcast::Sender<()>>,
+    tx_shutdown: Arc<StdRwLock<Option<tokio::sync::broadcast::Sender<()>>>>,
     started: Arc<AtomicBool>,
     task_handle: Arc<tokio::sync::Mutex<Option<ClientTrackedTaskHandle>>>,
     // Health check and metrics
@@ -218,9 +220,10 @@ impl RebalanceService {
 
         RebalanceService {
             config,
+            lifecycle_transition: Arc::new(Mutex::new(())),
             notify: Arc::new(Notify::new()),
             stopped_notify: Arc::new(Notify::new()),
-            tx_shutdown: None,
+            tx_shutdown: Arc::new(StdRwLock::new(None)),
             started: Arc::new(AtomicBool::new(false)),
             task_handle: Arc::new(tokio::sync::Mutex::new(None)),
             last_success_timestamp: Arc::new(AtomicU64::new(0)),
@@ -235,7 +238,8 @@ impl RebalanceService {
         &self.config
     }
 
-    pub async fn start(&mut self, mut instance: ArcMut<MQClientInstance>) -> RocketMQResult<()> {
+    pub async fn start(&self, instance: Arc<MQClientInstance>) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         // Prevent duplicate starts
         if self.started.swap(true, Ordering::SeqCst) {
             warn!("RebalanceService already started, ignoring duplicate start call");
@@ -245,7 +249,10 @@ impl RebalanceService {
         let notify = self.notify.clone();
         let stopped_notify = self.stopped_notify.clone();
         let (mut shutdown, tx_shutdown) = Shutdown::new(1);
-        self.tx_shutdown = Some(tx_shutdown);
+        *self
+            .tx_shutdown
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(tx_shutdown);
 
         let started_clone = self.started.clone();
         let last_success_ts = self.last_success_timestamp.clone();
@@ -334,7 +341,10 @@ impl RebalanceService {
             Ok(task_handle) => task_handle,
             Err(error) => {
                 self.started.store(false, Ordering::SeqCst);
-                self.tx_shutdown = None;
+                self.tx_shutdown
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take();
                 return Err(rebalance_service_startup_failed(error));
             }
         };
@@ -357,6 +367,7 @@ impl RebalanceService {
     }
 
     pub async fn shutdown(&self, timeout_ms: u64) -> RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
         // If not started, return directly
         if !self.started.load(Ordering::SeqCst) {
             info!("RebalanceService not started, shutdown skipped");
@@ -364,7 +375,12 @@ impl RebalanceService {
         }
 
         // Send shutdown signal
-        if let Some(tx_shutdown) = &self.tx_shutdown {
+        let tx_shutdown = self
+            .tx_shutdown
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(tx_shutdown) = tx_shutdown {
             if let Err(e) = tx_shutdown.send(()) {
                 warn!("Failed to send shutdown signal to RebalanceService, error: {:?}", e);
             }
@@ -478,8 +494,8 @@ pub async fn run_rebalance_service_lifecycle_probe() -> RebalanceServiceLifecycl
         min_interval_ms: 1,
         enable_dynamic_interval: true,
     };
-    let mut service = RebalanceService::with_config(config);
-    let mut instance = MQClientInstance::new_arc(
+    let service = RebalanceService::with_config(config);
+    let instance = MQClientInstance::new_arc(
         crate::base::client_config::ClientConfig::default(),
         0,
         "rebalance-service-probe",
@@ -624,7 +640,7 @@ mod tests {
             min_interval_ms: 1,
             enable_dynamic_interval: true,
         };
-        let mut service = RebalanceService::with_config(config);
+        let service = RebalanceService::with_config(config);
         let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "rebalance-no-runtime-client", None);
 
         futures::executor::block_on(service.start(instance))
@@ -639,7 +655,9 @@ mod tests {
         let stopped = service.stopped_notify.notified();
         let tx_shutdown = service
             .tx_shutdown
-            .as_ref()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
             .expect("start should install shutdown sender");
         let _ = tx_shutdown.send(());
 
@@ -653,9 +671,12 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_without_task_handle_waits_for_stop_notification() {
-        let mut service = RebalanceService::new();
+        let service = RebalanceService::new();
         let (mut shutdown, tx_shutdown) = Shutdown::new(1);
-        service.tx_shutdown = Some(tx_shutdown);
+        *service
+            .tx_shutdown
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(tx_shutdown);
         service.started.store(true, Ordering::SeqCst);
 
         let started = service.started.clone();
@@ -681,7 +702,7 @@ mod tests {
             min_interval_ms: 1,
             enable_dynamic_interval: true,
         };
-        let mut service = RebalanceService::with_config(config);
+        let service = RebalanceService::with_config(config);
         let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "rebalance-join-client", None);
 
         service.start(instance).await.expect("rebalance service should start");

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -29,7 +29,6 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_runtime::ScheduledTaskSnapshot;
-use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use std::sync::LazyLock;
 use tokio::fs;
@@ -78,7 +77,7 @@ enum PersistCommand {
 }
 
 pub struct LocalFileOffsetStore {
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
     group_name: CheetahString,
     store_path: CheetahString,
     offset_table: Arc<DashMap<MessageQueue, ControllableOffset>>,
@@ -204,7 +203,7 @@ pub struct LocalFileOffsetStoreLifecycleProbe {
 }
 
 impl LocalFileOffsetStore {
-    pub fn new(client_instance: ArcMut<MQClientInstance>, group_name: CheetahString) -> Self {
+    pub fn new(client_instance: Arc<MQClientInstance>, group_name: CheetahString) -> Self {
         let store_path = LOCAL_OFFSET_STORE_DIR
             .clone()
             .join(client_instance.client_id.as_str())

--- a/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
@@ -23,7 +23,6 @@ use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::TopicR
 use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
-use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
@@ -35,14 +34,14 @@ use crate::consumer::store::read_offset_type::ReadOffsetType;
 use crate::factory::mq_client_instance::MQClientInstance;
 
 pub struct RemoteBrokerOffsetStore {
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
     group_name: CheetahString,
     offset_table: Arc<Mutex<HashMap<MessageQueue, ControllableOffset>>>,
     persisted_offset_table: Arc<Mutex<HashMap<MessageQueue, i64>>>,
 }
 
 impl RemoteBrokerOffsetStore {
-    pub fn new(client_instance: ArcMut<MQClientInstance>, group_name: CheetahString) -> Self {
+    pub fn new(client_instance: Arc<MQClientInstance>, group_name: CheetahString) -> Self {
         Self {
             client_instance,
             group_name,
@@ -97,7 +96,7 @@ impl RemoteBrokerOffsetStore {
                     }),
                 }),
             };
-            let Some(mq_client_api_impl) = self.client_instance.mq_client_api_impl.as_ref() else {
+            let Some(mq_client_api_impl) = self.client_instance.mq_client_api_impl.load_full() else {
                 return Err(rocketmq_error::RocketMQError::not_initialized("MQClientAPIImpl"));
             };
             mq_client_api_impl
@@ -320,7 +319,7 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
                     }),
                 }),
             };
-            let Some(mq_client_api_impl) = self.client_instance.mq_client_api_impl.as_ref() else {
+            let Some(mq_client_api_impl) = self.client_instance.mq_client_api_impl.load_full() else {
                 return Err(rocketmq_error::RocketMQError::not_initialized("MQClientAPIImpl"));
             };
             if is_oneway {

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -17,9 +17,13 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::RwLock as StdRwLock;
+use std::sync::Weak;
 use std::time::Duration;
 use std::time::Instant;
 
+use arc_swap::ArcSwapOption;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use futures::future;
@@ -33,6 +37,7 @@ use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
+use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::TimeUtils::current_millis;
@@ -64,8 +69,8 @@ use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_runtime::schedule::simple_scheduler::ScheduledTaskManager;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::RocketMQTokioMutex;
-use rocketmq_rust::WeakArcMut;
 use serde::Serialize;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::error;
@@ -92,6 +97,7 @@ use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
+use crate::producer::send_result::SendResult;
 use crate::runtime::spawn_client_task;
 use crate::runtime::spawn_client_tracked_task;
 use crate::runtime::ClientTrackedTaskHandle;
@@ -128,7 +134,7 @@ fn get_topic_config_request_header(topic: CheetahString) -> GetTopicConfigReques
 
 async fn run_connection_net_event_listener(
     mut rx: tokio::sync::broadcast::Receiver<ConnectionNetEvent>,
-    weak_instance: WeakArcMut<MQClientInstance>,
+    weak_instance: Weak<MQClientInstance>,
     shutdown_token: CancellationToken,
 ) {
     loop {
@@ -168,7 +174,7 @@ async fn run_connection_net_event_listener(
 
 fn spawn_connection_net_event_listener(
     rx: tokio::sync::broadcast::Receiver<ConnectionNetEvent>,
-    weak_instance: WeakArcMut<MQClientInstance>,
+    weak_instance: Weak<MQClientInstance>,
     shutdown_token: CancellationToken,
 ) -> Option<ClientTrackedTaskHandle> {
     match spawn_client_tracked_task(
@@ -220,7 +226,7 @@ fn schedule_rebalance_wakeup(
 }
 
 pub struct MQClientInstance {
-    pub(crate) client_config: ArcMut<ClientConfig>,
+    pub(crate) client_config: Arc<ClientConfig>,
     pub(crate) client_id: CheetahString,
     boot_timestamp: u64,
     /**
@@ -238,17 +244,19 @@ pub struct MQClientInstance {
      * adminExtGroup.
      */
     admin_ext_table: AdminExtTable,
-    pub(crate) mq_client_api_impl: Option<Arc<MQClientAPIImpl>>,
+    pub(crate) mq_client_api_impl: ArcSwapOption<MQClientAPIImpl>,
     pub(crate) mq_admin_impl: Arc<MQAdminImpl>,
     pub(crate) topic_route_table: TopicRouteTable,
     topic_end_points_table: TopicEndPointsTable,
     lock_namesrv: Arc<RocketMQTokioMutex<()>>,
     lock_heartbeat: Arc<RocketMQTokioMutex<()>>,
 
-    service_state: ServiceState,
+    lifecycle_transition: Mutex<()>,
+    service_state: StdRwLock<ServiceState>,
     pub(crate) pull_message_service: ArcMut<PullMessageService>,
     rebalance_service: RebalanceService,
     pub(crate) default_producer: ArcMut<DefaultMQProducer>,
+    default_producer_transition: Mutex<()>,
     broker_addr_table: BrokerAddrTable,
     broker_version_table: BrokerVersionTable,
     send_heartbeat_times_total: Arc<AtomicI64>,
@@ -260,7 +268,7 @@ pub struct MQClientInstance {
     route_refresh_state: TopicRouteRefreshState,
     consumer_stats_manager: ConsumerStatsManager,
     connection_event_shutdown: CancellationToken,
-    connection_event_task_handle: Option<ClientTrackedTaskHandle>,
+    connection_event_task_handle: StdMutex<Option<ClientTrackedTaskHandle>>,
     rebalance_delay_tasks: TaskTracker,
     rebalance_delay_shutdown: CancellationToken,
 }
@@ -322,9 +330,9 @@ impl MQClientInstance {
         _instance_index: i32,
         client_id: impl Into<CheetahString>,
         rpc_hook: Option<Arc<dyn RPCHook>>,
-    ) -> ArcMut<MQClientInstance> {
+    ) -> Arc<MQClientInstance> {
         let client_id = client_id.into();
-        let shared_config = ArcMut::new(client_config.clone());
+        let shared_config = Arc::new(client_config.clone());
 
         let broker_addr_table = Arc::new(DashMap::default());
         let producer_table = Arc::new(DashMap::default());
@@ -342,25 +350,27 @@ impl MQClientInstance {
                 .client_config(client_config.clone())
                 .build(),
         );
-        let mut instance = ArcMut::new(MQClientInstance {
+        let instance = Arc::new(MQClientInstance {
             client_config: shared_config,
             client_id,
             boot_timestamp: current_millis(),
             producer_table,
             consumer_table,
             admin_ext_table,
-            mq_client_api_impl: None,
+            mq_client_api_impl: ArcSwapOption::empty(),
             mq_admin_impl: Arc::new(MQAdminImpl::new()),
             topic_route_table,
             topic_end_points_table,
             lock_namesrv: Arc::default(),
             lock_heartbeat: Arc::default(),
-            service_state: ServiceState::CreateJust,
+            lifecycle_transition: Mutex::new(()),
+            service_state: StdRwLock::new(ServiceState::CreateJust),
             pull_message_service: ArcMut::new(PullMessageService::with_shards(
                 client_config.pull_message_service_shards,
             )),
             rebalance_service: RebalanceService::new(),
             default_producer,
+            default_producer_transition: Mutex::new(()),
             broker_addr_table,
             broker_version_table,
             send_heartbeat_times_total: Arc::new(AtomicI64::new(0)),
@@ -370,21 +380,19 @@ impl MQClientInstance {
             route_refresh_state: TopicRouteRefreshState::default(),
             consumer_stats_manager: ConsumerStatsManager::new(),
             connection_event_shutdown: CancellationToken::new(),
-            connection_event_task_handle: None,
+            connection_event_task_handle: StdMutex::new(None),
             rebalance_delay_tasks: TaskTracker::new(),
             rebalance_delay_shutdown: CancellationToken::new(),
         });
 
-        // Clone instance first to avoid borrow checker issues
-        let instance_clone = instance.clone();
-        let client_bound = instance.mq_admin_impl.set_client(instance_clone);
+        let client_bound = instance.mq_admin_impl.set_client(&instance);
         debug_assert!(client_bound, "MQAdminImpl client must only be bound once");
 
         let (tx, rx) = tokio::sync::broadcast::channel::<ConnectionNetEvent>(16);
 
         let mq_client_api_impl = Arc::new(MQClientAPIImpl::new(
             Arc::new(TokioClientConfig::default()),
-            ClientRemotingProcessor::new(instance.clone()),
+            ClientRemotingProcessor::new(&instance),
             rpc_hook,
             Arc::new(client_config.clone()),
             Some(tx),
@@ -394,19 +402,77 @@ impl MQClientInstance {
             mq_client_api_impl.update_name_server_address_list_sync(namesrv_addr);
         }
 
-        instance.mq_client_api_impl = Some(mq_client_api_impl);
+        instance.mq_client_api_impl.store(Some(mq_client_api_impl));
 
         // Use weak reference to avoid circular dependencies
-        let weak_instance = ArcMut::downgrade(&instance);
+        let weak_instance = Arc::downgrade(&instance);
         let connection_event_shutdown = instance.connection_event_shutdown.clone();
-        instance.connection_event_task_handle =
+        *instance
+            .connection_event_task_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
             spawn_connection_net_event_listener(rx, weak_instance, connection_event_shutdown);
         instance
+    }
+
+    fn service_state(&self) -> ServiceState {
+        *self
+            .service_state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn set_service_state(&self, state: ServiceState) {
+        *self
+            .service_state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = state;
     }
 
     /// Returns a reference to the [`ConsumerStatsManager`] held by this instance.
     pub fn consumer_stats_manager(&self) -> &ConsumerStatsManager {
         &self.consumer_stats_manager
+    }
+
+    async fn start_default_producer(&self) -> rocketmq_error::RocketMQResult<()> {
+        let _transition = self.default_producer_transition.lock().await;
+        let Some(producer_impl) = self.default_producer.default_mqproducer_impl.as_ref() else {
+            return Err(mq_client_err!("default producer impl is None"));
+        };
+        let mut producer_impl = producer_impl.clone();
+        producer_impl.start_with_factory(false).await
+    }
+
+    async fn shutdown_default_producer(&self) -> rocketmq_error::RocketMQResult<()> {
+        let _transition = self.default_producer_transition.lock().await;
+        let Some(producer_impl) = self.default_producer.default_mqproducer_impl.as_ref() else {
+            return Ok(());
+        };
+        let mut producer_impl = producer_impl.clone();
+        Box::pin(producer_impl.shutdown_with_factory(false)).await
+    }
+
+    pub(crate) async fn send_with_default_producer(
+        &self,
+        message: Message,
+    ) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
+        let _transition = self.default_producer_transition.lock().await;
+        let mut default_producer = self.default_producer.clone();
+        default_producer.send(message).await
+    }
+
+    pub(crate) async fn send_with_default_producer_impl(
+        &self,
+        message: &mut Message,
+    ) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
+        let _transition = self.default_producer_transition.lock().await;
+        let producer_impl = self
+            .default_producer
+            .default_mqproducer_impl
+            .as_ref()
+            .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl"))?;
+        let mut producer_impl = producer_impl.clone();
+        producer_impl.send(message).await
     }
 
     pub fn on_channel_connect(&self, _remote_addr: &str) {}
@@ -455,43 +521,41 @@ impl MQClientInstance {
         );
     }
 
-    pub async fn start(&mut self, this: ArcMut<Self>) -> rocketmq_error::RocketMQResult<()> {
-        match self.service_state {
+    pub async fn start(self: &Arc<Self>) -> rocketmq_error::RocketMQResult<()> {
+        let _transition = self.lifecycle_transition.lock().await;
+        match self.service_state() {
             ServiceState::CreateJust => {
-                self.service_state = ServiceState::StartFailed;
+                self.set_service_state(ServiceState::StartFailed);
                 // If not specified,looking address from name remoting_server
                 if self.client_config.namesrv_addr.is_none() {
-                    let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+                    let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
                         return Err(mq_client_err!("mq_client_api_impl is None"));
                     };
                     mq_client_api_impl.fetch_name_server_addr().await;
                 }
                 // Start request-response channel
-                let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+                let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
                     return Err(mq_client_err!("mq_client_api_impl is None"));
                 };
                 mq_client_api_impl.start().await;
                 // Start various schedule tasks
-                self.start_scheduled_task(this.clone())?;
+                self.start_scheduled_task(self.clone())?;
                 // Start pull service
-                let instance = this.clone();
+                let instance = self.clone();
                 if let Err(e) = self.pull_message_service.start(instance).await {
                     error!("Failed to start pull message service: {:?}", e);
                 }
                 // Start rebalance service
-                if let Err(e) = self.rebalance_service.start(this).await {
+                if let Err(e) = self.rebalance_service.start(self.clone()).await {
                     error!("Failed to start rebalance service: {:?}", e);
                 }
                 // Start push service
 
-                let Some(default_producer_impl) = self.default_producer.default_mqproducer_impl.as_mut() else {
-                    return Err(mq_client_err!("default producer impl is None"));
-                };
-                default_producer_impl.start_with_factory(false).await?;
+                self.start_default_producer().await?;
                 // Start consumer stats manager
                 self.consumer_stats_manager.start();
                 info!("the client factory[{}] start OK", self.client_id);
-                self.service_state = ServiceState::Running;
+                self.set_service_state(ServiceState::Running);
             }
             ServiceState::Running => {}
             ServiceState::ShutdownAlready => {}
@@ -505,14 +569,15 @@ impl MQClientInstance {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self) {
-        match self.service_state {
+    pub async fn shutdown(&self) {
+        let _transition = self.lifecycle_transition.lock().await;
+        match self.service_state() {
             ServiceState::CreateJust | ServiceState::ShutdownAlready => {
                 warn!(
                     "MQClientInstance shutdown called but state is {:?}, ignoring shutdown request",
-                    self.service_state
+                    self.service_state()
                 );
-                if let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() {
+                if let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() {
                     if !mq_client_api_impl
                         .shutdown_background_tasks(Duration::from_secs(1))
                         .await
@@ -559,11 +624,8 @@ impl MQClientInstance {
         self.persist_all_consumer_offset().await;
 
         info!("MQClientInstance[{}] shutting down default producer", self.client_id);
-        if let Some(producer_impl) = self.default_producer.default_mqproducer_impl.as_mut() {
-            let shutdown_future = producer_impl.shutdown_with_factory(false);
-            if let Err(e) = Box::pin(shutdown_future).await {
-                warn!("Failed to shutdown default producer: {:?}", e);
-            }
+        if let Err(e) = self.shutdown_default_producer().await {
+            warn!("Failed to shutdown default producer: {:?}", e);
         }
 
         info!("MQClientInstance[{}] unregistering all consumers", self.client_id);
@@ -572,7 +634,7 @@ impl MQClientInstance {
         info!("MQClientInstance[{}] unregistering all producers", self.client_id);
         self.unregister_all_producers().await;
 
-        if let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() {
+        if let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() {
             info!(
                 "MQClientInstance[{}] shutting down client API background tasks and network client",
                 self.client_id
@@ -627,14 +689,19 @@ impl MQClientInstance {
         self.broker_addr_table.clear();
         self.broker_version_table.clear();
 
-        self.service_state = ServiceState::ShutdownAlready;
+        self.set_service_state(ServiceState::ShutdownAlready);
 
         info!("MQClientInstance[{}] shutdown completed successfully", self.client_id);
     }
 
-    async fn shutdown_connection_event_listener(&mut self, timeout: Duration) {
+    async fn shutdown_connection_event_listener(&self, timeout: Duration) {
         self.connection_event_shutdown.cancel();
-        let Some(handle) = self.connection_event_task_handle.take() else {
+        let handle = self
+            .connection_event_task_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let Some(handle) = handle else {
             return;
         };
 
@@ -650,6 +717,8 @@ impl MQClientInstance {
 
     fn connection_event_task_count(&self) -> usize {
         self.connection_event_task_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .as_ref()
             .map(ClientTrackedTaskHandle::task_count)
             .unwrap_or_default()
@@ -670,7 +739,7 @@ impl MQClientInstance {
     }
 
     /// Unregister all producers from broker
-    async fn unregister_all_producers(&mut self) {
+    async fn unregister_all_producers(&self) {
         // Get all producer groups before removing from table
         let producer_groups: Vec<CheetahString> = self.producer_table.iter().map(|entry| entry.key().clone()).collect();
 
@@ -682,7 +751,7 @@ impl MQClientInstance {
     }
 
     /// Unregister all consumers from broker
-    async fn unregister_all_consumers(&mut self) {
+    async fn unregister_all_consumers(&self) {
         // Get all consumer groups before removing from table
         let consumer_groups: Vec<CheetahString> = self.consumer_table.iter().map(|entry| entry.key().clone()).collect();
 
@@ -705,7 +774,7 @@ impl MQClientInstance {
         true
     }
 
-    pub async fn register_admin_ext(&mut self, group: &str, admin: MQAdminExtInnerImpl) -> bool {
+    pub async fn register_admin_ext(&self, group: &str, admin: MQAdminExtInnerImpl) -> bool {
         if group.is_empty() {
             return false;
         }
@@ -717,11 +786,11 @@ impl MQClientInstance {
         true
     }
 
-    fn start_scheduled_task(&mut self, this: ArcMut<Self>) -> rocketmq_error::RocketMQResult<()> {
+    fn start_scheduled_task(&self, this: Arc<Self>) -> rocketmq_error::RocketMQResult<()> {
         info!("Starting scheduled tasks with ScheduledTaskManager");
 
         if self.client_config.namesrv_addr.is_none() {
-            if let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref().cloned() {
+            if let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() {
                 self.scheduled_task_manager
                     .add_fixed_rate_task_async(Duration::from_secs(10), Duration::from_secs(120), async move |_token| {
                         info!("ScheduledTask: fetchNameServerAddr");
@@ -759,7 +828,7 @@ impl MQClientInstance {
                 Duration::from_secs(1),
                 Duration::from_millis(heartbeat_broker_interval as u64),
                 async move |_token| {
-                    let mut instance = client_instance.clone();
+                    let instance = client_instance.clone();
                     info!("ScheduledTask: clean_offline_broker and send_heartbeat");
                     instance.clean_offline_broker().await;
                     instance.send_heartbeat_to_all_broker_with_lock().await;
@@ -775,7 +844,7 @@ impl MQClientInstance {
                 Duration::from_secs(10),
                 Duration::from_millis(persist_consumer_offset_interval),
                 async move |_token| {
-                    let mut instance = client_instance.clone();
+                    let instance = client_instance.clone();
                     info!("ScheduledTask: persistAllConsumerOffset");
                     instance.persist_all_consumer_offset().await;
                     Ok(())
@@ -821,7 +890,7 @@ impl MQClientInstance {
     }
 
     pub async fn find_consumer_id_list(
-        &mut self,
+        &self,
         topic: &CheetahString,
         group: &CheetahString,
     ) -> Option<Vec<CheetahString>> {
@@ -831,7 +900,7 @@ impl MQClientInstance {
             broker_addr = self.find_broker_addr_by_topic(topic).await;
         }
         if let Some(broker_addr) = broker_addr {
-            if let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() {
+            if let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() {
                 match mq_client_api_impl
                     .get_consumer_id_list_by_group(
                         broker_addr.as_str(),
@@ -910,7 +979,7 @@ impl MQClientInstance {
         let started = Instant::now();
         let request_version = self.topic_route_version(topic);
 
-        let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+        let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
             error!(
                 "updateTopicRouteInfoFromNameServer skipped because mq_client_api_impl is None, Topic: {}. [{}]",
                 topic, self.client_id
@@ -1199,13 +1268,13 @@ impl MQClientInstance {
         false
     }
 
-    pub async fn persist_all_consumer_offset(&mut self) {
+    pub async fn persist_all_consumer_offset(&self) {
         for entry in self.consumer_table.iter() {
             entry.value().persist_consumer_offset().await;
         }
     }
 
-    pub async fn clean_offline_broker(&mut self) {
+    pub async fn clean_offline_broker(&self) {
         let lock = self
             .lock_namesrv
             .try_lock_timeout(Duration::from_millis(LOCK_TIMEOUT_MILLIS))
@@ -1282,8 +1351,7 @@ impl MQClientInstance {
 
     pub fn get_mq_client_api_impl(&self) -> rocketmq_error::RocketMQResult<Arc<MQClientAPIImpl>> {
         self.mq_client_api_impl
-            .as_ref()
-            .cloned()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)
     }
 
@@ -1303,7 +1371,7 @@ impl MQClientInstance {
 
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
 
         let mut result = MQClientAPIImpl::pull_message(
@@ -1335,7 +1403,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<i64> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1351,7 +1419,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<()> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1360,7 +1428,7 @@ impl MQClientInstance {
     }
 
     pub async fn consumer_send_message_back(
-        &mut self,
+        &self,
         broker_addr: &str,
         broker_name: Option<&str>,
         message: &MessageExt,
@@ -1371,7 +1439,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<()> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1395,7 +1463,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<i64> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1411,7 +1479,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<i64> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1429,7 +1497,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<i64> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .clone()
@@ -1446,7 +1514,7 @@ impl MQClientInstance {
         let request_header = get_topic_config_request_header(topic);
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         let topic_mapping = api_impl
             .get_topic_config(broker_addr, request_header, timeout_millis)
@@ -1462,7 +1530,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<SubscriptionGroupConfig> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl
             .get_subscription_group_config(broker_addr, group, timeout_millis)
@@ -1472,7 +1540,7 @@ impl MQClientInstance {
     pub async fn get_broker_cluster_info(&self, timeout_millis: u64) -> rocketmq_error::RocketMQResult<ClusterInfo> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl.get_broker_cluster_info(timeout_millis).await
     }
@@ -1485,7 +1553,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<Option<UserInfo>> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         api_impl.get_user(broker_addr, username, timeout_millis).await
     }
@@ -1498,7 +1566,7 @@ impl MQClientInstance {
     ) -> rocketmq_error::RocketMQResult<Option<AclInfo>> {
         let api_impl = self
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
         let acl_infos = api_impl
             .list_acl(broker_addr, subject.clone(), CheetahString::default(), timeout_millis)
@@ -1674,7 +1742,7 @@ impl MQClientInstance {
 
         // Collect all heartbeat futures without spawning detached runtime tasks.
         let mut tasks = Vec::new();
-        let Some(mq_client_api) = self.mq_client_api_impl.as_ref().cloned() else {
+        let Some(mq_client_api) = self.mq_client_api_impl.load_full() else {
             warn!("send heartbeat concurrently skipped because mq_client_api_impl is None");
             return false;
         };
@@ -1903,7 +1971,7 @@ impl MQClientInstance {
         addr: &CheetahString,
         heartbeat_data: &HeartbeatData,
     ) -> (bool, Option<bool>) {
-        let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+        let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
             warn!(
                 "send heart beat to broker[{} {} {}] skipped because mq_client_api_impl is None",
                 broker_name, id, addr
@@ -1998,7 +2066,7 @@ impl MQClientInstance {
         true
     }
 
-    pub async fn check_client_in_broker(&mut self) -> rocketmq_error::RocketMQResult<()> {
+    pub async fn check_client_in_broker(&self) -> rocketmq_error::RocketMQResult<()> {
         for entry in self.consumer_table.iter() {
             let subscription_inner = entry.value().subscriptions();
             if subscription_inner.is_empty() {
@@ -2010,7 +2078,7 @@ impl MQClientInstance {
                 }
                 let addr = self.find_broker_addr_by_topic(subscription_data.topic.as_str()).await;
                 if let Some(addr) = addr {
-                    let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+                    let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
                         return Err(rocketmq_error::RocketMQError::ClientNotStarted);
                     };
                     match mq_client_api_impl
@@ -2046,7 +2114,7 @@ impl MQClientInstance {
         Ok(())
     }
 
-    pub async fn do_rebalance(&mut self) -> RocketMQResult<bool> {
+    pub async fn do_rebalance(&self) -> RocketMQResult<bool> {
         let mut balanced = true;
         for entry in self.consumer_table.iter() {
             match entry.value().try_rebalance().await {
@@ -2068,7 +2136,7 @@ impl MQClientInstance {
         Ok(balanced)
     }
 
-    pub fn rebalance_later(&mut self, delay_millis: u64) {
+    pub fn rebalance_later(&self, delay_millis: u64) {
         schedule_rebalance_wakeup(
             self.rebalance_service.clone(),
             Duration::from_millis(delay_millis),
@@ -2207,7 +2275,7 @@ impl MQClientInstance {
         self.producer_table.get(group).map(|entry| entry.value().clone())
     }
 
-    pub async fn unregister_consumer(&mut self, group: impl Into<CheetahString>) -> bool {
+    pub async fn unregister_consumer(&self, group: impl Into<CheetahString>) -> bool {
         let group = group.into();
         if group.is_empty() {
             warn!("unregister_consumer: group name is empty");
@@ -2226,7 +2294,7 @@ impl MQClientInstance {
         }
     }
 
-    pub async fn unregister_producer(&mut self, group: impl Into<CheetahString>) -> bool {
+    pub async fn unregister_producer(&self, group: impl Into<CheetahString>) -> bool {
         let group = group.into();
         if group.is_empty() {
             warn!("unregister_producer: group name is empty");
@@ -2245,15 +2313,11 @@ impl MQClientInstance {
         }
     }
 
-    pub async fn unregister_admin_ext(&mut self, group: impl Into<CheetahString>) {
+    pub async fn unregister_admin_ext(&self, group: impl Into<CheetahString>) {
         let _ = self.admin_ext_table.remove(&group.into());
     }
-    async fn unregister_client(
-        &mut self,
-        producer_group: Option<CheetahString>,
-        consumer_group: Option<CheetahString>,
-    ) {
-        let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
+    async fn unregister_client(&self, producer_group: Option<CheetahString>, consumer_group: Option<CheetahString>) {
+        let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
             warn!(
                 "unregister client[Producer: {:?} Consumer: {:?}] skipped because mq_client_api_impl is None",
                 producer_group, consumer_group
@@ -2307,7 +2371,7 @@ impl MQClientInstance {
     /// A `Result` containing an `Option` with a `HashSet` of `MessageQueueAssignment` if the query
     /// is successful, or an error if it fails.
     pub async fn query_assignment(
-        &mut self,
+        &self,
         topic: &CheetahString,
         consumer_group: &CheetahString,
         strategy_name: &CheetahString,
@@ -2324,7 +2388,7 @@ impl MQClientInstance {
         }
         if let Some(broker_addr) = broker_addr {
             let client_id = self.client_id.clone();
-            match self.mq_client_api_impl.as_ref() {
+            match self.mq_client_api_impl.load_full() {
                 Some(api_impl) => {
                     api_impl
                         .query_assignment(
@@ -2478,7 +2542,7 @@ pub async fn run_connection_event_listener_lifecycle_probe() -> ConnectionEventL
         namesrv_addr: None,
         ..Default::default()
     };
-    let mut instance = MQClientInstance::new_arc(client_config, 0, "connection-event-listener-probe", None);
+    let instance = MQClientInstance::new_arc(client_config, 0, "connection-event-listener-probe", None);
     let task_count_before_shutdown = instance.connection_event_task_count();
 
     let shutdown_started = Instant::now();
@@ -2692,12 +2756,22 @@ mod tests {
 
     #[tokio::test]
     async fn get_mq_client_api_impl_returns_client_not_started_instead_of_panicking() {
-        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "test-client", None);
-        instance.mq_client_api_impl = None;
+        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "test-client", None);
+        instance.mq_client_api_impl.store(None);
 
         let result = instance.get_mq_client_api_impl();
 
         assert!(matches!(result, Err(RocketMQError::ClientNotStarted)));
+    }
+
+    #[tokio::test]
+    async fn standard_weak_callbacks_do_not_keep_client_root_alive() {
+        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "weak-client-root", None);
+        let weak = Arc::downgrade(&instance);
+
+        assert!(weak.upgrade().is_some());
+        drop(instance);
+        assert!(weak.upgrade().is_none());
     }
 
     #[tokio::test]
@@ -2766,7 +2840,7 @@ mod tests {
             namesrv_addr: None,
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "no-runtime-rebalance-test", None);
+        let instance = MQClientInstance::new_arc(client_config, 0, "no-runtime-rebalance-test", None);
 
         instance.re_balance_later(Duration::from_millis(1));
         instance.rebalance_later(1);
@@ -2780,9 +2854,9 @@ mod tests {
             namesrv_addr: None,
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "scheduled-shutdown-test", None);
-        instance.service_state = ServiceState::Running;
-        assert!(instance.connection_event_task_handle.is_some());
+        let instance = MQClientInstance::new_arc(client_config, 0, "scheduled-shutdown-test", None);
+        instance.set_service_state(ServiceState::Running);
+        assert!(instance.connection_event_task_count() > 0);
         instance
             .scheduled_task_manager
             .add_fixed_delay_task(Duration::from_secs(60), Duration::from_secs(60), |_token| async {
@@ -2794,9 +2868,9 @@ mod tests {
 
         instance.shutdown().await;
 
-        assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
+        assert_eq!(instance.service_state(), ServiceState::ShutdownAlready);
         assert_eq!(instance.scheduled_task_manager.task_count(), 0);
-        assert!(instance.connection_event_task_handle.is_none());
+        assert_eq!(instance.connection_event_task_count(), 0);
     }
 
     #[tokio::test]
@@ -2805,18 +2879,18 @@ mod tests {
             namesrv_addr: None,
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "pre-start-shutdown-test", None);
+        let instance = MQClientInstance::new_arc(client_config, 0, "pre-start-shutdown-test", None);
 
-        assert_eq!(instance.service_state, ServiceState::CreateJust);
-        assert!(instance.connection_event_task_handle.is_some());
+        assert_eq!(instance.service_state(), ServiceState::CreateJust);
+        assert!(instance.connection_event_task_count() > 0);
         instance.re_balance_later(Duration::from_secs(60));
         instance.rebalance_later(60_000);
         tokio::task::yield_now().await;
 
         instance.shutdown().await;
 
-        assert_eq!(instance.service_state, ServiceState::CreateJust);
-        assert!(instance.connection_event_task_handle.is_none());
+        assert_eq!(instance.service_state(), ServiceState::CreateJust);
+        assert_eq!(instance.connection_event_task_count(), 0);
         assert!(instance.rebalance_delay_shutdown.is_cancelled());
         tokio::time::timeout(Duration::from_secs(1), instance.rebalance_delay_tasks.wait())
             .await
@@ -3024,7 +3098,7 @@ mod tests {
             namesrv_addr: None,
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "heartbeat-clean-index-test", None);
+        let instance = MQClientInstance::new_arc(client_config, 0, "heartbeat-clean-index-test", None);
         let broker_name = CheetahString::from_static_str("heartbeat-offline-broker");
         let broker_addr = CheetahString::from_static_str("127.0.0.12:10911");
         let mut broker_addrs = HashMap::new();
@@ -3237,11 +3311,11 @@ mod tests {
             namesrv_addr: Some(CheetahString::from_static_str("127.0.0.1:9876")),
             ..Default::default()
         };
-        let mut instance = MQClientInstance::new_arc(client_config, 0, "partial-start-shutdown", None);
-        instance.service_state = ServiceState::StartFailed;
+        let instance = MQClientInstance::new_arc(client_config, 0, "partial-start-shutdown", None);
+        instance.set_service_state(ServiceState::StartFailed);
 
         instance.shutdown().await;
 
-        assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
+        assert_eq!(instance.service_state(), ServiceState::ShutdownAlready);
     }
 }

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -15,6 +15,8 @@
 use std::backtrace::Backtrace;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Weak;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::compression::compressor_factory::CompressorFactory;
@@ -45,7 +47,6 @@ use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
-use rocketmq_rust::ArcMut;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -55,12 +56,20 @@ use crate::producer::request_future_holder::REQUEST_FUTURE_HOLDER;
 
 #[derive(Clone)]
 pub struct ClientRemotingProcessor {
-    pub(crate) client_instance: ArcMut<MQClientInstance>,
+    client_instance: Weak<MQClientInstance>,
 }
 
 impl ClientRemotingProcessor {
-    pub fn new(client_instance: ArcMut<MQClientInstance>) -> Self {
-        Self { client_instance }
+    pub fn new(client_instance: &Arc<MQClientInstance>) -> Self {
+        Self {
+            client_instance: Arc::downgrade(client_instance),
+        }
+    }
+
+    fn client_instance(&self) -> rocketmq_error::RocketMQResult<Arc<MQClientInstance>> {
+        self.client_instance
+            .upgrade()
+            .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)
     }
 }
 
@@ -279,7 +288,7 @@ impl ClientRemotingProcessor {
             request_header.consumer_group
         );
 
-        self.client_instance.re_balance_immediately();
+        self.client_instance()?.re_balance_immediately();
 
         Ok(None)
     }
@@ -325,7 +334,7 @@ impl ClientRemotingProcessor {
             }
         };
 
-        self.client_instance
+        self.client_instance()?
             .reset_offset(&request_header.topic, &request_header.group, offset_table)
             .await;
         Ok(None)
@@ -347,7 +356,7 @@ impl ClientRemotingProcessor {
         };
 
         match self
-            .client_instance
+            .client_instance()?
             .get_consumer_status(&request_header.topic, &request_header.group)
             .await
         {
@@ -387,7 +396,7 @@ impl ClientRemotingProcessor {
         };
 
         match self
-            .client_instance
+            .client_instance()?
             .consumer_running_info(&request_header.consumer_group)
             .await
         {
@@ -431,10 +440,10 @@ impl ClientRemotingProcessor {
         };
         let message_ext = MessageDecoder::decode(body, true, true, false, false, false);
         if let Some(mut message_ext) = message_ext {
-            if let Some(namespace) = self
-                .client_instance
+            let client_instance = self.client_instance()?;
+            if let Some(namespace) = client_instance
                 .client_config
-                .get_namespace()
+                .resolved_namespace()
                 .filter(|namespace| !namespace.is_empty())
             {
                 let topic = Self::transaction_check_topic(message_ext.topic(), &namespace);
@@ -450,7 +459,7 @@ impl ClientRemotingProcessor {
             }
             let group = message_ext.property(&CheetahString::from_static_str(MessageConst::PROPERTY_PRODUCER_GROUP));
             if let Some(group) = group {
-                let producer = self.client_instance.select_producer(&group).await;
+                let producer = client_instance.select_producer(&group).await;
                 if let Some(producer) = producer {
                     let addr = CheetahString::from_string(channel.remote_address().to_string());
                     producer.check_transaction_state(&addr, message_ext, request_header);
@@ -512,7 +521,7 @@ impl ClientRemotingProcessor {
         };
 
         let result = self
-            .client_instance
+            .client_instance()?
             .consume_message_directly(msg, &request_header.consumer_group, request_header.broker_name.clone())
             .await;
         if let Some(result) = result {
@@ -561,10 +570,25 @@ mod tests {
     use crate::consumer::store::read_offset_type::ReadOffsetType;
     use crate::producer::request_response_future::RequestResponseFuture;
 
+    #[test]
+    fn processor_weak_reference_does_not_keep_client_alive() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "weak-processor-client", None);
+        let processor = ClientRemotingProcessor::new(&client_instance);
+        let weak = Arc::downgrade(&client_instance);
+
+        drop(client_instance);
+
+        assert!(weak.upgrade().is_none());
+        assert!(matches!(
+            processor.client_instance(),
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        ));
+    }
+
     async fn client_with_push_consumer(
         group: CheetahString,
         client_id: &str,
-    ) -> (ArcMut<MQClientInstance>, Arc<DefaultMQPushConsumerImpl>) {
+    ) -> (Arc<MQClientInstance>, Arc<DefaultMQPushConsumerImpl>) {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, client_id, None);
         let consumer_config = ConsumerConfig {
             consumer_group: group.clone(),
@@ -579,7 +603,6 @@ mod tests {
         consumer_impl.set_offset_store(Some(Arc::new(OffsetStore::new_test())));
 
         let registered = client_instance
-            .mut_from_ref()
             .register_consumer(&group, MQConsumerInnerImpl::from_push(consumer_impl.clone()))
             .await;
         assert!(registered, "test consumer should register");
@@ -594,7 +617,7 @@ mod tests {
             ..Default::default()
         };
         let client_instance = MQClientInstance::new_arc(client_config, 0, "reject-request-test", None);
-        let processor = ClientRemotingProcessor::new(client_instance);
+        let processor = ClientRemotingProcessor::new(&client_instance);
 
         let (rejected, response) =
             RequestProcessor::reject_request(&processor, RequestCode::CheckTransactionState as i32);
@@ -638,7 +661,7 @@ mod tests {
         let group = CheetahString::from_static_str("reset-group");
         let (client_instance, consumer_impl) =
             client_with_push_consumer(group.clone(), "reset-consumer-offset-test").await;
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -698,7 +721,7 @@ mod tests {
         let topic = CheetahString::from_static_str("reset-missing-body-topic");
         let group = CheetahString::from_static_str("reset-missing-body-group");
         let (client_instance, _) = client_with_push_consumer(group.clone(), "reset-missing-body-test").await;
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -739,7 +762,7 @@ mod tests {
             .update_offset(&mq, 456, false)
             .await;
 
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -770,7 +793,7 @@ mod tests {
     async fn get_consumer_status_from_client_missing_group_returns_empty_success_like_java() {
         let client_instance =
             MQClientInstance::new_arc(ClientConfig::default(), 0, "consumer-status-missing-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -801,7 +824,7 @@ mod tests {
     async fn consume_message_directly_with_malformed_header_returns_system_error() {
         let client_instance =
             MQClientInstance::new_arc(ClientConfig::default(), 0, "consume-direct-malformed-header-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -823,7 +846,7 @@ mod tests {
     async fn consume_message_directly_with_missing_body_returns_system_error() {
         let client_instance =
             MQClientInstance::new_arc(ClientConfig::default(), 0, "consume-direct-missing-body-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -852,7 +875,7 @@ mod tests {
     async fn consume_message_directly_with_malformed_body_returns_system_error() {
         let client_instance =
             MQClientInstance::new_arc(ClientConfig::default(), 0, "consume-direct-malformed-body-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -907,7 +930,7 @@ mod tests {
     #[tokio::test]
     async fn push_reply_message_with_malformed_header_returns_system_error() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-malformed-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -928,7 +951,7 @@ mod tests {
     #[tokio::test]
     async fn push_reply_message_with_compressed_missing_body_returns_system_error() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-missing-body-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -960,7 +983,7 @@ mod tests {
 
         let client_instance =
             MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-unknown-compression-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1006,7 +1029,7 @@ mod tests {
             .await;
 
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-roundtrip-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1037,7 +1060,7 @@ mod tests {
     #[tokio::test]
     async fn notify_unsubscribe_lite_callback_is_explicit_oneway_noop() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-lite-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1054,7 +1077,7 @@ mod tests {
     #[tokio::test]
     async fn notify_unsubscribe_lite_callback_with_valid_header_is_oneway_noop() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-lite-valid-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1080,7 +1103,7 @@ mod tests {
     #[tokio::test]
     async fn notify_consumer_ids_changed_with_malformed_header_is_oneway_noop() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-consumer-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1100,7 +1123,7 @@ mod tests {
     #[tokio::test]
     async fn check_transaction_state_with_malformed_header_is_oneway_noop() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "tx-malformed-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1120,7 +1143,7 @@ mod tests {
     #[tokio::test]
     async fn check_transaction_state_with_missing_body_is_oneway_noop() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "tx-missing-body-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1171,7 +1194,7 @@ mod tests {
     async fn get_consumer_running_info_returns_consumer_snapshot_body() {
         let group = CheetahString::from_static_str("running-info-group");
         let (client_instance, _consumer_impl) = client_with_push_consumer(group.clone(), "running-info-client").await;
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");
@@ -1211,7 +1234,7 @@ mod tests {
     #[tokio::test]
     async fn get_consumer_running_info_missing_group_returns_system_error() {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "running-info-missing-test", None);
-        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
         let harness = LocalRequestHarness::new()
             .await
             .expect("local remoting harness should start");

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -15,7 +15,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::Weak;
 
+use crate::base::client_config::ClientConfig;
+use crate::base::query_result::QueryResult;
+use crate::base::validators::Validators;
+use crate::factory::mq_client_instance;
+use crate::factory::mq_client_instance::MQClientInstance;
+use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::attribute::attribute_parser::AttributeParser;
 use rocketmq_common::common::boundary_type::BoundaryType;
@@ -34,18 +41,10 @@ use rocketmq_remoting::protocol::header::query_message_request_header::QueryMess
 use rocketmq_remoting::protocol::header::view_message_request_header::ViewMessageRequestHeader;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::route_facade::BrokerDataExt;
-use rocketmq_rust::ArcMut;
-
-use crate::base::client_config::ClientConfig;
-use crate::base::query_result::QueryResult;
-use crate::base::validators::Validators;
-use crate::factory::mq_client_instance;
-use crate::factory::mq_client_instance::MQClientInstance;
-use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
 
 pub struct MQAdminImpl {
     timeout_millis: u64,
-    client: OnceLock<ArcMut<MQClientInstance>>,
+    client: OnceLock<Weak<MQClientInstance>>,
 }
 
 impl MQAdminImpl {
@@ -56,14 +55,14 @@ impl MQAdminImpl {
         }
     }
 
-    pub fn set_client(&self, client: ArcMut<MQClientInstance>) -> bool {
-        self.client.set(client).is_ok()
+    pub fn set_client(&self, client: &Arc<MQClientInstance>) -> bool {
+        self.client.set(Arc::downgrade(client)).is_ok()
     }
 
-    fn client(&self) -> rocketmq_error::RocketMQResult<ArcMut<MQClientInstance>> {
+    fn client(&self) -> rocketmq_error::RocketMQResult<Arc<MQClientInstance>> {
         self.client
             .get()
-            .cloned()
+            .and_then(Weak::upgrade)
             .ok_or_else(|| RocketMQError::not_initialized("MQClientInstance"))
     }
 
@@ -179,7 +178,7 @@ impl MQAdminImpl {
         let client = self.client()?;
         let api_impl = client
             .mq_client_api_impl
-            .clone()
+            .load_full()
             .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?;
         let route_data = api_impl
             .get_topic_route_info_from_name_server(key, self.timeout_millis)
@@ -301,7 +300,7 @@ impl MQAdminImpl {
         if let Some(ref broker_addr) = broker_addr {
             return client
                 .mq_client_api_impl
-                .as_ref()
+                .load_full()
                 .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
                 .get_max_offset(broker_addr, mq, self.timeout_millis)
                 .await;
@@ -331,7 +330,7 @@ impl MQAdminImpl {
         if let Some(ref broker_addr) = broker_addr {
             return client
                 .mq_client_api_impl
-                .as_ref()
+                .load_full()
                 .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
                 .search_offset_by_timestamp(broker_addr, mq, timestamp, BoundaryType::Lower, self.timeout_millis)
                 .await;
@@ -351,7 +350,7 @@ impl MQAdminImpl {
         if let Some(ref broker_addr) = broker_addr {
             return client
                 .mq_client_api_impl
-                .as_ref()
+                .load_full()
                 .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
                 .get_min_offset(broker_addr, mq, self.timeout_millis)
                 .await;
@@ -371,7 +370,7 @@ impl MQAdminImpl {
         if let Some(ref broker_addr) = broker_addr {
             return client
                 .mq_client_api_impl
-                .as_ref()
+                .load_full()
                 .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
                 .get_earliest_msg_store_time(broker_addr, mq, self.timeout_millis)
                 .await;
@@ -394,7 +393,7 @@ impl MQAdminImpl {
         };
         self.client()?
             .mq_client_api_impl
-            .as_ref()
+            .load_full()
             .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
             .view_message(&broker_addr, request_header, self.timeout_millis)
             .await
@@ -424,7 +423,7 @@ impl MQAdminImpl {
         let client = self.client()?;
         let api_impl = client
             .mq_client_api_impl
-            .clone()
+            .load_full()
             .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?;
         let route_data = api_impl
             .get_topic_route_info_from_name_server(topic, self.timeout_millis)
@@ -511,12 +510,17 @@ mod tests {
         let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "admin-client-binding", None);
         let admin = MQAdminImpl::new();
 
-        assert!(admin.set_client(instance.clone()));
-        assert!(!admin.set_client(instance));
+        assert!(admin.set_client(&instance));
+        assert!(!admin.set_client(&instance));
         assert_eq!(
             admin.client().expect("bound client should remain available").client_id,
             "admin-client-binding"
         );
+
+        let weak = Arc::downgrade(&instance);
+        drop(instance);
+        assert!(weak.upgrade().is_none());
+        assert!(matches!(admin.client(), Err(RocketMQError::NotInitialized(_))));
     }
 
     #[test]

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -249,7 +249,6 @@ use rocketmq_remoting::rpc::topic_request_header::TopicRequestHeader;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_remoting::ConsumerConnection;
-use rocketmq_rust::ArcMut;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -2325,7 +2324,7 @@ impl MQClientAPIImpl {
         communication_mode: CommunicationMode,
         send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
-        instance: Option<ArcMut<MQClientInstance>>,
+        instance: Option<Arc<MQClientInstance>>,
         retry_times_when_send_failed: u32,
         context: &mut Option<SendMessageContext<'_>>,
         producer: &DefaultMQProducerImpl,
@@ -2509,7 +2508,7 @@ impl MQClientAPIImpl {
         request: RemotingCommand,
         send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
-        instance: Option<ArcMut<MQClientInstance>>,
+        instance: Option<Arc<MQClientInstance>>,
         retry_times_when_send_failed: u32,
         context: &mut Option<SendMessageContext<'_>>,
         producer: &DefaultMQProducerImpl,
@@ -2604,7 +2603,7 @@ impl MQClientAPIImpl {
         current_request: RemotingCommand,
         send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<TopicPublishInfo>,
-        instance: Option<ArcMut<MQClientInstance>>,
+        instance: Option<Arc<MQClientInstance>>,
         retry_times_when_send_failed: u32,
         context_data: Option<AsyncSendHookContext>,
         callback_executor: Option<tokio::runtime::Handle>,
@@ -2795,7 +2794,7 @@ impl MQClientAPIImpl {
     async fn select_async_retry_target(
         mq_fault_strategy: &MQFaultStrategy,
         topic_publish_info: Option<&TopicPublishInfo>,
-        instance: Option<&ArcMut<MQClientInstance>>,
+        instance: Option<&Arc<MQClientInstance>>,
         broker_name: &CheetahString,
         current_addr: &CheetahString,
     ) -> Option<(CheetahString, CheetahString)> {
@@ -2995,7 +2994,7 @@ impl MQClientAPIImpl {
         msg: &T,
         request: &mut RemotingCommand,
         topic_publish_info: Option<&TopicPublishInfo>,
-        instance: Option<&ArcMut<MQClientInstance>>,
+        instance: Option<&Arc<MQClientInstance>>,
         producer: &DefaultMQProducerImpl,
     ) -> Option<(CheetahString, CheetahString)> {
         let mut retry_broker_name = broker_name.clone();

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -20,14 +20,13 @@ use std::sync::LazyLock;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
 use tracing::info;
 
 use crate::base::client_config::ClientConfig;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::producer::produce_accumulator::ProduceAccumulator;
 
-type ClientInstanceHashMap = DashMap<CheetahString /* clientId */, ArcMut<MQClientInstance>>;
+type ClientInstanceHashMap = DashMap<CheetahString /* clientId */, Arc<MQClientInstance>>;
 type AccumulatorHashMap = DashMap<CheetahString /* clientId */, Arc<ProduceAccumulator>>;
 
 #[derive(Default)]
@@ -56,7 +55,7 @@ impl MQClientManager {
         &self,
         client_config: ClientConfig,
         rpc_hook: Option<Arc<dyn RPCHook>>,
-    ) -> ArcMut<MQClientInstance> {
+    ) -> Arc<MQClientInstance> {
         let client_id = CheetahString::from_string(client_config.build_mq_client_id());
 
         self.factory_table
@@ -90,7 +89,7 @@ impl MQClientManager {
     pub(crate) fn remove_client_factory_if_same(&self, client_id: &CheetahString, expected: *const ()) -> bool {
         self.factory_table
             .remove_if(client_id, |_, current| {
-                std::ptr::addr_eq(Arc::as_ptr(current.get_inner()).cast::<()>(), expected)
+                std::ptr::addr_eq(Arc::as_ptr(current).cast::<()>(), expected)
             })
             .is_some()
     }

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -163,11 +163,10 @@ pub mod proxy_adapter_compat {
     /// Opaque compatibility handle for the Client instance owned by the Proxy
     /// Cluster worker.
     ///
-    /// The raw shared-mutation carrier remains private to Client; the Cluster
-    /// adapter can only use the instance API and must keep cloned handles on
-    /// its single managed worker.
+    /// The standard shared owner remains private to Client; the Cluster adapter
+    /// can only use the instance API and keeps cloned handles on its managed worker.
     pub struct ClientInstanceHandle {
-        inner: rocketmq_rust::ArcMut<crate::factory::mq_client_instance::MQClientInstance>,
+        inner: Arc<crate::factory::mq_client_instance::MQClientInstance>,
         owner: ManagedClientOwner,
     }
 
@@ -263,8 +262,7 @@ pub mod proxy_adapter_compat {
 
         pub async fn start(&self) -> rocketmq_error::RocketMQResult<()> {
             let _operation = self.operation().await;
-            let mut instance = self.inner.clone();
-            instance.start(self.inner.clone()).await
+            self.inner.start().await
         }
 
         pub async fn topic_route(
@@ -472,8 +470,7 @@ pub mod proxy_adapter_compat {
             max_consume_retry_times: i32,
         ) -> rocketmq_error::RocketMQResult<()> {
             let _operation = self.operation().await;
-            let mut instance = self.inner.clone();
-            instance
+            self.inner
                 .consumer_send_message_back(
                     broker_addr,
                     broker_name,
@@ -602,8 +599,7 @@ pub mod proxy_adapter_compat {
                 return;
             }
             let _operation = self.operation().await;
-            let mut instance = self.inner.clone();
-            instance.shutdown().await;
+            self.inner.shutdown().await;
         }
 
         fn release_managed(&self) -> bool {
@@ -625,7 +621,7 @@ pub mod proxy_adapter_compat {
                 return false;
             }
 
-            let expected = Arc::as_ptr(self.inner.get_inner()).cast::<()>();
+            let expected = Arc::as_ptr(&self.inner).cast::<()>();
             crate::implementation::mq_client_manager::MQClientManager::get_instance()
                 .remove_client_factory_if_same(&self.owner.key.client_id, expected);
             entry.remove();
@@ -849,7 +845,7 @@ pub mod proxy_adapter_compat {
             let first = ClientInstanceHandle::get_or_create(domain_id, config.clone(), None).unwrap();
             let second = ClientInstanceHandle::get_or_create(domain_id, config, None).unwrap();
 
-            assert!(Arc::ptr_eq(first.inner.get_inner(), second.inner.get_inner(),));
+            assert!(Arc::ptr_eq(&first.inner, &second.inner));
             assert_eq!(
                 MANAGED_CLIENTS
                     .get(&key)
@@ -910,7 +906,7 @@ pub mod proxy_adapter_compat {
             let first = ClientInstanceHandle::get_or_create(first_domain, config.clone(), None).unwrap();
             let second = ClientInstanceHandle::get_or_create(second_domain, config, None).unwrap();
 
-            assert!(!Arc::ptr_eq(first.inner.get_inner(), second.inner.get_inner(),));
+            assert!(!Arc::ptr_eq(&first.inner, &second.inner));
             assert_eq!(
                 MANAGED_CLIENTS
                     .get(&first_key)
@@ -968,7 +964,7 @@ pub mod proxy_adapter_compat {
             first.shutdown_owned().await;
 
             let second = ClientInstanceHandle::get_or_create(71_008, config, None).unwrap();
-            assert!(!Arc::ptr_eq(first.inner.get_inner(), second.inner.get_inner()));
+            assert!(!Arc::ptr_eq(&first.inner, &second.inner));
             second.shutdown_owned().await;
         }
     }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -59,8 +59,6 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_remoting::rpc::topic_request_header::TopicRequestHeader;
 use rocketmq_remoting::runtime::RPCHook;
-use rocketmq_rust::ArcMut;
-use rocketmq_rust::WeakArcMut;
 use tokio::sync::watch;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
@@ -324,13 +322,13 @@ pub struct DefaultMQProducerImpl {
     topic_publish_info_table: Arc<DashMap<Topic, TopicPublishInfoSnapshot>>,
 
     rpc_hook: Option<Arc<dyn RPCHook>>,
-    client_instance: Option<ArcMut<MQClientInstance>>,
+    client_instance: Option<Arc<MQClientInstance>>,
     pub(crate) mq_fault_strategy: MQFaultStrategy,
 
     // ===== Backpressure control =====
     semaphore_async_send_num: Arc<Semaphore>,
     semaphore_async_send_size: Arc<Semaphore>,
-    default_mqproducer_impl_inner: Option<WeakArcMut<DefaultMQProducerImpl>>,
+    default_mqproducer_impl_inner: Option<rocketmq_rust::WeakArcMut<DefaultMQProducerImpl>>,
     transaction_listener: Option<ArcTransactionListener>,
     transaction_executor_service: Option<tokio::runtime::Handle>,
     transaction_check_env: Option<TransactionCheckEnv>,
@@ -496,14 +494,14 @@ impl DefaultMQProducerImpl {
     }
 
     #[inline]
-    fn client_instance(&self) -> rocketmq_error::RocketMQResult<ArcMut<MQClientInstance>> {
+    fn client_instance(&self) -> rocketmq_error::RocketMQResult<Arc<MQClientInstance>> {
         self.client_instance
             .as_ref()
             .cloned()
             .ok_or_else(|| mq_client_err!("MQClientInstance is not available; producer has not been started"))
     }
 
-    pub fn get_mq_client_factory(&self) -> rocketmq_error::RocketMQResult<ArcMut<MQClientInstance>> {
+    pub fn get_mq_client_factory(&self) -> rocketmq_error::RocketMQResult<Arc<MQClientInstance>> {
         self.client_instance()
     }
 
@@ -2024,7 +2022,7 @@ impl DefaultMQProducerImpl {
         let client_instance = self.client_instance()?;
         let mq_client_api_impl = client_instance
             .mq_client_api_impl
-            .clone()
+            .load_full()
             .ok_or_else(|| mq_client_err!("MQClientAPIImpl is not available; producer has not been started"))?;
         client_instance
             .mq_admin_impl
@@ -2701,7 +2699,7 @@ impl DefaultMQProducerImpl {
             .as_mut()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("MQClientInstance"))?
             .mq_client_api_impl
-            .as_mut()
+            .load_full()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("MQClientAPIImpl"))?
             .end_transaction_oneway(
                 &broker_addr,
@@ -2776,7 +2774,7 @@ impl DefaultMQProducerImpl {
 
     pub fn set_default_mqproducer_impl_inner(
         &mut self,
-        default_mqproducer_impl_inner: WeakArcMut<DefaultMQProducerImpl>,
+        default_mqproducer_impl_inner: rocketmq_rust::WeakArcMut<DefaultMQProducerImpl>,
     ) {
         self.default_mqproducer_impl_inner = Some(default_mqproducer_impl_inner);
     }
@@ -2919,7 +2917,7 @@ impl MQProducerInner for DefaultMQProducerImpl {
                 tracing::warn!("endTransactionOneway skipped: client instance is not available");
                 return;
             };
-            let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_ref() else {
+            let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
                 tracing::warn!("endTransactionOneway skipped: MQClientAPIImpl is not available");
                 return;
             };
@@ -3037,7 +3035,7 @@ impl DefaultMQProducerImpl {
                     )));
                 }
                 if start_factory {
-                    if let Err(error) = Box::pin(client_instance.mut_from_ref().start(client_instance.clone())).await {
+                    if let Err(error) = Box::pin(client_instance.start()).await {
                         self.store_state(ProducerState::StartFailed, Ordering::SeqCst);
                         return Err(error);
                     }
@@ -3520,7 +3518,7 @@ impl DefaultMQProducerImpl {
 }
 
 pub(crate) struct DefaultServiceDetector {
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
     topic_publish_info_table: Arc<DashMap<CheetahString /* topic */, TopicPublishInfoSnapshot>>,
 }
 
@@ -3540,7 +3538,7 @@ impl ServiceDetector for DefaultServiceDetector {
         let client_instance = self.client_instance.clone();
 
         let result = tokio::time::timeout(Duration::from_millis(timeout_millis), async move {
-            match client_instance.mq_client_api_impl.as_ref() {
+            match client_instance.mq_client_api_impl.load_full() {
                 Some(api) => api.get_max_offset(endpoint, &mq, timeout_millis).await.is_ok(),
                 None => false,
             }
@@ -3609,7 +3607,7 @@ where
 }
 
 pub(crate) struct DefaultResolver {
-    client_instance: ArcMut<MQClientInstance>,
+    client_instance: Arc<MQClientInstance>,
 }
 
 impl Resolver for DefaultResolver {
@@ -3623,11 +3621,12 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
 
-    use bytes::Bytes;
+    use rocketmq_rust::ArcMut;
 
     use super::*;
     use crate::producer::default_mq_producer::DefaultMQProducer;
     use crate::producer::transaction_listener::TransactionListener;
+    use bytes::Bytes;
 
     struct CountingCompressor {
         calls: AtomicUsize,

--- a/rocketmq-client/tests/pull_message_service_test.rs
+++ b/rocketmq-client/tests/pull_message_service_test.rs
@@ -34,10 +34,8 @@ use rocketmq_client_rust::consumer::consumer_impl::pull_message_service::PullMes
 use rocketmq_client_rust::consumer::consumer_impl::pull_request::PullRequest;
 use rocketmq_client_rust::factory::mq_client_instance::MQClientInstance;
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_rust::ArcMut;
-
 /// Creates a mock MQClientInstance for testing
-fn create_mock_client_instance() -> ArcMut<MQClientInstance> {
+fn create_mock_client_instance() -> Arc<MQClientInstance> {
     let client_config = ClientConfig::default();
     MQClientInstance::new_arc(client_config, 0, CheetahString::from_static_str("test_client"), None)
 }
@@ -89,7 +87,7 @@ fn test_same_queue_maps_to_same_pull_shard() {
 
 #[tokio::test]
 async fn test_service_start_and_shutdown() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
 
     // Start service
@@ -105,7 +103,7 @@ async fn test_service_start_and_shutdown() {
 
 #[tokio::test]
 async fn test_start_spawns_configured_pull_workers() {
-    let mut service = PullMessageService::with_capacity_and_shards(1024, 4);
+    let service = PullMessageService::with_capacity_and_shards(1024, 4);
     let instance = create_mock_client_instance();
 
     service.start(instance).await.unwrap();
@@ -128,7 +126,7 @@ async fn test_start_spawns_configured_pull_workers() {
 
 #[tokio::test]
 async fn test_double_start_warning() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
 
     // First start should succeed
@@ -140,7 +138,7 @@ async fn test_double_start_warning() {
 
 #[tokio::test]
 async fn test_double_shutdown_warning() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
 
     service.start(instance).await.unwrap();
@@ -154,7 +152,7 @@ async fn test_double_shutdown_warning() {
 
 #[tokio::test]
 async fn test_execute_pull_request_immediately() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -171,7 +169,7 @@ async fn test_execute_pull_request_immediately() {
 
 #[tokio::test]
 async fn test_execute_pull_request_after_shutdown() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
     service.shutdown(100).await.unwrap();
@@ -184,7 +182,7 @@ async fn test_execute_pull_request_after_shutdown() {
 
 #[tokio::test]
 async fn test_execute_pull_request_later() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -201,7 +199,7 @@ async fn test_execute_pull_request_later() {
 
 #[tokio::test]
 async fn test_delayed_task_cancelled_after_shutdown() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -220,7 +218,7 @@ async fn test_delayed_task_cancelled_after_shutdown() {
 
 #[tokio::test]
 async fn test_delayed_requests_use_single_scheduler_task() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -250,7 +248,7 @@ async fn test_delayed_requests_use_single_scheduler_task() {
 
 #[tokio::test]
 async fn test_execute_task() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -271,7 +269,7 @@ async fn test_execute_task() {
 
 #[tokio::test]
 async fn test_execute_task_later() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -338,7 +336,7 @@ async fn test_delayed_tasks_with_same_deadline_keep_insert_order() {
 
 #[tokio::test]
 async fn test_execute_task_after_shutdown() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
     service.shutdown(100).await.unwrap();
@@ -357,7 +355,7 @@ async fn test_execute_task_after_shutdown() {
 
 #[tokio::test]
 async fn test_concurrent_execute_immediately() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -386,7 +384,7 @@ async fn test_concurrent_execute_immediately() {
 
 #[tokio::test]
 async fn test_concurrent_delayed_requests() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -405,7 +403,7 @@ async fn test_concurrent_delayed_requests() {
 
 #[tokio::test]
 async fn test_shutdown_timeout() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -417,7 +415,7 @@ async fn test_shutdown_timeout() {
 
 #[tokio::test]
 async fn test_graceful_shutdown_with_pending_requests() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -435,7 +433,7 @@ async fn test_graceful_shutdown_with_pending_requests() {
 
 #[tokio::test]
 async fn test_is_stopped_flag() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
 
     // Before start
@@ -452,7 +450,7 @@ async fn test_is_stopped_flag() {
 
 #[tokio::test]
 async fn test_default_shutdown() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -464,7 +462,7 @@ async fn test_default_shutdown() {
 
 #[tokio::test]
 async fn test_service_clone() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -480,7 +478,7 @@ async fn test_service_clone() {
 
 #[tokio::test]
 async fn test_high_throughput() {
-    let mut service = PullMessageService::with_capacity(10000);
+    let service = PullMessageService::with_capacity(10000);
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 
@@ -503,7 +501,7 @@ async fn test_high_throughput() {
 
 #[tokio::test]
 async fn test_mixed_immediate_and_delayed_requests() {
-    let mut service = PullMessageService::new();
+    let service = PullMessageService::new();
     let instance = create_mock_client_instance();
     service.start(instance).await.unwrap();
 

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -84,9 +84,10 @@ fn client_rebalance_service_uses_typed_errors() {
     let mq_client_instance = include_str!("../src/factory/mq_client_instance.rs");
     let rebalance_service = include_str!("../src/consumer/consumer_impl/re_balance/rebalance_service.rs");
 
-    assert!(mq_client_instance.contains("pub async fn do_rebalance(&mut self) -> RocketMQResult<bool>"));
-    assert!(rebalance_service
-        .contains("pub async fn start(&mut self, mut instance: ArcMut<MQClientInstance>) -> RocketMQResult<()>"));
+    assert!(mq_client_instance.contains("pub async fn do_rebalance(&self) -> RocketMQResult<bool>"));
+    assert!(
+        rebalance_service.contains("pub async fn start(&self, instance: Arc<MQClientInstance>) -> RocketMQResult<()>")
+    );
     assert!(rebalance_service.contains("pub async fn shutdown(&self, timeout_ms: u64) -> RocketMQResult<()>"));
     assert!(!mq_client_instance.contains("do_rebalance(&mut self) -> Result<bool, Box<dyn std::error::Error"));
     assert!(!rebalance_service.contains("Box<dyn std::error::Error + Send + Sync>"));

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8383,82 +8383,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "1738dae1fb349137575ee6c9",
-      "path": "rocketmq-client/src/admin/default_mq_admin_ext_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "abbd3ab91a6b1b29dc7bf89d",
-          "fingerprint": "3523cbcef3d0becdc05a37b6",
-          "item": "<module>",
-          "line": 132
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c4d77a97648c2d592e1bf7ff",
-      "path": "rocketmq-client/src/admin/default_mq_admin_ext_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "15c48ce6502ef46b0740462f",
-          "fingerprint": "5aa7da33ae472a5906b6348c",
-          "item": "struct DefaultMQAdminExtImpl",
-          "line": 530
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "9d44edbb556e2cfdbc29c5d1",
-      "path": "rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a769e3c9807073f2b536ea6f",
-          "fingerprint": "9f1002806ae1463680b9d881",
-          "item": "fn send_message_back",
-          "line": 481
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "1cab90dbb12488e03b09a048",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "a1578a8e4532db53800d00f4",
-          "fingerprint": "f64ad1e2ea88a903e7f49ef5",
-          "item": "mod tests",
-          "line": 3104
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "501907cd2bf1b3766e62e4b8",
       "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
       "symbol": "ArcMut",
@@ -8880,623 +8804,21 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "f7213429ea3364d8de7ee122",
+      "identity": "d12f90682e2514b37e1d6228",
       "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
       "symbol": "ArcMut",
       "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "939ed63ba12930f75b3a20dc",
-          "fingerprint": "fb75c6af9a069ab85723aee3",
-          "item": "<module>",
-          "line": 50
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "70124fd45828547cfddeacb2",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "500010ea88bc0fcebba906c6",
-          "fingerprint": "a49bbbb059f2026e71176675",
-          "item": "struct DefaultLitePullConsumerImpl",
-          "line": 462
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "7524a58b4cacce3b5244550b",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "edcf7c7e2a826e0b9f9a3f85",
-          "fingerprint": "68c937800a8a73e65960cd67",
-          "item": "fn start",
-          "line": 1100
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "4ab30e9a71f2d946a0857595",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs",
-      "symbol": "*",
-      "kind": "import",
       "category": "test",
       "occurrences": [
         {
-          "id": "2e1a28fe9c0918e52bdf56a5",
-          "fingerprint": "d715357faf1d89e33d16251a",
+          "id": "d1881664ae1bd81839685bd4",
+          "fingerprint": "3751fe385085836ee702857c",
           "item": "mod tests",
-          "line": 2290
+          "line": 3102
         }
       ],
       "owner": "client",
       "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "5d8d34299181478755cdf2e1",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "137e73da98ba2dbeab89acd1",
-          "fingerprint": "27ef9dd54ebf4b14be92685a",
-          "item": "<module>",
-          "line": 60
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "4d522a016aaf102291bad5fb",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "c8341d9d6bc438c7d3a777da",
-          "fingerprint": "bfb0f073ea81599b95c38e62",
-          "item": "struct DefaultMQPushConsumerImpl",
-          "line": 129
-        },
-        {
-          "id": "f9672439d6944372b5a25971",
-          "fingerprint": "a0200e007c0c69e4ab415986",
-          "item": "fn get_mq_client_factory",
-          "line": 212
-        },
-        {
-          "id": "a13932693803f42799cb1c69",
-          "fingerprint": "89e467b6a0dd7b46f9ab29ed",
-          "item": "fn set_mq_client_factory",
-          "line": 223
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "aaf5ab055a13f8d77dae8641",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "1b636421d5ecbfe9f697118b",
-          "fingerprint": "ed934938abbd94ebf3ebbef8",
-          "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2463
-        },
-        {
-          "id": "4366210318539c2a7edb2dad",
-          "fingerprint": "69343b618ff42492b938e65c",
-          "item": "fn start_duplicate_consumer_group_rolls_back_like_java",
-          "line": 2480
-        },
-        {
-          "id": "1c3107c6e26e46a083528afa",
-          "fingerprint": "330c5301f067e7c751d78eae",
-          "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2510
-        },
-        {
-          "id": "860b3bf5713fe264936bc6d1",
-          "fingerprint": "dfd6ebf478835de6e623371d",
-          "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2517
-        },
-        {
-          "id": "70f393815241dacc87e7422f",
-          "fingerprint": "ef56c22737c574751b2011fe",
-          "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2529
-        },
-        {
-          "id": "3a80af2c5eb310032f5e64a4",
-          "fingerprint": "ed934938abbd94ebf3ebbef8",
-          "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2543
-        },
-        {
-          "id": "616daffd00e6d2e9b21ad31d",
-          "fingerprint": "ea89c3fc97c837d10c858c78",
-          "item": "fn startup_after_running_failure_shutdowns_and_unregisters_like_java",
-          "line": 2548
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "1db9e8d5c097aab38e688b34",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "20168c92697aac6e4b6dfcfd",
-          "fingerprint": "74aae28454f710f862ae6fbf",
-          "item": "mod tests",
-          "line": 586
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "b700ed0b696b560facdabfc1",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "b1e4d2dd85e80e63fcf324e1",
-          "fingerprint": "53f0f8b6de1332d4d0d638af",
-          "item": "<module>",
-          "line": 41
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "4fc1c7ba383865d96ec64cc4",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "469d2935ddbf4ae2b4e78bb5",
-          "fingerprint": "7709b23d13f5a7668e90306b",
-          "item": "struct PullAPIWrapper",
-          "line": 92
-        },
-        {
-          "id": "6ed5f399943aaac1ab706bab",
-          "fingerprint": "a8662dd2da31437ff49581a2",
-          "item": "fn new",
-          "line": 102
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e84acd8793a4b6e2cec3379f",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "ff3d63ef73d009f54935ac35",
-          "fingerprint": "cbd23aea7f36d6a293537041",
-          "item": "mod tests",
-          "line": 1098
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "07598cc82b290cf6ccd1015c",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "7591c8a7f36770677bbb8f3e",
-          "fingerprint": "d95ce722400f058b32de457c",
-          "item": "<module>",
-          "line": 34
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "bcf948f03ad9f2ec3a224e6f",
-      "path": "rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "62a21dfcb798c1bd6d4d0255",
-          "fingerprint": "799c12a43d4058eca0fc5563",
-          "item": "fn run_pull_request_shard_worker",
-          "line": 488
-        },
-        {
-          "id": "4b3367761288e8c3245465c5",
-          "fingerprint": "3b1f6d9648d1b264a7b7308c",
-          "item": "fn start",
-          "line": 582
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "9d964ad7941e1087df40eac6",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8bb7ccaa44344d5d1bc71425",
-          "fingerprint": "42550c6f71d3e6db57708c8b",
-          "item": "<module>",
-          "line": 37
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "cba028c121feeb97e5083c0e",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a27a22686ca54faf125acdb2",
-          "fingerprint": "1856b0819ddf11feea55b1d0",
-          "item": "struct RebalanceImpl",
-          "line": 103
-        },
-        {
-          "id": "3486ff84bcc0171306e0c46a",
-          "fingerprint": "79492b49182251dc9ed51498",
-          "item": "fn new",
-          "line": 136
-        },
-        {
-          "id": "aa418a4c77ae9b6761d2c2c5",
-          "fingerprint": "3e118da138d81b1d5da0bc03",
-          "item": "fn get_mq_client_factory",
-          "line": 165
-        },
-        {
-          "id": "f18763e81364c2af7fe22248",
-          "fingerprint": "9cc55439cdb120a32b1ab044",
-          "item": "fn set_mq_client_factory",
-          "line": 176
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "7e81b665abea82958607beb5",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "dfe48e514f65aab7ec8f4947",
-          "fingerprint": "cb716d4a8aa989b3613889f2",
-          "item": "<module>",
-          "line": 43
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "0365c4763c3a5a91a71191f6",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_lite_pull_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "7d38ca4a1c7972e9fd5e8f11",
-          "fingerprint": "26e77adf47997614b359273e",
-          "item": "fn set_mq_client_factory",
-          "line": 155
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "82dd21bb07d35dcda220d113",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "49d2821d385cf8bc99631cb6",
-          "fingerprint": "3fc627945656873f8d8f5379",
-          "item": "<module>",
-          "line": 35
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "9ec70d1a692a7e3a4773bc19",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "c4bc84529d3f712b130340d4",
-          "fingerprint": "90db19f48145b50b5d741612",
-          "item": "fn set_mq_client_factory",
-          "line": 129
-        },
-        {
-          "id": "b5285b7f6c85a4359a1d02e9",
-          "fingerprint": "a1646a5f680f703d98e34012",
-          "item": "fn build_process_queue_table_by_broker_name",
-          "line": 609
-        },
-        {
-          "id": "57ae5b411b2ae52c9a35399a",
-          "fingerprint": "0fdba8aa8161e45fff2cff9a",
-          "item": "fn lock_all_impl",
-          "line": 628
-        },
-        {
-          "id": "ae37eef15f023a2b35bca26c",
-          "fingerprint": "283dbe2c1e78bebdff1680ee",
-          "item": "fn unlock_all_impl",
-          "line": 700
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "96a9a46775f44c2567c95443",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "ec0c8722e75a4774b100c2c3",
-          "fingerprint": "96e5fd302d075bdbe6b995de",
-          "item": "mod tests",
-          "line": 512
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6486aba1bc6018c47bd698a7",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "df2fc5cad60ad51d14f3ac05",
-          "fingerprint": "9803d5665eb6f93ec2ecf3ba",
-          "item": "<module>",
-          "line": 27
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a0c343d7a52d2947753b12a3",
-      "path": "rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "7ca61af568ade8f3cbc7ca76",
-          "fingerprint": "4cd9f296f76f83a39226da50",
-          "item": "fn start",
-          "line": 238
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "522b5c1985586094d69fe888",
-      "path": "rocketmq-client/src/consumer/store/local_file_offset_store.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8aad077f5b625f95681f6f7a",
-          "fingerprint": "bcd4673cf3e3e6c6a0abdb23",
-          "item": "<module>",
-          "line": 32
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "14d537578ba5d77d67af2ab7",
-      "path": "rocketmq-client/src/consumer/store/local_file_offset_store.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "0d04a2e6dd833ba8a4d8b347",
-          "fingerprint": "fb2f13eb48f737b1472c67ca",
-          "item": "struct LocalFileOffsetStore",
-          "line": 81
-        },
-        {
-          "id": "8cf27eb448946a4201687772",
-          "fingerprint": "dd99b06743470ae418eee360",
-          "item": "fn new",
-          "line": 207
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "14b78f458a449d359e00c4a2",
-      "path": "rocketmq-client/src/consumer/store/remote_broker_offset_store.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "59807c8d6623ca5f3f02d2ae",
-          "fingerprint": "c376fa2b00729a66e11e6866",
-          "item": "mod tests",
-          "line": 344
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "b638bddf736603b89c07abe2",
-      "path": "rocketmq-client/src/consumer/store/remote_broker_offset_store.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "20027019bd592e7a07d6411d",
-          "fingerprint": "4b5c23da53ac82a8204ba797",
-          "item": "<module>",
-          "line": 26
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "207890378054a019a2b9f2d5",
-      "path": "rocketmq-client/src/consumer/store/remote_broker_offset_store.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "d734dad287a80d0e2120a9e6",
-          "fingerprint": "341c35177d6eabcfe044b290",
-          "item": "struct RemoteBrokerOffsetStore",
-          "line": 38
-        },
-        {
-          "id": "2d2dcc34f0e0ee41ba5d192f",
-          "fingerprint": "0b7049cf2caed0e92f3e4e79",
-          "item": "fn new",
-          "line": 45
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -9511,7 +8833,7 @@
           "id": "9cbe2d507037ccc178f23eb8",
           "fingerprint": "d26a6e9d75c77b5c7069d839",
           "item": "mod tests",
-          "line": 2668
+          "line": 2732
         }
       ],
       "owner": "client",
@@ -9527,28 +8849,16 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "4f4426bb5ffdefbd32f00464",
-          "fingerprint": "bc68fc2026a3802ede1fc0a5",
-          "item": "impl Into",
-          "line": 327
-        },
-        {
           "id": "35f6639321b0860fe607864f",
           "fingerprint": "53b20b22a3d6accd306ff337",
           "item": "impl Into",
-          "line": 339
+          "line": 347
         },
         {
-          "id": "180883366b3edd9a7f616acd",
-          "fingerprint": "07627625f3b38e72a1061992",
+          "id": "784363980e1771e83f8bfb29",
+          "fingerprint": "3e6849f1edd295f4036207c6",
           "item": "impl Into",
-          "line": 345
-        },
-        {
-          "id": "a545e29fb04f6ec655e6362f",
-          "fingerprint": "c0ddefea53f3b900e3c3b432",
-          "item": "impl Into",
-          "line": 359
+          "line": 368
         }
       ],
       "owner": "client",
@@ -9567,7 +8877,7 @@
           "id": "3537a7f5e9f85fea0a9ca95a",
           "fingerprint": "1e1dd2485b87b679d56fce30",
           "item": "fn apply_route_refresh_updates_producer_and_consumer_views",
-          "line": 2886
+          "line": 2960
         }
       ],
       "owner": "client",
@@ -9583,10 +8893,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "a75d9ccd8a3b108bbc39aecb",
-          "fingerprint": "5fae517e6c302dc1bf81fe99",
+          "id": "a06a3483560b4167a2ed391f",
+          "fingerprint": "e34876806dc1579f85c0a7b0",
           "item": "<module>",
-          "line": 65
+          "line": 70
         }
       ],
       "owner": "client",
@@ -9602,460 +8912,21 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ced5d64675bd5217995cd3f5",
-          "fingerprint": "8fe64022879d85bb1ce68792",
+          "id": "aed7f482b5176e2cec87b1d3",
+          "fingerprint": "643609116cdb0d77188b8e33",
           "item": "struct MQClientInstance",
-          "line": 223
+          "line": 256
         },
         {
-          "id": "46138f75cdf92f7ed803d3e4",
-          "fingerprint": "2a9f1469a895ab8c7529dcfc",
+          "id": "dc9a04df1f7e106799d3826e",
+          "fingerprint": "c4256156674745cfbd077ad5",
           "item": "struct MQClientInstance",
-          "line": 249
-        },
-        {
-          "id": "b2f7533839432d3434f40905",
-          "fingerprint": "8ac2ca9871d31e54e4e9fc3f",
-          "item": "struct MQClientInstance",
-          "line": 251
-        },
-        {
-          "id": "1a1c7ce11b7f0c3e785b0e91",
-          "fingerprint": "67c25eab2ff3e0b9cfa802a3",
-          "item": "impl Into",
-          "line": 325
-        },
-        {
-          "id": "3ae1fb9d30be0d6c185b346d",
-          "fingerprint": "9803c8d8017b5236972b4114",
-          "item": "impl Into",
-          "line": 400
-        },
-        {
-          "id": "ca1376cc209947df2ad88dd2",
-          "fingerprint": "ec054c8c5c736949cc8bcbe4",
-          "item": "fn start",
-          "line": 458
-        },
-        {
-          "id": "19229b23cd4be4f5ed4b8fa7",
-          "fingerprint": "601870d525a9d7fa55d52273",
-          "item": "fn start_scheduled_task",
-          "line": 720
+          "line": 258
         }
       ],
       "owner": "client",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "2958f9a716da106158f45b23",
-      "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-      "symbol": "WeakArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "4027c164133bd0b9cc54f344",
-          "fingerprint": "4af98d1439a7cd4535074b0e",
-          "item": "<module>",
-          "line": 67
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "910a4ad803399cc73e688cc6",
-      "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-      "symbol": "WeakArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "ca8efb81f1634446b7739ae7",
-          "fingerprint": "f66c27a0a0dc1c8a462cef70",
-          "item": "fn run_connection_net_event_listener",
-          "line": 131
-        },
-        {
-          "id": "95802fd02819079c8419d1b7",
-          "fingerprint": "186ded7a7c3ccc9e5e3bcf47",
-          "item": "fn spawn_connection_net_event_listener",
-          "line": 171
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "19bef71e1e633bbb60cd2aaa",
-      "path": "rocketmq-client/src/implementation/client_remoting_processor.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "12323fc53263baaa9cdd8305",
-          "fingerprint": "aacbd2b335a7bfd4cb2b9086",
-          "item": "mod tests",
-          "line": 554
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6ac0d6ed8e4d59db32aca4e0",
-      "path": "rocketmq-client/src/implementation/client_remoting_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "9a5c3b8ba65504f670b59f7f",
-          "fingerprint": "1e84d442abb8746be1110b0a",
-          "item": "<module>",
-          "line": 48
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6b9c1d08e603c680fb024803",
-      "path": "rocketmq-client/src/implementation/client_remoting_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "ee9dc4541b689625b9431c2e",
-          "fingerprint": "9a7659e1c82521f230d48a53",
-          "item": "struct ClientRemotingProcessor",
-          "line": 58
-        },
-        {
-          "id": "998ddf296c8ea17f4fe5f755",
-          "fingerprint": "bcb4c8510211b30e00f3340c",
-          "item": "fn new",
-          "line": 62
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "8984469a1621f38559895e31",
-      "path": "rocketmq-client/src/implementation/client_remoting_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "637f186740f224f4645b6def",
-          "fingerprint": "b20aa7ffe779742f569d2e52",
-          "item": "fn client_with_push_consumer",
-          "line": 567
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6bc3d95d80ec3dd31928fe1e",
-      "path": "rocketmq-client/src/implementation/client_remoting_processor.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "1be115ff4aa1e4608a758693",
-          "fingerprint": "36356460b0e9f6368436be95",
-          "item": "fn client_with_push_consumer",
-          "line": 582
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c16321362b35b75e3e748794",
-      "path": "rocketmq-client/src/implementation/mq_admin_impl.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "cce69073596954299718616e",
-          "fingerprint": "7aa586045540d1bc5fe92dca",
-          "item": "mod tests",
-          "line": 506
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "87169e915a17de16407aaea6",
-      "path": "rocketmq-client/src/implementation/mq_admin_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "b9b19ef630ce5a0ef38a202a",
-          "fingerprint": "c0f596ea777dc3b7d5b42f00",
-          "item": "<module>",
-          "line": 37
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "182dcb0f58b23120a9ac7cac",
-      "path": "rocketmq-client/src/implementation/mq_admin_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "baf2bb42ead27b7c0a150b6b",
-          "fingerprint": "0fad4d7e4c4ad4faeb74b024",
-          "item": "struct MQAdminImpl",
-          "line": 48
-        },
-        {
-          "id": "92c605b1eae672831fe59030",
-          "fingerprint": "ca6c4a60650bd5ea3ca91e95",
-          "item": "fn set_client",
-          "line": 59
-        },
-        {
-          "id": "6fbf93e8a11adebd8d8ab7ba",
-          "fingerprint": "87b43cabb2f857aeace31505",
-          "item": "fn client",
-          "line": 63
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "ec08dca8a046c2d987eca5ad",
-      "path": "rocketmq-client/src/implementation/mq_client_api_impl.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "8dd0c94e325297b656b173f0",
-          "fingerprint": "972c41753edd899738867f9d",
-          "item": "mod tests",
-          "line": 6564
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c6bcbc0ce95cb095877c132d",
-      "path": "rocketmq-client/src/implementation/mq_client_api_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a399c0791bed4a561db80a6a",
-          "fingerprint": "0f8655a1d4a00dcc97e1320b",
-          "item": "<module>",
-          "line": 252
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6cbaf8edfe3abdd67d158b31",
-      "path": "rocketmq-client/src/implementation/mq_client_api_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "436e5e4e43c43c52593d2f2d",
-          "fingerprint": "ad720cf5d09f13cd08bb1e20",
-          "item": "fn send_message",
-          "line": 2328
-        },
-        {
-          "id": "938da9511e6d99ecfe836972",
-          "fingerprint": "ad720cf5d09f13cd08bb1e20",
-          "item": "fn send_message_async",
-          "line": 2512
-        },
-        {
-          "id": "b707cabfb0ac55855f1b0180",
-          "fingerprint": "5a67d1e294ce8f269bed92e1",
-          "item": "fn send_message_async_impl",
-          "line": 2607
-        },
-        {
-          "id": "a4e0dd48aa0233e995f1ea02",
-          "fingerprint": "3d682987e275ee3fca84dbcd",
-          "item": "fn select_async_retry_target",
-          "line": 2798
-        },
-        {
-          "id": "6074144a9b590d32d044cff0",
-          "fingerprint": "40dc5b96b47ff465d6f09212",
-          "item": "fn prepare_retry",
-          "line": 2998
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "548dcb317e2ddbad3570958a",
-      "path": "rocketmq-client/src/implementation/mq_client_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "alias",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "63221c8f4931d98bc6201082",
-          "fingerprint": "985077b8f7b7dd91546699a6",
-          "item": "<module>",
-          "line": 30
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "70fa46e63735ff13e8475919",
-      "path": "rocketmq-client/src/implementation/mq_client_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "86f35163de5dd7dd4c463f19",
-          "fingerprint": "f23b242f1b197de19949cb33",
-          "item": "<module>",
-          "line": 23
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "9cc4e660e90bf1b5e7039796",
-      "path": "rocketmq-client/src/implementation/mq_client_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "d586a20ee2d55eb02ed2e1b6",
-          "fingerprint": "0f073d9c5665b00be5f46c2a",
-          "item": "fn get_or_create_mq_client_instance",
-          "line": 59
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "258a7897403ff0b6b2730c6d",
-      "path": "rocketmq-client/src/implementation/mq_client_manager.rs",
-      "symbol": "ClientInstanceHashMap",
-      "kind": "alias",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "199cfe621da7200ccd053384",
-          "fingerprint": "6b264bdbc4cbc113f5026fd9",
-          "item": "<module>",
-          "line": 30
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "9283163cbee1b92316f4f9bc",
-      "path": "rocketmq-client/src/implementation/mq_client_manager.rs",
-      "symbol": "ClientInstanceHashMap",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "5f5721ea20ea3a80cea83ae2",
-          "fingerprint": "93bddb9f490a78f9faa71add",
-          "item": "struct MQClientManager",
-          "line": 35
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "eb2cd2ebf89240c3b8d85247",
-      "path": "rocketmq-client/src/lib.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "e40bc2b361735e32fa250436",
-          "fingerprint": "dd85ceb9ec45f13745e23166",
-          "item": "struct ClientInstanceHandle",
-          "line": 170
-        }
-      ],
-      "owner": "proxy",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M08",
       "adr": "ADR-002"
     },
     {
@@ -10165,25 +9036,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "77bd90ea8ae670340b4fdab2",
-      "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "b1a22a9e0fa5d9ecfa852526",
-          "fingerprint": "d140ff4ac2a0ea79a857088b",
-          "item": "mod tests",
-          "line": 3628
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "5e670f69aff88a2e2dc94ccb",
       "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
       "symbol": "ArcMut",
@@ -10194,7 +9046,7 @@
           "id": "67b0046e6072159c90695c24",
           "fingerprint": "356398455444fa281e36bc8b",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3659
+          "line": 3658
         }
       ],
       "owner": "client",
@@ -10203,64 +9055,21 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "d82a52823e8413aa334247dd",
+      "identity": "c2822fbd0cf21717000b66d2",
       "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
       "symbol": "ArcMut",
       "kind": "import",
-      "category": "production",
+      "category": "test",
       "occurrences": [
         {
-          "id": "87e2b6c532fe08a3dbc4ba93",
-          "fingerprint": "ef3ad24167f749ba282d6647",
-          "item": "<module>",
-          "line": 62
+          "id": "0b248f4434f22cae96c63dbe",
+          "fingerprint": "3037e5faa98ff451cc59746e",
+          "item": "mod tests",
+          "line": 3624
         }
       ],
       "owner": "client",
       "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "01934c8762435d6c13b3bbc4",
-      "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "e79256d601200eac98e5068e",
-          "fingerprint": "4d3a3d736cc488c4afc80b45",
-          "item": "struct DefaultMQProducerImpl",
-          "line": 327
-        },
-        {
-          "id": "f191254954997718012ea998",
-          "fingerprint": "8fa76ae1cf4d7a79e625d045",
-          "item": "fn client_instance",
-          "line": 499
-        },
-        {
-          "id": "eb2954345f3cb5b34e2ba727",
-          "fingerprint": "ba20312aee336ba5ea0c4963",
-          "item": "fn get_mq_client_factory",
-          "line": 506
-        },
-        {
-          "id": "f4f791ad0cc15215ab5f9f9a",
-          "fingerprint": "f0e256b31aba61aae79c3c48",
-          "item": "struct DefaultServiceDetector",
-          "line": 3523
-        },
-        {
-          "id": "b1f91ffc3439d3410d7dee6b",
-          "fingerprint": "2d53d4eadb152009da2a1127",
-          "item": "struct DefaultResolver",
-          "line": 3612
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -10275,36 +9084,17 @@
           "id": "d9a05be2d5e4ad25924e45a9",
           "fingerprint": "e921f953fdb474ebfdf78609",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3658
+          "line": 3657
         },
         {
           "id": "47d45638c009526c0a6964ce",
           "fingerprint": "c4ea98db295aea5d035405e0",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3662
+          "line": 3661
         }
       ],
       "owner": "client",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a5fea02b933ed24fad223c37",
-      "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-      "symbol": "WeakArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "7542c0219eaccc5af5f8cea1",
-          "fingerprint": "0502b38fa01cd04bd1250582",
-          "item": "<module>",
-          "line": 63
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -10316,39 +9106,20 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "0b6330858f17ca4f7c9e79b7",
-          "fingerprint": "4292e92c2b2532b734456fa5",
+          "id": "4c7bac692c52addb14192646",
+          "fingerprint": "dbd79c1d76777e7d05e1f037",
           "item": "struct DefaultMQProducerImpl",
-          "line": 333
+          "line": 331
         },
         {
-          "id": "2b08b75b29fdd51394ca3fd3",
-          "fingerprint": "1b66359c3d04ea9077d40cac",
+          "id": "199678d9794d564d1f37ef76",
+          "fingerprint": "c55800b7539647dd988a1df6",
           "item": "fn set_default_mqproducer_impl_inner",
-          "line": 2779
+          "line": 2777
         }
       ],
       "owner": "client",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "19c1e9f4b8e3787f50c49252",
-      "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "bd3c6e3b22f6359b735d4be8",
-          "fingerprint": "4b07739b374c6b168ee272b5",
-          "item": "fn start_with_factory",
-          "line": 3040
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -10363,25 +9134,25 @@
           "id": "aba9ca5334cb9554b5016b9b",
           "fingerprint": "a51632360baadbb0bc486192",
           "item": "fn running_producer_arc_with_self_inner",
-          "line": 3661
+          "line": 3660
         },
         {
           "id": "16e189d4577b6391b57c80e4",
           "fingerprint": "8b150fb7bba37b260fdd92e9",
           "item": "fn async_send_to_queue_validates_message_before_kernel_like_java",
-          "line": 4153
+          "line": 4152
         },
         {
           "id": "e443a78aa00d5c904edc6f25",
           "fingerprint": "8b150fb7bba37b260fdd92e9",
           "item": "fn async_send_to_queue_topic_mismatch_uses_java_callback_error_message",
-          "line": 4189
+          "line": 4188
         },
         {
           "id": "8d72eb9eab5bdfe75d28666f",
           "fingerprint": "683fb6d123596cb2a5c150af",
           "item": "fn async_send_with_callback_reports_kernel_error_to_callback",
-          "line": 4230
+          "line": 4229
         }
       ],
       "owner": "client",
@@ -10439,44 +9210,6 @@
           "fingerprint": "45b338c1cc0a7539839c0635",
           "item": "struct MQProducerInnerImpl",
           "line": 47
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "8b5c5132e9610670b67bc86b",
-      "path": "rocketmq-client/tests/pull_message_service_test.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "2e607ea2c36c0faf89d61713",
-          "fingerprint": "c1a8697b482f88e51a1e2795",
-          "item": "<module>",
-          "line": 37
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c4d8266021e78f7b7a087fdb",
-      "path": "rocketmq-client/tests/pull_message_service_test.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "f19a79c3b45b4f816b3515fe",
-          "fingerprint": "4ac1397e2160671e983f9729",
-          "item": "fn create_mock_client_instance",
-          "line": 40
         }
       ],
       "owner": "client",


### PR DESCRIPTION
## Summary

- replace the `MQClientInstance` root and every Client/Proxy handle with standard `Arc`
- use standard `Weak` for remoting and admin back-references, with explicit lifecycle, API-slot, and task-handle synchronization
- narrow runtime paths to shared receivers while preserving the remaining producer and pull-service child boundaries behind serialized transitions
- refresh the governed ArcMut baseline and migration checklists

## Validation

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- `cargo test -p rocketmq-client-rust --all-features --quiet` (984 library tests plus all integration targets; 35 existing environment-dependent tests ignored)
- focused MQClientInstance, remoting, admin, pull, rebalance, pull integration, and typed-error tests
- Client and root workspace strict Clippy profiles
- Example, Tauri backend, and Web backend standalone format/Clippy checks; Web backend all-target build
- ArcMut guard: 67 unit tests, 24 fixtures, tracked guard pass
- architecture dependency/release guards: 49 unit tests; runtime audit and AGENTS routing checks
- `cargo fmt --all -- --check`
- `git diff --check`

## Debt delta

- tracked baseline: 599 identities / 1,612 occurrences -> 544 / 1,520
- production: 368 / 982 -> 326 / 909
- Client production: 50 / 89 -> 9 / 17
- Proxy production: 1 / 1 -> 0 / 0

This is one M11-12 implementation slice. The formal migration total remains 75/82; the parent soundness-closure package and its stable, compatibility, soak/SLO, dynamic-environment, and human gates remain open.

Closes #8369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved client lifecycle and ownership handling for more predictable startup, shutdown, and shared operation behavior.
  - Strengthened concurrency controls around pull, rebalance, connection, and producer services.
  - Improved handling when client services or broker APIs are unavailable.

- **Bug Fixes**
  - Retry and message-back paths now use more consistent sending behavior.
  - Client callbacks safely recognize when the associated client is no longer available.

- **Documentation**
  - Updated architecture migration plans, progress tracking, verification results, and remaining milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->