### PR TITLE
[ISSUE #8377]♻️Replace Broker topic metadata table ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -39,14 +39,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8375 的 M11-12an 子切片完成后，当前 ArcMut reviewed
-baseline 为 527 identities / 1,491 occurrences，其中 production 为 317/892、test 为 196/559、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8377 的 M11-12ao 子切片完成后，当前 ArcMut reviewed
+baseline 为 520 identities / 1,464 occurrences，其中 production 为 312/873、test 为 194/551、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 190 / 568 | 完成 BrokerRuntime、topic/offset、schedule/POP/processor/transaction owner 安全化 |
+| Broker | 185 / 549 | Topic route/queue mapping 表 owner 已完成；继续完成 BrokerRuntime、TopicConfig/offset、schedule/POP/processor/transaction owner 安全化 |
 | Store | 127 / 324 | 完成 message store、CommitLog/Flush、queue、Rocks/Timer 与 HA owner/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -670,7 +670,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12al Client MQClientInstance root ownership：Manager/Proxy handle 与 Admin/Producer/Consumer/Rebalance/API/OffsetStore 全链路改用标准 `Arc<MQClientInstance>`；Remoting/Admin 回指改用标准 `Weak`，lifecycle、API slot 与 task handle 显式同步，公开运行路径收窄为共享 receiver
   - [x] M11-12am Client internal child ownership：`MQClientInstance` 的 PullMessageService child 改用标准 `Arc`，internal DefaultMQProducer 改由单一异步 `Mutex` 所有并取代冗余 transition lock；production factory 文件不再包含 ArcMut
   - [x] M11-12an Client Producer root ownership：DefaultMQProducer facade/implementation/registry 改用标准 `Arc`/`Weak`；单一 runtime snapshot、短锁配置发布、异步 lifecycle、task admission 与 owner-aware unregister 替代共享可变 root，Client production ArcMut 清零
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375 与每次真实下降
+  - [x] M11-12ao Broker topic metadata table ownership：TopicRouteInfoManager 四张共享表改用标准 `Arc<DashMap>`，TopicQueueMappingManager 改用不可变标准 `Arc` 整值代际；读 guard 在同表写入或异步边界前释放，cleanup 以 observed Arc identity 做条件发布，旧 mapping 代际在替换后保持有效且不会覆盖并发新代际
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -711,7 +712,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8369 后实际快照降至 326 production/909 occurrence；Client owner 降至 9/17、Client test 降至 12/83、Proxy production 清零；MQClientInstance root 全链路共删除 42 个 production identity/73 occurrence 与 13 个 test identity/19 occurrence
   - [x] Issue #8371 后实际快照降至 323 production/904 occurrence；Client owner 降至 6/12，Client test 12/83 与 compatibility 14/40 不增；factory child owner 删除 3 个 production identity/5 occurrence
   - [x] Issue #8375 后实际快照降至 317 production/892 occurrence、196 test/559 occurrence；Client production 清零，Client test 降至 4/71，Producer root 删除 6 个 production identity/12 occurrence 与 8 个 test identity/12 occurrence
-  - [ ] M11-12ao 及后续：Broker、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8377 后实际快照降至 312 production/873 occurrence、194 test/551 occurrence；Broker 降至 185/549，topic route/queue mapping 表 owner 删除 5 个 production identity/19 occurrence 与 2 个 test identity/8 occurrence
+  - [ ] M11-12ap 及后续：Broker TopicConfig/offset/root/schedule/POP/processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -416,6 +416,13 @@ Client Producer root ownership 随 Issue #8375 将 DefaultMQProducer facade/impl
 `Arc`，这是移除 unsafe mutation capability 的有意 source break。实际快照降至 317 production/892 occurrence，
 Client production 清零、Client test 降至 4/71；剩余为 Broker 190/568 与 Store 127/324。总进度仍为 75/82，
 下一子切片 M11-12ao 进入 Broker owner，M11-12 父工作包未完成。
+Broker topic metadata table ownership 随 Issue #8377 将 `TopicRouteInfoManager` 的 route、broker-address、publish 和
+subscribe 四张共享表改为标准 `Arc<DashMap>`，并将 `TopicQueueMappingManager` 的表项改为不可变标准 `Arc` 整值代际；
+读取先克隆完整值，guard 在同表写入或 `.await` 前释放，decode/clean 只发布完整 replacement；cleanup 以 observed
+`Arc` identity 做条件发布，拒绝覆盖并发新代际，旧 mapping 代际继续有效。
+实际快照降至 312 production/873 occurrence、194 test/551 occurrence，Broker 降至 185/549；剩余为 Broker
+TopicConfig/offset/root/schedule/POP/processor/transaction 与 Store 127/324。总进度仍为 75/82，下一子切片
+M11-12ap 处理 Broker TopicConfig value/DataVersion ownership，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -428,6 +428,13 @@ M11-12an 已将 DefaultMQProducer facade/implementation/registry 改为标准 `A
 production ArcMut 清零；公开 implementation getter carrier 从 `ArcMut` 迁移为标准 `Arc`，由 public API compile
 test 固定。Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+M11-12ao 已将 `TopicRouteInfoManager` 的四张共享路由表改为标准 `Arc<DashMap>`，并将
+`TopicQueueMappingManager` 表项改为不可变标准 `Arc` 整值代际；读 guard 在同表写入或异步边界前释放，
+decode/clean 发布完整 replacement，cleanup 以 observed Arc identity 做条件发布并拒绝覆盖并发新代际，旧 mapping
+代际不被原地修改。实际快照降至 312 production/873
+occurrences、194 test/551 occurrences，Broker owner 降至 185/549；Broker TopicConfig/offset/root、Store、
+compatibility 与完整候选快照 Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -114,6 +114,9 @@ M11-12am 的 Client internal child ownership 由 Issue #8371 跟踪，分支为
 M11-12an 的 Client Producer root ownership 由 Issue #8375 跟踪，分支为
 `mxsm/architecture-refactor-client-producer-root-ownership`；它仍是同一 M11-12 工作包的子切片。
 
+M11-12ao 的 Broker topic metadata table ownership 由 Issue #8377 跟踪，分支为
+`mxsm/architecture-refactor-broker-topic-metadata-ownership`；它仍是同一 M11-12 工作包的子切片。
+
 ## 初始盘点
 
 在 main `86719f1bc77c2e78ff32195262bad820145f271b` 上生成当前源码快照：
@@ -999,6 +1002,29 @@ reviewed baseline 从 541→527、occurrences 从 1,515→1,491；全部 14 个 
 无 identity/occurrence relocation，因此不需要 ADR-013 临时 approval。下一子切片 M11-12ao 进入 Broker owner 收口；
 75/82 总进度不变。
 
+## M11-12ao Broker topic metadata table ownership
+
+| 目标 | 实现与证据 |
+|---|---|
+| route table owner | `TopicRouteInfoManager` 的 route、broker-address、publish-route 和 subscribe-queue 四张表从 `ArcMut<HashMap>` 改为标准 `Arc<DashMap>`；manager clone 仍共享表 owner，不再暴露共享裸可变引用 |
+| guard 与异步边界 | route/subscription/publish 查询先克隆完整值并释放 DashMap guard；同表 insert/remove 和 NameServer 异步刷新前均不保留 guard，不引入同步锁跨 `.await` |
+| immutable mapping generations | `TopicQueueMappingManager` 表项从 `ArcMut<TopicQueueMappingDetail>` 改为标准 `Arc`；update、decode 与 cleanup 构造完整新值后替换，cleanup 以 observed Arc identity 做条件发布，代际已变化时拒绝 stale replacement；旧 `Arc` 代际保持原内容且不会被原地修改 |
+| compatibility 边界 | 两个 manager 均为 Broker 内部 owner，getter carrier 仅在 crate 内从 legacy wrapper 迁移到标准 `Arc`；wire DTO、序列化字段、数据版本递增、静态 topic epoch/broker/expected-items 校验和最终一致语义保持不变 |
+| regression evidence | route manager clone 共享/route cleanup、queue mapping 13 项 lookup/update/decode/expected-version cleanup 测试通过；replacement 测试显式证明旧 mapping generation 在新值发布后仍有效，stale cleanup 测试证明并发新代际不会被覆盖 |
+
+M11-12ao 后实际快照为 520 个条目：production 312、test 194、compatibility 14；occurrence 精确为 production
+873、test 551、compatibility 40。相对 M11-12an 删除 5 个 production identity/19 occurrence 与 2 个 test
+identity/8 occurrence；Broker production 从 190/568 降至 185/549。剩余 production 债务为：
+
+| owner | 条目 | occurrence |
+|---|---:|---:|
+| Broker | 185 | 549 |
+| Store | 127 | 324 |
+
+reviewed baseline 从 527→520、occurrences 从 1,491→1,464；全部 7 个 identity/27 个 occurrence 都是源码真实删除，
+无 identity/occurrence relocation，因此不需要 ADR-013 临时 approval。下一子切片 M11-12ap 处理 Broker
+TopicConfig value/DataVersion ownership；75/82 总进度不变。
+
 ## 已执行验证
 
 | 命令 | 结果 |
@@ -1802,10 +1828,27 @@ M11-12an 追加验证：
 | Client Producer ArcMut 定向扫描 | facade/implementation/registry 的 production ArcMut/WeakArcMut/constructor/`mut_from_ref` 零匹配，Client production 总量清零 |
 | `git diff --check` | 通过；仅报告工作树 CRLF 转换提示，无 whitespace error |
 
+M11-12ao 追加验证：
+
+| 命令 | 结果 |
+|---|---|
+| `cargo test -p rocketmq-broker --all-features topic_route_info_manager` | 3/3 通过；覆盖标准共享表 clone、route cleanup 与后台 task lifecycle |
+| `cargo test -p rocketmq-broker --all-features topic_queue_mapping_manager` | 13/13 通过；覆盖 lookup/update/decode、epoch/broker/expected-items cleanup、旧 Arc 代际稳定性与 stale cleanup 条件发布 |
+| `cargo test -p rocketmq-broker lite_sharding` | 2/2 通过；DashMap publish route 读取适配保持既有 hash contract |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 550 passed、24 failed、1 ignored；失败集中在既有 lifecycle probe 与全局 Lite/consumer state tests，代表性 `get_broker_lite_info_returns_registry_aggregates` 在 clean `main@a158c49a8` 使用相同 all-features exact 命令同样失败，不能记为本切片通过，也未发现受影响定向测试失败 |
+| reviewed baseline reduction | 删除 5 个 production identity/19 occurrence 与 2 个 test identity/8 occurrence，无 relocation；baseline 527/1,491→520/1,464 |
+| `python scripts/arc_mut_guard.py` | 通过；production 312/873、test 194/551、compatibility 14/40；Broker production 185/549 |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` / root workspace strict Clippy | 通过；root workspace all-targets/all-features `-D warnings` profile 通过 |
+| architecture target/baseline/release guards | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates，dependency/release/performance guard 单测 60/60 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；表 owner 替换未增加 task/runtime 边界 |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| Broker topic metadata ArcMut 定向扫描 | `TopicQueueMappingManager` production/test ArcMut 清零；`TopicRouteInfoManager` 仅保留待 Broker root 切片处理的 `ArcMut<BrokerRuntimeInner>` 回边，四张表 owner 与 `mut_from_ref` 清零 |
+
 ## 剩余切片与 Gate
 
-1. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（190/568）；下一子切片
-   M11-12ao 从 Broker owner 开始。
+1. Broker TopicConfig/offset、BrokerRuntimeInner、schedule/POP/processor/transaction owner（185/549）；下一子切片
+   M11-12ap 处理 TopicConfig value/DataVersion ownership。
 2. Store TopicConfig snapshot、MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（127/324）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -6417,7 +6417,6 @@ accounts:
             .inner_for_test()
             .topic_route_info_manager_mut()
             .topic_publish_info_table
-            .mut_from_ref()
             .insert(CheetahString::from_static_str("parent-topic"), publish_info);
     }
 

--- a/rocketmq-broker/src/lite/lite_sharding.rs
+++ b/rocketmq-broker/src/lite/lite_sharding.rs
@@ -35,7 +35,7 @@ impl LiteSharding {
             .topic_route_info_manager()
             .topic_publish_info_table
             .get(parent_topic)
-            .cloned();
+            .map(|entry| entry.value().clone());
         let Some(publish_info) = publish_info.filter(|info| !info.message_queues().is_empty()) else {
             return current_broker;
         };

--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -37,7 +37,6 @@ use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::BlockingPoolPolicy;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
-use rocketmq_rust::ArcMut;
 use tokio::runtime::Handle;
 use tracing::info;
 use tracing::warn;
@@ -47,7 +46,7 @@ use crate::broker_path_config_helper::get_topic_queue_mapping_path;
 #[derive(Default)]
 pub(crate) struct TopicQueueMappingManager {
     pub(crate) data_version: Arc<parking_lot::Mutex<DataVersion>>,
-    pub(crate) topic_queue_mapping_table: DashMap<CheetahString /* topic */, ArcMut<TopicQueueMappingDetail>>,
+    pub(crate) topic_queue_mapping_table: DashMap<CheetahString /* topic */, Arc<TopicQueueMappingDetail>>,
     pub(crate) broker_config: Arc<BrokerConfig>,
     blocking_executor: OnceLock<BlockingExecutor>,
     parent_task_group: Option<TaskGroup>,
@@ -194,7 +193,7 @@ impl TopicQueueMappingManager {
         }
     }
 
-    pub fn get_topic_queue_mapping(&self, topic: &str) -> Option<ArcMut<TopicQueueMappingDetail>> {
+    pub fn get_topic_queue_mapping(&self, topic: &str) -> Option<Arc<TopicQueueMappingDetail>> {
         self.topic_queue_mapping_table.get(topic).as_deref().cloned()
     }
 
@@ -216,7 +215,7 @@ impl TopicQueueMappingManager {
         }
 
         self.topic_queue_mapping_table
-            .insert(topic, ArcMut::new(topic_queue_mapping_detail));
+            .insert(topic, Arc::new(topic_queue_mapping_detail));
         self.data_version.lock().next_version();
         self.persist();
     }
@@ -242,7 +241,8 @@ impl TopicQueueMappingManager {
         let Some(current_ref) = self.topic_queue_mapping_table.get(topic) else {
             return false;
         };
-        let current = current_ref.as_ref();
+        let observed = Arc::clone(current_ref.value());
+        let current = observed.as_ref();
         if current.topic_queue_mapping_info.epoch != expected_epoch
             || current.topic_queue_mapping_info.bname.as_ref() != Some(expected_bname)
         {
@@ -273,11 +273,7 @@ impl TopicQueueMappingManager {
         }
         drop(current_ref);
 
-        if changed {
-            self.topic_queue_mapping_table
-                .insert(topic.clone(), ArcMut::new(new_detail));
-        }
-        changed
+        changed && self.publish_if_current(topic, &observed, new_detail)
     }
 
     pub(crate) fn remove_cleaned_hosted_queues(
@@ -294,7 +290,8 @@ impl TopicQueueMappingManager {
         let Some(current_ref) = self.topic_queue_mapping_table.get(topic) else {
             return false;
         };
-        let current = current_ref.as_ref();
+        let observed = Arc::clone(current_ref.value());
+        let current = observed.as_ref();
         if current.topic_queue_mapping_info.epoch != expected_epoch
             || current.topic_queue_mapping_info.bname.as_ref() != Some(expected_bname)
         {
@@ -322,11 +319,23 @@ impl TopicQueueMappingManager {
         }
         drop(current_ref);
 
-        if changed {
-            self.topic_queue_mapping_table
-                .insert(topic.clone(), ArcMut::new(new_detail));
+        changed && self.publish_if_current(topic, &observed, new_detail)
+    }
+
+    fn publish_if_current(
+        &self,
+        topic: &CheetahString,
+        observed: &Arc<TopicQueueMappingDetail>,
+        replacement: TopicQueueMappingDetail,
+    ) -> bool {
+        let Some(mut current) = self.topic_queue_mapping_table.get_mut(topic) else {
+            return false;
+        };
+        if !Arc::ptr_eq(current.value(), observed) {
+            return false;
         }
-        changed
+        *current.value_mut() = Arc::new(replacement);
+        true
     }
 
     pub(crate) async fn persist_clean_result(&self) -> RocketMQResult<()> {
@@ -447,8 +456,7 @@ impl ConfigManager for TopicQueueMappingManager {
         }
         if let Some(map) = wrapper.take_topic_queue_mapping_info_map() {
             for (key, value) in map {
-                let mut shared = self.topic_queue_mapping_table.entry(key).or_default();
-                **shared = value;
+                self.topic_queue_mapping_table.insert(key, Arc::new(value));
             }
         }
     }
@@ -536,7 +544,7 @@ mod tests {
     fn get_topic_queue_mapping_returns_mapping_for_existing_topic() {
         let broker_config = Arc::new(BrokerConfig::default());
         let manager = TopicQueueMappingManager::new(broker_config);
-        let detail = ArcMut::new(TopicQueueMappingDetail::default());
+        let detail = Arc::new(TopicQueueMappingDetail::default());
         manager
             .topic_queue_mapping_table
             .insert(CheetahString::from_static_str("existing_topic"), detail);
@@ -548,7 +556,7 @@ mod tests {
     fn delete_removes_existing_topic() {
         let broker_config = Arc::new(BrokerConfig::default());
         let manager = TopicQueueMappingManager::new(broker_config);
-        let detail = ArcMut::new(TopicQueueMappingDetail::default());
+        let detail = Arc::new(TopicQueueMappingDetail::default());
         manager
             .topic_queue_mapping_table
             .insert("existing_topic".into(), detail);
@@ -601,7 +609,7 @@ mod tests {
         hosted_queues.insert(0, vec![item0.clone(), item1.clone()]);
         manager.topic_queue_mapping_table.insert(
             topic.clone(),
-            ArcMut::new(TopicQueueMappingDetail {
+            Arc::new(TopicQueueMappingDetail {
                 topic_queue_mapping_info:
                     rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
                         topic: Some(topic.clone()),
@@ -614,12 +622,39 @@ mod tests {
         );
         let mut replacements = HashMap::new();
         replacements.insert(0, (vec![item0, item1.clone()], vec![item1.clone()]));
+        let original = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
 
         assert!(manager.replace_cleaned_queue_items(&topic, 1, &broker_name, &replacements));
 
         let mapping = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
+        assert!(!Arc::ptr_eq(&original, &mapping));
+        assert_eq!(original.hosted_queues.as_ref().unwrap().get(&0).unwrap().len(), 2);
         assert_eq!(mapping.hosted_queues.as_ref().unwrap().get(&0).unwrap(), &vec![item1]);
         assert_eq!(manager.data_version.lock().get_state_version(), 0);
+    }
+
+    #[test]
+    fn stale_cleanup_cannot_overwrite_a_newer_mapping_generation() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let manager = TopicQueueMappingManager::new(broker_config);
+        let topic = CheetahString::from_static_str("static-topic");
+        let original = Arc::new(TopicQueueMappingDetail::default());
+        manager
+            .topic_queue_mapping_table
+            .insert(topic.clone(), original.clone());
+
+        let mut newer_detail = TopicQueueMappingDetail::default();
+        newer_detail.topic_queue_mapping_info.epoch = 2;
+        let newer = Arc::new(newer_detail);
+        manager.topic_queue_mapping_table.insert(topic.clone(), newer.clone());
+
+        let mut stale_replacement = TopicQueueMappingDetail::default();
+        stale_replacement.topic_queue_mapping_info.epoch = 1;
+        assert!(!manager.publish_if_current(&topic, &original, stale_replacement));
+
+        let current = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
+        assert!(Arc::ptr_eq(&current, &newer));
+        assert_eq!(current.topic_queue_mapping_info.epoch, 2);
     }
 
     #[test]
@@ -644,7 +679,7 @@ mod tests {
         hosted_queues.insert(0, vec![current_item]);
         manager.topic_queue_mapping_table.insert(
             topic.clone(),
-            ArcMut::new(TopicQueueMappingDetail {
+            Arc::new(TopicQueueMappingDetail {
                 topic_queue_mapping_info:
                     rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
                         topic: Some(topic.clone()),
@@ -691,7 +726,7 @@ mod tests {
         hosted_queues.insert(0, vec![item0.clone(), item1.clone()]);
         manager.topic_queue_mapping_table.insert(
             topic.clone(),
-            ArcMut::new(TopicQueueMappingDetail {
+            Arc::new(TopicQueueMappingDetail {
                 topic_queue_mapping_info:
                     rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
                         topic: Some(topic.clone()),
@@ -744,7 +779,7 @@ mod tests {
         hosted_queues.insert(0, vec![item.clone()]);
         manager.topic_queue_mapping_table.insert(
             topic.clone(),
-            ArcMut::new(TopicQueueMappingDetail {
+            Arc::new(TopicQueueMappingDetail {
                 topic_queue_mapping_info:
                     rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
                         topic: Some(topic.clone()),

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use dashmap::DashMap;
 use parking_lot::Mutex;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
@@ -43,11 +44,11 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) struct TopicRouteInfoManager<MS: MessageStore> {
     pub(crate) lock: Arc<RocketMQTokioMutex<()>>,
-    pub(crate) topic_route_table: ArcMut<HashMap<CheetahString /* Topic */, TopicRouteData>>,
+    pub(crate) topic_route_table: Arc<DashMap<CheetahString /* Topic */, TopicRouteData>>,
     pub(crate) broker_addr_table:
-        ArcMut<HashMap<CheetahString /* Broker Name */, HashMap<u64 /* brokerId */, CheetahString /* address */>>>,
-    pub(crate) topic_publish_info_table: ArcMut<HashMap<CheetahString /* topic */, BrokerPublishRoute>>,
-    pub(crate) topic_subscribe_info_table: ArcMut<HashMap<CheetahString /* topic */, HashSet<MessageQueue>>>,
+        Arc<DashMap<CheetahString /* Broker Name */, HashMap<u64 /* brokerId */, CheetahString /* address */>>>,
+    pub(crate) topic_publish_info_table: Arc<DashMap<CheetahString /* topic */, BrokerPublishRoute>>,
+    pub(crate) topic_subscribe_info_table: Arc<DashMap<CheetahString /* topic */, HashSet<MessageQueue>>>,
     pub(crate) broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     running: Arc<AtomicBool>,
     task_group: Arc<Mutex<Option<TaskGroup>>>,
@@ -72,10 +73,10 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
     pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
         TopicRouteInfoManager {
             lock: Arc::new(RocketMQTokioMutex::new(())),
-            topic_route_table: ArcMut::new(HashMap::new()),
-            broker_addr_table: ArcMut::new(HashMap::new()),
-            topic_publish_info_table: ArcMut::new(HashMap::new()),
-            topic_subscribe_info_table: ArcMut::new(HashMap::new()),
+            topic_route_table: Arc::new(DashMap::new()),
+            broker_addr_table: Arc::new(DashMap::new()),
+            topic_publish_info_table: Arc::new(DashMap::new()),
+            topic_subscribe_info_table: Arc::new(DashMap::new()),
             broker_runtime_inner,
             running: Arc::new(AtomicBool::new(false)),
             task_group: Arc::new(Mutex::new(None)),
@@ -157,13 +158,13 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
     async fn update_topic_route_info_from_name_server(&self) {
         let topic_set_for_pop_assignment = self
             .topic_subscribe_info_table
-            .keys()
-            .cloned()
+            .iter()
+            .map(|entry| entry.key().clone())
             .collect::<HashSet<CheetahString>>();
         let topic_set_for_escape_bridge = self
             .topic_route_table
-            .keys()
-            .cloned()
+            .iter()
+            .map(|entry| entry.key().clone())
             .collect::<HashSet<CheetahString>>();
         let topics_all = topic_set_for_pop_assignment
             .union(&topic_set_for_escape_bridge)
@@ -228,7 +229,7 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
 
     #[inline]
     fn clean_none_route_topic(&self, topic: &CheetahString) {
-        self.topic_subscribe_info_table.mut_from_ref().remove(topic);
+        self.topic_subscribe_info_table.remove(topic);
     }
 
     fn update_subscribe_info_table(&self, topic: CheetahString, topic_route_data: &TopicRouteData) -> bool {
@@ -238,8 +239,8 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
         let old_subscribe_info = self
             .topic_subscribe_info_table
             .get(&topic)
-            .cloned()
-            .unwrap_or(HashSet::new());
+            .map(|entry| entry.value().clone())
+            .unwrap_or_default();
         if new_subscribe_info == old_subscribe_info {
             return false;
         }
@@ -247,15 +248,13 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
             "the topic[{}] subscribe message queue changed, old[{:?}] ,new[{:?}]",
             topic, old_subscribe_info, new_subscribe_info,
         );
-        self.topic_subscribe_info_table
-            .mut_from_ref()
-            .insert(topic, new_subscribe_info);
+        self.topic_subscribe_info_table.insert(topic, new_subscribe_info);
         true
     }
 
     fn update_topic_route_table(&self, topic_route_data: &mut TopicRouteData, topic: CheetahString) -> bool {
-        let old = self.topic_route_table.get(&topic);
-        let changed = topic_route_data.topic_route_data_changed(old);
+        let old = self.topic_route_table.get(&topic).map(|entry| entry.value().clone());
+        let changed = topic_route_data.topic_route_data_changed(old.as_ref());
         if !changed {
             if !self.is_need_update_topic_route_info(&topic) {
                 return false;
@@ -268,7 +267,6 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
         };
         for bd in &topic_route_data.broker_datas {
             self.broker_addr_table
-                .mut_from_ref()
                 .insert(bd.broker_name().clone(), bd.broker_addrs().clone());
         }
         let publish_info = BrokerPublishRoute::from_topic_route_data(topic.as_str(), topic_route_data);
@@ -279,15 +277,13 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
             "topicRouteTable.put. Topic = {}, TopicRouteData[{:?}]",
             topic, clone_topic_route_data
         );
-        self.topic_route_table
-            .mut_from_ref()
-            .insert(topic, clone_topic_route_data);
+        self.topic_route_table.insert(topic, clone_topic_route_data);
         true
     }
 
     #[inline]
     fn update_topic_publish_info(&self, topic: &CheetahString, info: BrokerPublishRoute) {
-        self.topic_publish_info_table.mut_from_ref().insert(topic.clone(), info);
+        self.topic_publish_info_table.insert(topic.clone(), info);
     }
 
     #[inline]
@@ -301,11 +297,17 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
     }
 
     pub async fn try_to_find_topic_publish_info(&self, topic: &CheetahString) -> Option<BrokerPublishRoute> {
-        let mut topic_publish_info = self.topic_publish_info_table.get(topic).cloned();
+        let mut topic_publish_info = self
+            .topic_publish_info_table
+            .get(topic)
+            .map(|entry| entry.value().clone());
         if topic_publish_info.is_none() || !topic_publish_info.as_ref().unwrap().is_usable() {
             self.update_topic_route_info_from_name_server_ext(topic, true, false)
                 .await;
-            topic_publish_info = self.topic_publish_info_table.get(topic).cloned();
+            topic_publish_info = self
+                .topic_publish_info_table
+                .get(topic)
+                .map(|entry| entry.value().clone());
         }
         topic_publish_info
     }
@@ -354,11 +356,17 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
     }
 
     pub async fn get_topic_subscribe_info(&self, topic: &CheetahString) -> Option<HashSet<MessageQueue>> {
-        let mut queues = self.topic_subscribe_info_table.get(topic).cloned();
+        let mut queues = self
+            .topic_subscribe_info_table
+            .get(topic)
+            .map(|entry| entry.value().clone());
         if queues.as_ref().is_none_or(|q| q.is_empty()) {
             self.update_topic_route_info_from_name_server_ext(topic, false, true)
                 .await;
-            queues = self.topic_subscribe_info_table.get(topic).cloned();
+            queues = self
+                .topic_subscribe_info_table
+                .get(topic)
+                .map(|entry| entry.value().clone());
         }
         queues
     }
@@ -366,10 +374,14 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use cheetah_string::CheetahString;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
+    use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
     use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
@@ -413,5 +425,27 @@ mod tests {
         manager.shutdown().await;
         let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
+    }
+
+    #[test]
+    fn manager_clones_share_standard_route_tables() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let manager = broker_runtime.inner_for_test().topic_route_info_manager().clone();
+        let cloned_manager = manager.clone();
+        let topic = CheetahString::from_static_str("SharedRouteTopic");
+
+        manager
+            .topic_route_table
+            .insert(topic.clone(), TopicRouteData::default());
+        let queues = HashSet::from([MessageQueue::from_parts(topic.clone(), "broker-a", 0)]);
+        manager.topic_subscribe_info_table.insert(topic.clone(), queues);
+
+        assert!(cloned_manager.topic_route_table.contains_key(&topic));
+        assert!(cloned_manager.topic_subscribe_info_table.contains_key(&topic));
+
+        cloned_manager.clean_none_route_topic(&topic);
+        assert!(!manager.topic_subscribe_info_table.contains_key(&topic));
     }
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -934,55 +934,55 @@
           "id": "3e9cf8ecdb4471e2f5c043f5",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase3_send_message_processor_writes_to_local_store",
-          "line": 7200
+          "line": 7199
         },
         {
           "id": "cd355c13f4ab1f843807f393",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase3_consumer_send_msg_back_writes_retry_delay_message",
-          "line": 7273
+          "line": 7272
         },
         {
           "id": "e9bcd3faaa3763567bb762df",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase3_topic_config_admin_processor_returns_decodable_bodies",
-          "line": 7373
+          "line": 7372
         },
         {
           "id": "ec2343bcb7cf8f29bdc8f896",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase4_consumer_offset_processors_round_trip_committed_offset",
-          "line": 7473
+          "line": 7472
         },
         {
           "id": "fbf728a698328d5502da4e9a",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase5_admin_config_runtime_stats_and_empty_connection_queries_are_compatible",
-          "line": 7751
+          "line": 7750
         },
         {
           "id": "05647a770e7a227637cf743e",
           "fingerprint": "d3c8e7e66f108e9bc0a99e0f",
           "item": "fn phase6_store_offset_and_consume_queue_queries_return_decodable_models",
-          "line": 7901
+          "line": 7900
         },
         {
           "id": "21c69b7487ceefd61305dd26",
           "fingerprint": "8467b8e74a44e2436129e395",
           "item": "fn run_metadata_migration_to_rocksdb_case",
-          "line": 9472
+          "line": 9471
         },
         {
           "id": "a3c29627e8d7d7e68fa8faae",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_promotes_store_to_master",
-          "line": 9606
+          "line": 9605
         },
         {
           "id": "4ff61cc699c2c34d1b75fdec",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_demotes_store_to_slave",
-          "line": 9639
+          "line": 9638
         }
       ],
       "owner": "broker",
@@ -1511,12 +1511,6 @@
           "fingerprint": "931bd603377355c5e604a759",
           "item": "fn set_parent_topic_lite_expiration",
           "line": 6386
-        },
-        {
-          "id": "741868e10a001b222400dd90",
-          "fingerprint": "fc2788313c97067fb0425e87",
-          "item": "fn seed_lite_topic_publish_route",
-          "line": 6420
         }
       ],
       "owner": "broker",
@@ -7488,186 +7482,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "39c7a1fc0cd67680a7964016",
-      "path": "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "5c56b7a9c75e139e4ae0986f",
-          "fingerprint": "699061f925cdba4f87c8a0da",
-          "item": "mod tests",
-          "line": 465
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "db72268ca0ab2013e3e88b75",
-      "path": "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "867efd0facbac32f387f044c",
-          "fingerprint": "eb8de2276673eaf6999999ea",
-          "item": "fn update_topic_queue_mapping",
-          "line": 219
-        },
-        {
-          "id": "8b8271b2e461ef5cc257c1e2",
-          "fingerprint": "703b155d0a20a17736ec745a",
-          "item": "fn replace_cleaned_queue_items",
-          "line": 278
-        },
-        {
-          "id": "5e775ef4fdcdc352f588f00a",
-          "fingerprint": "703b155d0a20a17736ec745a",
-          "item": "fn remove_cleaned_hosted_queues",
-          "line": 327
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "0ded17a4f96a8b1338dbdc8d",
-      "path": "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "72d047a5fcf662524eee39a9",
-          "fingerprint": "f44ef742724ff78263c7618f",
-          "item": "fn get_topic_queue_mapping_returns_mapping_for_existing_topic",
-          "line": 539
-        },
-        {
-          "id": "a1a24bcaf63250354c70da27",
-          "fingerprint": "f44ef742724ff78263c7618f",
-          "item": "fn delete_removes_existing_topic",
-          "line": 551
-        },
-        {
-          "id": "95d508b3b5de6464a052194e",
-          "fingerprint": "da4b209751eae3bb39718b14",
-          "item": "fn replace_cleaned_queue_items_rechecks_expected_items",
-          "line": 604
-        },
-        {
-          "id": "058f72f79425019f142df296",
-          "fingerprint": "da4b209751eae3bb39718b14",
-          "item": "fn remove_cleaned_hosted_queues_skips_when_current_items_changed",
-          "line": 647
-        },
-        {
-          "id": "16a01e5a1435d8c48f809712",
-          "fingerprint": "da4b209751eae3bb39718b14",
-          "item": "fn clean_mutation_skips_when_epoch_or_broker_mismatch",
-          "line": 694
-        },
-        {
-          "id": "d00f275074cf9aeb52b0dcb4",
-          "fingerprint": "da4b209751eae3bb39718b14",
-          "item": "fn remove_cleaned_hosted_queues_deletes_expected_qid_without_bumping_version",
-          "line": 747
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "8200714f1e73902f2b2bcbcf",
-      "path": "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "07f567629f353b3682b18e91",
-          "fingerprint": "40dcd3801161608756f341df",
-          "item": "<module>",
-          "line": 40
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a058661b9b4f4dc0f735c982",
-      "path": "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "eb2134e056b1554a962a122f",
-          "fingerprint": "e3f79ff44d85886c8ff26fce",
-          "item": "struct TopicQueueMappingManager",
-          "line": 50
-        },
-        {
-          "id": "d7c4912d7b75d926e8720055",
-          "fingerprint": "c8652c09d512c30aefaf2b19",
-          "item": "fn get_topic_queue_mapping",
-          "line": 197
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "485a890c880f757c68c02de2",
-      "path": "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "6e4987e1015a0fb3e6993dd4",
-          "fingerprint": "18835d158daabf3d329402fa",
-          "item": "fn new",
-          "line": 75
-        },
-        {
-          "id": "6b75f566fb194d9409f21018",
-          "fingerprint": "41740f08e6fc18e8dd0d2aeb",
-          "item": "fn new",
-          "line": 76
-        },
-        {
-          "id": "e6c863adbe25bb6fab315d98",
-          "fingerprint": "a4e644e91e56a7d6923f8c32",
-          "item": "fn new",
-          "line": 77
-        },
-        {
-          "id": "e0ea561348f7c1d893b43653",
-          "fingerprint": "f752bbb635a562e1db2c5851",
-          "item": "fn new",
-          "line": 78
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "078d7b56d593baeb24b7525c",
       "path": "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs",
       "symbol": "ArcMut",
@@ -7678,7 +7492,7 @@
           "id": "324ddfe2023e4f39b847b1c2",
           "fingerprint": "a18476b4cd9b006627cbf6ca",
           "item": "<module>",
-          "line": 30
+          "line": 31
         }
       ],
       "owner": "broker",
@@ -7694,87 +7508,20 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ec59d1697ee9c14859370a2d",
-          "fingerprint": "7330763dd4cc3cb43f2ff203",
-          "item": "struct TopicRouteInfoManager",
-          "line": 46
-        },
-        {
-          "id": "f55b3139a383e47f28ee86c0",
-          "fingerprint": "6ad5bc76a129e7681ad5c6c7",
-          "item": "struct TopicRouteInfoManager",
-          "line": 48
-        },
-        {
-          "id": "200327696bbc467ba7dd3300",
-          "fingerprint": "663e09ded3f099dd2f77a922",
-          "item": "struct TopicRouteInfoManager",
-          "line": 49
-        },
-        {
-          "id": "db304471f7949401de1f8eaf",
-          "fingerprint": "bbf292ebcf96cdb6e9e25b56",
-          "item": "struct TopicRouteInfoManager",
-          "line": 50
-        },
-        {
           "id": "465b44de9a8596b5b9233bd1",
           "fingerprint": "9e6c94bee503cc16588ad18c",
           "item": "struct TopicRouteInfoManager",
-          "line": 51
+          "line": 52
         },
         {
           "id": "1c3bb3e722c472b0b9542b35",
           "fingerprint": "4e347ab555e4793756c33dff",
           "item": "fn new",
-          "line": 72
+          "line": 73
         }
       ],
       "owner": "broker",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "06108b436e195283a71b19b0",
-      "path": "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "18d34c075c0bf08e6a5e86de",
-          "fingerprint": "fdf612572bdf9f299c09f372",
-          "item": "fn clean_none_route_topic",
-          "line": 231
-        },
-        {
-          "id": "d91dbeae194dd13456099eb8",
-          "fingerprint": "4e1166118cd5d7f93aa849d5",
-          "item": "fn update_subscribe_info_table",
-          "line": 251
-        },
-        {
-          "id": "102031d8a0507f5b1979bc11",
-          "fingerprint": "70cc82689110bb25394e009c",
-          "item": "fn update_topic_route_table",
-          "line": 271
-        },
-        {
-          "id": "b398c18f5a296ebbf1aadee1",
-          "fingerprint": "38000162422eb7e87e62f0bf",
-          "item": "fn update_topic_route_table",
-          "line": 283
-        },
-        {
-          "id": "e04aab519acf51460ab8dae0",
-          "fingerprint": "39a4904e9f58d28949fcde81",
-          "item": "fn update_topic_publish_info",
-          "line": 290
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8377

### Brief Description

- Replace the four `TopicRouteInfoManager` shared metadata maps with standard `Arc<DashMap>` owners while preserving per-table eventually consistent updates.
- Replace `TopicQueueMappingManager` values with immutable standard `Arc` generations; update, decode, and cleanup paths publish complete replacements, and cleanup rejects stale observed generations instead of overwriting concurrent updates.
- Clone values before same-table writes or async refreshes so no DashMap guard crosses a write re-entry or `.await` boundary.
- Adapt Lite sharding and Broker test seeding, refresh the reviewed ArcMut baseline, and record the measured migration progress.
- Reduce Broker production ArcMut debt from 190 identities / 568 occurrences to 185 / 549, with no relocation approvals.

### How Did You Test This Change?

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-broker --all-features topic_route_info_manager`: 3 passed.
- `cargo test -p rocketmq-broker --all-features topic_queue_mapping_manager`: 13 passed.
- `cargo test -p rocketmq-broker lite_sharding`: 2 passed.
- `python scripts/arc_mut_guard.py`: passed; production 312/873, test 194/551, compatibility 14/40.
- ArcMut guard unit tests and fixtures: 67 unit tests and 24 fixtures passed.
- Architecture target, baseline, and release guards: passed; dependency, release, and performance guard tests passed 60/60.
- Runtime ownership audit and AGENTS routing check: passed.
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1`: 550 passed, 24 failed, and 1 ignored. The failures are in existing lifecycle-probe and global Lite/consumer-state tests; the representative exact failure `get_broker_lite_info_returns_registry_aggregates` reproduces unchanged on clean `main` at the parent commit. All tests directly affected by this change passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved concurrent handling of broker topic routes, publish/subscribe information, and queue mappings.
  - Updates now replace complete snapshots while protecting newer data from being overwritten.
  - Preserved existing routing, mapping, and compatibility behavior.

- **Documentation**
  - Updated architecture migration progress, metrics, validation results, and remaining work for the next milestone.

- **Tests**
  - Added coverage for shared route-table behavior and protection against stale mapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->