### PR TITLE
[ISSUE #8387]♻️Replace Broker Pull lifecycle ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -675,7 +675,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12aq Broker POP buffer ownership：`PopBufferMergeService` 与 checkpoint wrapper 改用标准 `Arc`，扫描任务独占复用 ACK scratch，服务 API 收窄为 `&self`；扫描在异步 I/O 前释放 DashMap guard，以 observed Arc identity 条件删除旧代际，并保留 commit-offset FIFO 直至按序提交
   - [x] M11-12ar Broker POP lifecycle ownership：`PopMessageProcessor`/`NotificationProcessor` root 与长轮询 service 改用标准 `Arc`，processor/service 与 service/scan-task 回边改为标准 `Weak`；共享 wake-up receiver、原子 cleanup 时间和异步 lifecycle gate 消除别名可变访问并串行 start/shutdown/restart
   - [x] M11-12as Broker POP Lite lifecycle ownership：`PopLiteMessageProcessor`/`PopLiteLongPollingService` root 与 Broker processor/runtime carrier 改用标准 `Arc`，processor 回边和 scan task 改用标准 `Weak`；共享 wake-up trait、每次 start 的新 channel、停止状态轮询拒绝与双层异步 lifecycle gate 消除共享可变别名并支持安全重启
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385 与每次真实下降
+  - [x] M11-12at Broker Pull lifecycle ownership：`PullMessageProcessor`/result handler/request-hold service 与 Broker carrier 改用标准 `Arc`，hold service 与 scan task 改用标准 `Weak`；共享 processor 能力、异步 lifecycle gate、停止准入/清理与锁内 deadline 发布消除强引用环、共享可变别名和 start/shutdown/deadline 竞态
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -721,7 +722,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8381 后实际快照降至 298 production/764 occurrence、167 test/464 occurrence；Broker 降至 176/456，POP buffer/checkpoint owner 共删除 2 个 production identity/19 occurrence 与 1 个 test identity/2 occurrence，compatibility 14/40 不增
   - [x] Issue #8383 后实际快照降至 296 production/738 occurrence、166 test/463 occurrence；Broker 降至 174/430，POP/Notification lifecycle 共删除 2 个 production identity/26 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
   - [x] Issue #8385 后实际快照降至 294 production/725 occurrence、165 test/462 occurrence；Broker 降至 172/417，POP Lite lifecycle 共删除 2 个 production identity/13 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
-  - [ ] M11-12at 及后续：Broker Pull lifecycle、offset/root/schedule/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8387 后实际快照降至 289 production/706 occurrence、162 test/458 occurrence；Broker 降至 167/398，Pull lifecycle 共删除 5 个 production identity/19 occurrence 与 3 个 test identity/4 occurrence，compatibility 14/40 不增
+  - [ ] M11-12au 及后续：Broker ConsumerOffsetManager/root/schedule/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -446,6 +446,13 @@ Broker POP Lite lifecycle ownership 随 Issue #8385 将 `PopLiteMessageProcessor
 经 `&self` 分发请求，每次成功 start 创建新 channel 并发布 sender，双层异步 lifecycle gate 串行 start/shutdown/restart，
 停止状态拒绝新增挂起。实际快照降至 294 production/725 occurrence、165 test/462 occurrence，Broker 降至 172/417；
 总进度仍为 75/82，下一子切片 M11-12at 处理 Broker Pull processor/request-hold lifecycle ownership，M11-12 父工作包未完成。
+Broker Pull lifecycle ownership 随 Issue #8387 将 `PullMessageProcessor`、`DefaultPullMessageResultHandler` 与
+`PullRequestHoldService` carrier 改为标准 `Arc`，hold service 只保留 processor 标准 `Weak` 回边并通过窄 trait 获取动态
+scan/store 能力，不再强持有 BrokerRuntimeInner；scan task 只捕获 service `Weak`。异步 lifecycle gate 串行
+start/shutdown/restart，停止状态拒绝新挂起并清空既有请求，deadline 重建在 table read 边界内发布，master-change 路径不再
+重入同一 Tokio RwLock。实际快照降至 289 production/706 occurrence、162 test/458 occurrence，Broker production 降至
+167/398；compatibility 保持 14/40。总进度仍为 75/82，下一子切片 M11-12au 处理 Broker ConsumerOffsetManager
+ownership，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -461,6 +461,13 @@ start/shutdown/restart。实际快照降至 294 production/725 occurrences、165
 172/417；compatibility 14/40 不增。下一子切片 M11-12at 处理 Broker Pull processor/request-hold lifecycle ownership，
 完整候选快照与 HUMAN Gate 仍保持开放。
 
+M11-12at 已将 `PullMessageProcessor`、`DefaultPullMessageResultHandler`、`PullRequestHoldService` 与 Broker carrier 改为
+标准 `Arc`，hold service 和 scan task 只持标准 `Weak` 回边；service 通过窄 processor capability 获取动态配置和 Store
+offset，不再强持有 BrokerRuntimeInner。异步 lifecycle gate 串行 start/shutdown/restart，停止状态拒绝新挂起并清空请求，
+deadline 发布与 master-change lock 顺序已收紧。实际快照为 289 production/706 occurrences、162 test/458 occurrences，
+Broker owner 为 167/398；compatibility 14/40 不增。下一子切片 M11-12au 处理 Broker ConsumerOffsetManager ownership，
+完整候选快照与 HUMAN Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -1974,10 +1974,40 @@ Broker POP Lite lifecycle ownership 随 Issue #8385 完成以下边界收敛：
 下一子切片 M11-12at 处理 `PullMessageProcessor`/`PullRequestHoldService` lifecycle owner；75/82 总进度不变，
 Broker/Store、compatibility 与完整候选快照 Gate 仍保持开放。
 
+## M11-12at 实现
+
+Broker Pull lifecycle ownership 随 Issue #8387 完成以下边界收敛：
+
+- `PullMessageProcessor`、`DefaultPullMessageResultHandler`、`PullRequestHoldService`、Broker processor enum/runtime carrier 与未启用的 V2 migration example 统一改用标准 `Arc`；remoting `RequestProcessor` 只保留无可变 capability 的兼容 adapter，实际 Pull/LitePull 分发使用共享 `&self` 入口。
+- hold service 只保留 processor 标准 `Weak` 回边，并通过 crate-private 窄 capability 读取 long-polling 配置、Store max offset 与提交 wake-up；service 不再强持有 BrokerRuntimeInner，processor/service/runtime 强引用环已拆除。
+- scan task 只捕获 service `Weak`、schedule signal 和 cancellation token；每轮等待前释放升级得到的 service owner。异步 lifecycle gate 串行 start/shutdown/restart，TaskGroup 在 spawn 前发布且失败回滚，shutdown 停止准入、等待 scan 并清空挂起请求与 deadline。
+- suspend 在 table write guard 内检查 running 与 processor 存活，停止或 processor 已释放时返回原 `PullNotFound` response，避免请求进入无 scanner 队列；deadline rebuild 在 table read guard 内完成 atomic publish，避免覆盖并发新 deadline。
+- master-online wake-up 先移出 owned requests、锁外提交；`NotifyMinBrokerChangeIdHandler` 更新 snapshot 后立即释放 Tokio RwLock write guard，不再写锁内重入 read lock 或跨后续 `.await` 持锁。
+- reviewed baseline 从 473 identities / 1,227 occurrences 降至 465 / 1,204；production 从 294/725 降至 289/706，test 从 165/462 降至 162/458，compatibility 保持 14/40。Broker production 为 167/398、test 为 62/77；净删除 5 个 production identity/19 occurrence 与 3 个 test identity/4 occurrence，无新增 identity。
+
+## M11-12at 验证
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-broker --all-targets --all-features` | 通过；标准 Arc/Weak owner、共享 request handler、异步 lifecycle、stopped admission 与全部 Broker targets/features 编译通过 |
+| Pull hold-service / processor / Broker dispatch focused tests | 5/5、14/14、1/1 通过；覆盖 weak back-reference、活动 scan owner drop、start/shutdown/restart、spawn failure rollback、TaskGroup wake-up worker、Pull 处理逻辑和 request-code 注册 |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 567 passed、25 failed、1 ignored；25 个失败与上一 main 已记录失败名单完全一致，本切片新增净 3 个 lifecycle 测试均通过，故不能把全套记为通过，也未新增 baseline failure |
+| RocksDB specialized gates | Store/Broker strict Clippy 通过；foundation 82/82、semantics 9/9、Broker `rocksdb` 20/20、`pop_consumer` 4/4 通过 |
+| reviewed baseline reduction | baseline 473/1,227→465/1,204；3 个保留 occurrence 因相邻 carrier 变化发生一对一指纹位移，以临时 ADR-013 approval 逐项审核且 approval 不提交 |
+| `python scripts/arc_mut_guard.py` | 通过；production 289/706、test 162/458、compatibility 14/40，Broker production 167/398；没有新增 identity |
+| `python -m unittest scripts.tests.test_arc_mut_guard -v` / `python scripts/arc_mut_guard.py --fixtures` | 67/67 单测、24/24 fixtures 通过 |
+| `cargo fmt --all -- --check` / root workspace strict Clippy | 通过；root workspace 32 个 package 的 all-targets/all-features `-D warnings` profile 通过 |
+| architecture target/baseline/release/performance guards | 通过；35/35 target edges、3/3 test edges、32/32 release topology、10/10 R0 crates、8 profiles/11 variants/50 metric contracts，dependency/release/performance guard 单测 60/60 通过 |
+| `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | 通过；scan task 由 TaskGroup 所有，Weak capture 与串行 lifecycle transition 未新增 detached task/runtime 边界 |
+| `./scripts/check-agents-routing.ps1` / `git diff --check` | routing 通过；4 个 standalone Cargo、3 个 Node project、8 条 route；diff check 无 whitespace error |
+
+下一子切片 M11-12au 处理 `ConsumerOffsetManager` immutable/serialized ownership；75/82 总进度不变，Broker/Store、
+compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
+
 ## 剩余切片与 Gate
 
-1. Broker offset、BrokerRuntimeInner、schedule/其他 processor/transaction owner（172/417）；下一子切片 M11-12at
-   处理 PullMessageProcessor/PullRequestHoldService lifecycle ownership。
+1. Broker offset、BrokerRuntimeInner、schedule/其他 processor/transaction owner（167/398）；下一子切片 M11-12au
+   处理 ConsumerOffsetManager immutable/serialized ownership。
 2. Store MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（122/308）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1289,7 +1289,7 @@ impl BrokerRuntime {
 
         let started = Instant::now();
         let mut pull_request_hold_present = false;
-        if let Some(pull_request_hold_service) = self.inner.pull_request_hold_service.as_mut() {
+        if let Some(pull_request_hold_service) = self.inner.pull_request_hold_service.as_ref() {
             pull_request_hold_present = true;
             pull_request_hold_service.shutdown().await;
         }
@@ -2207,21 +2207,20 @@ impl BrokerRuntime {
             self.inner.transactional_message_service.as_ref().unwrap().clone(),
             self.inner.clone(),
         );
-        let pull_message_result_handler = ArcMut::new(DefaultPullMessageResultHandler::new(
+        let pull_message_result_handler = Arc::new(DefaultPullMessageResultHandler::new(
             Arc::new(Default::default()), //optimize
             self.inner.clone(),
         ));
 
-        let pull_message_processor = ArcMut::new(PullMessageProcessor::new(
+        let pull_message_processor = Arc::new(PullMessageProcessor::new(
             pull_message_result_handler,
             self.inner.clone(),
         ));
 
         let consumer_manage_processor = ConsumerManageProcessor::new(self.inner.clone());
-        self.inner.pull_request_hold_service = Some(PullRequestHoldService::new(
-            pull_message_processor.clone(),
-            self.inner.clone(),
-        ));
+        self.inner.pull_request_hold_service = Some(Arc::new(PullRequestHoldService::new(Arc::downgrade(
+            &pull_message_processor,
+        ))));
 
         let inner = self.inner.clone();
         self.inner
@@ -2252,9 +2251,7 @@ impl BrokerRuntime {
             )
         });
         if let Some(task_group) = request_processor_task_group.clone() {
-            pull_message_processor
-                .mut_from_ref()
-                .set_wakeup_task_group(task_group.clone());
+            pull_message_processor.set_wakeup_task_group(task_group.clone());
             broker_request_processor.set_request_task_group(task_group);
         }
         self.request_processor_task_group = request_processor_task_group;
@@ -2829,9 +2826,15 @@ impl BrokerRuntime {
             topic_queue_mapping_clean_service.start();
         }
 
-        let inner = self.inner.clone();
-        if let Some(pull_request_hold_service) = self.inner.pull_request_hold_service.as_mut() {
-            pull_request_hold_service.start(inner);
+        let pull_request_hold_task_group = self.broker_task_group_or_current(
+            "rocketmq-broker.long-polling.pull-request-hold",
+            "failed to start PullRequestHoldService outside Tokio runtime",
+        );
+        if let (Some(pull_request_hold_service), Some(task_group)) = (
+            self.inner.pull_request_hold_service.as_ref(),
+            pull_request_hold_task_group,
+        ) {
+            PullRequestHoldService::start(pull_request_hold_service, task_group).await;
         }
 
         if let Some(broker_stats_manager) = self.inner.broker_stats_manager.as_mut() {
@@ -3337,7 +3340,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     update_master_haserver_addr_periodically: bool,
     should_start_time: Arc<AtomicU64>,
     is_isolated: Arc<AtomicBool>,
-    pull_request_hold_service: Option<PullRequestHoldService<MS>>,
+    pull_request_hold_service: Option<Arc<PullRequestHoldService<MS>>>,
     rebalance_lock_manager: RebalanceLockManager,
     broker_member_group: BrokerMemberGroup,
     transactional_message_check_listener: Option<DefaultTransactionalMessageCheckListener<MS>>,
@@ -3518,11 +3521,6 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn update_master_haserver_addr_periodically_mut(&mut self) -> &mut bool {
         &mut self.update_master_haserver_addr_periodically
-    }
-
-    #[inline]
-    pub fn pull_request_hold_service_mut(&mut self) -> Option<&mut PullRequestHoldService<MS>> {
-        self.pull_request_hold_service.as_mut()
     }
 
     #[inline]
@@ -3805,12 +3803,12 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
 
     #[inline]
     pub fn pull_request_hold_service(&self) -> Option<&PullRequestHoldService<MS>> {
-        self.pull_request_hold_service.as_ref()
+        self.pull_request_hold_service.as_deref()
     }
 
     #[inline]
     pub fn pull_request_hold_service_unchecked(&self) -> &PullRequestHoldService<MS> {
-        unsafe { self.pull_request_hold_service.as_ref().unwrap_unchecked() }
+        unsafe { self.pull_request_hold_service.as_deref().unwrap_unchecked() }
     }
 
     #[inline]
@@ -4004,7 +4002,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn set_pull_request_hold_service(&mut self, pull_request_hold_service: PullRequestHoldService<MS>) {
+    pub fn set_pull_request_hold_service(&mut self, pull_request_hold_service: Arc<PullRequestHoldService<MS>>) {
         self.pull_request_hold_service = Some(pull_request_hold_service);
     }
 
@@ -5006,7 +5004,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
 
         // notify PullRequest on hold to pull from master.
         if self.min_broker_id_in_group.load(Ordering::SeqCst) == MASTER_ID {
-            self.pull_request_hold_service_unchecked().notify_master_online().await;
+            self.pull_request_hold_service_unchecked().notify_master_online();
         }
     }
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -13,25 +13,29 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Weak;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_runtime::TaskGroup;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::consume_queue::cq_ext_unit::CqExtUnit;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::Notify;
 use tokio::time::Instant;
 use tracing::info;
 use tracing::warn;
 
-use crate::broker_runtime::BrokerRuntimeInner;
 use crate::long_polling::many_pull_request::ManyPullRequest;
 use crate::long_polling::pull_request::PullRequest;
 use crate::processor::pull_message_processor::PullMessageProcessor;
@@ -40,106 +44,126 @@ const TOPIC_QUEUE_ID_SEPARATOR: &str = "@";
 const NO_PENDING_DEADLINE: u64 = u64::MAX;
 const LONG_POLLING_FALLBACK_SCAN_MILLIS: u64 = 5_000;
 
-pub struct PullRequestHoldService<MS: MessageStore> {
-    pull_request_table: Arc<parking_lot::RwLock<HashMap<String, ManyPullRequest>>>,
-    pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
-    shutdown: Arc<Notify>,
-    schedule_signal: Arc<Notify>,
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-    running: AtomicBool,
-    next_deadline_millis: AtomicU64,
-    task_group: Mutex<Option<TaskGroup>>,
+pub(crate) trait PullRequestProcessor: Send + Sync {
+    fn long_polling_scan_config(&self) -> (bool, u64);
+
+    fn max_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<i64>;
+
+    fn execute_request_when_wakeup(
+        self: Arc<Self>,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: RemotingCommand,
+    );
 }
 
-impl<MS> PullRequestHoldService<MS>
+pub struct PullRequestHoldService<MS: MessageStore, RP = PullMessageProcessor<MS>> {
+    pull_request_table: Arc<parking_lot::RwLock<HashMap<String, ManyPullRequest>>>,
+    pull_message_processor: Weak<RP>,
+    schedule_signal: Arc<Notify>,
+    running: AtomicBool,
+    accepting_requests: AtomicBool,
+    next_deadline_millis: AtomicU64,
+    lifecycle: AsyncMutex<()>,
+    task_group: Mutex<Option<TaskGroup>>,
+    marker: PhantomData<fn() -> MS>,
+}
+
+impl<MS, RP> PullRequestHoldService<MS, RP>
 where
     MS: MessageStore + Send + Sync,
+    RP: PullRequestProcessor + 'static,
 {
-    pub fn new(
-        pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
-        broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-    ) -> Self {
+    pub fn new(pull_message_processor: Weak<RP>) -> Self {
         PullRequestHoldService {
             pull_request_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             pull_message_processor,
-            shutdown: Arc::new(Default::default()),
             schedule_signal: Arc::new(Default::default()),
-            broker_runtime_inner,
             running: AtomicBool::new(false),
+            accepting_requests: AtomicBool::new(false),
             next_deadline_millis: AtomicU64::new(NO_PENDING_DEADLINE),
+            lifecycle: AsyncMutex::new(()),
             task_group: Mutex::new(None),
+            marker: PhantomData,
         }
     }
 }
 
 #[allow(unused_variables)]
-impl<MS> PullRequestHoldService<MS>
+impl<MS, RP> PullRequestHoldService<MS, RP>
 where
     MS: MessageStore + Send + Sync,
+    RP: PullRequestProcessor + 'static,
 {
-    pub fn start(&mut self, this: ArcMut<BrokerRuntimeInner<MS>>) {
-        if self
+    pub async fn start(this: &Arc<Self>, task_group: TaskGroup) {
+        let _lifecycle = this.lifecycle.lock().await;
+        if this
             .running
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
             return;
         }
-
-        let Some(task_group) = this.broker_task_group_or_current(
-            "rocketmq-broker.long-polling.pull-request-hold",
-            "failed to start PullRequestHoldService outside Tokio runtime",
-        ) else {
-            self.running.store(false, Ordering::Release);
+        let Some(_processor_guard) = this.pull_message_processor.upgrade() else {
+            this.running.store(false, Ordering::Release);
             return;
         };
+
         let cancellation_token = task_group.cancellation_token();
+        let service = Arc::downgrade(this);
+        *this.task_group.lock() = Some(task_group.clone());
 
         if let Err(error) = task_group.spawn_service("broker.long-polling.pull-request-hold.scan", async move {
             loop {
-                let service = this.pull_request_hold_service().unwrap();
-                let shutdown = Arc::clone(&service.shutdown);
-                let schedule_signal = Arc::clone(&service.schedule_signal);
-                let handle_future = tokio::time::sleep(service.next_scan_delay());
+                let Some(current) = service.upgrade() else {
+                    break;
+                };
+                let Some(delay) = current.next_scan_delay() else {
+                    current.accepting_requests.store(false, Ordering::Release);
+                    current.running.store(false, Ordering::Release);
+                    break;
+                };
+                let schedule_signal = Arc::clone(&current.schedule_signal);
+                drop(current);
+                let handle_future = tokio::time::sleep(delay);
                 tokio::select! {
                     _ = cancellation_token.cancelled() => {
-                        if let Some(service) = this.pull_request_hold_service() {
-                            service.running.store(false, Ordering::Release);
-                        }
                         info!("PullRequestHoldService: shutdown..........");
                         break;
                     }
                     _ = handle_future => {}
-                    _ = shutdown.notified() => {
-                        if let Some(service) = this.pull_request_hold_service() {
-                            service.running.store(false, Ordering::Release);
-                        }
-                        info!("PullRequestHoldService: shutdown..........");
-                        break;
-                    }
                     _ = schedule_signal.notified() => {
                         continue;
                     }
                 }
+                let Some(current) = service.upgrade() else {
+                    break;
+                };
                 let instant = Instant::now();
-                this.pull_request_hold_service().as_ref().unwrap().check_hold_request();
+                current.check_hold_request();
                 let elapsed = instant.elapsed().as_millis();
                 if elapsed > 5000 {
                     warn!("PullRequestHoldService: check hold pull request cost {}ms", elapsed);
                 }
             }
+            if let Some(current) = service.upgrade() {
+                current.accepting_requests.store(false, Ordering::Release);
+                current.running.store(false, Ordering::Release);
+            }
         }) {
-            self.running.store(false, Ordering::Release);
+            this.task_group.lock().take();
+            this.accepting_requests.store(false, Ordering::Release);
+            this.running.store(false, Ordering::Release);
             warn!(?error, "failed to spawn PullRequestHoldService scan task");
-            return;
+        } else {
+            this.accepting_requests.store(true, Ordering::Release);
         }
-
-        *self.task_group.lock() = Some(task_group);
     }
 
-    pub async fn shutdown(&mut self) {
+    pub async fn shutdown(&self) {
+        let _lifecycle = self.lifecycle.lock().await;
+        self.accepting_requests.store(false, Ordering::Release);
         self.running.store(false, Ordering::Release);
-        self.shutdown.notify_waiters();
         let task_group = self.task_group.lock().take();
         if let Some(task_group) = task_group {
             let report = task_group.shutdown(Duration::from_secs(5)).await;
@@ -150,19 +174,31 @@ where
                 );
             }
         }
+        self.pull_request_table.write().clear();
+        self.next_deadline_millis.store(NO_PENDING_DEADLINE, Ordering::Release);
     }
 
     pub fn is_running(&self) -> bool {
         self.running.load(Ordering::Acquire)
     }
 
-    pub fn suspend_pull_request(&self, topic: &str, queue_id: i32, mut pull_request: PullRequest) {
+    pub fn suspend_pull_request(&self, topic: &str, queue_id: i32, mut pull_request: PullRequest) -> bool {
         let key = build_key(topic, queue_id);
         let mut table = self.pull_request_table.write();
+        if !self.can_accept_request() {
+            return false;
+        }
         let mpr = table.entry(key).or_insert_with(ManyPullRequest::new);
         pull_request.request_command_mut().set_suspended_ref(true);
         self.note_request_deadline(pull_request.deadline_millis());
         mpr.add_pull_request(pull_request);
+        true
+    }
+
+    fn can_accept_request(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+            && self.accepting_requests.load(Ordering::Acquire)
+            && self.pull_message_processor.upgrade().is_some()
     }
 
     fn note_request_deadline(&self, deadline_millis: u64) {
@@ -184,9 +220,8 @@ where
     }
 
     fn rebuild_next_deadline(&self) {
-        let next_deadline = self
-            .pull_request_table
-            .read()
+        let table = self.pull_request_table.read();
+        let next_deadline = table
             .values()
             .filter_map(ManyPullRequest::min_deadline_millis)
             .min()
@@ -194,14 +229,16 @@ where
         self.next_deadline_millis.store(next_deadline, Ordering::Release);
     }
 
-    fn next_scan_delay(&self) -> Duration {
+    fn next_scan_delay(&self) -> Option<Duration> {
+        let processor = self.pull_message_processor.upgrade()?;
+        let (long_polling_enable, short_polling_time_mills) = processor.long_polling_scan_config();
         let delay_millis = next_hold_scan_delay_millis(
             self.next_deadline_millis.load(Ordering::Acquire),
             current_millis(),
-            self.broker_runtime_inner.broker_config().long_polling_enable,
-            self.broker_runtime_inner.broker_config().short_polling_time_mills,
+            long_polling_enable,
+            short_polling_time_mills,
         );
-        Duration::from_millis(delay_millis)
+        Some(Duration::from_millis(delay_millis))
     }
 
     fn check_hold_request(&self) {
@@ -215,11 +252,12 @@ where
             }
             let topic = CheetahString::from(key_parts[0]);
             let queue_id = key_parts[1].parse::<i32>().unwrap();
-            let max_offset = self
-                .broker_runtime_inner
-                .message_store()
-                .unwrap()
-                .get_max_offset_in_queue(&topic, queue_id);
+            let Some(processor) = self.pull_message_processor.upgrade() else {
+                return;
+            };
+            let Some(max_offset) = processor.max_offset_in_queue(&topic, queue_id) else {
+                return;
+            };
             self.notify_message_arriving(&topic, queue_id, max_offset);
         }
         self.rebuild_next_deadline();
@@ -253,11 +291,13 @@ where
                 for request in request_list {
                     let mut newest_offset = max_offset;
                     if newest_offset <= request.pull_from_this_offset() {
-                        newest_offset = self
-                            .broker_runtime_inner
-                            .message_store()
-                            .unwrap()
-                            .get_max_offset_in_queue(topic, queue_id);
+                        let Some(processor) = self.pull_message_processor.upgrade() else {
+                            return;
+                        };
+                        let Some(current_max_offset) = processor.max_offset_in_queue(topic, queue_id) else {
+                            return;
+                        };
+                        newest_offset = current_max_offset;
                     }
 
                     if newest_offset > request.pull_from_this_offset() {
@@ -275,25 +315,25 @@ where
                         }
 
                         if match_by_commit_log {
-                            let pull_message_this = self.pull_message_processor.clone();
-                            self.pull_message_processor.execute_request_when_wakeup(
-                                pull_message_this,
-                                request.client_channel().clone(),
-                                request.connection_handler_context().clone(),
-                                request.request_command().clone(),
-                            );
+                            if let Some(processor) = self.pull_message_processor.upgrade() {
+                                processor.execute_request_when_wakeup(
+                                    request.client_channel().clone(),
+                                    request.connection_handler_context().clone(),
+                                    request.request_command().clone(),
+                                );
+                            }
                             continue;
                         }
                     }
 
                     if current_millis() >= (request.suspend_timestamp() + request.timeout_millis()) {
-                        let pull_message_this = self.pull_message_processor.clone();
-                        self.pull_message_processor.execute_request_when_wakeup(
-                            pull_message_this,
-                            request.client_channel().clone(),
-                            request.connection_handler_context().clone(),
-                            request.request_command().clone(),
-                        );
+                        if let Some(processor) = self.pull_message_processor.upgrade() {
+                            processor.execute_request_when_wakeup(
+                                request.client_channel().clone(),
+                                request.connection_handler_context().clone(),
+                                request.request_command().clone(),
+                            );
+                        }
                         continue;
                     }
 
@@ -316,23 +356,22 @@ where
         }
     }
 
-    pub async fn notify_master_online(&self) {
-        for mpr in self.pull_request_table.read().values() {
-            if let Some(request_list) = mpr.clone_list_and_clear() {
-                for request in request_list {
-                    info!(
-                        "notify master online, wakeup {}",
-                        //  request.client_channel(),
-                        request.request_command()
-                    );
-                    let pull_message_this = self.pull_message_processor.clone();
-                    self.pull_message_processor.execute_request_when_wakeup(
-                        pull_message_this,
-                        request.client_channel().clone(),
-                        request.connection_handler_context().clone(),
-                        request.request_command().clone(),
-                    );
-                }
+    pub fn notify_master_online(&self) {
+        let requests = self
+            .pull_request_table
+            .read()
+            .values()
+            .filter_map(ManyPullRequest::clone_list_and_clear)
+            .flatten()
+            .collect::<Vec<_>>();
+        for request in requests {
+            info!("notify master online, wakeup {}", request.request_command());
+            if let Some(processor) = self.pull_message_processor.upgrade() {
+                processor.execute_request_when_wakeup(
+                    request.client_channel().clone(),
+                    request.connection_handler_context().clone(),
+                    request.request_command().clone(),
+                );
             }
         }
         self.rebuild_next_deadline();
@@ -361,33 +400,113 @@ fn next_hold_scan_delay_millis(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
-    use rocketmq_common::common::broker::broker_config::BrokerConfig;
-    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_runtime::RuntimeHandle;
+    use rocketmq_store::message_store::GenericMessageStore;
 
     use super::*;
-    use crate::broker_runtime::BrokerRuntime;
-    use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
+
+    struct TestPullProcessor;
+
+    impl PullRequestProcessor for TestPullProcessor {
+        fn long_polling_scan_config(&self) -> (bool, u64) {
+            (true, 10)
+        }
+
+        fn max_offset_in_queue(&self, _topic: &CheetahString, _queue_id: i32) -> Option<i64> {
+            Some(0)
+        }
+
+        fn execute_request_when_wakeup(
+            self: Arc<Self>,
+            _channel: Channel,
+            _ctx: ConnectionHandlerContext,
+            _request: RemotingCommand,
+        ) {
+        }
+    }
+
+    fn task_group(name: &'static str) -> TaskGroup {
+        TaskGroup::root(name, RuntimeHandle::new(tokio::runtime::Handle::current()))
+    }
 
     #[tokio::test]
-    async fn start_is_idempotent_and_shutdown_stops_background_task() {
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let mut broker_runtime = BrokerRuntime::new(broker_config, message_store_config);
-        let inner = broker_runtime.inner_for_test().clone();
-        let result_handler = ArcMut::new(DefaultPullMessageResultHandler::new(
-            Arc::new(Default::default()),
-            inner.clone(),
-        ));
-        let pull_message_processor = ArcMut::new(PullMessageProcessor::new(result_handler, inner.clone()));
-        let mut service = PullRequestHoldService::new(pull_message_processor, inner.clone());
+    async fn start_shutdown_and_restart_are_serialized() {
+        let processor = Arc::new(TestPullProcessor);
+        let service = Arc::new(PullRequestHoldService::<GenericMessageStore, _>::new(Arc::downgrade(
+            &processor,
+        )));
 
-        service.start(inner.clone());
-        service.start(inner);
+        let first_group = task_group("pull-request-hold-first");
+        PullRequestHoldService::start(&service, first_group.clone()).await;
+        PullRequestHoldService::start(&service, first_group).await;
         assert!(service.is_running());
 
         service.shutdown().await;
         assert!(!service.is_running());
+        assert!(!service.can_accept_request());
+
+        PullRequestHoldService::start(&service, task_group("pull-request-hold-second")).await;
+        assert!(service.is_running());
+        assert!(service.can_accept_request());
+
+        service.shutdown().await;
+        assert!(!service.is_running());
+    }
+
+    #[test]
+    fn service_uses_weak_processor_back_reference() {
+        let processor = Arc::new(TestPullProcessor);
+        let processor_weak = Arc::downgrade(&processor);
+        let service = Arc::new(PullRequestHoldService::<GenericMessageStore, _>::new(
+            processor_weak.clone(),
+        ));
+
+        drop(processor);
+
+        assert!(processor_weak.upgrade().is_none());
+        assert!(!service.can_accept_request());
+    }
+
+    #[tokio::test]
+    async fn active_scan_does_not_keep_service_owner_alive() {
+        let processor = Arc::new(TestPullProcessor);
+        let service = Arc::new(PullRequestHoldService::<GenericMessageStore, _>::new(Arc::downgrade(
+            &processor,
+        )));
+        let service_weak = Arc::downgrade(&service);
+        let group = task_group("pull-request-hold-drop");
+
+        PullRequestHoldService::start(&service, group.clone()).await;
+        drop(service);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while service_weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scan task must not keep PullRequestHoldService alive");
+
+        let report = group.shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn start_rolls_back_when_task_group_is_closed() {
+        let processor = Arc::new(TestPullProcessor);
+        let service = Arc::new(PullRequestHoldService::<GenericMessageStore, _>::new(Arc::downgrade(
+            &processor,
+        )));
+        let group = task_group("pull-request-hold-closed");
+        let report = group.clone().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        PullRequestHoldService::start(&service, group).await;
+
+        assert!(!service.is_running());
+        assert!(service.task_group.lock().is_none());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -79,7 +79,7 @@ pub(crate) mod send_message_processor;
 
 pub enum BrokerProcessorType<MS: MessageStore, TS> {
     Send(ArcMut<SendMessageProcessor<MS, TS>>),
-    Pull(ArcMut<PullMessageProcessor<MS>>),
+    Pull(Arc<PullMessageProcessor<MS>>),
     Peek(ArcMut<PeekMessageProcessor<MS>>),
     Pop(Arc<PopMessageProcessor<MS>>),
     PopLite(Arc<PopLiteMessageProcessor<MS>>),
@@ -171,7 +171,7 @@ where
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self {
             BrokerProcessorType::Send(processor) => processor.process_request(channel, ctx, request).await,
-            BrokerProcessorType::Pull(processor) => processor.process_request(channel, ctx, request).await,
+            BrokerProcessorType::Pull(processor) => processor.process_request_shared(channel, ctx, request).await,
             BrokerProcessorType::Peek(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::Pop(processor) => processor.process_request_shared(channel, ctx, request).await,
             BrokerProcessorType::PopLite(processor) => processor.process_request_shared(channel, ctx, request).await,
@@ -199,7 +199,7 @@ where
     fn reject_request(&self, code: i32) -> RejectRequestResponse {
         match self {
             BrokerProcessorType::Send(processor) => processor.reject_request(code),
-            BrokerProcessorType::Pull(processor) => processor.reject_request(code),
+            BrokerProcessorType::Pull(processor) => processor.reject_request_shared(),
             BrokerProcessorType::Peek(processor) => processor.reject_request(code),
             BrokerProcessorType::Pop(processor) => processor.reject_request(code),
             BrokerProcessorType::PopLite(processor) => processor.reject_request(code),

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -129,12 +129,13 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
             min_broker_addr
         );
 
-        let mut lock_guard = self.lock.write().await;
-        lock_guard.min_broker_id_in_group = Some(min_broker_id);
-        lock_guard.min_broker_addr_in_group = Arc::new(CheetahString::from_slice(min_broker_addr));
+        {
+            let mut lock_guard = self.lock.write().await;
+            lock_guard.min_broker_id_in_group = Some(min_broker_id);
+            lock_guard.min_broker_addr_in_group = Arc::new(CheetahString::from_slice(min_broker_addr));
+        }
 
-        let should_start = self.broker_runtime_inner.get_min_broker_id_in_group()
-            == self.lock.read().await.min_broker_id_in_group.unwrap();
+        let should_start = self.broker_runtime_inner.get_min_broker_id_in_group() == min_broker_id;
 
         self.change_special_service_status(should_start).await;
 
@@ -154,10 +155,10 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
             self.on_master_on_line(min_broker_addr, master_ha_addr).await;
         }
 
-        if self.lock.read().await.min_broker_id_in_group.unwrap() == MASTER_ID {
+        if min_broker_id == MASTER_ID {
             let pull_request_hold_service = self.broker_runtime_inner.pull_request_hold_service();
             if let Some(pull_request_hold_service) = pull_request_hold_service {
-                pull_request_hold_service.notify_master_online().await;
+                pull_request_hold_service.notify_master_online();
             } else {
                 error!("pull_request_hold_service is empty");
             }

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -44,7 +44,6 @@ use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::filter::ArcMessageFilter;
-use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 use rocketmq_store::stats::broker_stats_manager::BrokerStatsManager;
 use rocketmq_store::stats::stats_type::StatsType;
 use tracing::debug;
@@ -73,14 +72,6 @@ impl<MS: MessageStore> DefaultPullMessageResultHandler<MS> {
             broker_runtime_inner,
             consume_message_hook_list,
         }
-    }
-
-    pub fn set_pull_request_hold_service(
-        &mut self,
-        //pull_request_hold_service: Option<ArcMut<PullRequestHoldService<DefaultMessageStore>>>,
-        _inner: ArcMut<BrokerRuntimeInner<LocalFileMessageStore>>,
-    ) {
-        //self.pull_request_hold_service = pull_request_hold_service;
     }
 }
 
@@ -244,12 +235,15 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
                         subscription_data,
                         message_filter,
                     );
-                    self.broker_runtime_inner
+                    let suspended = self
+                        .broker_runtime_inner
                         .pull_request_hold_service()
                         .as_ref()
                         .unwrap()
                         .suspend_pull_request(topic, queue_id, pull_request);
-                    return None;
+                    if suspended {
+                        return None;
+                    }
                 }
                 Some(response)
             }

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -18,6 +18,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_role::BrokerRole;
@@ -69,6 +70,7 @@ use crate::coldctr::cold_data_pull_request_hold_service::NO_SUSPEND_KEY;
 use crate::filter::consumer_filter_data::ConsumerFilterData;
 use crate::filter::expression_for_retry_message_filter::ExpressionForRetryMessageFilter;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
+use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
 
@@ -119,12 +121,12 @@ fn store_read_max_msg_bytes(max_msg_bytes: Option<i32>) -> i32 {
 /// - PUSH consumers receive `SYSTEM_BUSY` immediately
 /// - PULL consumers are either suspended or limited to 1 message
 pub struct PullMessageProcessor<MS: MessageStore> {
-    pull_message_result_handler: ArcMut<DefaultPullMessageResultHandler<MS>>,
+    pull_message_result_handler: Arc<DefaultPullMessageResultHandler<MS>>,
     /// Sharded write guards used only for suspended-pull wakeup responses.
     /// Same-channel responses map to the same guard; unrelated channels can write in parallel.
     wakeup_write_locks: Arc<Vec<Arc<Mutex<()>>>>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-    wakeup_task_group: Option<TaskGroup>,
+    wakeup_task_group: OnceLock<TaskGroup>,
 }
 
 impl<MS> RequestProcessor for PullMessageProcessor<MS>
@@ -133,6 +135,24 @@ where
 {
     async fn process_request(
         &mut self,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_request_shared(channel, ctx, request).await
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestResponse {
+        self.reject_request_shared()
+    }
+}
+
+impl<MS> PullMessageProcessor<MS>
+where
+    MS: MessageStore,
+{
+    pub(crate) async fn process_request_shared(
+        &self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
@@ -155,7 +175,7 @@ where
         }
     }
 
-    fn reject_request(&self, _code: i32) -> RejectRequestResponse {
+    pub(crate) fn reject_request_shared(&self) -> RejectRequestResponse {
         if !self.broker_runtime_inner.broker_config().slave_read_enable
             && self.broker_runtime_inner.message_store_config().broker_role == BrokerRole::Slave
         {
@@ -182,19 +202,21 @@ where
     MS: MessageStore,
 {
     pub fn new(
-        pull_message_result_handler: ArcMut<DefaultPullMessageResultHandler<MS>>,
+        pull_message_result_handler: Arc<DefaultPullMessageResultHandler<MS>>,
         broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     ) -> Self {
         Self {
             pull_message_result_handler,
             wakeup_write_locks: new_wakeup_write_locks(),
             broker_runtime_inner,
-            wakeup_task_group: None,
+            wakeup_task_group: OnceLock::new(),
         }
     }
 
-    pub(crate) fn set_wakeup_task_group(&mut self, task_group: TaskGroup) {
-        self.wakeup_task_group = Some(task_group);
+    pub(crate) fn set_wakeup_task_group(&self, task_group: TaskGroup) {
+        if self.wakeup_task_group.set(task_group).is_err() {
+            warn!("PullMessageProcessor wake-up task group is already initialized");
+        }
     }
 
     /// Creates an error response with the given code and remark.
@@ -620,7 +642,7 @@ where
 {
     /// Processes a pull message request with all the entry point options.
     pub async fn process_request_(
-        &mut self,
+        &self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
@@ -653,7 +675,7 @@ where
     /// * `Ok(None)` - Request was suspended (cold data flow control or long polling)
     #[allow(unused_assignments)]
     async fn process_request_inner(
-        &mut self,
+        &self,
         request_code: RequestCode,
         channel: Channel,
         ctx: ConnectionHandlerContext,
@@ -976,7 +998,7 @@ where
     }
 
     fn query_broadcast_pull_init_offset(
-        &mut self,
+        &self,
         topic: &CheetahString,
         group: &CheetahString,
         queue_id: i32,
@@ -1017,12 +1039,12 @@ where
     }
 
     pub fn execute_request_when_wakeup(
-        &self,
-        mut pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
+        self: &Arc<Self>,
         channel: Channel,
         ctx: ConnectionHandlerContext,
         mut request: RemotingCommand,
     ) {
+        let pull_message_processor = Arc::clone(self);
         let locks = Arc::clone(&self.wakeup_write_locks);
         let task = async move {
             let broker_allow_flow_ctr_suspend =
@@ -1048,7 +1070,34 @@ where
                 drop(guard);
             }
         };
-        spawn_wakeup_pull_task(self.wakeup_task_group.as_ref(), task);
+        spawn_wakeup_pull_task(self.wakeup_task_group.get(), task);
+    }
+}
+
+impl<MS> PullRequestProcessor for PullMessageProcessor<MS>
+where
+    MS: MessageStore + Send + Sync + 'static,
+{
+    fn long_polling_scan_config(&self) -> (bool, u64) {
+        (
+            self.broker_runtime_inner.broker_config().long_polling_enable,
+            self.broker_runtime_inner.broker_config().short_polling_time_mills,
+        )
+    }
+
+    fn max_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<i64> {
+        self.broker_runtime_inner
+            .message_store()
+            .map(|message_store| message_store.get_max_offset_in_queue(topic, queue_id))
+    }
+
+    fn execute_request_when_wakeup(
+        self: Arc<Self>,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: RemotingCommand,
+    ) {
+        PullMessageProcessor::execute_request_when_wakeup(&self, channel, ctx, request);
     }
 }
 
@@ -1178,7 +1227,7 @@ mod tests {
     }
 
     fn new_processor<MS: MessageStore>(inner: ArcMut<BrokerRuntimeInner<MS>>) -> PullMessageProcessor<MS> {
-        let handler = ArcMut::new(DefaultPullMessageResultHandler::new(Arc::new(vec![]), inner.clone()));
+        let handler = Arc::new(DefaultPullMessageResultHandler::new(Arc::new(vec![]), inner.clone()));
         PullMessageProcessor::new(handler, inner)
     }
 

--- a/rocketmq-broker/src/processor_v2_migration_example.rs
+++ b/rocketmq-broker/src/processor_v2_migration_example.rs
@@ -18,6 +18,7 @@
 //! architecture to the new Core + Plugin + GAT design.
 
 use std::future::Future;
+use std::sync::Arc;
 
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::net::channel::Channel;
@@ -75,12 +76,12 @@ where
 
 /// Wrapper for PullMessageProcessor
 pub struct PullMessageProcessorV2<MS: MessageStore> {
-    inner: ArcMut<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
+    inner: Arc<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
 }
 
 impl<MS: MessageStore> PullMessageProcessorV2<MS> {
     pub fn new(
-        inner: ArcMut<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
+        inner: Arc<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
     ) -> Self {
         Self { inner }
     }
@@ -101,8 +102,7 @@ where
         request: &'a mut RemotingCommand,
     ) -> Self::Fut<'a> {
         async move {
-            use rocketmq_remoting::runtime::processor::RequestProcessor;
-            self.inner.process_request(channel, ctx, request).await
+            self.inner.process_request_shared(channel, ctx, request).await
         }
     }
 }
@@ -168,7 +168,7 @@ where
 {
     pub fn new(
         send_processor: ArcMut<crate::processor::send_message_processor::SendMessageProcessor<MS, TS>>,
-        pull_processor: ArcMut<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
+        pull_processor: Arc<crate::processor::pull_message_processor::PullMessageProcessor<MS>>,
         admin_processor: ArcMut<crate::processor::admin_broker_processor::AdminBrokerProcessor<MS>>,
     ) -> Self {
         // Wrap existing processors
@@ -244,7 +244,7 @@ mod integration_example {
     async fn example_broker_runtime_integration() {
         // Assume we have existing processor instances
         // let send_processor = ArcMut::new(SendMessageProcessor::new(...));
-        // let pull_processor = ArcMut::new(PullMessageProcessor::new(...));
+        // let pull_processor = Arc::new(PullMessageProcessor::new(...));
         // let admin_processor = ArcMut::new(AdminBrokerProcessor::new(...));
 
         // Create V2 processor dispatcher

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -553,7 +553,7 @@
           "id": "ab7b36e73225c82ba5237e56",
           "fingerprint": "3f50ae58593a221c0712bf87",
           "item": "mod tests",
-          "line": 5310
+          "line": 5308
         }
       ],
       "owner": "broker",
@@ -611,160 +611,148 @@
           "line": 1948
         },
         {
-          "id": "a40c13a535cceab8027a497f",
-          "fingerprint": "612129a924b724d4c2f7e53d",
-          "item": "fn init_processor",
-          "line": 2210
-        },
-        {
-          "id": "660a8dbaae497d4477905d15",
-          "fingerprint": "a0e978b292318100fa107b20",
-          "item": "fn init_processor",
-          "line": 2215
-        },
-        {
           "id": "5ee21c896b913562301a1077",
           "fingerprint": "5e4000a4cc6080e4ca942578",
           "item": "fn init_processor",
-          "line": 2237
+          "line": 2236
         },
         {
           "id": "a9d9cd968a048a3fe6cf8f93",
           "fingerprint": "fc2f3e9288372a0b2837cceb",
           "item": "fn init_processor",
-          "line": 2242
+          "line": 2241
         },
         {
           "id": "1261e094b358c311bc99e294",
           "fingerprint": "673811bcf14817412131737b",
           "item": "fn init_processor",
-          "line": 2265
+          "line": 2262
         },
         {
           "id": "75c6a12d7b84cf3f323168d6",
           "fingerprint": "99833e949d3c71e1d5dd2b34",
           "item": "fn init_processor",
-          "line": 2295
+          "line": 2292
         },
         {
           "id": "e003cfa8512a2b810c0757d6",
           "fingerprint": "a537097d2f3e1cde35c3d52e",
           "item": "fn init_processor",
-          "line": 2323
+          "line": 2320
         },
         {
           "id": "4ccce9fd1347e4a45feac84e",
           "fingerprint": "e7a096569f5933abcc48c4ac",
           "item": "fn init_processor",
-          "line": 2337
+          "line": 2334
         },
         {
           "id": "75e1a673a946ebc357449d2a",
           "fingerprint": "08be866a023550837c09fd04",
           "item": "fn init_processor",
-          "line": 2341
+          "line": 2338
         },
         {
           "id": "296a16fed1d97b8cce083f41",
           "fingerprint": "3b45a75867d3d8259a18e878",
           "item": "fn init_processor",
-          "line": 2352
+          "line": 2349
         },
         {
           "id": "a8e78537fab6a9416548e578",
           "fingerprint": "f109de874facf7759b44b0cc",
           "item": "fn init_processor",
-          "line": 2359
+          "line": 2356
         },
         {
           "id": "a25650b9781c069d18dede16",
           "fingerprint": "2954c908f9f536cef1ec05ea",
           "item": "fn init_processor",
-          "line": 2369
+          "line": 2366
         },
         {
           "id": "0f2465204cf8ff01245010fc",
           "fingerprint": "69c2447e085ce4c966d72ac3",
           "item": "fn init_processor",
-          "line": 2384
+          "line": 2381
         },
         {
           "id": "4899f108c82dd486c0cf801c",
           "fingerprint": "175b407bc96e49b8d505d4e6",
           "item": "fn init_processor",
-          "line": 2412
+          "line": 2409
         },
         {
           "id": "f211d11a474bb3f5368805ed",
           "fingerprint": "c1764c299f852ca96797ace1",
           "item": "fn init_processor",
-          "line": 2416
+          "line": 2413
         },
         {
           "id": "33c26215dc7e03370a77c147",
           "fingerprint": "cc22e2933269cd811997eac9",
           "item": "fn init_processor",
-          "line": 2420
+          "line": 2417
         },
         {
           "id": "d3c6ae41c6dfe325630c06ee",
           "fingerprint": "f69f1a42f8ff860e25c4d7e5",
           "item": "fn init_processor",
-          "line": 2424
+          "line": 2421
         },
         {
           "id": "643cda9c4a05b706a451df65",
           "fingerprint": "ac6ddfa809adcb48c4d79a5e",
           "item": "fn init_processor",
-          "line": 2428
+          "line": 2425
         },
         {
           "id": "c441d0a988807c325c3caf2d",
           "fingerprint": "b25abc1219eee2f2848952ec",
           "item": "fn init_processor",
-          "line": 2432
+          "line": 2429
         },
         {
           "id": "c792564ccb545baf12948fef",
           "fingerprint": "391568cfda5c595730431b9b",
           "item": "fn init_processor",
-          "line": 2436
+          "line": 2433
         },
         {
           "id": "cd90bfb953e2d7ea8fe7a5b8",
           "fingerprint": "e90bb773b49e6b17487fdbca",
           "item": "fn init_processor",
-          "line": 2444
+          "line": 2441
         },
         {
           "id": "085b114fa4b32ee717392eac",
           "fingerprint": "697b006598311fd21b7be444",
           "item": "fn init_processor",
-          "line": 2457
+          "line": 2454
         },
         {
           "id": "965666e18236c5c5a79f06e7",
           "fingerprint": "702475d3ef19c5b4889f53b5",
           "item": "fn initial_transaction",
-          "line": 2673
+          "line": 2670
         },
         {
           "id": "5a11a6fa9237fdd8ea0dafa1",
           "fingerprint": "700bae83c5efcc96fd63bae4",
           "item": "fn set_message_store",
-          "line": 3940
+          "line": 3938
         },
         {
           "id": "9f53a0559f1829cddb44bc38",
           "fingerprint": "7bef337a5f22e42fb0555ac1",
           "item": "fn set_schedule_message_service",
-          "line": 3950
+          "line": 3948
         },
         {
           "id": "dd6c73ad6af3fe3f85a70c79",
           "fingerprint": "d87e787b1a6fd3613b6561ec",
           "item": "fn register_broker_all_inner",
-          "line": 4149
+          "line": 4147
         }
       ],
       "owner": "broker",
@@ -783,19 +771,19 @@
           "id": "5689243529837bbe350032c7",
           "fingerprint": "c7fde3d9b289d1ecd7941a05",
           "item": "fn new_controller_mode_message_store",
-          "line": 6000
+          "line": 5998
         },
         {
           "id": "a3c29627e8d7d7e68fa8faae",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_promotes_store_to_master",
-          "line": 9670
+          "line": 9668
         },
         {
           "id": "4ff61cc699c2c34d1b75fdec",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_demotes_store_to_slave",
-          "line": 9703
+          "line": 9701
         }
       ],
       "owner": "broker",
@@ -845,223 +833,223 @@
           "id": "d401d680f8ca98d08bd04ab0",
           "fingerprint": "0a5f27aeb7f38fd768017093",
           "item": "fn initial_transaction",
-          "line": 2674
+          "line": 2671
         },
         {
           "id": "2ebccb514bd3132632b6c47c",
           "fingerprint": "e7621f9bc48de4dcc0f47b88",
           "item": "fn register_increment_broker_data",
-          "line": 3146
+          "line": 3149
         },
         {
           "id": "2ad77a362f45944644a1c0df",
           "fingerprint": "fa49348dda87e0d66c4d8a3b",
           "item": "fn do_register_broker_all",
-          "line": 3199
+          "line": 3202
         },
         {
           "id": "037d56b431aa67608a06a9f6",
           "fingerprint": "231a8bb1057f09fa5309d044",
           "item": "struct ProducerStateGetter",
-          "line": 3267
+          "line": 3270
         },
         {
           "id": "99eff2a5cb8dbdbbd54f4795",
           "fingerprint": "7dd3cf4c20f1c213bd9345db",
           "item": "struct ConsumerStateGetter",
-          "line": 3287
+          "line": 3290
         },
         {
           "id": "fb274c3282855e73a012ee3f",
           "fingerprint": "db30298987fa29f77b4e9a6b",
           "item": "struct BrokerRuntimeInner",
-          "line": 3324
+          "line": 3327
         },
         {
           "id": "4eaa4217407a38518017234a",
           "fingerprint": "b6e5e7bce482bb940ea3404f",
           "item": "struct BrokerRuntimeInner",
-          "line": 3326
+          "line": 3329
         },
         {
           "id": "f248d64f116cda3a8fac82bc",
           "fingerprint": "11c496708854f974676df3a1",
           "item": "struct BrokerRuntimeInner",
-          "line": 3362
+          "line": 3365
         },
         {
           "id": "a2b47c6106f9889032a7f0fc",
           "fingerprint": "99c1915f18b2509de56034fe",
           "item": "struct BrokerRuntimeInner",
-          "line": 3364
+          "line": 3367
         },
         {
           "id": "308b151d14ae319a9736cf32",
           "fingerprint": "99554467b5d11b6489bf98bd",
           "item": "struct BrokerRuntimeInner",
-          "line": 3367
+          "line": 3370
         },
         {
           "id": "4ade86c96052f2090dbb7f77",
           "fingerprint": "cdae48c0ebbb111839de0523",
           "item": "fn message_store_mut",
-          "line": 3464
+          "line": 3467
         },
         {
           "id": "c1cae73ceb0817d0ee5737a5",
           "fingerprint": "bb36b785611582c90a04314b",
           "item": "fn schedule_message_service_mut",
-          "line": 3474
+          "line": 3477
         },
         {
           "id": "65fc6539ac3842d150aa6ab7",
           "fingerprint": "bfce165132795dfb1f1b43be",
           "item": "fn schedule_message_service_unchecked_mut",
-          "line": 3479
+          "line": 3482
         },
         {
           "id": "9fc500ec718d709b7ac0642d",
           "fingerprint": "4ce1300d14e00cbb2c3f6de0",
           "item": "fn transactional_message_service_mut",
-          "line": 3539
+          "line": 3537
         },
         {
           "id": "bfb12f611c07f201feb00cc8",
           "fingerprint": "7e8542f406042396ea595c53",
           "item": "fn message_store",
-          "line": 3681
+          "line": 3679
         },
         {
           "id": "51723d390366120a3abf406a",
           "fingerprint": "23ba055600cc3437a7375e8a",
           "item": "fn message_store_unchecked",
-          "line": 3706
+          "line": 3704
         },
         {
           "id": "073675840d7d1847ac6b9986",
           "fingerprint": "c827c069638d3aa68520a4e4",
           "item": "fn message_store_unchecked_mut",
-          "line": 3711
+          "line": 3709
         },
         {
           "id": "2c94ed052f2870d2bea9a0e5",
           "fingerprint": "9cd2720850b21c7ba6852574",
           "item": "fn schedule_message_service",
-          "line": 3721
+          "line": 3719
         },
         {
           "id": "b10317af933e930e8e5eb2be",
           "fingerprint": "c6e6cb4278fe5f23928cbe9d",
           "item": "fn schedule_message_service_unchecked",
-          "line": 3726
+          "line": 3724
         },
         {
           "id": "bab394cd446ee88f68c6ddd5",
           "fingerprint": "3fa31838c3340571bc19a4a5",
           "item": "fn register_broker_all_inner",
-          "line": 4087
+          "line": 4085
         },
         {
           "id": "daaaf0da4630c3d390481e48",
           "fingerprint": "2a8132de51b1b9bbebef6afa",
           "item": "fn do_register_broker_all_inner",
-          "line": 4185
+          "line": 4183
         },
         {
           "id": "397e52506121c49464b3bd42",
           "fingerprint": "604fe15af2dc366b3c1d1774",
           "item": "fn bootstrap_controller_mode",
-          "line": 4248
+          "line": 4246
         },
         {
           "id": "f772ab897753003c3b31ce78",
           "fingerprint": "d73c8ce1a6d38fdadfa82088",
           "item": "fn apply_controller_replica_info",
-          "line": 4423
+          "line": 4421
         },
         {
           "id": "ac29bee3c291d5419f18d69b",
           "fingerprint": "31047896d79098c6d503858e",
           "item": "fn ensure_controller_broker_id",
-          "line": 4454
+          "line": 4452
         },
         {
           "id": "faeaca698e3042def1d5ca17",
           "fingerprint": "a0e5eaac85b95545b35def48",
           "item": "fn discover_controller_leader",
-          "line": 4521
+          "line": 4519
         },
         {
           "id": "077e0c83f6570b890f8218b1",
           "fingerprint": "2533bd3e1a1f747535f7d232",
           "item": "fn refresh_controller_leader",
-          "line": 4546
+          "line": 4544
         },
         {
           "id": "e06e6b9b1da0c69b604502dd",
           "fingerprint": "6127abc01652c94842823b44",
           "item": "fn sync_controller_replica_info",
-          "line": 4554
+          "line": 4552
         },
         {
           "id": "7758ba9d150d1bf2fb773517",
           "fingerprint": "fafa781033d91e20b0059b84",
           "item": "fn fetch_controller_replica_info",
-          "line": 4622
+          "line": 4620
         },
         {
           "id": "36f745dd8380e3136af2cc39",
           "fingerprint": "4d37a31386e95dcaaebb2c7c",
           "item": "fn sync_broker_member_group",
-          "line": 4657
+          "line": 4655
         },
         {
           "id": "3d53c2e89ab668e271f8142d",
           "fingerprint": "198bb68697b47e45b2d7539d",
           "item": "fn update_min_broker",
-          "line": 4701
+          "line": 4699
         },
         {
           "id": "3427582ef504bcbb0dceb9d6",
           "fingerprint": "ae555e6b3b3ad0a94f0de73e",
           "item": "fn ack_message_processor_unchecked",
-          "line": 4728
+          "line": 4726
         },
         {
           "id": "fe110583eb8708bc703ebd8e",
           "fingerprint": "3cec3e2aa6d0fb2fa1aa9196",
           "item": "fn query_assignment_processor_unchecked",
-          "line": 4736
+          "line": 4734
         },
         {
           "id": "df79f1f95a9e8ff82331286d",
           "fingerprint": "b6d49391281d848012e7c67a",
           "item": "fn query_assignment_processor",
-          "line": 4740
+          "line": 4738
         },
         {
           "id": "e20993d001795adb23cf8c7b",
           "fingerprint": "ce70b42c454fb5b3b890704d",
           "item": "fn query_assignment_processor_mut",
-          "line": 4744
+          "line": 4742
         },
         {
           "id": "1f1d6dd47e1103f2a385d99c",
           "fingerprint": "5bc8aad2956d9b8b26600f1b",
           "item": "fn query_assignment_processor_unchecked_mut",
-          "line": 4748
+          "line": 4746
         },
         {
           "id": "bcd154dd4496146de09f72ed",
           "fingerprint": "137d02287d2e84512645a7bd",
           "item": "fn start_service",
-          "line": 4805
+          "line": 4803
         },
         {
           "id": "2e408d42e425425565e4bb10",
           "fingerprint": "29427e076444659b1b597065",
           "item": "fn apply_controller_role_change",
-          "line": 4829
+          "line": 4827
         }
       ],
       "owner": "broker",
@@ -1080,7 +1068,7 @@
           "id": "2b6ee8edd4a6435a6b3007b2",
           "fingerprint": "6503d57af85359294b26eef5",
           "item": "fn new_controller_mode_message_store",
-          "line": 5997
+          "line": 5995
         }
       ],
       "owner": "broker",
@@ -1099,7 +1087,7 @@
           "id": "8895e852d36c6c4ae6c94696",
           "fingerprint": "a236422f00598205b2ff717d",
           "item": "fn new_controller_mode_message_store",
-          "line": 6000
+          "line": 5998
         }
       ],
       "owner": "broker",
@@ -1137,7 +1125,7 @@
           "id": "49d7d37cd53bb0360ffa9e98",
           "fingerprint": "fc95bb9dd1e409338174f0ca",
           "item": "mod tests",
-          "line": 5301
+          "line": 5299
         }
       ],
       "owner": "broker",
@@ -1175,7 +1163,7 @@
           "id": "76c8a751ce4984912169a2f1",
           "fingerprint": "7fc8adc251a6107872dc0c3c",
           "item": "fn new_controller_mode_message_store",
-          "line": 5997
+          "line": 5995
         }
       ],
       "owner": "broker",
@@ -1218,25 +1206,6 @@
       ],
       "owner": "broker",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "5180e60d4b7f33e2853b1d72",
-      "path": "rocketmq-broker/src/broker_runtime.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "0287fedd24aca5a7cf9ffcb4",
-          "fingerprint": "3ad37c963ddf37d78420e69d",
-          "item": "fn init_processor",
-          "line": 2256
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -1731,112 +1700,6 @@
           "fingerprint": "dc9d72fd67d70f856ad81177",
           "item": "fn new",
           "line": 76
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "86f91d50cdec45dc5c7fcb3b",
-      "path": "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "a10ac7be64eaa28f478ecf7a",
-          "fingerprint": "d2f15176be988d9698dc1634",
-          "item": "mod tests",
-          "line": 368
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "737bd1b7c783ec4720afefe3",
-      "path": "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "6961da8724a047b870df46a9",
-          "fingerprint": "a19b7f0f13c9e86f8a14a9cc",
-          "item": "fn start_is_idempotent_and_shutdown_stops_background_task",
-          "line": 378
-        },
-        {
-          "id": "f93f239057336168857f92e9",
-          "fingerprint": "3252f78605393153ed2c5f5d",
-          "item": "fn start_is_idempotent_and_shutdown_stops_background_task",
-          "line": 382
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "ce12030edc1f271f44fbc53f",
-      "path": "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "d646bda47651e1e9c0303dc5",
-          "fingerprint": "918d2ae10e65b664b57fde54",
-          "item": "<module>",
-          "line": 26
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "66d364f72ccc685954922c82",
-      "path": "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "9bc13ea5518cbfcd89f2e3f4",
-          "fingerprint": "742a4475090960f0d1192be5",
-          "item": "struct PullRequestHoldService",
-          "line": 45
-        },
-        {
-          "id": "1b60787beb5670a46d6272e9",
-          "fingerprint": "dec89ba920984bbcaf5259d7",
-          "item": "struct PullRequestHoldService",
-          "line": 48
-        },
-        {
-          "id": "ef6da8c023f6f856627000fb",
-          "fingerprint": "08e21b0dfc5e3f5ea994d4ad",
-          "item": "fn new",
-          "line": 59
-        },
-        {
-          "id": "fe5c83bffa49ecd2d286d7c6",
-          "fingerprint": "d50e14f8a57a4cb0324d9ec0",
-          "item": "fn new",
-          "line": 60
-        },
-        {
-          "id": "2aa3af1b69ba4831652c8d08",
-          "fingerprint": "19856624e169cae0b0cef3cc",
-          "item": "fn start",
-          "line": 80
         }
       ],
       "owner": "broker",
@@ -2996,13 +2859,13 @@
           "id": "64d33fc26cd1e8e0bc629bbc",
           "fingerprint": "36ad0099d952d8fdd6826204",
           "item": "fn change_special_service_status",
-          "line": 169
+          "line": 170
         },
         {
           "id": "c294c71bf7f5b4aa4485ac17",
           "fingerprint": "52e23399aed85552125cbe37",
           "item": "fn on_master_offline",
-          "line": 175
+          "line": 176
         }
       ],
       "owner": "broker",
@@ -3713,63 +3576,19 @@
           "id": "ff9c76817c6290ea9655ba92",
           "fingerprint": "43b8061b9dac967c6bd6ba0b",
           "item": "struct DefaultPullMessageResultHandler",
-          "line": 63
+          "line": 62
         },
         {
           "id": "f86535dc3a4900d88ed3e7b5",
           "fingerprint": "68e7a9c32dc6e3d8d4074ac7",
           "item": "fn new",
-          "line": 70
-        },
-        {
-          "id": "d917c6fb50b8e5e1871b7cce",
-          "fingerprint": "54609d84d566b4ea3a0599d5",
-          "item": "fn set_pull_request_hold_service",
-          "line": 81
+          "line": 69
         },
         {
           "id": "cfd93e07e04b19dc02fc8f50",
           "fingerprint": "9a05f3b003f5b0cd0849463c",
           "item": "fn compose_response_header",
-          "line": 473
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6d919072403c66216df3aadc",
-      "path": "rocketmq-broker/src/processor/default_pull_message_result_handler.rs",
-      "symbol": "LocalFileMessageStore",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "af4d5c58811f41b77625965f",
-          "fingerprint": "6183e4539d41dfe86b85f702",
-          "item": "<module>",
-          "line": 47
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "b17ba72b033433dd0e6b9889",
-      "path": "rocketmq-broker/src/processor/default_pull_message_result_handler.rs",
-      "symbol": "LocalFileMessageStore",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a33ae38ce4c988fa36b19d00",
-          "fingerprint": "52d1dd6cf85fb6a901610cf0",
-          "item": "fn set_pull_request_hold_service",
-          "line": 81
+          "line": 467
         }
       ],
       "owner": "broker",
@@ -4577,30 +4396,11 @@
           "id": "8000920bc9db3794a603c2a1",
           "fingerprint": "dbc7cea9e63f1ab8fd1b52ed",
           "item": "mod tests",
-          "line": 1109
+          "line": 1158
         }
       ],
       "owner": "broker",
       "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "afc86bd40f04e6b03053fb74",
-      "path": "rocketmq-broker/src/processor/pull_message_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "c165ae9236e6fe8f2ddca580",
-          "fingerprint": "228cfbb4496a462ab7fbf149",
-          "item": "fn new_processor",
-          "line": 1181
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -4615,7 +4415,7 @@
           "id": "d616d975df39f676f8a6e341",
           "fingerprint": "d2f6e00c47a19a9aac15f76e",
           "item": "<module>",
-          "line": 54
+          "line": 55
         }
       ],
       "owner": "broker",
@@ -4631,34 +4431,16 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "065797b2a07005c1fce49399",
-          "fingerprint": "03ab998a9bad3ced046aa539",
+          "id": "ec7fb818aece40112dece874",
+          "fingerprint": "1c1be1b5e6b6105b17f6952f",
           "item": "struct PullMessageProcessor",
-          "line": 122
+          "line": 128
         },
         {
-          "id": "c51655fe1d5e5ee935f5ac4a",
-          "fingerprint": "2f34bbcd3f4bda729be89c4f",
-          "item": "struct PullMessageProcessor",
-          "line": 126
-        },
-        {
-          "id": "b2000055c2c1898c3c180cba",
-          "fingerprint": "69e6ef5905e033e946b293b7",
+          "id": "f6b4964b9cf85d0b1e049dd0",
+          "fingerprint": "01c0acc87477a4026aaa994d",
           "item": "fn new",
-          "line": 185
-        },
-        {
-          "id": "7613d2a7da0008befcdd245e",
-          "fingerprint": "3397211ccec2b9df1e5b7a46",
-          "item": "fn new",
-          "line": 186
-        },
-        {
-          "id": "622d7aab3e17bd23f8a1f4b6",
-          "fingerprint": "1a3f21c48dd0a5d8cd545401",
-          "item": "fn execute_request_when_wakeup",
-          "line": 1021
+          "line": 206
         }
       ],
       "owner": "broker",
@@ -4677,19 +4459,19 @@
           "id": "9ac4fb052eb5bf898c969fb2",
           "fingerprint": "e66c2696c41fd52c91d11aaf",
           "item": "fn new_processor",
-          "line": 1180
+          "line": 1229
         },
         {
           "id": "40de34163d9d81c0c494bbea",
           "fingerprint": "23c89e6a2fd2b586616ff4ae",
           "item": "fn register_consumer_group_without_subscriptions",
-          "line": 1238
+          "line": 1287
         },
         {
           "id": "4a013d19193a45d02907a5b7",
           "fingerprint": "c52481050bf3c6b8c7c023b3",
           "item": "fn inject_subscription",
-          "line": 1253
+          "line": 1302
         }
       ],
       "owner": "broker",
@@ -5175,14 +4957,8 @@
           "line": 81
         },
         {
-          "id": "cf46b8bebd05985e4381ee5c",
-          "fingerprint": "dfe3eb63bab090647909a632",
-          "item": "enum BrokerProcessorType",
-          "line": 82
-        },
-        {
-          "id": "232db2389b9462ecce82337b",
-          "fingerprint": "674eae2f0fb49ef7178fe732",
+          "id": "dea3836c3c1b746623c0db95",
+          "fingerprint": "e1d0ab6e65d3705f72993efb",
           "item": "enum BrokerProcessorType",
           "line": 83
         },
@@ -5400,7 +5176,7 @@
           "id": "947a1f843673dfa391ae24bb",
           "fingerprint": "4aa4d3246843fb4aaeea89b2",
           "item": "<module>",
-          "line": 30
+          "line": 31
         }
       ],
       "owner": "broker",
@@ -5419,25 +5195,13 @@
           "id": "6f88cdcb85c2f36bcf23d809",
           "fingerprint": "f5158fda4debcee4cc4c995e",
           "item": "struct SendMessageProcessorV2",
-          "line": 42
+          "line": 43
         },
         {
           "id": "26b6afc9062a6ee9784d2ca9",
           "fingerprint": "13f7eab89dac3ad96953ca6e",
           "item": "fn new",
-          "line": 47
-        },
-        {
-          "id": "cb23525679d064338f69d981",
-          "fingerprint": "eb885f2715f61c9afcfe4bbf",
-          "item": "struct PullMessageProcessorV2",
-          "line": 78
-        },
-        {
-          "id": "ba9993621fd062d496128abf",
-          "fingerprint": "098f9c58f0d35751c0a1f647",
-          "item": "fn new",
-          "line": 83
+          "line": 48
         },
         {
           "id": "16a6d34e92747a140ad35f08",
@@ -5456,12 +5220,6 @@
           "fingerprint": "aa282e14972194ebea88addb",
           "item": "fn new",
           "line": 170
-        },
-        {
-          "id": "ca1937de04cdd842a704f61c",
-          "fingerprint": "ac4163808897814379227a5d",
-          "item": "fn new",
-          "line": 171
         },
         {
           "id": "37aad2286ee0c8a325990f81",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8387

### Brief Description

- Replace the Broker Pull processor, result-handler carrier, request-hold service, processor enum, runtime carrier, and migration example with standard `Arc` ownership.
- Keep only a standard `Weak` processor back-reference in `PullRequestHoldService`; expose a narrow shared capability for scan configuration, store offsets, and wake-up dispatch so the service no longer strongly owns `BrokerRuntimeInner`.
- Serialize start, shutdown, restart, and spawn rollback; open request admission only after the scan task is owned, reject stopped admission, clear retained requests on shutdown, and prevent stale deadline publication.
- Move master-online wake-up dispatch outside the request-table guard and release the minimum-broker snapshot write lock before asynchronous follow-up work.
- Update the reviewed ownership baseline and M11-12 migration evidence. The snapshot decreases from 473 identities / 1,227 occurrences to 465 / 1,204, with Broker production decreasing from 172/417 to 167/398 and no compatibility growth.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-targets --all-features`
- `cargo test -p rocketmq-broker pull_request_hold_service --lib` (5 passed)
- `cargo test -p rocketmq-broker pull_message_processor --lib` (14 passed)
- `cargo test -p rocketmq-broker phase4_broker_consumer_request_codes_dispatch_to_expected_processors --lib` (1 passed)
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` (567 passed, 25 pre-existing failures, 1 ignored; the failure list matches the previously reviewed main baseline)
- `cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings`
- `cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests` (82 passed)
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests` (9 passed)
- `cargo test -p rocketmq-broker --features rocksdb_store rocksdb` (20 passed)
- `cargo test -p rocketmq-broker --features rocksdb_store pop_consumer` (4 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard -v` (67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24 passed)
- Architecture target, baseline, release, performance, and 60 unit-test guards
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Broker pull-request lifecycle management and coordination.
  * Pull requests are now handled more reliably during startup, shutdown, restart, and master changes.
  * Pending requests are rejected or cleared appropriately when the service is stopping.
  * Improved deadline and wake-up handling for long-polling requests.

* **Documentation**
  * Updated production-readiness plans, progress tracking, validation results, and remaining migration milestones.

* **Tests**
  * Added and updated coverage for asynchronous lifecycle behavior, shutdown handling, and request rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->