### PR TITLE
[ISSUE #8456]♻️Replace flush-manager weak owner with wakeup capability

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,15 +40,15 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8454 的 M11-12bc24 子切片完成后，当前 ArcMut reviewed
-baseline 为 346 identities / 936 occurrences，其中 production 为 188/458、test 为 144/438、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8456 的 M11-12bc25 子切片完成后，当前 ArcMut reviewed
+baseline 为 344 identities / 932 occurrences，其中 production 为 186/454、test 为 144/438、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
 | Broker | 85 / 184 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control/min-broker transition、batch lock、subscription-group/message-related/offset/consumer Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
-| Store | 103 / 274 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child 直接 ownership 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
+| Store | 101 / 270 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership 与 commit-to-flush 窄唤醒能力已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
 Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook/rollback 证据；M10 固定硬件性能、五镜像动态验证、
@@ -709,7 +709,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc22 Offset borrow：handler 改为无状态 leaf；offset/delay/subscription/cleanup 请求与 static-topic max/min/earliest 重写只使用父层请求期共享 runtime 借用，unsupported RocksDB 路径无需 runtime
   - [x] M11-12bc23 minimum-broker transition borrow：handler 只保留 broker-id/address 状态锁，Admin dispatch 传入请求期独占 runtime 借用；special-service 与 master offline/online 路径删除 `mut_from_ref`
   - [x] M11-12bc24 Consumer Admin borrow：handler 改为无状态 leaf；reset-offset 使用父层请求期独占 runtime 借用，其余 consumer diagnostics/query/offset 请求使用共享借用
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc25 flush wakeup capability：commit worker 只持 group/real-time `Notify` 与 timed policy，删除对完整 `DefaultFlushManager` 的 `WeakArcMut` 回指、晚绑定 setter 与 `CommitLog::start` downgrade
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -788,7 +789,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8450 后实际快照降至 351 identities/944 occurrences：production 193/466、test 144/438、compatibility 14/40、Broker production 90/192；Offset leaf 净删除 2 个 production identity/3 occurrence，无 relocation
   - [x] Issue #8452 后实际快照降至 348 identities/939 occurrences：production 190/461、test 144/438、compatibility 14/40、Broker production 87/187；minimum-broker leaf 净删除 3 个 production identity/5 occurrence，无 relocation
   - [x] Issue #8454 后实际快照降至 346 identities/936 occurrences：production 188/458、test 144/438、compatibility 14/40、Broker production 85/184；Consumer Admin leaf 净删除 2 个 production identity/3 occurrence，无 relocation
-  - [ ] M11-12bc25 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8456 后实际快照降至 344 identities/932 occurrences：production 186/454、test 144/438、compatibility 14/40、Store production 101/270；flush-manager weak owner 净删除 2 个 production identity/4 occurrence，2 个保留 import occurrence 经一对一指纹审核更新，无新增 identity
+  - [ ] M11-12bc26 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -648,6 +648,14 @@ consumer 聚焦回归 9/9、ownership 回归通过。ArcMut 快照降至 346 ide
 test 144/438、compatibility 14/40、Broker production 85/184），净删除 2 个 production identities/3 occurrences，
 且无 relocation。总进度仍为 75/82，下一子切片 M11-12bc25 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Store flush wakeup capability 随 Issue #8456 收窄：`CommitRealTimeService` 不再持有或升级完整
+`WeakArcMut<DefaultFlushManager>`，只保留 group-commit/flush-realtime 的可选 `Notify` 与 timed-flush policy；
+`CommitLog::start` 删除 downgrade、late setter 和无调用 accessor。sync flush、async untimed 与 async timed 三类行为
+由确定性测试固定，worker 仍由原 `CancellationToken`/`TaskGroup` 所有。ArcMut 快照降至 344 identities/932
+occurrences（production 186/454、test 144/438、compatibility 14/40、Store production 101/270），净删除 2 个
+production identities/4 occurrences；2 个保留 import occurrence 仅作一对一指纹更新，无新增 identity。
+总进度仍为 75/82，下一子切片 M11-12bc26 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8454 / M11-12bc24 完成后
+> 代码基线：Issue #8456 / M11-12bc25 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,20 +19,20 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8454 后 reviewed ArcMut baseline 为 346 identities / 936 occurrences：production 188/458、test
+Issue #8456 后 reviewed ArcMut baseline 为 344 identities / 932 occurrences：production 186/454、test
 144/438、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
 | Broker | 85 / 184 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
-| Store | 103 / 274 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability 与未共享 HA child 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
+| Store | 101 / 270 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child 与 commit-to-flush 窄唤醒能力已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
 1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 85/184）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control/min-broker transition、BatchMq、SubscriptionGroup、MessageRelated、Offset 与 Consumer handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
-3. Store WAL：收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
+3. Store WAL：commit worker 已只持 `Notify` 唤醒能力；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
 5. Store timer/HA：BrokerStats observer、HA notification service、connection registry 查询与未共享 client/connection child 已退出多余 owner；继续收口 Timer、Default/General/AutoSwitch HA service 与 actor 回指。
 6. compatibility/stable：迁移剩余测试/兼容调用方和 Store `WeakArcMut`；按 next-major/HUMAN 窗口处理公开 facade，并替换 `sync_unsafe_cell`、`async_fn_traits`、`unboxed_closures` 等 nightly surface。
@@ -163,6 +163,12 @@ connection/stats/status/subscription/time-span、request-mode、running-info 与
 仅 reset-offset 路径传入独占借用。production 净删除 2 identities / 3 occurrences，因此 reviewed 总量降至
 346/936、production 降至 188/458、Broker 降至 85/184；test 144/438、Store 103/274 与 compatibility 14/40
 不增，无 relocation。
+
+M11-12bc25 将 `CommitRealTimeService` 对完整 `DefaultFlushManager` 的 `WeakArcMut` 回指收窄为仅含
+group-commit/flush-realtime `Notify` 与 timed policy 的 `FlushWakeup`；`CommitLog::start` 不再 downgrade 或晚绑定
+manager，sync/async timed policy 与原 TaskGroup 生命周期保持不变。production 净删除 2 identities / 4 occurrences，
+因此 reviewed 总量降至 344/932、production 降至 186/454、Store 降至 101/270；test 144/438、Broker 85/184
+与 compatibility 14/40 不增。2 个保留 import occurrence 经一对一指纹审核更新，无新增 identity。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2761,10 +2761,30 @@ Consumer Admin runtime borrow 随 Issue #8454 完成以下边界收敛：
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc25 实现
+
+Store flush wakeup capability 随 Issue #8456 完成以下边界收敛：
+
+- `CommitRealTimeService` 删除完整 `WeakArcMut<DefaultFlushManager>` back-reference 和 late setter，改持只包含 group-commit/flush-realtime 可选 `Notify` 与 `flush_commit_log_timed` policy 的 `FlushWakeup`。
+- commit worker 成功后直接调用窄唤醒能力；sync flush 唤醒 group-commit，async untimed 唤醒 flush-realtime，async timed 留给周期 worker，不再升级完整 manager。
+- `CommitLog::start` 删除 `ArcMut::downgrade` 与注入路径，并删除无其他调用方的 commit-service accessors；worker 的 `CancellationToken`、`TaskGroup`、start/shutdown 顺序保持不变。
+- reviewed baseline 从 346 identities / 936 occurrences 降至 344 / 932；production 从 188/458 降至 186/454，test 保持 144/438，compatibility 保持 14/40。Store production 从 103/274 降至 101/270；净删除 2 个 production identity/4 occurrence。相邻 import 删除和测试扩展导致 2 个保留 import occurrence 指纹一对一变化，已按实际扫描审核更新，无新增 identity。
+
+## M11-12bc25 验证
+
+| 命令 | 结果 |
+|---|---|
+| Store focused / all-feature check / lib / strict Clippy | flush wakeup 三类 policy 回归 3/3；`cargo check -p rocketmq-store --all-features`、507/507 all-feature library tests 与 all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib 回归 | 611 passed、24 failed、1 ignored；失败仍全部属于 main 已登记的 lifecycle/Lite/subscription 动态基线，无 flush/commit 新失败；`three_controller_two_broker` 串行重跑 3/4，唯一失败仍是已登记的 rejoin namesrv/store/HA slave-view 收敛超时，因此全套如实记为未通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 候选精确从 346/936 降至 344/932；正式 baseline 删除 2 identity/4 occurrence并审核更新 2 个保留 import 指纹；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无新增 identity或临时 approval 文件 |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
 1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（85/184）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
-2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（103/274）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力与未共享 HA child direct ownership 已完成。
+2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（101/270）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child direct ownership 与 commit-to-flush 窄唤醒能力已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态
    Kind/K3d/container、M10 固定硬件和 Human Gate。

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -692,11 +692,6 @@ impl CommitLog {
 
     pub fn start(&mut self) {
         let mut flush_manager = self.flush_manager.clone();
-        let flush_manager_weak = ArcMut::downgrade(&flush_manager);
-
-        if let Some(service) = flush_manager.commit_real_time_service_mut() {
-            service.set_flush_manager(flush_manager_weak);
-        }
         flush_manager.start();
     }
 

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
-use rocketmq_rust::WeakArcMut;
 use rocketmq_store_local::flush::group_commit::run_group_commit_worker;
 use rocketmq_store_local::flush::group_commit::GroupCommitStatus;
 use rocketmq_store_local::flush::group_commit::GroupCommitWorkerConfig;
@@ -131,7 +130,15 @@ impl DefaultFlushManager {
                 message_store_config: message_store_config.clone(),
                 store_checkpoint,
                 notified: Arc::new(Default::default()),
-                flush_manager: None,
+                flush_wakeup: FlushWakeup {
+                    group_commit_notified: group_commit_service
+                        .as_ref()
+                        .map(|service| Arc::clone(&service.notified)),
+                    flush_real_time_notified: flush_real_time_service
+                        .as_ref()
+                        .map(|service| Arc::clone(&service.notified)),
+                    flush_commit_log_timed: message_store_config.flush_commit_log_timed,
+                },
                 shutdown_token: CancellationToken::new(),
                 worker_group: None,
             })
@@ -166,14 +173,6 @@ impl DefaultFlushManager {
 impl DefaultFlushManager {
     pub fn sync_flush_runtime_info(&self) -> SyncFlushRuntimeInfo {
         self.sync_flush_stats.snapshot()
-    }
-
-    pub(crate) fn commit_real_time_service(&self) -> Option<&CommitRealTimeService> {
-        self.commit_real_time_service.as_ref()
-    }
-
-    pub(crate) fn commit_real_time_service_mut(&mut self) -> Option<&mut CommitRealTimeService> {
-        self.commit_real_time_service.as_mut()
     }
 
     pub(crate) async fn shutdown_gracefully(&mut self) -> Result<FlushProgress, StoreError> {
@@ -505,11 +504,31 @@ impl FlushRealTimeService {
     }
 }
 
-pub(crate) struct CommitRealTimeService {
+#[derive(Clone)]
+struct FlushWakeup {
+    group_commit_notified: Option<Arc<Notify>>,
+    flush_real_time_notified: Option<Arc<Notify>>,
+    flush_commit_log_timed: bool,
+}
+
+impl FlushWakeup {
+    fn wakeup(&self) {
+        if let Some(notified) = &self.group_commit_notified {
+            notified.notify_one();
+        }
+        if !self.flush_commit_log_timed {
+            if let Some(notified) = &self.flush_real_time_notified {
+                notified.notify_one();
+            }
+        }
+    }
+}
+
+struct CommitRealTimeService {
     message_store_config: Arc<MessageStoreConfig>,
     store_checkpoint: Arc<StoreCheckpoint>,
     notified: Arc<Notify>,
-    flush_manager: Option<WeakArcMut<DefaultFlushManager>>,
+    flush_wakeup: FlushWakeup,
     shutdown_token: CancellationToken,
     worker_group: Option<TaskGroup>,
 }
@@ -539,20 +558,12 @@ impl CommitRealTimeService {
         );
         let store_checkpoint = self.store_checkpoint.clone();
         let notified = self.notified.clone();
-        let flush_manager = self.flush_manager.clone();
+        let flush_wakeup = self.flush_wakeup.clone();
         let shutdown_token = self.shutdown_token.clone();
         if let Err(error) = worker_group.spawn_service("commit-log-commit-real-time", async move {
             let ports = CommitRealTimeWorkerPorts::new(
                 move |least_pages| commit_mapped_file_queue(mapped_file_queue.clone(), least_pages),
-                move || {
-                    if let Some(flush_manager) =
-                        flush_manager.as_ref().and_then(|flush_manager| flush_manager.upgrade())
-                    {
-                        flush_manager.wake_up_flush();
-                    } else {
-                        warn!("CommitRealTimeService cannot wake flush because flush manager is not initialized");
-                    }
-                },
+                move || flush_wakeup.wakeup(),
                 move |timestamp| store_checkpoint.set_physic_msg_timestamp(timestamp),
                 time::sleep,
             );
@@ -574,10 +585,6 @@ impl CommitRealTimeService {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
         shutdown_worker_gracefully("CommitRealTimeService", &mut self.worker_group).await;
-    }
-
-    pub fn set_flush_manager(&mut self, flush_manager: WeakArcMut<DefaultFlushManager>) {
-        self.flush_manager = Some(flush_manager);
     }
 }
 
@@ -638,6 +645,7 @@ async fn commit_mapped_file_queue(
 mod tests {
     use super::*;
 
+    use futures_util::FutureExt;
     use rocketmq_common::TimeUtils::current_millis;
     use rocketmq_store_local::flush::group_commit::complete_group_commit_batch;
     use rocketmq_store_local::flush::group_commit::complete_group_commit_batch_error;
@@ -648,6 +656,48 @@ mod tests {
 
     fn health_recorder() -> StoreHealthRecorder {
         StoreHealthRecorder::new(Arc::new(RunningFlags::new()))
+    }
+
+    #[test]
+    fn flush_wakeup_notifies_group_commit_service() {
+        let notified = Arc::new(Notify::new());
+        let wakeup = FlushWakeup {
+            group_commit_notified: Some(Arc::clone(&notified)),
+            flush_real_time_notified: None,
+            flush_commit_log_timed: false,
+        };
+
+        wakeup.wakeup();
+
+        assert!(notified.notified().now_or_never().is_some());
+    }
+
+    #[test]
+    fn flush_wakeup_notifies_untimed_flush_service() {
+        let notified = Arc::new(Notify::new());
+        let wakeup = FlushWakeup {
+            group_commit_notified: None,
+            flush_real_time_notified: Some(Arc::clone(&notified)),
+            flush_commit_log_timed: false,
+        };
+
+        wakeup.wakeup();
+
+        assert!(notified.notified().now_or_never().is_some());
+    }
+
+    #[test]
+    fn flush_wakeup_leaves_timed_flush_service_for_periodic_worker() {
+        let notified = Arc::new(Notify::new());
+        let wakeup = FlushWakeup {
+            group_commit_notified: None,
+            flush_real_time_notified: Some(Arc::clone(&notified)),
+            flush_commit_log_timed: true,
+        };
+
+        wakeup.wakeup();
+
+        assert!(notified.notified().now_or_never().is_none());
     }
 
     #[test]

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -6212,12 +6212,6 @@
           "line": 369
         },
         {
-          "id": "aec82b8b7e282c35e688884a",
-          "fingerprint": "f21f51d8b9df36d609f3e72d",
-          "item": "fn start",
-          "line": 695
-        },
-        {
           "id": "7b82a0c547144271333e00f4",
           "fingerprint": "f888bd2b5652943d91e73499",
           "item": "fn recover_normally_optimized",
@@ -6436,10 +6430,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "142e50c0a2fe6071fa98ca69",
-          "fingerprint": "9f544a8c23139aecaf354bdc",
+          "id": "dd044f8e799d54c7117e31f9",
+          "fingerprint": "8035c90fa25e4939a7500d0d",
           "item": "mod tests",
-          "line": 639
+          "line": 646
         }
       ],
       "owner": "store",
@@ -6504,8 +6498,8 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ed90aef20d1d02193c746b52",
-          "fingerprint": "a1242bb96af1e085537b9869",
+          "id": "b931a0448320ad80ead2a81d",
+          "fingerprint": "de491a778310e6cc68132e5d",
           "item": "<module>",
           "line": 22
         }
@@ -6563,50 +6557,6 @@
           "fingerprint": "04b812ce9b8d375ca570c5d4",
           "item": "fn commit_mapped_file_queue",
           "line": 618
-        }
-      ],
-      "owner": "store",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
-      "identity": "3c663e49572a9aa0b69c5ffb",
-      "path": "rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs",
-      "symbol": "WeakArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "40abdeec7b706b7a903595f0",
-          "fingerprint": "59b42a0e45fe95bcf5977fb7",
-          "item": "<module>",
-          "line": 23
-        }
-      ],
-      "owner": "store",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
-      "identity": "fc0828c03794a02c19d17143",
-      "path": "rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs",
-      "symbol": "WeakArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "6884b5555e6af46ed03a9942",
-          "fingerprint": "31835f75c3027b6e8821d43d",
-          "item": "struct CommitRealTimeService",
-          "line": 512
-        },
-        {
-          "id": "d616fbddd744b8a1b0138594",
-          "fingerprint": "ede5b0008432693bdd4cc261",
-          "item": "fn set_flush_manager",
-          "line": 579
         }
       ],
       "owner": "store",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8456

### Brief Description

- Replace the commit worker's `WeakArcMut<DefaultFlushManager>` back-reference with a cloneable flush-wakeup capability containing only the relevant `Notify` handles and timed-flush policy.
- Preserve sync-flush, asynchronous untimed-flush, and asynchronous timed-flush wakeup behavior while retaining the existing CancellationToken/TaskGroup lifecycle.
- Remove the `CommitLog::start` downgrade/injection path, late setter, and unused commit-service accessors.
- Reduce the reviewed ArcMut baseline from 346 identities / 936 occurrences to 344 / 932 and update the migration checklist and remaining-work inventory.

### How Did You Test This Change?

- Passed 3/3 focused wakeup-policy tests, the Store all-feature check, 507/507 Store library tests, and strict Store Clippy.
- Reproduced the registered Broker baseline without new flush/commit failures: 611 passed, 24 failed, 1 ignored. The serial controller rerun passed 3/4, with only the known rejoin slave-view convergence timeout remaining.
- Passed Store/Broker RocksDB strict Clippy and the 82/82, 9/9, 21/21, and 4/4 focused suites.
- Passed the ArcMut guard and 67/67 tests plus 24/24 fixtures, architecture dependency/release/performance guards, runtime audit, AGENTS routing, workspace formatting, and workspace all-target/all-feature strict Clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified flush wakeup handling with targeted notifications for group-commit and timed flush scenarios.
  * Removed unnecessary flush-manager back-references and setup steps.

* **Tests**
  * Added coverage verifying the appropriate wakeup behavior across supported flush configurations.

* **Documentation**
  * Updated architecture migration progress, completion evidence, remaining tasks, and tracking baselines for the Store flush wakeup milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->