### PR TITLE
[ISSUE #8385]♻️Replace Broker POP Lite lifecycle ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -39,14 +39,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8383 的 M11-12ar 子切片完成后，当前 ArcMut reviewed
-baseline 为 476 identities / 1,241 occurrences，其中 production 为 296/738、test 为 166/463、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8385 的 M11-12as 子切片完成后，当前 ArcMut reviewed
+baseline 为 473 identities / 1,227 occurrences，其中 production 为 294/725、test 为 165/462、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 174 / 430 | Topic route/queue mapping、TopicConfig、POP buffer/checkpoint 与 POP processor/long-poll lifecycle owner 已完成；继续完成 BrokerRuntime、offset、schedule/POP Lite/其他 processor/transaction owner 安全化 |
+| Broker | 172 / 417 | Topic route/queue mapping、TopicConfig、POP buffer/checkpoint 与 POP/POP Lite processor/long-poll lifecycle owner 已完成；继续完成 BrokerRuntime、offset、schedule/其他 processor/transaction owner 安全化 |
 | Store | 122 / 308 | TopicConfig 只读代际 carrier 已完成；继续完成 message store、CommitLog/Flush、queue、Rocks/Timer 与 HA owner/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -674,7 +674,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ap Broker topic configuration ownership：TopicConfig 表值、快照和 Store carrier 改用不可变标准 `Arc` 代际；TopicConfig 与 DataVersion 在单一 metadata transition 中提交，注册发送共用异步顺序锁并在取锁后重采样，持久化/从节点替换发布一致表与版本
   - [x] M11-12aq Broker POP buffer ownership：`PopBufferMergeService` 与 checkpoint wrapper 改用标准 `Arc`，扫描任务独占复用 ACK scratch，服务 API 收窄为 `&self`；扫描在异步 I/O 前释放 DashMap guard，以 observed Arc identity 条件删除旧代际，并保留 commit-offset FIFO 直至按序提交
   - [x] M11-12ar Broker POP lifecycle ownership：`PopMessageProcessor`/`NotificationProcessor` root 与长轮询 service 改用标准 `Arc`，processor/service 与 service/scan-task 回边改为标准 `Weak`；共享 wake-up receiver、原子 cleanup 时间和异步 lifecycle gate 消除别名可变访问并串行 start/shutdown/restart
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383 与每次真实下降
+  - [x] M11-12as Broker POP Lite lifecycle ownership：`PopLiteMessageProcessor`/`PopLiteLongPollingService` root 与 Broker processor/runtime carrier 改用标准 `Arc`，processor 回边和 scan task 改用标准 `Weak`；共享 wake-up trait、每次 start 的新 channel、停止状态轮询拒绝与双层异步 lifecycle gate 消除共享可变别名并支持安全重启
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -719,7 +720,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8379 后实际快照降至 300 production/783 occurrence、168 test/466 occurrence；Broker 降至 178/475、Store 降至 122/308，TopicConfig value/DataVersion owner 共删除 12 个 production identity/90 occurrence 与 26 个 test identity/85 occurrence，compatibility 14/40 不增
   - [x] Issue #8381 后实际快照降至 298 production/764 occurrence、167 test/464 occurrence；Broker 降至 176/456，POP buffer/checkpoint owner 共删除 2 个 production identity/19 occurrence 与 1 个 test identity/2 occurrence，compatibility 14/40 不增
   - [x] Issue #8383 后实际快照降至 296 production/738 occurrence、166 test/463 occurrence；Broker 降至 174/430，POP/Notification lifecycle 共删除 2 个 production identity/26 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
-  - [ ] M11-12as 及后续：Broker POP Lite lifecycle、offset/root/schedule/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8385 后实际快照降至 294 production/725 occurrence、165 test/462 occurrence；Broker 降至 172/417，POP Lite lifecycle 共删除 2 个 production identity/13 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
+  - [ ] M11-12at 及后续：Broker Pull lifecycle、offset/root/schedule/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -441,6 +441,11 @@ service `Weak`；共享 wake-up trait 直接经 `&self` 分发请求，不引入
 start/shutdown/restart，`AtomicU64` 发布 cleanup 时间，TaskGroup 在 spawn 前完成发布且同步 guard 不跨 `.await`。
 实际快照降至 296 production/738 occurrence、166 test/463 occurrence，Broker 降至 174/430；总进度仍为 75/82，
 下一子切片 M11-12as 处理 Broker POP Lite processor/long-poll lifecycle ownership，M11-12 父工作包未完成。
+Broker POP Lite lifecycle ownership 随 Issue #8385 将 `PopLiteMessageProcessor` 与
+`PopLiteLongPollingService` root 改为标准 `Arc`，processor 回边与扫描任务 owner 改为标准 `Weak`；共享 wake-up trait
+经 `&self` 分发请求，每次成功 start 创建新 channel 并发布 sender，双层异步 lifecycle gate 串行 start/shutdown/restart，
+停止状态拒绝新增挂起。实际快照降至 294 production/725 occurrence、165 test/462 occurrence，Broker 降至 172/417；
+总进度仍为 75/82，下一子切片 M11-12at 处理 Broker Pull processor/request-hold lifecycle ownership，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -454,6 +454,13 @@ processor/service 回边与 service/scan-task 回边改为标准 `Weak`。共享
 production/738 occurrences、166 test/463 occurrences，Broker owner 降至 174/430；compatibility 14/40 不增。
 下一子切片 M11-12as 处理 Broker POP Lite processor/long-poll lifecycle ownership，完整候选快照与 HUMAN Gate 仍保持开放。
 
+M11-12as 已将 `PopLiteMessageProcessor` 与 `PopLiteLongPollingService` root、Broker processor/runtime carrier 改为标准
+`Arc`，processor 回边和 scan task 改为标准 `Weak`。共享 wake-up trait 经 `&self` 分发恢复请求；每次成功 start 创建
+新 channel 并向 Lite dispatcher 发布 sender，停止状态拒绝新增挂起，processor/service 双层异步 lifecycle gate 串行
+start/shutdown/restart。实际快照降至 294 production/725 occurrences、165 test/462 occurrences，Broker owner 降至
+172/417；compatibility 14/40 不增。下一子切片 M11-12at 处理 Broker Pull processor/request-hold lifecycle ownership，
+完整候选快照与 HUMAN Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～ar 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～as 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -125,6 +125,9 @@ M11-12aq 的 Broker POP buffer ownership 由 Issue #8381 跟踪，分支为
 
 M11-12ar 的 Broker POP lifecycle ownership 由 Issue #8383 跟踪，分支为
 `mxsm/architecture-refactor-broker-pop-lifecycle-ownership`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12as 的 Broker POP Lite lifecycle ownership 由 Issue #8385 跟踪，分支为
+`mxsm/architecture-refactor-broker-pop-lite-lifecycle-ownership`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -1940,13 +1943,41 @@ Broker POP lifecycle ownership 随 Issue #8383 完成以下边界收敛：
 | `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
 | POP lifecycle ArcMut 定向扫描 / `git diff --check` | POP/Notification processor root、long-poll service carrier/constructor/back-reference 与对应 `mut_from_ref` 零匹配；保留 `BrokerRuntimeInner`/`GetMessageResult` 既有边界，diff check 无 whitespace error |
 
-下一子切片 M11-12as 处理 `PopLiteMessageProcessor`/`PopLiteLongPollingService` lifecycle owner；75/82 总进度不变，
+## M11-12as 实现
+
+Broker POP Lite lifecycle ownership 随 Issue #8385 完成以下边界收敛：
+
+- `PopLiteMessageProcessor`、`PopLiteLongPollingService`、Broker processor enum 与 BrokerRuntime field/accessor 统一改用标准 `Arc`；processor 通过 `Arc::new_cyclic` 向 service 一次安装标准 `Weak` 回边，删除运行期 setter 与 processor/service 强引用环。
+- crate-private shared wake-up trait 接收 owned request 并经 processor `&self` handler 分发；remoting `RequestProcessor` 仅保留为兼容 adapter，不为标准 Arc 引入整 processor mutex 或共享 `&mut` 别名。
+- scan task 只捕获 service `Weak` 和本轮 receiver；每次成功 start 创建新 channel，spawn 成功后向 `LiteEventDispatcher` 发布 sender，shutdown/restart 不再复用已消费或已关闭的 receiver，owner 释放时 scan 自然退出。
+- processor 与 service 分别使用异步 lifecycle gate 串行 start/shutdown/restart；TaskGroup 在 spawn 前发布、失败时回滚，短 parking_lot guard 在任何 `.await` 前释放，停止状态拒绝新增挂起以避免 drain 后重新入队。
+- 新增标准 Arc Send+Sync、Weak 回边、重复 start/停止/重启与活动 scan 不保活 owner 覆盖；保留的两个目标文件仍有 4 个 `BrokerRuntimeInner` 与 2 个 MessageStore `ArcMut` type reference 及 2 个 import occurrence，留待 Broker root/Store 边界后续切片处理。
+- reviewed baseline 从 476 identities / 1,241 occurrences 降至 473 / 1,227；production 从 296/738 降至 294/725，test 从 166/463 降至 165/462，compatibility 保持 14/40。Broker production 为 172/417、test 为 65/81；净删除 2 个 production identity/13 occurrence 与 1 个 test identity/1 occurrence，无新增 identity。
+
+## M11-12as 验证
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-broker --all-targets --all-features` / Broker strict Clippy | 通过；标准 Arc/Weak owner、共享 request handler、重启 channel 与双层异步 lifecycle gate 在全部 Broker targets/features 编译及 lint 通过 |
+| POP Lite lifecycle focused tests | 3/3 通过；覆盖 Send+Sync/Weak 回边、重复 start/停止/重启、活动 scan 不保活 owner |
+| RocksDB specialized gates | Store/Broker strict Clippy 通过；foundation 82/82、semantics 9/9、Broker `rocksdb` 20/20、`pop_consumer` 4/4 通过；隔离 main 对照污染增量缓存后曾触发 nightly rustc ICE，按编译器建议定向 clean 后重跑通过 |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 564 passed、25 failed、1 ignored；其中 24 项与上一 main 已登记失败集合一致，额外 lifecycle probe 已在隔离 `main@2c301e71a` 以同一聚焦测试命令复现；新增 3 个测试全部通过，故不能把全套记为通过，也未新增 baseline failure |
+| reviewed baseline reduction | baseline 476/1,241→473/1,227；5 个保留 occurrence 因相邻 carrier/签名/测试 import 变化发生一对一指纹位移，以临时 ADR-013 approval 逐项审核且 approval 不提交 |
+| `python scripts/arc_mut_guard.py` | 通过；production 294/725、test 165/462、compatibility 14/40，Broker production 172/417；没有新增 identity |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` / root workspace strict Clippy | 通过；root workspace 32 个 package 的 all-targets/all-features `-D warnings` profile 通过 |
+| architecture target/baseline/release/performance guards | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates、8 profiles/11 variants/50 metric contracts，dependency/release/performance guard 单测 60/60 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；scan task 仍由 TaskGroup 所有，Weak capture、fresh receiver 与串行 lifecycle transition 未新增 detached task/runtime 边界 |
+| `./scripts/check-agents-routing.ps1` | 通过；4 个 standalone Cargo、3 个 Node project、8 条 route |
+| POP Lite ArcMut 定向扫描 / `git diff --check` | processor/service root、Broker carrier、processor back-reference、service-self `mut_from_ref` 与测试 glob import 零匹配；保留 BrokerRuntimeInner/MessageStore 既有边界，diff check 无 whitespace error |
+
+下一子切片 M11-12at 处理 `PullMessageProcessor`/`PullRequestHoldService` lifecycle owner；75/82 总进度不变，
 Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
 ## 剩余切片与 Gate
 
-1. Broker offset、BrokerRuntimeInner、schedule/POP Lite/其他 processor/transaction owner（174/430）；下一子切片 M11-12as
-   处理 PopLiteMessageProcessor/PopLiteLongPollingService lifecycle ownership。
+1. Broker offset、BrokerRuntimeInner、schedule/其他 processor/transaction owner（172/417）；下一子切片 M11-12at
+   处理 PullMessageProcessor/PullRequestHoldService lifecycle ownership。
 2. Store MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（122/308）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1307,7 +1307,7 @@ impl BrokerRuntime {
             pop_message_processor.shutdown().await;
         }
 
-        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
+        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_ref() {
             pop_services_present = true;
             pop_lite_message_processor.shutdown().await;
         }
@@ -2232,7 +2232,7 @@ impl BrokerRuntime {
 
         let pop_message_processor = PopMessageProcessor::new(self.inner.clone());
         self.inner.pop_message_processor = Some(pop_message_processor.clone());
-        let pop_lite_message_processor = PopLiteMessageProcessor::new_arc_mut(self.inner.clone());
+        let pop_lite_message_processor = PopLiteMessageProcessor::new(self.inner.clone());
         self.inner.pop_lite_message_processor = Some(pop_lite_message_processor.clone());
         let ack_message_processor = ArcMut::new(AckMessageProcessor::new(
             self.inner.clone(),
@@ -2814,8 +2814,8 @@ impl BrokerRuntime {
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_ref() {
             pop_message_processor.start().await;
         }
-        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
-            pop_lite_message_processor.start();
+        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_ref() {
+            pop_lite_message_processor.start().await;
         }
         if let Some(ack_message_processor) = self.inner.ack_message_processor.as_mut() {
             ack_message_processor.start();
@@ -3358,7 +3358,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     client_housekeeping_service: Option<Arc<ClientHousekeepingService<MS>>>,
     //Processor
     pop_message_processor: Option<Arc<PopMessageProcessor<MS>>>,
-    pop_lite_message_processor: Option<ArcMut<PopLiteMessageProcessor<MS>>>,
+    pop_lite_message_processor: Option<Arc<PopLiteMessageProcessor<MS>>>,
     ack_message_processor: Option<ArcMut<AckMessageProcessor<MS>>>,
     notification_processor: Option<Arc<NotificationProcessor<MS>>>,
     query_assignment_processor: Option<ArcMut<QueryAssignmentProcessor<MS>>>,
@@ -3698,7 +3698,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn pop_lite_message_processor(&self) -> Option<&ArcMut<PopLiteMessageProcessor<MS>>> {
+    pub fn pop_lite_message_processor(&self) -> Option<&Arc<PopLiteMessageProcessor<MS>>> {
         self.pop_lite_message_processor.as_ref()
     }
 
@@ -8980,10 +8980,10 @@ accounts:
         runtime
             .inner
             .pop_lite_message_processor
-            .as_mut()
+            .as_ref()
             .expect("pop lite processor should be initialized")
-            .start();
-
+            .start()
+            .await;
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let header = PopLiteMessageRequestHeader {
@@ -9023,7 +9023,7 @@ accounts:
         runtime
             .inner
             .pop_lite_message_processor
-            .as_mut()
+            .as_ref()
             .expect("pop lite processor should be initialized")
             .shutdown()
             .await;
@@ -9041,9 +9041,10 @@ accounts:
         runtime
             .inner
             .pop_lite_message_processor
-            .as_mut()
+            .as_ref()
             .expect("pop lite processor should be initialized")
-            .start();
+            .start()
+            .await;
 
         let pop_channel = create_test_channel().await;
         let pop_ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(pop_channel.clone()));
@@ -9121,7 +9122,7 @@ accounts:
         runtime
             .inner
             .pop_lite_message_processor
-            .as_mut()
+            .as_ref()
             .expect("pop lite processor should be initialized")
             .shutdown()
             .await;

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Weak;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
@@ -24,16 +25,13 @@ use dashmap::DashMap;
 use parking_lot::Mutex;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tokio::select;
 use tokio::sync::mpsc::unbounded_channel;
-use tokio::sync::mpsc::UnboundedReceiver;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Notify;
+use tokio::sync::Mutex as AsyncMutex;
 use tracing::error;
 use tracing::warn;
 
@@ -41,35 +39,41 @@ use crate::broker_runtime::BrokerRuntimeInner;
 use crate::long_polling::polling_result::PollingResult;
 use crate::long_polling::pop_request::PopRequest;
 
+#[trait_variant::make(PopLiteLongPollingRequestProcessor: Send)]
+pub(crate) trait LocalPopLiteLongPollingRequestProcessor {
+    async fn process_request_when_wakeup(
+        &self,
+        channel: rocketmq_remoting::net::channel::Channel,
+        ctx: ConnectionHandlerContext,
+        request: RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>>;
+}
+
 pub(crate) struct PopLiteLongPollingService<MS: MessageStore, RP> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     polling_map: DashMap<CheetahString, SkipSet<Arc<PopRequest>>>,
     total_polling_num: AtomicU64,
-    processor: Option<ArcMut<RP>>,
-    notify: Notify,
-    wakeup_tx: UnboundedSender<CheetahString>,
-    wakeup_rx: Option<UnboundedReceiver<CheetahString>>,
+    processor: Weak<RP>,
     running: AtomicBool,
+    lifecycle: AsyncMutex<()>,
     task_group: Mutex<Option<TaskGroup>>,
 }
 
-impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPollingService<MS, RP> {
-    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        let (wakeup_tx, wakeup_rx) = unbounded_channel();
+impl<MS: MessageStore, RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPollingService<MS, RP> {
+    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>, processor: Weak<RP>) -> Self {
         Self {
             broker_runtime_inner: broker_runtime_inner.clone(),
             polling_map: DashMap::with_capacity(broker_runtime_inner.broker_config().pop_polling_map_size),
             total_polling_num: AtomicU64::new(0),
-            processor: None,
-            notify: Notify::new(),
-            wakeup_tx,
-            wakeup_rx: Some(wakeup_rx),
+            processor,
             running: AtomicBool::new(false),
+            lifecycle: AsyncMutex::new(()),
             task_group: Mutex::new(None),
         }
     }
 
-    pub(crate) fn start(this: ArcMut<Self>) {
+    pub(crate) async fn start(this: &Arc<Self>) {
+        let _lifecycle = this.lifecycle.lock().await;
         if this
             .running
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -85,29 +89,30 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
             this.running.store(false, Ordering::Release);
             return;
         };
-        let Some(mut wakeup_rx) = this.mut_from_ref().wakeup_rx.take() else {
-            this.running.store(false, Ordering::Release);
-            warn!("PopLiteLongPollingService receiver has already been taken");
-            return;
-        };
-
         let cancellation_token = task_group.cancellation_token();
-        let service = this.clone();
+        let service = Arc::downgrade(this);
+        let (wakeup_tx, mut wakeup_rx) = unbounded_channel();
+        *this.task_group.lock() = Some(task_group.clone());
 
         let spawn_result = task_group.spawn_service("broker.long-polling.pop-lite.scan", async move {
             loop {
-                select! {
+                let client_id = select! {
                     _ = cancellation_token.cancelled() => { break; }
-                    _ = service.notify.notified() => { break; }
                     wakeup = wakeup_rx.recv() => {
                         match wakeup {
-                            Some(client_id) => {
-                                service.wake_up_client(&client_id);
-                            }
+                            Some(client_id) => Some(client_id),
                             None => break,
                         }
                     }
-                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(20)) => {}
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(20)) => None,
+                };
+
+                let Some(service) = service.upgrade() else {
+                    break;
+                };
+
+                if let Some(client_id) = client_id {
+                    service.wake_up_client(&client_id);
                 }
 
                 if service.polling_map.is_empty() {
@@ -133,27 +138,33 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
                 }
             }
 
-            for entry in service.polling_map.iter() {
-                let queue = entry.value();
-                while let Some(first) = queue.pop_front() {
-                    service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                    service.wake_up(first.value().clone());
+            if let Some(service) = service.upgrade() {
+                for entry in service.polling_map.iter() {
+                    let queue = entry.value();
+                    while let Some(first) = queue.pop_front() {
+                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                        service.wake_up(first.value().clone());
+                    }
                 }
+                service.running.store(false, Ordering::Release);
             }
-            service.running.store(false, Ordering::Release);
         });
 
         if let Err(error) = spawn_result {
+            this.task_group.lock().take();
             this.running.store(false, Ordering::Release);
             warn!(?error, "failed to spawn PopLiteLongPollingService scan task");
             return;
         }
 
-        *this.task_group.lock() = Some(task_group);
+        this.broker_runtime_inner
+            .lite_event_dispatcher()
+            .set_wakeup_sender(wakeup_tx);
     }
 
-    pub(crate) async fn shutdown(&mut self) {
-        self.notify.notify_waiters();
+    pub(crate) async fn shutdown(&self) {
+        let _lifecycle = self.lifecycle.lock().await;
+        self.running.store(false, Ordering::Release);
         let task_group = self.task_group.lock().take();
         if let Some(task_group) = task_group {
             let report = task_group.shutdown(Duration::from_secs(5)).await;
@@ -167,10 +178,6 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
         self.running.store(false, Ordering::Release);
     }
 
-    pub(crate) fn wakeup_sender(&self) -> UnboundedSender<CheetahString> {
-        self.wakeup_tx.clone()
-    }
-
     pub(crate) fn polling(
         &self,
         ctx: ConnectionHandlerContext,
@@ -181,6 +188,9 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
     ) -> PollingResult {
         if poll_time <= 0 {
             return PollingResult::NotPolling;
+        }
+        if !self.running.load(Ordering::Acquire) {
+            return PollingResult::PollingTimeout;
         }
 
         let expired = born_time.saturating_add(poll_time);
@@ -227,9 +237,9 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
         if !pop_request.complete() {
             return false;
         }
-        match self.processor.clone() {
+        match self.processor.upgrade() {
             None => false,
-            Some(mut processor) => {
+            Some(processor) => {
                 let task_group = self.task_group.lock().as_ref().cloned();
                 let Some(task_group) = task_group else {
                     warn!("PopLiteLongPollingService wake-up skipped because task group is not running");
@@ -242,7 +252,7 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
                         let ctx = pop_request.get_ctx().clone();
                         let opaque = pop_request.get_remoting_command().opaque();
                         let response = processor
-                            .process_request(channel, ctx, &mut pop_request.get_remoting_command().clone())
+                            .process_request_when_wakeup(channel, ctx, pop_request.get_remoting_command().clone())
                             .await;
                         match response {
                             Ok(result) => {
@@ -286,7 +296,13 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
         self.polling_map.get(key).map(|queue| queue.len() as i32).unwrap_or(0)
     }
 
-    pub(crate) fn set_processor(&mut self, processor: ArcMut<RP>) {
-        self.processor = Some(processor);
+    #[cfg(test)]
+    pub(crate) fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_group_for_test(&self) -> Option<TaskGroup> {
+        self.task_group.lock().as_ref().cloned()
     }
 }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -82,7 +82,7 @@ pub enum BrokerProcessorType<MS: MessageStore, TS> {
     Pull(ArcMut<PullMessageProcessor<MS>>),
     Peek(ArcMut<PeekMessageProcessor<MS>>),
     Pop(Arc<PopMessageProcessor<MS>>),
-    PopLite(ArcMut<PopLiteMessageProcessor<MS>>),
+    PopLite(Arc<PopLiteMessageProcessor<MS>>),
     Ack(ArcMut<AckMessageProcessor<MS>>),
     ChangeInvisible(ArcMut<ChangeInvisibleTimeProcessor<MS>>),
     Notification(Arc<NotificationProcessor<MS>>),
@@ -174,7 +174,7 @@ where
             BrokerProcessorType::Pull(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::Peek(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::Pop(processor) => processor.process_request_shared(channel, ctx, request).await,
-            BrokerProcessorType::PopLite(processor) => processor.process_request(channel, ctx, request).await,
+            BrokerProcessorType::PopLite(processor) => processor.process_request_shared(channel, ctx, request).await,
             BrokerProcessorType::Ack(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::ChangeInvisible(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::Notification(processor) => {

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -33,9 +34,11 @@ use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 use crate::lite::memory_consumer_order_info_manager::MemoryConsumerOrderInfoManager;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingRequestProcessor;
 use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
 use crate::long_polling::polling_result::PollingResult;
 use crate::processor::pop_message_processor::queue_lock_manager_for_broker;
@@ -43,9 +46,10 @@ use crate::processor::pop_message_processor::QueueLockManager;
 
 pub(crate) struct PopLiteMessageProcessor<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-    pop_lite_long_polling_service: ArcMut<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>>,
+    pop_lite_long_polling_service: Arc<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>>,
     consumer_order_info_manager: MemoryConsumerOrderInfoManager,
     queue_lock_manager: QueueLockManager,
+    lifecycle: AsyncMutex<()>,
 }
 
 enum PopLmqResult {
@@ -60,40 +64,35 @@ enum PopLmqResult {
 }
 
 impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
-    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self {
-            pop_lite_long_polling_service: ArcMut::new(PopLiteLongPollingService::new(broker_runtime_inner.clone())),
+    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Arc<Self> {
+        let queue_lock_manager = queue_lock_manager_for_broker(&broker_runtime_inner);
+        Arc::new_cyclic(|processor| Self {
+            pop_lite_long_polling_service: Arc::new(PopLiteLongPollingService::new(
+                broker_runtime_inner.clone(),
+                processor.clone(),
+            )),
             consumer_order_info_manager: MemoryConsumerOrderInfoManager::default(),
-            queue_lock_manager: queue_lock_manager_for_broker(&broker_runtime_inner),
+            queue_lock_manager,
             broker_runtime_inner,
-        }
+            lifecycle: AsyncMutex::new(()),
+        })
     }
 
-    pub(crate) fn new_arc_mut(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> ArcMut<Self> {
-        let mut processor = ArcMut::new(Self::new(broker_runtime_inner.clone()));
-        let wakeup_sender = processor.pop_lite_long_polling_service.wakeup_sender();
-        broker_runtime_inner
-            .lite_event_dispatcher()
-            .set_wakeup_sender(wakeup_sender);
-
-        let cloned = processor.clone();
-        processor.pop_lite_long_polling_service.set_processor(cloned);
-        processor
-    }
-
-    pub(crate) fn start(&mut self) {
-        PopLiteLongPollingService::start(self.pop_lite_long_polling_service.clone());
+    pub(crate) async fn start(&self) {
+        let _lifecycle = self.lifecycle.lock().await;
+        PopLiteLongPollingService::start(&self.pop_lite_long_polling_service).await;
         self.queue_lock_manager.start();
     }
 
-    pub(crate) async fn shutdown(&mut self) {
+    pub(crate) async fn shutdown(&self) {
+        let _lifecycle = self.lifecycle.lock().await;
         self.pop_lite_long_polling_service.shutdown().await;
         self.queue_lock_manager.shutdown().await;
     }
 
     pub(crate) fn pop_lite_long_polling_service(
         &self,
-    ) -> &ArcMut<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>> {
+    ) -> &Arc<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>> {
         &self.pop_lite_long_polling_service
     }
 
@@ -466,9 +465,9 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
     }
 }
 
-impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
-    async fn process_request(
-        &mut self,
+impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
+    pub(crate) async fn process_request_shared(
+        &self,
         _channel: Channel,
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
@@ -540,11 +539,40 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
     }
 }
 
+impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
+    async fn process_request(
+        &mut self,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_request_shared(channel, ctx, request).await
+    }
+}
+
+impl<MS: MessageStore> PopLiteLongPollingRequestProcessor for PopLiteMessageProcessor<MS> {
+    async fn process_request_when_wakeup(
+        &self,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        mut request: RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_request_shared(channel, ctx, &mut request).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 
-    use super::*;
+    use super::PopLiteMessageProcessor;
+    use crate::broker_runtime::BrokerRuntime;
+    use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
 
     #[test]
     fn transform_order_count_info_drops_queue_level_suffix_when_offset_entries_exist() {
@@ -552,5 +580,84 @@ mod tests {
             PopLiteMessageProcessor::<LocalFileMessageStore>::transform_order_count_info("0 qo0%100 1;0 0 1", 1);
 
         assert_eq!(result, "0 qo0%100 1");
+    }
+
+    #[tokio::test]
+    async fn pop_lite_long_polling_service_uses_weak_processor_back_reference() {
+        fn assert_send_sync<T: Send + Sync>(_: &T) {}
+
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let processor = PopLiteMessageProcessor::new(runtime.inner_for_test().clone());
+        let processor_weak = Arc::downgrade(&processor);
+        let service = processor.pop_lite_long_polling_service.clone();
+
+        assert_send_sync(&processor);
+        drop(processor);
+
+        assert!(processor_weak.upgrade().is_none());
+        assert_eq!(Arc::strong_count(&service), 1);
+    }
+
+    #[tokio::test]
+    async fn pop_lite_long_polling_service_start_shutdown_and_restart_are_serialized() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let processor = PopLiteMessageProcessor::new(runtime.inner_for_test().clone());
+        let service = processor.pop_lite_long_polling_service.clone();
+
+        PopLiteLongPollingService::start(&service).await;
+        let first_task_group = service
+            .task_group_for_test()
+            .expect("long-polling task group should be installed");
+        PopLiteLongPollingService::start(&service).await;
+        assert_eq!(
+            service
+                .task_group_for_test()
+                .expect("duplicate start should retain the task group")
+                .task_count(),
+            1
+        );
+        assert_eq!(first_task_group.task_count(), 1);
+        assert!(service.is_running());
+
+        service.shutdown().await;
+        assert!(!service.is_running());
+        assert!(service.task_group_for_test().is_none());
+
+        PopLiteLongPollingService::start(&service).await;
+        let restarted_task_group = service
+            .task_group_for_test()
+            .expect("restart should install a task group");
+        assert_eq!(restarted_task_group.task_count(), 1);
+        assert!(!restarted_task_group.cancellation_token().is_cancelled());
+        service.shutdown().await;
+        assert!(!service.is_running());
+    }
+
+    #[tokio::test]
+    async fn active_pop_lite_long_polling_scan_does_not_keep_owner_alive() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let processor = PopLiteMessageProcessor::new(runtime.inner_for_test().clone());
+        let service = processor.pop_lite_long_polling_service.clone();
+        let processor_weak = Arc::downgrade(&processor);
+        let service_weak = Arc::downgrade(&service);
+
+        PopLiteLongPollingService::start(&service).await;
+        drop(processor);
+        drop(service);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while service_weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scan task should release the service owner");
+        assert!(processor_weak.upgrade().is_none());
     }
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -789,13 +789,13 @@
           "id": "a3c29627e8d7d7e68fa8faae",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_promotes_store_to_master",
-          "line": 9669
+          "line": 9670
         },
         {
           "id": "4ff61cc699c2c34d1b75fdec",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_demotes_store_to_slave",
-          "line": 9702
+          "line": 9703
         }
       ],
       "owner": "broker",
@@ -884,12 +884,6 @@
           "line": 3326
         },
         {
-          "id": "a4581ac092036fd9e83cb0b4",
-          "fingerprint": "c7097209a6e85abc30842435",
-          "item": "struct BrokerRuntimeInner",
-          "line": 3361
-        },
-        {
           "id": "f248d64f116cda3a8fac82bc",
           "fingerprint": "11c496708854f974676df3a1",
           "item": "struct BrokerRuntimeInner",
@@ -936,12 +930,6 @@
           "fingerprint": "7e8542f406042396ea595c53",
           "item": "fn message_store",
           "line": 3681
-        },
-        {
-          "id": "af914556887c67791df7dfd8",
-          "fingerprint": "5c66d04b8339ebd1b5e8f1a1",
-          "item": "fn pop_lite_message_processor",
-          "line": 3701
         },
         {
           "id": "51723d390366120a3abf406a",
@@ -1692,54 +1680,17 @@
           "id": "eca1ff4ca952398cae8fa2f3",
           "fingerprint": "23dc51c7be1eb64e851149ae",
           "item": "struct PopLiteLongPollingService",
-          "line": 45
+          "line": 53
         },
         {
-          "id": "c1b4e20de9cf4c98eff0c7ce",
-          "fingerprint": "7c99663a9dd01e448430e63d",
-          "item": "struct PopLiteLongPollingService",
-          "line": 48
-        },
-        {
-          "id": "d8c31bf5b2f9a76f042e49c0",
-          "fingerprint": "baf993ae90865ea6ebddfd8d",
+          "id": "b03649b97362b5417d843b3c",
+          "fingerprint": "e9d911094ce80b00f21f4c03",
           "item": "fn new",
-          "line": 57
-        },
-        {
-          "id": "065ea47a9d23cca6f3668eec",
-          "fingerprint": "0cc599b3e33c53086125e9cf",
-          "item": "fn start",
-          "line": 72
-        },
-        {
-          "id": "aa681a2402381bf6acccfe6a",
-          "fingerprint": "858e66e8f61a65f6153c4bda",
-          "item": "fn set_processor",
-          "line": 289
+          "line": 63
         }
       ],
       "owner": "broker",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a878158de9fb3db61e2de961",
-      "path": "rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "b845d1b71282336802eabf78",
-          "fingerprint": "460e80157407375d8ae99881",
-          "item": "fn start",
-          "line": 88
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -4160,50 +4111,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "02e51aa995b8eadeae2a890d",
-      "path": "rocketmq-broker/src/processor/pop_lite_message_processor.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "d09129793d10143e2a76b0d1",
-          "fingerprint": "ac16edb63b38368133fb4f17",
-          "item": "mod tests",
-          "line": 547
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "1db79a152cb99d3684abec56",
-      "path": "rocketmq-broker/src/processor/pop_lite_message_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "5ffde42fb64b31e89f8e9d74",
-          "fingerprint": "b3a2af64f08552541d5c14f6",
-          "item": "fn new",
-          "line": 65
-        },
-        {
-          "id": "536997b562b794d4918d07c8",
-          "fingerprint": "60da66baee0140eeb058a635",
-          "item": "fn new_arc_mut",
-          "line": 73
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "fb23e3d232b1ceaad894942b",
       "path": "rocketmq-broker/src/processor/pop_lite_message_processor.rs",
       "symbol": "ArcMut",
@@ -4214,7 +4121,7 @@
           "id": "b3787b31af8bbab34476a9b1",
           "fingerprint": "90b9a8c27c9425758f0828a7",
           "item": "<module>",
-          "line": 32
+          "line": 33
         }
       ],
       "owner": "broker",
@@ -4230,52 +4137,28 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ed42d999e11b02573f51d007",
-          "fingerprint": "2f1927308b4ca147d99c38a4",
+          "id": "f5c43b17c7f8d357fe408bd0",
+          "fingerprint": "53ff93622e9601a3ad609d82",
           "item": "struct PopLiteMessageProcessor",
-          "line": 45
+          "line": 48
         },
         {
-          "id": "a8996b7b1f82ad1ab89a1d5c",
-          "fingerprint": "7856da80cda4529e82867fcb",
-          "item": "struct PopLiteMessageProcessor",
-          "line": 46
-        },
-        {
-          "id": "47df3de3d2300eb38b8b9d2b",
-          "fingerprint": "67501e494530b522a9bce160",
+          "id": "30694cb75e166177586be952",
+          "fingerprint": "66c6898e03481421bea2bf85",
           "item": "fn new",
-          "line": 63
-        },
-        {
-          "id": "9edf6bd47d7611034e93d4c3",
-          "fingerprint": "28dd0ee60ea8116311db6e19",
-          "item": "fn new_arc_mut",
-          "line": 72
-        },
-        {
-          "id": "316613bfa8ed07442b78e257",
-          "fingerprint": "4681985d9052463cda536ac0",
-          "item": "fn new_arc_mut",
-          "line": 72
-        },
-        {
-          "id": "d4126c1e4e8de9cdb759b394",
-          "fingerprint": "11a7ce5ee267a406616a9a39",
-          "item": "fn pop_lite_long_polling_service",
-          "line": 96
+          "line": 67
         },
         {
           "id": "b188ec8d7310558440dd9a52",
           "fingerprint": "154565f293c8878bedec0967",
           "item": "fn pop_from_lmq",
-          "line": 313
+          "line": 312
         },
         {
           "id": "26d1634bee537318d96760f7",
           "fingerprint": "384ccb1c0a07541c6f474c27",
           "item": "fn get_message",
-          "line": 394
+          "line": 393
         }
       ],
       "owner": "broker",
@@ -4291,10 +4174,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "740e05ac0b0df6d7f3954efa",
-          "fingerprint": "0357bf2ef305f43dd33a662c",
+          "id": "0257464670a30b2b0ad19855",
+          "fingerprint": "1ba8b6af64c53055007da37a",
           "item": "mod tests",
-          "line": 545
+          "line": 571
         }
       ],
       "owner": "broker",
@@ -4313,7 +4196,7 @@
           "id": "954c573c45dcf60d39e499c7",
           "fingerprint": "f84fa0ca9f64055f30e67cbe",
           "item": "fn transform_order_count_info_drops_queue_level_suffix_when_offset_entries_exist",
-          "line": 552
+          "line": 580
         }
       ],
       "owner": "broker",
@@ -5304,14 +5187,8 @@
           "line": 83
         },
         {
-          "id": "291c539917e70b7afe9e0b09",
-          "fingerprint": "5b5c97f2639f2a81edbe15c6",
-          "item": "enum BrokerProcessorType",
-          "line": 85
-        },
-        {
-          "id": "e7ca20ae5c543f4f8de0f921",
-          "fingerprint": "62e2731be06de656117f1b89",
+          "id": "e390813c4f45519515004dfe",
+          "fingerprint": "b1dd1d89163e9d12bafc56c1",
           "item": "enum BrokerProcessorType",
           "line": 86
         },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8385

### Brief Description

- Replace the `PopLiteMessageProcessor` and `PopLiteLongPollingService` root carriers with standard `Arc` ownership and a standard `Weak` processor back-reference.
- Route normal and wake-up requests through a shared `&self` boundary, and make the scan task capture only a weak service owner.
- Serialize processor/service lifecycle transitions, publish a fresh wake-up channel on every successful start, and reject new suspended requests after shutdown begins.
- Reduce the reviewed ArcMut baseline from 476 identities / 1,241 occurrences to 473 / 1,227 and update the M11-12 migration checklist and evidence.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-targets --all-features`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-broker --all-features pop_lite_long_polling_service_ -- --nocapture`
- `cargo test -p rocketmq-broker --all-features active_pop_lite_long_polling_scan_does_not_keep_owner_alive -- --nocapture`
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` (564 passed, 25 pre-existing failures, 1 ignored; the additional lifecycle probe failure was reproduced on isolated `main@2c301e71a`)
- RocksDB Store/Broker Clippy and focused test gates (82/82, 9/9, 20/20, and 4/4)
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard -v`
- `python scripts/arc_mut_guard.py --fixtures`
- architecture target/baseline/release/performance guards and 60 guard tests
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved POP Lite message processing and long-polling lifecycle management.
  * Added safer start, shutdown, restart, and wake-up handling for POP Lite requests.
  * Prevented new pending work from being accepted after the service stops.

* **Bug Fixes**
  * Improved cleanup of polling tasks and reduced lifecycle-related resource retention.
  * Updated production-readiness tracking and verification records for the completed milestone.

* **Documentation**
  * Updated architecture migration checklists, progress metrics, evidence references, and the next milestone target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->