### PR TITLE
[ISSUE #8471]♻️Make topic admin handler stateless

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8469 的 M11-12bc30 子切片完成后，当前 ArcMut reviewed
-baseline 为 328 identities / 899 occurrences，其中 production 为 171/424、test 为 143/435、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8471 的 M11-12bc31 子切片完成后，当前 ArcMut reviewed
+baseline 为 325 identities / 895 occurrences，其中 production 为 169/421、test 为 142/434、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 83 / 181 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 81 / 178 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer/topic Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 88 / 243 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush 与 auto-switch replication-state capability 已完成；production `WeakArcMut` 已清零，继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -715,7 +715,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc28 HA connection runtime handle：read/write worker 只持连接标识、地址、状态和可选 slave id，不再以 `WeakArcMut<GeneralHAConnection>` 形成自引用；service callback 改收窄标量能力
   - [x] M11-12bc29 CommitLog shared disk-flush：group-commit enqueue 改用共享 receiver，公开 FlushManager 可变签名委托共享实现，CommitLog 热路径删除唯一 `mut_from_ref`
   - [x] M11-12bc30 HA replication-state capability：DefaultHAService 只持标准 `Arc<ReplicationStateRoot>`，连接事件不再升级完整 `WeakArcMut<AutoSwitchHAService>`；sync-state 与 confirm-offset 语义保持不变
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc31 Topic Admin request borrow：Topic handler 改为无状态非泛型 leaf，查询与删除使用父层请求期借用，异步持久化/注册复用已有 BrokerConfig owner
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469/#8471 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -800,7 +801,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8464 后实际快照降至 331 identities/907 occurrences：production 174/432、test 143/435、compatibility 14/40、Store production 91/251；HA connection weak self-cycle 净删除 8 个 production identity/13 occurrence与 1 个 test identity/3 occurrence，1 个保留 import occurrence 经同位置指纹审核更新，无 relocation
   - [x] Issue #8467 后实际快照降至 330 identities/906 occurrences：production 173/431、test 143/435、compatibility 14/40、Store production 90/250；CommitLog disk-flush 热路径净删除 1 个 production identity/1 occurrence，无 relocation
   - [x] Issue #8469 后实际快照降至 328 identities/899 occurrences：production 171/424、test 143/435、compatibility 14/40、Store production 88/243；DefaultHAService 完整 auto-switch weak owner 净删除 2 个 production identity/7 occurrence，4 个保留 occurrence 经临时 ADR-013 一对一 relocation 审核，无新增 identity
-  - [ ] M11-12bc31 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8471 后实际快照降至 325 identities/895 occurrences：production 169/421、test 142/434、compatibility 14/40、Broker production 81/178；Topic Admin 无状态 leaf 净删除 2 个 production identity/3 occurrence与 1 个 test identity/1 occurrence，无 relocation
+  - [ ] M11-12bc32 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -702,6 +702,15 @@ Store production 88/243），净删除 2 个 production identity/7 occurrence；
 一对一 relocation 审核，无新增 identity，production `WeakArcMut` 已清零。总进度仍为 75/82，下一子切片
 M11-12bc31 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Broker Topic Admin 重复 owner 随 Issue #8471 收窄：`TopicRequestHandler` 改为无状态、非泛型 leaf，topic 查询与
+clean 请求从父层既有 `BrokerConfigRequestHandler` 取得请求期共享 runtime 借用，删除请求取得独占借用；create/update
+继续先更新 TopicConfig/静态映射，再由 BrokerConfig owner 执行原有 coordinator persist 和 single/increment broker
+registration。Topic 校验、Mixed/system 限制、删除 POP retry v2/v1/main 顺序、offset/inflight/Store 清理、stats/query
+响应保持不变；零大小回归证明 handler 不再保活完整 runtime。ArcMut 快照降至 325 identities/895 occurrences
+（production 169/421、test 142/434、compatibility 14/40、Broker production 81/178、Store production 88/243），
+净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation。总进度仍为
+75/82，下一子切片 M11-12bc32 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8469 / M11-12bc30 完成后
+> 代码基线：Issue #8471 / M11-12bc31 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,19 +19,19 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8469 后 reviewed ArcMut baseline 为 328 identities / 899 occurrences：production 171/424、test
-143/435、compatibility 14/40。production 全部分布在 Broker 与 Store。
+Issue #8471 后 reviewed ArcMut baseline 为 325 identities / 895 occurrences：production 169/421、test
+142/434、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 83 / 181 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 81 / 178 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer/Topic Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 88 / 243 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush 与 auto-switch replication-state capability 已收窄；production `WeakArcMut` 已清零，其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | production Store `WeakArcMut` 已清零；继续迁移测试/兼容调用方，公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 83/181）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset 与 Consumer handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
-2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 81/178）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener 与 ClientHousekeepingService 强保活边已拆除，HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer 与 Topic handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
+2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力，Topic Admin 已由 M11-12bc31 改为无状态 leaf。
 3. Store WAL：commit worker 已只持 `Notify` 唤醒能力，CommitLog disk-flush 已通过共享 receiver enqueue；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
 5. Store timer/HA：BrokerStats observer、HA notification service、connection registry 查询、未共享 client/connection child、HA connection worker 自引用和完整 auto-switch weak owner 已退出多余 owner；继续收口 Timer、Default/General/AutoSwitch HA service 与其余 actor 回指。
@@ -204,6 +204,14 @@ shutdown 短路、sync-state expansion/removal、confirm-offset runtime snapshot
 auto-switch owner 的 weak count 为零。production 净删除 2 identities / 7 occurrences，因此 reviewed 总量降至
 328/899、production 降至 171/424、Store 降至 88/243；test 143/435、Broker 83/181 与 compatibility 14/40
 不增。4 个保留 occurrence 经临时 ADR-013 一对一 relocation 审核，无新增 identity，审批文件不提交。
+
+M11-12bc31 将 `TopicRequestHandler` 改为无状态、非泛型 leaf；Admin dispatch 为 topic 查询/clean 传入请求期共享
+`BrokerRuntimeInner` 借用，为删除传入请求期独占借用，create/update 则复用已有 `BrokerConfigRequestHandler` owner
+执行 coordinator persist 与 single/increment registration。Topic validation、static mapping、Mixed/system 限制、
+idempotency、删除 POP retry v2/v1/main 顺序、offset/inflight/Store 清理和查询响应保持不变；零大小回归证明 handler
+不再保活完整 runtime。production 净删除 2 identities / 3 occurrences，test 净删除 1 identity / 1 occurrence，因此
+reviewed 总量降至 325/895、production 降至 169/421、test 降至 142/434、Broker 降至 81/178；Store 88/243 与
+compatibility 14/40 不增，无 relocation。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2893,9 +2893,30 @@ Store HA replication-state callback 随 Issue #8469 完成以下边界收敛：
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、127/127 guard tests 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc31 实现
+
+Broker Topic Admin request borrow 随 Issue #8471 完成以下边界收敛：
+
+- `TopicRequestHandler<MS>` 改为无状态、非泛型 `TopicRequestHandler`，删除完整 `ArcMut<BrokerRuntimeInner>` field、constructor clone 与模块 import。
+- `AdminBrokerProcessor` 复用 `BrokerConfigRequestHandler` 已有 runtime owner：topic 查询与 clean 请求取得请求期共享借用，删除请求取得请求期独占借用。
+- create/update 继续先更新 TopicConfig 与可选静态映射，再由 BrokerConfig handler 的窄动作执行 coordinator persist 和原 single/increment registration；注册闭包中的 runtime clone 只存在于请求期异步动作。
+- Topic validation、system/Mixed 限制、idempotency、DataVersion、POP retry v2/v1/main 删除顺序、config/mapping/offset/inflight/Store 清理、stats/query 响应保持不变。
+- 零大小回归证明 Topic handler 不再保活完整 runtime；reviewed baseline 从 328 identities / 899 occurrences 降至 325 / 895，production 从 171/424 降至 169/421，test 从 143/435 降至 142/434，compatibility 保持 14/40。Broker production 从 83/181 降至 81/178，Store 保持 88/243；净删除 2 个 production identity/3 occurrences 与 1 个 test identity/1 occurrence，无 relocation。
+
+## M11-12bc31 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused / compatibility / strict Clippy | `cargo check -p rocketmq-broker --all-features` 通过；Topic handler 3/3 与 phase3/5/6 跨处理器回归 3/3 通过；Broker all-target/all-feature strict Clippy 通过 |
+| Broker all-feature lib | 612 passed、25 failed、1 ignored；失败仍集中于既有 lifecycle/Lite/subscription 动态基线，无 Topic Admin 新失败，因此全套如实记为未通过 |
+| Store all-feature lib / RocksDB 专项 | Store 507/507；Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--prune-resolved` 候选与正式最小补丁均从 328/899 精确降至 325/895；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 ArcMut guard tests 通过，无 relocation、新增 identity 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、architecture 60/60 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（83/181）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（81/178）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer、Topic handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（88/243）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA replication-state callback、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle 与 CommitLog shared disk-flush 已完成。
 3. Production `WeakArcMut` 已清零；继续迁移 test/compatibility 中受控使用并移除其余 nightly feature。公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -84,7 +84,7 @@ mod update_global_white_addrs_config_request_handler;
 mod update_user_request_handler;
 
 pub struct AdminBrokerProcessor<MS: MessageStore> {
-    topic_request_handler: TopicRequestHandler<MS>,
+    topic_request_handler: TopicRequestHandler,
     broker_config_request_handler: BrokerConfigRequestHandler<MS>,
     consumer_request_handler: ConsumerRequestHandler,
     offset_request_handler: OffsetRequestHandler,
@@ -134,7 +134,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
         auth_admin_service: Arc<AuthAdminService>,
     ) -> Self {
-        let topic_request_handler = TopicRequestHandler::new(broker_runtime_inner.clone());
+        let topic_request_handler = TopicRequestHandler::new();
         let broker_config_request_handler = BrokerConfigRequestHandler::new(broker_runtime_inner.clone());
         let consumer_request_handler = ConsumerRequestHandler::new();
         let offset_request_handler = OffsetRequestHandler::new();
@@ -214,22 +214,30 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         match request_code {
             RequestCode::UpdateAndCreateTopic => {
                 self.topic_request_handler
-                    .update_and_create_topic(channel, ctx, request_code, request)
+                    .update_and_create_topic(&self.broker_config_request_handler, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateTopicList => {
                 self.topic_request_handler
-                    .update_and_create_topic_list(channel, ctx, request_code, request)
+                    .update_and_create_topic_list(
+                        &self.broker_config_request_handler,
+                        channel,
+                        ctx,
+                        request_code,
+                        request,
+                    )
                     .await
             }
             RequestCode::DeleteTopicInBroker => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
                 self.topic_request_handler
-                    .delete_topic(channel, ctx, request_code, request)
+                    .delete_topic(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetAllTopicConfig => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_all_topic_config(channel, ctx, request_code, request)
+                    .get_all_topic_config(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetTimerCheckPoint => {
@@ -344,8 +352,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::GetTopicStatsInfo => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_topic_stats_info(channel, ctx, request_code, request)
+                    .get_topic_stats_info(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetConsumerConnectionList => {
@@ -397,13 +406,15 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::QueryTopicConsumeByWho => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .query_topic_consume_by_who(channel, ctx, request_code, request)
+                    .query_topic_consume_by_who(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::QueryTopicsByConsumer => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .query_topics_by_consumer(channel, ctx, request_code, request)
+                    .query_topics_by_consumer(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::QuerySubscriptionByConsumer => {
@@ -436,8 +447,9 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::CleanUnusedTopic => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .clean_unused_topic(channel, ctx, request_code, request)
+                    .clean_unused_topic(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetConsumerRunningInfo => {
@@ -533,13 +545,20 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::GetTopicConfig => {
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_topic_config(channel, ctx, request_code, request)
+                    .get_topic_config(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateStaticTopic => {
                 self.topic_request_handler
-                    .update_and_create_static_topic(channel, ctx, request_code, request)
+                    .update_and_create_static_topic(
+                        &self.broker_config_request_handler,
+                        channel,
+                        ctx,
+                        request_code,
+                        request,
+                    )
                     .await
             }
             RequestCode::NotifyMinBrokerIdChange => {

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -14,9 +14,11 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::file_readahead_mode::READ_AHEAD_MODE;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::mix_all;
@@ -30,6 +32,7 @@ use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_h
 #[cfg(feature = "rocksdb_store")]
 use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigType;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
@@ -38,6 +41,7 @@ use rocketmq_store::utils::ffi::MADV_RANDOM;
 use sysinfo::Disks;
 
 use crate::broker_runtime::BrokerRuntimeInner;
+use crate::topic::manager::topic_config_coordinator::TopicRegistrationAction;
 
 #[derive(Clone)]
 pub(super) struct BrokerConfigRequestHandler<MS: MessageStore> {
@@ -55,6 +59,32 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
 
     pub(super) fn broker_runtime_inner_mut(&mut self) -> &mut BrokerRuntimeInner<MS> {
         self.broker_runtime_inner.as_mut()
+    }
+
+    pub(super) async fn persist_and_register_topic_updates(
+        &self,
+        topic_config_list: Vec<Arc<TopicConfig>>,
+        data_version: DataVersion,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let runtime = self.broker_runtime_inner.clone();
+        let single_topic_registration = runtime.broker_config().enable_single_topic_register;
+        let registration: TopicRegistrationAction = Box::new(move || {
+            Box::pin(async move {
+                if single_topic_registration {
+                    for topic_config in topic_config_list {
+                        runtime.register_single_topic_all(topic_config).await;
+                    }
+                } else {
+                    BrokerRuntimeInner::<MS>::register_increment_broker_data(runtime, topic_config_list, data_version)
+                        .await;
+                }
+                Ok(())
+            })
+        });
+        self.broker_runtime_inner
+            .topic_config_coordinator()
+            .persist_and_register_wait(registration)
+            .await
     }
 
     pub(super) async fn apply_controller_role_change(

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use cheetah_string::CheetahString;
 use rocketmq_common::common::attribute::attribute_parser::AttributeParser;
 use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
@@ -42,16 +39,15 @@ use rocketmq_remoting::protocol::header::query_topics_by_consumer_request_header
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
-use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
+use std::collections::HashMap;
 use tracing::info;
 
 use crate::broker_runtime::BrokerRuntimeInner;
-use crate::topic::manager::topic_config_coordinator::TopicRegistrationAction;
+use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 
 fn decode_topic_queue_mapping_detail(body: &[u8]) -> Result<TopicQueueMappingDetail, String> {
     match serde_json::from_slice::<TopicQueueMappingDetail>(body) {
@@ -117,51 +113,23 @@ fn quote_unquoted_numeric_json_keys(input: &str) -> String {
     output
 }
 
-#[derive(Clone)]
-pub(super) struct TopicRequestHandler<MS: MessageStore> {
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
-}
+#[derive(Clone, Copy, Default)]
+pub(super) struct TopicRequestHandler;
 
-impl<MS: MessageStore> TopicRequestHandler<MS> {
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        TopicRequestHandler { broker_runtime_inner }
+impl TopicRequestHandler {
+    pub fn new() -> Self {
+        Self
     }
 
-    async fn persist_and_register_topic_updates(
+    pub async fn update_and_create_topic<MS: MessageStore>(
         &self,
-        topic_config_list: Vec<Arc<TopicConfig>>,
-        data_version: DataVersion,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        let runtime = self.broker_runtime_inner.clone();
-        let single_topic_registration = runtime.broker_config().enable_single_topic_register;
-        let registration: TopicRegistrationAction = Box::new(move || {
-            Box::pin(async move {
-                if single_topic_registration {
-                    for topic_config in topic_config_list {
-                        runtime.register_single_topic_all(topic_config).await;
-                    }
-                } else {
-                    BrokerRuntimeInner::<MS>::register_increment_broker_data(runtime, topic_config_list, data_version)
-                        .await;
-                }
-                Ok(())
-            })
-        });
-        self.broker_runtime_inner
-            .topic_config_coordinator()
-            .persist_and_register_wait(registration)
-            .await
-    }
-}
-
-impl<MS: MessageStore> TopicRequestHandler<MS> {
-    pub async fn update_and_create_topic(
-        &mut self,
+        broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
         let response = RemotingCommand::create_response_command();
         let request_header = request
             .decode_command_custom_header::<CreateTopicRequestHeader>()
@@ -180,8 +148,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                     .set_remark(result.remark().clone()),
             ));
         }
-        if self
-            .broker_runtime_inner
+        if broker_runtime_inner
             .broker_config()
             .validate_system_topic_when_update_topic
             && TopicValidator::is_system_topic(topic.as_str())
@@ -220,7 +187,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             attributes,
         };
         if topic_config.get_topic_message_type() == TopicMessageType::Mixed
-            && !self.broker_runtime_inner.broker_config().enable_mixed_message_type
+            && !broker_runtime_inner.broker_config().enable_mixed_message_type
         {
             return Ok(Some(
                 response
@@ -229,8 +196,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             ));
         }
 
-        let topic_config_origin = self
-            .broker_runtime_inner
+        let topic_config_origin = broker_runtime_inner
             .topic_config_manager()
             .get_topic_config(topic.as_str());
         if topic_config_origin.as_deref() == Some(&topic_config) {
@@ -242,24 +208,26 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             );
             return Ok(Some(response.set_code(ResponseCode::Success)));
         }
-        let update = self.broker_runtime_inner.topic_config_manager().update_topic_config(
-            topic_config,
-            self.broker_runtime_inner.topic_config_state_machine_version(),
-        );
+        let update = broker_runtime_inner
+            .topic_config_manager()
+            .update_topic_config(topic_config, broker_runtime_inner.topic_config_state_machine_version());
 
-        self.persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
+        broker_config_request_handler
+            .persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
             .await?;
 
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
-    pub async fn update_and_create_static_topic(
-        &mut self,
+    pub async fn update_and_create_static_topic<MS: MessageStore>(
+        &self,
+        broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
         let response = RemotingCommand::create_response_command();
         let request_header = request.decode_command_custom_header::<CreateTopicRequestHeader>()?;
         info!(
@@ -295,8 +263,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                     .set_remark(result.remark().clone()),
             ));
         }
-        if self
-            .broker_runtime_inner
+        if broker_runtime_inner
             .broker_config()
             .validate_system_topic_when_update_topic
             && TopicValidator::is_system_topic(topic.as_str())
@@ -329,10 +296,9 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             order: request_header.order,
             attributes,
         };
-        let update = self.broker_runtime_inner.topic_config_manager().update_topic_config(
-            topic_config,
-            self.broker_runtime_inner.topic_config_state_machine_version(),
-        );
+        let update = broker_runtime_inner
+            .topic_config_manager()
+            .update_topic_config(topic_config, broker_runtime_inner.topic_config_state_machine_version());
 
         topic_queue_mapping_detail.topic_queue_mapping_info.topic = Some(topic.clone());
         if topic_queue_mapping_detail.topic_queue_mapping_info.total_queues <= 0 {
@@ -340,25 +306,28 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         }
         if topic_queue_mapping_detail.topic_queue_mapping_info.bname.is_none() {
             topic_queue_mapping_detail.topic_queue_mapping_info.bname =
-                Some(self.broker_runtime_inner.broker_config().broker_name().clone());
+                Some(broker_runtime_inner.broker_config().broker_name().clone());
         }
-        self.broker_runtime_inner
+        broker_runtime_inner
             .topic_queue_mapping_manager()
             .update_topic_queue_mapping(topic_queue_mapping_detail);
 
-        self.persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
+        broker_config_request_handler
+            .persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
             .await?;
 
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
-    pub async fn update_and_create_topic_list(
-        &mut self,
+    pub async fn update_and_create_topic_list<MS: MessageStore>(
+        &self,
+        broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
         let request_body = CreateTopicListRequestBody::decode(request.body().as_ref().unwrap().as_ref()).unwrap();
         let mut topic_names = String::new();
         for topic_config in request_body.topic_config_list.iter() {
@@ -381,8 +350,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                         .set_remark(result.remark().clone()),
                 ));
             }
-            if self
-                .broker_runtime_inner
+            if broker_runtime_inner
                 .broker_config()
                 .validate_system_topic_when_update_topic
                 && TopicValidator::is_system_topic(topic)
@@ -394,7 +362,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                 ));
             }
             if topic_config.get_topic_message_type() == TopicMessageType::Mixed
-                && !self.broker_runtime_inner.broker_config().enable_mixed_message_type
+                && !broker_runtime_inner.broker_config().enable_mixed_message_type
             {
                 return Ok(Some(
                     response
@@ -402,7 +370,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                         .set_remark("MIXED message type is not supported.".to_string()),
                 ));
             }
-            let topic_config_origin = self.broker_runtime_inner.topic_config_manager().get_topic_config(topic);
+            let topic_config_origin = broker_runtime_inner.topic_config_manager().get_topic_config(topic);
             if topic_config_origin.is_some() && topic_config.clone() == *topic_config_origin.unwrap() {
                 info!(
                     "Broker receive request to update or create topic={}, but topicConfig has  no changes , so \
@@ -415,20 +383,19 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         }
 
         let mut topic_config_list = request_body.topic_config_list;
-        let (topic_config_list, data_version) = self
-            .broker_runtime_inner
-            .topic_config_manager()
-            .update_topic_config_list(
-                topic_config_list.as_mut_slice(),
-                self.broker_runtime_inner.topic_config_state_machine_version(),
-            );
-        self.persist_and_register_topic_updates(topic_config_list, data_version)
+        let (topic_config_list, data_version) = broker_runtime_inner.topic_config_manager().update_topic_config_list(
+            topic_config_list.as_mut_slice(),
+            broker_runtime_inner.topic_config_state_machine_version(),
+        );
+        broker_config_request_handler
+            .persist_and_register_topic_updates(topic_config_list, data_version)
             .await?;
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
-    pub async fn delete_topic(
-        &mut self,
+    pub async fn delete_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &mut BrokerRuntimeInner<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -451,8 +418,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                     .set_remark("he specified topic is blank."),
             ));
         }
-        if self
-            .broker_runtime_inner
+        if broker_runtime_inner
             .broker_config()
             .validate_system_topic_when_update_topic
             && TopicValidator::is_system_topic(topic)
@@ -463,42 +429,40 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                     .set_remark(format!("The topic[{topic}] is conflict with system topic.",)),
             ));
         }
-        let groups = self
-            .broker_runtime_inner
+        let groups = broker_runtime_inner
             .consumer_offset_manager()
             .which_group_by_topic(topic);
         for group in groups.iter() {
             let pop_retry_topic_v2 =
                 CheetahString::from_string(KeyBuilder::build_pop_retry_topic(topic, group.as_str(), true));
-            if self
-                .broker_runtime_inner
+            if broker_runtime_inner
                 .topic_config_manager()
                 .select_topic_config(pop_retry_topic_v2.as_ref())
                 .is_some()
             {
-                self.delete_topic_in_broker(pop_retry_topic_v2.as_ref());
+                self.delete_topic_in_broker(broker_runtime_inner, pop_retry_topic_v2.as_ref());
             }
             let pop_retry_topic_v1 =
                 CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v1(topic, group.as_str()));
-            if self
-                .broker_runtime_inner
+            if broker_runtime_inner
                 .topic_config_manager()
                 .select_topic_config(pop_retry_topic_v1.as_ref())
                 .is_some()
             {
-                self.delete_topic_in_broker(pop_retry_topic_v1.as_ref());
+                self.delete_topic_in_broker(broker_runtime_inner, pop_retry_topic_v1.as_ref());
             }
         }
-        self.delete_topic_in_broker(topic);
-        self.broker_runtime_inner
+        self.delete_topic_in_broker(broker_runtime_inner, topic);
+        broker_runtime_inner
             .topic_config_coordinator()
             .persist_and_wait()
             .await?;
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
-    pub async fn get_all_topic_config(
-        &mut self,
+    pub async fn get_all_topic_config<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -506,17 +470,15 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response = RemotingCommand::create_response_command();
         let (topic_config_table, topic_config_data_version) =
-            self.broker_runtime_inner.topic_config_manager().metadata_snapshot();
+            broker_runtime_inner.topic_config_manager().metadata_snapshot();
         let topic_config_and_mapping_serialize_wrapper = TopicConfigAndMappingSerializeWrapper {
-            topic_queue_mapping_detail_map: self
-                .broker_runtime_inner
+            topic_queue_mapping_detail_map: broker_runtime_inner
                 .topic_queue_mapping_manager()
                 .topic_queue_mapping_table
                 .iter()
                 .map(|entry| (entry.key().clone(), (**entry.value()).clone()))
                 .collect(),
-            mapping_data_version: self
-                .broker_runtime_inner
+            mapping_data_version: broker_runtime_inner
                 .topic_queue_mapping_manager()
                 .data_version
                 .lock()
@@ -537,7 +499,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
     }
 
     pub async fn get_system_topic_list_from_broker(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -553,8 +515,9 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         Ok(Some(response))
     }
 
-    pub async fn get_topic_stats_info(
-        &mut self,
+    pub async fn get_topic_stats_info<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -565,10 +528,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             .decode_command_custom_header::<GetTopicStatsRequestHeader>()
             .unwrap();
         let topic = request_header.topic.as_ref();
-        let topic_config = self
-            .broker_runtime_inner
-            .topic_config_manager()
-            .select_topic_config(topic);
+        let topic_config = broker_runtime_inner.topic_config_manager().select_topic_config(topic);
         if topic_config.is_none() {
             return Ok(Some(
                 response
@@ -583,18 +543,18 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         for i in 0..max_queue_nums {
             let mut message_queue = MessageQueue::new();
             message_queue.set_topic(topic.clone());
-            message_queue.set_broker_name(self.broker_runtime_inner.broker_config().broker_name().clone());
+            message_queue.set_broker_name(broker_runtime_inner.broker_config().broker_name().clone());
             message_queue.set_queue_id(i as i32);
             let mut topic_offset = TopicOffset::new();
             let min = std::cmp::max(
-                self.broker_runtime_inner
+                broker_runtime_inner
                     .message_store()
                     .unwrap()
                     .get_min_offset_in_queue(topic, i as i32),
                 0,
             );
             let max = std::cmp::max(
-                self.broker_runtime_inner
+                broker_runtime_inner
                     .message_store()
                     .unwrap()
                     .get_max_offset_in_queue(topic, i as i32),
@@ -602,8 +562,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             );
             let mut timestamp = 0;
             if max > 0 {
-                timestamp = self
-                    .broker_runtime_inner
+                timestamp = broker_runtime_inner
                     .message_store()
                     .unwrap()
                     .get_message_store_timestamp(topic, i as i32, max - 1);
@@ -618,8 +577,9 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         Ok(Some(response))
     }
 
-    pub async fn get_topic_config(
-        &mut self,
+    pub async fn get_topic_config<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -628,10 +588,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request.decode_command_custom_header::<GetTopicConfigRequestHeader>()?;
         let topic = &request_header.topic;
-        let topic_config = self
-            .broker_runtime_inner
-            .topic_config_manager()
-            .select_topic_config(topic);
+        let topic_config = broker_runtime_inner.topic_config_manager().select_topic_config(topic);
         if topic_config.is_none() {
             return Ok(Some(
                 response
@@ -643,8 +600,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         if let Some(value) = request_header.topic_request_header.as_ref() {
             if let Some(lo) = value.get_lo() {
                 if *lo {
-                    topic_queue_mapping_detail = self
-                        .broker_runtime_inner
+                    topic_queue_mapping_detail = broker_runtime_inner
                         .topic_queue_mapping_manager()
                         .topic_queue_mapping_table
                         .get(topic)
@@ -658,8 +614,9 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         Ok(Some(response))
     }
 
-    pub async fn query_topic_consume_by_who(
-        &mut self,
+    pub async fn query_topic_consume_by_who<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -668,12 +625,10 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request.decode_command_custom_header::<QueryTopicConsumeByWhoRequestHeader>()?;
         let topic = request_header.topic.as_ref();
-        let mut groups = self
-            .broker_runtime_inner
+        let mut groups = broker_runtime_inner
             .consumer_manager()
             .query_topic_consume_by_who(topic);
-        let group_in_offset = self
-            .broker_runtime_inner
+        let group_in_offset = broker_runtime_inner
             .consumer_offset_manager()
             .which_group_by_topic(topic);
         groups.extend(group_in_offset);
@@ -682,8 +637,9 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         Ok(Some(response))
     }
 
-    pub async fn query_topics_by_consumer(
-        &mut self,
+    pub async fn query_topics_by_consumer<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -693,14 +649,13 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         let request_header = request
             .decode_command_custom_header::<QueryTopicsByConsumerRequestHeader>()
             .unwrap();
-        let topics = self
-            .broker_runtime_inner
+        let topics = broker_runtime_inner
             .consumer_offset_manager()
             .which_topic_by_consumer(request_header.get_group());
         let broker_addr = format!(
             "{}:{}",
-            self.broker_runtime_inner.broker_config().broker_ip1,
-            self.broker_runtime_inner.server_config().listen_port
+            broker_runtime_inner.broker_config().broker_ip1,
+            broker_runtime_inner.server_config().listen_port
         );
         let topic_list = TopicList {
             topic_list: topics.into_iter().collect(),
@@ -710,21 +665,21 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         Ok(Some(response))
     }
 
-    pub async fn clean_unused_topic(
-        &mut self,
+    pub async fn clean_unused_topic<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &BrokerRuntimeInner<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let retain_topics = self
-            .broker_runtime_inner
+        let retain_topics = broker_runtime_inner
             .topic_config_manager()
             .topic_config_table_hash_map()
             .keys()
             .map(|topic| topic.to_string())
             .collect();
-        self.broker_runtime_inner
+        broker_runtime_inner
             .message_store()
             .unwrap()
             .clean_unused_topic(&retain_topics);
@@ -733,18 +688,22 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         ))
     }
 
-    fn delete_topic_in_broker(&mut self, topic: &CheetahString) {
-        self.broker_runtime_inner
+    fn delete_topic_in_broker<MS: MessageStore>(
+        &self,
+        broker_runtime_inner: &mut BrokerRuntimeInner<MS>,
+        topic: &CheetahString,
+    ) {
+        broker_runtime_inner
             .topic_config_manager()
-            .delete_topic_config(topic, self.broker_runtime_inner.topic_config_state_machine_version());
-        self.broker_runtime_inner.topic_queue_mapping_manager().delete(topic);
-        self.broker_runtime_inner
+            .delete_topic_config(topic, broker_runtime_inner.topic_config_state_machine_version());
+        broker_runtime_inner.topic_queue_mapping_manager().delete(topic);
+        broker_runtime_inner
             .consumer_offset_manager()
             .clean_offset_by_topic(topic);
-        self.broker_runtime_inner
+        broker_runtime_inner
             .pop_inflight_message_counter()
             .clear_in_flight_message_num_by_topic_name(topic);
-        self.broker_runtime_inner
+        broker_runtime_inner
             .message_store_mut()
             .as_mut()
             .unwrap()
@@ -769,12 +728,15 @@ mod tests {
     use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+    use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
     use rocketmq_remoting::protocol::RemotingSerializable;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
-    use super::*;
+    use super::decode_topic_queue_mapping_detail;
+    use super::TopicRequestHandler;
     use crate::broker_runtime::BrokerRuntime;
+    use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 
     fn temp_test_root(label: &str) -> std::path::PathBuf {
         let millis = SystemTime::now()
@@ -814,6 +776,11 @@ mod tests {
     }
 
     #[test]
+    fn topic_request_handler_is_stateless() {
+        assert_eq!(std::mem::size_of::<TopicRequestHandler>(), 0);
+    }
+
+    #[test]
     fn decode_topic_queue_mapping_detail_accepts_java_fastjson_numeric_keys() {
         let body = br#"{"topic":"static-topic","scope":"__global__","totalQueues":2,"bname":"interopBroker","epoch":1,"dirty":false,"currIdMap":{0:0,1:1},"hostedQueues":{0:[{"gen":0,"queueId":0,"bname":"interopBroker","logicOffset":0,"startOffset":0,"endOffset":-1,"timeOfStart":-1,"timeOfEnd":-1}],1:[{"gen":0,"queueId":1,"bname":"interopBroker","logicOffset":0,"startOffset":0,"endOffset":-1,"timeOfStart":-1,"timeOfEnd":-1}]}}"#;
 
@@ -843,7 +810,8 @@ mod tests {
     async fn update_and_create_static_topic_persists_mapping_detail() {
         let mut runtime = new_test_runtime("static-topic").await;
         let inner = runtime.inner_for_test().clone();
-        let mut handler = TopicRequestHandler::new(inner.clone());
+        let handler = TopicRequestHandler::new();
+        let broker_config_request_handler = BrokerConfigRequestHandler::new(inner.clone());
 
         let detail = TopicQueueMappingDetail {
             topic_queue_mapping_info:
@@ -881,7 +849,13 @@ mod tests {
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .update_and_create_static_topic(channel, ctx, RequestCode::UpdateAndCreateStaticTopic, &mut request)
+            .update_and_create_static_topic(
+                &broker_config_request_handler,
+                channel,
+                ctx,
+                RequestCode::UpdateAndCreateStaticTopic,
+                &mut request,
+            )
             .await
             .expect("update and create static topic should succeed")
             .expect("update and create static topic should return response");

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -1582,69 +1582,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "2cbf19c5585608c3e2669169",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "f2e66655c0874e511bcddd29",
-          "fingerprint": "f0a573438a21979c4c8219d8",
-          "item": "mod tests",
-          "line": 776
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "02749549b6489125c41327ac",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "418ecd7ab9a818a2c61310bd",
-          "fingerprint": "353397efe163cf37285096f9",
-          "item": "<module>",
-          "line": 49
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "4f52c6a4c88e40ac1e76ef5d",
-      "path": "rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "1f85c444b28325eddab9f786",
-          "fingerprint": "01172cde7d66acfbdc3b7170",
-          "item": "struct TopicRequestHandler",
-          "line": 122
-        },
-        {
-          "id": "5255ebd56c0d15233bc39f81",
-          "fingerprint": "4c2ed25434f2a642d6be176b",
-          "item": "fn new",
-          "line": 126
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "21c2f5279a6f17e611af4850",
       "path": "rocketmq-broker/src/processor/admin_broker_processor.rs",
       "symbol": "*",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8471

### Brief Description

- Make `TopicRequestHandler` a stateless, non-generic leaf instead of retaining a duplicate `ArcMut<BrokerRuntimeInner>` owner.
- Pass request-scoped shared or exclusive runtime borrows from `AdminBrokerProcessor` for topic queries, cleanup, and deletion.
- Reuse the existing `BrokerConfigRequestHandler` owner for the narrow asynchronous topic persistence and broker-registration action.
- Preserve topic validation, static mapping, idempotency, registration mode, deletion order, Store cleanup, and response contracts.
- Add a zero-size ownership regression and reduce the reviewed ArcMut baseline from 328 identities / 899 occurrences to 325 / 895 with no relocation.
- Update the migration checklist, remaining-task inventory, and soundness evidence to production 169/421, test 142/434, and Broker production 81/178.

### How Did You Test This Change?

- `cargo check -p rocketmq-broker --all-features`
- `cargo test -p rocketmq-broker --lib --all-features topic_request_handler -- --test-threads=1` (3 passed)
- Phase 3, 5, and 6 topic/config/admin compatibility regressions (3 passed)
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-broker --lib --all-features` (612 passed, 25 existing dynamic lifecycle/Lite/subscription failures, 1 ignored; suite remains non-green)
- `cargo test -p rocketmq-store --lib --all-features` (507 passed)
- Required RocksDB Store/Broker Clippy and focused test matrix (82 + 9 + 21 + 4 passed)
- `python scripts/arc_mut_guard.py`
- ArcMut guard unit tests (67 passed), fixtures (24 passed), and reviewed baseline pruning comparison
- Architecture dependency unit tests (60 passed), dependency target/baseline/fixtures, release-topology, and performance-profile guards
- `pwsh -File scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `pwsh -File scripts/check-agents-routing.ps1`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Topic administration handling now uses a streamlined, stateless design.
  * Topic creation and updates continue to persist configuration and register broker changes in the expected order.
  * Topic queries, statistics, cleanup, and deletion retain their existing behavior and response semantics.

* **Documentation**
  * Updated architecture migration plans, progress tracking, verification guidance, and completion metrics to reflect the latest topic administration work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->