### PR TITLE
[ISSUE #8371]♻️Replace Client internal child ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -654,7 +654,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12aj Client Push implementation root ownership：facade、consumer registry、callback 与 task capture 改用标准 `Arc`，root-owned consume/rebalance 回边改用 `Weak`；start/shutdown 由 lifecycle mutex 串行，组件槽位短锁发布快照，rebalance metadata 使用共享引用安全更新且未新增 production `mut_from_ref`
   - [x] M11-12ak Client Rebalance root ownership：Push/LitePull concrete rebalance root 改用标准 `Arc`，core self-reference 与 concrete setter 改用标准 `Weak`；释放 root 后 weak upgrade 失败的定向测试通过，`MQClientInstance` 兼容 handle 保留给后续切片
   - [x] M11-12al Client MQClientInstance root ownership：Manager/Proxy handle 与 Admin/Producer/Consumer/Rebalance/API/OffsetStore 全链路改用标准 `Arc<MQClientInstance>`；Remoting/Admin 回指改用标准 `Weak`，lifecycle、API slot 与 task handle 显式同步，公开运行路径收窄为共享 receiver
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369 与每次真实下降
+  - [x] M11-12am Client internal child ownership：`MQClientInstance` 的 PullMessageService child 改用标准 `Arc`，internal DefaultMQProducer 改由单一异步 `Mutex` 所有并取代冗余 transition lock；production factory 文件不再包含 ArcMut
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -693,7 +694,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8365 后实际快照降至 376 production/995 occurrence；Client owner 降至 58/102，Client test 降至 25/102；Push implementation root、consume service/callback owner 与过时 rebalance 可变 receiver 共删除 21 个 production identity/50 occurrence、22 个 test identity/30 occurrence
   - [x] Issue #8367 后实际快照降至 368 production/982 occurrence；Client owner 降至 50/89；Push/LitePull Rebalance root 与 standard-weak self reference 共删除 8 个 production identity/13 occurrence，测试/compatibility 不增
   - [x] Issue #8369 后实际快照降至 326 production/909 occurrence；Client owner 降至 9/17、Client test 降至 12/83、Proxy production 清零；MQClientInstance root 全链路共删除 42 个 production identity/73 occurrence 与 13 个 test identity/19 occurrence
-  - [ ] M11-12am 及后续：Client Producer/PullMessageService child owner、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8371 后实际快照降至 323 production/904 occurrence；Client owner 降至 6/12，Client test 12/83 与 compatibility 14/40 不增；factory child owner 删除 3 个 production identity/5 occurrence
+  - [ ] M11-12an 及后续：Client DefaultMQProducer facade/implementation/registry 标准 Arc/Weak 与强环拆除、Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -403,6 +403,11 @@ Admin/Producer/Consumer/Rebalance/API/OffsetStore 持有链统一改为标准 `A
 receiver。实际快照降至 326 production/909 occurrence，Client owner 降至 9/17、Client test 降至 12/83，Proxy
 production 债务清零；剩余为 Broker 190/568、Client 9/17 与 Store 127/324，总进度仍为 75/82。下一子切片为
 M11-12am Client Producer root ownership，M11-12 父工作包未完成。
+Client internal child ownership 随 Issue #8371 将 `MQClientInstance::pull_message_service` 改为标准 `Arc`，并以
+单一 Tokio Mutex 直接拥有 internal DefaultMQProducer，取代原本在完整 start/shutdown/send future 上持有的独立
+transition mutex；序列化范围与锁顺序不变。实际快照降至 323 production/904 occurrence，Client owner 降至 6/12；
+剩余为 Broker 190/568、Client 6/12 与 Store 127/324，总进度仍为 75/82。下一子切片为 M11-12an 完整 Producer
+root/registry/standard-weak 与强引用环拆除，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -417,6 +417,11 @@ connection task handle 使用显式同步，start/shutdown 与 default producer 
 production/909 occurrences，Client owner 降至 9/17、Client test 降至 12/83，Proxy production 债务清零；其余
 Client Producer/PullMessageService、Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12am 已将 `MQClientInstance` 内部 PullMessageService child 改为标准 `Arc`，internal DefaultMQProducer 改由
+单一 Tokio Mutex 所有；该 mutex 直接取代旧 default-producer transition，保持完整 start/shutdown/send future 的
+既有串行边界，且没有同步 guard 跨 `.await`。实际快照降至 323 production/904 occurrences，Client owner 降至
+6/12；完整 Producer root/registry/standard-weak、Broker/Store、compatibility 与候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -108,6 +108,9 @@ M11-12ak 的 Client Rebalance root ownership 由 Issue #8367 跟踪，分支为
 M11-12al 的 Client MQClientInstance root ownership 由 Issue #8369 跟踪，分支为
 `mxsm/architecture-refactor-mq-client-instance-root-ownership`；它仍是同一 M11-12 工作包的子切片。
 
+M11-12am 的 Client internal child ownership 由 Issue #8371 跟踪，分支为
+`mxsm/architecture-refactor-client-internal-child-ownership`；它仍是同一 M11-12 工作包的子切片。
+
 ## 初始盘点
 
 在 main `86719f1bc77c2e78ff32195262bad820145f271b` 上生成当前源码快照：
@@ -943,6 +946,31 @@ test-only import identity relocation 逐条按 ADR-013 临时审核且 approval 
 `ArcMut<MQClientInstance>`、`WeakArcMut<MQClientInstance>`、对应 constructor 与 root `mut_from_ref` 已零匹配。
 下一子切片 M11-12am 处理 DefaultMQProducer root/Weak self owner；75/82 总进度不变。
 
+## M11-12am Client internal child ownership
+
+| 目标 | 实现与证据 |
+|---|---|
+| Pull child owner | `MQClientInstance::pull_message_service` 从 `ArcMut` 改为标准 `Arc<PullMessageService>`；其 start/shutdown/dispatch API 已是共享 receiver，内部 Clone 只共享原子与同步句柄 |
+| internal producer owner | `MQClientInstance::default_producer` 从 `ArcMut` 改为 `tokio::sync::Mutex<DefaultMQProducer>`；start/shutdown/send 在同一异步 guard 内完成 |
+| lifecycle equivalence | 新 owner mutex 直接替代 `default_producer_transition`；旧 transition 本来就在完整 future 上持有，因此串行范围与 `MQClientInstance lifecycle → default producer` 锁顺序均不扩大 |
+| production boundary | `mq_client_instance.rs` production 不再包含 ArcMut import/type/constructor；测试所需 ArcMut 显式留在 `#[cfg(test)]` module |
+| regression evidence | MQClientInstance 30/30、Pull service 10/10、Pull integration 28/28 与 typed-error 5/5 定向测试通过；Client 全量 library 984/984 及全部 integration targets 通过 |
+
+M11-12am 后实际快照为 541 个条目：production 323、test 204、compatibility 14；occurrence 精确为 production
+904、test 571、compatibility 40。相对 M11-12al 删除 3 个 production identity/5 occurrence，test 与 compatibility
+不增加；Client owner 从 9/17 降至 6/12，Client test 保持 12/83。剩余 production 债务为：
+
+| owner | 条目 | occurrence |
+|---|---:|---:|
+| Broker | 190 | 568 |
+| Client | 6 | 12 |
+| Store | 127 | 324 |
+
+reviewed baseline 从 544→541、occurrences 从 1,520→1,515。1 个 test-only import identity relocation 按
+ADR-013 临时审核且 approval 不提交；3 个 production identity/5 occurrence 为真实删除。下一子切片 M11-12an
+必须一次完成 facade/implementation/registry 的标准 Arc/Weak、config snapshot、task admission 与 Client/fault
+resolver 强环拆除，不能用全局 impl mutex 串行发送；75/82 总进度不变。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1708,10 +1736,29 @@ M11-12al 追加验证：
 | MQClientInstance root ArcMut 定向扫描 | repository 中 `ArcMut<MQClientInstance>` / `WeakArcMut<MQClientInstance>` / 对应 constructor 零匹配；root 文件无 `mut_from_ref` |
 | `git diff --check` | 通过；仅报告工作树 CRLF 转换提示，无 whitespace error |
 
+M11-12am 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-client-rust --all-targets --all-features` | 通过；标准 PullMessageService child 与 internal producer mutex owner 在所有 Client target 编译通过 |
+| MQClientInstance / PullMessageService focused tests | 30/30、10/10 通过；Pull integration 28/28、typed-error 5/5 通过 |
+| `cargo test -p rocketmq-client-rust --all-features --quiet` | 退出码 0 全部通过；library 984/984，其余 integration targets 全部通过，35 项既有外部环境测试忽略 |
+| reviewed baseline promotion（临时 ADR-013 approval） | 删除 3 个 production identity/5 occurrence；1 个 test import identity relocation 逐条审核且 approval 不提交；baseline 544/1,520→541/1,515 |
+| `python scripts/arc_mut_guard.py` | 通过；production 323/904、test 204/571、compatibility 14/40；Client owner 6/12、Client test 12/83；没有新增 production `mut_from_ref` |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` | 通过 |
+| Client package / root workspace strict Clippy | `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings` 与 root workspace profile 均通过 |
+| standalone Example / Tauri Rust backend / Web backend | 各自 fmt + strict Clippy 通过；Web backend `cargo build --all-targets --all-features` 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；internal producer 的异步 owner 保持原 start/shutdown/send 串行范围，Pull child 使用标准共享 owner |
+| architecture target/baseline 与 release guard | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates，guard 单测 60/60 通过 |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| MQClientInstance child ArcMut 定向扫描 | production factory 文件中 PullMessageService/default producer ArcMut owner 零匹配；仅 test module 保留显式 test-only ArcMut fixture |
+| `git diff --check` | 通过；仅报告工作树 CRLF 转换提示，无 whitespace error |
+
 ## 剩余切片与 Gate
 
-1. Client DefaultMQProducer self owner、PullMessageService child owner 与剩余可变 receiver（Client owner 9/17）；
-   下一子切片 M11-12am 先统一 Producer facade/implementation/registry/callback 的 root 与 standard-weak self owner。
+1. Client DefaultMQProducer facade/implementation/registry 的标准 Arc/Weak root、配置快照、生命周期与任务接纳边界，
+   并拆除 producer/client/registry 强引用环（Client owner 6/12）；下一子切片 M11-12an 完成该 Producer root。
 2. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）。
 3. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 4. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -67,7 +67,6 @@ use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_runtime::schedule::simple_scheduler::ScheduledTaskManager;
-use rocketmq_rust::ArcMut;
 use rocketmq_rust::RocketMQTokioMutex;
 use serde::Serialize;
 use tokio::sync::Mutex;
@@ -253,10 +252,9 @@ pub struct MQClientInstance {
 
     lifecycle_transition: Mutex<()>,
     service_state: StdRwLock<ServiceState>,
-    pub(crate) pull_message_service: ArcMut<PullMessageService>,
+    pub(crate) pull_message_service: Arc<PullMessageService>,
     rebalance_service: RebalanceService,
-    pub(crate) default_producer: ArcMut<DefaultMQProducer>,
-    default_producer_transition: Mutex<()>,
+    pub(crate) default_producer: Mutex<DefaultMQProducer>,
     broker_addr_table: BrokerAddrTable,
     broker_version_table: BrokerVersionTable,
     send_heartbeat_times_total: Arc<AtomicI64>,
@@ -344,7 +342,7 @@ impl MQClientInstance {
         let broker_heartbeat_fingerprint_table = Arc::new(DashMap::default());
         let broker_support_v2_heartbeat_set = Arc::new(DashMap::default());
 
-        let default_producer = ArcMut::new(
+        let default_producer = Mutex::new(
             DefaultMQProducer::builder()
                 .producer_group(mix_all::CLIENT_INNER_PRODUCER_GROUP)
                 .client_config(client_config.clone())
@@ -365,12 +363,11 @@ impl MQClientInstance {
             lock_heartbeat: Arc::default(),
             lifecycle_transition: Mutex::new(()),
             service_state: StdRwLock::new(ServiceState::CreateJust),
-            pull_message_service: ArcMut::new(PullMessageService::with_shards(
+            pull_message_service: Arc::new(PullMessageService::with_shards(
                 client_config.pull_message_service_shards,
             )),
             rebalance_service: RebalanceService::new(),
             default_producer,
-            default_producer_transition: Mutex::new(()),
             broker_addr_table,
             broker_version_table,
             send_heartbeat_times_total: Arc::new(AtomicI64::new(0)),
@@ -435,20 +432,18 @@ impl MQClientInstance {
     }
 
     async fn start_default_producer(&self) -> rocketmq_error::RocketMQResult<()> {
-        let _transition = self.default_producer_transition.lock().await;
-        let Some(producer_impl) = self.default_producer.default_mqproducer_impl.as_ref() else {
+        let mut default_producer = self.default_producer.lock().await;
+        let Some(producer_impl) = default_producer.default_mqproducer_impl.as_mut() else {
             return Err(mq_client_err!("default producer impl is None"));
         };
-        let mut producer_impl = producer_impl.clone();
         producer_impl.start_with_factory(false).await
     }
 
     async fn shutdown_default_producer(&self) -> rocketmq_error::RocketMQResult<()> {
-        let _transition = self.default_producer_transition.lock().await;
-        let Some(producer_impl) = self.default_producer.default_mqproducer_impl.as_ref() else {
+        let mut default_producer = self.default_producer.lock().await;
+        let Some(producer_impl) = default_producer.default_mqproducer_impl.as_mut() else {
             return Ok(());
         };
-        let mut producer_impl = producer_impl.clone();
         Box::pin(producer_impl.shutdown_with_factory(false)).await
     }
 
@@ -456,8 +451,7 @@ impl MQClientInstance {
         &self,
         message: Message,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-        let _transition = self.default_producer_transition.lock().await;
-        let mut default_producer = self.default_producer.clone();
+        let mut default_producer = self.default_producer.lock().await;
         default_producer.send(message).await
     }
 
@@ -465,13 +459,11 @@ impl MQClientInstance {
         &self,
         message: &mut Message,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-        let _transition = self.default_producer_transition.lock().await;
-        let producer_impl = self
-            .default_producer
+        let mut default_producer = self.default_producer.lock().await;
+        let producer_impl = default_producer
             .default_mqproducer_impl
-            .as_ref()
+            .as_mut()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl"))?;
-        let mut producer_impl = producer_impl.clone();
         producer_impl.send(message).await
     }
 
@@ -2728,6 +2720,7 @@ mod tests {
     use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+    use rocketmq_rust::ArcMut;
 
     use super::*;
     use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -8823,50 +8823,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "9b3a63491f45dc351868c027",
-      "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "9cbe2d507037ccc178f23eb8",
-          "fingerprint": "d26a6e9d75c77b5c7069d839",
-          "item": "mod tests",
-          "line": 2732
-        }
-      ],
-      "owner": "client",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "4063c06e2ac7585f4420c905",
-      "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "35f6639321b0860fe607864f",
-          "fingerprint": "53b20b22a3d6accd306ff337",
-          "item": "impl Into",
-          "line": 347
-        },
-        {
-          "id": "784363980e1771e83f8bfb29",
-          "fingerprint": "3e6849f1edd295f4036207c6",
-          "item": "impl Into",
-          "line": 368
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "23e1911b2485a1882e890a09",
       "path": "rocketmq-client/src/factory/mq_client_instance.rs",
       "symbol": "ArcMut",
@@ -8877,7 +8833,7 @@
           "id": "3537a7f5e9f85fea0a9ca95a",
           "fingerprint": "1e1dd2485b87b679d56fce30",
           "item": "fn apply_route_refresh_updates_producer_and_consumer_views",
-          "line": 2960
+          "line": 2953
         }
       ],
       "owner": "client",
@@ -8886,46 +8842,21 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "1be0f89c3e6ce50709be57c2",
+      "identity": "4848d322810c42cc92e155c7",
       "path": "rocketmq-client/src/factory/mq_client_instance.rs",
       "symbol": "ArcMut",
       "kind": "import",
-      "category": "production",
+      "category": "test",
       "occurrences": [
         {
-          "id": "a06a3483560b4167a2ed391f",
-          "fingerprint": "e34876806dc1579f85c0a7b0",
-          "item": "<module>",
-          "line": 70
+          "id": "c112c76b28cf8a81dd78c86c",
+          "fingerprint": "e4d3ec506046407c3c7fb340",
+          "item": "mod tests",
+          "line": 2723
         }
       ],
       "owner": "client",
       "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a52cb090a8035bb00e4dbc89",
-      "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "aed7f482b5176e2cec87b1d3",
-          "fingerprint": "643609116cdb0d77188b8e33",
-          "item": "struct MQClientInstance",
-          "line": 256
-        },
-        {
-          "id": "dc9a04df1f7e106799d3826e",
-          "fingerprint": "c4256156674745cfbd077ad5",
-          "item": "struct MQClientInstance",
-          "line": 258
-        }
-      ],
-      "owner": "client",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },


### PR DESCRIPTION
## Summary

- replace `MQClientInstance` pull-service ownership with standard `Arc`
- make the internal default producer directly owned by one async mutex while preserving the existing start/shutdown/send serialization boundary
- update the reviewed ArcMut baseline and the M11-12 migration checklists

## Validation

- `cargo check -p rocketmq-client-rust --all-targets --all-features`
- focused MQClientInstance, PullMessageService, pull integration, and typed-error tests
- `cargo test -p rocketmq-client-rust --all-features --quiet`
- Client package and root workspace strict Clippy
- Example, Tauri backend, and Web backend standalone validation
- ArcMut guard, unit tests, and fixtures
- architecture dependency/release guards, runtime audit, and AGENTS routing check

Closes #8371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved client-side message producer lifecycle handling for more consistent start, shutdown, and send operations.
  * Strengthened concurrency management around internal producer and message-pull services.
  * Added clearer initialization errors when the default producer is unavailable.

* **Documentation**
  * Updated architecture migration checklists, progress evidence, verification results, and remaining milestone gates.
  * Recorded the latest production-readiness and soundness-closure progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->