### PR TITLE
[ISSUE #8467]♻️Remove mutable escape from CommitLog disk flush

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,15 +40,15 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8464 的 M11-12bc28 子切片完成后，当前 ArcMut reviewed
-baseline 为 331 identities / 907 occurrences，其中 production 为 174/432、test 为 143/435、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8467 的 M11-12bc29 子切片完成后，当前 ArcMut reviewed
+baseline 为 330 identities / 906 occurrences，其中 production 为 173/431、test 为 143/435、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
 | Broker | 83 / 181 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
-| Store | 91 / 251 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布与 HA connection runtime handle 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
+| Store | 90 / 250 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle 与 CommitLog shared disk-flush 已完成；继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
 Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook/rollback 证据；M10 固定硬件性能、五镜像动态验证、
@@ -713,7 +713,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc26 HA replication atomic publication：confirm offset 改由 `AtomicI64` 共享发布；epoch/state-machine 已有原子字段增加窄发布入口，HA service/client 删除对完整 `LocalFileMessageStore` 的 `mut_from_ref`
   - [x] M11-12bc27 Broker role-change owner reuse：通知 handler 改为无状态 leaf，经既有 BrokerConfig handler 窄委托应用 controller role change，不再长期持有第二份完整 runtime owner
   - [x] M11-12bc28 HA connection runtime handle：read/write worker 只持连接标识、地址、状态和可选 slave id，不再以 `WeakArcMut<GeneralHAConnection>` 形成自引用；service callback 改收窄标量能力
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc29 CommitLog shared disk-flush：group-commit enqueue 改用共享 receiver，公开 FlushManager 可变签名委托共享实现，CommitLog 热路径删除唯一 `mut_from_ref`
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -796,7 +797,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8459 后实际快照降至 342 identities/926 occurrences：production 184/448、test 144/438、compatibility 14/40、Store production 99/264；HA confirm/epoch 原子发布净删除 2 个 production identity/6 occurrence，无 relocation
   - [x] Issue #8461 后实际快照降至 340 identities/923 occurrences：production 182/445、test 144/438、compatibility 14/40、Broker production 83/181；role-change duplicate owner 净删除 2 个 production identity/3 occurrence，无 relocation
   - [x] Issue #8464 后实际快照降至 331 identities/907 occurrences：production 174/432、test 143/435、compatibility 14/40、Store production 91/251；HA connection weak self-cycle 净删除 8 个 production identity/13 occurrence与 1 个 test identity/3 occurrence，1 个保留 import occurrence 经同位置指纹审核更新，无 relocation
-  - [ ] M11-12bc29 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8467 后实际快照降至 330 identities/906 occurrences：production 173/431、test 143/435、compatibility 14/40、Store production 90/250；CommitLog disk-flush 热路径净删除 1 个 production identity/1 occurrence，无 relocation
+  - [ ] M11-12bc30 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -684,6 +684,15 @@ compatibility 14/40、Store production 91/251），production 净删除 8 identi
 总进度仍为 75/82，下一子切片 M11-12bc29 继续
 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Store WAL sync-flush enqueue 随 Issue #8467 收窄：`GroupCommitService::put_request` 改为共享 receiver；
+`DefaultFlushManager` 新增 crate-private shared disk-flush 实现，公开 `FlushManager::handle_disk_flush(&mut self, ...)`
+兼容签名保持不变并委托该实现。CommitLog 的共享热路径直接调用 shared 方法，不再通过 `mut_from_ref` 取得完整
+flush manager 可变引用。enqueue 前后 cancellation、bounded channel backpressure、原子统计、flush completion timeout、
+`PutMessageStatus` 映射与 start/shutdown 独占生命周期保持不变。ArcMut 快照降至 330 identities/906 occurrences
+（production 173/431、test 143/435、compatibility 14/40、Store production 90/250），净删除 1 个 production
+identity/1 occurrence，无 relocation。总进度仍为 75/82，下一子切片 M11-12bc30 优先清理 Store 最后的
+production `WeakArcMut` 或继续 Broker aggregate/leaf。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8464 / M11-12bc28 完成后
+> 代码基线：Issue #8467 / M11-12bc29 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,20 +19,20 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8464 后 reviewed ArcMut baseline 为 331 identities / 907 occurrences：production 174/432、test
+Issue #8467 后 reviewed ArcMut baseline 为 330 identities / 906 occurrences：production 173/431、test
 143/435、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
 | Broker | 83 / 181 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
-| Store | 91 / 251 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布与 HA connection runtime handle 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
+| Store | 90 / 250 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle 与 CommitLog shared disk-flush 已收窄；其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | 先迁移 Store 对 `WeakArcMut` 的剩余使用；公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
 1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 83/181）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset 与 Consumer handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
-3. Store WAL：commit worker 已只持 `Notify` 唤醒能力；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
+3. Store WAL：commit worker 已只持 `Notify` 唤醒能力，CommitLog disk-flush 已通过共享 receiver enqueue；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
 5. Store timer/HA：BrokerStats observer、HA notification service、connection registry 查询、未共享 client/connection child 与 HA connection worker 自引用已退出多余 owner；继续收口 Timer、Default/General/AutoSwitch HA service 与其余 actor 回指。
 6. compatibility/stable：迁移剩余测试/兼容调用方和 Store `WeakArcMut`；按 next-major/HUMAN 窗口处理公开 facade，并替换 `sync_unsafe_cell`、`async_fn_traits`、`unboxed_closures` 等 nightly surface。
@@ -189,6 +189,13 @@ offset 与 sync-state 更新时间、shutdown/TaskGroup 顺序保持不变。pro
 test 净删除 1 identity / 3 occurrences，因此 reviewed 总量降至 331/907、production 降至 174/432、test 降至
 143/435、Store 降至 91/251；Broker 83/181 与 compatibility 14/40 不增，1 个保留 import occurrence 经同位置
 指纹审核更新，无 relocation。
+
+M11-12bc29 将 sync-flush enqueue 的真实只读边界显式化：`GroupCommitService::put_request` 改为 `&self`，
+`DefaultFlushManager` 以 crate-private shared 方法承载原实现，公开 `FlushManager` 的 `&mut self` 签名继续作为兼容
+facade；CommitLog 直接调用 shared 方法并删除唯一 `mut_from_ref`。cancellation、bounded channel backpressure、
+原子 enqueue stats、receiver timeout、状态映射与独占 start/shutdown lifecycle 保持不变。production 净删除
+1 identity / 1 occurrence，因此 reviewed 总量降至 330/906、production 降至 173/431、Store 降至 90/250；
+test 143/435、Broker 83/181 与 compatibility 14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2848,10 +2848,33 @@ Store HA connection weak self-cycle 随 Issue #8464 完成以下边界收敛：
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
 | root workspace final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc29 实现
+
+Store WAL sync-flush enqueue 随 Issue #8467 完成以下边界收敛：
+
+- `GroupCommitService::put_request` 从 `&mut self` 收窄为 `&self`；该路径只读取 cancellation token 与 sender、等待 bounded-channel send/cancellation，并更新原子统计，不修改 service 字段。
+- `DefaultFlushManager::handle_disk_flush_shared` 以共享 receiver 承载原 sync/async flush 逻辑；公开 `FlushManager::handle_disk_flush(&mut self, ...)` 签名保持兼容并直接委托 shared 实现。
+- `CommitLog::handle_disk_flush(&self, ...)` 直接调用 shared 实现，删除 WAL put 热路径唯一的 `mut_from_ref`；observability latency 记录位置与状态返回不变。
+- sync-flush enqueue 前后的 cancellation 快速失败、bounded backpressure、成功后统计、completion timeout/error mapping，以及 async wakeup 分支保持不变。
+- flush manager start/shutdown、sender 发布和 worker TaskGroup 仍由独占可变 lifecycle owner 管理；不增加锁、后台任务或跨 `.await` 同步 guard。
+- reviewed baseline 从 331 identities / 907 occurrences 降至 330 / 906；production 从 174/432 降至 173/431，test 保持 143/435，compatibility 保持 14/40。Store production 从 91/251 降至 90/250；净删除 1 个 production identity/1 occurrence，无 relocation、新增 identity 或临时 approval。
+
+## M11-12bc29 验证
+
+| 命令 | 结果 |
+|---|---|
+| Store focused / all-feature check / strict Clippy | shared receiver sync-flush 成功完成并保留 missing-service timeout 的聚焦回归 1/1；`cargo check -p rocketmq-store --all-features` 与 Store all-target/all-feature strict Clippy 通过 |
+| Store all-feature lib | 507/507 通过；sync/async flush、group-commit shutdown 与 CommitLog 行为无新增失败 |
+| Broker all-feature lib | 611 passed、25 failed、1 ignored；失败仍集中于既有 lifecycle/Lite/subscription 动态基线，flush/HA/RocksDB/controller 均无新失败，因此全套如实记为未通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--prune-resolved` 候选与正式最小补丁均从 331/907 精确降至 330/906；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 guard tests 通过，无 relocation、新增 identity 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
 1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（83/181）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
-2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（91/251）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布与 HA connection runtime handle 已完成。
+2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（90/250）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle 与 CommitLog shared disk-flush 已完成。
 3. 先迁移 Store 对 `WeakArcMut` 的剩余使用并移除其余 nightly feature；公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态
    Kind/K3d/container、M10 固定硬件和 Human Gate。

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1425,12 +1425,9 @@ impl CommitLog {
         #[cfg(feature = "observability")]
         let start_time = Instant::now();
 
-        // Acquire lock and immediately call handle_disk_flush which internally
-        // only triggers async operations without holding the lock
         let status = self
             .flush_manager
-            .mut_from_ref()
-            .handle_disk_flush(put_message_result, msg)
+            .handle_disk_flush_shared(put_message_result, msg)
             .await;
 
         #[cfg(feature = "observability")]

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -175,6 +175,69 @@ impl DefaultFlushManager {
         self.sync_flush_stats.snapshot()
     }
 
+    pub(crate) async fn handle_disk_flush_shared(
+        &self,
+        result: &AppendMessageResult,
+        message_ext: &MessageExtBrokerInner,
+    ) -> PutMessageStatus {
+        match self.message_store_config.flush_disk_type {
+            FlushDiskType::SyncFlush => {
+                if message_ext.is_wait_store_msg_ok() {
+                    let (commit_request, flush_ok_receiver) = GroupCommitRequest::new(
+                        result.wrote_offset + result.wrote_bytes as i64,
+                        self.message_store_config.sync_flush_timeout,
+                    );
+
+                    time::timeout(
+                        time::Duration::from_millis(self.message_store_config.sync_flush_timeout),
+                        async {
+                            let Some(group_commit_service) = self.group_commit_service.as_ref() else {
+                                return PutMessageStatus::FlushDiskTimeout;
+                            };
+                            if !group_commit_service.put_request(commit_request).await {
+                                return PutMessageStatus::FlushDiskTimeout;
+                            }
+                            match flush_ok_receiver.await {
+                                Ok(Ok(GroupCommitStatus::Flushed)) => PutMessageStatus::PutOk,
+                                Ok(Ok(GroupCommitStatus::TimedOut)) => PutMessageStatus::FlushDiskTimeout,
+                                Ok(Err(error)) => {
+                                    warn!(error = %error, "sync flush failed");
+                                    PutMessageStatus::FlushDiskTimeout
+                                }
+                                Err(_) => PutMessageStatus::FlushDiskTimeout,
+                            }
+                        },
+                    )
+                    .await
+                    .unwrap_or(PutMessageStatus::FlushDiskTimeout)
+                } else {
+                    let Some(group_commit_service) = self.group_commit_service.as_ref() else {
+                        warn!("Sync flush requested but GroupCommitService is not initialized");
+                        return PutMessageStatus::FlushDiskTimeout;
+                    };
+                    group_commit_service.wakeup();
+                    PutMessageStatus::PutOk
+                }
+            }
+            FlushDiskType::AsyncFlush => {
+                if self.message_store_config.transient_store_pool_enable {
+                    let Some(commit_real_time_service) = self.commit_real_time_service.as_ref() else {
+                        warn!("Async flush requested but CommitRealTimeService is not initialized");
+                        return PutMessageStatus::FlushDiskTimeout;
+                    };
+                    commit_real_time_service.wakeup();
+                } else {
+                    let Some(flush_real_time_service) = self.flush_real_time_service.as_ref() else {
+                        warn!("Async flush requested but FlushRealTimeService is not initialized");
+                        return PutMessageStatus::FlushDiskTimeout;
+                    };
+                    flush_real_time_service.wakeup();
+                }
+                PutMessageStatus::PutOk
+            }
+        }
+    }
+
     pub(crate) async fn shutdown_gracefully(&mut self) -> Result<FlushProgress, StoreError> {
         if let Some(ref mut group_commit_service) = self.group_commit_service {
             group_commit_service.shutdown_gracefully().await;
@@ -263,62 +326,7 @@ impl FlushManager for DefaultFlushManager {
         result: &AppendMessageResult,
         message_ext: &MessageExtBrokerInner,
     ) -> PutMessageStatus {
-        match self.message_store_config.flush_disk_type {
-            FlushDiskType::SyncFlush => {
-                if message_ext.is_wait_store_msg_ok() {
-                    let (commit_request, flush_ok_receiver) = GroupCommitRequest::new(
-                        result.wrote_offset + result.wrote_bytes as i64,
-                        self.message_store_config.sync_flush_timeout,
-                    );
-
-                    time::timeout(
-                        time::Duration::from_millis(self.message_store_config.sync_flush_timeout),
-                        async {
-                            let Some(group_commit_service) = self.group_commit_service.as_mut() else {
-                                return PutMessageStatus::FlushDiskTimeout;
-                            };
-                            if !group_commit_service.put_request(commit_request).await {
-                                return PutMessageStatus::FlushDiskTimeout;
-                            }
-                            match flush_ok_receiver.await {
-                                Ok(Ok(GroupCommitStatus::Flushed)) => PutMessageStatus::PutOk,
-                                Ok(Ok(GroupCommitStatus::TimedOut)) => PutMessageStatus::FlushDiskTimeout,
-                                Ok(Err(error)) => {
-                                    warn!(error = %error, "sync flush failed");
-                                    PutMessageStatus::FlushDiskTimeout
-                                }
-                                Err(_) => PutMessageStatus::FlushDiskTimeout,
-                            }
-                        },
-                    )
-                    .await
-                    .unwrap_or(PutMessageStatus::FlushDiskTimeout)
-                } else {
-                    let Some(group_commit_service) = self.group_commit_service.as_ref() else {
-                        warn!("Sync flush requested but GroupCommitService is not initialized");
-                        return PutMessageStatus::FlushDiskTimeout;
-                    };
-                    group_commit_service.wakeup();
-                    PutMessageStatus::PutOk
-                }
-            }
-            FlushDiskType::AsyncFlush => {
-                if self.message_store_config.transient_store_pool_enable {
-                    let Some(commit_real_time_service) = self.commit_real_time_service.as_ref() else {
-                        warn!("Async flush requested but CommitRealTimeService is not initialized");
-                        return PutMessageStatus::FlushDiskTimeout;
-                    };
-                    commit_real_time_service.wakeup();
-                } else {
-                    let Some(flush_real_time_service) = self.flush_real_time_service.as_ref() else {
-                        warn!("Async flush requested but FlushRealTimeService is not initialized");
-                        return PutMessageStatus::FlushDiskTimeout;
-                    };
-                    flush_real_time_service.wakeup();
-                }
-                PutMessageStatus::PutOk
-            }
-        }
+        self.handle_disk_flush_shared(result, message_ext).await
     }
 }
 
@@ -338,7 +346,7 @@ impl GroupCommitService {
         self.forced_flush_error.clone()
     }
 
-    pub async fn put_request(&mut self, request: GroupCommitRequest) -> bool {
+    async fn put_request(&self, request: GroupCommitRequest) -> bool {
         if self.shutdown_token.is_cancelled() {
             return false;
         }
@@ -808,6 +816,15 @@ mod tests {
             mapped_file_queue,
             store_checkpoint,
         );
+        manager.start();
+
+        let shared_manager: &DefaultFlushManager = &manager;
+        let status = shared_manager
+            .handle_disk_flush_shared(&AppendMessageResult::default(), &MessageExtBrokerInner::default())
+            .await;
+        assert_eq!(status, PutMessageStatus::PutOk);
+
+        manager.shutdown_gracefully().await.unwrap();
         manager.group_commit_service = None;
 
         let status = manager

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -6085,25 +6085,6 @@
       "adr": "ADR-013"
     },
     {
-      "identity": "40b7e2ab4ef7d3cf278da5e1",
-      "path": "rocketmq-store/src/log_file/commit_log.rs",
-      "symbol": "mut_from_ref",
-      "kind": "mut_from_ref_call",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "0cd68a581e68a2823e818fc8",
-          "fingerprint": "570f4410e324e24a9bd6add0",
-          "item": "fn handle_disk_flush",
-          "line": 1433
-        }
-      ],
-      "owner": "store",
-      "reason": "Legacy safe mutable-reference escape pending ownership migration",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
       "identity": "527ebe3ad5a4c0369200bcb4",
       "path": "rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs",
       "symbol": "*",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8467

### Brief Description

- Add a shared-receiver disk-flush path so `CommitLog` no longer obtains a mutable reference through `ArcMut::mut_from_ref`.
- Keep the public `FlushManager` trait contract compatible by delegating its mutable-receiver method to the shared implementation.
- Narrow `GroupCommitService::put_request` to `&self`, preserving shutdown, enqueue, timeout, and flush-result behavior.
- Extend the existing sync-flush test to exercise the shared path and retain the missing-service timeout assertion.
- Remove the resolved ArcMut baseline identity and update the migration checklist, remaining-task inventory, and soundness evidence from 331/907 to 330/906.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --all-features handle_disk_flush_returns_timeout_when_sync_service_missing`
- `cargo check -p rocketmq-store --all-features`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-store --lib --all-features` (507 passed)
- `cargo test -p rocketmq-broker --lib --all-features` (611 passed, 25 existing dynamic lifecycle/Lite/subscription failures, 1 ignored; suite remains non-green)
- Required RocksDB Store/Broker Clippy and focused test matrix (82 + 9 + 21 + 4 passed)
- `python scripts/arc_mut_guard.py`
- ArcMut guard unit tests (67 passed) and fixtures (24 passed)
- Architecture, dependency, release-topology, and performance guard suites
- `pwsh -File scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `pwsh -File scripts/check-agents-routing.ps1`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the message storage flush workflow to use a shared, streamlined processing path.
  * Preserved existing flush status reporting, timeout behavior, cancellation, backpressure, and lifecycle handling.
  * Removed an unsafe internal ownership workaround from the message write path.

* **Tests**
  * Expanded validation for synchronous and asynchronous flushing, shutdown behavior, and successful completion scenarios.

* **Documentation**
  * Updated architecture migration progress, completion tracking, and reviewed baseline metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->