### PR TITLE
[ISSUE #8435]♻️Break MessageArrivingListener runtime cycle

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8433 的 M11-12bc14 子切片完成后，当前 ArcMut reviewed
-baseline 为 374 identities / 977 occurrences，其中 production 为 213/496、test 为 147/441、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8435 的 M11-12bc15 子切片完成后，当前 ArcMut reviewed
+baseline 为 372 identities / 974 occurrences，其中 production 为 211/493、test 为 147/441、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 110 / 222 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 108 / 219 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 103 / 274 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child 直接 ownership 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -699,7 +699,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc12 ConsumerOrderInfo capability：manager 删除完整 BrokerRuntime back-reference 与 MessageStore 泛型，只注入存储根目录、标准 `Arc<TopicConfigManager>` 和实时 subscription-group table；删除无调用方 mutable/unchecked/setter accessor
   - [x] M11-12bc13 orphan V2 example removal：删除从未进入 Broker module tree、从未被 Cargo/测试编译且重复 Remoting canonical example/tests 的迁移示例残留；Remoting V2 example 与 7/7 自动化测试继续作为可执行证据
   - [x] M11-12bc14 TopicRouteInfo capability：manager 删除完整 BrokerRuntime back-reference 与 MessageStore 泛型，只注入共享 BrokerOuterAPI、轮询间隔与父 TaskGroup；无 ServiceContext 时保留 ambient Tokio fallback，并删除无调用方 unchecked/setter 入口
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc15 MessageArrivingListener weak capability：Store-owned listener 只持 Pull hold、POP 与 Notification processor 的标准 Weak handle，注册移至三项 owner 初始化后；late notification 在 owner 已释放时安全跳过，强引用计数回归证明不再反向保活 Broker runtime
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -768,7 +769,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8429 后实际快照降至 379 identities/989 occurrences：production 217/506、test 148/443、compatibility 14/40、Broker production 114/232；ConsumerOrderInfo runtime back-reference 净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation
   - [x] Issue #8431 后实际快照降至 376 identities/980 occurrences：production 215/499、test 147/441、compatibility 14/40、Broker production 112/225；未编译 Broker V2 示例残留净删除 2 个 production identity/7 occurrence 与 1 个 test identity/2 occurrence，无 relocation
   - [x] Issue #8433 后实际快照降至 374 identities/977 occurrences：production 213/496、test 147/441、compatibility 14/40、Broker production 110/222；TopicRouteInfo runtime back-reference 净删除 2 个 production identity/3 occurrence，无 relocation
-  - [ ] M11-12bc15 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8435 后实际快照降至 372 identities/974 occurrences：production 211/493、test 147/441、compatibility 14/40、Broker production 108/219；MessageArrivingListener runtime back-reference 净删除 2 个 production identity/3 occurrence，无 relocation
+  - [ ] M11-12bc16 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -572,6 +572,13 @@ ambient Tokio runtime root。幂等启动/有界关闭、父任务组和共享 r
 14/40、Broker production 110/222），净删除 2 个 production identities/3 occurrences，且无 relocation。总进度
 仍为 75/82，下一子切片 M11-12bc15 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+MessageArrivingListener runtime cycle 随 Issue #8435 拆除：Store-owned listener 不再强持完整 Broker runtime，改持
+Pull hold、POP 与 Notification processor 的标准 `Weak` handle；注册顺序移至三项 owner 初始化后，late notification
+在 teardown owner 已释放时安全跳过。移除 listener 前后 Broker runtime strong count 不变的回归通过。ArcMut 快照
+降至 372 identities/974 occurrences（production 211/493、test 147/441、compatibility 14/40、Broker production
+108/219），净删除 2 个 production identities/3 occurrences，且无 relocation。总进度仍为 75/82，下一子切片
+M11-12bc16 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-20
-> 代码基线：Issue #8433 / M11-12bc14 完成后
+> 代码基线：Issue #8435 / M11-12bc15 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,18 +19,18 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8433 后 reviewed ArcMut baseline 为 374 identities / 977 occurrences：production 213/496、test
+Issue #8435 后 reviewed ArcMut baseline 为 372 identities / 974 occurrences：production 211/493、test
 147/441、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 110 / 222 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager 与未编译 V2 示例残留已退出完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 108 / 219 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与未编译 V2 示例残留已退出完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 103 / 274 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability 与未共享 HA child 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 110/222）；Schedule hook、put-message preflight、ConsumerOrderInfoManager 与 TopicRouteInfoManager 强保活边已拆除，未编译 V2 示例残留已清理；继续清理只读取少量能力的 admin/processor leaf。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 108/219）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager 与 MessageArrivingListener 强保活边已拆除，未编译 V2 示例残留已清理；继续清理只读取少量能力的 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
 3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
@@ -103,6 +103,12 @@ M11-12bc14 将 `TopicRouteInfoManager` 从完整 `ArcMut<BrokerRuntimeInner>` ba
 `ServiceContext` 时保留 ambient Tokio runtime fallback。production 净删除 2 identities / 3 occurrences，因此
 reviewed 总量降至 374/977、production 降至 213/496、Broker 降至 110/222；test 147/441、Store 103/274 与
 compatibility 14/40 不增，无 relocation。
+
+M11-12bc15 将 Store-owned `NotifyMessageArrivingListener` 从完整 `ArcMut<BrokerRuntimeInner>` back-reference 收窄为
+Pull hold、POP 与 Notification processor 的三项标准 `Weak` handle，注册移至三项 owner 初始化后；late notification
+在 teardown owner 已释放时安全跳过。production 净删除 2 identities / 3 occurrences，因此 reviewed 总量降至
+372/974、production 降至 211/493、Broker 降至 108/219；test 147/441、Store 103/274 与 compatibility 14/40
+不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2551,9 +2551,32 @@ TopicRouteInfo runtime capability 随 Issue #8433 完成以下边界收敛：
 下一子切片 M11-12bc15 继续收窄 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner；75/82 总进度不变，
 compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
 
+## M11-12bc15 实现
+
+MessageArrivingListener runtime cycle 随 Issue #8435 完成以下边界收敛：
+
+- Store-owned `NotifyMessageArrivingListener` 删除完整 `ArcMut<BrokerRuntimeInner>` back-reference，改为 Pull request hold service、POP processor 与 Notification processor 三项标准 `Weak` handle；listener 无法再读取或保活其他 Broker runtime capability。
+- listener 注册从 Pull hold 初始化后移动到三项 owner 均已建立之后；arrival fan-out 逐项 upgrade，正常运行时仍调用同一三个通知 API，teardown 后的 late notification 对已释放 owner 安全跳过而不再经 unchecked accessor panic。
+- 新增真实 Broker runtime 回归：初始化 MessageStore listener 后采样 runtime strong count，清除 listener 后计数保持完全不变；旧完整 runtime owner 会使该断言下降 1。
+- reviewed baseline 从 374 identities / 977 occurrences 降至 372 / 974；production 从 213/496 降至 211/493，test 保持 147/441，compatibility 保持 14/40。Broker production 从 110/222 降至 108/219；净删除 2 个 production identity/3 occurrence，无 relocation。
+
+## M11-12bc15 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused tests / strict Clippy | `cargo check -p rocketmq-broker --all-features` 通过；listener runtime strong-count 回归 1/1 通过；Broker all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib 回归 | 608 passed、25 failed、1 ignored；25 项与 main 已登记失败名单一致，新增 listener ownership 回归通过且未新增失败名称，因此全套仍如实记为基线复现而非通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 审核候选精确删除 2 identity/3 occurrence；正式 baseline 补丁后 `python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation/临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
+| root workspace final gates | `cargo fmt --all -- --check`、`git diff --check` 与 workspace all-target/all-feature strict Clippy 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
+下一子切片 M11-12bc16 继续收窄 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner；75/82 总进度不变，
+compatibility、stable/Miri/Loom/soak/SLO 与完整候选快照 Gate 仍保持开放。
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（110/222）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager 与未编译 V2 示例残留已退出完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（108/219）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与未编译 V2 示例残留已退出完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（103/274）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child direct ownership 已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -2495,16 +2495,8 @@ impl BrokerRuntime {
         ));
 
         let consumer_manage_processor = ConsumerManageProcessor::new(self.inner.clone());
-        self.inner.pull_request_hold_service = Some(Arc::new(PullRequestHoldService::new(Arc::downgrade(
-            &pull_message_processor,
-        ))));
-
-        let inner = self.inner.clone();
-        self.inner
-            .message_store
-            .as_mut()
-            .unwrap()
-            .set_message_arriving_listener(Some(Arc::new(Box::new(NotifyMessageArrivingListener::new(inner)))));
+        let pull_request_hold_service = Arc::new(PullRequestHoldService::new(Arc::downgrade(&pull_message_processor)));
+        self.inner.pull_request_hold_service = Some(Arc::clone(&pull_request_hold_service));
 
         let pop_message_processor = PopMessageProcessor::new(self.inner.clone());
         self.inner.pop_message_processor = Some(pop_message_processor.clone());
@@ -2520,6 +2512,16 @@ impl BrokerRuntime {
 
         let notification_processor = NotificationProcessor::new(self.inner.clone());
         self.inner.notification_processor = Some(notification_processor.clone());
+        let message_arriving_listener = NotifyMessageArrivingListener::new(
+            &pull_request_hold_service,
+            &pop_message_processor,
+            &notification_processor,
+        );
+        self.inner
+            .message_store
+            .as_mut()
+            .unwrap()
+            .set_message_arriving_listener(Some(Arc::new(Box::new(message_arriving_listener))));
         let mut broker_request_processor = BrokerRequestProcessor::new();
         let request_processor_task_group = self.request_processor_task_group.clone().or_else(|| {
             self.broker_task_group_or_current(
@@ -6658,6 +6660,22 @@ accounts:
                 .strong_count(),
             store_strong_count_before
         );
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn message_arriving_listener_does_not_retain_runtime_root() {
+        let mut runtime = new_phase3_test_runtime("message-arriving-listener-ownership").await;
+        let strong_count_before = runtime.inner.strong_count();
+
+        runtime
+            .inner
+            .message_store
+            .as_mut()
+            .expect("message store should be initialized")
+            .set_message_arriving_listener(None);
+
+        assert_eq!(runtime.inner.strong_count(), strong_count_before);
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 

--- a/rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs
+++ b/rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs
@@ -13,25 +13,37 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Weak;
 
 use cheetah_string::CheetahString;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_arriving_listener::MessageArrivingListener;
 use rocketmq_store::base::message_store::MessageStore;
 
-use crate::broker_runtime::BrokerRuntimeInner;
+use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestHoldService;
+use crate::processor::notification_processor::NotificationProcessor;
+use crate::processor::pop_message_processor::PopMessageProcessor;
 
 pub struct NotifyMessageArrivingListener<MS: MessageStore> {
-    //pull_request_hold_service: ArcMut<PullRequestHoldService<MS>>,
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    pull_request_hold_service: Weak<PullRequestHoldService<MS>>,
+    pop_message_processor: Weak<PopMessageProcessor<MS>>,
+    notification_processor: Weak<NotificationProcessor<MS>>,
 }
 
 impl<MS> NotifyMessageArrivingListener<MS>
 where
     MS: MessageStore + Send + Sync,
 {
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+    pub fn new(
+        pull_request_hold_service: &Arc<PullRequestHoldService<MS>>,
+        pop_message_processor: &Arc<PopMessageProcessor<MS>>,
+        notification_processor: &Arc<NotificationProcessor<MS>>,
+    ) -> Self {
+        Self {
+            pull_request_hold_service: Arc::downgrade(pull_request_hold_service),
+            pop_message_processor: Arc::downgrade(pop_message_processor),
+            notification_processor: Arc::downgrade(notification_processor),
+        }
     }
 }
 
@@ -50,11 +62,8 @@ where
         filter_bit_map: Option<Vec<u8>>,
         properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) {
-        self.broker_runtime_inner
-            .pull_request_hold_service()
-            .as_ref()
-            .unwrap()
-            .notify_message_arriving_ext(
+        if let Some(pull_request_hold_service) = self.pull_request_hold_service.upgrade() {
+            pull_request_hold_service.notify_message_arriving_ext(
                 topic,
                 queue_id,
                 logic_offset,
@@ -63,10 +72,10 @@ where
                 filter_bit_map.clone(),
                 properties,
             );
+        }
 
-        self.broker_runtime_inner
-            .pop_message_processor_unchecked()
-            .notify_message_arriving_full(
+        if let Some(pop_message_processor) = self.pop_message_processor.upgrade() {
+            pop_message_processor.notify_message_arriving_full(
                 topic.clone(),
                 queue_id,
                 tags_code,
@@ -74,10 +83,10 @@ where
                 filter_bit_map.clone(),
                 properties,
             );
+        }
 
-        self.broker_runtime_inner
-            .notification_processor_unchecked()
-            .notify_message_arriving(
+        if let Some(notification_processor) = self.notification_processor.upgrade() {
+            notification_processor.notify_message_arriving(
                 topic.clone(),
                 queue_id,
                 tags_code,
@@ -85,5 +94,6 @@ where
                 filter_bit_map,
                 properties,
             );
+        }
     }
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -1389,50 +1389,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "35bccdc66c666877667b086c",
-      "path": "rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "38e717991eea0d0eaf1dc954",
-          "fingerprint": "72f7dd34b8244ed304f4e2ea",
-          "item": "<module>",
-          "line": 18
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "777db846f66738a52c39e2b7",
-      "path": "rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "02c2a72e574d0e871dc67cb8",
-          "fingerprint": "d5a89338077015ccda330b0e",
-          "item": "struct NotifyMessageArrivingListener",
-          "line": 26
-        },
-        {
-          "id": "fa873935af6ef90d74ced7d6",
-          "fingerprint": "a3d46b8e4774b97ec70b0013",
-          "item": "fn new",
-          "line": 33
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "4e08d549e9698518ba84279d",
       "path": "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs",
       "symbol": "ArcMut",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8435

### Brief Description

- Replace the Store-owned `NotifyMessageArrivingListener` back-reference to the complete `BrokerRuntimeInner` with weak handles to the pull hold service, POP processor, and notification processor.
- Register the listener only after all three owners exist, and safely skip a target after its owner has been released during teardown.
- Add a runtime strong-reference regression proving that the MessageStore listener no longer retains the Broker runtime root.
- Reduce the reviewed ArcMut baseline from 374 identities and 977 occurrences to 372 identities and 974 occurrences, with no relocation, and update the architecture migration checklists.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-features`: passed.
- `cargo test -p rocketmq-broker --all-features message_arriving_listener_does_not_retain_runtime_root -- --test-threads=1`: passed.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-broker --all-features --lib -- --test-threads=1`: 608 passed, 25 failed, and 1 ignored; the 25 failures match the existing main baseline and this change introduced no new failing test names.
- Store and Broker RocksDB strict Clippy passed; RocksDB foundation 82/82, semantics 9/9, Broker RocksDB 21/21, and pop consumer 4/4 passed.
- `python scripts/arc_mut_guard.py`, 24 ArcMut fixtures, and 67 ArcMut guard tests passed.
- The enforcing runtime audit, dependency baseline/target checks, release guard, eight performance profiles, 60 architecture guard tests, and AGENTS routing check passed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`, and `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message-arrival notifications by using safer service connections.
  * Notifications now gracefully skip unavailable services during shutdown.

* **Bug Fixes**
  * Fixed a lifecycle issue where message listeners could keep broker runtime resources alive after removal.
  * Added regression coverage to verify resources are released correctly.

* **Documentation**
  * Updated architecture migration plans, progress tracking, and remaining-task documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->