### PR TITLE
[ISSUE #8416]♻️Detach schedule hooks from broker runtime ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8414 的 M11-12bc5 子切片完成后，当前 ArcMut reviewed
-baseline 为 413 identities / 1,044 occurrences，其中 production 为 246/556、test 为 153/448、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8416 的 M11-12bc6 子切片完成后，当前 ArcMut reviewed
+baseline 为 408 identities / 1,036 occurrences，其中 production 为 242/549、test 为 152/447、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 124 / 248 | Topic route/queue mapping、TopicConfig value/coordinator、POP/Pull、offset、schedule、transaction service/check listener/bridge、核心 processor root、auth/Producer/ColdData admin 与统计 handler 已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 120 / 241 | Topic route/queue mapping、TopicConfig value/coordinator、POP/Pull、offset、schedule service/root/hook、transaction service/check listener/bridge、核心 processor root、auth/Producer/ColdData admin 与统计 handler 已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 122 / 308 | TopicConfig 只读代际 carrier 已完成；继续完成 message store、CommitLog/Flush、queue、Rocks/Timer 与 HA owner/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -690,7 +690,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc3 Transaction check runtime capability：listener 改持 broker name、producer channel registry、Broker2Client 与 leased TaskGroup；discard 写入回归 transaction service，bridge 写路径删除 `mut_from_ref`；事务服务在 Topic coordinator/Store 前有界排空并 `take` runtime slot，BrokerStatsHandler 只持统计 manager
   - [x] M11-12bc4 Transaction bridge capability：bridge/service 删除完整 `BrokerRuntimeInner` owner，只持 offset、Topic registration、EscapeBridge、Broker config 与显式 MessageStore capability；ConsumerOffset/TopicQueueMapping 发布标准 `Arc` 代际，Slave master address 以 `ArcSwapOption` 发布不可变代际
   - [x] M11-12bc5 Broker admin leaf capability：Producer 查询 handler 只持共享 live registry，ColdData handler 只持标准 `Arc<ColdDataCgCtrService>`；两者删除完整 runtime owner、`MessageStore` 泛型与 ArcMut import/type
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc6 Schedule hook capability：MessageStore hook 只持 `MessageStoreConfig`、可选 `TimerMessageStore` 与标准 `Arc<ScheduleMessageService>`；helper 改收窄参数，注册不再克隆 Broker runtime，强引用计数回归防止 Store→Hook→Runtime 环恢复
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -750,7 +751,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8410 后实际快照降至 418 identities/1,051 occurrences：production 250/562、test 154/449、compatibility 14/40、Broker production 128/254；净删除 5 个 production identity/9 occurrence 与 1 个 test identity/1 occurrence，无 relocation
   - [x] Issue #8412 后 ArcMut 快照保持 418 identities/1,051 occurrences：production 250/562、test 154/449、compatibility 14/40、Broker production 128/254；transaction bridge 删除完整 runtime owner，2 个 identity/3 occurrence 搬到显式 `TransactionMessageStore` 兼容边界，另有 2 个相邻上下文 occurrence 经 ADR-013 一对一 relocation 审核，临时 approval 不提交且剩余债务未隐藏
   - [x] Issue #8414 后实际快照降至 413 identities/1,044 occurrences：production 246/556、test 153/448、compatibility 14/40、Broker production 124/248；Producer/ColdData admin leaf 净删除 4 个 production identity/6 occurrence 与 1 个 test identity/1 occurrence，无 relocation
-  - [ ] M11-12bc6 及后续：Schedule hook/runtime 强环、Broker aggregate/leaf、Store WAL/queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8416 后实际快照降至 408 identities/1,036 occurrences：production 242/549、test 152/447、compatibility 14/40、Broker production 120/241；Schedule hook/helper 净删除 4 个 production identity/7 occurrence 与 1 个 test glob identity/1 occurrence，无 relocation
+  - [ ] M11-12bc7 及后续：Broker aggregate/leaf、Store WAL/queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-20
-> 代码基线：Issue #8414 / M11-12bc5 完成后
+> 代码基线：Issue #8416 / M11-12bc6 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,19 +19,19 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8414 后 reviewed ArcMut baseline 为 413 identities / 1,044 occurrences：production 246/556、test
-153/448、compatibility 14/40。production 全部分布在 Broker 与 Store。
+Issue #8416 后 reviewed ArcMut baseline 为 408 identities / 1,036 occurrences：production 242/549、test
+152/447、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 124 / 248 | transaction bridge、Producer/ColdData admin leaf 已退出完整 runtime owner；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 120 / 241 | transaction bridge、Producer/ColdData admin leaf 与 Schedule hook 已退出完整 runtime owner；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 122 / 308 | MessageStore、CommitLog/Flush、ConsumeQueue、Rocks/Timer 与 HA 生命周期改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 删除 `rocketmq/src/arc_mut.rs` production/public re-export 与兼容入口 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（热点文件 `broker_runtime.rs` 为 7/48）；下一子切片优先拆除 MessageStore Schedule hook 对完整 runtime 的强保活环。
-2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（热点文件 `broker_runtime.rs` 为 7/47）；Schedule hook 强保活环已拆除，下一子切片继续清理只读取少量能力的 admin/processor leaf。
+2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
 3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：收口 ConsumeQueue、queue store、index/mapped-file carrier。
 5. Store timer/HA：收口 Timer、Default/General/AutoSwitch HA service、client 与 connection actor。
@@ -49,6 +49,11 @@ EscapeBridge 使用窄标准 `Arc` capability；原有 2 个 ArcMut identity / 3
 M11-12bc5 将 Producer 查询与 ColdData 管理 handler 从完整 runtime owner 收窄为 live producer registry 和标准
 `Arc<ColdDataCgCtrService>`。production 净删除 4 identities / 6 occurrences；ColdData 测试 glob 不再传递导入
 ArcMut，额外删除 test 1/1，因此 reviewed 总量降至 413/1,044，无 relocation，compatibility 不增。
+
+M11-12bc6 将 MessageStore 的 Schedule hook 从完整 runtime owner 收窄为 `MessageStoreConfig`、可选
+`TimerMessageStore` 与标准 `Arc<ScheduleMessageService>`；helper 只接收配置、timer 借用和实时最大延迟级别，
+注册不再复制 runtime owner。production 净删除 4 identities / 7 occurrences，测试 glob 额外删除 test 1/1，
+因此 reviewed 总量降至 408/1,036，无 relocation，compatibility 不增。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2342,9 +2342,33 @@ Broker admin leaf capability 随 Issue #8414 完成以下 owner 收敛：
 下一子切片 M11-12bc6 拆除 MessageStore Schedule hook 对完整 BrokerRuntimeInner 的强保活环，只注入
 MessageStoreConfig、TimerMessageStore 与 ScheduleMessageService capability；75/82 总进度不变。
 
+## M11-12bc6 实现
+
+Schedule hook runtime ownership 随 Issue #8416 完成以下 capability 收敛：
+
+- `ScheduleMessageHook` 删除完整 `ArcMut<BrokerRuntimeInner<MS>>` owner，改持 `Arc<MessageStoreConfig>`、可选 `Arc<TimerMessageStore>` 与标准 `Arc<ScheduleMessageService<MS>>`。MessageStore 不再经 hook 强保活 Broker aggregate，`BrokerRuntimeInner → MessageStore → Hook → BrokerRuntimeInner` 环被拆除。
+- `HookUtils::handle_schedule_message` 与 delay-level transform 删除 runtime 参数和泛型，只接收配置、timer 借用、当前最大延迟级别与消息；hook 每次执行仍从共享 Schedule service 读取实时 max level，保留 transaction gate、timer 校验/重写及固定延迟 Topic/queue/property 语义。
+- timer wheel 已启用但 Timer store capability 缺失时返回既有 `WheelTimerNotEnable` 状态并记录警告，不再依赖 aggregate unchecked accessor；timer wheel 禁用时的既有拒绝状态保持不变。
+- `register_message_store_hook` 在注册前采样三项能力，不再 `ArcMut::clone` runtime。源码 contract 禁止 hook/helper 重新引入完整 runtime/ArcMut，重复注册强引用计数回归直接证明 runtime root 不会被 Hook 保留。
+- reviewed baseline 从 413 identities / 1,044 occurrences 降至 408 / 1,036；production 从 246/556 降至 242/549，test 从 153/448 降至 152/447，compatibility 保持 14/40。Broker production 从 124/248 降至 120/241；净删除 4 个 production identity/7 occurrence 与 1 个 test glob identity/1 occurrence，无 relocation。
+
+## M11-12bc6 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / strict Clippy | `cargo check -p rocketmq-broker --all-targets --all-features` 与 Broker all-target/all-feature strict Clippy 通过 |
+| Schedule hook focused tests | HookUtils 9/9、source capability contract 1/1、runtime strong-count ownership 1/1 通过；覆盖 timer disabled/missing、timer transformation、实时 max delay 输入、目标重写和无 runtime 回边 |
+| `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1` | 605 passed、25 failed、1 ignored；25 项与 main 已登记失败集合一致，本切片新增 5 个测试全部通过且未新增失败名称，因此全套仍如实记为基线复现而非通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 精确删除 5 identity/8 occurrence；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation/临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
+| root workspace final gates | `cargo fmt --all -- --check`、`git diff --check` 与 workspace all-target/all-feature strict Clippy 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
+下一子切片 M11-12bc7 继续收窄只读取少量能力的 Broker admin/processor leaf，随后进入 Store WAL/queue/timer/HA
+owner 清零；75/82 总进度不变。
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（124/248）；transaction bridge、Producer/ColdData admin leaf 已退出完整 runtime owner，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（120/241）；transaction bridge、Producer/ColdData admin leaf 与 Schedule hook 已退出完整 runtime owner，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与 HA actor（122/308）。
 3. 删除 compatibility `arc_mut.rs` 和公开 re-export；移除其余 nightly feature，将 guard 切到 production/public zero。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -2199,12 +2199,20 @@ impl BrokerRuntime {
     pub fn register_message_store_hook(&mut self) {
         let config = self.inner.message_store_config.clone();
         let topic_config_table = self.inner.topic_config_manager().topic_config_table();
-        let broker_runtime_inner = ArcMut::clone(&self.inner);
+        let timer_message_store = self.inner.timer_message_store().cloned();
+        let schedule_message_service = self.inner.schedule_message_service().clone();
         if let Some(ref mut message_store) = self.inner.message_store {
             let message_store_clone = message_store.clone();
-            message_store.set_put_message_hook(Box::new(CheckBeforePutMessageHook::new(message_store_clone, config)));
+            message_store.set_put_message_hook(Box::new(CheckBeforePutMessageHook::new(
+                message_store_clone,
+                config.clone(),
+            )));
             message_store.set_put_message_hook(Box::new(BatchCheckBeforePutMessageHook::new(topic_config_table)));
-            message_store.set_put_message_hook(Box::new(ScheduleMessageHook::new(broker_runtime_inner)))
+            message_store.set_put_message_hook(Box::new(ScheduleMessageHook::new(
+                config,
+                timer_message_store,
+                schedule_message_service,
+            )))
         }
     }
 
@@ -6629,6 +6637,17 @@ accounts:
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
         assert!(runtime.initialize().await);
         runtime
+    }
+
+    #[tokio::test]
+    async fn registering_message_store_hooks_does_not_retain_runtime_root() {
+        let mut runtime = new_phase3_test_runtime("schedule-hook-ownership").await;
+        let strong_count_before = runtime.inner.strong_count();
+
+        runtime.register_message_store_hook();
+
+        assert_eq!(runtime.inner.strong_count(), strong_count_before);
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 
     #[cfg(feature = "tieredstore")]

--- a/rocketmq-broker/src/hook/schedule_message_hook.rs
+++ b/rocketmq-broker/src/hook/schedule_message_hook.rs
@@ -12,24 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::message::MessageTrait;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::hook::put_message_hook::PutMessageHook;
+use rocketmq_store::timer::timer_message_store::TimerMessageStore;
 use tracing::warn;
 
-use crate::broker_runtime::BrokerRuntimeInner;
+use crate::schedule::schedule_message_service::ScheduleMessageService;
 use crate::util::hook_utils::HookUtils;
 
 pub struct ScheduleMessageHook<MS: MessageStore> {
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    message_store_config: Arc<MessageStoreConfig>,
+    timer_message_store: Option<Arc<TimerMessageStore>>,
+    schedule_message_service: Arc<ScheduleMessageService<MS>>,
 }
 
 impl<MS: MessageStore> ScheduleMessageHook<MS> {
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+    pub fn new(
+        message_store_config: Arc<MessageStoreConfig>,
+        timer_message_store: Option<Arc<TimerMessageStore>>,
+        schedule_message_service: Arc<ScheduleMessageService<MS>>,
+    ) -> Self {
+        Self {
+            message_store_config,
+            timer_message_store,
+            schedule_message_service,
+        }
     }
 }
 
@@ -46,10 +59,42 @@ impl<MS: MessageStore> PutMessageHook for ScheduleMessageHook<MS> {
         // so we log a warning and return None to indicate that no further processing
         // can be performed for this message.
         if let Some(msg) = msg.as_any_mut().downcast_mut::<MessageExtBrokerInner>() {
-            HookUtils::handle_schedule_message(&self.broker_runtime_inner, msg)
+            HookUtils::handle_schedule_message(
+                self.message_store_config.as_ref(),
+                self.timer_message_store.as_deref(),
+                self.schedule_message_service.get_max_delay_level(),
+                msg,
+            )
         } else {
             warn!("Message is not of type MessageExtBrokerInner");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn schedule_hook_source_depends_only_on_explicit_capabilities() {
+        let hook_source = include_str!("schedule_message_hook.rs");
+        let helper_source = include_str!("../util/hook_utils.rs");
+        let forbidden = [
+            concat!("rocketmq_", "rust"),
+            concat!("Broker", "Runtime", "Inner"),
+            concat!("Arc", "Mut"),
+        ];
+
+        for source in [hook_source, helper_source] {
+            for identifier in forbidden {
+                assert!(
+                    !source.contains(identifier),
+                    "schedule hook boundary contains forbidden dependency {identifier}"
+                );
+            }
+        }
+        assert!(hook_source.contains("message_store_config: Arc<MessageStoreConfig>"));
+        assert!(hook_source.contains("timer_message_store: Option<Arc<TimerMessageStore>>"));
+        assert!(hook_source.contains("schedule_message_service: Arc<ScheduleMessageService<MS>>"));
+        assert!(hook_source.contains("self.schedule_message_service.get_max_delay_level()"));
     }
 }

--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -30,7 +30,6 @@ use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::utils::queue_type_utils::QueueTypeUtils;
 use rocketmq_common::MessageDecoder::message_properties_to_string;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
@@ -40,7 +39,6 @@ use rocketmq_store::timer::timer_message_store::TimerMessageStore;
 use tracing::error;
 use tracing::warn;
 
-use crate::broker_runtime::BrokerRuntimeInner;
 use crate::out_api::broker_outer_api::BrokerOuterAPI;
 use crate::schedule::schedule_message_service::delay_level_to_queue_id;
 
@@ -139,28 +137,32 @@ impl HookUtils {
         None
     }
 
-    pub fn handle_schedule_message<MS: MessageStore>(
-        broker_runtime_inner: &ArcMut<BrokerRuntimeInner<MS>>,
+    pub fn handle_schedule_message(
+        message_store_config: &MessageStoreConfig,
+        timer_message_store: Option<&TimerMessageStore>,
+        max_delay_level: i32,
         msg: &mut MessageExtBrokerInner,
     ) -> Option<PutMessageResult> {
         let tran_type = MessageSysFlag::get_transaction_value(msg.sys_flag());
         if tran_type == MessageSysFlag::TRANSACTION_NOT_TYPE || tran_type == MessageSysFlag::TRANSACTION_COMMIT_TYPE {
             if !Self::is_rolled_timer_message(msg) && Self::check_if_timer_message(msg) {
-                if !broker_runtime_inner.message_store_config().timer_wheel_enable {
+                if !message_store_config.timer_wheel_enable {
                     // wheel timer is not enabled, reject the message
                     return Some(PutMessageResult::new_default(PutMessageStatus::WheelTimerNotEnable));
                 }
-                if let Some(transform_res) = Self::transform_timer_message(
-                    broker_runtime_inner.timer_message_store_unchecked(),
-                    broker_runtime_inner.message_store_config(),
-                    msg,
-                ) {
+                let Some(timer_message_store) = timer_message_store else {
+                    warn!("timer message store is unavailable while timer wheel is enabled");
+                    return Some(PutMessageResult::new_default(PutMessageStatus::WheelTimerNotEnable));
+                };
+                if let Some(transform_res) =
+                    Self::transform_timer_message(timer_message_store, message_store_config, msg)
+                {
                     return Some(transform_res);
                 }
             }
             // Delay Delivery
             if msg.message_ext_inner.message.delay_time_level() > 0 {
-                Self::transform_delay_level_message(broker_runtime_inner, msg);
+                Self::transform_delay_level_message(max_delay_level, msg);
             }
         }
         None
@@ -301,22 +303,11 @@ impl HookUtils {
     ///
     /// # Arguments
     ///
-    /// * `broker_runtime_inner` - Reference to the broker runtime that contains the schedule
-    ///   message service
+    /// * `max_delay_level` - Current maximum delay level from the schedule message service
     /// * `msg` - Mutable reference to the message to be transformed
-    ///
-    /// # Type Parameters
-    ///
-    /// * `MS` - A type that implements the `MessageStore` trait
-    pub fn transform_delay_level_message<MS: MessageStore>(
-        broker_runtime_inner: &ArcMut<BrokerRuntimeInner<MS>>,
-        msg: &mut MessageExtBrokerInner,
-    ) {
-        let schedule_message_service = broker_runtime_inner.schedule_message_service();
-        if msg.message_ext_inner.message.delay_time_level() > schedule_message_service.get_max_delay_level() {
-            msg.message_ext_inner
-                .message
-                .set_delay_time_level(schedule_message_service.get_max_delay_level());
+    pub fn transform_delay_level_message(max_delay_level: i32, msg: &mut MessageExtBrokerInner) {
+        if msg.message_ext_inner.message.delay_time_level() > max_delay_level {
+            msg.message_ext_inner.message.set_delay_time_level(max_delay_level);
         }
 
         // Backup real topic, queueId
@@ -540,5 +531,72 @@ mod tests {
         assert!(msg
             .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELIVER_MS))
             .is_none());
+    }
+
+    #[test]
+    fn handle_schedule_message_rejects_timer_message_when_timer_wheel_is_disabled() {
+        let message_store_config = MessageStoreConfig::default();
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(CheetahString::from_static_str("timer_topic"));
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELAY_MS),
+            CheetahString::from_static_str("1000"),
+        );
+
+        let result = HookUtils::handle_schedule_message(&message_store_config, None, 18, &mut msg);
+
+        assert_eq!(
+            result.unwrap().put_message_status(),
+            PutMessageStatus::WheelTimerNotEnable
+        );
+    }
+
+    #[test]
+    fn handle_schedule_message_rejects_timer_message_when_timer_store_is_unavailable() {
+        let message_store_config = MessageStoreConfig {
+            timer_wheel_enable: true,
+            ..MessageStoreConfig::default()
+        };
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(CheetahString::from_static_str("timer_topic"));
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELAY_MS),
+            CheetahString::from_static_str("1000"),
+        );
+
+        let result = HookUtils::handle_schedule_message(&message_store_config, None, 18, &mut msg);
+
+        assert_eq!(
+            result.unwrap().put_message_status(),
+            PutMessageStatus::WheelTimerNotEnable
+        );
+    }
+
+    #[test]
+    fn handle_schedule_message_uses_current_max_delay_level_and_rewrites_destination() {
+        let message_store_config = MessageStoreConfig::default();
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(CheetahString::from_static_str("delay_topic"));
+        msg.message_ext_inner.queue_id = 4;
+        msg.set_delay_time_level(12);
+
+        let result = HookUtils::handle_schedule_message(&message_store_config, None, 3, &mut msg);
+
+        assert!(result.is_none());
+        assert_eq!(msg.delay_time_level(), 3);
+        assert_eq!(msg.topic().as_str(), TopicValidator::RMQ_SYS_SCHEDULE_TOPIC);
+        assert_eq!(msg.message_ext_inner.queue_id, delay_level_to_queue_id(3));
+        assert_eq!(
+            msg.property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+                .as_ref()
+                .map(CheetahString::as_str),
+            Some("delay_topic")
+        );
+        assert_eq!(
+            msg.property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID))
+                .as_ref()
+                .map(CheetahString::as_str),
+            Some("4")
+        );
     }
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -553,7 +553,7 @@
           "id": "ab7b36e73225c82ba5237e56",
           "fingerprint": "3f50ae58593a221c0712bf87",
           "item": "mod tests",
-          "line": 5579
+          "line": 5592
         }
       ],
       "owner": "broker",
@@ -599,76 +599,70 @@
           "line": 2108
         },
         {
-          "id": "98030f96fd8311a69a3711a5",
-          "fingerprint": "e0ca4aa28a47fa45bd483bf3",
-          "item": "fn register_message_store_hook",
-          "line": 2202
-        },
-        {
           "id": "5ee21c896b913562301a1077",
           "fingerprint": "5e4000a4cc6080e4ca942578",
           "item": "fn init_processor",
-          "line": 2490
+          "line": 2498
         },
         {
           "id": "e003cfa8512a2b810c0757d6",
           "fingerprint": "a537097d2f3e1cde35c3d52e",
           "item": "fn init_processor",
-          "line": 2574
+          "line": 2582
         },
         {
           "id": "4899f108c82dd486c0cf801c",
           "fingerprint": "175b407bc96e49b8d505d4e6",
           "item": "fn init_processor",
-          "line": 2663
+          "line": 2671
         },
         {
           "id": "f211d11a474bb3f5368805ed",
           "fingerprint": "c1764c299f852ca96797ace1",
           "item": "fn init_processor",
-          "line": 2667
+          "line": 2675
         },
         {
           "id": "33c26215dc7e03370a77c147",
           "fingerprint": "cc22e2933269cd811997eac9",
           "item": "fn init_processor",
-          "line": 2671
+          "line": 2679
         },
         {
           "id": "d3c6ae41c6dfe325630c06ee",
           "fingerprint": "f69f1a42f8ff860e25c4d7e5",
           "item": "fn init_processor",
-          "line": 2675
+          "line": 2683
         },
         {
           "id": "643cda9c4a05b706a451df65",
           "fingerprint": "ac6ddfa809adcb48c4d79a5e",
           "item": "fn init_processor",
-          "line": 2679
+          "line": 2687
         },
         {
           "id": "c441d0a988807c325c3caf2d",
           "fingerprint": "b25abc1219eee2f2848952ec",
           "item": "fn init_processor",
-          "line": 2683
+          "line": 2691
         },
         {
           "id": "c792564ccb545baf12948fef",
           "fingerprint": "391568cfda5c595730431b9b",
           "item": "fn init_processor",
-          "line": 2687
+          "line": 2695
         },
         {
           "id": "085b114fa4b32ee717392eac",
           "fingerprint": "697b006598311fd21b7be444",
           "item": "fn init_processor",
-          "line": 2708
+          "line": 2716
         },
         {
           "id": "5a11a6fa9237fdd8ea0dafa1",
           "fingerprint": "700bae83c5efcc96fd63bae4",
           "item": "fn set_message_store",
-          "line": 4220
+          "line": 4233
         }
       ],
       "owner": "broker",
@@ -687,19 +681,19 @@
           "id": "5689243529837bbe350032c7",
           "fingerprint": "c7fde3d9b289d1ecd7941a05",
           "item": "fn new_controller_mode_message_store",
-          "line": 6352
+          "line": 6365
         },
         {
           "id": "a3c29627e8d7d7e68fa8faae",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_promotes_store_to_master",
-          "line": 10026
+          "line": 10050
         },
         {
           "id": "4ff61cc699c2c34d1b75fdec",
           "fingerprint": "e21707b42c3ee99cb2a5e67d",
           "item": "fn apply_message_store_role_change_demotes_store_to_slave",
-          "line": 10059
+          "line": 10083
         }
       ],
       "owner": "broker",
@@ -749,145 +743,145 @@
           "id": "2ebccb514bd3132632b6c47c",
           "fingerprint": "e7621f9bc48de4dcc0f47b88",
           "item": "fn register_increment_broker_data",
-          "line": 3453
+          "line": 3461
         },
         {
           "id": "2ad77a362f45944644a1c0df",
           "fingerprint": "fa49348dda87e0d66c4d8a3b",
           "item": "fn do_register_broker_all",
-          "line": 3505
+          "line": 3513
         },
         {
           "id": "037d56b431aa67608a06a9f6",
           "fingerprint": "231a8bb1057f09fa5309d044",
           "item": "struct ProducerStateGetter",
-          "line": 3573
+          "line": 3581
         },
         {
           "id": "99eff2a5cb8dbdbbd54f4795",
           "fingerprint": "7dd3cf4c20f1c213bd9345db",
           "item": "struct ConsumerStateGetter",
-          "line": 3593
+          "line": 3601
         },
         {
           "id": "fb274c3282855e73a012ee3f",
           "fingerprint": "db30298987fa29f77b4e9a6b",
           "item": "struct BrokerRuntimeInner",
-          "line": 3631
+          "line": 3639
         },
         {
           "id": "f248d64f116cda3a8fac82bc",
           "fingerprint": "11c496708854f974676df3a1",
           "item": "struct BrokerRuntimeInner",
-          "line": 3669
+          "line": 3677
         },
         {
           "id": "4ade86c96052f2090dbb7f77",
           "fingerprint": "cdae48c0ebbb111839de0523",
           "item": "fn message_store_mut",
-          "line": 3757
+          "line": 3765
         },
         {
           "id": "bfb12f611c07f201feb00cc8",
           "fingerprint": "7e8542f406042396ea595c53",
           "item": "fn message_store",
-          "line": 3952
+          "line": 3960
         },
         {
           "id": "51723d390366120a3abf406a",
           "fingerprint": "23ba055600cc3437a7375e8a",
           "item": "fn message_store_unchecked",
-          "line": 3977
+          "line": 3985
         },
         {
           "id": "073675840d7d1847ac6b9986",
           "fingerprint": "c827c069638d3aa68520a4e4",
           "item": "fn message_store_unchecked_mut",
-          "line": 3982
+          "line": 3990
         },
         {
           "id": "bab394cd446ee88f68c6ddd5",
           "fingerprint": "3fa31838c3340571bc19a4a5",
           "item": "fn register_broker_all_inner",
-          "line": 4357
+          "line": 4370
         },
         {
           "id": "c6edd12cc424af0d9cb42bba",
           "fingerprint": "af228ab0ff9d67691c021df2",
           "item": "fn do_register_broker_all_inner",
-          "line": 4456
+          "line": 4469
         },
         {
           "id": "397e52506121c49464b3bd42",
           "fingerprint": "604fe15af2dc366b3c1d1774",
           "item": "fn bootstrap_controller_mode",
-          "line": 4517
+          "line": 4530
         },
         {
           "id": "f772ab897753003c3b31ce78",
           "fingerprint": "d73c8ce1a6d38fdadfa82088",
           "item": "fn apply_controller_replica_info",
-          "line": 4692
+          "line": 4705
         },
         {
           "id": "ac29bee3c291d5419f18d69b",
           "fingerprint": "31047896d79098c6d503858e",
           "item": "fn ensure_controller_broker_id",
-          "line": 4723
+          "line": 4736
         },
         {
           "id": "faeaca698e3042def1d5ca17",
           "fingerprint": "a0e5eaac85b95545b35def48",
           "item": "fn discover_controller_leader",
-          "line": 4790
+          "line": 4803
         },
         {
           "id": "077e0c83f6570b890f8218b1",
           "fingerprint": "2533bd3e1a1f747535f7d232",
           "item": "fn refresh_controller_leader",
-          "line": 4815
+          "line": 4828
         },
         {
           "id": "e06e6b9b1da0c69b604502dd",
           "fingerprint": "6127abc01652c94842823b44",
           "item": "fn sync_controller_replica_info",
-          "line": 4823
+          "line": 4836
         },
         {
           "id": "7758ba9d150d1bf2fb773517",
           "fingerprint": "fafa781033d91e20b0059b84",
           "item": "fn fetch_controller_replica_info",
-          "line": 4891
+          "line": 4904
         },
         {
           "id": "36f745dd8380e3136af2cc39",
           "fingerprint": "4d37a31386e95dcaaebb2c7c",
           "item": "fn sync_broker_member_group",
-          "line": 4926
+          "line": 4939
         },
         {
           "id": "3d53c2e89ab668e271f8142d",
           "fingerprint": "198bb68697b47e45b2d7539d",
           "item": "fn update_min_broker",
-          "line": 4970
+          "line": 4983
         },
         {
           "id": "3427582ef504bcbb0dceb9d6",
           "fingerprint": "ae555e6b3b3ad0a94f0de73e",
           "item": "fn ack_message_processor_unchecked",
-          "line": 4997
+          "line": 5010
         },
         {
           "id": "bcd154dd4496146de09f72ed",
           "fingerprint": "137d02287d2e84512645a7bd",
           "item": "fn start_service",
-          "line": 5070
+          "line": 5083
         },
         {
           "id": "2e408d42e425425565e4bb10",
           "fingerprint": "29427e076444659b1b597065",
           "item": "fn apply_controller_role_change",
-          "line": 5094
+          "line": 5107
         }
       ],
       "owner": "broker",
@@ -906,7 +900,7 @@
           "id": "2b6ee8edd4a6435a6b3007b2",
           "fingerprint": "6503d57af85359294b26eef5",
           "item": "fn new_controller_mode_message_store",
-          "line": 6349
+          "line": 6362
         }
       ],
       "owner": "broker",
@@ -925,7 +919,7 @@
           "id": "8895e852d36c6c4ae6c94696",
           "fingerprint": "a236422f00598205b2ff717d",
           "item": "fn new_controller_mode_message_store",
-          "line": 6352
+          "line": 6365
         }
       ],
       "owner": "broker",
@@ -963,7 +957,7 @@
           "id": "49d7d37cd53bb0360ffa9e98",
           "fingerprint": "fc95bb9dd1e409338174f0ca",
           "item": "mod tests",
-          "line": 5570
+          "line": 5583
         }
       ],
       "owner": "broker",
@@ -1001,7 +995,7 @@
           "id": "76c8a751ce4984912169a2f1",
           "fingerprint": "7fc8adc251a6107872dc0c3c",
           "item": "fn new_controller_mode_message_store",
-          "line": 6349
+          "line": 6362
         }
       ],
       "owner": "broker",
@@ -1324,50 +1318,6 @@
           "fingerprint": "fae47900db522d415c294d74",
           "item": "fn new",
           "line": 33
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "34b7744219a534fdd9ae7dc9",
-      "path": "rocketmq-broker/src/hook/schedule_message_hook.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "581daf880908cdead06d7ed6",
-          "fingerprint": "75ffa34ff20a7864cd005c99",
-          "item": "<module>",
-          "line": 17
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "ecf97832e56508fe847b7cc7",
-      "path": "rocketmq-broker/src/hook/schedule_message_hook.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "830f7083eb026b2520fa13ad",
-          "fingerprint": "8a602a2816ce5134c5980483",
-          "item": "struct ScheduleMessageHook",
-          "line": 27
-        },
-        {
-          "id": "92863587424c7eac722f2a08",
-          "fingerprint": "6dc42f2be1e03386e7943ede",
-          "item": "fn new",
-          "line": 31
         }
       ],
       "owner": "broker",
@@ -2529,7 +2479,7 @@
           "id": "996961975697b8e2b4507f35",
           "fingerprint": "e7abdcdb186b84937c2a798a",
           "item": "mod tests",
-          "line": 652
+          "line": 653
         }
       ],
       "owner": "broker",
@@ -4619,69 +4569,6 @@
           "fingerprint": "1f7041dfa3835fa6df01447d",
           "item": "fn new",
           "line": 41
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "12e95fafb57431eeb19e02ad",
-      "path": "rocketmq-broker/src/util/hook_utils.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "45b14cf1d3c126cf9506d66d",
-          "fingerprint": "a5aad589d5deab723fe98942",
-          "item": "mod tests",
-          "line": 369
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "60913b181245e30cc3b5d9b4",
-      "path": "rocketmq-broker/src/util/hook_utils.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "d2886e860ad4d689d65c3554",
-          "fingerprint": "8ba193ceb9b361b362a0bf47",
-          "item": "<module>",
-          "line": 33
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "fcbe411ee66d789d23404ff4",
-      "path": "rocketmq-broker/src/util/hook_utils.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "c8e0e23ce1b48c474e93d873",
-          "fingerprint": "02226bed1a7ef60279b41b23",
-          "item": "fn handle_schedule_message",
-          "line": 143
-        },
-        {
-          "id": "b89304af75fdc21ec5114bb1",
-          "fingerprint": "2bccee9ed4e7acf837a8d1c1",
-          "item": "fn transform_delay_level_message",
-          "line": 312
         }
       ],
       "owner": "broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8416

### Brief Description

- detach the message-store schedule hook from the complete broker runtime owner
- inject the message-store configuration, optional timer store, and shared schedule service as explicit capabilities
- preserve timer and delay-level behavior while rejecting a missing timer capability with the existing timer-disabled status
- add behavior, source-boundary, and strong-reference regression coverage
- reduce the reviewed ownership baseline from 413 identities / 1,044 occurrences to 408 / 1,036 and update the migration checklists

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib util::hook_utils::tests` (9 passed)
- focused schedule source-boundary and runtime strong-count tests (2 passed)
- `cargo check -p rocketmq-broker --all-targets --all-features`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- enforcing runtime audit, ArcMut fixtures and tests, architecture dependency/release/performance guards, architecture tests, AGENTS routing, and diff checks
- full Broker all-feature library suite: 605 passed, 25 known baseline failures, 1 ignored; all five tests added by this change passed and the failure set did not expand


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled-message hook handling to avoid retaining unnecessary broker runtime state.
  * Added safer behavior when timer-wheel functionality is disabled or unavailable.
  * Preserved delay-level transformation while enforcing configured maximum delay limits.

* **Tests**
  * Added coverage to verify runtime resources are not unintentionally retained.
  * Expanded validation for timer-store availability and delay-level handling.

* **Documentation**
  * Updated architecture migration progress, readiness evidence, completion targets, and baseline metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->