### PR TITLE
[ISSUE #8429]♻️Remove ConsumerOrderInfo runtime back-reference

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8427 的 M11-12bc11 子切片完成后，当前 ArcMut reviewed
-baseline 为 382 identities / 993 occurrences，其中 production 为 219/509、test 为 149/444、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8429 的 M11-12bc12 子切片完成后，当前 ArcMut reviewed
+baseline 为 379 identities / 989 occurrences，其中 production 为 217/506、test 为 148/443、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 116 / 235 | Topic route/queue mapping、TopicConfig value/coordinator、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、核心 processor root、auth/Producer/ColdData admin 与统计 handler 已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 114 / 232 | Topic route/queue mapping、TopicConfig value/coordinator、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin 与统计 handler 已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 103 / 274 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child 直接 ownership 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -696,7 +696,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc9 HA connection registry capability：HAService 只发布 owned ack snapshot 与单地址 state；group transfer/notification 不再取得连接 owner，notification 非终态请求保持注册并修复 master 双重 `take` 失效
   - [x] M11-12bc10 Put-message preflight capability：Store-owned hook 只持 shutdown/running-flags/commit-log-lock 三项原子状态，不再反向保留完整 MessageStore；LiteLifecycle 只读查询同步收窄为普通 `&MS` 借用
   - [x] M11-12bc11 HA child direct ownership：General/AutoSwitch HA client 与 General HA connection 直接拥有从未独立共享的 child；外层 service/connection registry 和 `WeakArcMut<GeneralHAConnection>` task 回指保持原边界
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc12 ConsumerOrderInfo capability：manager 删除完整 BrokerRuntime back-reference 与 MessageStore 泛型，只注入存储根目录、标准 `Arc<TopicConfigManager>` 和实时 subscription-group table；删除无调用方 mutable/unchecked/setter accessor
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -762,7 +763,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8423 后实际快照降至 394 identities/1,014 occurrences：production 230/529、test 150/445、compatibility 14/40、Store production 110/288；HA connection registry API 净删除 2 个 production identity/5 occurrence，无 relocation
   - [x] Issue #8425 后实际快照降至 389 identities/1,007 occurrences：production 226/523、test 149/444、compatibility 14/40、Broker production 116/235；put-message preflight 与 LiteLifecycle 借用边界净删除 4 个 production identity/6 occurrence 与 1 个 test identity/1 occurrence，无 relocation
   - [x] Issue #8427 后实际快照降至 382 identities/993 occurrences：production 219/509、test 149/444、compatibility 14/40、Store production 103/274；HA client/connection nested owner 净删除 7 个 production identity/14 occurrence，无 relocation
-  - [ ] M11-12bc12 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8429 后实际快照降至 379 identities/989 occurrences：production 217/506、test 148/443、compatibility 14/40、Broker production 114/232；ConsumerOrderInfo runtime back-reference 净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation
+  - [ ] M11-12bc13 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -550,6 +550,14 @@ occurrences（production 219/509、test 149/444、compatibility 14/40、Store pr
 7 个 production identities/14 occurrences 且无 relocation。总进度仍为 75/82，下一子切片 M11-12bc12
 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+ConsumerOrderInfo runtime capability 随 Issue #8429 收口：`ConsumerOrderInfoManager` 删除完整
+`BrokerRuntimeInner` back-reference 与 `MessageStore` 泛型，改为注入存储根目录、标准 `Arc<TopicConfigManager>`
+和共享 subscription-group live table；同时删除 4 个无调用方 mutable/unchecked/setter accessor。配置路径与
+topic/group 自动清理回归通过。ArcMut 快照降至 379 identities/989 occurrences（production 217/506、test
+148/443、compatibility 14/40、Broker production 114/232），净删除 2 个 production identities/3 occurrences
+和 1 个 test identity/1 occurrence，且无 relocation。总进度仍为 75/82，下一子切片 M11-12bc13 继续 Broker
+aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-20
-> 代码基线：Issue #8427 / M11-12bc11 完成后
+> 代码基线：Issue #8429 / M11-12bc12 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,18 +19,18 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8427 后 reviewed ArcMut baseline 为 382 identities / 993 occurrences：production 219/509、test
-149/444、compatibility 14/40。production 全部分布在 Broker 与 Store。
+Issue #8429 后 reviewed ArcMut baseline 为 379 identities / 989 occurrences：production 217/506、test
+148/443、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 116 / 235 | transaction bridge、Producer/ColdData admin leaf、Schedule hook 与 put-message preflight 已退出完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 114 / 232 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight 与 ConsumerOrderInfoManager 已退出完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 103 / 274 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability 与未共享 HA child 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 116/235）；Schedule hook 与 put-message preflight 强保活环已拆除，继续清理只读取少量能力的 admin/processor leaf。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 114/232）；Schedule hook、put-message preflight 与 ConsumerOrderInfoManager 强保活边已拆除，继续清理只读取少量能力的 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
 3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
@@ -84,6 +84,13 @@ M11-12bc11 将 `GeneralHAClient` 的 Default/AutoSwitch payload、`AutoSwitchHAC
 `WeakArcMut<GeneralHAConnection>` 回指保持不变。production 净删除 7 identities / 14 occurrences，因此 reviewed
 总量降至 382/993、production 降至 219/509、Store 降至 103/274；test 149/444 与 compatibility 14/40 不增，
 无 relocation。
+
+M11-12bc12 将 `ConsumerOrderInfoManager` 从完整 `ArcMut<BrokerRuntimeInner>` back-reference 收窄为存储根目录、
+标准 `Arc<TopicConfigManager>` 与共享 subscription-group live table，删除 `MessageStore` 泛型和 4 个无调用方
+mutable/unchecked/setter accessor。配置路径仍由初始化时的 Broker 配置决定，topic/group 自动清理继续观察共享
+live table。production 净删除 2 identities / 3 occurrences，test glob 净删除 1/1，因此 reviewed 总量降至
+379/989、production 降至 217/506、Broker 降至 114/232、test 降至 148/443；Store 103/274 与 compatibility
+14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2486,9 +2486,32 @@ HA nested child ownership 随 Issue #8427 完成以下边界收敛：
 下一子切片 M11-12bc12 继续收窄 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner；75/82 总进度不变，
 compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
 
+## M11-12bc12 实现
+
+ConsumerOrderInfo runtime capability 随 Issue #8429 完成以下边界收敛：
+
+- `ConsumerOrderInfoManager` 删除完整 `ArcMut<BrokerRuntimeInner>` back-reference 与 `MessageStore` 泛型，改为只持存储根目录、标准 `Arc<TopicConfigManager>` 和共享 subscription-group live table；配置路径、topic existence 与 group existence 不再通过完整 Broker runtime 间接读取。
+- Broker 初始化在 manager 边界注入同一代 Topic manager 与同一 live subscription-group table；配置路径与实时 topic/group 自动清理回归证明能力代际和原行为不变。
+- 删除 4 个仓内无调用方的 `consumer_order_info_manager_mut`、`consumer_order_info_manager_unchecked_mut`、`consumer_order_info_manager_unchecked` 与 setter；共享只读 accessor 保留，consumer-order lock/info 行为不变。
+- reviewed baseline 从 382 identities / 993 occurrences 降至 379 / 989；production 从 219/509 降至 217/506，test 从 149/444 降至 148/443，compatibility 保持 14/40。Broker production 从 116/235 降至 114/232；净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation。
+
+## M11-12bc12 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused tests / strict Clippy | `cargo check -p rocketmq-broker --all-features` 通过；ConsumerOrderInfoManager 7/7 通过；Broker all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib 回归 | 607 passed、25 failed、1 ignored；25 项与 main 已登记失败名单一致，较上一切片增加的 2 个通过项均为本切片回归，因此全套仍如实记为基线复现而非通过 |
+| RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 审核候选精确删除 3 identity/4 occurrence；正式 baseline 补丁后 `python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation/临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
+| root workspace final gates | `cargo fmt --all -- --check`、`git diff --check` 与 workspace all-target/all-feature strict Clippy 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
+下一子切片 M11-12bc13 继续收窄 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner；75/82 总进度不变，
+compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（116/235）；transaction bridge、Producer/ColdData admin leaf、Schedule hook 与 put-message preflight 已退出完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（114/232）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight 与 ConsumerOrderInfoManager 已退出完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（103/274）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child direct ownership 已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1271,7 +1271,12 @@ impl BrokerRuntime {
         {
             inner.subscription_group_manager = Some(SubscriptionGroupManager::new(inner.clone()));
         }
-        inner.consumer_order_info_manager = Some(ConsumerOrderInfoManager::new(inner.clone()));
+        let consumer_order_info_manager = ConsumerOrderInfoManager::new(
+            inner.broker_config.store_path_root_dir.clone(),
+            inner.topic_config_manager_handle(),
+            Arc::clone(inner.subscription_group_manager().subscription_group_table()),
+        );
+        inner.consumer_order_info_manager = Some(consumer_order_info_manager);
         inner.producer_manager.set_broker_stats_manager(stats_manager.clone());
         inner
             .consumer_manager
@@ -3641,7 +3646,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     consumer_offset_manager: Arc<ConsumerOffsetManager<MS>>,
     subscription_group_manager: Option<SubscriptionGroupManager<MS>>,
     consumer_filter_manager: Option<ConsumerFilterManager>,
-    consumer_order_info_manager: Option<ConsumerOrderInfoManager<MS>>,
+    consumer_order_info_manager: Option<ConsumerOrderInfoManager>,
     message_store: Option<ArcMut<MS>>,
     broker_stats: Option<BrokerStats<MS>>,
     schedule_message_service: Option<Arc<ScheduleMessageService<MS>>>,
@@ -3755,16 +3760,6 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn consumer_filter_manager_unchecked_mut(&mut self) -> &mut ConsumerFilterManager {
         unsafe { self.consumer_filter_manager.as_mut().unwrap_unchecked() }
-    }
-
-    #[inline]
-    pub fn consumer_order_info_manager_mut(&mut self) -> &mut ConsumerOrderInfoManager<MS> {
-        self.consumer_order_info_manager.as_mut().unwrap()
-    }
-
-    #[inline]
-    pub fn consumer_order_info_manager_unchecked_mut(&mut self) -> &mut ConsumerOrderInfoManager<MS> {
-        unsafe { self.consumer_order_info_manager.as_mut().unwrap_unchecked() }
     }
 
     #[inline]
@@ -3953,13 +3948,8 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn consumer_order_info_manager(&self) -> &ConsumerOrderInfoManager<MS> {
+    pub fn consumer_order_info_manager(&self) -> &ConsumerOrderInfoManager {
         self.consumer_order_info_manager.as_ref().unwrap()
-    }
-
-    #[inline]
-    pub fn consumer_order_info_manager_unchecked(&self) -> &ConsumerOrderInfoManager<MS> {
-        unsafe { self.consumer_order_info_manager.as_ref().unwrap_unchecked() }
     }
 
     #[inline]
@@ -4232,11 +4222,6 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn set_consumer_filter_manager(&mut self, consumer_filter_manager: ConsumerFilterManager) {
         self.consumer_filter_manager = Some(consumer_filter_manager);
-    }
-
-    #[inline]
-    pub fn set_consumer_order_info_manager(&mut self, consumer_order_info_manager: ConsumerOrderInfoManager<MS>) {
-        self.consumer_order_info_manager = Some(consumer_order_info_manager);
     }
 
     #[inline]

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -18,46 +18,56 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use cheetah_string::CheetahString;
+use dashmap::DashMap;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_rust::ArcMut;
-use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::info;
 use tracing::warn;
 
 use crate::broker_path_config_helper::get_consumer_order_info_path;
-use crate::broker_runtime::BrokerRuntimeInner;
 use crate::offset::manager::consumer_order_info_lock_manager::ConsumerOrderInfoLockManager;
+use crate::topic::manager::topic_config_manager::TopicConfigManager;
 
 const TOPIC_GROUP_SEPARATOR: &str = "@";
 const CLEAN_SPAN_FROM_LAST: u64 = 24 * 3600 * 1000;
+type SubscriptionGroupTable = Arc<DashMap<CheetahString, Arc<SubscriptionGroupConfig>>>;
 
-pub(crate) struct ConsumerOrderInfoManager<MS: MessageStore> {
+pub(crate) struct ConsumerOrderInfoManager {
     pub(crate) consumer_order_info_wrapper: parking_lot::Mutex<ConsumerOrderInfoWrapper>,
     pub(crate) consumer_order_info_lock_manager: Option<ConsumerOrderInfoLockManager>,
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    store_path_root_dir: CheetahString,
+    topic_config_manager: Arc<TopicConfigManager>,
+    subscription_group_table: SubscriptionGroupTable,
 }
 
-impl<MS: MessageStore> ConsumerOrderInfoManager<MS> {
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> ConsumerOrderInfoManager<MS> {
+impl ConsumerOrderInfoManager {
+    pub fn new(
+        store_path_root_dir: CheetahString,
+        topic_config_manager: Arc<TopicConfigManager>,
+        subscription_group_table: SubscriptionGroupTable,
+    ) -> Self {
         Self {
             consumer_order_info_wrapper: parking_lot::Mutex::new(ConsumerOrderInfoWrapper::default()),
             consumer_order_info_lock_manager: None,
-            broker_runtime_inner,
+            store_path_root_dir,
+            topic_config_manager,
+            subscription_group_table,
         }
     }
 }
 
 //Fully implemented will be removed
 #[allow(unused_variables)]
-impl<MS: MessageStore> ConfigManager for ConsumerOrderInfoManager<MS> {
+impl ConfigManager for ConsumerOrderInfoManager {
     fn config_file_path(&self) -> String {
-        get_consumer_order_info_path(self.broker_runtime_inner.broker_config().store_path_root_dir.as_str())
+        get_consumer_order_info_path(self.store_path_root_dir.as_str())
     }
 
     fn encode_pretty(&self, pretty_format: bool) -> String {
@@ -84,7 +94,7 @@ impl<MS: MessageStore> ConfigManager for ConsumerOrderInfoManager<MS> {
     }
 }
 
-impl<MS: MessageStore> ConsumerOrderInfoManager<MS> {
+impl ConsumerOrderInfoManager {
     pub fn clear_block(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32) {
         unimplemented!()
     }
@@ -105,19 +115,14 @@ impl<MS: MessageStore> ConsumerOrderInfoManager<MS> {
             let group = arrays[1];
 
             let topic_config = self
-                .broker_runtime_inner
-                .topic_config_manager()
+                .topic_config_manager
                 .select_topic_config(&CheetahString::from(topic));
             if topic_config.is_none() {
                 info!("Topic not exist, Clean order info, {}:{:?}", topic_at_group, qs);
                 keys_to_remove.push(topic_at_group.clone());
                 continue;
             }
-            let subscription_group_table = self
-                .broker_runtime_inner
-                .subscription_group_manager()
-                .subscription_group_table();
-            let subscription_group_config = subscription_group_table.get(&CheetahString::from(group));
+            let subscription_group_config = self.subscription_group_table.get(&CheetahString::from(group));
             if subscription_group_config.is_none() {
                 info!("Group not exist, Clean order info, {}:{:?}", topic_at_group, qs);
                 keys_to_remove.push(topic_at_group.clone());
@@ -513,7 +518,66 @@ impl OrderInfo {
 mod tests {
     use std::collections::HashMap;
 
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
     use super::*;
+
+    fn test_manager() -> (
+        ConsumerOrderInfoManager,
+        Arc<TopicConfigManager>,
+        SubscriptionGroupTable,
+    ) {
+        let broker_config = BrokerConfig {
+            store_path_root_dir: CheetahString::from_static_str("consumer-order-root"),
+            ..BrokerConfig::default()
+        };
+        let topic_config_manager = Arc::new(TopicConfigManager::new(
+            &broker_config,
+            &MessageStoreConfig::default(),
+            false,
+        ));
+        let subscription_group_table = Arc::new(DashMap::new());
+        let manager = ConsumerOrderInfoManager::new(
+            broker_config.store_path_root_dir,
+            Arc::clone(&topic_config_manager),
+            Arc::clone(&subscription_group_table),
+        );
+        (manager, topic_config_manager, subscription_group_table)
+    }
+
+    #[test]
+    fn config_file_path_uses_injected_store_root() {
+        let (manager, _, _) = test_manager();
+
+        assert_eq!(
+            manager.config_file_path(),
+            get_consumer_order_info_path("consumer-order-root")
+        );
+    }
+
+    #[test]
+    fn auto_clean_observes_injected_topic_and_subscription_tables() {
+        let (manager, topic_config_manager, subscription_group_table) = test_manager();
+        let topic = CheetahString::from_static_str("OrderTopic");
+        let group = CheetahString::from_static_str("OrderGroup");
+        topic_config_manager.update_topic_config(TopicConfig::new(topic.as_str()), 0);
+        subscription_group_table.insert(group.clone(), Arc::new(SubscriptionGroupConfig::new(group.clone())));
+        let key = CheetahString::from_string(build_key(&topic, &group));
+        manager
+            .consumer_order_info_wrapper
+            .lock()
+            .table
+            .insert(key.clone(), HashMap::from([(0, OrderInfo::default())]));
+
+        manager.auto_clean();
+        assert!(manager.consumer_order_info_wrapper.lock().table.contains_key(&key));
+
+        subscription_group_table.remove(&group);
+        manager.auto_clean();
+        assert!(!manager.consumer_order_info_wrapper.lock().table.contains_key(&key));
+    }
 
     #[test]
     fn build_offset_list_with_single_element() {

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -764,10 +764,10 @@
           "line": 3601
         },
         {
-          "id": "fb274c3282855e73a012ee3f",
-          "fingerprint": "db30298987fa29f77b4e9a6b",
+          "id": "4ff86f94755506ecea829db9",
+          "fingerprint": "e8143bac4e115cee5a064d74",
           "item": "struct BrokerRuntimeInner",
-          "line": 3639
+          "line": 3650
         },
         {
           "id": "f248d64f116cda3a8fac82bc",
@@ -1543,69 +1543,6 @@
           "fingerprint": "507b9f9640d80f2d0ae706be",
           "item": "fn consumer_offset_manager_clean_group_deletes_offsets_from_rocksdb",
           "line": 1298
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "29b31eab02e51a8dd7348e98",
-      "path": "rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "94d2a063fbbd9332202fa780",
-          "fingerprint": "1f0d5ad97db515c58344edf5",
-          "item": "mod tests",
-          "line": 516
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e10969eeec74e5807658474b",
-      "path": "rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "1ad2fea806aa155e0b3fd744",
-          "fingerprint": "a2f6e14e2ba324e28d0da644",
-          "item": "<module>",
-          "line": 26
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "a3256d80a76dd9a8d9b20906",
-      "path": "rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "a90250d8761ddc8a53aa0532",
-          "fingerprint": "ffb12e8192d98e1dbf7d1743",
-          "item": "struct ConsumerOrderInfoManager",
-          "line": 43
-        },
-        {
-          "id": "82d2cc5b29b242edf6148fca",
-          "fingerprint": "fc8784a5c4bccef1edad41c2",
-          "item": "fn new",
-          "line": 47
         }
       ],
       "owner": "broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8429

### Brief Description

- Replace the `ConsumerOrderInfoManager` back-reference to the complete `BrokerRuntimeInner` with the store root, a shared `TopicConfigManager`, and the live subscription-group table.
- Remove the unnecessary `MessageStore` generic and four unused mutable, unchecked, and setter accessors while preserving the shared read-only accessor.
- Add focused coverage for the injected configuration path and live topic/group cleanup behavior.
- Reduce the reviewed ArcMut baseline from 382 identities and 993 occurrences to 379 identities and 989 occurrences, with no relocation, and update the architecture migration checklists.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-features`: passed.
- `cargo test -p rocketmq-broker --all-features offset::manager::consumer_order_info_manager::tests -- --test-threads=1`: 7 passed.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1`: 607 passed, 25 failed, and 1 ignored; the 25 failures match the existing main baseline and this change introduced no new failing test names.
- Store and Broker RocksDB strict Clippy passed; RocksDB foundation 82/82, semantics 9/9, Broker RocksDB 21/21, and pop consumer 4/4 passed.
- `python scripts/arc_mut_guard.py`, 24 ArcMut fixtures, 67 ArcMut guard tests, dependency baseline/target checks, release guard, eight performance profiles, and 60 architecture guard tests passed.
- The enforcing runtime audit and AGENTS routing check passed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`, and `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consumer order information management by using focused runtime configuration and shared subscription data.
  * Updated automatic cleanup to reflect current topic and subscription-group state.
  * Removed unused mutable management access paths, reducing opportunities for unintended changes.

* **Documentation**
  * Updated architecture migration progress, remaining tasks, verification results, and baseline metrics.
  * Recorded completion of the consumer order information capability milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->