### PR TITLE
[ISSUE #8459]♻️Publish HA replication state without mutable Store escape

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,15 +40,15 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8456 的 M11-12bc25 子切片完成后，当前 ArcMut reviewed
-baseline 为 344 identities / 932 occurrences，其中 production 为 186/454、test 为 144/438、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8459 的 M11-12bc26 子切片完成后，当前 ArcMut reviewed
+baseline 为 342 identities / 926 occurrences，其中 production 为 184/448、test 为 144/438、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
 | Broker | 85 / 184 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control/min-broker transition、batch lock、subscription-group/message-related/offset/consumer Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
-| Store | 101 / 270 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership 与 commit-to-flush 窄唤醒能力已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
+| Store | 99 / 264 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力与 HA confirm/epoch 原子发布已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
 Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook/rollback 证据；M10 固定硬件性能、五镜像动态验证、
@@ -710,7 +710,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc23 minimum-broker transition borrow：handler 只保留 broker-id/address 状态锁，Admin dispatch 传入请求期独占 runtime 借用；special-service 与 master offline/online 路径删除 `mut_from_ref`
   - [x] M11-12bc24 Consumer Admin borrow：handler 改为无状态 leaf；reset-offset 使用父层请求期独占 runtime 借用，其余 consumer diagnostics/query/offset 请求使用共享借用
   - [x] M11-12bc25 flush wakeup capability：commit worker 只持 group/real-time `Notify` 与 timed policy，删除对完整 `DefaultFlushManager` 的 `WeakArcMut` 回指、晚绑定 setter 与 `CommitLog::start` downgrade
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc26 HA replication atomic publication：confirm offset 改由 `AtomicI64` 共享发布；epoch/state-machine 已有原子字段增加窄发布入口，HA service/client 删除对完整 `LocalFileMessageStore` 的 `mut_from_ref`
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -790,7 +791,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8452 后实际快照降至 348 identities/939 occurrences：production 190/461、test 144/438、compatibility 14/40、Broker production 87/187；minimum-broker leaf 净删除 3 个 production identity/5 occurrence，无 relocation
   - [x] Issue #8454 后实际快照降至 346 identities/936 occurrences：production 188/458、test 144/438、compatibility 14/40、Broker production 85/184；Consumer Admin leaf 净删除 2 个 production identity/3 occurrence，无 relocation
   - [x] Issue #8456 后实际快照降至 344 identities/932 occurrences：production 186/454、test 144/438、compatibility 14/40、Store production 101/270；flush-manager weak owner 净删除 2 个 production identity/4 occurrence，2 个保留 import occurrence 经一对一指纹审核更新，无新增 identity
-  - [ ] M11-12bc26 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8459 后实际快照降至 342 identities/926 occurrences：production 184/448、test 144/438、compatibility 14/40、Store production 99/264；HA confirm/epoch 原子发布净删除 2 个 production identity/6 occurrence，无 relocation
+  - [ ] M11-12bc27 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -656,6 +656,15 @@ occurrences（production 186/454、test 144/438、compatibility 14/40、Store pr
 production identities/4 occurrences；2 个保留 import occurrence 仅作一对一指纹更新，无新增 identity。
 总进度仍为 75/82，下一子切片 M11-12bc26 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Store HA replication state publication 随 Issue #8459 收窄：`CommitLogRuntimeState::confirm_offset` 改为
+`AtomicI64`，保留原有可变 setter facade，并新增仅供 Store 内部 HA 路径使用的共享发布入口；controller epoch start
+offset 与 state-machine version 复用已有原子字段的窄发布入口。Auto-switch HA service 和 HA reader 不再通过
+`mut_from_ref` 取得完整 `LocalFileMessageStore` 可变引用，confirm offset 仍允许随角色切换下降，reader 仍先按本地
+min/max 物理位点 clamp，epoch transition 仍只在 Advanced 时按 state-machine version、epoch start offset 顺序发布。
+ArcMut 快照降至 342 identities/926 occurrences（production 184/448、test 144/438、compatibility 14/40、
+Store production 99/264），净删除 2 个 production identities/6 occurrences且无 relocation。总进度仍为 75/82，
+下一子切片 M11-12bc27 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8456 / M11-12bc25 完成后
+> 代码基线：Issue #8459 / M11-12bc26 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,13 +19,13 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8456 后 reviewed ArcMut baseline 为 344 identities / 932 occurrences：production 186/454、test
+Issue #8459 后 reviewed ArcMut baseline 为 342 identities / 926 occurrences：production 184/448、test
 144/438、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
 | Broker | 85 / 184 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
-| Store | 101 / 270 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child 与 commit-to-flush 窄唤醒能力已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
+| Store | 99 / 264 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力与 HA confirm/epoch 原子发布已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
@@ -169,6 +169,12 @@ group-commit/flush-realtime `Notify` 与 timed policy 的 `FlushWakeup`；`Commi
 manager，sync/async timed policy 与原 TaskGroup 生命周期保持不变。production 净删除 2 identities / 4 occurrences，
 因此 reviewed 总量降至 344/932、production 降至 186/454、Store 降至 101/270；test 144/438、Broker 85/184
 与 compatibility 14/40 不增。2 个保留 import occurrence 经一对一指纹审核更新，无新增 identity。
+
+M11-12bc26 将 HA confirm offset 从普通 `i64` 改为 `AtomicI64` 共享发布，并为已有原子 epoch start offset 与
+state-machine version 增加窄发布入口；Auto-switch HA service 与 HA reader 不再通过 `mut_from_ref` 取得完整
+`LocalFileMessageStore` 可变引用。confirm offset 下降、reader clamp 与 Advanced epoch 发布顺序保持不变。
+production 净删除 2 identities / 6 occurrences，因此 reviewed 总量降至 342/926、production 降至 184/448、
+Store 降至 99/264；test 144/438、Broker 85/184 与 compatibility 14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2781,10 +2781,32 @@ Store flush wakeup capability 随 Issue #8456 完成以下边界收敛：
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc26 实现
+
+Store HA replication state publication 随 Issue #8459 完成以下边界收敛：
+
+- `CommitLogRuntimeState::confirm_offset` 从普通 `i64` 改为 `AtomicI64`，共享读写使用 `SeqCst`；原有可变 setter facade 保持兼容并委托给共享发布入口。
+- `CommitLog` 与 `LocalFileMessageStore` 增加 crate-private confirm/epoch/state-machine 窄发布入口；auto-switch HA service 的 sync-state、slave ack、connection removal、epoch transition 与 role-change 路径不再取得完整 Store 可变引用。
+- HA reader 继续先将 master confirm offset clamp 到本地 `[min_phy_offset, max_phy_offset]` 再原子发布；confirm offset 允许在角色切换时下降，因此没有错误地使用单调 `fetch_max`。
+- epoch transition 仍只在 `Advanced` 时按 state-machine version、epoch start offset 的既有顺序发布；checkpoint 更新与公开 API 签名保持不变。
+- reviewed baseline 从 344 identities / 932 occurrences 降至 342 / 926；production 从 186/454 降至 184/448，test 保持 144/438，compatibility 保持 14/40。Store production 从 101/270 降至 99/264；净删除 2 个 production identity/6 occurrence，无 relocation、新增 identity 或临时 approval。
+
+## M11-12bc26 验证
+
+| 命令 | 结果 |
+|---|---|
+| Store Local / Store focused、all-feature check 与 strict Clippy | shared confirm offset 下降回归 1/1、HA confirm/role/epoch 回归 5/5；`cargo check -p rocketmq-store --all-features` 与 Store Local/Store all-target/all-feature strict Clippy 通过 |
+| Store Local / Store all-feature lib | Store Local 186/186、Store 507/507 通过 |
+| Broker all-feature lib 回归 | 610 passed、25 failed、1 ignored；失败集中于 lifecycle/Lite/subscription 动态基线，无 HA/confirm/epoch 新失败；独立 lifecycle probe 仍失败于 consumer-offset/subscription-group shutdown 健康度，`three_controller_two_broker` 串行重跑 4/4 通过，因此全量套件如实记为未通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--prune-resolved` 候选与正式补丁均从 344/932 精确降至 342/926；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation、新增 identity 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
 1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（85/184）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
-2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（101/270）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child direct ownership 与 commit-to-flush 窄唤醒能力已完成。
+2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（99/264）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力与 HA confirm/epoch 原子发布已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态
    Kind/K3d/container、M10 固定硬件和 Human Gate。

--- a/rocketmq-store-local/src/commit_log/runtime_state.rs
+++ b/rocketmq-store-local/src/commit_log/runtime_state.rs
@@ -15,6 +15,7 @@
 //! Runtime-neutral state owned by the Local CommitLog boundary.
 
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -164,7 +165,7 @@ impl CommitLogActiveMemoryLock {
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct CommitLogRuntimeState {
-    confirm_offset: i64,
+    confirm_offset: AtomicI64,
     put_message_lock_stats: CommitLogPutMessageLockStats,
     begin_time_in_lock: Arc<AtomicU64>,
     active_memory_lock: Mutex<CommitLogActiveMemoryLock>,
@@ -177,7 +178,7 @@ impl CommitLogRuntimeState {
     #[doc(hidden)]
     pub fn new(memory_lock_warn_only: bool, memory_lock_budget_bytes: u64) -> Self {
         Self {
-            confirm_offset: -1,
+            confirm_offset: AtomicI64::new(-1),
             put_message_lock_stats: CommitLogPutMessageLockStats::default(),
             begin_time_in_lock: Arc::new(AtomicU64::new(0)),
             active_memory_lock: Mutex::new(CommitLogActiveMemoryLock::new(
@@ -192,13 +193,19 @@ impl CommitLogRuntimeState {
     /// Returns the stored confirm offset without applying HA/config policy.
     #[doc(hidden)]
     pub fn confirm_offset(&self) -> i64 {
-        self.confirm_offset
+        self.confirm_offset.load(Ordering::SeqCst)
     }
 
     /// Replaces the stored confirm offset.
     #[doc(hidden)]
     pub fn set_confirm_offset(&mut self, confirm_offset: i64) {
-        self.confirm_offset = confirm_offset;
+        self.publish_confirm_offset(confirm_offset);
+    }
+
+    /// Publishes the stored confirm offset through the shared HA boundary.
+    #[doc(hidden)]
+    pub fn publish_confirm_offset(&self, confirm_offset: i64) {
+        self.confirm_offset.store(confirm_offset, Ordering::SeqCst);
     }
 
     /// Returns the current put-message lock timing snapshot.
@@ -247,5 +254,21 @@ impl CommitLogRuntimeState {
     #[doc(hidden)]
     pub fn load_statistics(&self) -> LoadStatistics {
         self.last_load_statistics.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CommitLogRuntimeState;
+
+    #[test]
+    fn shared_confirm_offset_publication_preserves_decreases() {
+        let state = CommitLogRuntimeState::new(true, 0);
+
+        state.publish_confirm_offset(128);
+        assert_eq!(state.confirm_offset(), 128);
+
+        state.publish_confirm_offset(64);
+        assert_eq!(state.confirm_offset(), 64);
     }
 }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -111,10 +111,7 @@ impl AutoSwitchHAService {
         let max_phy_offset = self.message_store.get_max_phy_offset();
         let current_confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
         let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
-        self.message_store
-            .clone()
-            .mut_from_ref()
-            .set_confirm_offset(confirm_offset);
+        self.message_store.publish_confirm_offset(confirm_offset);
     }
 
     pub fn is_synchronizing_sync_state_set(&self) -> bool {
@@ -149,10 +146,7 @@ impl AutoSwitchHAService {
         let max_phy_offset = self.message_store.get_max_phy_offset();
         let current_confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
         let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
-        self.message_store
-            .clone()
-            .mut_from_ref()
-            .set_confirm_offset(confirm_offset);
+        self.message_store.publish_confirm_offset(confirm_offset);
     }
 
     pub(crate) fn handle_connection_added(&self, connection: &GeneralHAConnection) {
@@ -200,10 +194,7 @@ impl AutoSwitchHAService {
             let max_phy_offset = self.message_store.get_max_phy_offset();
             let current_confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
             let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
-            self.message_store
-                .clone()
-                .mut_from_ref()
-                .set_confirm_offset(confirm_offset);
+            self.message_store.publish_confirm_offset(confirm_offset);
         }
     }
 
@@ -275,10 +266,9 @@ impl AutoSwitchHAService {
                     .message_store
                     .get_max_phy_offset()
                     .max(self.message_store.get_min_phy_offset());
-                let message_store = self.message_store.clone();
-                let message_store = message_store.mut_from_ref();
-                message_store.set_state_machine_version(epoch as i64);
-                message_store.set_controller_epoch_start_offset(epoch_start_offset);
+                self.message_store.publish_state_machine_version(epoch as i64);
+                self.message_store
+                    .publish_controller_epoch_start_offset(epoch_start_offset);
             }
         }
         true
@@ -293,9 +283,7 @@ impl AutoSwitchHAService {
             self.message_store.get_commit_log().get_confirm_offset_directly()
         };
         self.message_store
-            .clone()
-            .mut_from_ref()
-            .set_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
+            .publish_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
     }
 
     pub fn current_master_epoch(&self) -> i32 {

--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -686,7 +686,7 @@ impl ReaderTask {
         let max_phy_offset = store.get_max_phy_offset().max(min_phy_offset);
         let confirm_offset =
             rocketmq_store_local::ha::wire::clamp_confirm_offset(confirm_offset, min_phy_offset, max_phy_offset);
-        store.clone().mut_from_ref().set_confirm_offset(confirm_offset);
+        store.publish_confirm_offset(confirm_offset);
     }
 
     // Move the unconsumed data to the start of the buffer to save space.

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -751,7 +751,11 @@ impl CommitLog {
     }
 
     pub fn set_confirm_offset(&mut self, phy_offset: i64) {
-        self.runtime_state.set_confirm_offset(phy_offset);
+        self.publish_confirm_offset(phy_offset);
+    }
+
+    pub(crate) fn publish_confirm_offset(&self, phy_offset: i64) {
+        self.runtime_state.publish_confirm_offset(phy_offset);
         self.store_checkpoint.set_confirm_phy_offset(phy_offset as u64);
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1482,13 +1482,25 @@ impl LocalFileMessageStore {
     }
 
     pub fn set_state_machine_version(&mut self, state_machine_version: i64) {
+        self.publish_state_machine_version(state_machine_version);
+    }
+
+    pub(crate) fn publish_state_machine_version(&self, state_machine_version: i64) {
         self.state_machine_version
             .store(state_machine_version, Ordering::SeqCst);
     }
 
     pub fn set_controller_epoch_start_offset(&mut self, epoch_start_offset: i64) {
+        self.publish_controller_epoch_start_offset(epoch_start_offset);
+    }
+
+    pub(crate) fn publish_controller_epoch_start_offset(&self, epoch_start_offset: i64) {
         self.controller_epoch_start_offset
             .store(epoch_start_offset, Ordering::SeqCst);
+    }
+
+    pub(crate) fn publish_confirm_offset(&self, phy_offset: i64) {
+        self.commit_log.publish_confirm_offset(phy_offset);
     }
 
     pub fn get_controller_epoch_start_offset(&self) -> i64 {
@@ -3317,7 +3329,7 @@ impl MessageStore for LocalFileMessageStore {
     }
 
     fn set_confirm_offset(&mut self, phy_offset: i64) {
-        self.commit_log.set_confirm_offset(phy_offset);
+        self.publish_confirm_offset(phy_offset);
     }
 
     fn is_os_page_cache_busy(&self) -> bool {

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -4889,49 +4889,6 @@
       "adr": "ADR-013"
     },
     {
-      "identity": "5ba88f9581a8078b38af3d26",
-      "path": "rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "be9142c031a7e6bb801e2a98",
-          "fingerprint": "f26fb880a9d928bd927ec162",
-          "item": "fn set_sync_state_set",
-          "line": 116
-        },
-        {
-          "id": "a6eee7c44dc4e7c41d082c3d",
-          "fingerprint": "7a17348b07a667ab265749c7",
-          "item": "fn update_confirm_offset_when_slave_ack",
-          "line": 154
-        },
-        {
-          "id": "0861b9b5206073884eea7596",
-          "fingerprint": "ae361ecb24065212a1a98603",
-          "item": "fn handle_connection_removed",
-          "line": 205
-        },
-        {
-          "id": "168cb56afd15ebc5b7a5d606",
-          "fingerprint": "77f5d1b2cef0f9de68ce5611",
-          "item": "fn apply_epoch_transition",
-          "line": 279
-        },
-        {
-          "id": "9e89ff40ee15c4c61fc60d7f",
-          "fingerprint": "7ae6c9b0b8c0629701ae09ec",
-          "item": "fn refresh_confirm_offset_after_role_change",
-          "line": 297
-        }
-      ],
-      "owner": "store",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
       "identity": "df14a93c88f4b62845b3ddbe",
       "path": "rocketmq-store/src/ha/default_ha_client.rs",
       "symbol": "*",
@@ -5185,25 +5142,6 @@
       ],
       "owner": "store",
       "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
-      "identity": "e24854c4cfa62b92b52ef485",
-      "path": "rocketmq-store/src/ha/default_ha_client.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "62a8c8336f52e3f9d909d4dd",
-          "fingerprint": "d1f02a68c4f4dcb3cb87bb96",
-          "item": "fn apply_master_confirm_offset",
-          "line": 689
-        }
-      ],
-      "owner": "store",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
       "remove_by": "M11",
       "adr": "ADR-013"
     },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8459

### Brief Description

Publish Store HA replication state without obtaining a shared mutable
`LocalFileMessageStore` reference.

- store the CommitLog confirm offset in `AtomicI64` while preserving the existing
  mutable compatibility setter;
- add narrow internal publishers for confirm offset, controller epoch start offset,
  and state-machine version;
- remove six HA `mut_from_ref` occurrences while preserving confirm-offset decreases,
  reader clamping, checkpoint publication, and epoch-transition ordering;
- reduce the reviewed ArcMut baseline from 344 identities / 932 occurrences to
  342 / 926, with no relocation or new identity;
- update the migration checklist, progress evidence, and remaining-task inventory.

### How Did You Test This Change?

- `cargo test -p rocketmq-store-local --all-features --lib` (186 passed)
- `cargo test -p rocketmq-store --all-features --lib` (507 passed)
- focused HA confirm-offset, role-change, and epoch tests (6 passed)
- `cargo test -p rocketmq-broker --all-features three_controller_two_broker --lib -- --test-threads=1` (4 passed)
- Store/Broker RocksDB strict Clippy and regression suites (82 + 9 + 21 + 4 passed)
- ArcMut guard (67 tests, 24 fixtures), architecture guard (60 tests), runtime audit,
  dependency/release/performance guards, and AGENTS routing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

The full Broker library baseline remains non-green at 610 passed, 25 failed, and
1 ignored. The failures are confined to the existing lifecycle/Lite/subscription
dynamic area; no HA confirm-offset or epoch test failed.
