### PR TITLE
[ISSUE #8515]♻️Quantify remaining architecture refactor work

### DIFF
--- a/docs/plans/architecture-refactor-migration/CHECKLIST.md
+++ b/docs/plans/architecture-refactor-migration/CHECKLIST.md
@@ -23,7 +23,7 @@
 | Phase 3 | M10–M11 | 进行中 | Codex 执行组 | 8–12 周 | — | [`phase-3-production-readiness/`](phase-3-production-readiness/) |
 | Phase 4 | M12 | 未开始 | 待分配 | 8–12 周 | — | — |
 
-### 2.1 剩余重构盘点（2026-07-21）
+### 2.1 剩余重构盘点（2026-07-22）
 
 > 统计口径：只统计 82 个顶层 `PR-Mxx-yy` 工作包；M06-03a～ah 等内部迁移证据不重复计数。
 > 详细 owner 热点、M11-12 建议批次与 M12 清单见 [`REMAINING-TASKS.md`](REMAINING-TASKS.md)。
@@ -39,6 +39,10 @@
 剩余 7 个工作包分布：M10 为 0 个、M11 为 1 个且正在实施、M12 为 6 个且尚未开始。
 PR-M10-05 已完成性能门禁实现；真实固定硬件 baseline/candidate 与 HUMAN M10 Gate 尚未完成，因此 M10 为
 `待验收`而非`已完成`。M11 为`实施中`，当前下一工作包为 PR-M11-12。
+
+执行层按当前热点进一步拆为 31 个最小可审查单元：16 个 production owner、2 个 test/compatibility、7 个
+M10/Phase 3 动态验收与签署、6 个 M12。该数字是剩余实施下界，不替代 82 个顶层工作包口径；逐项 checklist
+及每组精确 baseline 见 [`REMAINING-TASKS.md`](REMAINING-TASKS.md#执行层最小审查清单31-项)。
 
 PR-M11-12 的内部子切片不重复计入 82 个顶层工作包。Issue #8513 的 M11-12bc51 子切片完成后，当前 ArcMut reviewed
 baseline 为 263 identities / 797 occurrences，其中 production 为 123/341、test 为 126/416、compatibility

--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -7,7 +7,8 @@
 > 当前复核状态：根 workspace 已达到目标 32 个 package；75/82 工作包完成，PR-M11-12 进行中，
 > PR-M12-01～06 未开始，合计剩余 7 个
 
-剩余任务数量、M11-12 内部执行批次与 M12 六个工作包见 [`REMAINING-TASKS.md`](REMAINING-TASKS.md)。
+剩余任务数量、M11-12 内部执行批次与 M12 六个工作包见 [`REMAINING-TASKS.md`](REMAINING-TASKS.md)：正式口径
+剩余 7 个工作包，当前执行层下界为 31 个最小可审查单元。
 
 ## 1. 使用方式
 

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -17,6 +17,11 @@ owner 清零、compatibility 删除和同一候选快照验收。
 | Phase Gate | 2 | 2 | Phase 3、Phase 4 |
 | 目标边界 crate | 10 | 0 | 根 workspace 已为目标 32 package |
 
+按当前代码热点、兼容窗口和候选快照 Gate 进一步拆分，建议以 **31 个最小可审查单元**管理剩余执行：
+16 个 production owner 收口、2 个 test/compatibility 收口、7 个 M10/Phase 3 动态验收与签署、6 个 M12
+工作包。31 是 2026-07-22 基线上的执行估算，不是新的正式工作包总数；相邻单元可以合并到同一 PR，遇到高风险
+owner 也可以继续拆分，但 7 个正式工作包的统计口径保持不变。
+
 ## PR-M11-12 剩余实现
 
 Issue #8513 后 reviewed ArcMut baseline 为 263 identities / 797 occurrences：production 123/341、test
@@ -41,6 +46,55 @@ Issue #8513 后 reviewed ArcMut baseline 为 263 identities / 797 occurrences：
 
 上述 7 个批次是依据当前代码热点形成的执行计划，不是“还剩 7 个正式工作包”。实际 PR 数可因每个切片的风险与审查
 大小拆分，但完成目标不能通过合并批次而减少。
+
+## 执行层最小审查清单（31 项）
+
+> 本清单给出当前可执行下界。`identity / occurrence` 来自 Issue #8513 后通过
+> `python scripts/arc_mut_guard.py` 验证的 reviewed baseline；production 16 项精确合计 Broker 41/107、Store
+> 82/234。test 条目会随相邻 production 切片同步下降，因此 R17 只在 production 收口后处理真实余量。
+
+### Production owner（16 项）
+
+- [ ] R01 Broker runtime aggregate：`broker_runtime.rs` 的 root carrier、controller/start helper 与 Local/Rocks 构造边界（7/40）。
+- [ ] R02 Broker processor wrapper：`processor.rs` 与 `ack_message_processor.rs` 的共享 wrapper/请求期可变访问（5/9）。
+- [ ] R03 Broker send/reply：`send_message_processor.rs` 与 `reply_message_processor.rs` 的 processor/store capability（6/13）。
+- [ ] R04 Broker POP：`pop_message_processor.rs`、`pop_buffer_merge_service.rs`、`pop_revive_service.rs`（8/20）。
+- [ ] R05 Broker pull：`pull_message_processor.rs` 与 `default_pull_message_result_handler.rs`（4/7）。
+- [ ] R06 Broker admin config：`admin_broker_processor.rs` 与 `broker_config_request_handler.rs`（5/7）。
+- [ ] R07 Broker offset/failover：`consumer_offset_manager.rs` 与 `escape_bridge.rs`（4/8）。
+- [ ] R08 Broker pre-online：`broker_pre_online_service.rs` 启动与角色切换 capability（2/3）。
+- [ ] R09 Store root facade：`lib.rs`、`message_store.rs`、`base/message_store.rs` 的 concrete alias/unsafe facade（13/20）。
+- [ ] R10 Store LocalFile root：`local_file_message_store.rs` 的内部 owner 与 `mut_from_ref`（8/54）。
+- [ ] R11 Store RocksDB root：`rocksdb_message_store.rs` 的 Local/Rocks delegate 与 unsafe wrapper（12/34）。
+- [ ] R12 Store queue：queue facade、consume-queue store、local queue store 与 single queue（19/39）。
+- [ ] R13 Store WAL/flush：`commit_log.rs` 与 `default_flush_manager.rs`（7/28）。
+- [ ] R14 Store timer：`timer_message_store.rs` 的 LocalStore 回指与可变访问（5/12）。
+- [ ] R15 Store default HA：Default HA service/client/connection 的 service/actor ownership（13/38）。
+- [ ] R16 Store general/auto-switch HA：General 与 AutoSwitch HA service 的剩余 carrier（5/9）。
+
+### Caller 与 compatibility（2 项）
+
+- [ ] R17 Test/bench caller 迁移：在 R01～R16 后重新盘点并清理真实余量；当前上界为 126 identities / 416 occurrences（Store 90/296、Broker 30/41、Client 4/71、runtime-foundation 2/8）。
+- [ ] R18 Public compatibility 删除：在 next-major 两轮弃用和 Release Manager/HUMAN 批准后，删除 `rocketmq/src/arc_mut.rs` 与 `rocketmq/src/lib.rs` 的 14 identities / 40 occurrences；不得以重置 public API baseline 代替迁移。
+
+### M10 / Phase 3 候选快照 Gate（7 项）
+
+- [ ] R19 M10 固定硬件 baseline/candidate、正确性优先性能 Gate 与 HUMAN 签署。
+- [ ] R20 M11 五服务镜像动态构建/启动、non-root/read-only、SBOM、签名与漏洞策略验证。
+- [ ] R21 M11 Kind/K3d 七类 fault/rolling 场景和持久化证据验证。
+- [ ] R22 同一冻结 commit 的 stable default、完整 feature matrix 与 nightly surface 删除验证。
+- [ ] R23 Miri/Loom 可用切片、soundness proof 与保留 wrapper ADR 审核。
+- [ ] R24 Soak/SLO fault、dashboard、alert、runbook、rollback 与 evidence index 对齐。
+- [ ] R25 冻结 Phase 3 候选快照，完成 `[ARCH]`、`[REV]`、`[TEST]`、`[HUMAN]` 签署。
+
+### Phase 4 / M12（6 项）
+
+- [ ] R26 / PR-M12-01：Evidence normalization 与 Knowledge Graph。
+- [ ] R27 / PR-M12-02：受控 RAG。
+- [ ] R28 / PR-M12-03：多领域确定性诊断。
+- [ ] R29 / PR-M12-04：冻结 Plan contract 并证明无副作用。
+- [ ] R30 / PR-M12-05：仅在 HUMAN 单独批准后实现独立 Apply；若拒绝实施，以签署的 no-Apply 决策关闭条件分支。
+- [ ] R31 / PR-M12-06：Eval、red-team 与离线 fallback，并关闭 Phase 4 Gate。
 
 M11-12bc4 没有虚报数量下降：transaction bridge 删除了完整 `BrokerRuntimeInner` 访问，offset、Topic registration、
 EscapeBridge 使用窄标准 `Arc` capability；原有 2 个 ArcMut identity / 3 个 occurrence 被搬到显式

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -3429,6 +3429,10 @@ Broker mut-from-ref lint boundary 随 Issue #8513 完成以下收口：
 
 ## 剩余切片与 Gate
 
+2026-07-22 盘点将全部剩余工作固化为 31 个最小可审查单元：16 个 production owner、2 个
+test/compatibility、7 个 M10/Phase 3 动态验收与签署、6 个 M12；这只是执行层下界，正式进度仍为 75/82。
+完整逐项 checklist 见 `docs/plans/architecture-refactor-migration/REMAINING-TASKS.md`。
+
 1. Broker BrokerRuntimeInner capability carrier 与其他 admin/processor/leaf owner（41/107）；transaction bridge/Store compatibility、Producer/ColdData admin leaf、Schedule hook、put-message preflight、ConsumerOrderInfoManager、TopicRouteInfoManager、TopicQueueMappingCleanService、MessageArrivingListener、ClientHousekeepingService、ClientManage heartbeat registration/retry-topic capability、ConsumerManage list/offset capability、Query Assignment、QueryMessage/RecallMessage/EndTransaction/PeekMessage/Notification/ChangeInvisibleTime Store capability、POP long-polling、POP Lite processor/long-polling、LiteSubscriptionCtl、LiteManager 与 SlaveSynchronize 显式 policy/query/view/provider/dispatcher/TaskGroup、LiteManager/LiteSubscriptionCtl 标准 Arc wrapper、crate-wide mut_from_ref lint allowance、PollingInfo weak provider、SubscriptionGroup config lookup、HA diagnostics/control/min-broker transition、controller role-change duplicate owner、BatchMq、SubscriptionGroup、MessageRelated、Offset、Consumer、Topic handler 与未编译 V2 示例残留已退出 leaf-level 完整 runtime/store owner，LiteLifecycle 只读 Store carrier 已收窄为普通借用。
 2. Store MappedFileQueue/其余 ConsumeQueue、CommitLog/Flush、StoreHandle/Rocks/Timer 与其余 HA service/actor（82/234）；BrokerStats observer、ConsumeQueueExt 显式锁 owner、HA replication-state callback、未共享 HA child direct ownership、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、auto-switch client construction 与 single delegate Store owner 已完成。
 3. Production `WeakArcMut` 已清零；继续迁移 test/compatibility 中受控使用并移除其余 nightly feature。公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8515

### Brief Description

- reconcile the remaining-task documents with the reviewed ArcMut baseline after Issue #8513
- preserve the official 75/82 progress count while adding 31 minimum reviewable execution units
- group the remaining 41/107 Broker and 82/234 Store production debt into 16 exact ownership batches
- list caller/compatibility, Phase 3 acceptance, and M12 work as explicit Markdown checklist items

### How Did You Test This Change?

- `python scripts/arc_mut_guard.py`
- verified that R01-R31 contains exactly 31 checklist entries
- verified that the production groups sum to Broker 41/107 and Store 82/234
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture migration plans with the latest progress date and remaining-work details.
  * Added a 31-item minimum review checklist covering production, compatibility, validation, and Phase 4 work.
  * Clarified that 31 items represent an execution baseline, while the official scope remains seven work packages.
  * Documented that overall progress remains at 75/82 and linked to the detailed remaining-task checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->