### PR TITLE
[ISSUE #8491]♻️Narrow recall message runtime capabilities

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -40,14 +40,14 @@
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
 
-PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8489 的 M11-12bc39 子切片完成后，当前 ArcMut reviewed
-baseline 为 295 identities / 852 occurrences，其中 production 为 149/390、test 为 132/422、compatibility
+PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8491 的 M11-12bc40 子切片完成后，当前 ArcMut reviewed
+baseline 为 292 identities / 848 occurrences，其中 production 为 147/387、test 为 131/421、compatibility
 为 14/40。production 剩余分布和完成目标如下：
 
 | owner | identity / occurrence | PR-M11-12 完成目标 |
 |---|---:|---|
 | Client | 0 / 0 | 已完成 DefaultMQProducer facade/implementation/registry 标准 Arc/Weak、配置快照、生命周期/任务接纳边界，并拆除强引用环 |
-| Broker | 67 / 156 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、topic-mapping cleanup capability、message-arriving weak listener、client-housekeeping narrow handle、client heartbeat registration/retry-topic capability、consumer-list/offset request capability、Query Assignment、QueryMessage Store capability、PollingInfo weak query、SubscriptionGroup 配置查询与 Store 版本 capability、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer/topic Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
+| Broker | 65 / 153 | Topic route/queue mapping、TopicConfig value/coordinator、TopicRouteInfo capability、topic-mapping cleanup capability、message-arriving weak listener、client-housekeeping narrow handle、client heartbeat registration/retry-topic capability、consumer-list/offset request capability、Query Assignment、QueryMessage/RecallMessage Store capability、PollingInfo weak query、SubscriptionGroup 配置查询与 Store 版本 capability、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、batch lock、subscription-group/message-related/offset/consumer/topic Admin request borrow、POP/Pull、offset、schedule service/root/hook、put-message preflight、transaction service/check listener/bridge、ConsumerOrderInfo capability、核心 processor root、auth/Producer/ColdData admin、统计 handler 与未编译 V2 示例残留已完成；继续删除显式 transaction Store 兼容 owner，并完成 BrokerRuntime carrier 与其他 admin/processor 安全化 |
 | Store | 82 / 234 | TopicConfig 只读代际 carrier、BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA notification/connection registry 窄能力、未共享 HA child 直接 ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state/client construction 与单一 delegate Store owner 已完成；production `WeakArcMut` 已清零，继续完成 message store、CommitLog/Flush、其余 queue、Rocks/Timer 与其他 HA service/actor 安全化 |
 
 ArcMut production/public compatibility 清零之后，PR-M11-12 还必须在同一冻结候选快照完成 stable feature matrix、
@@ -724,7 +724,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] M11-12bc37 Client heartbeat capability：processor 只持启动配置、live Topic/SubscriptionGroup/Producer/Consumer 能力和显式 retry-topic registration，不再保活完整 BrokerRuntime owner
   - [x] M11-12bc38 Consumer offset capability：processor 只持 live consumer-id/offset/topic/subscription/mapping/RPC 能力与启动配置标量，不再保活完整 BrokerRuntime owner
   - [x] M11-12bc39 QueryMessage capability：processor 只持默认查询上限与只读 Store 查询 capability，不再保活完整 BrokerRuntime owner
-  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469/#8471/#8473/#8475/#8478/#8481/#8483/#8485/#8487/#8489 与每次真实下降或经审核的边界搬迁
+  - [x] M11-12bc40 RecallMessage capability：processor 只持启动 policy、live Topic/Stats 与弱 Store role/put capability，不再保活完整 BrokerRuntime owner
+  - [x] [`M11-12 进度证据`](phase-3-production-readiness/11-soundness-closure-progress.md) 记录父 Issue #8292、子切片 Issue #8293/#8295/#8297/#8299/#8301/#8303/#8307/#8309/#8311/#8313/#8315/#8317/#8319/#8321/#8323/#8325/#8327/#8329/#8331/#8333/#8335/#8337/#8339/#8341/#8343/#8345/#8347/#8349/#8351/#8353/#8355/#8357/#8359/#8361/#8363/#8365/#8367/#8369/#8371/#8375/#8377/#8379/#8381/#8383/#8385/#8387/#8389/#8391/#8393/#8395/#8398/#8400/#8402/#8404/#8406/#8408/#8410/#8412/#8414/#8416/#8419/#8421/#8423/#8425/#8427/#8429/#8431/#8433/#8435/#8438/#8440/#8442/#8444/#8446/#8448/#8450/#8452/#8454/#8456/#8459/#8461/#8464/#8467/#8469/#8471/#8473/#8475/#8478/#8481/#8483/#8485/#8487/#8489/#8491 与每次真实下降或经审核的边界搬迁
   - [x] Issue #8295 后累计降至 711 production/2,029 occurrence；Controller 配置债务清零但其他 Controller owner 仍有 31 条 production 债务
   - [x] Issue #8297 后实际快照降至 697 production/1,986 occurrence；Controller 降至 17 条/51 occurrence，Manager/heartbeat/embedded-NameServer owner 已退出 `ArcMut`
   - [x] Issue #8299 后实际快照降至 690 production/1,961 occurrence；Controller 降至 10 条/26 occurrence，Raft/OpenRaft owner 与 Manager Raft `mut_from_ref` 已清零
@@ -818,7 +819,8 @@ M09-04 再删除 MCP 未使用的 Auth/Error direct edges，并把承担 owned t
   - [x] Issue #8485 后实际快照降至 300 identities/859 occurrences：production 153/396、test 133/423、compatibility 14/40、Broker production 71/162；ClientManage heartbeat 完整 runtime owner 净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation、新增 identity 或临时 approval
   - [x] Issue #8487 后实际快照降至 298 identities/856 occurrences：production 151/393、test 133/423、compatibility 14/40、Broker production 69/159；ConsumerManage 完整 runtime owner 净删除 2 个 production identity/3 occurrence，无 relocation、新增 identity 或临时 approval
   - [x] Issue #8489 后实际快照降至 295 identities/852 occurrences：production 149/390、test 132/422、compatibility 14/40、Broker production 67/156；QueryMessage 完整 runtime owner 净删除 2 个 production identity/3 occurrence，测试通配导入债务额外删除 1 identity/1 occurrence，无 relocation、新增 identity 或临时 approval
-  - [ ] M11-12bc40 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
+  - [x] Issue #8491 后实际快照降至 292 identities/848 occurrences：production 147/387、test 131/421、compatibility 14/40、Broker production 65/153；RecallMessage 完整 runtime owner 净删除 2 个 production identity/3 occurrence，测试通配导入债务额外删除 1 identity/1 occurrence，无 relocation、新增 identity 或临时 approval
+  - [ ] M11-12bc41 及后续：Broker aggregate/leaf、Store WAL/其余 queue/timer/HA、compatibility 删除、stable/Miri/Loom/soak/SLO 与同一候选快照 Gate 仍待完成
   - [ ] 总进度仍为 75/82；本子切片不提前计作完成工作包，M10/Kind-K3d/container dynamic/HUMAN Gate 保持开放
 - [ ] 对应任务文档的 Exit Checklist 全部通过
 

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -780,6 +780,15 @@ test 132/422、compatibility 14/40、Broker production 67/156、Store production
 identity/3 occurrence 与 1 个 test identity/1 occurrence，无 relocation、新增 identity 或临时 approval。总进度仍为
 75/82，下一子切片 M11-12bc40 继续 Broker aggregate/leaf 或 Store WAL/queue/timer/HA owner。
 
+Broker recall-message runtime capability 随 Issue #8491 收窄：`RecallMessageProcessor` 不再持有完整
+`ArcMut<BrokerRuntimeInner>`，只注入启动期 recall policy、共享 Topic/Stats handle 与 `Weak<EscapeBridge>` Store
+capability；broker role 保持 live 读取，controller 降级为 Slave 后不会使用旧快照，provider shutdown 与 Store 缺失均
+fail closed。Recall 校验顺序、tombstone properties、直接本地 Store put、put-result/统计映射保持不变。ArcMut 快照降至
+292 identities/848 occurrences（production 147/387、test 131/421、compatibility 14/40、Broker production 65/153、
+Store production 82/234），净删除 2 个 production identity/3 occurrence 与 1 个 test identity/1 occurrence，无
+relocation、新增 identity 或临时 approval。总进度仍为 75/82，下一子切片 M11-12bc41 继续 Broker aggregate/leaf 或
+Store WAL/queue/timer/HA owner。
+
 ### 9.3 证据目录
 
 - 运行期生成物：`target/architecture-refactor/Mxx/<run-id>/`，不提交 Git。

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,7 +1,7 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-21
-> 代码基线：Issue #8489 / M11-12bc39 完成后
+> 代码基线：Issue #8491 / M11-12bc40 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
@@ -19,18 +19,18 @@ owner 清零、compatibility 删除和同一候选快照验收。
 
 ## PR-M11-12 剩余实现
 
-Issue #8489 后 reviewed ArcMut baseline 为 295 identities / 852 occurrences：production 149/390、test
-132/422、compatibility 14/40。production 全部分布在 Broker 与 Store。
+Issue #8491 后 reviewed ArcMut baseline 为 292 identities / 848 occurrences：production 147/387、test
+131/421、compatibility 14/40。production 全部分布在 Broker 与 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 67 / 156 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage Store capability、PollingInfo weak provider 与 SubscriptionGroup config lookup、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer/Topic Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
+| Broker | 65 / 153 | transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage/RecallMessage Store capability、PollingInfo weak provider 与 SubscriptionGroup config lookup、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq lock/unlock、SubscriptionGroup/MessageRelated/Offset/Consumer/Topic Admin 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner；LiteLifecycle 只读 API 已改为普通借用；继续让显式 Store 兼容边界、BrokerRuntime aggregate carrier、其余 admin/processor/service 不再传播不安全共享可变 owner |
 | Store | 82 / 234 | BrokerStats observer、ConsumeQueueExt owner、HA notification/connection registry capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch replication-state/client construction 与单一 delegate Store owner 已收窄；production `WeakArcMut` 已清零，其余 MessageStore、CommitLog/Flush、queue、Rocks/Timer 与 HA service/actor 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | production Store `WeakArcMut` 已清零；继续迁移测试/兼容调用方，公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 67/156）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage Store capability、PollingInfo 与 SubscriptionGroup config lookup 完整 runtime 强保活边已拆除，HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer 与 Topic handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
+1. Broker aggregate：收窄 `BrokerRuntimeInner`、processor variant 和启动 carrier（Broker 当前为 65/153）；Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage/RecallMessage Store capability、PollingInfo 与 SubscriptionGroup config lookup 完整 runtime 强保活边已拆除，HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer 与 Topic handler 已改为父层请求期借用，未编译 V2 示例残留已清理；继续清理其他 admin/processor leaf。
 2. Broker leaf：完成其余 admin/processor/revive/slave/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力，Topic Admin 已由 M11-12bc31 改为无状态 leaf。
 3. Store WAL：commit worker 已只持 `Notify` 唤醒能力，CommitLog disk-flush 已通过共享 receiver enqueue；继续收口 Local/Rocks MessageStore、CommitLog 与 Flush manager，并替换 transaction 的直接 Store 兼容 owner。
 4. Store queue：ConsumeQueueExt 已改用显式锁 owner；继续收口其余 ConsumeQueue、queue store、index/mapped-file carrier。
@@ -271,6 +271,13 @@ M11-12bc39 将 `QueryMessageProcessor` 从完整 `ArcMut<BrokerRuntimeInner>` ow
 语义保持不变。production 净删除 2 identities / 3 occurrences，test 通配导入债务额外净删除 1/1，因此 reviewed 总量
 降至 295/852、production 降至 149/390、test 降至 132/422、Broker 降至 67/156；Store 82/234 与 compatibility
 14/40 不增。无 relocation、新增 identity 或临时 approval。
+
+M11-12bc40 将 `RecallMessageProcessor` 从完整 `ArcMut<BrokerRuntimeInner>` owner 收窄为 `RecallMessagePolicy`、
+共享 Topic/Stats handle 与 `RecallMessageStoreCapability`。Store capability 只持 `Weak<EscapeBridge>`，请求期读取 live
+Broker role 并执行直接本地 Store put；controller role change 不会被冻结，provider/Store 退出时 fail closed。recall 校验、
+tombstone properties、put-result 与统计语义保持不变。production 净删除 2 identities / 3 occurrences，test 通配导入
+债务额外净删除 1/1，因此 reviewed 总量降至 292/848、production 降至 147/387、test 降至 131/421、Broker 降至
+65/153；Store 82/234 与 compatibility 14/40 不增。无 relocation、新增 identity 或临时 approval。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -3106,9 +3106,37 @@ Broker query-message runtime capability 随 Issue #8489 完成以下边界收敛
 | runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、60/60 architecture tests 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
 | root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 
+## M11-12bc40 实现
+
+Broker recall-message runtime capability 随 Issue #8491 完成以下边界收敛：
+
+- `RecallMessageProcessor` 删除完整 `ArcMut<BrokerRuntimeInner<MS>>` field、production import、构造参数与 clone 传播，
+  改为 `RecallMessageProcessorContext` 显式组合启动 policy、Topic/Stats handle 和弱 Store capability。
+- `RecallMessagePolicy` 只快照当前配置更新白名单之外的 region、recall 开关、接收时间、permission、broker name、
+  timer delay 上限和 store host；Broker role 由 `RecallMessageStoreCapability` 在每次请求读取 live 值，保留 controller
+  master/slave transition 语义。
+- Store capability 只持 `Weak<EscapeBridge<MS>>`，请求期间升级并复用既有 Store 边界执行直接本地 put；不强保活
+  runtime/Store，provider 或 Store 缺失时 fail closed，不再以生产 `expect` 处理恢复性生命周期状态。
+- Topic existence 与 BrokerStats 更新使用标准共享 handle；RecallMessage 校验顺序、tombstone message properties、
+  put-result/response 映射和成功统计保持不变。
+- reviewed baseline 从 295 identities / 852 occurrences 降至 292 / 848；production 从 149/390 降至
+  147/387，test 从 132/422 降至 131/421，compatibility 保持 14/40。Broker production 从 67/156 降至
+  65/153，Store 保持 82/234；净删除 2 个 production identity/3 occurrences 与 1 个 test identity/1
+  occurrence，无 relocation、新增 identity 或临时 approval。
+
+## M11-12bc40 验证
+
+| 命令 | 结果 |
+|---|---|
+| Broker check / focused / strict Clippy | `cargo check -p rocketmq-broker` 通过；RecallMessage 5/5 与 phase3 真实 processor 路由测试通过，覆盖 owner 源码合同、policy 快照、provider shutdown fail-closed、typed error 与 route wiring；Broker all-target/all-feature strict Clippy 通过 |
+| Broker broad lib suite | 627 passed、25 failed、1 ignored；失败仍集中于既有 lifecycle/Lite/subscription 与 controller 收敛动态基线，RecallMessage 聚焦项均通过，因此全套如实记为未通过 |
+| reviewed baseline / fixtures | `--apply-reviewed-reductions` 候选从 295/852 精确降至 292/848；正式最小 baseline 补丁后 `python scripts/arc_mut_guard.py`、candidate compare、24/24 fixtures 与 67/67 guard tests 通过，无 relocation、新增 identity 或临时 approval |
+| runtime / architecture guards | enforcing runtime audit、dependency fixtures/target/baseline、release、8-profile/11-variant performance、60/60 architecture tests 与 AGENTS routing 通过；目标 compatibility 35/35、test edge 3/3、release topology 32/32 |
+| root workspace final gates | `cargo fmt --all -- --check` 与 workspace all-target/all-feature strict Clippy 通过；最终补丁后复跑 `git diff --check`；Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+
 ## 剩余切片与 Gate
 
-1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（67/156）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage Store capability、PollingInfo weak provider、SubscriptionGroup config lookup、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer、Topic handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
+1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（65/153）；transaction bridge、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage/RecallMessage Store capability、PollingInfo weak provider、SubscriptionGroup config lookup、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer、Topic handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用，显式 Store 兼容 owner 留待 Store 批次删除。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（82/234）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA replication-state callback、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch client construction 与 single delegate Store owner 已完成。
 3. Production `WeakArcMut` 已清零；继续迁移 test/compatibility 中受控使用并移除其余 nightly feature。公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -148,7 +148,10 @@ use crate::processor::pull_message_processor::PullMessageProcessor;
 use crate::processor::query_assignment_processor::QueryAssignmentProcessor;
 use crate::processor::query_message_processor::QueryMessageProcessor;
 use crate::processor::query_message_processor::QueryMessageStoreCapability;
+use crate::processor::recall_message_processor::RecallMessagePolicy;
 use crate::processor::recall_message_processor::RecallMessageProcessor;
+use crate::processor::recall_message_processor::RecallMessageProcessorContext;
+use crate::processor::recall_message_processor::RecallMessageStoreCapability;
 use crate::processor::reply_message_processor::ReplyMessageProcessor;
 use crate::processor::send_message_processor::SendMessageProcessor;
 use crate::processor::BrokerProcessorType;
@@ -2658,7 +2661,16 @@ impl BrokerRuntime {
         );
 
         //RecallMessageProcessor
-        let recall_message_processor = Arc::new(RecallMessageProcessor::new(self.inner.clone()));
+        let recall_message_processor = Arc::new(RecallMessageProcessor::new(RecallMessageProcessorContext::new(
+            RecallMessagePolicy::from_configs(
+                self.inner.broker_config(),
+                self.inner.message_store_config(),
+                self.inner.store_host(),
+            ),
+            self.inner.topic_config_manager_handle(),
+            RecallMessageStoreCapability::new(&self.escape_bridge_owner),
+            self.inner.broker_stats_manager_handle(),
+        )));
         broker_request_processor.register_processor(
             RequestCode::RecallMessage as i32,
             BrokerProcessorType::Recall(recall_message_processor),

--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use cheetah_string::CheetahString;
 use futures::future::BoxFuture;
 use futures::FutureExt;
+use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_common::common::hasher::string_hasher::JavaStringHasher;
 use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -156,6 +157,22 @@ impl<MS: MessageStore> EscapeBridge<MS> {
             .message_store()
             .ok_or(MessageStoreUnavailable)?;
         Ok(message_store.select_one_message_by_offset(offset))
+    }
+
+    pub(crate) async fn put_message_to_local_store(
+        &self,
+        message: MessageExtBrokerInner,
+    ) -> Result<PutMessageResult, MessageStoreUnavailable> {
+        let mut message_store = self
+            .broker_runtime_inner
+            .message_store()
+            .cloned()
+            .ok_or(MessageStoreUnavailable)?;
+        Ok(message_store.put_message(message).await)
+    }
+
+    pub(crate) fn is_message_store_slave(&self) -> bool {
+        self.broker_runtime_inner.message_store_config().broker_role == BrokerRole::Slave
     }
 }
 

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Weak;
+
 use bytes::Bytes;
 use cheetah_string::CheetahString;
-use rocketmq_common::common::broker::broker_role::BrokerRole;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
@@ -34,35 +38,136 @@ use rocketmq_remoting::protocol::header::recall_message_response_header::RecallM
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
-use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
+use rocketmq_store::stats::broker_stats_manager::BrokerStatsManager;
 use rocketmq_store::timer::timer_message_store::build_delete_key;
 use tracing::info;
 use tracing::warn;
 
-use crate::broker_runtime::BrokerRuntimeInner;
+use crate::failover::escape_bridge::EscapeBridge;
+use crate::failover::escape_bridge::MessageStoreUnavailable;
+use crate::topic::manager::topic_config_manager::TopicConfigManager;
 
 const RECALL_MESSAGE_TAG: &str = "_RECALL_TAG_";
 
-pub struct RecallMessageProcessor<MS: MessageStore> {
-    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+#[derive(Clone)]
+pub(crate) struct RecallMessagePolicy {
+    region_id: CheetahString,
+    recall_message_enable: bool,
+    start_accept_send_request_time_stamp: i64,
+    broker_permission: u32,
+    allow_recall_when_broker_not_writeable: bool,
+    broker_name: CheetahString,
+    timer_max_delay_sec: i64,
+    store_host: SocketAddr,
 }
 
-impl<MS> RecallMessageProcessor<MS>
-where
-    MS: MessageStore,
-{
-    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+impl RecallMessagePolicy {
+    pub(crate) fn from_configs(
+        broker_config: &BrokerConfig,
+        message_store_config: &MessageStoreConfig,
+        store_host: SocketAddr,
+    ) -> Self {
+        Self {
+            region_id: broker_config.region_id.clone(),
+            recall_message_enable: broker_config.recall_message_enable,
+            start_accept_send_request_time_stamp: broker_config.start_accept_send_request_time_stamp,
+            broker_permission: broker_config.broker_permission,
+            allow_recall_when_broker_not_writeable: broker_config.allow_recall_when_broker_not_writeable,
+            broker_name: broker_config.broker_name().clone(),
+            timer_max_delay_sec: message_store_config.timer_max_delay_sec as i64,
+            store_host,
+        }
+    }
+}
+
+pub(crate) struct RecallMessageStoreCapability<MS: MessageStore> {
+    escape_bridge: Weak<EscapeBridge<MS>>,
+}
+
+impl<MS: MessageStore> RecallMessageStoreCapability<MS> {
+    pub(crate) fn new(escape_bridge: &Arc<EscapeBridge<MS>>) -> Self {
+        Self {
+            escape_bridge: Arc::downgrade(escape_bridge),
+        }
+    }
+
+    async fn put_message(&self, message: MessageExtBrokerInner) -> Result<PutMessageResult, MessageStoreUnavailable> {
+        self.escape_bridge
+            .upgrade()
+            .ok_or(MessageStoreUnavailable)?
+            .put_message_to_local_store(message)
+            .await
+    }
+
+    fn is_slave(&self) -> Result<bool, MessageStoreUnavailable> {
+        Ok(self
+            .escape_bridge
+            .upgrade()
+            .ok_or(MessageStoreUnavailable)?
+            .is_message_store_slave())
+    }
+}
+
+impl<MS: MessageStore> Clone for RecallMessageStoreCapability<MS> {
+    fn clone(&self) -> Self {
+        Self {
+            escape_bridge: Weak::clone(&self.escape_bridge),
+        }
+    }
+}
+
+pub(crate) struct RecallMessageProcessorContext<MS: MessageStore> {
+    policy: RecallMessagePolicy,
+    topic_config_manager: Arc<TopicConfigManager>,
+    message_store: RecallMessageStoreCapability<MS>,
+    broker_stats_manager: Arc<BrokerStatsManager>,
+}
+
+impl<MS: MessageStore> RecallMessageProcessorContext<MS> {
+    pub(crate) fn new(
+        policy: RecallMessagePolicy,
+        topic_config_manager: Arc<TopicConfigManager>,
+        message_store: RecallMessageStoreCapability<MS>,
+        broker_stats_manager: Arc<BrokerStatsManager>,
+    ) -> Self {
+        Self {
+            policy,
+            topic_config_manager,
+            message_store,
+            broker_stats_manager,
+        }
+    }
+}
+
+impl<MS: MessageStore> Clone for RecallMessageProcessorContext<MS> {
+    fn clone(&self) -> Self {
+        Self {
+            policy: self.policy.clone(),
+            topic_config_manager: Arc::clone(&self.topic_config_manager),
+            message_store: self.message_store.clone(),
+            broker_stats_manager: Arc::clone(&self.broker_stats_manager),
+        }
+    }
+}
+
+pub struct RecallMessageProcessor<MS: MessageStore> {
+    context: RecallMessageProcessorContext<MS>,
+}
+
+impl<MS: MessageStore> RecallMessageProcessor<MS> {
+    pub(crate) fn new(context: RecallMessageProcessorContext<MS>) -> Self {
+        Self { context }
     }
 }
 
 impl<MS: MessageStore> Clone for RecallMessageProcessor<MS> {
     fn clone(&self) -> Self {
         Self {
-            broker_runtime_inner: self.broker_runtime_inner.clone(),
+            context: self.context.clone(),
         }
     }
 }
@@ -127,18 +232,18 @@ where
         let mut response = RemotingCommand::create_response_command_with_header(RecallMessageResponseHeader::default());
         response.set_opaque_mut(request.opaque());
 
-        let region_id = self.broker_runtime_inner.broker_config().region_id.clone();
+        let region_id = self.context.policy.region_id.clone();
         response.add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id);
 
         let request_header = request.decode_command_custom_header::<RecallMessageRequestHeader>()?;
 
-        if !self.broker_runtime_inner.broker_config().recall_message_enable {
+        if !self.context.policy.recall_message_enable {
             return Ok(response
                 .set_code(ResponseCode::NoPermission)
                 .set_remark(CheetahString::from_static_str("recall failed, operation is forbidden")));
         }
 
-        if self.broker_runtime_inner.message_store_config().broker_role == BrokerRole::Slave {
+        if !matches!(self.context.message_store.is_slave(), Ok(false)) {
             return Ok(response
                 .set_code(ResponseCode::SlaveNotAvailable)
                 .set_remark(CheetahString::from_static_str(
@@ -146,21 +251,15 @@ where
                 )));
         }
 
-        let start_timestamp = self
-            .broker_runtime_inner
-            .broker_config()
-            .start_accept_send_request_time_stamp;
+        let start_timestamp = self.context.policy.start_accept_send_request_time_stamp;
         if current_millis() < start_timestamp as u64 {
             return Ok(response.set_code(ResponseCode::ServiceNotAvailable).set_remark(
                 CheetahString::from_static_str("recall failed, broker service not available"),
             ));
         }
 
-        let broker_permission = self.broker_runtime_inner.broker_config().broker_permission;
-        let allow_recall_when_not_writeable = self
-            .broker_runtime_inner
-            .broker_config()
-            .allow_recall_when_broker_not_writeable;
+        let broker_permission = self.context.policy.broker_permission;
+        let allow_recall_when_not_writeable = self.context.policy.allow_recall_when_broker_not_writeable;
 
         if !PermName::is_writeable(broker_permission) && !allow_recall_when_not_writeable {
             return Ok(response.set_code(ResponseCode::ServiceNotAvailable).set_remark(
@@ -169,8 +268,8 @@ where
         }
 
         let _topic_config = self
-            .broker_runtime_inner
-            .topic_config_manager()
+            .context
+            .topic_config_manager
             .select_topic_config(request_header.topic());
 
         if _topic_config.is_none() {
@@ -202,7 +301,7 @@ where
                 .set_remark(CheetahString::from_static_str("recall failed, topic not match")));
         }
 
-        let broker_name = self.broker_runtime_inner.broker_config().broker_name();
+        let broker_name = &self.context.policy.broker_name;
         if broker_name.as_str() != handle_broker_name {
             return Ok(response
                 .set_code(ResponseCode::IllegalOperation)
@@ -214,7 +313,7 @@ where
         let timestamp = handle_timestamp_str.parse::<i64>().unwrap_or(-1);
         let current_time_millis = current_millis() as i64;
         let time_left = timestamp - current_time_millis;
-        let timer_max_delay_sec = self.broker_runtime_inner.message_store_config().timer_max_delay_sec as i64;
+        let timer_max_delay_sec = self.context.policy.timer_max_delay_sec;
 
         if time_left <= 0 || time_left >= timer_max_delay_sec * 1000 {
             return Ok(response
@@ -231,13 +330,14 @@ where
         );
 
         let begin_time_millis = current_millis();
-        let put_message_result = self
-            .broker_runtime_inner
-            .message_store_mut()
-            .as_mut()
-            .expect("message store not initialized")
-            .put_message(msg_inner)
-            .await;
+        let put_message_result = match self.context.message_store.put_message(msg_inner).await {
+            Ok(put_message_result) => put_message_result,
+            Err(MessageStoreUnavailable) => {
+                return Ok(response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark(CheetahString::from_static_str("recall failed, execute error")));
+            }
+        };
 
         self.handle_put_message_result(
             put_message_result,
@@ -297,7 +397,7 @@ where
         let properties_string = MessageDecoder::message_properties_to_string(&properties);
 
         let born_host = ctx.remote_address();
-        let store_host = self.broker_runtime_inner.store_host();
+        let store_host = self.context.policy.store_host;
 
         let mut message = Message::builder()
             .topic(handle_topic)
@@ -359,21 +459,17 @@ where
                 let msg_num = append_result.msg_num;
                 let wrote_bytes = append_result.wrote_bytes;
 
-                self.broker_runtime_inner
-                    .broker_stats_manager()
-                    .inc_topic_put_nums(&topic, msg_num, 1);
+                self.context.broker_stats_manager.inc_topic_put_nums(&topic, msg_num, 1);
 
-                self.broker_runtime_inner
-                    .broker_stats_manager()
+                self.context
+                    .broker_stats_manager
                     .inc_topic_put_size(&topic, wrote_bytes);
 
-                self.broker_runtime_inner
-                    .broker_stats_manager()
-                    .inc_broker_put_nums(&topic, msg_num);
+                self.context.broker_stats_manager.inc_broker_put_nums(&topic, msg_num);
 
                 let latency = (current_millis() - begin_time_millis) as i32;
-                self.broker_runtime_inner
-                    .broker_stats_manager()
+                self.context
+                    .broker_stats_manager
                     .inc_topic_put_latency(&topic, 0, latency);
 
                 {
@@ -416,6 +512,7 @@ fn recall_response_header_missing() -> RocketMQError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_store::message_store::GenericMessageStore;
 
     #[test]
     fn test_recall_message_tag_constant() {
@@ -427,5 +524,56 @@ mod tests {
         let error = recall_response_header_missing();
 
         assert_eq!(error.kind(), rocketmq_error::ErrorKind::ResponseProcessFailed);
+    }
+
+    #[test]
+    fn recall_policy_captures_only_required_startup_values() {
+        let broker_config = BrokerConfig {
+            region_id: CheetahString::from_static_str("region-a"),
+            recall_message_enable: false,
+            start_accept_send_request_time_stamp: 42,
+            broker_permission: 3,
+            allow_recall_when_broker_not_writeable: true,
+            ..Default::default()
+        };
+        let message_store_config = MessageStoreConfig {
+            timer_max_delay_sec: 99,
+            ..Default::default()
+        };
+        let store_host = "127.0.0.1:10911".parse().expect("valid store host");
+
+        let policy = RecallMessagePolicy::from_configs(&broker_config, &message_store_config, store_host);
+
+        assert_eq!(policy.region_id, "region-a");
+        assert!(!policy.recall_message_enable);
+        assert_eq!(policy.start_accept_send_request_time_stamp, 42);
+        assert_eq!(policy.broker_permission, 3);
+        assert!(policy.allow_recall_when_broker_not_writeable);
+        assert_eq!(policy.broker_name, broker_config.broker_name().clone());
+        assert_eq!(policy.timer_max_delay_sec, 99);
+        assert_eq!(policy.store_host, store_host);
+    }
+
+    #[tokio::test]
+    async fn recall_put_capability_fails_closed_after_provider_shutdown() {
+        let capability = RecallMessageStoreCapability::<GenericMessageStore> {
+            escape_bridge: Weak::new(),
+        };
+
+        assert!(matches!(capability.is_slave(), Err(MessageStoreUnavailable)));
+        assert!(matches!(
+            capability.put_message(MessageExtBrokerInner::default()).await,
+            Err(MessageStoreUnavailable)
+        ));
+    }
+
+    #[test]
+    fn recall_processor_source_uses_only_explicit_capabilities() {
+        let source = include_str!("recall_message_processor.rs");
+
+        assert!(!source.contains(concat!("ArcMut<Broker", "RuntimeInner")));
+        assert!(!source.contains(concat!("broker_runtime", "_inner")));
+        assert!(source.contains("RecallMessageProcessorContext"));
+        assert!(source.contains(concat!("Weak<Escape", "Bridge")));
     }
 }

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -2529,69 +2529,6 @@
       "adr": "ADR-002"
     },
     {
-      "identity": "bf2ce2d59bc785fbbcab0b35",
-      "path": "rocketmq-broker/src/processor/recall_message_processor.rs",
-      "symbol": "*",
-      "kind": "import",
-      "category": "test",
-      "occurrences": [
-        {
-          "id": "d928781381fc02827eec5ece",
-          "fingerprint": "7dd47c7170cf63f47a49a772",
-          "item": "mod tests",
-          "line": 418
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "7df7b3db7937e6021cca8625",
-      "path": "rocketmq-broker/src/processor/recall_message_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "import",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "fed2da6abf678815452e0730",
-          "fingerprint": "e48428a219f57ef2df2dc9c4",
-          "item": "<module>",
-          "line": 37
-        }
-      ],
-      "owner": "broker",
-      "reason": "Import or glob brings governed shared-mutation debt into this module",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "6939ecd77cccafdb8e588243",
-      "path": "rocketmq-broker/src/processor/recall_message_processor.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8f29fc856630d9fafdb25c1d",
-          "fingerprint": "a01e77e1ba48bae51acfe753",
-          "item": "struct RecallMessageProcessor",
-          "line": 50
-        },
-        {
-          "id": "3a59621a7a1281797b16822a",
-          "fingerprint": "1fe88213f7fb3cfc3eb42806",
-          "item": "fn new",
-          "line": 57
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "d7f764613b1de15dc2b80890",
       "path": "rocketmq-broker/src/processor/reply_message_processor.rs",
       "symbol": "*",


### PR DESCRIPTION
## Summary

- replace `RecallMessageProcessor` complete runtime owner with startup policy, shared Topic/Stats handles, and a weak Store capability
- keep Broker role live across controller transitions, use direct local Store put, and fail closed when the provider/store exits
- reduce the reviewed ArcMut baseline from 295 identities / 852 occurrences to 292 / 848 and sync the four migration documents

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p rocketmq-broker`
- focused RecallMessage tests: 5/5 passed
- focused production request-code routing test: 1/1 passed
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- ArcMut guard, reviewed baseline comparison, 24 fixtures, and 67 guard unit tests
- runtime audit, dependency guard, architecture tests, performance profiles, and AGENTS routing
- broad Broker all-feature lib suite: 627 passed, 25 pre-existing failures, 1 ignored; no RecallMessage regression

Closes #8491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved recall-message handling with dedicated policy and store capabilities.
  - Added local message-store support for recall operations.
  - Recall requests now fail safely when required services or storage are unavailable.
  - Preserved existing recall validation, message persistence, response mapping, and statistics behavior.

- **Bug Fixes**
  - Improved broker-role checks and error reporting during recall processing.

- **Documentation**
  - Updated architecture and migration progress documentation with the completed recall-message capability and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->