### PR TITLE
[ISSUE #8450]♻️Borrow runtime for Broker offset Admin handler

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8448 的 M11-12bc21 子切片完成后，当前 ArcMut reviewed
-baseline 为 353 identities / 947 occurrences，其中 production 为 195/469、test 为 144/438、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8450 的 M11-12bc22 子切片完成后，当前 ArcMut reviewed
+baseline 为 351 identities / 944 occurrences，其中 production 为 193/466、test 为 144/438、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 92 / 195 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control、batch lock、subscription-group/message-related Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 90 / 192 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control、batch lock、subscription-group/message-related/offset Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 103 / 274 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child 直接 ownership 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -706,7 +706,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc19 BatchMq borrow：handler 改为无状态 leaf，Admin dispatch 请求期借用 runtime；严格锁 fan-out 只 clone `BrokerOuterAPI` 窄能力，不再为每个副本 future 捕获完整 runtime
   - [x] M11-12bc20 SubscriptionGroup borrow：handler 改为无状态 leaf，Admin dispatch 仅在 manager 写请求期间取得现有 owner 的独占借用、读请求使用共享借用，并删除未被 dispatch 调用的重复 unlock 实现
   - [x] M11-12bc21 MessageRelated borrow：handler 改为无状态 leaf；search/query/POP rollback 使用请求期共享 runtime 借用，仅半消息重入写 Store 时使用独占借用，静态主题重写继续沿用同一共享借用
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc22 Offset borrow：handler 改为无状态 leaf；offset/delay/subscription/cleanup 请求与 static-topic max/min/earliest 重写只使用父层请求期共享 runtime 借用，unsupported RocksDB 路径无需 runtime
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -782,7 +783,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8444 后实际快照降至 358 identities/954 occurrences：production 199/475、test 145/439、compatibility 14/40、Broker production 96/201；BatchMq leaf 净删除 2 个 production identity/3 occurrence，无 relocation
   - [x] Issue #8446 后实际快照降至 355 identities/950 occurrences：production 197/472、test 144/438、compatibility 14/40、Broker production 94/198；SubscriptionGroup leaf 净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation
   - [x] Issue #8448 后实际快照降至 353 identities/947 occurrences：production 195/469、test 144/438、compatibility 14/40、Broker production 92/195；MessageRelated leaf 净删除 2 个 production identity/3 occurrence，无 relocation
-  - [ ] M11-12bc22 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8450 后实际快照降至 351 identities/944 occurrences：production 193/466、test 144/438、compatibility 14/40、Broker production 90/192；Offset leaf 净删除 2 个 production identity/3 occurrence，无 relocation
+  - [ ] M11-12bc23 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -626,6 +626,14 @@ ownership 回归通过。ArcMut 快照降至 353 identities/947 occurrences（pr
 compatibility 14/40、Broker production 92/195），净删除 2 个 production identities/3 occurrences，且无
 relocation。总进度仍为 75/82，下一子切片 M11-12bc22 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Broker offset Admin handler 随 Issue #8450 收窄：`OffsetRequestHandler` 删除完整 runtime 字段、Clone 与 struct-level
+`MessageStore` 泛型，改为无状态 leaf；Admin dispatch 为 offset/delay/subscription/cleanup 请求传入父层现有 owner 的
+请求期共享借用，static-topic max/min/earliest 重写沿用同一借用，unsupported RocksDB 路径不再取得 runtime。
+offset 聚焦回归 5/5、ownership 回归通过。ArcMut 快照降至 351 identities/944 occurrences（production 193/466、
+test 144/438、compatibility 14/40、Broker production 90/192），净删除 2 个 production identities/3
+occurrences，且无 relocation。总进度仍为 75/82，下一子切片 M11-12bc23 继续 Broker aggregate/leaf 或 Store
+WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8448 / M11-12bc21 完成后
+> 代码基线：Issue #8450 / M11-12bc22 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,18 +19,18 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8448 后 reviewed ArcMut baseline 为 353 identities / 947 occurrences：production 195/469、test
+Issue #8450 后 reviewed ArcMut baseline 为 351 identities / 944 occurrences：production 193/466、test
 144/438、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 92 / 195 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq lock/unlock、SubscriptionGroup/MessageRelated Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 90 / 192 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 103 / 274 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability 与未共享 HA child 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 92/195）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control、BatchMq、SubscriptionGroup 与 MessageRelated handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 90/192）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control、BatchMq、SubscriptionGroup、MessageRelated 与 Offset handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
 3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
@@ -144,6 +144,12 @@ M11-12bc21 将 `MessageRelatedHandler` 改为无状态 leaf，删除 runtime fie
 search-offset、query-consume-queue 和 POP rollback 从 broker-config handler 的现有 owner 取得请求期共享借用，只有
 resume-check-half-message 重入写 Store 使用独占借用，静态主题重写沿用同一共享借用。production 净删除 2 identities /
 3 occurrences，因此 reviewed 总量降至 353/947、production 降至 195/469、Broker 降至 92/195；test 144/438、
+Store 103/274 与 compatibility 14/40 不增，无 relocation。
+
+M11-12bc22 将 `OffsetRequestHandler` 改为无状态 leaf，删除 runtime field、Clone 与 struct-level `MessageStore`
+泛型；offset/delay/subscription/cleanup 请求从 broker-config handler 的现有 owner 取得请求期共享借用，static-topic
+max/min/earliest 重写沿用同一借用，unsupported RocksDB 路径不取得 runtime。production 净删除 2 identities /
+3 occurrences，因此 reviewed 总量降至 351/944、production 降至 193/466、Broker 降至 90/192；test 144/438、
 Store 103/274 与 compatibility 14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2699,9 +2699,30 @@ Message-related Admin runtime borrow 随 Issue #8448 完成以下边界收敛：
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc22 实现
+
+Broker offset Admin runtime borrow 随 Issue #8450 完成以下边界收敛：
+
+- `OffsetRequestHandler` 删除完整 `ArcMut<BrokerRuntimeInner>` field、Clone 与 struct-level `MessageStore` 泛型，改为无状态 leaf；Admin 父层不新增 runtime owner。
+- Admin dispatch 对 max/min/earliest offset、delay offset、subscription snapshot、expired consume-queue/commitlog cleanup 请求从 broker-config handler 已登记的 owner 取得普通 `&BrokerRuntimeInner` 共享借用；unsupported RocksDB CQ progress 路径无需 runtime。
+- static-topic max/min/earliest 重写沿用调用方传入的同一共享借用；本地 Store 查询、远端 Broker RPC、cleanup trigger 与响应语义保持不变。
+- offset 聚焦回归 5/5、stateless handler runtime strong-count 回归通过；构造和释放 handler 不改变 runtime root 强引用计数。
+- reviewed baseline 从 353 identities / 947 occurrences 降至 351 / 944；production 从 195/469 降至 193/466，test 保持 144/438，compatibility 保持 14/40。Broker production 从 92/195 降至 90/192；净删除 2 个 production identity/3 occurrence，无 relocation。
+
+## M11-12bc22 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused tests / strict Clippy | `cargo check -p rocketmq-broker --all-features` 通过；offset 回归 5/5 与 stateless handler ownership 回归通过；Broker all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib 回归 | 首轮 608 passed、27 failed、1 ignored；25 项属于 main 已登记的 lifecycle/Lite/subscription 基线失败集合，另 2 个 controller-mode 用例受固定端口 20011 占用影响；`three_controller_two_broker` 串行重跑 3/4，唯一失败仍是已登记的 namesrv/store/HA slave-view 收敛超时。offset 聚焦回归无新增失败，因此全套仍如实记为未通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--prune-resolved` 候选与正式补丁均只删除 2 identity/3 occurrence；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation、父层新增 owner 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
+| root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（92/195）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq、SubscriptionGroup、MessageRelated handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（90/192）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control、BatchMq、SubscriptionGroup、MessageRelated、Offset handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（103/274）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child direct ownership 已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -87,7 +87,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     topic_request_handler: TopicRequestHandler<MS>,
     broker_config_request_handler: BrokerConfigRequestHandler<MS>,
     consumer_request_handler: ConsumerRequestHandler<MS>,
-    offset_request_handler: OffsetRequestHandler<MS>,
+    offset_request_handler: OffsetRequestHandler,
     batch_mq_handler: BatchMqHandler,
     subscription_group_handler: SubscriptionGroupHandler,
 
@@ -137,7 +137,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         let topic_request_handler = TopicRequestHandler::new(broker_runtime_inner.clone());
         let broker_config_request_handler = BrokerConfigRequestHandler::new(broker_runtime_inner.clone());
         let consumer_request_handler = ConsumerRequestHandler::new(broker_runtime_inner.clone());
-        let offset_request_handler = OffsetRequestHandler::new(broker_runtime_inner.clone());
+        let offset_request_handler = OffsetRequestHandler::new();
         let batch_mq_handler = BatchMqHandler::new();
         let subscription_group_handler = SubscriptionGroupHandler::new();
 
@@ -279,18 +279,21 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::GetMaxOffset => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_max_offset(channel, ctx, request_code, request)
+                    .get_max_offset(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetMinOffset => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_min_offset(channel, ctx, request_code, request)
+                    .get_min_offset(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetEarliestMsgStoreTime => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_earliest_msg_store_time(channel, ctx, request_code, request)
+                    .get_earliest_msg_store_time(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetBrokerRuntimeInfo => {
@@ -329,8 +332,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::GetAllSubscriptionGroupConfig => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_all_subscription_group_config(channel, ctx, request_code, request)
+                    .get_all_subscription_group_config(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::DeleteSubscriptionGroup => {
@@ -366,8 +370,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::GetAllDelayOffset => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_all_delay_offset(channel, ctx, request_code, request)
+                    .get_all_delay_offset(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetAllMessageRequestMode => {
@@ -411,13 +416,15 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::CleanExpiredConsumequeue => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .clean_expired_consumequeue(channel, ctx, request_code, request)
+                    .clean_expired_consumequeue(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::DeleteExpiredCommitlog => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .delete_expired_commitlog(channel, ctx, request_code, request)
+                    .delete_expired_commitlog(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::CleanUnusedTopic => {

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
@@ -92,6 +92,7 @@ mod tests {
     use crate::processor::admin_broker_processor::batch_mq_handler::BatchMqHandler;
     use crate::processor::admin_broker_processor::broker_epoch_cache_handler::BrokerEpochCacheHandler;
     use crate::processor::admin_broker_processor::message_related_handler::MessageRelatedHandler;
+    use crate::processor::admin_broker_processor::offset_request_handler::OffsetRequestHandler;
     use crate::processor::admin_broker_processor::reset_master_flusg_offset_handler::ResetMasterFlushOffsetHandler;
     use crate::processor::admin_broker_processor::subscription_group_handler::SubscriptionGroupHandler;
     use crate::processor::admin_broker_processor::update_broker_ha_handler::UpdateBrokerHaHandler;
@@ -205,6 +206,7 @@ mod tests {
             let _batch_mq_handler = BatchMqHandler::new();
             let _subscription_group_handler = SubscriptionGroupHandler::new();
             let _message_related_handler = MessageRelatedHandler::new();
+            let _offset_request_handler = OffsetRequestHandler::new();
             assert_eq!(inner.strong_count(), strong_count_before);
         }
         assert_eq!(inner.strong_count(), strong_count_before);

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -31,26 +31,21 @@ use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQ
 use rocketmq_remoting::rpc::rpc_client::RpcClient;
 use rocketmq_remoting::rpc::rpc_request::RpcRequest;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tracing::error;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 
-#[derive(Clone)]
-pub(super) struct OffsetRequestHandler<MS: MessageStore> {
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-}
+pub(super) struct OffsetRequestHandler;
 
-impl<MS: MessageStore> OffsetRequestHandler<MS> {
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+impl OffsetRequestHandler {
+    pub const fn new() -> Self {
+        Self
     }
-}
 
-impl<MS: MessageStore> OffsetRequestHandler<MS> {
-    pub async fn get_max_offset(
-        &mut self,
+    pub async fn get_max_offset<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -59,21 +54,19 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         let request_header = request
             .decode_command_custom_header::<GetMaxOffsetRequestHeader>()
             .unwrap(); //need to optimize
-        let mapping_context = self
-            .broker_runtime_inner
+        let mapping_context = broker_runtime_inner
             .topic_queue_mapping_manager()
             .build_topic_queue_mapping_context(&request_header, false);
         let topic = request_header.topic.clone();
         let queue_id = request_header.queue_id;
         let rewrite_result = self
-            .rewrite_request_for_static_topic(request_header, mapping_context)
+            .rewrite_request_for_static_topic(broker_runtime_inner, request_header, mapping_context)
             .await?;
         if rewrite_result.is_some() {
             return Ok(rewrite_result);
         }
 
-        let offset = self
-            .broker_runtime_inner
+        let offset = broker_runtime_inner
             .message_store()
             .unwrap()
             .get_max_offset_in_queue(topic.as_ref(), queue_id);
@@ -83,8 +76,9 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         )))
     }
 
-    pub async fn get_min_offset(
-        &mut self,
+    pub async fn get_min_offset<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -94,21 +88,19 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
             .decode_command_custom_header::<GetMinOffsetRequestHeader>()
             .unwrap(); //need to optimize
 
-        let mapping_context = self
-            .broker_runtime_inner
+        let mapping_context = broker_runtime_inner
             .topic_queue_mapping_manager()
             .build_topic_queue_mapping_context(&request_header, false);
         let topic = request_header.topic.clone();
         let queue_id = request_header.queue_id;
         let rewrite_result = self
-            .handle_get_min_offset_for_static_topic(request_header, mapping_context)
+            .handle_get_min_offset_for_static_topic(broker_runtime_inner, request_header, mapping_context)
             .await?;
         if rewrite_result.is_some() {
             return Ok(rewrite_result);
         }
 
-        let offset = self
-            .broker_runtime_inner
+        let offset = broker_runtime_inner
             .message_store()
             .unwrap()
             .get_min_offset_in_queue(topic.as_ref(), queue_id);
@@ -118,8 +110,9 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         )))
     }
 
-    async fn handle_get_min_offset_for_static_topic(
-        &mut self,
+    async fn handle_get_min_offset_for_static_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         mut request_header: GetMinOffsetRequestHeader,
         mapping_context: TopicQueueMappingContext,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -149,17 +142,16 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         request_header.set_lo(Some(false));
         request_header.queue_id = max_item.queue_id;
         let max_physical_offset = if max_item.bname == mapping_detail.topic_queue_mapping_info.bname {
-            self.broker_runtime_inner
+            broker_runtime_inner
                 .message_store()
                 .unwrap()
                 .get_min_offset_in_queue(mapping_context.topic.as_ref(), max_item.queue_id)
         } else {
             let rpc_request = RpcRequest::new(RequestCode::GetMinOffset.to_i32(), request_header, None);
-            let rpc_response = self
-                .broker_runtime_inner
+            let rpc_response = broker_runtime_inner
                 .broker_outer_api()
                 .rpc_client()
-                .invoke(rpc_request, self.broker_runtime_inner.broker_config().forward_timeout)
+                .invoke(rpc_request, broker_runtime_inner.broker_config().forward_timeout)
                 .await;
             if let Err(e) = rpc_response {
                 return Ok(Some(
@@ -185,8 +177,9 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         )))
     }
 
-    async fn rewrite_request_for_static_topic(
-        &mut self,
+    async fn rewrite_request_for_static_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         mut request_header: GetMaxOffsetRequestHeader,
         mapping_context: TopicQueueMappingContext,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -216,17 +209,16 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         request_header.set_lo(Some(false));
         request_header.queue_id = max_item.queue_id;
         let max_physical_offset = if max_item.bname == mapping_detail.topic_queue_mapping_info.bname {
-            self.broker_runtime_inner
+            broker_runtime_inner
                 .message_store()
                 .unwrap()
                 .get_max_offset_in_queue(mapping_context.topic.as_ref(), max_item.queue_id)
         } else {
             let rpc_request = RpcRequest::new(RequestCode::GetMaxOffset.to_i32(), request_header.clone(), None);
-            let rpc_response = self
-                .broker_runtime_inner
+            let rpc_response = broker_runtime_inner
                 .broker_outer_api()
                 .rpc_client()
-                .invoke(rpc_request, self.broker_runtime_inner.broker_config().forward_timeout)
+                .invoke(rpc_request, broker_runtime_inner.broker_config().forward_timeout)
                 .await;
             if let Err(e) = rpc_response {
                 return Ok(Some(
@@ -252,18 +244,16 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         )))
     }
 
-    pub async fn get_all_delay_offset(
-        &mut self,
+    pub async fn get_all_delay_offset<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response_command = RemotingCommand::create_response_command();
-        let content = self
-            .broker_runtime_inner
-            .schedule_message_service()
-            .encode_pretty(false);
+        let content = broker_runtime_inner.schedule_message_service().encode_pretty(false);
         if content.is_empty() {
             return Ok(Some(
                 response_command
@@ -275,29 +265,28 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         Ok(Some(response_command))
     }
 
-    pub async fn get_earliest_msg_store_time(
-        &mut self,
+    pub async fn get_earliest_msg_store_time<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetEarliestMsgStoretimeRequestHeader>()?;
-        let mapping_context = self
-            .broker_runtime_inner
+        let mapping_context = broker_runtime_inner
             .topic_queue_mapping_manager()
             .build_topic_queue_mapping_context(&request_header, false);
         let topic = request_header.topic.clone();
         let queue_id = request_header.queue_id;
         let rewrite_result = self
-            .rewrite_get_earliest_request_for_static_topic(request_header, mapping_context)
+            .rewrite_get_earliest_request_for_static_topic(broker_runtime_inner, request_header, mapping_context)
             .await?;
         if rewrite_result.is_some() {
             return Ok(rewrite_result);
         }
 
-        let timestamp = self
-            .broker_runtime_inner
+        let timestamp = broker_runtime_inner
             .message_store()
             .unwrap()
             .get_earliest_message_time(topic.as_ref(), queue_id);
@@ -306,14 +295,15 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         )))
     }
 
-    pub async fn clean_expired_consumequeue(
-        &mut self,
+    pub async fn clean_expired_consumequeue<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.broker_runtime_inner
+        broker_runtime_inner
             .message_store()
             .unwrap()
             .clean_expired_consumer_queue();
@@ -322,14 +312,15 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         ))
     }
 
-    pub async fn delete_expired_commitlog(
-        &mut self,
+    pub async fn delete_expired_commitlog<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.broker_runtime_inner
+        broker_runtime_inner
             .message_store()
             .unwrap()
             .execute_delete_files_manually();
@@ -339,7 +330,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
     }
 
     pub async fn check_rocksdb_cq_write_progress(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -356,18 +347,16 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         ))
     }
 
-    pub async fn get_all_subscription_group_config(
-        &mut self,
+    pub async fn get_all_subscription_group_config<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response_command = RemotingCommand::create_response_command();
-        let content = self
-            .broker_runtime_inner
-            .subscription_group_manager()
-            .encode_pretty(false);
+        let content = broker_runtime_inner.subscription_group_manager().encode_pretty(false);
         if content.is_empty() {
             error!(
                 "No subscription group config in this broker,client:{}",
@@ -383,8 +372,9 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         Ok(Some(response_command))
     }
 
-    async fn rewrite_get_earliest_request_for_static_topic(
-        &mut self,
+    async fn rewrite_get_earliest_request_for_static_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         mut request_header: GetEarliestMsgStoretimeRequestHeader,
         mapping_context: TopicQueueMappingContext,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -422,17 +412,16 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         request_header.queue_id = mapping_item.queue_id;
 
         let timestamp = if mapping_item.bname == mapping_detail.topic_queue_mapping_info.bname {
-            self.broker_runtime_inner
+            broker_runtime_inner
                 .message_store()
                 .unwrap()
                 .get_earliest_message_time(mapping_context.topic.as_ref(), mapping_item.queue_id)
         } else {
             let rpc_request = RpcRequest::new(RequestCode::GetEarliestMsgStoreTime.to_i32(), request_header, None);
-            match self
-                .broker_runtime_inner
+            match broker_runtime_inner
                 .broker_outer_api()
                 .rpc_client()
-                .invoke(rpc_request, self.broker_runtime_inner.broker_config().forward_timeout)
+                .invoke(rpc_request, broker_runtime_inner.broker_config().forward_timeout)
                 .await
             {
                 Ok(response) => match response.get_header::<GetEarliestMsgStoretimeResponseHeader>() {
@@ -565,7 +554,7 @@ mod tests {
             .expect("message store should exist")
             .get_earliest_message_time(&CheetahString::from_static_str("topic-a"), 0);
 
-        let mut handler = OffsetRequestHandler::new(inner);
+        let handler = OffsetRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::GetEarliestMsgStoreTime,
             GetEarliestMsgStoretimeRequestHeader {
@@ -579,7 +568,13 @@ mod tests {
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .get_earliest_msg_store_time(channel, ctx, RequestCode::GetEarliestMsgStoreTime, &mut request)
+            .get_earliest_msg_store_time(
+                inner.as_ref(),
+                channel,
+                ctx,
+                RequestCode::GetEarliestMsgStoreTime,
+                &mut request,
+            )
             .await
             .expect("get earliest msg store time should succeed")
             .expect("get earliest msg store time should return response");
@@ -600,14 +595,20 @@ mod tests {
     async fn clean_expired_consumequeue_returns_success() {
         let mut runtime = new_test_runtime("clean-expired-cq").await;
         let inner = runtime.inner_for_test().clone();
-        let mut handler = OffsetRequestHandler::new(inner);
+        let handler = OffsetRequestHandler::new();
         let mut request =
             RemotingCommand::create_request_command(RequestCode::CleanExpiredConsumequeue, EmptyHeader {});
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .clean_expired_consumequeue(channel, ctx, RequestCode::CleanExpiredConsumequeue, &mut request)
+            .clean_expired_consumequeue(
+                inner.as_ref(),
+                channel,
+                ctx,
+                RequestCode::CleanExpiredConsumequeue,
+                &mut request,
+            )
             .await
             .expect("clean expired consumequeue should succeed")
             .expect("clean expired consumequeue should return response");
@@ -619,9 +620,8 @@ mod tests {
 
     #[tokio::test]
     async fn check_rocksdb_cq_write_progress_without_rocksdb_returns_not_supported() {
-        let mut runtime = new_test_runtime("check-rocksdb-progress").await;
-        let inner = runtime.inner_for_test().clone();
-        let mut handler = OffsetRequestHandler::new(inner);
+        let runtime = new_test_runtime("check-rocksdb-progress").await;
+        let handler = OffsetRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::CheckRocksdbCqWriteProgress,
             CheckRocksdbCqWriteProgressRequestHeader {

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -1739,50 +1739,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "dc41d8819c3ec0ccbf1a200d",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "e1c73cfba9519f6bc54b0465",
-          "fingerprint": "353397efe163cf37285096f9",
-          "item": "<module>",
-          "line": 34
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e718ce26b1625b1e000bc40b",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "3824f9663d87adf7e5d519dc",
-          "fingerprint": "d92f306439a5e5efd07616a4",
-          "item": "struct OffsetRequestHandler",
-          "line": 42
-        },
-        {
-          "id": "03ffb1493b47429d31050b20",
-          "fingerprint": "cc19641a62f92940d6a4e5c9",
-          "item": "fn new",
-          "line": 46
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "2cbf19c5585608c3e2669169",
       "path": "rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs",
       "symbol": "*",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8450

### Brief Description

- Make `OffsetRequestHandler` stateless and remove its retained `ArcMut<BrokerRuntimeInner>` owner.
- Borrow the existing Admin runtime owner for offset, delay, subscription snapshot, cleanup, and static-topic rewrite requests.
- Keep the unsupported RocksDB CQ progress path independent of Broker runtime access.
- Reduce the reviewed ArcMut baseline from 353 identities / 947 occurrences to 351 / 944 and update the migration checklist and remaining-work inventory.

### How Did You Test This Change?

- Passed Broker all-feature check, 5/5 offset focused tests, the stateless ownership regression, and strict Broker Clippy.
- Reproduced the registered Broker baseline: 608 passed, 27 failed, 1 ignored; 25 failures are registered and two controller tests hit the fixed-port conflict. The serial controller rerun passed 3/4, with the known slave-view convergence timeout remaining.
- Passed Store/Broker RocksDB strict Clippy and the 82/82, 9/9, 21/21, and 4/4 focused suites.
- Passed ArcMut guard and fixtures, architecture dependency/release/performance guards, runtime audit, AGENTS routing, workspace formatting, and workspace all-target/all-feature strict Clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved broker offset administration by using temporary runtime access during request processing instead of retaining runtime ownership.
  - Updated offset-related operations, including min/max offsets, delay offsets, subscription configuration, and cleanup tasks.
  - Static-topic and unsupported storage paths now use streamlined runtime handling.

- **Tests**
  - Expanded verification to ensure administration handlers do not retain unnecessary runtime references.

- **Documentation**
  - Updated Phase 3 migration progress, baselines, issue tracking, completion evidence, and remaining-task status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->