### PR TITLE
[ISSUE #8478]♻️Remove duplicate auto-switch message-store ownership

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,15 +40,15 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8475 的 M11-12bc33 子切片完成后，当前 ArcMut reviewed
-baseline 为 317 identities / 886 occurrences，其中 production 为 163/414、test 为 140/432、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8478 的 M11-12bc34 子切片完成后，当前 ArcMut reviewed
+baseline 为 315 identities / 881 occurrences，其中 production 为 161/409、test 为 140/432、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
 | Broker | 79 / 175 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、message-arriving weak listener、client-housekeeping narrow handle、Query Assignment capability、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer/topic Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
-| Store | 84 / 239 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state 与 client construction capability 已完成；production `WeakArcMut` 已清零，继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
+| Store | 82 / 234 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state/client construction 与单一 delegate Store owner 已完成；production `WeakArcMut` 已清零，继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
 Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook/rollback 证据；M10 固定硬件性能、五镜像动态验证、
@@ -718,7 +718,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc31 Topic Admin request borrow：Topic handler 改为无状态非泛型 leaf，查询与删除使用父层请求期借用，异步持久化/注册复用已有 BrokerConfig owner
   - [x] M11-12bc32 auto-switch client construction capability：`AutoSwitchHAClient` 只包装已构造的 `DefaultHAClient`，不再直接接收完整 LocalFileMessageStore；service 保留原构造错误映射与安装顺序
   - [x] M11-12bc33 Query Assignment capability：processor 改为非泛型并只持启动配置、route manager 与 live consumer-id view，不再保活完整 BrokerRuntime owner
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469/#8471/#8473/#8475 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc34 auto-switch single delegate owner：service 接收已构造的 DefaultHAService，删除重复 Store field；client 构造与所有 Store 访问均经唯一 delegate
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469/#8471/#8473/#8475/#8478 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -806,7 +807,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8471 后实际快照降至 325 identities/895 occurrences：production 169/421、test 142/434、compatibility 14/40、Broker production 81/178；Topic Admin 无状态 leaf 净删除 2 个 production identity/3 occurrence与 1 个 test identity/1 occurrence，无 relocation
   - [x] Issue #8473 后实际快照降至 320 identities/890 occurrences：production 165/417、test 141/433、compatibility 14/40、Store production 84/239；auto-switch client 构造边界净删除 4 个 production identity/4 occurrence与 1 个 test identity/1 occurrence，4 个保留 test occurrence 经临时 ADR-013 一对一 relocation 审核，无新增 identity
   - [x] Issue #8475 后实际快照降至 317 identities/886 occurrences：production 163/414、test 140/432、compatibility 14/40、Broker production 79/175；Query Assignment capability 净删除 2 个 production identity/3 occurrence与 1 个 test identity/1 occurrence，1 个相邻保留 occurrence 经临时 ADR-013 一对一 relocation 审核，无新增 identity
-  - [ ] M11-12bc34 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8478 后实际快照降至 315 identities/881 occurrences：production 161/409、test 140/432、compatibility 14/40、Store production 82/234；auto-switch 重复 Store owner 净删除 2 个 production identity/5 occurrence，18 个保留 occurrence 经临时 ADR-013 一对一 relocation 审核，无新增 identity
+  - [ ] M11-12bc35 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -729,6 +729,15 @@ occurrences（production 163/414、test 140/432、compatibility 14/40、Broker p
 经临时 ADR-013 一对一 relocation 审核，无新增 identity。总进度仍为 75/82，下一子切片 M11-12bc34 优先收窄
 Store auto-switch service 的重复完整 delegate owner，或继续 Broker aggregate/leaf。
 
+Store auto-switch 单一 delegate owner 随 Issue #8478 收窄：`AutoSwitchHAService` 构造改接收已完成 Store 绑定的
+`DefaultHAService`，删除 wrapper 自身重复的完整 `ArcMut<LocalFileMessageStore>` field。初始角色、sync-state、confirm
+offset、epoch publication、alive replica 查询和 client 构造均经唯一 delegate；crate-private client factory 保留原
+`HAClientError` 映射与 Default/AutoSwitch 初始化顺序。强引用回归证明 wrapper 只保留 delegate 所需的一份 Store owner。
+ArcMut 快照降至 315 identities/881 occurrences（production 161/409、test 140/432、compatibility 14/40、Broker
+production 79/175、Store production 82/234），净删除 2 个 production identity/5 occurrence；18 个保留 occurrence
+经临时 ADR-013 一对一 relocation 审核，无新增 identity。总进度仍为 75/82，下一子切片 M11-12bc35 继续 Broker
+aggregate/leaf 或 Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8475 / M11-12bc33 完成后
+> 代码基线：Issue #8478 / M11-12bc34 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,13 +19,13 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8475 后 reviewed ArcMut baseline 为 317 identities / 886 occurrences：production 163/414、test
+Issue #8478 后 reviewed ArcMut baseline 为 315 identities / 881 occurrences：production 161/409、test
 140/432、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
 | Broker | 79 / 175 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、Query Assignment capability、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer/Topic Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
-| Store | 84 / 239 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state 与 client construction capability 已收窄；production `WeakArcMut` 已清零，其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
+| Store | 82 / 234 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state/client construction 与单一 delegate Store owner 已收窄；production `WeakArcMut` 已清零，其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | production Store `WeakArcMut` 已清零；继续迁移测试/兼容调用方，公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
@@ -34,7 +34,7 @@ Issue #8475 后 reviewed ArcMut baseline 为 317 identities / 886 occurrences：
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力，Topic Admin 已由 M11-12bc31 改为无状态 leaf。
 3. Store WAL：commit worker 已只持 `Notify` 唤醒能力，CommitLog disk-flush 已通过共享 receiver enqueue；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
-5. Store timer/HA：BrokerStats observer、HA notification service、connection registry 查询、未共享 client/connection child、HA connection worker 自引用、完整 auto-switch weak owner 与 client 构造 Store capability 已退出多余 owner；继续收口 Timer、Default/General/AutoSwitch HA service 与其余 actor 回指。
+5. Store timer/HA：BrokerStats observer、HA notification service、connection registry 查询、未共享 client/connection child、HA connection worker 自引用、完整 auto-switch weak owner、client 构造 Store capability 与 wrapper 重复 Store owner 已退出多余 owner；继续收口 Timer、Default/General/AutoSwitch HA service 与其余 actor 回指。
 6. compatibility/stable：production Store `WeakArcMut` 已清零；迁移剩余测试/兼容调用方，按 next-major/HUMAN 窗口处理公开 facade，并替换 `sync_unsafe_cell`、`async_fn_traits`、`unboxed_closures` 等 nightly surface。
 7. 候选快照 Gate：冻结同一 commit，执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、动态
    Kind/K3d/container、dashboard/runbook/rollback，并完成 `[ARCH]`、`[REV]`、`[TEST]`、`[HUMAN]` 签署。
@@ -228,6 +228,13 @@ MessageStore 泛型。请求模式 load/persist、NameServer route refresh、主
 1 identity / 1 occurrence，因此 reviewed 总量降至 317/886、production 降至 163/414、test 降至 140/432、Broker
 降至 79/175；Store 84/239 与 compatibility 14/40 不增。1 个相邻保留 production occurrence 经临时 ADR-013
 一对一 relocation 审核，无新增 identity，审批文件不提交。
+
+M11-12bc34 将 `AutoSwitchHAService` 的构造输入改为 owned `DefaultHAService` delegate，删除 wrapper 重复保存的
+完整 `ArcMut<LocalFileMessageStore>` field；初始角色和所有 Store 读/发布操作均经 delegate 只读访问，AutoSwitch client
+通过 delegate 的 crate-private factory 构造并保留原错误映射与初始化顺序。强引用回归证明构造只增加 delegate 所需的一份
+Store owner。production 净删除 2 identities / 5 occurrences，因此 reviewed 总量降至 315/881、production 降至
+161/409、Store 降至 82/234；test 140/432、Broker 79/175 与 compatibility 14/40 不增。18 个保留 occurrence
+经临时 ADR-013 一对一 relocation 审核，无新增 identity，审批文件不提交。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -2956,10 +2956,31 @@ Broker Query Assignment runtime capability 随 Issue #8475 完成以下边界收
 | disk recovery | 首次 focused build 因 D 盘空间耗尽失败；按用户授权执行 `cargo clean` 释放 201.2 GiB 后，以上命令在同一源码快照重新执行并取得所列结果 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc34 实现
+
+Store auto-switch single delegate ownership 随 Issue #8478 完成以下边界收敛：
+
+- `AutoSwitchHAService::new` 改为接收 owned `DefaultHAService`，wrapper 删除重复的完整 `ArcMut<LocalFileMessageStore>` field、production import 与构造参数。
+- 初始 master/slave 角色、sync-state confirm-offset 更新、HA timeout/alive-replica 查询、epoch/state-machine publication 与角色切换后的 confirm-offset refresh 均经唯一 delegate 的只读 Store 访问。
+- `DefaultHAService::create_default_ha_client` 作为 crate-private 窄构造能力复用其 Store owner；AutoSwitch init 继续先初始化 delegate，再按原 `HAClientError` 到 `HAError::Service` 映射包装 client 并安装。
+- LocalFileMessageStore production 入口与既有 HA 测试显式先构造 delegate；强引用回归证明 AutoSwitch wrapper 只增加 delegate 所需的一份 Store strong owner，drop 后恢复原计数。
+- reviewed baseline 从 317 identities / 886 occurrences 降至 315 / 881；production 从 163/414 降至 161/409，test 保持 140/432，compatibility 保持 14/40。Store production 从 84/239 降至 82/234，Broker 保持 79/175；净删除 2 个 production identity/5 occurrences，18 个保留 occurrence 经同 item 一对一指纹审核更新，无新增 identity。
+
+## M11-12bc34 验证
+
+| 命令 | 结果 |
+|---|---|
+| Store check / focused / strict Clippy | `cargo check -p rocketmq-store --all-features` 通过；AutoSwitch HA 12/12（含单一 Store owner 回归）与 Default HA 11/11 通过；Store all-target/all-feature strict Clippy 通过 |
+| Store / Broker all-feature lib | Store 508/508；Broker 614 passed、25 failed、1 ignored，失败与 bc33 一致，集中于既有 lifecycle/Lite/subscription/controller 动态基线，无 AutoSwitch/Default HA 单元失败，因此 Broker 全套如实记为未通过 |
+| Store/RocksDB 专项 | Store/Broker `rocksdb_store` strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 从 317/886 精确降至 315/881，18 个保留 occurrence 通过同 item 一对一审核；`python scripts/arc_mut_guard.py`、24/24 fixtures 与 67/67 ArcMut guard tests 通过，无新增 identity 或提交态临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、127/127 guard tests 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
 1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（79/175）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、MessageArrivingListener、ClientHousekeepingService、Query Assignment capability、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer、Topic handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
-2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（84/239）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA replication-state callback、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush 与 auto-switch client construction capability 已完成。
+2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（82/234）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA replication-state callback、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch client construction 与 single delegate Store owner 已完成。
 3. Production `WeakArcMut` 已清零；继续迁移 test/compatibility 中受控使用并移除其余 nightly feature。公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态
    Kind/K3d/container、M10 固定硬件和 Human Gate。

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -16,7 +16,6 @@ use std::collections::HashSet;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
-use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
@@ -25,7 +24,6 @@ use tokio::sync::Notify;
 
 use crate::base::message_store::MessageStore;
 use crate::ha::auto_switch::auto_switch_ha_client::AutoSwitchHAClient;
-use crate::ha::default_ha_client::DefaultHAClient;
 use crate::ha::default_ha_service::DefaultHAService;
 use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_service::GeneralHAService;
@@ -36,7 +34,6 @@ use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotifi
 use crate::ha::ha_service::HAAckedReplicaSnapshot;
 use crate::ha::ha_service::HAService;
 use crate::log_file::group_commit_request::GroupCommitRequest;
-use crate::message_store::local_file_message_store::LocalFileMessageStore;
 use crate::store_error::HAResult;
 use rocketmq_store_local::ha::replication::EpochTransition;
 use rocketmq_store_local::ha::replication::HAReplicaRuntimeSnapshot;
@@ -44,16 +41,18 @@ use rocketmq_store_local::ha::replication::ReplicationStateRoot;
 
 pub struct AutoSwitchHAService {
     delegate: ArcMut<DefaultHAService>,
-    message_store: ArcMut<LocalFileMessageStore>,
     replication: Arc<ReplicationStateRoot>,
 }
 
 impl AutoSwitchHAService {
-    pub fn new(message_store: ArcMut<LocalFileMessageStore>) -> Self {
-        let is_master = message_store.message_store_config_ref().broker_role != BrokerRole::Slave;
+    pub fn new(delegate: DefaultHAService) -> Self {
+        let is_master = delegate
+            .get_default_message_store()
+            .message_store_config_ref()
+            .broker_role
+            != rocketmq_common::common::broker::broker_role::BrokerRole::Slave;
         Self {
-            delegate: ArcMut::new(DefaultHAService::new(message_store.clone())),
-            message_store,
+            delegate: ArcMut::new(delegate),
             replication: Arc::new(ReplicationStateRoot::new(is_master)),
         }
     }
@@ -65,7 +64,8 @@ impl AutoSwitchHAService {
     pub(crate) fn init(this: &mut ArcMut<Self>, general_ha_service: GeneralHAService) -> HAResult<()> {
         let mut delegate = this.delegate.clone();
         DefaultHAService::init(&mut delegate, general_ha_service)?;
-        let client = DefaultHAClient::new(this.message_store.clone())
+        let client = delegate
+            .create_default_ha_client()
             .map_err(|error| crate::store_error::HAError::Service(error.to_string()))?;
         let client = AutoSwitchHAClient::from_delegate(client, None);
         delegate.set_general_ha_client(GeneralHAClient::new_with_auto_switch_ha_client(client));
@@ -112,10 +112,11 @@ impl AutoSwitchHAService {
     pub fn set_sync_state_set(&self, sync_state_set: HashSet<i64>) {
         self.replication.replace_sync_state_set(sync_state_set);
 
-        let max_phy_offset = self.message_store.get_max_phy_offset();
-        let current_confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
+        let message_store = self.delegate.get_default_message_store();
+        let max_phy_offset = message_store.get_max_phy_offset();
+        let current_confirm_offset = message_store.get_commit_log().get_confirm_offset_directly();
         let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
-        self.message_store.publish_confirm_offset(confirm_offset);
+        message_store.publish_confirm_offset(confirm_offset);
     }
 
     pub fn is_synchronizing_sync_state_set(&self) -> bool {
@@ -130,14 +131,19 @@ impl AutoSwitchHAService {
     pub fn maybe_shrink_sync_state_set(&self) -> HashSet<i64> {
         let now = current_millis();
         let timeout_millis = self
-            .message_store
+            .delegate
+            .get_default_message_store()
             .message_store_config_ref()
             .ha_max_time_slave_not_catchup as u64;
         self.replication.maybe_shrink_sync_state_set(now, timeout_millis)
     }
 
     pub fn maybe_expand_in_sync_state_set(&self, slave_broker_id: i64, slave_max_offset: i64) -> Option<HashSet<i64>> {
-        let confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
+        let confirm_offset = self
+            .delegate
+            .get_default_message_store()
+            .get_commit_log()
+            .get_confirm_offset_directly();
         self.replication
             .maybe_expand_sync_state_set(slave_broker_id, slave_max_offset, confirm_offset)
     }
@@ -147,10 +153,11 @@ impl AutoSwitchHAService {
             return;
         }
 
-        let max_phy_offset = self.message_store.get_max_phy_offset();
-        let current_confirm_offset = self.message_store.get_commit_log().get_confirm_offset_directly();
+        let message_store = self.delegate.get_default_message_store();
+        let max_phy_offset = message_store.get_max_phy_offset();
+        let current_confirm_offset = message_store.get_commit_log().get_confirm_offset_directly();
         let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
-        self.message_store.publish_confirm_offset(confirm_offset);
+        message_store.publish_confirm_offset(confirm_offset);
     }
 
     fn tracked_sync_state_set_size(&self) -> Option<usize> {
@@ -164,9 +171,12 @@ impl AutoSwitchHAService {
 
     pub fn compute_confirm_offset(&self, current_confirm_offset: i64, max_phy_offset: i64) -> i64 {
         let runtime_info = self.get_runtime_info(max_phy_offset);
-        let expected_sync_state_set_size = self
-            .tracked_sync_state_set_size()
-            .unwrap_or_else(|| self.message_store.get_alive_replica_num_in_group().max(1) as usize);
+        let expected_sync_state_set_size = self.tracked_sync_state_set_size().unwrap_or_else(|| {
+            self.delegate
+                .get_default_message_store()
+                .get_alive_replica_num_in_group()
+                .max(1) as usize
+        });
         Self::compute_confirm_offset_from_runtime(
             current_confirm_offset,
             max_phy_offset,
@@ -210,28 +220,27 @@ impl AutoSwitchHAService {
             EpochTransition::Rejected => return false,
             EpochTransition::Unchanged => {}
             EpochTransition::Advanced { epoch } => {
-                let epoch_start_offset = self
-                    .message_store
+                let message_store = self.delegate.get_default_message_store();
+                let epoch_start_offset = message_store
                     .get_max_phy_offset()
-                    .max(self.message_store.get_min_phy_offset());
-                self.message_store.publish_state_machine_version(epoch as i64);
-                self.message_store
-                    .publish_controller_epoch_start_offset(epoch_start_offset);
+                    .max(message_store.get_min_phy_offset());
+                message_store.publish_state_machine_version(epoch as i64);
+                message_store.publish_controller_epoch_start_offset(epoch_start_offset);
             }
         }
         true
     }
 
     fn refresh_confirm_offset_after_role_change(&self) {
-        let min_phy_offset = self.message_store.get_min_phy_offset();
-        let max_phy_offset = self.message_store.get_max_phy_offset().max(min_phy_offset);
+        let message_store = self.delegate.get_default_message_store();
+        let min_phy_offset = message_store.get_min_phy_offset();
+        let max_phy_offset = message_store.get_max_phy_offset().max(min_phy_offset);
         let next_confirm_offset = if self.replication.is_master() {
             max_phy_offset
         } else {
-            self.message_store.get_commit_log().get_confirm_offset_directly()
+            message_store.get_commit_log().get_confirm_offset_directly()
         };
-        self.message_store
-            .publish_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
+        message_store.publish_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
     }
 
     pub fn current_master_epoch(&self) -> i32 {
@@ -304,7 +313,12 @@ impl HAService for AutoSwitchHAService {
     fn in_sync_replicas_nums(&self, _master_put_where: i64) -> i32 {
         self.tracked_sync_state_set_size()
             .map(|size| size.max(1) as i32)
-            .unwrap_or_else(|| self.message_store.get_alive_replica_num_in_group().max(1))
+            .unwrap_or_else(|| {
+                self.delegate
+                    .get_default_message_store()
+                    .get_alive_replica_num_in_group()
+                    .max(1)
+            })
     }
 
     fn get_connection_count(&self) -> &AtomicU32 {
@@ -392,7 +406,9 @@ mod tests {
     use crate::config::message_store_config::MessageStoreConfig;
     use crate::ha::ha_client::HAClient;
 
-    fn new_test_message_store(root: &Path) -> ArcMut<LocalFileMessageStore> {
+    fn new_test_message_store(
+        root: &Path,
+    ) -> ArcMut<crate::message_store::local_file_message_store::LocalFileMessageStore> {
         std::fs::create_dir_all(root).expect("create temp root dir");
 
         let broker_config = BrokerConfig {
@@ -408,13 +424,15 @@ mod tests {
         };
 
         let topic_table: Arc<DashMap<CheetahString, Arc<TopicConfig>>> = Arc::new(DashMap::new());
-        let mut store = ArcMut::new(LocalFileMessageStore::new(
-            Arc::new(message_store_config),
-            Arc::new(broker_config),
-            topic_table,
-            None,
-            false,
-        ));
+        let mut store = ArcMut::new(
+            crate::message_store::local_file_message_store::LocalFileMessageStore::new(
+                Arc::new(message_store_config),
+                Arc::new(broker_config),
+                topic_table,
+                None,
+                false,
+            ),
+        );
         let store_clone = store.clone();
         store.set_message_store_arc(store_clone);
         store
@@ -444,13 +462,28 @@ mod tests {
         }
     }
 
+    #[test]
+    fn constructor_keeps_message_store_ownership_in_delegate() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-auto-switch-owner-{}", current_millis()));
+        let store = new_test_message_store(&temp_root);
+        let strong_count_before = store.strong_count();
+
+        let service = AutoSwitchHAService::new(DefaultHAService::new(store.clone()));
+
+        assert_eq!(store.strong_count(), strong_count_before + 1);
+        drop(service);
+        assert_eq!(store.strong_count(), strong_count_before);
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
     #[tokio::test]
     async fn auto_switch_service_initializes_client_and_tracks_sync_state_set_size() {
         let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-auto-switch-ha-service-{}", current_millis()));
         let store = new_test_message_store(&temp_root);
         store.set_alive_replica_num_in_group(3);
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
 
@@ -480,7 +513,7 @@ mod tests {
         let mut store = new_test_message_store(&temp_root);
         store.init().await.expect("init message store");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
 
@@ -523,7 +556,7 @@ mod tests {
             .await
             .expect("append data");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
         service.sync_controller_sync_state_set(7, &HashSet::from([7_i64]));
@@ -553,7 +586,7 @@ mod tests {
             .await
             .expect("append data");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
         service.sync_controller_sync_state_set(7, &HashSet::from([7_i64]));
@@ -582,7 +615,7 @@ mod tests {
         let mut store = new_test_message_store(&temp_root);
         store.init().await.expect("init message store");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
         service.sync_controller_sync_state_set(7, &HashSet::from([7_i64, 9_i64, 10_i64]));
@@ -608,7 +641,7 @@ mod tests {
             .await
             .expect("append data");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
         service.sync_controller_sync_state_set(7, &HashSet::from([7_i64]));
@@ -638,7 +671,7 @@ mod tests {
             .await
             .expect("append data");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
         service.sync_controller_sync_state_set(7, &HashSet::from([7_i64]));
@@ -679,7 +712,7 @@ mod tests {
             .expect("append data");
         store.set_confirm_offset(0);
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
 
@@ -701,7 +734,7 @@ mod tests {
         let mut store = new_test_message_store(&temp_root);
         store.init().await.expect("init message store");
 
-        let mut service = ArcMut::new(AutoSwitchHAService::new(store.clone()));
+        let mut service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store.clone())));
         let general_service = GeneralHAService::new_with_auto_switch_ha_service(service.clone());
         AutoSwitchHAService::init(&mut service, general_service).expect("init auto switch ha service");
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -40,6 +40,7 @@ use crate::config::message_store_config::MessageStoreConfig;
 use crate::ha::auto_switch::auto_switch_ha_connection::AutoSwitchHAConnection;
 use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
 use crate::ha::default_ha_client::DefaultHAClient;
+use crate::ha::default_ha_client::HAClientError;
 use crate::ha::default_ha_connection::DefaultHAConnection;
 use crate::ha::default_ha_connection::HAConnectionRuntimeHandle;
 use crate::ha::general_ha_client::GeneralHAClient;
@@ -124,10 +125,15 @@ impl DefaultHAService {
             return Ok(false);
         }
 
-        let client = DefaultHAClient::new(self.default_message_store.clone())
+        let client = self
+            .create_default_ha_client()
             .map_err(|e| HAError::Service(format!("Failed to create DefaultHAClient: {e}")))?;
         self.ha_client = Some(GeneralHAClient::new_with_default_ha_client(client));
         Ok(true)
+    }
+
+    pub(crate) fn create_default_ha_client(&self) -> Result<DefaultHAClient, HAClientError> {
+        DefaultHAClient::new(self.default_message_store.clone())
     }
 
     pub(crate) fn set_ha_client_reported_broker_id(&self, broker_id: Option<i64>) {
@@ -801,7 +807,7 @@ mod tests {
     fn new_auto_switch_services(root: &Path) -> (ArcMut<DefaultHAService>, ArcMut<AutoSwitchHAService>) {
         let store = new_test_message_store(root, true);
         let mut default_service = ArcMut::new(DefaultHAService::new(store.clone()));
-        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(store));
+        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store)));
 
         DefaultHAService::init(
             &mut default_service,
@@ -874,7 +880,7 @@ mod tests {
         let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-shutdown-{}", current_millis()));
         let store = new_test_message_store(&temp_root, true);
         let mut service = ArcMut::new(DefaultHAService::new(store.clone()));
-        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(store));
+        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store)));
 
         DefaultHAService::init(
             &mut service,
@@ -902,7 +908,7 @@ mod tests {
         let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-init-{}", current_millis()));
         let store = new_test_message_store(&temp_root, true);
         let mut service = ArcMut::new(DefaultHAService::new(store.clone()));
-        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(store));
+        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(DefaultHAService::new(store)));
 
         DefaultHAService::init(
             &mut service,

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1846,7 +1846,9 @@ impl MessageStore for LocalFileMessageStore {
             let message_store_arc = self.message_store_arc_or_error("init")?;
             if self.message_store_config.enable_controller_mode {
                 let mut auto_switch_ha_service = GeneralHAService::AutoSwitchHAService(ArcMut::new(
-                    crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService::new(message_store_arc),
+                    crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService::new(
+                        crate::ha::default_ha_service::DefaultHAService::new(message_store_arc),
+                    ),
                 ));
                 let _ = auto_switch_ha_service.init();
                 self.ha_service = Some(auto_switch_ha_service);

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -4338,8 +4338,8 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "9bcb5e9909e2a326c1f092a9",
-          "fingerprint": "5c368e38ee565dfebfe2d1cc",
+          "id": "497024e2b7c80c2559435eb5",
+          "fingerprint": "0f3644b4cbcd1896ebf325af",
           "item": "fn new",
           "line": 55
         }
@@ -4357,64 +4357,64 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "73da0d8c0eb1fb9366dc5fbb",
-          "fingerprint": "88a50625f8b4ef1eb68814de",
+          "id": "d11835cce7db7af9a114a028",
+          "fingerprint": "b7e974ad46492709a2538750",
           "item": "fn new_test_message_store",
-          "line": 475
+          "line": 427
         },
         {
-          "id": "31563961163080e52d85b497",
-          "fingerprint": "8ae36e15029a503727d86ba4",
+          "id": "1a5cc51fcc8633b82796bbb0",
+          "fingerprint": "1ccd89f3b55b40eebcb70d2f",
           "item": "fn auto_switch_service_initializes_client_and_tracks_sync_state_set_size",
-          "line": 517
+          "line": 486
         },
         {
-          "id": "582c4c0f6759873d58b4a4e4",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "c146475401463fec9c44abb4",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn sync_controller_sync_state_set_updates_local_membership",
-          "line": 547
+          "line": 516
         },
         {
-          "id": "44b44e3af298f19a649db20c",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "39badfe7b1d204f064806d5b",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn maybe_expand_in_sync_state_set_marks_remote_membership",
-          "line": 590
+          "line": 559
         },
         {
-          "id": "7c8a6f8585ad109e2bbc1cd2",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "cf85ae8291e7b4b4ae100942",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn maybe_expand_in_sync_state_set_does_not_reenter_sync_state_lock",
-          "line": 620
+          "line": 589
         },
         {
-          "id": "f5dbceb50629de7092518b31",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "7654ce754cb4789fbef6798d",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn maybe_shrink_sync_state_set_removes_stale_members",
-          "line": 649
+          "line": 618
         },
         {
-          "id": "3ea4db825b90339b2dc93754",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "eafa839d0d01520d54d101d5",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn sync_controller_sync_state_set_clears_pending_remote_membership",
-          "line": 675
+          "line": 644
         },
         {
-          "id": "4a68cc3a47bcba222b89197a",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "1124cb95d988771bc45769c2",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn change_to_slave_clears_pending_remote_membership_and_updates_reported_broker_id",
-          "line": 705
+          "line": 674
         },
         {
-          "id": "6ec3bcdb179359f9f7faf00d",
-          "fingerprint": "d29404160773e320cc55f104",
+          "id": "b0a8112805a7bafdd1724873",
+          "fingerprint": "af4db393d1d98475ed20b7d5",
           "item": "fn change_to_master_records_epoch_boundary_and_refreshes_confirm_offset",
-          "line": 746
+          "line": 715
         },
         {
-          "id": "790db8829ca5de2dc275a1d8",
-          "fingerprint": "64d0a676efe092515e29f2a4",
+          "id": "b02afec43c198498b1fb4b9a",
+          "fingerprint": "57a74acd692369bc8611f6d1",
           "item": "fn follower_rejects_stale_epoch",
-          "line": 768
+          "line": 737
         }
       ],
       "owner": "store",
@@ -4449,22 +4449,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "439c16b8ee37f0cfe7344fef",
-          "fingerprint": "788a1614cc3a237d3d707f04",
+          "id": "09f6d735e5ec5b6817035ec8",
+          "fingerprint": "e52b7e6a148822b41278a1e7",
           "item": "struct AutoSwitchHAService",
-          "line": 46
-        },
-        {
-          "id": "bad2ecd9d5aafdda1dfe700f",
-          "fingerprint": "c480c2e078ef28cc6ccac8a9",
-          "item": "struct AutoSwitchHAService",
-          "line": 46
-        },
-        {
-          "id": "986118788ce5ef833c579a35",
-          "fingerprint": "1842dbf8cfbf74a8f9ba8e29",
-          "item": "fn new",
-          "line": 51
+          "line": 43
         },
         {
           "id": "2207f2ab20ff84fad9a70823",
@@ -4486,10 +4474,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "c3d9fdd314a81d293103e253",
-          "fingerprint": "87b2740a1679e6d19027cce9",
+          "id": "8f393d2be828df6737236dec",
+          "fingerprint": "dfb2a9895f17d2fdcae2fd78",
           "item": "fn new_test_message_store",
-          "line": 459
+          "line": 411
         }
       ],
       "owner": "store",
@@ -4505,54 +4493,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "1f8ce7320bee6458decddc37",
-          "fingerprint": "92cd79aafb87511baa6f4a3f",
+          "id": "6220444dbebc66a4168c73f2",
+          "fingerprint": "106a9b07de76edf8b1283f11",
           "item": "fn new_test_message_store",
-          "line": 475
-        }
-      ],
-      "owner": "store",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
-      "identity": "71a36d2fa63ab6135096c5ad",
-      "path": "rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs",
-      "symbol": "LocalFileMessageStore",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "b312fa57e298d846a6443a2e",
-          "fingerprint": "000836ab6efa68ef608cdf2b",
-          "item": "<module>",
-          "line": 39
-        }
-      ],
-      "owner": "store",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M11",
-      "adr": "ADR-013"
-    },
-    {
-      "identity": "b4c3e01bbf3af7d5bf73c267",
-      "path": "rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs",
-      "symbol": "LocalFileMessageStore",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "5e10889f36c46c8b963ea3f2",
-          "fingerprint": "b857e655a573cb74a746cb21",
-          "item": "struct AutoSwitchHAService",
-          "line": 46
-        },
-        {
-          "id": "2946430ecc346d640de71250",
-          "fingerprint": "0933cb8703b34a460fb3ea90",
-          "item": "fn new",
-          "line": 52
+          "line": 428
         }
       ],
       "owner": "store",
@@ -4568,10 +4512,10 @@
       "category": "test",
       "occurrences": [
         {
-          "id": "1ed14b7d95e05c7c1035e308",
-          "fingerprint": "d7425232be170cd9e4ba9687",
+          "id": "8dfdf5c9deec5c91bfbcdf55",
+          "fingerprint": "9bc32c83a1ca7c7e128befd7",
           "item": "fn new_test_message_store",
-          "line": 459
+          "line": 411
         }
       ],
       "owner": "store",
@@ -5006,10 +4950,10 @@
           "line": 682
         },
         {
-          "id": "3ce56492a93cf937d1a8861d",
-          "fingerprint": "f650c4dfaf5a8e4ec495bcad",
+          "id": "0214852f9fb14076f6838f05",
+          "fingerprint": "c079219eb8f1508de6971217",
           "item": "fn new_auto_switch_services",
-          "line": 683
+          "line": 810
         },
         {
           "id": "aa0904a6c01650df05d89371",
@@ -5024,10 +4968,10 @@
           "line": 755
         },
         {
-          "id": "6c48bc6ce5035655ffddda3c",
-          "fingerprint": "f650c4dfaf5a8e4ec495bcad",
+          "id": "fe83c1fe60a6607c5893b0ec",
+          "fingerprint": "c079219eb8f1508de6971217",
           "item": "fn accept_socket_service_shutdown_joins_worker",
-          "line": 756
+          "line": 883
         },
         {
           "id": "a536498f42b67b99b2791d41",
@@ -5036,10 +4980,10 @@
           "line": 783
         },
         {
-          "id": "403cc0dde90411c5ffdf9dcb",
-          "fingerprint": "f650c4dfaf5a8e4ec495bcad",
+          "id": "721249006b4452bef443f9cf",
+          "fingerprint": "c079219eb8f1508de6971217",
           "item": "fn init_uses_auto_switch_accept_socket_service_for_auto_switch_mode",
-          "line": 784
+          "line": 911
         },
         {
           "id": "8a35258ff1ab6ce2cb692b5b",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8478

### Brief Description

- Change `AutoSwitchHAService` to accept an owned `DefaultHAService` delegate and remove the wrapper's duplicate complete `ArcMut<LocalFileMessageStore>` field.
- Route initial role detection, sync-state/confirm-offset operations, epoch publication, replica queries, and HA client construction through the single delegate while preserving initialization order and error mapping.
- Add a Store strong-owner regression, reduce the reviewed ArcMut baseline from 317 identities / 886 occurrences to 315 / 881, and update the migration checklist and remaining-task inventory.

### How Did You Test This Change?

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- Store and Broker all-feature checks and all-target/all-feature strict Clippy: passed.
- AutoSwitch HA 12/12, including the single Store owner regression, and Default HA 11/11: passed.
- `cargo test -p rocketmq-store --lib --all-features -- --test-threads=1`: 508/508 passed.
- `cargo test -p rocketmq-broker --lib --all-features -- --test-threads=1`: 614 passed, 25 known lifecycle/Lite/subscription/controller dynamic-baseline failures, and 1 ignored; no AutoSwitch or Default HA unit test failed.
- Store and Broker `rocksdb_store` strict Clippy, Store foundation 82/82, Store semantics 9/9, Broker rocksdb 21/21, and Broker pop-consumer 4/4: passed.
- ArcMut guard, 24/24 fixtures, 67/67 ArcMut guard tests, dependency target/baseline, release topology, 8-profile/11-variant performance validation, 127/127 architecture guard tests, enforcing runtime audit, AGENTS routing, and `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined HA auto-switch service ownership to use a single delegated service.
  * Improved routing of replication state, confirmation offsets, timeout handling, and role-change updates.
  * Refined controller-mode auto-switch initialization.

* **Tests**
  * Added coverage validating delegated message-store ownership and updated HA service construction scenarios.

* **Documentation**
  * Updated architecture migration milestones, completion tracking, production-readiness evidence, and ownership metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->