### PR TITLE
Clarify namesrv.toml vs namesrv-example.toml and add production baseline

### DIFF
--- a/rocketmq-namesrv/README.md
+++ b/rocketmq-namesrv/README.md
@@ -99,18 +99,30 @@ cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- \
   --bindAddress 0.0.0.0
 ```
 
-Start from the example configuration file:
+Start from a config file. Three examples are provided under `resource/`,
+depending on what you need (see [Configuration](#configuration) below for the
+difference between them):
 
 ```bash
+# Small dev baseline - only the keys worth overriding locally are set.
+cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- \
+  -c rocketmq-namesrv/resource/namesrv.toml
+
+# Every available key, fully annotated with defaults - a reference, not
+# meant to be run as-is without reviewing the paths it sets.
 cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- \
   -c rocketmq-namesrv/resource/namesrv-example.toml
+
+# Production-oriented baseline with larger thread pool/queue sizes.
+cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- \
+  -c rocketmq-namesrv/resource/namesrv-production.toml
 ```
 
 Print the merged configuration and exit:
 
 ```bash
 cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- \
-  -c rocketmq-namesrv/resource/namesrv-example.toml \
+  -c rocketmq-namesrv/resource/namesrv.toml \
   -p
 ```
 
@@ -123,10 +135,17 @@ Configuration precedence is:
 
 ## Configuration
 
-The example file
-[`resource/namesrv-example.toml`](resource/namesrv-example.toml) documents the
-supported keys. The configuration model accepts Java-style camelCase keys and
-Rust-style field names where serde aliases are defined.
+Three example config files are provided under `resource/`, each serving a
+different purpose:
+
+| File | Purpose |
+| ---- | ------- |
+| [`resource/namesrv.toml`](resource/namesrv.toml) | Small dev baseline - only the keys you're likely to change for a local run; everything else falls back to its built-in default. |
+| [`resource/namesrv-example.toml`](resource/namesrv-example.toml) | Fully annotated reference documenting every supported key and its default. Not meant to be run unmodified - review the paths it sets first. |
+| [`resource/namesrv-production.toml`](resource/namesrv-production.toml) | Production-oriented baseline with thread-pool and queue sizes raised above the defaults; review against your own capacity plan before deploying. |
+
+The configuration model accepts Java-style camelCase keys and Rust-style
+field names where serde aliases are defined.
 
 | Key | Default | Purpose |
 | --- | ------- | ------- |

--- a/rocketmq-namesrv/resource/namesrv-production.toml
+++ b/rocketmq-namesrv/resource/namesrv-production.toml
@@ -1,0 +1,63 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# RocketMQ Name Server Configuration File (TOML Format)
+# Production baseline: a starting point for a production deployment, with
+# thread-pool and queue sizes raised above the built-in defaults to handle
+# higher broker/client concurrency. Review every value against your own
+# capacity plan before deploying - see namesrv-example.toml for the full
+# list of available keys.
+
+# RocketMQ installation directory.
+# Default: $ROCKETMQ_HOME / $ROCKETMQ_HOME_PROPERTY env var, or empty.
+# Point at a real, durable install path in production.
+rocketmqHome = "/opt/rocketmq"
+
+# Key-Value configuration file path.
+# Default: ~/rocketmq-namesrv/kvConfig.json
+kvConfigPath = "/opt/rocketmq/data/kvConfig.json"
+
+# Configuration persistence file path.
+# Default: ~/rocketmq-namesrv/rocketmq-namesrv.properties
+configStorePath = "/opt/rocketmq/data/rocketmq-namesrv.properties"
+
+# Client request thread pool size (handles broker/client registration and
+# heartbeat traffic).
+# Default: 8. Suggested range: 16-32, scaled with expected concurrent
+# broker/client connections.
+clientRequestThreadPoolNums = 16
+
+# Default thread pool size for general (non client-request) tasks.
+# Default: 16. Suggested range: 32-64 for higher-throughput clusters.
+defaultThreadPoolNums = 32
+
+# Client request thread pool queue capacity (pending task backlog).
+# Default: 50000. Raise if client requests are rejected/dropped under
+# burst load; each queued task is a lightweight struct.
+clientRequestThreadPoolQueueCapacity = 100000
+
+# Default thread pool queue capacity.
+# Default: 10000. Suggested range: 20000-50000 for higher-throughput
+# clusters.
+defaultThreadPoolQueueCapacity = 20000
+
+# Unregister broker queue capacity.
+# Default: 3000. Raise alongside cluster size / broker churn rate.
+unRegisterBrokerQueueCapacity = 5000
+
+# Use RouteInfoManager V2 (DashMap-based concurrent implementation).
+# Default: true. V2 provides 5-50x better concurrency than the legacy V1
+# implementation and is the recommended production setting.
+useRouteInfoManagerV2 = true

--- a/rocketmq-namesrv/resource/namesrv.toml
+++ b/rocketmq-namesrv/resource/namesrv.toml
@@ -13,4 +13,24 @@
 # limitations under the License.
 
 
-rocketmqHome=11111
+# RocketMQ Name Server Configuration File (TOML Format)
+# Development baseline: a small set of keys worth overriding for a local,
+# throw-away NameServer run. Every key left unset here falls back to its
+# built-in default.
+#
+# For a fully annotated reference of every available key, see
+# namesrv-example.toml. For a production-oriented starting point, see
+# namesrv-production.toml.
+
+# RocketMQ installation directory.
+# Default: $ROCKETMQ_HOME / $ROCKETMQ_HOME_PROPERTY env var, or empty.
+# Pointed at a scratch directory so a local dev run is self-contained.
+rocketmqHome = "/tmp/rocketmq"
+
+# Key-Value configuration file path (persisted broker/topic KV data).
+# Default: ~/rocketmq-namesrv/kvConfig.json
+kvConfigPath = "/tmp/rocketmq/kvConfig.json"
+
+# Configuration persistence file path.
+# Default: ~/rocketmq-namesrv/rocketmq-namesrv.properties
+configStorePath = "/tmp/rocketmq/rocketmq-namesrv.properties"

--- a/rocketmq-namesrv/src/namesrv_config_parse.rs
+++ b/rocketmq-namesrv/src/namesrv_config_parse.rs
@@ -98,6 +98,11 @@ useRouteInfoManagerV2 = false
         let config = parse_command_and_config_file(path).expect("production baseline config should parse");
 
         assert_eq!(config.rocketmq_home, "/opt/rocketmq");
+        assert_eq!(config.kv_config_path, "/opt/rocketmq/data/kvConfig.json");
+        assert_eq!(
+            config.config_store_path,
+            "/opt/rocketmq/data/rocketmq-namesrv.properties"
+        );
         assert_eq!(config.client_request_thread_pool_nums, 16);
         assert_eq!(config.default_thread_pool_nums, 32);
         assert_eq!(config.client_request_thread_pool_queue_capacity, 100000);

--- a/rocketmq-namesrv/src/namesrv_config_parse.rs
+++ b/rocketmq-namesrv/src/namesrv_config_parse.rs
@@ -81,6 +81,32 @@ useRouteInfoManagerV2 = false
     }
 
     #[test]
+    fn namesrv_config_parse_loads_dev_baseline_file() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resource/namesrv.toml");
+
+        let config = parse_command_and_config_file(path).expect("dev baseline config should parse");
+
+        assert_eq!(config.rocketmq_home, "/tmp/rocketmq");
+        assert_eq!(config.kv_config_path, "/tmp/rocketmq/kvConfig.json");
+        assert_eq!(config.config_store_path, "/tmp/rocketmq/rocketmq-namesrv.properties");
+    }
+
+    #[test]
+    fn namesrv_config_parse_loads_production_baseline_file() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resource/namesrv-production.toml");
+
+        let config = parse_command_and_config_file(path).expect("production baseline config should parse");
+
+        assert_eq!(config.rocketmq_home, "/opt/rocketmq");
+        assert_eq!(config.client_request_thread_pool_nums, 16);
+        assert_eq!(config.default_thread_pool_nums, 32);
+        assert_eq!(config.client_request_thread_pool_queue_capacity, 100000);
+        assert_eq!(config.default_thread_pool_queue_capacity, 20000);
+        assert_eq!(config.unregister_broker_queue_capacity, 5000);
+        assert!(config.use_route_info_manager_v2);
+    }
+
+    #[test]
     fn namesrv_config_parse_falls_back_to_default_for_missing_file() {
         let config =
             parse_command_and_config_file(temp_config_path("missing")).expect("missing config should fall back");


### PR DESCRIPTION
## Summary

Addresses #7622.

`rocketmq-namesrv`'s `resource/namesrv.toml` shipped as a non-functional placeholder (`rocketmqHome=11111` — a number where a path belongs), with no documentation explaining how it differs from the fully-annotated `resource/namesrv-example.toml`. This PR:

- Replaces the placeholder in `resource/namesrv.toml` with a small, documented **dev baseline** (a handful of commonly-changed keys, pointed at `/tmp` for a self-contained local run).
- Adds `resource/namesrv-production.toml`, a **production baseline** with thread-pool/queue sizes tuned above the built-in defaults, each commented with its default value and a suggested range — per the maintainer's request in the issue thread for units/defaults/ranges and a dev/production pair.
- Updates `rocketmq-namesrv/README.md`'s Quick Start and Configuration sections to explain what each of the three example config files is for, and re-verifies every Quick Start command against the actual files.
- Extends the existing config-parser fixture test (`namesrv_config_parse_loads_example_file`) with two more tests covering the new dev/production files, so the documented keys and the real `NamesrvConfig` parser can't silently drift apart.

Per the maintainer's comment on the issue ("Don't worry about the Chinese text for now. Just submit the PR."), `README-zh_cn.md` is intentionally left untouched — the Chinese sync is deferred as a follow-up for someone who can do the translation properly.

## Test plan

- [x] `cargo fmt -p rocketmq-namesrv` — no changes needed
- [x] `cargo clippy -p rocketmq-namesrv --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p rocketmq-namesrv --lib namesrv_config_parse` — 5/5 passed
- [x] Manually ran `cargo run -p rocketmq-namesrv --bin rocketmq-namesrv-rust -- -c <file> -p` against all three config files (`namesrv.toml`, `namesrv-example.toml`, `namesrv-production.toml`) to confirm the README's Quick Start commands work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documented development and production baseline configurations for the RocketMQ Name Server.
  * Added production-oriented settings for higher concurrency and enabled the V2 route information manager.
  * Expanded configuration guidance with examples, usage instructions, and supported naming conventions.

* **Bug Fixes**
  * Updated configuration paths and defaults for consistent local and production setup.

* **Tests**
  * Added validation for loading and parsing development and production configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->