### PR TITLE
[ISSUE #8448]♻️Borrow runtime for message-related Admin handler

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8446 的 M11-12bc20 子切片完成后，当前 ArcMut reviewed
-baseline 为 355 identities / 950 occurrences，其中 production 为 197/472、test 为 144/438、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8448 的 M11-12bc21 子切片完成后，当前 ArcMut reviewed
+baseline 为 353 identities / 947 occurrences，其中 production 为 195/469、test 为 144/438、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 94 / 198 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control、batch lock、subscription-group Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 92 / 195 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control、batch lock、subscription-group/message-related Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 103 / 274 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child 直接 ownership 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -705,7 +705,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc18 Broker HA control borrow：reset-master-flush-offset 与 exchange-broker-HA-info handler 改为无状态 leaf，Admin dispatch 从既有 broker-config owner 取得普通 runtime 借用；构造/释放不改变 runtime strong count且不新增父层 owner
   - [x] M11-12bc19 BatchMq borrow：handler 改为无状态 leaf，Admin dispatch 请求期借用 runtime；严格锁 fan-out 只 clone `BrokerOuterAPI` 窄能力，不再为每个副本 future 捕获完整 runtime
   - [x] M11-12bc20 SubscriptionGroup borrow：handler 改为无状态 leaf，Admin dispatch 仅在 manager 写请求期间取得现有 owner 的独占借用、读请求使用共享借用，并删除未被 dispatch 调用的重复 unlock 实现
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc21 MessageRelated borrow：handler 改为无状态 leaf；search/query/POP rollback 使用请求期共享 runtime 借用，仅半消息重入写 Store 时使用独占借用，静态主题重写继续沿用同一共享借用
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -780,7 +781,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8442 后实际快照降至 360 identities/957 occurrences：production 201/478、test 145/439、compatibility 14/40、Broker production 98/204；两个 HA control leaf 净删除 4 个 production identity/6 occurrence，无 relocation
   - [x] Issue #8444 后实际快照降至 358 identities/954 occurrences：production 199/475、test 145/439、compatibility 14/40、Broker production 96/201；BatchMq leaf 净删除 2 个 production identity/3 occurrence，无 relocation
   - [x] Issue #8446 后实际快照降至 355 identities/950 occurrences：production 197/472、test 144/438、compatibility 14/40、Broker production 94/198；SubscriptionGroup leaf 净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation
-  - [ ] M11-12bc21 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8448 后实际快照降至 353 identities/947 occurrences：production 195/469、test 144/438、compatibility 14/40、Broker production 92/195；MessageRelated leaf 净删除 2 个 production identity/3 occurrence，无 relocation
+  - [ ] M11-12bc22 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -619,6 +619,13 @@ forbidden 聚焦回归通过，delete-offset-cleanup 复现既有同名基线失
 94/198），净删除 2 个 production identities/3 occurrences 与 1 个 test identity/1 occurrence，且无 relocation。
 总进度仍为 75/82，下一子切片 M11-12bc21 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Message-related Admin handler 随 Issue #8448 收窄：`MessageRelatedHandler` 删除完整 runtime 字段与 struct-level
+`MessageStore` 泛型，改为无状态 leaf；Admin dispatch 为 search/query/POP rollback 传入请求期共享 runtime 借用，
+仅在 resume-half-message 重入写 Store 时传入独占借用，静态主题重写沿用同一共享借用。消息处理聚焦回归 4/4、
+ownership 回归通过。ArcMut 快照降至 353 identities/947 occurrences（production 195/469、test 144/438、
+compatibility 14/40、Broker production 92/195），净删除 2 个 production identities/3 occurrences，且无
+relocation。总进度仍为 75/82，下一子切片 M11-12bc22 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8446 / M11-12bc20 完成后
+> 代码基线：Issue #8448 / M11-12bc21 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,18 +19,18 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8446 后 reviewed ArcMut baseline 为 355 identities / 950 occurrences：production 197/472、test
+Issue #8448 后 reviewed ArcMut baseline 为 353 identities / 947 occurrences：production 195/469、test
 144/438、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 94 / 198 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq lock/unlock、SubscriptionGroup Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 92 / 195 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq lock/unlock、SubscriptionGroup/MessageRelated Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 103 / 274 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability 与未共享 HA child 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 94/198）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control、BatchMq 与 SubscriptionGroup handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 92/195）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control、BatchMq、SubscriptionGroup 与 MessageRelated handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
 3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
@@ -139,6 +139,12 @@ M11-12bc20 将 `SubscriptionGroupHandler` 改为无状态 leaf，删除 runtime 
 重复 unlock 方法和 imports 同步删除。production 净删除 2 identities / 3 occurrences，test glob 净删除 1/1，
 因此 reviewed 总量降至 355/950、production 降至 197/472、Broker 降至 94/198、test 降至 144/438；Store
 103/274 与 compatibility 14/40 不增，无 relocation。
+
+M11-12bc21 将 `MessageRelatedHandler` 改为无状态 leaf，删除 runtime field 与 struct-level `MessageStore` 泛型；
+search-offset、query-consume-queue 和 POP rollback 从 broker-config handler 的现有 owner 取得请求期共享借用，只有
+resume-check-half-message 重入写 Store 使用独占借用，静态主题重写沿用同一共享借用。production 净删除 2 identities /
+3 occurrences，因此 reviewed 总量降至 353/947、production 降至 195/469、Broker 降至 92/195；test 144/438、
+Store 103/274 与 compatibility 14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2678,9 +2678,30 @@ Subscription-group Admin runtime borrow 随 Issue #8446 完成以下边界收敛
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc21 实现
+
+Message-related Admin runtime borrow 随 Issue #8448 完成以下边界收敛：
+
+- `MessageRelatedHandler` 删除完整 `ArcMut<BrokerRuntimeInner>` field 与 struct-level `MessageStore` 泛型，改为无状态 leaf；Admin 父层不新增 runtime owner。
+- Admin dispatch 对 search-offset、query-consume-queue 和 POP rollback 请求从 broker-config handler 已登记的 owner 取得普通 `&BrokerRuntimeInner` 共享借用；仅 resume-check-half-message 重入写 Store 时取得请求期 `&mut BrokerRuntimeInner` 独占借用。
+- 静态主题 search-offset 重写沿用调用方传入的同一共享借用；本地 Store 查询、远端 Broker RPC、consumer/filter 查询、POP service restart 与半消息重新入队语义保持不变。
+- 消息处理聚焦回归 4/4、stateless handler runtime strong-count 回归通过；构造和释放 handler 不改变 runtime root 强引用计数。
+- reviewed baseline 从 355 identities / 950 occurrences 降至 353 / 947；production 从 197/472 降至 195/469，test 保持 144/438，compatibility 保持 14/40。Broker production 从 94/198 降至 92/195；净删除 2 个 production identity/3 occurrence，无 relocation。
+
+## M11-12bc21 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused tests / strict Clippy | `cargo check -p rocketmq-broker --all-features` 通过；message-related 回归 4/4 与 stateless handler ownership 回归通过；Broker all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib 回归 | 610 passed、25 failed、1 ignored；25 项均属于 main 已登记的 lifecycle/Lite/subscription 基线失败集合，controller-mode 4/4 本轮全部通过；message-related 聚焦回归无新增失败，因此全套仍如实记为基线失败复现而非通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--prune-resolved` 候选与正式补丁均只删除 2 identity/3 occurrence；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation、父层新增 owner 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
+| root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（94/198）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq、SubscriptionGroup handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（92/195）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq、SubscriptionGroup、MessageRelated handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（103/274）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child direct ownership 已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -96,7 +96,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     reset_master_flusg_offset_handler: ResetMasterFlushOffsetHandler,
     broker_epoch_cache_handler: BrokerEpochCacheHandler,
     notify_broker_role_change_handler: NotifyBrokerRoleChangeHandler<MS>,
-    message_related_handler: MessageRelatedHandler<MS>,
+    message_related_handler: MessageRelatedHandler,
     producer_request_handler: ProducerRequestHandler,
     create_acl_request_handler: CreateAclRequestHandler,
     create_user_request_handler: CreateUserRequestHandler,
@@ -151,7 +151,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
 
         let notify_broker_role_change_handler = NotifyBrokerRoleChangeHandler::new(broker_runtime_inner.clone());
 
-        let message_related_handler = MessageRelatedHandler::new(broker_runtime_inner.clone());
+        let message_related_handler = MessageRelatedHandler::new();
         let producer_request_handler =
             ProducerRequestHandler::new(broker_runtime_inner.producer_manager().channel_registry());
         let create_acl_request_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
@@ -273,8 +273,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::SearchOffsetByTimestamp => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .search_offset_by_timestamp(channel, ctx, request_code, request)
+                    .search_offset_by_timestamp(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetMaxOffset => {
@@ -455,8 +456,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::QueryConsumeQueue => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .query_consume_queue(channel, ctx, request_code, request)
+                    .query_consume_queue(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::CheckRocksdbCqWriteProgress => {
@@ -499,13 +501,15 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::ResumeCheckHalfMessage => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
                 self.message_related_handler
-                    .resume_check_half_message(channel, ctx, request_code, request)
+                    .resume_check_half_message(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::PopRollback => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .pop_rollback(channel, ctx, request_code, request)
+                    .pop_rollback(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetTopicConfig => {

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
@@ -91,6 +91,7 @@ mod tests {
     use crate::broker_runtime::BrokerRuntime;
     use crate::processor::admin_broker_processor::batch_mq_handler::BatchMqHandler;
     use crate::processor::admin_broker_processor::broker_epoch_cache_handler::BrokerEpochCacheHandler;
+    use crate::processor::admin_broker_processor::message_related_handler::MessageRelatedHandler;
     use crate::processor::admin_broker_processor::reset_master_flusg_offset_handler::ResetMasterFlushOffsetHandler;
     use crate::processor::admin_broker_processor::subscription_group_handler::SubscriptionGroupHandler;
     use crate::processor::admin_broker_processor::update_broker_ha_handler::UpdateBrokerHaHandler;
@@ -203,6 +204,7 @@ mod tests {
             let _update_broker_ha_handler = UpdateBrokerHaHandler::new();
             let _batch_mq_handler = BatchMqHandler::new();
             let _subscription_group_handler = SubscriptionGroupHandler::new();
+            let _message_related_handler = MessageRelatedHandler::new();
             assert_eq!(inner.strong_count(), strong_count_before);
         }
         assert_eq!(inner.strong_count(), strong_count_before);

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -36,7 +36,6 @@ use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::rpc::rpc_client::RpcClient;
 use rocketmq_remoting::rpc::rpc_request::RpcRequest;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::filter::MessageFilter;
@@ -47,43 +46,33 @@ use crate::broker_runtime::BrokerRuntimeInner;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
 use crate::transaction::queue::transactional_message_util::TransactionalMessageUtil;
 
-pub(super) struct MessageRelatedHandler<MS: MessageStore> {
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-}
+pub(super) struct MessageRelatedHandler;
 
-impl<MS> MessageRelatedHandler<MS>
-where
-    MS: MessageStore,
-{
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+impl MessageRelatedHandler {
+    pub const fn new() -> Self {
+        Self
     }
-}
 
-impl<MS> MessageRelatedHandler<MS>
-where
-    MS: MessageStore,
-{
-    pub async fn search_offset_by_timestamp(
-        &mut self,
+    pub async fn search_offset_by_timestamp<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let search_offset_request_header = request.decode_command_custom_header::<SearchOffsetRequestHeader>()?;
-        let mapping_context = self
-            .broker_runtime_inner
+        let mapping_context = broker_runtime_inner
             .topic_queue_mapping_manager()
             .build_topic_queue_mapping_context(&search_offset_request_header, false);
         let rewrite_result = self
-            .rewrite_request_for_static_topic(&search_offset_request_header, mapping_context)
+            .rewrite_request_for_static_topic(broker_runtime_inner, &search_offset_request_header, mapping_context)
             .await?;
         if rewrite_result.is_some() {
             return Ok(rewrite_result);
         }
         let response = RemotingCommand::create_response_command();
-        let message_store = match self.broker_runtime_inner.message_store() {
+        let message_store = match broker_runtime_inner.message_store() {
             Some(store) => store,
             None => {
                 return Ok(Some(
@@ -116,8 +105,9 @@ where
         Ok(Some(response.set_command_custom_header(response_header)))
     }
 
-    pub async fn resume_check_half_message(
-        &mut self,
+    pub async fn resume_check_half_message<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &mut BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -145,8 +135,7 @@ where
             }
         };
 
-        let Some(mut message_ext) = self
-            .broker_runtime_inner
+        let Some(mut message_ext) = broker_runtime_inner
             .message_store()
             .unwrap()
             .look_message_by_offset(message_id.offset)
@@ -164,8 +153,7 @@ where
             CheetahString::from_static_str("0"),
         );
 
-        let put_message_result = self
-            .broker_runtime_inner
+        let put_message_result = broker_runtime_inner
             .message_store_mut()
             .as_mut()
             .unwrap()
@@ -183,8 +171,9 @@ where
         }
     }
 
-    pub async fn query_consume_queue(
-        &mut self,
+    pub async fn query_consume_queue<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -192,7 +181,7 @@ where
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<QueryConsumeQueueRequestHeader>()?;
         let response = RemotingCommand::create_response_command().set_code(ResponseCode::Success);
-        let Some(message_store) = self.broker_runtime_inner.message_store() else {
+        let Some(message_store) = broker_runtime_inner.message_store() else {
             return Ok(Some(
                 response
                     .set_code(ResponseCode::SystemError)
@@ -219,14 +208,12 @@ where
             .as_ref()
             .filter(|consumer_group| !consumer_group.is_empty())
         {
-            let subscription_data = self
-                .broker_runtime_inner
+            let subscription_data = broker_runtime_inner
                 .consumer_manager()
                 .find_subscription_data(consumer_group, &request_header.topic);
             body.subscription_data = subscription_data.clone();
             if let Some(subscription_data) = subscription_data {
-                let consumer_filter_data = self
-                    .broker_runtime_inner
+                let consumer_filter_data = broker_runtime_inner
                     .consumer_filter_manager()
                     .get_consumer_filter_data(&request_header.topic, consumer_group);
                 body.filter_data = Some(match consumer_filter_data.as_ref() {
@@ -238,7 +225,7 @@ where
                 message_filter = Some(ExpressionMessageFilter::new(
                     Some(subscription_data),
                     consumer_filter_data,
-                    std::sync::Arc::new(self.broker_runtime_inner.consumer_filter_manager().clone()),
+                    std::sync::Arc::new(broker_runtime_inner.consumer_filter_manager().clone()),
                 ));
             } else {
                 body.filter_data = Some(CheetahString::from_string(format!(
@@ -298,15 +285,16 @@ where
         Ok(Some(response.set_body(body.encode()?)))
     }
 
-    pub async fn pop_rollback(
-        &mut self,
+    pub async fn pop_rollback<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = RemotingCommand::create_response_command();
-        let Some(pop_message_processor) = self.broker_runtime_inner.pop_message_processor().cloned() else {
+        let Some(pop_message_processor) = broker_runtime_inner.pop_message_processor().cloned() else {
             return Ok(Some(response.set_code(ResponseCode::Success)));
         };
 
@@ -327,8 +315,9 @@ where
         }
     }
 
-    async fn rewrite_request_for_static_topic(
-        &mut self,
+    async fn rewrite_request_for_static_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         request_header: &SearchOffsetRequestHeader,
         mapping_context: TopicQueueMappingContext,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -363,7 +352,7 @@ where
 
             if mapping_detail.topic_queue_mapping_info.bname == item.bname {
                 // Local broker - query directly from message store
-                if let Some(message_store) = self.broker_runtime_inner.message_store() {
+                if let Some(message_store) = broker_runtime_inner.message_store() {
                     let local_offset = match message_store
                         .get_offset_in_queue_by_time_with_boundary_async(
                             &mapping_context.topic,
@@ -405,11 +394,10 @@ where
                     None,
                 );
 
-                let rpc_response = self
-                    .broker_runtime_inner
+                let rpc_response = broker_runtime_inner
                     .broker_outer_api()
                     .rpc_client()
-                    .invoke(rpc_request, self.broker_runtime_inner.broker_config().forward_timeout)
+                    .invoke(rpc_request, broker_runtime_inner.broker_config().forward_timeout)
                     .await;
 
                 match rpc_response {
@@ -618,7 +606,7 @@ mod tests {
             .and_then(|result| result.get_message_id())
             .expect("put message should return msg id");
 
-        let mut handler = MessageRelatedHandler::new(inner.clone());
+        let handler = MessageRelatedHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -631,7 +619,13 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .resume_check_half_message(channel, ctx, RequestCode::ResumeCheckHalfMessage, &mut request)
+            .resume_check_half_message(
+                inner.as_mut(),
+                channel,
+                ctx,
+                RequestCode::ResumeCheckHalfMessage,
+                &mut request,
+            )
             .await
             .expect("resume check half message should succeed")
             .expect("resume check half message should return response");
@@ -693,7 +687,7 @@ mod tests {
             ..Default::default()
         });
 
-        let mut handler = MessageRelatedHandler::new(inner.clone());
+        let handler = MessageRelatedHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -710,7 +704,13 @@ mod tests {
         request.make_custom_header_to_net();
 
         let mut response = handler
-            .query_consume_queue(channel, ctx, RequestCode::QueryConsumeQueue, &mut request)
+            .query_consume_queue(
+                inner.as_ref(),
+                channel,
+                ctx,
+                RequestCode::QueryConsumeQueue,
+                &mut request,
+            )
             .await
             .expect("query consume queue should succeed")
             .expect("query consume queue should return response");
@@ -760,14 +760,14 @@ mod tests {
             .await;
         assert!(service.get_offset_total_size().await > 0);
 
-        let mut handler = MessageRelatedHandler::new(inner.clone());
+        let handler = MessageRelatedHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(RequestCode::PopRollback, EmptyHeader::default());
         request.make_custom_header_to_net();
 
         let response = handler
-            .pop_rollback(channel, ctx, RequestCode::PopRollback, &mut request)
+            .pop_rollback(inner.as_ref(), channel, ctx, RequestCode::PopRollback, &mut request)
             .await
             .expect("pop rollback should succeed")
             .expect("pop rollback should return response");

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -1626,50 +1626,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "529e4b812f5e53c58d993da3",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "63cf4b2c4bd8341f84e6260c",
-          "fingerprint": "b2f8441a923ef7c772f06cf8",
-          "item": "<module>",
-          "line": 39
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "50fd3ada04debf5ecfdaa555",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "60ef4010dc99be2d287ef0d0",
-          "fingerprint": "eeb5eea0bf3b37c112c46fe6",
-          "item": "struct MessageRelatedHandler",
-          "line": 51
-        },
-        {
-          "id": "e9fb747aff7c93f83d10228c",
-          "fingerprint": "1fe88213f7fb3cfc3eb42806",
-          "item": "fn new",
-          "line": 58
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "8b41cc49b8a29ce4cf3748a1",
       "path": "rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs",
       "symbol": "ArcMut",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8448

### Brief Description

- Make `MessageRelatedHandler` stateless and remove its retained `ArcMut<BrokerRuntimeInner>` owner.
- Borrow the existing Admin runtime owner for each request: shared access for search, consume-queue query, and POP rollback; exclusive access only while re-enqueuing a half message.
- Pass the shared runtime borrow through static-topic offset rewriting without adding a parent owner.
- Reduce the reviewed ArcMut baseline from 355 identities / 950 occurrences to 353 / 947 and update the migration checklist and remaining-work inventory.

### How Did You Test This Change?

- Passed Broker all-feature check, 4/4 message-related focused tests, the stateless ownership regression, and strict Broker Clippy.
- Reproduced the registered Broker baseline: 610 passed, 25 failed, 1 ignored; all failures remain in the known lifecycle/Lite/subscription set and controller-mode tests passed 4/4.
- Passed Store/Broker RocksDB strict Clippy and the 82/82, 9/9, 21/21, and 4/4 focused suites.
- Passed ArcMut guard and fixtures, architecture dependency/release/performance guards, runtime audit, AGENTS routing, workspace formatting, and workspace all-target/all-feature strict Clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Refined broker administration handling for message-related operations, including offset searches, consume-queue queries, half-message checks, and pop rollback.
  - Preserved existing static-topic rewriting and message restart/requeue behavior while improving request-time runtime access.
  - Updated validation coverage and progress tracking for the completed message-related administration work.

- **Documentation**
  - Updated architecture migration checklists, readiness notes, remaining-task inventories, and evidence references with the latest completion status and baseline metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->