### PR TITLE
[ISSUE #8389]♻️Replace Broker consumer offset version ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -676,7 +676,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ar Broker POP lifecycle ownership：`PopMessageProcessor`/`NotificationProcessor` root 与长轮询 service 改用标准 `Arc`，processor/service 与 service/scan-task 回边改为标准 `Weak`；共享 wake-up receiver、原子 cleanup 时间和异步 lifecycle gate 消除别名可变访问并串行 start/shutdown/restart
   - [x] M11-12as Broker POP Lite lifecycle ownership：`PopLiteMessageProcessor`/`PopLiteLongPollingService` root 与 Broker processor/runtime carrier 改用标准 `Arc`，processor 回边和 scan task 改用标准 `Weak`；共享 wake-up trait、每次 start 的新 channel、停止状态轮询拒绝与双层异步 lifecycle gate 消除共享可变别名并支持安全重启
   - [x] M11-12at Broker Pull lifecycle ownership：`PullMessageProcessor`/result handler/request-hold service 与 Broker carrier 改用标准 `Arc`，hold service 与 scan task 改用标准 `Weak`；共享 processor 能力、异步 lifecycle gate、停止准入/清理与锁内 deadline 发布消除强引用环、共享可变别名和 start/shutdown/deadline 竞态
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387 与每次真实下降
+  - [x] M11-12au Broker ConsumerOffsetManager ownership：`DataVersion` 以 `ArcSwap` 发布不可变代际，单一 transition 串行 offset/version 更新；主从 merge 与 JSON/RocksDB 恢复只发布完整 snapshot，删除可写 table escape、无用 Clone/runtime mutable accessor，并修复并发阈值与零步长 panic
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -723,7 +724,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8383 后实际快照降至 296 production/738 occurrence、166 test/463 occurrence；Broker 降至 174/430，POP/Notification lifecycle 共删除 2 个 production identity/26 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
   - [x] Issue #8385 后实际快照降至 294 production/725 occurrence、165 test/462 occurrence；Broker 降至 172/417，POP Lite lifecycle 共删除 2 个 production identity/13 occurrence 与 1 个 test identity/1 occurrence，compatibility 14/40 不增
   - [x] Issue #8387 后实际快照降至 289 production/706 occurrence、162 test/458 occurrence；Broker 降至 167/398，Pull lifecycle 共删除 5 个 production identity/19 occurrence 与 3 个 test identity/4 occurrence，compatibility 14/40 不增
-  - [ ] M11-12au 及后续：Broker ConsumerOffsetManager/root/schedule/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8389 后实际快照降至 287 production/699 occurrence、160 test/455 occurrence；Broker 降至 165/391，ConsumerOffset DataVersion owner 共删除 2 个 production identity/7 occurrence 与 2 个 test identity/3 occurrence，无 relocation，compatibility 14/40 不增
+  - [ ] M11-12av 及后续：Broker ScheduleMessageService/root/其他 processor/transaction、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -453,6 +453,12 @@ start/shutdown/restart，停止状态拒绝新挂起并清空既有请求，dead
 重入同一 Tokio RwLock。实际快照降至 289 production/706 occurrence、162 test/458 occurrence，Broker production 降至
 167/398；compatibility 保持 14/40。总进度仍为 75/82，下一子切片 M11-12au 处理 Broker ConsumerOffsetManager
 ownership，M11-12 父工作包未完成。
+Broker ConsumerOffsetManager ownership 随 Issue #8389 将 `DataVersion` 改为 `ArcSwap` 不可变代际，并以单一
+transition 串行 offset 表写入、版本计数和完整发布；`fetch_add` 返回值精确决定更新阈值，零步长不再除零 panic。
+主从同步改用窄 merge API，JSON/RocksDB 在完整解析后一次发布，reset/pull 表可在主表为空时恢复；manager/table
+Clone 与可写 table lock escape、无用 runtime mutable accessor 已删除。实际快照降至 287 production/699 occurrence、
+160 test/455 occurrence，Broker production 降至 165/391；compatibility 保持 14/40。总进度仍为 75/82，下一
+子切片 M11-12av 处理 Broker `ScheduleMessageService` 内部状态 ownership，M11-12 父工作包未完成。
 
 ### 9.3 证据目录
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -468,6 +468,13 @@ deadline 发布与 master-change lock 顺序已收紧。实际快照为 289 prod
 Broker owner 为 167/398；compatibility 14/40 不增。下一子切片 M11-12au 处理 Broker ConsumerOffsetManager ownership，
 完整候选快照与 HUMAN Gate 仍保持开放。
 
+M11-12au 已将 ConsumerOffsetManager 的 `DataVersion` 改为 `ArcSwap` 不可变代际，并由单一短 transition 串行
+offset 表写入、版本计数和发布。主从同步、JSON/RocksDB load/persist 使用 manager 窄 API 和 owned snapshot；
+失败解析不再先发布新版本，空主表仍恢复 reset/pull 表。可写 offset table escape、manager/wrapper Clone 与只读
+encode 所需的 runtime mutable accessor 已删除；`ArcMut<MessageStore>` 明确保留给 Store/root 后续切片。实际快照为
+287 production/699 occurrences、160 test/455 occurrences，Broker owner 为 165/391；compatibility 14/40 不增。
+下一子切片 M11-12av 处理 Broker `ScheduleMessageService` 内部状态 ownership，完整候选快照与 HUMAN Gate 仍保持开放。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -6,7 +6,7 @@ M11-12 的最终目标是 production/public compatibility API 中不存在 `ArcM
 `mut_from_ref` 或 clone-safe `AsMut`/`DerefMut`，并让默认 workspace 在 stable Rust 下通过，同时把 Miri/Loom、
 soak、SLO fault、dashboard/runbook、rollback 和 Human Gate 绑定到同一候选快照。
 
-该目标尚未完成。本文件记录 M11-12a～as 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
+该目标尚未完成。本文件记录 M11-12a～au 子切片的真实下降，不把子切片计为第 76 个工作包，也不刷新
 baseline 来掩盖剩余债务。父 Issue 为 #8292；M11-12a 子切片 Issue 为 #8293；分支为
 `mxsm/architecture-refactor-owned-values`。
 
@@ -128,6 +128,12 @@ M11-12ar 的 Broker POP lifecycle ownership 由 Issue #8383 跟踪，分支为
 
 M11-12as 的 Broker POP Lite lifecycle ownership 由 Issue #8385 跟踪，分支为
 `mxsm/architecture-refactor-broker-pop-lite-lifecycle-ownership`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12at 的 Broker Pull lifecycle ownership 由 Issue #8387 跟踪，分支为
+`mxsm/architecture-refactor-broker-pull-lifecycle-ownership`；它仍是同一 M11-12 工作包的子切片。
+
+M11-12au 的 Broker ConsumerOffsetManager ownership 由 Issue #8389 跟踪，分支为
+`mxsm/architecture-refactor-broker-consumer-offset-version`；它仍是同一 M11-12 工作包的子切片。
 
 ## 初始盘点
 
@@ -2004,10 +2010,39 @@ Broker Pull lifecycle ownership 随 Issue #8387 完成以下边界收敛：
 下一子切片 M11-12au 处理 `ConsumerOffsetManager` immutable/serialized ownership；75/82 总进度不变，Broker/Store、
 compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
 
+## M11-12au 实现
+
+Broker ConsumerOffsetManager ownership 随 Issue #8389 完成以下边界收敛：
+
+- `ConsumerOffsetManager` 保持由 BrokerRuntimeInner 按值独占，不新增 root `Arc`；删除 manager/wrapper 无调用的 Clone、完整可写 offset-table lock escape、无用 mutable accessor 与 setter。Lite lag/diagnostics 只读取 owned snapshot 或长度。
+- `DataVersion` 改由 `ArcSwap` 发布完整不可变代际；单一短 transition 串行 offset/reset/pull 写入、commit 计数和版本发布，旧 reader 在更新后继续持有旧 snapshot。`ArcMut<MessageStore>` 初始化 carrier 明确延期到 Store/root 切片。
+- `commit_offset` 使用 `fetch_add` 返回值精确判断 `consumer_offset_update_version_step`，并发 writer 不再经第二次 load 重复或漏过阈值；非正 step 不再触发取模除零 panic。
+- Broker pre-online/slave 同步通过单一 `merge_offsets_from_peer` 安装表与版本，不再分别取得可写 DataVersion/table owner；read-only admin encode 改用共享 accessor。
+- JSON serialize 在 transition 内构造一致视图，decode 即使主 offset 表为空也恢复 reset/pull/version；RocksDB 先完整读取和解析全部记录，成功后一次发布，解析失败不再留下新版本或部分新表。RocksDB persist 在锁内克隆表与版本、锁外编码和 I/O。
+- reviewed baseline 从 465 identities / 1,204 occurrences 降至 461 / 1,194；production 从 289/706 降至 287/699，test 从 162/458 降至 160/455，compatibility 保持 14/40。Broker production 为 165/391、test 为 60/74；净删除 2 个 production identity/7 occurrence 与 2 个 test identity/3 occurrence，无新增 identity或 fingerprint relocation。
+
+## M11-12au 验证
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-broker --all-targets --all-features` | 通过；ArcSwap generation、transition、narrow peer/table API 与全部 Broker targets/features 编译通过 |
+| ConsumerOffset focused default/all-feature tests | 13/13、15/15 通过；覆盖旧 snapshot 隔离、16 writer 精确阈值、零步长、peer merge、空主表 JSON reset/pull round-trip 与 RocksDB restart/delete |
+| processor/export/file→RocksDB migration focused tests | 1/1、1/1、2/2 通过；wire handler round-trip、JSON export、single/separate RocksDB metadata migration/recovery 保持通过 |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 572 passed、25 failed、1 ignored；相对上一 main 的 567 passed、25 failed、1 ignored，新增 5 个测试全部通过且失败名单完全一致，故不能把全套记为通过，也未新增 baseline failure |
+| RocksDB specialized gates | Store/Broker strict Clippy 通过；foundation 82/82、semantics 9/9、Broker `rocksdb` 20/20、`pop_consumer` 4/4 通过 |
+| reviewed baseline reduction / `python scripts/arc_mut_guard.py` | baseline 465/1,204→461/1,194，无 relocation/临时 approval；guard 通过，production 287/699、test 160/455、compatibility 14/40，Broker production 165/391 |
+| ArcMut / architecture guard tests | ArcMut 67/67、fixtures 24/24、architecture dependency/release/performance 60/60 通过；target/baseline/release/performance profiles 全绿 |
+| `cargo fmt --all -- --check` / root workspace strict Clippy | 通过；root workspace 32 个 package 的 all-targets/all-features `-D warnings` profile 通过 |
+| runtime audit / AGENTS routing / `git diff --check` | runtime boundary 与 routing 通过；4 个 standalone Cargo、3 个 Node project、8 条 route；diff check 无 whitespace error |
+
+下一子切片 M11-12av 处理 Broker `ScheduleMessageService` 内部 offset/delay/DataVersion/status ownership；75/82 总进度
+不变，Broker root/其他 processor/transaction、Store、compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate
+仍保持开放。
+
 ## 剩余切片与 Gate
 
-1. Broker offset、BrokerRuntimeInner、schedule/其他 processor/transaction owner（167/398）；下一子切片 M11-12au
-   处理 ConsumerOffsetManager immutable/serialized ownership。
+1. Broker BrokerRuntimeInner、schedule/其他 processor/transaction owner（165/391）；下一子切片 M11-12av 处理
+   `ScheduleMessageService` 内部 offset/delay/DataVersion/status ownership。
 2. Store MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（122/308）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -234,21 +234,11 @@ where
             .await
         {
             Ok(Some(offset_wrapper)) => {
-                let local_version = self
-                    .broker_runtime_inner
-                    .consumer_offset_manager()
-                    .data_version()
-                    .as_ref()
-                    .clone();
+                let local_version = self.broker_runtime_inner.consumer_offset_manager().data_version();
                 if should_sync_from_peer(&local_version, Some(offset_wrapper.data_version())) {
                     let consumer_offset_manager = self.broker_runtime_inner.consumer_offset_manager();
-                    consumer_offset_manager
-                        .data_version()
-                        .assign_new_one(offset_wrapper.data_version());
-                    let offset_table = consumer_offset_manager.offset_table();
-                    let mut consumer_offset_table = offset_table.write();
-                    consumer_offset_table.extend(offset_wrapper.offset_table());
-                    drop(consumer_offset_table);
+                    let data_version = offset_wrapper.data_version().clone();
+                    consumer_offset_manager.merge_offsets_from_peer(offset_wrapper.offset_table(), data_version);
                     consumer_offset_manager.persist();
                     info!(
                         "{}'s consumer offset data version is newer or equal, merged into local broker",

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -3429,11 +3429,6 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn consumer_offset_manager_mut(&mut self) -> &mut ConsumerOffsetManager<MS> {
-        &mut self.consumer_offset_manager
-    }
-
-    #[inline]
     pub fn subscription_group_manager_mut(&mut self) -> &mut SubscriptionGroupManager<MS> {
         self.subscription_group_manager.as_mut().unwrap()
     }
@@ -3911,11 +3906,6 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn set_topic_queue_mapping_manager(&mut self, topic_queue_mapping_manager: TopicQueueMappingManager) {
         self.topic_queue_mapping_manager = topic_queue_mapping_manager;
-    }
-
-    #[inline]
-    pub fn set_consumer_offset_manager(&mut self, consumer_offset_manager: ConsumerOffsetManager<MS>) {
-        self.consumer_offset_manager = consumer_offset_manager;
     }
 
     #[inline]

--- a/rocketmq-broker/src/lite/lite_consumer_lag_calculator.rs
+++ b/rocketmq-broker/src/lite/lite_consumer_lag_calculator.rs
@@ -111,11 +111,10 @@ impl LiteConsumerLagCalculator {
         broker_runtime_inner: &BrokerRuntimeInner<MS>,
         target_group: Option<&CheetahString>,
     ) -> Vec<(CheetahString, i64)> {
-        let offset_table = broker_runtime_inner.consumer_offset_manager().offset_table();
-        let read_guard = offset_table.read();
+        let offset_table = broker_runtime_inner.consumer_offset_manager().offset_table_snapshot();
         let mut offsets = Vec::new();
 
-        for (topic_at_group, queue_offsets) in read_guard.iter() {
+        for (topic_at_group, queue_offsets) in &offset_table {
             let Some((topic, group)) = topic_at_group.as_str().split_once(TOPIC_GROUP_SEPARATOR) else {
                 continue;
             };

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use cheetah_string::CheetahBuilder;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
@@ -76,7 +77,6 @@ fn split_topic_group_key(key: &CheetahString) -> Option<(&str, &str)> {
     Some((topic, group))
 }
 
-#[derive(Clone)]
 pub(crate) struct ConsumerOffsetManager<MS: MessageStore> {
     broker_config: Arc<BrokerConfig>,
     message_store_config: Arc<MessageStoreConfig>,
@@ -99,11 +99,12 @@ where
             broker_config,
             message_store_config,
             consumer_offset_wrapper: ConsumerOffsetWrapper {
-                data_version: ArcMut::new(DataVersion::default()),
-                offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
-                reset_offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
-                pull_offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
-                version_change_counter: Arc::new(AtomicI64::new(0)),
+                data_version: ArcSwap::from_pointee(DataVersion::default()),
+                data_version_transition: parking_lot::Mutex::new(()),
+                offset_table: parking_lot::RwLock::new(HashMap::new()),
+                reset_offset_table: parking_lot::RwLock::new(HashMap::new()),
+                pull_offset_table: parking_lot::RwLock::new(HashMap::new()),
+                version_change_counter: AtomicI64::new(0),
             },
             message_store,
             #[cfg(feature = "rocksdb_store")]
@@ -159,6 +160,7 @@ where
         queue_id: i32,
         offset: i64,
     ) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_key(topic, group);
         self.consumer_offset_wrapper
             .pull_offset_table
@@ -174,6 +176,7 @@ where
         group: &CheetahString,
         queue_id: i32,
     ) -> Option<i64> {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_lookup_key(topic, group);
         let mut write_guard = self.consumer_offset_wrapper.reset_offset_table.write();
         let offset_table = write_guard.get_mut(key.as_str());
@@ -184,6 +187,7 @@ where
     }
 
     pub fn assign_reset_offset(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32, offset: i64) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_key(topic, group);
         self.consumer_offset_wrapper
             .reset_offset_table
@@ -206,11 +210,13 @@ where
     }
 
     pub fn clear_pull_offset(&self, group: &CheetahString, topic: &CheetahString) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_key(topic, group);
         self.consumer_offset_wrapper.pull_offset_table.write().remove(&key);
     }
 
     pub fn clone_offset(&self, src_group: &CheetahString, dest_group: &CheetahString, topic: &CheetahString) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let src_key = build_topic_group_key(topic, src_group);
         let Some(offsets) = self.consumer_offset_wrapper.offset_table.read().get(&src_key).cloned() else {
             return;
@@ -244,6 +250,7 @@ where
         queue_id: i32,
         offset: i64,
     ) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_key(topic, group);
 
         {
@@ -265,26 +272,19 @@ where
             map.insert(queue_id, offset);
         }
 
-        let _ = self
+        let committed_updates = self
             .consumer_offset_wrapper
             .version_change_counter
-            .fetch_add(1, Ordering::Release);
-        if self
-            .consumer_offset_wrapper
-            .version_change_counter
-            .load(Ordering::Acquire)
-            % self.broker_config.consumer_offset_update_version_step
-            == 0
-        {
+            .fetch_add(1, Ordering::AcqRel)
+            + 1;
+        let update_step = self.broker_config.consumer_offset_update_version_step;
+        if update_step > 0 && committed_updates % update_step == 0 {
             let state_machine_version = if let Some(ref message_store) = self.message_store {
                 message_store.get_state_machine_version()
             } else {
                 0
             };
-            self.consumer_offset_wrapper
-                .data_version
-                .mut_from_ref()
-                .next_version_with(state_machine_version);
+            self.advance_data_version_with_locked(state_machine_version);
         }
     }
 
@@ -380,32 +380,62 @@ where
         topics
     }
 
-    pub fn offset_table(&self) -> Arc<parking_lot::RwLock<HashMap<CheetahString, HashMap<i32, i64>>>> {
-        self.consumer_offset_wrapper.offset_table.clone()
+    pub fn offset_table_snapshot(&self) -> HashMap<CheetahString, HashMap<i32, i64>> {
+        self.consumer_offset_wrapper.offset_table.read().clone()
     }
 
-    pub fn data_version(&self) -> ArcMut<DataVersion> {
-        self.consumer_offset_wrapper.data_version.clone()
+    pub fn offset_table_len(&self) -> usize {
+        self.consumer_offset_wrapper.offset_table.read().len()
+    }
+
+    pub fn data_version(&self) -> Arc<DataVersion> {
+        self.consumer_offset_wrapper.data_version.load_full()
+    }
+
+    pub(crate) fn advance_data_version(&self) {
+        self.advance_data_version_with(0);
+    }
+
+    fn advance_data_version_with(&self, state_machine_version: i64) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+        self.advance_data_version_with_locked(state_machine_version);
+    }
+
+    fn advance_data_version_with_locked(&self, state_machine_version: i64) {
+        let mut data_version = self.consumer_offset_wrapper.data_version.load_full().as_ref().clone();
+        data_version.next_version_with(state_machine_version);
+        self.consumer_offset_wrapper.data_version.store(Arc::new(data_version));
+    }
+
+    pub(crate) fn merge_offsets_from_peer(
+        &self,
+        offset_table: HashMap<CheetahString, HashMap<i32, i64>>,
+        data_version: DataVersion,
+    ) {
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+        self.consumer_offset_wrapper.offset_table.write().extend(offset_table);
+        self.consumer_offset_wrapper.data_version.store(Arc::new(data_version));
     }
 
     fn remove_keys_matching<F>(&self, predicate: F)
     where
         F: Fn(&CheetahString) -> bool,
     {
-        let keys_to_remove: Vec<CheetahString> = self
-            .consumer_offset_wrapper
-            .offset_table
-            .read()
-            .keys()
-            .filter(|key| predicate(key))
-            .cloned()
-            .collect();
+        let _keys_to_remove = {
+            let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+            let keys_to_remove: Vec<CheetahString> = self
+                .consumer_offset_wrapper
+                .offset_table
+                .read()
+                .keys()
+                .filter(|key| predicate(key))
+                .cloned()
+                .collect();
 
-        if keys_to_remove.is_empty() {
-            return;
-        }
+            if keys_to_remove.is_empty() {
+                return;
+            }
 
-        {
             let mut offset_table = self.consumer_offset_wrapper.offset_table.write();
             let mut reset_offset_table = self.consumer_offset_wrapper.reset_offset_table.write();
             let mut pull_offset_table = self.consumer_offset_wrapper.pull_offset_table.write();
@@ -414,10 +444,11 @@ where
                 reset_offset_table.remove(key);
                 pull_offset_table.remove(key);
             }
-        }
+            keys_to_remove
+        };
 
         #[cfg(feature = "rocksdb_store")]
-        if let Err(error) = self.delete_offsets_from_rocksdb(&keys_to_remove) {
+        if let Err(error) = self.delete_offsets_from_rocksdb(&_keys_to_remove) {
             error!("delete consumer offsets from rocksdb failed: {}", error);
         }
     }
@@ -430,7 +461,7 @@ where
         for key in keys {
             rocksdb_config_manager.delete(key.as_str())?;
         }
-        rocksdb_config_manager.set_kv_data_version(self.consumer_offset_wrapper.data_version.as_ref().clone())?;
+        rocksdb_config_manager.set_kv_data_version(self.data_version().as_ref().clone())?;
         self.flush_rocksdb_config_if_needed(rocksdb_config_manager)
     }
 
@@ -476,18 +507,14 @@ where
             return false;
         };
 
-        match rocksdb_config_manager.load_data_version() {
-            Ok(Some(data_version)) => self
-                .consumer_offset_wrapper
-                .data_version
-                .mut_from_ref()
-                .assign_new_one(&data_version),
-            Ok(None) => {}
+        let data_version = match rocksdb_config_manager.load_data_version() {
+            Ok(Some(data_version)) => data_version,
+            Ok(None) => self.data_version().as_ref().clone(),
             Err(error) => {
                 error!("load consumer offset rocksdb dataVersion failed: {}", error);
                 return false;
             }
-        }
+        };
 
         let records = match rocksdb_config_manager.load_data() {
             Ok(records) => records,
@@ -497,7 +524,7 @@ where
             }
         };
 
-        let mut offset_table = self.consumer_offset_wrapper.offset_table.write();
+        let mut decoded_offsets = HashMap::with_capacity(records.len());
         for (key, body) in records {
             let topic_at_group = match String::from_utf8(key) {
                 Ok(value) => CheetahString::from_string(value),
@@ -513,8 +540,15 @@ where
                     return false;
                 }
             };
-            offset_table.insert(topic_at_group, wrapper.offset_table);
+            decoded_offsets.insert(topic_at_group, wrapper.offset_table);
         }
+
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+        self.consumer_offset_wrapper
+            .offset_table
+            .write()
+            .extend(decoded_offsets);
+        self.consumer_offset_wrapper.data_version.store(Arc::new(data_version));
         true
     }
 
@@ -523,10 +557,14 @@ where
         let Some(rocksdb_config_manager) = &self.rocksdb_config_manager else {
             return Ok(());
         };
-        let records = self
-            .consumer_offset_wrapper
-            .offset_table
-            .read()
+        let (data_version, offset_table) = {
+            let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+            (
+                self.consumer_offset_wrapper.data_version.load_full(),
+                self.consumer_offset_wrapper.offset_table.read().clone(),
+            )
+        };
+        let records = offset_table
             .iter()
             .map(|(key, offset_table)| {
                 let wrapper = RocksDbOffsetSerializeWrapper {
@@ -542,7 +580,7 @@ where
                 )
             })?;
         rocksdb_config_manager.batch_put_with_wal(&records)?;
-        rocksdb_config_manager.set_kv_data_version(self.consumer_offset_wrapper.data_version.as_ref().clone())?;
+        rocksdb_config_manager.set_kv_data_version(data_version.as_ref().clone())?;
         self.flush_rocksdb_config_if_needed(rocksdb_config_manager)
     }
 
@@ -644,14 +682,22 @@ where
             return;
         }
         let wrapper = SerdeJsonUtils::from_json_str::<ConsumerOffsetWrapper>(json_string).unwrap();
-        if !wrapper.offset_table.read().is_empty() {
-            self.consumer_offset_wrapper
-                .offset_table
-                .write()
-                .extend(wrapper.offset_table.read().clone());
-            let data_version = self.consumer_offset_wrapper.data_version.mut_from_ref();
-            *data_version = wrapper.data_version.as_ref().clone();
-        }
+        let data_version = wrapper.data_version.load_full();
+        let offset_table = wrapper.offset_table.read().clone();
+        let reset_offset_table = wrapper.reset_offset_table.read().clone();
+        let pull_offset_table = wrapper.pull_offset_table.read().clone();
+
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+        self.consumer_offset_wrapper.offset_table.write().extend(offset_table);
+        self.consumer_offset_wrapper
+            .reset_offset_table
+            .write()
+            .extend(reset_offset_table);
+        self.consumer_offset_wrapper
+            .pull_offset_table
+            .write()
+            .extend(pull_offset_table);
+        self.consumer_offset_wrapper.data_version.store(data_version);
     }
 }
 
@@ -662,18 +708,29 @@ struct RocksDbOffsetSerializeWrapper {
     offset_table: HashMap<i32, i64>,
 }
 
-#[derive(Default, Clone)]
 struct ConsumerOffsetWrapper {
-    data_version: ArcMut<DataVersion>,
+    data_version: ArcSwap<DataVersion>,
+    data_version_transition: parking_lot::Mutex<()>,
     // Pop mode offset table
-    offset_table: Arc<parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>>,
+    offset_table: parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>,
     // Pop mode reset offset table
-    reset_offset_table:
-        Arc<parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>>,
+    reset_offset_table: parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>,
     //Pull mode offset table
-    pull_offset_table:
-        Arc<parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>>,
-    version_change_counter: Arc<AtomicI64>,
+    pull_offset_table: parking_lot::RwLock<HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>>,
+    version_change_counter: AtomicI64,
+}
+
+impl Default for ConsumerOffsetWrapper {
+    fn default() -> Self {
+        Self {
+            data_version: ArcSwap::from_pointee(DataVersion::default()),
+            data_version_transition: parking_lot::Mutex::new(()),
+            offset_table: parking_lot::RwLock::new(HashMap::new()),
+            reset_offset_table: parking_lot::RwLock::new(HashMap::new()),
+            pull_offset_table: parking_lot::RwLock::new(HashMap::new()),
+            version_change_counter: AtomicI64::new(0),
+        }
+    }
 }
 
 impl ConsumerOffsetWrapper {
@@ -695,8 +752,10 @@ impl ConsumerOffsetWrapper {
 
 impl Serialize for ConsumerOffsetWrapper {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let _transition = self.data_version_transition.lock();
         let mut state = serializer.serialize_struct("ConsumerOffsetWrapper", 5)?;
-        state.serialize_field("dataVersion", self.data_version.as_ref())?;
+        let data_version = self.data_version.load_full();
+        state.serialize_field("dataVersion", data_version.as_ref())?;
         state.serialize_field("offsetTable", &*self.offset_table.read())?;
         state.serialize_field("resetOffsetTable", &*self.reset_offset_table.read())?;
         state.serialize_field("pullOffsetTable", &*self.pull_offset_table.read())?;
@@ -794,11 +853,12 @@ impl<'de> Deserialize<'de> for ConsumerOffsetWrapper {
                 let pull_offset_table = pull_offset_table.unwrap_or_default();
 
                 Ok(ConsumerOffsetWrapper {
-                    data_version: ArcMut::new(data_version),
-                    offset_table: Arc::new(parking_lot::RwLock::new(offset_table)),
-                    reset_offset_table: Arc::new(parking_lot::RwLock::new(reset_offset_table)),
-                    pull_offset_table: Arc::new(parking_lot::RwLock::new(pull_offset_table)),
-                    version_change_counter: Arc::new(AtomicI64::new(0)),
+                    data_version: ArcSwap::from_pointee(data_version),
+                    data_version_transition: parking_lot::Mutex::new(()),
+                    offset_table: parking_lot::RwLock::new(offset_table),
+                    reset_offset_table: parking_lot::RwLock::new(reset_offset_table),
+                    pull_offset_table: parking_lot::RwLock::new(pull_offset_table),
+                    version_change_counter: AtomicI64::new(0),
                 })
             }
         }
@@ -814,13 +874,12 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::sync::Barrier;
 
     use cheetah_string::CheetahString;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
-    #[cfg(feature = "rocksdb_store")]
     use rocketmq_common::common::config_manager::ConfigManager;
-    #[cfg(feature = "rocksdb_store")]
-    use rocketmq_remoting::protocol::data_version_facade::DataVersionExt;
+    use rocketmq_remoting::protocol::DataVersion;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 
@@ -925,12 +984,10 @@ mod tests {
         assert_eq!(manager.query_offset(&group, &topic, 0), -1);
         assert!(!manager.has_offset_reset(group.as_str(), topic.as_str(), 0));
         assert!(!manager
-            .offset_table()
-            .read()
+            .offset_table_snapshot()
             .contains_key(&CheetahString::from_static_str("topic-a@group-a")));
         assert!(manager
-            .offset_table()
-            .read()
+            .offset_table_snapshot()
             .contains_key(&CheetahString::from_static_str("topic-a@group-b")));
     }
 
@@ -1014,6 +1071,134 @@ mod tests {
     }
 
     #[test]
+    fn data_version_snapshots_remain_immutable_after_publish() {
+        let manager = new_manager();
+        let initial = manager.data_version();
+
+        manager.advance_data_version();
+        let advanced = manager.data_version();
+
+        assert_eq!(initial.counter(), 0);
+        assert_eq!(advanced.counter(), 1);
+        assert!(!Arc::ptr_eq(&initial, &advanced));
+    }
+
+    #[test]
+    fn concurrent_commits_advance_data_version_once_per_threshold() {
+        const COMMIT_COUNT: usize = 16;
+
+        let mut manager = new_manager();
+        Arc::get_mut(&mut manager.broker_config)
+            .expect("test manager should own its broker config")
+            .consumer_offset_update_version_step = 1;
+        let manager = Arc::new(manager);
+        let barrier = Arc::new(Barrier::new(COMMIT_COUNT));
+        let mut workers = Vec::with_capacity(COMMIT_COUNT);
+
+        for queue_id in 0..COMMIT_COUNT {
+            let manager = manager.clone();
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                manager.commit_offset(
+                    "127.0.0.1:10911".into(),
+                    &CheetahString::from_static_str("group-a"),
+                    &CheetahString::from_static_str("topic-a"),
+                    queue_id as i32,
+                    queue_id as i64,
+                );
+            }));
+        }
+
+        for worker in workers {
+            worker.join().expect("consumer offset commit worker should finish");
+        }
+
+        assert_eq!(manager.data_version().counter(), COMMIT_COUNT as i64);
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            COMMIT_COUNT as i64
+        );
+        assert_eq!(manager.offset_table_snapshot()["topic-a@group-a"].len(), COMMIT_COUNT);
+    }
+
+    #[test]
+    fn zero_version_update_step_does_not_panic_or_advance_version() {
+        let mut manager = new_manager();
+        Arc::get_mut(&mut manager.broker_config)
+            .expect("test manager should own its broker config")
+            .consumer_offset_update_version_step = 0;
+
+        manager.commit_offset(
+            "127.0.0.1:10911".into(),
+            &CheetahString::from_static_str("group-a"),
+            &CheetahString::from_static_str("topic-a"),
+            0,
+            1,
+        );
+
+        assert_eq!(manager.data_version().counter(), 0);
+    }
+
+    #[test]
+    fn merge_offsets_from_peer_publishes_complete_version_generation() {
+        let manager = new_manager();
+        let local_group = CheetahString::from_static_str("group-local");
+        let topic = CheetahString::from_static_str("topic-a");
+        manager.commit_offset("127.0.0.1:10911".into(), &local_group, &topic, 0, 7);
+
+        let mut remote_offsets = HashMap::new();
+        remote_offsets.insert(
+            CheetahString::from_static_str("topic-a@group-remote"),
+            HashMap::from([(0, 19)]),
+        );
+        let remote_version = DataVersion::with_values(3, 4, 5);
+        manager.merge_offsets_from_peer(remote_offsets, remote_version.clone());
+
+        assert_eq!(manager.query_offset(&local_group, &topic, 0), 7);
+        assert_eq!(
+            manager.query_offset(&CheetahString::from_static_str("group-remote"), &topic, 0),
+            19
+        );
+        assert_eq!(manager.data_version().as_ref(), &remote_version);
+    }
+
+    #[test]
+    fn json_round_trip_preserves_version_reset_and_pull_tables_without_committed_offsets() {
+        let manager = new_manager();
+        let group = CheetahString::from_static_str("group-a");
+        let topic = CheetahString::from_static_str("topic-a");
+        manager.assign_reset_offset(&topic, &group, 0, 5);
+        manager.commit_pull_offset(
+            std::net::SocketAddr::from(([127, 0, 0, 1], 10911)),
+            &group,
+            &topic,
+            0,
+            9,
+        );
+        manager.advance_data_version();
+
+        let encoded = manager.encode();
+        let restored = new_manager();
+        restored.decode(encoded.as_str());
+
+        assert_eq!(restored.data_version().counter(), 1);
+        assert_eq!(restored.query_then_erase_reset_offset(&topic, &group, 0), Some(5));
+        assert_eq!(
+            restored
+                .consumer_offset_wrapper
+                .pull_offset_table
+                .read()
+                .get("topic-a@group-a")
+                .and_then(|offsets| offsets.get(&0)),
+            Some(&9)
+        );
+    }
+
+    #[test]
     fn query_offsets_returns_full_queue_map() {
         let manager = new_manager();
         let group = CheetahString::from_static_str("group-a");
@@ -1056,7 +1241,7 @@ mod tests {
 
         manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 12);
         manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 1, 24);
-        manager.data_version().mut_from_ref().next_version();
+        manager.advance_data_version();
         manager.persist();
         drop(manager);
 
@@ -1109,7 +1294,7 @@ mod tests {
         let topic = CheetahString::from_static_str("topic-a");
 
         manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 12);
-        manager.data_version().mut_from_ref().next_version();
+        manager.advance_data_version();
         manager.persist();
         manager.clean_offset_by_group(&group);
         drop(manager);

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -738,8 +738,6 @@ mod tests {
     use rocketmq_remoting::connection::Connection;
     use rocketmq_remoting::net::channel::Channel;
     use rocketmq_remoting::net::channel::ChannelInner;
-    #[cfg(feature = "rocksdb_store")]
-    use rocketmq_remoting::protocol::data_version_facade::DataVersionExt;
     use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
     #[cfg(feature = "rocksdb_store")]
@@ -1041,11 +1039,7 @@ mod tests {
                 0,
                 77,
             );
-            inner_mut
-                .consumer_offset_manager()
-                .data_version()
-                .mut_from_ref()
-                .next_version();
+            inner_mut.consumer_offset_manager().advance_data_version();
             inner_mut.consumer_offset_manager().persist();
             let mut group_config = SubscriptionGroupConfig::new(group.clone());
             group_config.set_consume_broadcast_enable(false);

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -518,7 +518,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response = RemotingCommand::create_response_command();
-        let content = self.broker_runtime_inner.consumer_offset_manager_mut().encode();
+        let content = self.broker_runtime_inner.consumer_offset_manager().encode();
         if !content.is_empty() {
             response.set_body_mut_ref(content);
             Ok(Some(response))

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -128,13 +128,7 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
                 .map_or(0, |processor| processor.order_info_count()),
         );
         body.set_cq_table_size(cq_table_size);
-        body.set_offset_table_size(
-            self.broker_runtime_inner
-                .consumer_offset_manager()
-                .offset_table()
-                .read()
-                .len() as i32,
-        );
+        body.set_offset_table_size(self.broker_runtime_inner.consumer_offset_manager().offset_table_len() as i32);
         body.set_event_map_size(self.broker_runtime_inner.lite_event_dispatcher().event_map_size() as i32);
         body.set_topic_meta(topic_meta);
         body.set_group_meta(group_meta);

--- a/rocketmq-broker/src/slave/slave_synchronize.rs
+++ b/rocketmq-broker/src/slave/slave_synchronize.rs
@@ -194,13 +194,9 @@ where
                     Ok(offset_wrapper) => {
                         if let Some(offset_wrapper) = offset_wrapper {
                             let consumer_offset_manager = self.broker_runtime_inner.consumer_offset_manager();
+                            let data_version = offset_wrapper.data_version().clone();
                             consumer_offset_manager
-                                .data_version()
-                                .assign_new_one(offset_wrapper.data_version());
-                            let offset_table = consumer_offset_manager.offset_table();
-                            let mut consumer_offset_table = offset_table.write();
-                            consumer_offset_table.extend(offset_wrapper.offset_table());
-                            drop(consumer_offset_table);
+                                .merge_offsets_from_peer(offset_wrapper.offset_table(), data_version);
                             consumer_offset_manager.persist();
                             info!("Update slave consumer offset from master, {}", master_addr);
                         } else {

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -553,7 +553,7 @@
           "id": "ab7b36e73225c82ba5237e56",
           "fingerprint": "3f50ae58593a221c0712bf87",
           "item": "mod tests",
-          "line": 5308
+          "line": 5298
         }
       ],
       "owner": "broker",
@@ -740,19 +740,19 @@
           "id": "5a11a6fa9237fdd8ea0dafa1",
           "fingerprint": "700bae83c5efcc96fd63bae4",
           "item": "fn set_message_store",
-          "line": 3938
+          "line": 3928
         },
         {
           "id": "9f53a0559f1829cddb44bc38",
           "fingerprint": "7bef337a5f22e42fb0555ac1",
           "item": "fn set_schedule_message_service",
-          "line": 3948
+          "line": 3938
         },
         {
           "id": "dd6c73ad6af3fe3f85a70c79",
           "fingerprint": "d87e787b1a6fd3613b6561ec",
           "item": "fn register_broker_all_inner",
-          "line": 4147
+          "line": 4137
         }
       ],
       "owner": "broker",
@@ -771,19 +771,19 @@
           "id": "5689243529837bbe350032c7",
           "fingerprint": "c7fde3d9b289d1ecd7941a05",
           "item": "fn new_controller_mode_message_store",
-          "line": 5998
+          "line": 5988
         },
         {
           "id": "a3c29627e8d7d7e68fa8faae",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_promotes_store_to_master",
-          "line": 9668
+          "line": 9658
         },
         {
           "id": "4ff61cc699c2c34d1b75fdec",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_demotes_store_to_slave",
-          "line": 9701
+          "line": 9691
         }
       ],
       "owner": "broker",
@@ -893,163 +893,163 @@
           "id": "4ade86c96052f2090dbb7f77",
           "fingerprint": "cdae48c0ebbb111839de0523",
           "item": "fn message_store_mut",
-          "line": 3467
+          "line": 3462
         },
         {
           "id": "c1cae73ceb0817d0ee5737a5",
           "fingerprint": "bb36b785611582c90a04314b",
           "item": "fn schedule_message_service_mut",
-          "line": 3477
+          "line": 3472
         },
         {
           "id": "65fc6539ac3842d150aa6ab7",
           "fingerprint": "bfce165132795dfb1f1b43be",
           "item": "fn schedule_message_service_unchecked_mut",
-          "line": 3482
+          "line": 3477
         },
         {
           "id": "9fc500ec718d709b7ac0642d",
           "fingerprint": "4ce1300d14e00cbb2c3f6de0",
           "item": "fn transactional_message_service_mut",
-          "line": 3537
+          "line": 3532
         },
         {
           "id": "bfb12f611c07f201feb00cc8",
           "fingerprint": "7e8542f406042396ea595c53",
           "item": "fn message_store",
-          "line": 3679
+          "line": 3674
         },
         {
           "id": "51723d390366120a3abf406a",
           "fingerprint": "23ba055600cc3437a7375e8a",
           "item": "fn message_store_unchecked",
-          "line": 3704
+          "line": 3699
         },
         {
           "id": "073675840d7d1847ac6b9986",
           "fingerprint": "c827c069638d3aa68520a4e4",
           "item": "fn message_store_unchecked_mut",
-          "line": 3709
+          "line": 3704
         },
         {
           "id": "2c94ed052f2870d2bea9a0e5",
           "fingerprint": "9cd2720850b21c7ba6852574",
           "item": "fn schedule_message_service",
-          "line": 3719
+          "line": 3714
         },
         {
           "id": "b10317af933e930e8e5eb2be",
           "fingerprint": "c6e6cb4278fe5f23928cbe9d",
           "item": "fn schedule_message_service_unchecked",
-          "line": 3724
+          "line": 3719
         },
         {
           "id": "bab394cd446ee88f68c6ddd5",
           "fingerprint": "3fa31838c3340571bc19a4a5",
           "item": "fn register_broker_all_inner",
-          "line": 4085
+          "line": 4075
         },
         {
           "id": "daaaf0da4630c3d390481e48",
           "fingerprint": "2a8132de51b1b9bbebef6afa",
           "item": "fn do_register_broker_all_inner",
-          "line": 4183
+          "line": 4173
         },
         {
           "id": "397e52506121c49464b3bd42",
           "fingerprint": "604fe15af2dc366b3c1d1774",
           "item": "fn bootstrap_controller_mode",
-          "line": 4246
+          "line": 4236
         },
         {
           "id": "f772ab897753003c3b31ce78",
           "fingerprint": "d73c8ce1a6d38fdadfa82088",
           "item": "fn apply_controller_replica_info",
-          "line": 4421
+          "line": 4411
         },
         {
           "id": "ac29bee3c291d5419f18d69b",
           "fingerprint": "31047896d79098c6d503858e",
           "item": "fn ensure_controller_broker_id",
-          "line": 4452
+          "line": 4442
         },
         {
           "id": "faeaca698e3042def1d5ca17",
           "fingerprint": "a0e5eaac85b95545b35def48",
           "item": "fn discover_controller_leader",
-          "line": 4519
+          "line": 4509
         },
         {
           "id": "077e0c83f6570b890f8218b1",
           "fingerprint": "2533bd3e1a1f747535f7d232",
           "item": "fn refresh_controller_leader",
-          "line": 4544
+          "line": 4534
         },
         {
           "id": "e06e6b9b1da0c69b604502dd",
           "fingerprint": "6127abc01652c94842823b44",
           "item": "fn sync_controller_replica_info",
-          "line": 4552
+          "line": 4542
         },
         {
           "id": "7758ba9d150d1bf2fb773517",
           "fingerprint": "fafa781033d91e20b0059b84",
           "item": "fn fetch_controller_replica_info",
-          "line": 4620
+          "line": 4610
         },
         {
           "id": "36f745dd8380e3136af2cc39",
           "fingerprint": "4d37a31386e95dcaaebb2c7c",
           "item": "fn sync_broker_member_group",
-          "line": 4655
+          "line": 4645
         },
         {
           "id": "3d53c2e89ab668e271f8142d",
           "fingerprint": "198bb68697b47e45b2d7539d",
           "item": "fn update_min_broker",
-          "line": 4699
+          "line": 4689
         },
         {
           "id": "3427582ef504bcbb0dceb9d6",
           "fingerprint": "ae555e6b3b3ad0a94f0de73e",
           "item": "fn ack_message_processor_unchecked",
-          "line": 4726
+          "line": 4716
         },
         {
           "id": "fe110583eb8708bc703ebd8e",
           "fingerprint": "3cec3e2aa6d0fb2fa1aa9196",
           "item": "fn query_assignment_processor_unchecked",
-          "line": 4734
+          "line": 4724
         },
         {
           "id": "df79f1f95a9e8ff82331286d",
           "fingerprint": "b6d49391281d848012e7c67a",
           "item": "fn query_assignment_processor",
-          "line": 4738
+          "line": 4728
         },
         {
           "id": "e20993d001795adb23cf8c7b",
           "fingerprint": "ce70b42c454fb5b3b890704d",
           "item": "fn query_assignment_processor_mut",
-          "line": 4742
+          "line": 4732
         },
         {
           "id": "1f1d6dd47e1103f2a385d99c",
           "fingerprint": "5bc8aad2956d9b8b26600f1b",
           "item": "fn query_assignment_processor_unchecked_mut",
-          "line": 4746
+          "line": 4736
         },
         {
           "id": "bcd154dd4496146de09f72ed",
           "fingerprint": "137d02287d2e84512645a7bd",
           "item": "fn start_service",
-          "line": 4803
+          "line": 4793
         },
         {
           "id": "2e408d42e425425565e4bb10",
           "fingerprint": "29427e076444659b1b597065",
           "item": "fn apply_controller_role_change",
-          "line": 4827
+          "line": 4817
         }
       ],
       "owner": "broker",
@@ -1068,7 +1068,7 @@
           "id": "2b6ee8edd4a6435a6b3007b2",
           "fingerprint": "6503d57af85359294b26eef5",
           "item": "fn new_controller_mode_message_store",
-          "line": 5995
+          "line": 5985
         }
       ],
       "owner": "broker",
@@ -1087,7 +1087,7 @@
           "id": "8895e852d36c6c4ae6c94696",
           "fingerprint": "a236422f00598205b2ff717d",
           "item": "fn new_controller_mode_message_store",
-          "line": 5998
+          "line": 5988
         }
       ],
       "owner": "broker",
@@ -1125,7 +1125,7 @@
           "id": "49d7d37cd53bb0360ffa9e98",
           "fingerprint": "fc95bb9dd1e409338174f0ca",
           "item": "mod tests",
-          "line": 5299
+          "line": 5289
         }
       ],
       "owner": "broker",
@@ -1163,7 +1163,7 @@
           "id": "76c8a751ce4984912169a2f1",
           "fingerprint": "7fc8adc251a6107872dc0c3c",
           "item": "fn new_controller_mode_message_store",
-          "line": 5995
+          "line": 5985
         }
       ],
       "owner": "broker",
@@ -1752,31 +1752,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "34fabcac030f90c8da206f18",
-      "path": "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "f49858cc87dc822380505cca",
-          "fingerprint": "6eba27b148b80af23a1b4b25",
-          "item": "fn new",
-          "line": 102
-        },
-        {
-          "id": "80367ba618fc6622f67c8329",
-          "fingerprint": "02aec271339afedcbd69d58e",
-          "item": "fn visit_map",
-          "line": 797
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "4e08d549e9698518ba84279d",
       "path": "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs",
       "symbol": "ArcMut",
@@ -1787,7 +1762,7 @@
           "id": "046cc4ca0d765447f46b4957",
           "fingerprint": "b9b70ca3feb4e4c879b7e9f8",
           "item": "<module>",
-          "line": 34
+          "line": 35
         }
       ],
       "owner": "broker",
@@ -1818,25 +1793,13 @@
           "id": "f1243ac1bb2728458310ea60",
           "fingerprint": "b6cf9796d879472ea72b01ba",
           "item": "fn new_with_rocksdb_config_manager",
-          "line": 118
+          "line": 119
         },
         {
           "id": "f19ee8c8b6735abd5d76260c",
           "fingerprint": "71d4256b414c8fed57421f6e",
           "item": "fn set_message_store",
-          "line": 150
-        },
-        {
-          "id": "f1bf0919ac6d04e7be0ad90a",
-          "fingerprint": "7604265f6ddb04c83968f40c",
-          "item": "fn data_version",
-          "line": 387
-        },
-        {
-          "id": "88f395487bb450854add00bb",
-          "fingerprint": "438f1beb2a0677c670ca6674",
-          "item": "struct ConsumerOffsetWrapper",
-          "line": 667
+          "line": 151
         }
       ],
       "owner": "broker",
@@ -1855,7 +1818,7 @@
           "id": "70a0dc47a65ed1ef366bf92f",
           "fingerprint": "600ea6ef3e0e04c93cb77f99",
           "item": "mod tests",
-          "line": 825
+          "line": 884
         }
       ],
       "owner": "broker",
@@ -1874,91 +1837,35 @@
           "id": "722ec2b6282ec420ff76a949",
           "fingerprint": "a84b5e711b250c7639696af4",
           "item": "fn new_manager",
-          "line": 832
+          "line": 891
         },
         {
           "id": "59e369b48baebac73a4a99ef",
           "fingerprint": "0c90022bdbadcfdd3e0abfa1",
           "item": "fn consumer_offset_manager_persists_offsets_to_rocksdb_and_loads_after_restart",
-          "line": 1038
+          "line": 1223
         },
         {
           "id": "9c904132dd9a542001b883c6",
           "fingerprint": "507b9f9640d80f2d0ae706be",
           "item": "fn consumer_offset_manager_persists_offsets_to_rocksdb_and_loads_after_restart",
-          "line": 1063
+          "line": 1248
         },
         {
           "id": "d45cec3ce8e736180dc98060",
           "fingerprint": "0c90022bdbadcfdd3e0abfa1",
           "item": "fn consumer_offset_manager_clean_group_deletes_offsets_from_rocksdb",
-          "line": 1092
+          "line": 1277
         },
         {
           "id": "aebd27c96949c1eb443fee47",
           "fingerprint": "507b9f9640d80f2d0ae706be",
           "item": "fn consumer_offset_manager_clean_group_deletes_offsets_from_rocksdb",
-          "line": 1117
+          "line": 1302
         }
       ],
       "owner": "broker",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "1c8fee39160e7ac3c630a11b",
-      "path": "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "3cda7099a9572da42919f55a",
-          "fingerprint": "87bdd5742470426d2ce4ec46",
-          "item": "fn commit_offset",
-          "line": 286
-        },
-        {
-          "id": "fcc41509bd265657537a88d3",
-          "fingerprint": "b17d02f86801c8c67b1dfe27",
-          "item": "fn load_from_rocksdb",
-          "line": 483
-        },
-        {
-          "id": "d7f54629560775660d9bc2e5",
-          "fingerprint": "2733ed7ad7b6d2e5f2ce0c5e",
-          "item": "fn decode",
-          "line": 652
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "d9f03c8d58d18f0d31126346",
-      "path": "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "2069a84d3228185c2b6137ad",
-          "fingerprint": "64aeef953d73c7ceeb42fc2e",
-          "item": "fn consumer_offset_manager_persists_offsets_to_rocksdb_and_loads_after_restart",
-          "line": 1059
-        },
-        {
-          "id": "09a6b8ad7035a2e70af6d7d0",
-          "fingerprint": "12dc5bbd07ea50d9cebb81aa",
-          "item": "fn consumer_offset_manager_clean_group_deletes_offsets_from_rocksdb",
-          "line": 1112
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M05",
       "adr": "ADR-002"
     },
@@ -2257,25 +2164,6 @@
           "fingerprint": "b6015c3e904ef97400dcc292",
           "item": "fn set_commitlog_read_mode",
           "line": 200
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "297db7b0ccbf4a56b5fa7422",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "5d9006742c3f2b744aa8086b",
-          "fingerprint": "39d89d0e12ba83f496be8b14",
-          "item": "fn export_rocksdb_config_to_json_writes_requested_json_files",
-          "line": 1047
         }
       ],
       "owner": "broker",
@@ -5607,7 +5495,7 @@
           "id": "8271b1faef87df463b3c9cc6",
           "fingerprint": "ad0fc2f2205a1a0b740782b7",
           "item": "fn sync_subscription_group_config",
-          "line": 276
+          "line": 272
         }
       ],
       "owner": "broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8389

### Brief Description

- Publish immutable consumer-offset `DataVersion` generations with `ArcSwap` and serialize offset/version transitions behind one manager-owned boundary.
- Use the exact `fetch_add` result for version thresholds, handle non-positive update steps safely, and replace peer synchronization with a narrow complete-generation merge API.
- Remove cloneable manager state, writable offset-table escape hatches, and unnecessary mutable runtime access; migrate Lite diagnostics to owned snapshots.
- Parse JSON and RocksDB state completely before publication, restore reset/pull tables even when the committed-offset table is empty, and persist an owned table/version snapshot outside the transition lock.
- Update the M11-12 checklist, remaining-work inventory, and reviewed ArcMut baseline from 465 identities / 1,204 occurrences to 461 / 1,194.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-targets --all-features`
- `cargo test -p rocketmq-broker offset::manager::consumer_offset_manager::tests --lib` (13 passed)
- `cargo test -p rocketmq-broker --all-features offset::manager::consumer_offset_manager::tests --lib` (15 passed)
- Focused processor, export, and single/separate RocksDB migration tests (4 passed)
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` (572 passed, 25 pre-existing failures, 1 ignored; the failure list matches the recorded main baseline)
- Required Store/Broker RocksDB Clippy and test matrix (foundation 82/82, semantics 9/9, Broker rocksdb 20/20, pop_consumer 4/4)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- ArcMut guard and tests (67/67 unit tests, 24/24 fixtures), architecture dependency/release/performance guards and tests (60/60), runtime audit, AGENTS routing, and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consumer offset management with consistent immutable snapshots and safer concurrent updates.
  * Enhanced broker and slave synchronization to merge offset data more reliably.
  * Improved JSON and RocksDB persistence consistency, including recovery when source tables are empty.
  * Fixed edge cases involving zero-length updates and version advancement that could cause failures.
  * Updated consumer lag reporting and broker offset metrics to use stable snapshots.

* **Documentation**
  * Updated architecture and production-readiness documentation with the latest progress and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->