### PR TITLE
[ISSUE #8402]♻️Remove unused Broker runtime ownership from auth admin handlers

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -39,14 +39,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8400 的 M11-12az 子切片完成后，当前 ArcMut reviewed
-baseline 为 443 identities / 1,096 occurrences，其中 production 为 273/605、test 为 156/451、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8402 的 M11-12ba 子切片完成后，当前 ArcMut reviewed
+baseline 为 429 identities / 1,071 occurrences，其中 production 为 259/580、test 为 156/451、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 151 / 297 | Topic route/queue mapping、TopicConfig value、POP/Pull、offset、schedule、transaction service 与核心 processor root 已完成；继续完成 BrokerRuntime capability carrier、admin/其他 processor、transaction bridge/listener 与 TopicConfigManager runtime carrier 安全化 |
+| Broker | 137 / 272 | Topic route/queue mapping、TopicConfig value、POP/Pull、offset、schedule、transaction service、核心 processor root 与 auth admin handler 已完成；继续完成 BrokerRuntime capability carrier、其他 admin/processor、transaction bridge/listener 与 TopicConfigManager runtime carrier 安全化 |
 | Store | 122 / 308 | TopicConfig 只读代际 carrier 已完成；继续完成 message store、CommitLog/Flush、queue、Rocks/Timer 与 HA owner/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -682,7 +682,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12ax Broker transaction service ownership：transaction service root 与 request processors 改用标准 `Arc`，op-batch 回边改用标准 `Weak`；共享 service API、显式 bridge async mutex、窄化 check-service capability、Broker2Client 标准 `Arc`、check-before-batch shutdown 与 delete-context snapshot-before-I/O 消除 `mut_from_ref`、后台强回边和嵌套锁风险
   - [x] M11-12ay Broker transaction processor root ownership：send/reply/end-transaction processor variant 与 Broker startup root 改用标准 `Arc`，共享入口按请求复制轻量 capability 句柄而不引入全局 mutex；注册完成后只读的 request table/default processor 改用标准 `Arc` 与注册期 copy-on-write
   - [x] M11-12az Broker core request processor roots：peek/polling-info/recall/query-message/client-manage/consumer-manage/query-assignment variant、startup root 与 query-assignment runtime slot 改用标准 `Arc`；共享入口复用轻量 capability clone，Peek 保持单一共享原子序列，未引入全局请求锁
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400 与每次真实下降
+  - [x] M11-12ba Broker auth admin handler ownership：11 个 auth/user admin handler 删除未使用的完整 BrokerRuntime owner 与无意义 `MessageStore` 泛型，只保留标准 `Arc<AuthAdminService>` capability；Admin processor wiring 与 focused auth 行为测试同步更新
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402 与每次真实下降
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -735,7 +736,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8395 后实际快照降至 274 production/634 occurrence、156 test/451 occurrence；Broker 降至 152/326，transaction service/check/batch 与 processor capability 共删除 8 个 production identity/20 occurrence 与 1 个 test identity/1 occurrence；6 个保留 occurrence 经临时 ADR-013 一对一 relocation 审核，compatibility 14/40 不增
   - [x] Issue #8398 后实际快照降至 273 production/624 occurrence，test 保持 156/451；Broker 降至 151/316，transaction processor root 与 immutable request registry 共删除 1 个 production identity/10 occurrence；2 个保留 variant 经临时 ADR-013 一对一 relocation 审核，compatibility 14/40 不增
   - [x] Issue #8400 后 production identity 保持 273、occurrence 降至 605，test 保持 156/451；Broker 保持 151 identities、occurrence 降至 297，七类核心 processor root 共删除 19 个 production occurrence；1 个 retained LiteManager variant 经临时 ADR-013 一对一 relocation 审核，compatibility 14/40 不增
-  - [ ] M11-12ba 及后续：Broker admin/其他 processor、transaction bridge/listener 与 TopicConfigManager runtime capability carrier、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8402 后实际快照降至 259 production/580 occurrence，test 保持 156/451；Broker 降至 137/272，11 个 auth/user admin handler 共删除 14 个 production identity/25 occurrence；1 个 test-module import 经临时 ADR-013 一对一 relocation 审核，compatibility 14/40 不增
+  - [ ] M11-12bb 及后续：Broker 其他 admin/processor、transaction bridge/listener 与 TopicConfigManager runtime capability carrier、Store/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -499,6 +499,12 @@ consumer-manage 与 query-assignment 的 variant/startup root 改为标准 `Arc`
 compatibility 保持 14/40。总进度仍为 75/82，下一子切片 M11-12ba 配对拆分 transaction bridge/listener 与
 TopicConfigManager runtime capability carrier，并继续收口 Broker admin/其他 processor；M11-12 父工作包未完成。
 
+Broker auth admin handler ownership 随 Issue #8402 从 11 个 auth/user admin handler 删除从未读取的完整
+`BrokerRuntimeInner` carrier 与无意义 `MessageStore` 泛型；handler 现在只持有标准 `Arc<AuthAdminService>`，Admin
+processor wiring 与 auth ACL/user/global-white 行为保持不变。实际快照降至 259 production/580 occurrence，test 保持
+156/451，Broker production 降至 137/272；compatibility 保持 14/40。总进度仍为 75/82，下一子切片 M11-12bb
+配对拆分 transaction bridge/listener 与 TopicConfigManager runtime capability carrier；M11-12 父工作包未完成。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-security-observability-cloud.md
@@ -513,6 +513,12 @@ root/runtime slot 改为标准 `Arc`；共享入口只复制轻量 capability，
 14/40 不增。下一子切片 M11-12ba 配对处理 transaction bridge/listener 与 TopicConfigManager runtime capability
 carrier，并继续处理 Broker admin/其他 processor；完整候选快照与 HUMAN Gate 仍未满足。
 
+M11-12ba 已从 11 个 auth/user admin handler 删除未使用的完整 BrokerRuntime carrier 与 `MessageStore` 泛型；每个 handler
+只保留标准 `Arc<AuthAdminService>` capability，避免 narrow auth control-plane handler 反向保活整个 Broker。实际快照降至
+259 production/580 occurrences，test 保持 156/451，Broker owner 降至 137/272；compatibility 14/40 不增。下一子切片
+M11-12bb 配对处理 transaction bridge/listener 与 TopicConfigManager runtime capability carrier；完整候选快照与 HUMAN
+Gate 仍未满足。
+
 ## 公共兼容面
 
 - development/compatibility仍可显式选择；secure只作为新部署默认，不静默重解释旧配置。

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2170,9 +2170,34 @@ Broker core request processor roots 随 Issue #8400 完成以下边界收敛：
 Broker admin/其他 processor；75/82 总进度不变，Store、compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate
 仍保持开放。
 
+## M11-12ba 实现
+
+Broker auth admin handler ownership 随 Issue #8402 完成以下边界收敛：
+
+- create/update/delete/get/list user 与 ACL，以及 global-white update 共 11 个 auth admin handler 删除从未读取的 `ArcMut<BrokerRuntimeInner<MS>>` 字段和构造参数；handler 只保留实际使用的标准 `Arc<AuthAdminService>` capability。
+- handler 类型删除不再表达真实依赖的 `MS: MessageStore` 泛型，`AdminBrokerProcessor` startup wiring 不再向这些 narrow control-plane handler 复制完整 Broker runtime owner。
+- auth ACL/user round-trip、malformed body、super-user protection、empty list、policy-type delete 与 global-white snapshot 测试继续使用同一 `AuthAdminService` 状态，行为与 wire response 不变。
+- source ownership contract 固定 11 个 handler 文件不得重新引入 `BrokerRuntimeInner` 或 `ArcMut`，防止构造兼容参数再次变为无意义强持有。
+- reviewed baseline 从 443 identities / 1,096 occurrences 降至 429 / 1,071；production 从 273/605 降至 259/580，test 保持 156/451，compatibility 保持 14/40。Broker production 从 151/297 降至 137/272；净删除 14 个 production identity/25 occurrence。1 个 test-module import 因新增 source contract 发生同 item 一对一 fingerprint relocation，经临时 ADR-013 approval 审核且 approval 不提交。
+
+## M11-12ba 验证
+
+| 命令 | 结果 |
+|---|---|
+| `cargo check -p rocketmq-broker --all-features` / Broker strict Clippy | 通过；无 runtime owner 的 auth admin handler 与 Admin processor wiring 在 all-features/all-targets 下编译和 lint 通过 |
+| auth admin ownership / ACL / global-white / phase-7 focused tests | ownership 1/1、ACL/user 6/6、global-white 2/2、phase-7 lifecycle 与 dispatch 各 1/1 通过；覆盖 capability-only 构造与既有 auth admin 行为 |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 587 passed、25 failed、1 ignored；25 个失败与 main 已登记失败名单一致，本切片新增 ownership test 通过且未新增 baseline failure，故不能把全套记为通过 |
+| reviewed baseline reduction / `python scripts/arc_mut_guard.py` | baseline 443/1,096→429/1,071；1 个 test occurrence 经临时 ADR-013 一对一 relocation 审核，approval 不提交；guard 通过，production 259/580、test 156/451、compatibility 14/40，Broker production 137/272 |
+| ArcMut / architecture guard tests | ArcMut 67/67、fixtures 24/24、architecture dependency/release/performance 60/60 通过；target/baseline/release/performance profiles 全绿 |
+| `cargo fmt --all -- --check` / root workspace strict Clippy | 通过；root workspace 32 个 package 的 all-targets/all-features `-D warnings` profile 通过 |
+| runtime audit / AGENTS routing / `git diff --check` | runtime boundary 与 routing 通过；4 个 standalone Cargo、3 个 Node project、8 条 route；diff check 无 whitespace error |
+
+下一子切片 M11-12bb 配对拆分 transaction bridge/listener 与 TopicConfigManager runtime capability carrier；75/82 总进度
+不变，Store、compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier、admin/其他 processor、transaction bridge/listener 与 TopicConfigManager runtime carrier（151/297）；下一子切片 M11-12ba 继续拆分 Broker owner。
+1. Broker BrokerRuntimeInner capability carrier、其他 admin/processor、transaction bridge/listener 与 TopicConfigManager runtime carrier（137/272）；下一子切片 M11-12bb 继续拆分 Broker owner。
 2. Store MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（122/308）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -100,17 +100,17 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     notify_broker_role_change_handler: NotifyBrokerRoleChangeHandler<MS>,
     message_related_handler: MessageRelatedHandler<MS>,
     producer_request_handler: ProducerRequestHandler<MS>,
-    create_acl_request_handler: CreateAclRequestHandler<MS>,
-    create_user_request_handler: CreateUserRequestHandler<MS>,
-    get_acl_request_handler: GetAclRequestHandler<MS>,
-    update_user_request_handler: UpdateUserRequestHandler<MS>,
-    update_acl_request_handler: UpdateAclRequestHandler<MS>,
-    delete_user_request_handler: DeleteUserRequestHandler<MS>,
-    list_users_request_handler: ListUsersRequestHandler<MS>,
-    get_user_request_handler: GetUserRequestHandler<MS>,
-    delete_acl_request_handler: DeleteAclRequestHandler<MS>,
-    list_acl_request_handler: ListAclRequestHandler<MS>,
-    update_global_white_addrs_config_request_handler: UpdateGlobalWhiteAddrsConfigRequestHandler<MS>,
+    create_acl_request_handler: CreateAclRequestHandler,
+    create_user_request_handler: CreateUserRequestHandler,
+    get_acl_request_handler: GetAclRequestHandler,
+    update_user_request_handler: UpdateUserRequestHandler,
+    update_acl_request_handler: UpdateAclRequestHandler,
+    delete_user_request_handler: DeleteUserRequestHandler,
+    list_users_request_handler: ListUsersRequestHandler,
+    get_user_request_handler: GetUserRequestHandler,
+    delete_acl_request_handler: DeleteAclRequestHandler,
+    list_acl_request_handler: ListAclRequestHandler,
+    update_global_white_addrs_config_request_handler: UpdateGlobalWhiteAddrsConfigRequestHandler,
     update_cold_data_flow_ctr_group_config_request_handler: UpdateColdDataFlowCtrGroupConfigRequestHandler<MS>,
     get_broker_ha_status_handler: GetBrokerHaStatusHandler<MS>,
     broker_stats_handler: BrokerStatsHandler<MS>,
@@ -155,28 +155,18 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
 
         let message_related_handler = MessageRelatedHandler::new(broker_runtime_inner.clone());
         let producer_request_handler = ProducerRequestHandler::new(broker_runtime_inner.clone());
-        let create_acl_request_handler =
-            CreateAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let create_user_request_handler =
-            CreateUserRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let get_acl_request_handler =
-            GetAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let update_user_request_handler =
-            UpdateUserRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let update_acl_request_handler =
-            UpdateAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let delete_user_request_handler =
-            DeleteUserRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let list_users_request_handler =
-            ListUsersRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let get_user_request_handler =
-            GetUserRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let delete_acl_request_handler =
-            DeleteAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let list_acl_request_handler =
-            ListAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
+        let create_acl_request_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
+        let create_user_request_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
+        let get_acl_request_handler = GetAclRequestHandler::new(auth_admin_service.clone());
+        let update_user_request_handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
+        let update_acl_request_handler = UpdateAclRequestHandler::new(auth_admin_service.clone());
+        let delete_user_request_handler = DeleteUserRequestHandler::new(auth_admin_service.clone());
+        let list_users_request_handler = ListUsersRequestHandler::new(auth_admin_service.clone());
+        let get_user_request_handler = GetUserRequestHandler::new(auth_admin_service.clone());
+        let delete_acl_request_handler = DeleteAclRequestHandler::new(auth_admin_service.clone());
+        let list_acl_request_handler = ListAclRequestHandler::new(auth_admin_service.clone());
         let update_global_white_addrs_config_request_handler =
-            UpdateGlobalWhiteAddrsConfigRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service);
+            UpdateGlobalWhiteAddrsConfigRequestHandler::new(auth_admin_service);
         let update_cold_data_flow_ctr_group_config_request_handler =
             UpdateColdDataFlowCtrGroupConfigRequestHandler::new(broker_runtime_inner.clone());
         let get_broker_ha_status_handler = GetBrokerHaStatusHandler::new(broker_runtime_inner.clone());
@@ -663,6 +653,26 @@ mod tests {
     use rocketmq_error::RocketMQError;
 
     use super::*;
+
+    #[test]
+    fn auth_admin_handlers_do_not_retain_broker_runtime() {
+        for source in [
+            include_str!("admin_broker_processor/create_acl_request_handler.rs"),
+            include_str!("admin_broker_processor/create_user_request_handler.rs"),
+            include_str!("admin_broker_processor/delete_acl_request_handler.rs"),
+            include_str!("admin_broker_processor/delete_user_request_handler.rs"),
+            include_str!("admin_broker_processor/get_acl_request_handler.rs"),
+            include_str!("admin_broker_processor/get_user_request_handler.rs"),
+            include_str!("admin_broker_processor/list_acl_request_handler.rs"),
+            include_str!("admin_broker_processor/list_users_request_handler.rs"),
+            include_str!("admin_broker_processor/update_acl_request_handler.rs"),
+            include_str!("admin_broker_processor/update_global_white_addrs_config_request_handler.rs"),
+            include_str!("admin_broker_processor/update_user_request_handler.rs"),
+        ] {
+            assert!(!source.contains("BrokerRuntimeInner"));
+            assert!(!source.contains(concat!("Arc", "Mut")));
+        }
+    }
 
     #[test]
     fn legacy_acl_responses_are_explicitly_deprecated() {

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -22,27 +22,18 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::header::create_acl_request_header::CreateAclRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingDeserializable;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::acl_converter::AclConverter;
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct CreateAclRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct CreateAclRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> CreateAclRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl CreateAclRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn create_acl(

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -10,27 +10,18 @@ use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserR
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 use crate::auth::user_converter::UserConverter;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct CreateUserRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct CreateUserRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> CreateUserRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl CreateUserRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn create_user(

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
@@ -7,26 +7,17 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::delete_acl_request_header::DeleteAclRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct DeleteAclRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct DeleteAclRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> DeleteAclRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl DeleteAclRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn delete_acl(

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -8,26 +8,17 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::delete_user_request_header::DeleteUserRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct DeleteUserRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct DeleteUserRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> DeleteUserRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl DeleteUserRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn delete_user(

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -21,26 +21,17 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::get_acl_request_header::GetAclRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct GetAclRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct GetAclRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> GetAclRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl GetAclRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn get_acl(
@@ -202,9 +193,9 @@ mod tests {
         alice.set_user_status(UserStatus::Enable);
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
-        let mut create_handler = CreateAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut update_handler = UpdateAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut get_handler = GetAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut create_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
+        let mut update_handler = UpdateAclRequestHandler::new(auth_admin_service.clone());
+        let mut get_handler = GetAclRequestHandler::new(auth_admin_service.clone());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -302,10 +293,10 @@ mod tests {
             })
             .expect("create auth admin service"),
         );
-        let mut create_user_handler = CreateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut update_user_handler = UpdateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut create_acl_handler = CreateAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut update_acl_handler = UpdateAclRequestHandler::new(inner.clone(), auth_admin_service);
+        let mut create_user_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
+        let mut update_user_handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
+        let mut create_acl_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
+        let mut update_acl_handler = UpdateAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -415,8 +406,8 @@ mod tests {
             })
             .expect("create auth admin service"),
         );
-        let mut list_users_handler = ListUsersRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut list_acl_handler = ListAclRequestHandler::new(inner.clone(), auth_admin_service);
+        let mut list_users_handler = ListUsersRequestHandler::new(auth_admin_service.clone());
+        let mut list_acl_handler = ListAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -482,7 +473,7 @@ mod tests {
         alice.set_user_status(UserStatus::Enable);
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
-        let mut handler = UpdateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -541,7 +532,7 @@ mod tests {
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
-        let mut create_handler = CreateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut create_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
         let mut create_request = RemotingCommand::create_request_command(
             RequestCode::AuthCreateUser,
             CreateUserRequestHeader {
@@ -577,7 +568,7 @@ mod tests {
             Some("The super user can only be create by super user")
         );
 
-        let mut update_handler = UpdateUserRequestHandler::new(inner.clone(), auth_admin_service);
+        let mut update_handler = UpdateUserRequestHandler::new(auth_admin_service);
         let mut update_request = RemotingCommand::create_request_command(
             RequestCode::AuthUpdateUser,
             UpdateUserRequestHeader {
@@ -648,8 +639,8 @@ mod tests {
             .await
             .expect("create acl");
 
-        let mut delete_handler = DeleteAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
-        let mut get_handler = GetAclRequestHandler::new(inner.clone(), auth_admin_service);
+        let mut delete_handler = DeleteAclRequestHandler::new(auth_admin_service.clone());
+        let mut get_handler = GetAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut delete_request = RemotingCommand::create_request_command(

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -22,25 +21,16 @@ use rocketmq_remoting::protocol::header::get_user_request_headers::GetUserReques
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
-use rocketmq_store::base::message_store::MessageStore;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct GetUserRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+pub struct GetUserRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> GetUserRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl GetUserRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn get_user(

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -8,26 +8,17 @@ use rocketmq_remoting::protocol::header::list_acl_request_header::ListAclRequest
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct ListAclRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct ListAclRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> ListAclRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl ListAclRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn list_acl(

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -22,25 +21,16 @@ use rocketmq_remoting::protocol::header::list_users_request_header::ListUsersReq
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
-use rocketmq_store::base::message_store::MessageStore;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct ListUsersRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+pub struct ListUsersRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> ListUsersRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl ListUsersRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn list_users(

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -22,27 +22,18 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::header::update_acl_request_header::UpdateAclRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingDeserializable;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::acl_converter::AclConverter;
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct UpdateAclRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct UpdateAclRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> UpdateAclRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl UpdateAclRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn update_acl(

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -20,26 +20,17 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-use rocketmq_store::base::message_store::MessageStore;
 
 use crate::auth::auth_admin_service::AuthAdminService;
-use crate::broker_runtime::BrokerRuntimeInner;
 
 #[derive(Clone)]
-pub struct UpdateGlobalWhiteAddrsConfigRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+pub struct UpdateGlobalWhiteAddrsConfigRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> UpdateGlobalWhiteAddrsConfigRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl UpdateGlobalWhiteAddrsConfigRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn update_global_white_addrs_config(
@@ -175,7 +166,7 @@ mod tests {
         })
         .expect("create provider registry");
         let auth_admin_service = Arc::new(AuthAdminService::with_provider_registry(provider_registry.clone()));
-        let mut handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(inner.clone(), auth_admin_service);
+        let mut handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -1,6 +1,5 @@
 use crate::auth::auth_admin_service::AuthAdminService;
 use crate::auth::user_converter::UserConverter;
-use crate::broker_runtime::BrokerRuntimeInner;
 use rocketmq_auth::authentication::enums::user_type::UserType;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -11,25 +10,16 @@ use rocketmq_remoting::protocol::header::update_user_request_header::UpdateUserR
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
-use rocketmq_store::base::message_store::MessageStore;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct UpdateUserRequestHandler<MS: MessageStore> {
-    _broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+pub struct UpdateUserRequestHandler {
     auth_admin_service: Arc<AuthAdminService>,
 }
 
-impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
-    pub fn new(
-        broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-        auth_admin_service: Arc<AuthAdminService>,
-    ) -> Self {
-        Self {
-            _broker_runtime_inner: broker_runtime_inner,
-            auth_admin_service,
-        }
+impl UpdateUserRequestHandler {
+    pub fn new(auth_admin_service: Arc<AuthAdminService>) -> Self {
+        Self { auth_admin_service }
     }
 
     pub async fn update_user(

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -2148,131 +2148,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "dc55a5324c380d1fb24ebd80",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "7535d1f72fca2f14e1b6b542",
-          "fingerprint": "aed2b3046f010a53bcc4bd8c",
-          "item": "struct CreateAclRequestHandler",
-          "line": 33
-        },
-        {
-          "id": "8911600434df60c603aadd9e",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 39
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "51ffd333a041af3759b6dc64",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "cafa69cdfa9cd6a6f99772b6",
-          "fingerprint": "b40b3c2038e3ef09adbed997",
-          "item": "struct CreateUserRequestHandler",
-          "line": 21
-        },
-        {
-          "id": "22fdafe28e7ef363f7058779",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 27
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "d3a36d8c1dad3ea9ac03d2c2",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "789b8bc3fa429800cb4829a1",
-          "fingerprint": "cc0def5419f5315cf7207fb1",
-          "item": "struct DeleteAclRequestHandler",
-          "line": 17
-        },
-        {
-          "id": "80c3eac270ea3c357ca11884",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 23
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a5af9f16c7086ed850de0a3a",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "1104b52303f22d3c275c12f1",
-          "fingerprint": "40ab0958c34873e584d4653d",
-          "item": "struct DeleteUserRequestHandler",
-          "line": 18
-        },
-        {
-          "id": "45c5c3bb794c51c62cc7a476",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 24
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "722d18068712ee9d6c6dc82a",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "2e35b5461ff19ca99c79ea91",
-          "fingerprint": "013f41ad73a68090547eddbe",
-          "item": "struct GetAclRequestHandler",
-          "line": 31
-        },
-        {
-          "id": "d1cd723fb9610a3cc553bd20",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 37
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "9ff28503aa5923cc0ee896ef",
       "path": "rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs",
       "symbol": "*",
@@ -2328,119 +2203,6 @@
           "fingerprint": "bd5b6854b5bb7e71a79ee0fe",
           "item": "fn new",
           "line": 31
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "11d160037c69d0bdf8e5f133",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8a316e15a5f3dfa8f4119206",
-          "fingerprint": "e4ae88c3e53baa95398c2a9c",
-          "item": "<module>",
-          "line": 25
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "c5d0c1076631c037f216e5b1",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "afd4b9ec1b8eb655331bee69",
-          "fingerprint": "158ec1ec36d2aebc5eb09fed",
-          "item": "struct GetUserRequestHandler",
-          "line": 31
-        },
-        {
-          "id": "5e3686ac782a2a1c59627b1c",
-          "fingerprint": "174aa72bc4c613aad26404a4",
-          "item": "fn new",
-          "line": 37
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "2a9a15bfaa359255bfe498bc",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "90f67668f1e6286821056d33",
-          "fingerprint": "b72188db07a23ac4a3d7794c",
-          "item": "struct ListAclRequestHandler",
-          "line": 18
-        },
-        {
-          "id": "a6b5c8d3a6188a9e2fce2e17",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 24
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "aea52e9952f990a93efa5ae5",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "9d2c28b7c4cea1b0a25fa70e",
-          "fingerprint": "e4ae88c3e53baa95398c2a9c",
-          "item": "<module>",
-          "line": 25
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6ff35fc48c878f87ec93e3c5",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "d9149e8f60bbe674be141f6a",
-          "fingerprint": "2b84f5509d7a83aa856d0d9e",
-          "item": "struct ListUsersRequestHandler",
-          "line": 31
-        },
-        {
-          "id": "51d368fcce353b927a42b8ad",
-          "fingerprint": "6d32234cb30a161e8fef7ca8",
-          "item": "fn new",
-          "line": 37
         }
       ],
       "owner": "broker",
@@ -2864,31 +2626,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "ef7e695272d65f4369d3dd6d",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "ee1d9e4f666e665864741c3d",
-          "fingerprint": "d361eca9177a17b9c54aaf3f",
-          "item": "struct UpdateAclRequestHandler",
-          "line": 33
-        },
-        {
-          "id": "ea15c1672925ed4e439c5631",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 39
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "d18223388e7b28031f2636b6",
       "path": "rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs",
       "symbol": "ArcMut",
@@ -2996,75 +2733,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "74c6e2098def204c3b427043",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "ffaf06975186a3952acd092f",
-          "fingerprint": "b6beb56e6f83c4654b2759ff",
-          "item": "struct UpdateGlobalWhiteAddrsConfigRequestHandler",
-          "line": 30
-        },
-        {
-          "id": "06f18c81353825210f1d9d12",
-          "fingerprint": "39cce241aff9b042d6d55264",
-          "item": "fn new",
-          "line": 36
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e2f9f3d485b78ab98667c279",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "2c594be49009017f6dfc3dd7",
-          "fingerprint": "e4ae88c3e53baa95398c2a9c",
-          "item": "<module>",
-          "line": 14
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "cae5a1f2f81f61b8d6a000dc",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "b79020d774727b529a65d21d",
-          "fingerprint": "d838b6edd2f7b7acf985dcc6",
-          "item": "struct UpdateUserRequestHandler",
-          "line": 20
-        },
-        {
-          "id": "48e494ad8fe16eaf345b0ebf",
-          "fingerprint": "09d36541ebd63b0a381d18f5",
-          "item": "fn new",
-          "line": 26
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "21c2f5279a6f17e611af4850",
       "path": "rocketmq-broker/src/processor/admin_broker_processor.rs",
       "symbol": "*",
@@ -3072,10 +2740,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "53846f016e560ac8f0d04e60",
-          "fingerprint": "af0aa0c5e4927fbeccacbfd9",
+          "id": "996961975697b8e2b4507f35",
+          "fingerprint": "e7abdcdb186b84937c2a798a",
           "item": "mod tests",
-          "line": 665
+          "line": 655
         }
       ],
       "owner": "broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8402

### Brief Description

- Remove unused `BrokerRuntimeInner` ownership from eleven auth and user administration request handlers.
- Remove handler-local `MessageStore` generics and construct the handlers from their actual `AuthAdminService` capability only.
- Add a source ownership contract and update the reviewed ArcMut baseline and migration evidence.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo check -p rocketmq-broker --all-features`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- Auth admin ownership, ACL/user, global-white, and phase-7 focused tests: 11 passed.
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` completed with 587 passed, 25 pre-existing failures matching `main`, and 1 ignored test; the suite therefore remains non-passing without a new failure.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard -v` (67 passed)
- `python scripts/arc_mut_guard.py --fixtures` (24 passed)
- `python -m unittest scripts.tests.test_architecture_dependency_guard scripts.tests.test_architecture_release_guard scripts.tests.test_architecture_performance_guard -v` (60 passed)
- `python scripts/architecture_dependency_guard.py --mode target`
- `python scripts/architecture_dependency_guard.py --mode baseline`
- `python scripts/architecture_release_guard.py`
- `python scripts/architecture_performance_guard.py --validate-profiles`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved authentication, ACL, user-management, and global allowlist administration behavior while simplifying internal request handling.
  * Removed unnecessary runtime dependencies from administrative authentication handlers, improving component isolation and reducing coupling.

* **Tests**
  * Updated validation coverage to confirm administrative handlers no longer retain unnecessary broker runtime state.
  * Refreshed architecture migration checklists, progress metrics, and verification baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->