### PR TITLE
[ISSUE #8613]🐛Normalize ArcMut guard paths on Windows

### DIFF
--- a/scripts/arc_mut_guard.py
+++ b/scripts/arc_mut_guard.py
@@ -476,13 +476,18 @@ def _crate_layout(root: Path) -> tuple[dict[Path, tuple[str, ...]], dict[str, tu
 
 def _module_info(path: Path, root: Path, manifests: dict[Path, tuple[str, ...]]) -> ModuleInfo:
     resolved = path.resolve()
+    resolved_root = root.resolve()
     candidates = [(directory, crate_root) for directory, crate_root in manifests.items() if resolved.is_relative_to(directory)]
-    directory, crate_root = max(candidates, key=lambda item: len(item[0].parts)) if candidates else (root, ("@crate", "."))
-    relative = path.relative_to(directory)
+    directory, crate_root = (
+        max(candidates, key=lambda item: len(item[0].parts))
+        if candidates
+        else (resolved_root, ("@crate", "."))
+    )
+    relative = resolved.relative_to(directory)
     parts = list(relative.parts)
     if "src" in parts:
         src_index = parts.index("src")
-        if src_index > 0 and directory == root:
+        if src_index > 0 and directory == resolved_root:
             crate_root = ("@crate", Path(*parts[:src_index]).as_posix())
         parts = parts[src_index + 1:]
     stem = Path(parts[-1]).stem if parts else "lib"

--- a/scripts/tests/test_arc_mut_guard.py
+++ b/scripts/tests/test_arc_mut_guard.py
@@ -45,6 +45,28 @@ class ArcMutScannerTests(unittest.TestCase):
     def kinds(self, source: str):
         return {item.kind for item in self.scan(source)}
 
+    def test_module_info_uses_resolved_paths_for_relative_lookup(self):
+        guard = load_guard()
+
+        class AliasedPath:
+            def __init__(self, resolved: Path):
+                self.resolved = resolved
+
+            def resolve(self):
+                return self.resolved
+
+        with tempfile.TemporaryDirectory() as tmp:
+            resolved_root = Path(tmp).resolve()
+            resolved_path = resolved_root / "crate" / "src" / "lib.rs"
+            module_info = guard._module_info(
+                AliasedPath(resolved_path),
+                AliasedPath(resolved_root),
+                {resolved_root: ("@crate", ".")},
+            )
+
+        self.assertEqual(("@crate", "crate"), module_info.module)
+        self.assertEqual(("@crate", "crate"), module_info.crate_root)
+
     def test_ignores_comments_normal_and_raw_strings_and_chars(self):
         findings = self.scan(
             '// ArcMut::new(x)\n/* mut_from_ref */\nlet a="WeakArcMut";\n'


### PR DESCRIPTION
Normalize scanned files and fallback roots before ArcMut guard module-relative lookup. This prevents Windows runner 8.3 aliases such as RUNNER~1 and expanded account paths from being treated as different directories. Adds a focused regression and passes all 147 architecture guard tests plus the formal ArcMut baseline. Fixes #8613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust module path detection when files or directories use aliased or unresolved paths.
  - Ensured crate roots and relative module lookups consistently resolve to the correct locations.

- **Tests**
  - Added coverage verifying module information is calculated correctly with resolved paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->