### PR TITLE
[ISSUE #8635]♻️Replace the Broker legacy Store owner

### DIFF
--- a/docs/plans/architecture-refactor-migration/README.md
+++ b/docs/plans/architecture-refactor-migration/README.md
@@ -8,14 +8,15 @@
 > PR-M12-01～06 未开始，合计剩余 7 个
 
 剩余任务数量、M11-12 内部执行批次与 M12 六个工作包见 [`REMAINING-TASKS.md`](REMAINING-TASKS.md)：正式口径
-剩余 7 个工作包；31 个最小可审查单元已完成 13 个，当前剩余 18 个。Issue #8633 / M11-12bc106 后
-reviewed ArcMut baseline 降至 28 identities / 67 occurrences（production 11/18、test 3/9、
-compatibility 14/40）；Broker runtime 现在是唯一 Store 生命周期强 owner，EscapeBridge 与 Admin runtime
-只保留标准弱 provider，强引用仅存在于单次请求期间；普通单条、批量和 Admin append
+剩余 7 个工作包；31 个最小可审查单元已完成 14 个，当前剩余 17 个。Issue #8635 / M11-12bc107 后
+reviewed ArcMut baseline 降至 26 identities / 65 occurrences（production 9/16、test 3/9、
+compatibility 14/40）；Broker production ArcMut 已清零，Broker runtime 直接持有标准
+`Arc<OwnedMessageStore>`，EscapeBridge 与 Admin runtime 只保留标准弱 provider，请求只在单次操作期间取得
+标准 Arc 读租约；普通单条、批量和 Admin append
 已通过私有强类型共享端口执行，controller role-change 不再跨 await 持完整 Store clone，read-mode/topic-delete
-只调用具名同步操作；composition-root lifecycle lease 已删除，生命周期修改统一先解绑 provider，再通过
-`Arc::get_mut` 取得独占 owner，shutdown 在共享 deadline 内等待已接纳读租约退出；剩余只读能力继续从私有
-legacy owner 提取。
+只调用线程安全具名操作；composition-root lifecycle lease 与私有 `LegacyEscapeStoreOwner<ArcMut<_>>` 均已删除，
+生命周期修改统一先解绑 provider，再通过 `Arc::get_mut` 取得独占 Store，shutdown 在共享 deadline 内等待已接纳
+读租约退出。
 
 ## 1. 使用方式
 
@@ -1342,6 +1343,18 @@ init、hook wiring、processor listener、load、start 与 shutdown 修改 Store
 保持 28/67（production 11/18、test 3/9、compatibility 14/40、Broker production 2/2、Store production
 9/16），无 identity relocation、新债务或 baseline 变更。R01 尚未完成，下一切片提取剩余只读 capability 并
 删除私有 legacy owner；执行清单保持完成 13 项、剩余 18 项，正式进度仍为 75/82。
+
+Broker Store 私有 legacy owner 随 Issue #8635 完成删除：`BrokerRuntimeInner` 直接持有标准
+`Arc<OwnedMessageStore>`，`EscapeBridgeStoreCapability` 只保存 `Weak<MS>`，请求期
+`EscapeStoreReadLease` 仅为一次操作升级标准 Arc；普通/批量 append 的私有端口也只保存
+`Weak<OwnedMessageStore>`。Local/Rocks/Owned 的 read-mode、topic-delete 与 role-sync 改为共享借用，动态
+role/read-ahead 由 Store 内部原子运行态发布，CommitLog、Timer、offset correction 与 Reput 读取同一状态，不使用
+同步大锁、unsafe 可变别名或替代 ArcMut wrapper。Broker 配置代际继续同步发布动态 read-ahead/role，生命周期仍在
+解绑 provider 后通过 `Arc::get_mut` 取得独占 Store。reviewed baseline 从 28/67 单调降至 26/65
+（production 11/18→9/16、test 保持 3/9、compatibility 保持 14/40）；删除的 2 个 production
+identity/occurrence 均为原私有 owner 的 ArcMut constructor/type reference，无 relocation、新债务或临时
+approval。Broker production 从 2/2 降至 0/0，Store production 保持 9/16，R01 完成；31 项执行清单现为
+完成 14 项、剩余 17 项，正式进度仍为 75/82。
 
 Default HA client runtime ownership 随 Issue #8567 完成收窄：`DefaultHAClient` 以标准 `Arc<Inner>` 共享只读组合根，
 `Inner` 仅保留原子、锁、Notify、flow monitor 与现有 LocalStore 兼容句柄；从未安装连接的 stream 字段和重复 buffer/

--- a/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
+++ b/docs/plans/architecture-refactor-migration/REMAINING-TASKS.md
@@ -1,14 +1,14 @@
 # 架构重构剩余任务盘点
 
 > 盘点日期：2026-07-23
-> 代码基线：Issue #8633 / M11-12bc106 完成后
+> 代码基线：Issue #8635 / M11-12bc107 完成后
 > 统计规则：82 个顶层 `PR-Mxx-yy` 工作包与 M11-12 内部实施切片分开统计，禁止重复计数。
 
 ## 结论
 
 正式工作包已完成 75/82，尚余 7 个：正在实施的 PR-M11-12，以及尚未开始的 PR-M12-01～PR-M12-06。
-Phase 1、Phase 2 和 10 个目标边界 crate 已完成；当前主要工程量已不在 crate 拆分，而在 Broker/Store 共享可变
-owner 清零、compatibility 删除和同一候选快照验收。
+Phase 1、Phase 2 和 10 个目标边界 crate 已完成；Broker production ArcMut 已清零，当前主要工程量已不在 crate
+拆分，而在 Store 剩余 facade/root carrier、compatibility 删除和同一候选快照验收。
 
 | 口径 | 已完成 | 剩余 | 说明 |
 |---|---:|---:|---|
@@ -16,34 +16,35 @@ owner 清零、compatibility 删除和同一候选快照验收。
 | 里程碑 | 9 | 3 个未关闭 | M10 待验收、M11 实施中、M12 未开始 |
 | Phase Gate | 2 | 2 | Phase 3、Phase 4 |
 | 目标边界 crate | 10 | 0 | 根 workspace 已为目标 32 package |
-| 最小可审查执行单元 | 13 | 18 | 31 项清单中的 R02～R08、R10、R12～R16 已完成 |
+| 最小可审查执行单元 | 14 | 17 | 31 项清单中的 R01～R08、R10、R12～R16 已完成 |
 
 按当前代码热点、兼容窗口和候选快照 Gate 进一步拆分的清单共 **31 个最小可审查单元**：
 16 个 production owner 收口、2 个 test/compatibility 收口、7 个 M10/Phase 3 动态验收与签署、6 个 M12
-工作包；R02、R03、R04、R05、R06、R07、R08、R10、R12、R13、R14、R15、R16 已完成，当前剩余 18 个。31 是执行估算，不是新的正式工作包总数；相邻单元可以合并到同一 PR，遇到高风险
+工作包；R01、R02、R03、R04、R05、R06、R07、R08、R10、R12、R13、R14、R15、R16 已完成，当前剩余 17 个。31 是执行估算，不是新的正式工作包总数；相邻单元可以合并到同一 PR，遇到高风险
 owner 也可以继续拆分，但 7 个正式工作包的统计口径保持不变。
 
 ## PR-M11-12 剩余实现
 
-Issue #8633 / M11-12bc106 后 reviewed ArcMut baseline 保持 28 identities / 67 occurrences：production
-11/18、test 3/9、compatibility 14/40。bc100 让 fast-failure 改持 `PutMessagePreflight`，bc101 让
+Issue #8635 / M11-12bc107 后 reviewed ArcMut baseline 为 26 identities / 65 occurrences：production
+9/16、test 3/9、compatibility 14/40。bc100 让 fast-failure 改持 `PutMessagePreflight`，bc101 让
 `BrokerAdminRuntime` 只持 `Weak<EscapeBridge>`，bc102 进一步让 `BrokerRuntimeInner` 成为唯一 Store 生命周期强
 owner，EscapeBridge 只保存标准 `Weak` provider；bc103 删除 Admin/processor 完整 Store 可变租约，仅保留三个具名
 Admin Store 操作；bc104 又让普通单条、批量和 Admin append 通过私有强类型共享端口执行，不再克隆完整可变
 Store carrier；bc105 让 controller role-change 不再跨 await 持完整 Store clone，并把 read-mode/topic-delete
 收窄为 owner 具名同步操作；bc106 删除 composition-root lifecycle lease，init/hook/start/shutdown 统一先解绑弱
-provider，再通过 `Arc::get_mut` 取得独占 owner，shutdown 还会在绝对 deadline 内等待已接纳读租约退出。
-production 全部分布在 Broker 与 Store。
+provider，再通过 `Arc::get_mut` 取得独占 owner，shutdown 还会在绝对 deadline 内等待已接纳读租约退出；
+bc107 最终删除私有 `LegacyEscapeStoreOwner<ArcMut<_>>`，Broker 改为直接持有标准 Arc Store，动态 role/read-ahead
+通过 Store 原子运行态发布。production 现全部位于 Store。
 
 | owner | 剩余 identity / occurrence | 完成条件 |
 |---|---:|---|
-| Broker | 2 / 2 | `BrokerRuntime.inner` 已改为独占 `Box<BrokerRuntimeInner>`，production 完整 runtime root clone 与 test root clone 均已清零；bc65 删除 Store 的共享引用可变逃逸后，Local/Rocks concrete wrapper 传播同步退出；bc98 删除无调用方的 `BrokerRuntimeInner::set_message_store` wrapper；bc99 以 owned composition 直接拥有 concrete Local/Rocks backend，删除两个内层 wrapper；bc100 让 fast-failure 只持 `PutMessagePreflight` 与超时标量；bc101 让 Admin runtime 只持弱 provider；bc102 让 Broker runtime 成为唯一 Store lifecycle 强 owner，EscapeBridge 改持标准 `Weak`，并把兼容 pointer 构造收回私有 owner factory；bc103 删除 Admin/processor 完整可变 Store lease，改为 append/read-mode/topic-delete 具名操作，并使只读 size-limit 路径不再克隆 mutable carrier；bc104 将单条、批量和 Admin append 迁入私有强类型共享端口；bc105 让 controller role-change 不再跨 await 持完整 Store clone，read-mode/topic-delete 只调用具名同步操作；bc106 删除通用 lifecycle lease，所有组合根生命周期修改必须先解绑 provider，再由 `Arc::get_mut` 证明 owner 独占，shutdown 在 deadline 内等待已接纳读租约退出。剩余 2 个 scanner occurrence 仅为该私有 owner 的 constructor 与字段，随只读 capability 提取删除 |
+| Broker | 0 / 0 | bc107 删除私有 `LegacyEscapeStoreOwner<ArcMut<_>>`，Broker 直接持有标准 `Arc<OwnedMessageStore>`；EscapeBridge/Admin 只保留 Weak provider，请求期读 lease 和 append port 只升级标准 Arc。read-mode/topic-delete/role-sync 使用线程安全窄运行态，生命周期仍先解绑 provider 再由 `Arc::get_mut` 证明独占。Broker production ArcMut 已清零，R01 完成 |
 | Store | 9 / 16 | BrokerStats observer、ConsumeQueueExt owner、HA notification capability、未共享 HA child、commit-to-flush 窄唤醒能力、HA confirm/epoch 原子发布、HA connection runtime handle、CommitLog shared disk-flush、标准 Arc cleanup/mapped-file flush/dispatcher/store-context/read capability、auto-switch replication-state/client construction 与单一 delegate Store owner 已收窄；LocalFileMessageStore 直接独占 CommitLog 且不再保留完整自身 `ArcMut`，Default HA client runtime 与 ConsumeQueueStore root 使用标准 Arc，`ArcConsumeQueue` 使用标准 Arc + 每队列 RwLock 且 guard 不跨 await，simple queue 只持窄上下文与标准 Weak lookup，完整 LocalStore compatibility carrier 已删除；commit-log create/reset/truncate 与消息追加已通过现有同步边界退出 `mut_from_ref`，bench lifecycle probe 已直接独占 LocalFile root 且不再需要临时 shared-owner factory，Default/General/AutoSwitch HA 组合根已使用标准 Arc/Weak 且 child 回指不再保活根；其余 MessageStore、Local/Rocks 与 Timer carrier 改为独占 owner、标准 Arc/Weak 或显式 actor/锁边界 |
 | compatibility | 14 / 40 | production Store `WeakArcMut` 已清零；继续迁移测试/兼容调用方，公开 `ArcMut`/`WeakArcMut`/`SyncUnsafeCellWrapper` 删除必须满足 next-major 两轮弃用与独立 HUMAN/Release Manager 批准，不能通过重置 API baseline 提前关闭 |
 
 建议按以下最小可审查批次继续推进；它们是 PR-M11-12 的内部切片，不增加 82 个顶层工作包总数：
 
-1. Broker aggregate：`BrokerRuntime.inner` 已改为独占 `Box<BrokerRuntimeInner>`（Broker 当前为 2/2），production 与 test 均不能再克隆完整 runtime root；Admin dispatcher、controller 周期、NameServer 注册、producer/consumer state observer、observability 与后台维护任务均持显式 context/runtime/manager/capability，MessageStore accessor 仅返回普通借用；Local/Rocks backend 已由 owned composition 直接拥有，fast-failure 已改持 `PutMessagePreflight`，Admin 与 EscapeBridge 均只持弱 Store provider，Broker runtime 是唯一长期 Store lifecycle owner；普通单条、批量和 Admin append 已通过私有强类型共享端口执行，controller role-change 不再跨 await 持完整 Store clone，read-mode/topic-delete 只调用具名同步操作。剩余私有 legacy owner 需继续提取 read/lifecycle capability 后替代。
+1. Broker aggregate 已完成（0/0）：`BrokerRuntime.inner` 独占 `Box<BrokerRuntimeInner>`，production/test 完整 runtime root clone 均已清零；Broker 直接持有标准 Arc Store，Admin/EscapeBridge 只持 Weak provider，请求期读/append capability 只升级标准 Arc；生命周期由解绑 provider + `Arc::get_mut` 保持独占，read-mode/topic-delete/role-sync 由线程安全窄运行态承担。
 2. Broker leaf：完成其余 admin/processor/revive/offset leaf owner；transaction bridge 已由 M11-12bc4 收窄，Producer/ColdData admin handler 已由 M11-12bc5 改持 live registry/standard Arc capability，Schedule hook 已由 M11-12bc6 改持三项显式能力，Topic Admin 已由 M11-12bc31 改为无状态 leaf，slave metadata synchronization 已由 M11-12bc50 改持显式 policy/弱 provider/晚绑定 capability。
 3. Store WAL：commit worker 已只持 `Notify` 唤醒能力，CommitLog disk-flush 已通过共享 receiver enqueue，CommitLog 已独占 MappedFileQueue/DefaultFlushManager/ConsumeQueue recovery completion，dispatcher worker 只持不可变快照 capability，LocalStore back-reference 已由原子发布的窄 context 替代，transaction 的直接 Store 兼容 owner 已删除；R13 已完成。
 4. Store queue：ConsumeQueueExt 与 trait-object handle 已改用每实例显式锁 owner；local/single queue 只持窄标准 Arc 上下文与 Weak lookup，完整 LocalStore carrier 已删除，R12 已完成。
@@ -57,13 +58,13 @@ production 全部分布在 Broker 与 Store。
 
 ## 执行层最小审查清单（31 项）
 
-> 本清单给出当前可执行下界。`identity / occurrence` 来自 Issue #8633 / M11-12bc106 后通过
-> `python scripts/arc_mut_guard.py` 验证的 reviewed baseline；production 16 项精确合计 Broker 2/2、Store
+> 本清单给出当前可执行下界。`identity / occurrence` 来自 Issue #8635 / M11-12bc107 后通过
+> `python scripts/arc_mut_guard.py` 验证的 reviewed baseline；production 16 项精确合计 Broker 0/0、Store
 > 9/16。test 条目会随相邻 production 切片同步下降，因此 R17 只在 production 收口后处理真实余量。
 
 ### Production owner（16 项）
 
-- [ ] R01 Broker runtime aggregate：`broker_runtime.rs` 与 Store lifecycle/capability carrier（2/2；bc60～bc63 已删除 Admin/controller/registration/state/background root carrier；bc64 将 `BrokerRuntime.inner` 改为独占 `Box`，43 处 test root clone 改为 owned admin runtime 或窄 manager/registry handle；bc65 删除 Local/Rocks concrete unsafe-wrapper 传播；bc98 删除无调用方的 `set_message_store` wrapper；Issue #8617 / bc99 新增 non-exhaustive owned composition 并让 Broker 直接拥有 concrete Local/Rocks backend，删除两个内层 constructor occurrence，同时保持公开 Generic facade 不变；Issue #8621 / bc100 让 fast-failure 只克隆 `PutMessagePreflight` 与超时标量；Issue #8623 / bc101 让 Admin runtime 只持 `Weak<EscapeBridge>`；Issue #8625 / bc102 让 Broker runtime 成为唯一 Store lifecycle 强 owner，EscapeBridge 改持标准 `Weak`，生命周期/请求可变操作仅取得短期 write lease，并将兼容 pointer 构造集中到私有 `LegacyEscapeStoreOwner` factory；Issue #8627 / bc103 删除 Admin/processor 完整可变 Store lease，改为 append/read-mode/topic-delete 具名操作，测试启动回归 composition root，只读 size-limit 路径不再克隆 mutable carrier；Issue #8629 / bc104 将普通单条、批量和 Admin append 迁入私有强类型共享端口，不再克隆完整 mutable carrier；Issue #8631 / bc105 让 controller role-change 不再跨 await 持完整 Store clone，read-mode/topic-delete 只调用 owner 具名同步操作；Issue #8633 / bc106 删除 composition-root lifecycle lease，init/hook/start/shutdown 先解绑 provider，再通过 `Arc::get_mut` 取得独占 owner，shutdown 在 deadline 内等待已接纳读租约退出。剩余仅该私有 owner 的 constructor 与字段，需继续提取只读 capability 后收口）。
+- [x] R01 Broker runtime aggregate：Issue #8635 / bc107 删除最后的私有 `LegacyEscapeStoreOwner<ArcMut<_>>` constructor/type reference；Broker 直接持有标准 `Arc<OwnedMessageStore>`，EscapeBridge/Admin 只保存 Weak provider，请求期只读 lease 与共享 append port 只升级标准 Arc。read-mode/topic-delete/role-sync 使用 Store 原子运行态，生命周期继续通过解绑 provider + `Arc::get_mut` 保持独占；Broker production 从 2/2 降至 0/0。
 - [x] R02 Broker Ack 内部 capability：Issue #8519 已删除 `ack_message_processor.rs` 的完整 runtime/revive ArcMut owner（3/5），改持显式 policy/capability，PopRevive task receiver 同步改为标准 Arc。
 - [x] R03 Broker send/reply：Issue #8523 已删除 `send_message_processor.rs` 与 `reply_message_processor.rs` 的完整 runtime/ArcMut owner（6/13），改持标准 Arc、热更新 policy、弱 Store 与显式 Topic/订阅/重平衡/统计/reply-channel capability；测试 glob 同步删除 2/2。
 - [x] R04 Broker POP：Issue #8531 已删除 `pop_message_processor.rs`、`pop_buffer_merge_service.rs`、`pop_revive_service.rs` 的 8 个 production identities/17 occurrences 与 3 个 test identities/3 occurrences；改持热更新 policy、显式 capability、弱 Store 与父 TaskGroup，`GetMessageResult` 改为独占借用，无 relocation 或新增 identity。
@@ -820,6 +821,16 @@ hook、processor dispatch 与 owner 释放后的 fail-closed 语义保持。revi
 occurrences（production 11/18、test 3/9、compatibility 14/40、Broker production 2/2、Store production
 9/16），无 identity relocation、新增债务或 baseline 变更。R01 尚未完成，下一切片提取剩余只读 capability 并
 删除私有 legacy owner；执行清单保持完成 13 项、剩余 18 项，正式进度仍为 75/82。
+
+M11-12bc107 随 Issue #8635 删除 Broker 最后的私有 legacy Store owner：`BrokerRuntimeInner` 直接持有
+`Arc<OwnedMessageStore>`，EscapeBridge 与 Admin runtime 只保存 Weak provider，`EscapeStoreReadLease` 与共享
+append port 只在单次请求期间升级标准 Arc。Local/Rocks/Owned 的 read-mode、topic-delete、role-sync 改为共享
+借用，动态 broker role 与 read-ahead 通过 Store 原子运行态发布给 CommitLog、Timer、offset correction 与 Reput；
+未引入同步大锁、unsafe 可变别名或替代 wrapper。生命周期仍先解绑 provider，再通过 `Arc::get_mut` 取得独占 Store；
+Broker 配置代际继续同步发布动态 role/read-ahead。reviewed baseline 从 28/67 降至 26/65（production
+11/18→9/16、test 保持 3/9、compatibility 保持 14/40），Broker production 从 2/2 降至 0/0，Store production
+保持 9/16；净删除 2 个 production identities/occurrences，无 relocation、新债务或临时 approval。R01 完成，
+执行清单现为完成 14 项、剩余 17 项，正式进度仍为 75/82。
 
 ## PR-M12 剩余工作包
 

--- a/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
+++ b/docs/plans/architecture-refactor-migration/phase-3-production-readiness/11-soundness-closure-progress.md
@@ -4713,14 +4713,46 @@ Cross-crate LocalFile test roots 随 Issue #8609 完成以下批量收口：
 | final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；最终 Clippy 复用增量缓存并在 22 秒内完成，Windows linker stdout 与既有 future-incompatibility note 不受 `-D warnings` 管辖 |
 | reduced validation scope | 只验证四个直接 consumer 的代表行为、ArcMut 治理和一次最终 workspace 门禁；不重复 CommitLog recovery 全套、Store/Broker 全包测试、额外 package check/Clippy、runtime audit、M06、RocksDB matrix、telemetry、release、Rustdoc 或 routing gate。public doc 没有链接、示例或 feature-gated item，因此不增加独立 Rustdoc build |
 
+## M11-12bc107 实现
+
+Broker Store 私有 legacy owner 随 Issue #8635 完成以下收口：
+
+- `BrokerRuntimeInner.message_store` 直接持有标准 `Arc<OwnedMessageStore>`，删除
+  `LegacyEscapeStoreOwner<ArcMut<_>>` 的 constructor、字段传播与内部 clone；Broker composition root 仍是唯一
+  长期强 owner。
+- `EscapeBridgeStoreCapability` 只保存 `Weak<MS>`，请求期 `EscapeStoreReadLease` 与 Local/Rocks 共享 append
+  port 只在一次操作期间升级标准 Arc；provider detach 后新请求 fail closed，已接纳 lease 继续阻止生命周期独占访问。
+- MessageStore 的 read-mode、topic-delete 与 role-sync 收窄为共享借用；新增 Store 私有原子运行态发布当前
+  broker role/read-ahead，CommitLog read/append、Timer dequeue、offset correction 与 Reput 使用同一动态状态，
+  不以同步大锁、unsafe 可变别名或替代 shared-mutation wrapper 承载控制。
+- Broker config RCU generation 同步发布 Admin read-ahead 与 controller role，外部配置查询继续观察 live snapshot；
+  Local/Rocks 的初始化、HA role transition、topic deletion、CommitLog read mode 与 shutdown deadline 语义保持。
+- reviewed baseline 从 28/67 单调降至 26/65：production 11/18→9/16，test 保持 3/9，compatibility
+  保持 14/40；Broker production 2/2→0/0，Store production 保持 9/16。净删除 2 个 production
+  identities/occurrences，无 relocation、新 governed debt 或临时 approval。
+- R01 完成；31 项最小审查清单现为完成 14 项、剩余 17 项，正式进度仍为 75/82。
+
+## M11-12bc107 验证
+
+| 命令 | 结果 |
+|---|---|
+| affected checks / behavior | Store all-target check、Broker all-target/all-feature check 通过；Store role/timer/controller 2/2，Broker provider owner、shutdown admitted-read、Admin owner/read-mode、config generation、shared append 与 controller role 8/8，standard Arc source contract 1/1 通过 |
+| Proxy recursion regression | `cargo check -p rocketmq-proxy-local --all-targets --all-features` 通过；crate 保留 `recursion_limit = "256"`，完整嵌套 Broker worker future 不再触发 query-depth overflow |
+| reviewed baseline / runtime | `python scripts/arc_mut_guard.py` 与 enforcing runtime audit 通过；reviewed baseline 只删除原私有 owner 的 2 个 production identity/occurrence，28/67→26/65，无 relocation、新 debt 或临时 approval |
+| RocksDB specialized gate | Store/Broker rocksdb feature strict Clippy 通过；foundation 82/82、semantics 9/9、Broker rocksdb 21/21、pop_consumer 4/4 通过 |
+| final gates | `cargo fmt --all -- --check`、workspace all-target/all-feature strict Clippy 与 `git diff --check` 通过；Windows linker stdout 和既有 future-incompatibility note 不受 `-D warnings` 管辖 |
+| reduced validation scope | 不运行 Store/Broker 全量 lib suite、M06 mutation、dependency/release/performance/telemetry、Rustdoc 或 AGENTS routing；聚焦回归覆盖本切片全部 owner/control/role/read-mode 语义，RocksDB 专项覆盖受影响 backend，最终 workspace Clippy 覆盖完整 workspace 编译/lint |
+
 ## 剩余切片与 Gate
 
 2026-07-23 盘点将执行工作固化为 31 个最小可审查单元：16 个 production owner、2 个
-test/compatibility、7 个 M10/Phase 3 动态验收与签署、6 个 M12；R02、R03、R04、R05、R06、R07、R08、R12、R13、R15、R16 已完成，当前剩余 20 个，正式进度仍为 75/82。
+test/compatibility、7 个 M10/Phase 3 动态验收与签署、6 个 M12；R01～R08、R10、R12～R16 已完成，当前剩余
+17 个，正式进度仍为 75/82。
 完整逐项 checklist 见 `docs/plans/architecture-refactor-migration/REMAINING-TASKS.md`。
 
-1. Broker runtime root 已改为独占 `Box<BrokerRuntimeInner>`，production/test 完整 root clone 均已清零；bc65 删除 Local/Rocks concrete unsafe-wrapper 传播后，仅剩显式 `ArcMut` Store 组合根 capability carrier（4/8），随 R09～R11/R14 Store owner 安全化删除。
-2. Store 其余 StoreHandle/Local-Rocks/Timer owner（9/16）；Default/General/AutoSwitch HA composition root、replication-state callback、未共享 child、client/service runtime、replica-store capability、owned connection registry、窄 context/Weak lookup、direct delegate/exclusive init、confirm/epoch 发布与 connection runtime handle 已退出 `ArcMut`。ConsumeQueue、WAL/flush、Local root maintenance/read capability 等已完成切片保持关闭，剩余仅按 R09～R11/R14 及 compatibility 窗口继续收口。
+1. Broker production ArcMut 已清零（0/0）：runtime root 独占 `Box<BrokerRuntimeInner>`，Store root 直接持有标准 Arc，
+   EscapeBridge/Admin 只保存 Weak provider，生命周期使用 detach + `Arc::get_mut` 保持独占。
+2. Store 其余 StoreHandle/Local-Rocks/Timer owner（9/16）；Default/General/AutoSwitch HA composition root、replication-state callback、未共享 child、client/service runtime、replica-store capability、owned connection registry、窄 context/Weak lookup、direct delegate/exclusive init、confirm/epoch 发布与 connection runtime handle 已退出 `ArcMut`。ConsumeQueue、WAL/flush、Local root maintenance/read capability 等已完成切片保持关闭，剩余仅按 R09/R11 与转入 R18 的 Local/Timer 兼容窗口继续收口。
 3. Production `WeakArcMut` 已清零；继续迁移 test/compatibility 中受控使用并移除其余 nightly feature。公开 `arc_mut.rs`/re-export 的 destructive 删除受 next-major 两轮弃用与 Release Manager/HUMAN Gate 约束，不能静默重置 public API baseline。
 4. 对同一候选快照执行 stable feature matrix、Miri/Loom 可用切片、soak/SLO fault、dashboard/runbook、动态
    Kind/K3d/container、M10 固定硬件和 Human Gate。

--- a/rocketmq-broker/src/broker/broker_admin_runtime.rs
+++ b/rocketmq-broker/src/broker/broker_admin_runtime.rs
@@ -32,6 +32,7 @@ use rocketmq_store::stats::broker_stats::BrokerStats;
 use rocketmq_store::stats::broker_stats_manager::BrokerStatsManager;
 use rocketmq_store::store_error::StoreError;
 use rocketmq_store::timer::timer_message_store::TimerMessageStore;
+use rocketmq_store::utils::ffi::MADV_NORMAL;
 use tracing::warn;
 
 use crate::broker::broker_control_plane::BrokerControllerRuntime;
@@ -49,7 +50,7 @@ use crate::controller::replicas_manager::ReplicasManager;
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
 use crate::failover::escape_bridge_capability::EscapeBridgePolicyState;
-use crate::failover::escape_bridge_capability::LegacyEscapeStoreReadLease;
+use crate::failover::escape_bridge_capability::EscapeStoreReadLease;
 use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestHoldService;
 use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
@@ -249,7 +250,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
         self.broker_config().broker_server_config.clone()
     }
 
-    pub(crate) fn message_store(&self) -> Option<LegacyEscapeStoreReadLease<MS>> {
+    pub(crate) fn message_store(&self) -> Option<EscapeStoreReadLease<MS>> {
         self.message_store_provider.upgrade()?.lease_message_store().ok()
     }
 
@@ -265,7 +266,9 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
         self.message_store_provider
             .upgrade()
             .ok_or(StoreError::NotStarted)?
-            .set_commitlog_read_mode(read_ahead_mode)
+            .set_commitlog_read_mode(read_ahead_mode)?;
+        self.config.apply_data_read_ahead(read_ahead_mode == MADV_NORMAL);
+        Ok(())
     }
 
     pub(crate) fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> Result<i32, MessageStoreUnavailable> {

--- a/rocketmq-broker/src/broker/broker_runtime_config_state.rs
+++ b/rocketmq-broker/src/broker/broker_runtime_config_state.rs
@@ -98,6 +98,18 @@ impl BrokerRuntimeConfigState {
         });
         self.snapshot()
     }
+
+    pub(crate) fn apply_data_read_ahead(&self, enabled: bool) -> Arc<BrokerRuntimeConfigGeneration> {
+        self.current.rcu(|current| {
+            let mut store = current.store().as_ref().clone();
+            store.data_read_ahead_enable = enabled;
+            Arc::new(BrokerRuntimeConfigGeneration {
+                broker: Arc::clone(current.broker()),
+                store: Arc::new(store),
+            })
+        });
+        self.snapshot()
+    }
 }
 
 #[cfg(test)]
@@ -151,6 +163,25 @@ mod tests {
         assert_eq!(generation.broker().broker_identity.broker_id, 7);
         assert_eq!(generation.broker().listen_port, 30912);
         assert_eq!(generation.store().broker_role, BrokerRole::Slave);
+        assert_eq!(generation.store().ha_listen_port, 30913);
+    }
+
+    #[test]
+    fn read_ahead_generation_preserves_unrelated_fields() {
+        let broker = BrokerConfig {
+            listen_port: 30912,
+            ..BrokerConfig::default()
+        };
+        let store = MessageStoreConfig {
+            ha_listen_port: 30913,
+            ..MessageStoreConfig::default()
+        };
+        let state = BrokerRuntimeConfigState::new(Arc::new(broker), Arc::new(store));
+
+        let generation = state.apply_data_read_ahead(true);
+
+        assert_eq!(generation.broker().listen_port, 30912);
+        assert!(generation.store().data_read_ahead_enable);
         assert_eq!(generation.store().ha_listen_port, 30913);
     }
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -113,7 +113,6 @@ use crate::config::rocksdb_manager::RocksDbBrokerConfigStorageLayout;
 use crate::controller::replicas_manager::ReplicasManager;
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::failover::escape_bridge_capability::EscapeBridgePolicyState;
-use crate::failover::escape_bridge_capability::LegacyEscapeStoreOwner;
 use crate::filter::commit_log_dispatcher_calc_bit_map::CommitLogDispatcherCalcBitMap;
 use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 use crate::hook::batch_check_before_put_message::BatchCheckBeforePutMessageHook;
@@ -2240,13 +2239,11 @@ impl BrokerRuntime {
                 return false;
             }
             self.inner.timer_message_store = local_file_store.get_timer_message_store().cloned();
-            let message_store = Arc::new(LegacyEscapeStoreOwner::new(BrokerMessageStore::local_file(
-                local_file_store,
-            )));
+            let message_store = Arc::new(BrokerMessageStore::local_file(local_file_store));
             self.inner.broker_stats = Some(Arc::new(BrokerStats::from_manager(
                 self.inner.broker_stats_manager.clone(),
             )));
-            let put_message_preflight = message_store.store().put_message_preflight();
+            let put_message_preflight = message_store.put_message_preflight();
             self.inner.message_store = Some(message_store);
             let page_cache_busy_timeout_millis = message_store_config.os_page_cache_busy_timeout_mills;
             self.inner.broker_fast_failure.set_page_cache_busy_checker(move || {
@@ -2281,13 +2278,11 @@ impl BrokerRuntime {
                     }
                 };
                 self.inner.timer_message_store = rocksdb_message_store.get_timer_message_store().cloned();
-                let message_store = Arc::new(LegacyEscapeStoreOwner::new(BrokerMessageStore::rocksdb(
-                    rocksdb_message_store,
-                )));
+                let message_store = Arc::new(BrokerMessageStore::rocksdb(rocksdb_message_store));
                 self.inner.broker_stats = Some(Arc::new(BrokerStats::from_manager(
                     self.inner.broker_stats_manager.clone(),
                 )));
-                let put_message_preflight = message_store.store().put_message_preflight();
+                let put_message_preflight = message_store.put_message_preflight();
                 self.inner.message_store = Some(message_store);
                 let page_cache_busy_timeout_millis = message_store_config.os_page_cache_busy_timeout_mills;
                 self.inner.broker_fast_failure.set_page_cache_busy_checker(move || {
@@ -3879,7 +3874,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     subscription_group_manager: Option<SubscriptionGroupManager>,
     consumer_filter_manager: Option<ConsumerFilterManager>,
     consumer_order_info_manager: Option<Arc<ConsumerOrderInfoManager>>,
-    message_store: Option<Arc<LegacyEscapeStoreOwner<MS>>>,
+    message_store: Option<Arc<MS>>,
     broker_stats: Option<Arc<BrokerStats<MS>>>,
     schedule_message_service: Option<Arc<ScheduleMessageService<MS>>>,
     timer_message_store: Option<Arc<TimerMessageStore>>,
@@ -4195,10 +4190,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
 
     #[inline]
     pub fn message_store_mut(&mut self) -> Option<&mut MS> {
-        self.message_store
-            .as_mut()
-            .and_then(Arc::get_mut)
-            .map(LegacyEscapeStoreOwner::store_mut)
+        self.message_store.as_mut().and_then(Arc::get_mut)
     }
 
     #[inline]
@@ -4388,12 +4380,12 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
 
     #[inline]
     pub fn message_store(&self) -> Option<&MS> {
-        self.message_store.as_deref().map(LegacyEscapeStoreOwner::store)
+        self.message_store.as_deref()
     }
 
     #[inline]
     pub(crate) fn message_store_ref(&self) -> Option<&MS> {
-        self.message_store.as_deref().map(LegacyEscapeStoreOwner::store)
+        self.message_store.as_deref()
     }
 
     #[inline]
@@ -4422,9 +4414,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             .message_store
             .as_mut()
             .expect("message store should be initialized before mutable access");
-        Arc::get_mut(owner)
-            .expect("message store lifecycle access requires the exclusive Broker owner")
-            .store_mut()
+        Arc::get_mut(owner).expect("message store lifecycle access requires the exclusive Broker owner")
     }
 
     #[inline]
@@ -6128,22 +6118,24 @@ accounts:
     #[tokio::test]
     async fn registering_message_store_hooks_does_not_retain_runtime_root() {
         let mut runtime = new_phase3_test_runtime("schedule-hook-ownership").await;
-        let store_strong_count_before = runtime
-            .inner
-            .message_store
-            .as_ref()
-            .expect("message store should be initialized")
-            .legacy_strong_count();
-
-        runtime.register_message_store_hook();
-
-        assert_eq!(
+        let store_strong_count_before = Arc::strong_count(
             runtime
                 .inner
                 .message_store
                 .as_ref()
-                .expect("message store should remain initialized")
-                .legacy_strong_count(),
+                .expect("message store should be initialized"),
+        );
+
+        runtime.register_message_store_hook();
+
+        assert_eq!(
+            Arc::strong_count(
+                runtime
+                    .inner
+                    .message_store
+                    .as_ref()
+                    .expect("message store should remain initialized"),
+            ),
             store_strong_count_before
         );
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
@@ -7073,11 +7065,6 @@ accounts:
             1,
             "BrokerRuntime must be the only long-lived Store lifecycle owner"
         );
-        assert_eq!(
-            message_store.legacy_strong_count(),
-            1,
-            "the weak provider must not clone the legacy compatibility pointer"
-        );
         assert!(capability.with_store(|_| ()).is_ok());
 
         let message_store = runtime
@@ -7089,7 +7076,7 @@ accounts:
             Ok(owner) => owner,
             Err(_) => panic!("released provider must leave one exclusive Store owner"),
         };
-        message_store.store_mut().shutdown().await;
+        message_store.shutdown().await;
         drop(message_store);
         assert!(
             capability.with_store(|_| ()).is_err(),
@@ -7216,7 +7203,6 @@ accounts:
             .as_ref()
             .expect("message store should remain initialized");
         assert_eq!(Arc::strong_count(message_store), 1);
-        assert_eq!(message_store.legacy_strong_count(), 1);
 
         runtime.shutdown_message_store_for_test().await;
         let _ = std::fs::remove_dir_all(temp_root);
@@ -7240,7 +7226,6 @@ accounts:
             .as_ref()
             .expect("message store should be initialized");
         let store_owner_count = Arc::strong_count(store_owner);
-        let legacy_owner_count = store_owner.legacy_strong_count();
         let admin = runtime.admin_runtime_for_test();
         let admin_clone = admin.clone();
 
@@ -7256,16 +7241,6 @@ accounts:
             store_owner_count,
             "Admin runtime instances must retain only a weak Store provider"
         );
-        assert_eq!(
-            runtime
-                .inner
-                .message_store
-                .as_ref()
-                .expect("message store should remain initialized")
-                .legacy_strong_count(),
-            legacy_owner_count,
-            "Admin runtime instances must not clone the legacy compatibility pointer"
-        );
         assert!(admin.set_commitlog_read_mode(MADV_NORMAL).is_ok());
         assert_eq!(admin.delete_topics(Vec::new()).expect("empty topic deletion"), 0);
         assert_eq!(
@@ -7273,10 +7248,10 @@ accounts:
                 .inner
                 .message_store
                 .as_ref()
-                .expect("message store should remain initialized")
-                .legacy_strong_count(),
-            legacy_owner_count,
-            "named Admin controls must release their temporary compatibility wrapper"
+                .map(Arc::strong_count)
+                .expect("message store should remain initialized"),
+            store_owner_count,
+            "named Admin controls must release their temporary Store lease"
         );
 
         let message_store = runtime
@@ -7288,7 +7263,7 @@ accounts:
             Ok(owner) => owner,
             Err(_) => panic!("released provider must leave one exclusive Store owner"),
         };
-        message_store.store_mut().shutdown().await;
+        message_store.shutdown().await;
         drop(message_store);
 
         assert!(admin.message_store().is_none());
@@ -9835,7 +9810,7 @@ accounts:
         let runtime_info = ha_service.get_runtime_info(0);
         assert!(runtime_info.master);
         assert_eq!(runtime_info.ha_client_runtime_info.master_addr, "");
-        assert_eq!(store.get_message_store_config().broker_role, BrokerRole::SyncMaster);
+        assert_eq!(store.current_broker_role(), BrokerRole::SyncMaster);
 
         let _ = std::fs::remove_dir_all(temp_root);
     }
@@ -9875,7 +9850,7 @@ accounts:
         let runtime_info = ha_service.get_runtime_info(0);
         assert!(!runtime_info.master);
         assert_eq!(runtime_info.ha_client_runtime_info.master_addr, "127.0.0.1:10911");
-        assert_eq!(store.get_message_store_config().broker_role, BrokerRole::Slave);
+        assert_eq!(store.current_broker_role(), BrokerRole::Slave);
 
         let _ = std::fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -49,8 +49,7 @@ use tracing::warn;
 
 use crate::failover::escape_bridge_capability::EscapeBridgePolicyState;
 use crate::failover::escape_bridge_capability::EscapeBridgeStoreCapability;
-use crate::failover::escape_bridge_capability::LegacyEscapeStoreOwner;
-use crate::failover::escape_bridge_capability::LegacyEscapeStoreReadLease;
+use crate::failover::escape_bridge_capability::EscapeStoreReadLease;
 use crate::out_api::broker_outer_api::BrokerOuterAPI;
 use crate::topic::manager::topic_route_info_manager::TopicRouteInfoManager;
 use crate::transaction::queue::transactional_message_util::TransactionalMessageUtil;
@@ -143,7 +142,7 @@ impl<MS: MessageStore> EscapeBridge<MS> {
         self.message_store.detach();
     }
 
-    pub(crate) fn lease_message_store(&self) -> Result<LegacyEscapeStoreReadLease<MS>, MessageStoreUnavailable> {
+    pub(crate) fn lease_message_store(&self) -> Result<EscapeStoreReadLease<MS>, MessageStoreUnavailable> {
         self.message_store.read_lease()
     }
 
@@ -380,8 +379,8 @@ impl<MS: MessageStore> EscapeBridge<MS> {
 }
 
 impl EscapeBridge<OwnedMessageStore> {
-    pub(crate) fn bind_message_store(&self, owner: &Arc<LegacyEscapeStoreOwner<OwnedMessageStore>>) {
-        self.message_store.bind_owned(owner);
+    pub(crate) fn bind_message_store(&self, store: &Arc<OwnedMessageStore>) {
+        self.message_store.bind_owned(store);
     }
 }
 
@@ -793,6 +792,9 @@ mod tests {
         let capability_source = include_str!("escape_bridge_capability.rs");
 
         assert!(!capability_source.contains("LegacyEscapeStoreLifecycleLease"));
+        assert!(!capability_source.contains("LegacyEscapeStoreOwner"));
+        assert!(!capability_source.contains("rocketmq_rust::ArcMut"));
+        assert!(capability_source.contains("current: Arc<RwLock<Option<Weak<MS>>>>"));
         assert!(runtime_source.contains(".and_then(Arc::get_mut)"));
         let shutdown_source = runtime_source
             .split_once("// Store durability therefore cannot be starved by a slow background component.")

--- a/rocketmq-broker/src/failover/escape_bridge_capability.rs
+++ b/rocketmq-broker/src/failover/escape_bridge_capability.rs
@@ -120,46 +120,6 @@ impl EscapeBridgePolicyState {
     }
 }
 
-/// Temporary Store lifecycle owner used while the Store facade is migrated by R09-R16.
-///
-/// Broker runtime keeps the only long-lived strong owner. Other capabilities retain a weak
-/// provider and upgrade it only for the duration of one operation.
-pub(crate) struct LegacyEscapeStoreOwner<MS: MessageStore>(rocketmq_rust::ArcMut<MS>);
-
-impl<MS: MessageStore> LegacyEscapeStoreOwner<MS> {
-    pub(crate) fn new(store: MS) -> Self {
-        Self(rocketmq_rust::ArcMut::new(store))
-    }
-
-    pub(crate) fn store(&self) -> &MS {
-        self.0.as_ref()
-    }
-
-    pub(crate) fn store_mut(&mut self) -> &mut MS {
-        self.0.as_mut()
-    }
-
-    fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), LegacyStoreError> {
-        let mut store = self.0.clone();
-        store.set_commitlog_read_mode(read_ahead_mode)
-    }
-
-    fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> i32 {
-        let mut store = self.0.clone();
-        store.delete_topics(delete_topics)
-    }
-
-    fn sync_broker_role(&self, broker_role: BrokerRole) {
-        let mut store = self.0.clone();
-        store.sync_broker_role(broker_role);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn legacy_strong_count(&self) -> usize {
-        self.0.strong_count()
-    }
-}
-
 struct SharedAppendOutcome {
     result: PutMessageResult,
     appended_watermark: i64,
@@ -168,63 +128,63 @@ struct SharedAppendOutcome {
 
 #[derive(Clone)]
 struct SharedStoreAppendPort {
-    owner: Weak<LegacyEscapeStoreOwner<OwnedMessageStore>>,
+    store: Weak<OwnedMessageStore>,
 }
 
 impl SharedStoreAppendPort {
-    fn new(owner: &Arc<LegacyEscapeStoreOwner<OwnedMessageStore>>) -> Self {
+    fn new(store: &Arc<OwnedMessageStore>) -> Self {
         Self {
-            owner: Arc::downgrade(owner),
+            store: Arc::downgrade(store),
         }
     }
 
-    fn owner(&self) -> Result<Arc<LegacyEscapeStoreOwner<OwnedMessageStore>>, MessageStoreUnavailable> {
-        self.owner.upgrade().ok_or(MessageStoreUnavailable)
+    fn store(&self) -> Result<Arc<OwnedMessageStore>, MessageStoreUnavailable> {
+        self.store.upgrade().ok_or(MessageStoreUnavailable)
     }
 
     async fn put_message(
         &self,
         message: MessageExtBrokerInner,
     ) -> Result<SharedAppendOutcome, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let result = owner.store().put_message_shared(message).await;
+        let store = self.store()?;
+        let result = store.put_message_shared(message).await;
         Ok(SharedAppendOutcome {
             result,
-            appended_watermark: owner.store().get_max_phy_offset(),
-            durable_watermark: owner.store().get_flushed_where(),
+            appended_watermark: store.get_max_phy_offset(),
+            durable_watermark: store.get_flushed_where(),
         })
     }
 
     async fn put_messages(&self, batch: MessageExtBatch) -> Result<SharedAppendOutcome, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let result = owner.store().put_messages_shared(batch).await;
+        let store = self.store()?;
+        let result = store.put_messages_shared(batch).await;
         Ok(SharedAppendOutcome {
             result,
-            appended_watermark: owner.store().get_max_phy_offset(),
-            durable_watermark: owner.store().get_flushed_where(),
+            appended_watermark: store.get_max_phy_offset(),
+            durable_watermark: store.get_flushed_where(),
         })
     }
 }
 
-/// Request-scoped read access to the legacy Store boundary.
+/// Request-scoped read access to the Store boundary.
 ///
-/// The lease upgrades the weak provider for one operation without cloning the underlying
-/// compatibility pointer. Long-lived Broker capabilities must not retain this lease.
-pub(crate) struct LegacyEscapeStoreReadLease<MS: MessageStore> {
-    owner: Arc<LegacyEscapeStoreOwner<MS>>,
+/// The lease upgrades the weak provider for one operation. Long-lived Broker
+/// capabilities must retain only the weak provider, not this lease.
+pub(crate) struct EscapeStoreReadLease<MS: MessageStore> {
+    store: Arc<MS>,
 }
 
-impl<MS: MessageStore> Deref for LegacyEscapeStoreReadLease<MS> {
+impl<MS: MessageStore> Deref for EscapeStoreReadLease<MS> {
     type Target = MS;
 
     fn deref(&self) -> &Self::Target {
-        self.owner.store()
+        self.store.as_ref()
     }
 }
 
 /// Late-bound Store operations required by failover and offset processing.
 pub(crate) struct EscapeBridgeStoreCapability<MS: MessageStore> {
-    current: Arc<RwLock<Option<Weak<LegacyEscapeStoreOwner<MS>>>>>,
+    current: Arc<RwLock<Option<Weak<MS>>>>,
     shared_append: Arc<RwLock<Option<SharedStoreAppendPort>>>,
 }
 
@@ -247,8 +207,8 @@ impl<MS: MessageStore> Default for EscapeBridgeStoreCapability<MS> {
 }
 
 impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
-    fn bind(&self, owner: &Arc<LegacyEscapeStoreOwner<MS>>) {
-        *self.current.write() = Some(Arc::downgrade(owner));
+    fn bind(&self, store: &Arc<MS>) {
+        *self.current.write() = Some(Arc::downgrade(store));
     }
 
     pub(crate) fn detach(&self) {
@@ -256,7 +216,7 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         *self.shared_append.write() = None;
     }
 
-    fn owner(&self) -> Result<Arc<LegacyEscapeStoreOwner<MS>>, MessageStoreUnavailable> {
+    fn store(&self) -> Result<Arc<MS>, MessageStoreUnavailable> {
         self.current
             .read()
             .as_ref()
@@ -268,13 +228,13 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         self.shared_append.read().clone().ok_or(MessageStoreUnavailable)
     }
 
-    pub(crate) fn read_lease(&self) -> Result<LegacyEscapeStoreReadLease<MS>, MessageStoreUnavailable> {
-        Ok(LegacyEscapeStoreReadLease { owner: self.owner()? })
+    pub(crate) fn read_lease(&self) -> Result<EscapeStoreReadLease<MS>, MessageStoreUnavailable> {
+        Ok(EscapeStoreReadLease { store: self.store()? })
     }
 
     pub(crate) fn with_store<R>(&self, operation: impl FnOnce(&MS) -> R) -> Result<R, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        Ok(operation(owner.store()))
+        let store = self.store()?;
+        Ok(operation(store.as_ref()))
     }
 
     pub(crate) fn health_snapshot(&self) -> Result<LegacyStoreHealthSnapshot, MessageStoreUnavailable> {
@@ -336,8 +296,8 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         &self,
         request: HAConnectionStateNotificationRequest,
     ) -> Result<bool, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let Some(ha_service) = owner.store().get_ha_service() else {
+        let store = self.store()?;
+        let Some(ha_service) = store.get_ha_service() else {
             return Ok(false);
         };
         ha_service.put_group_connection_state_request(request).await;
@@ -349,8 +309,7 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         master_ha_address: &CheetahString,
         master_address: &CheetahString,
     ) -> Result<(), MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let store = owner.store();
+        let store = self.store()?;
         store.update_ha_master_address(master_ha_address.as_str()).await;
         store.update_master_address(master_address);
         Ok(())
@@ -372,11 +331,11 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         master_address: Option<&CheetahString>,
         master_epoch: i32,
     ) -> HAResult<()> {
-        let owner = match self.owner() {
-            Ok(owner) => owner,
+        let store = match self.store() {
+            Ok(store) => store,
             Err(_) => return Ok(()),
         };
-        let Some(ha_service) = owner.store().get_ha_service().cloned() else {
+        let Some(ha_service) = store.get_ha_service().cloned() else {
             return Ok(());
         };
         let result = match target_role {
@@ -404,7 +363,7 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
             }
         };
         result?;
-        owner.sync_broker_role(match target_role {
+        store.sync_broker_role(match target_role {
             BrokerReplicaRole::Master => BrokerRole::SyncMaster,
             BrokerReplicaRole::Slave => BrokerRole::Slave,
         });
@@ -416,8 +375,8 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
     }
 
     pub(crate) async fn update_ha_master_address(&self, address: &str) -> Result<(), MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        owner.store().update_ha_master_address(address).await;
+        let store = self.store()?;
+        store.update_ha_master_address(address).await;
         Ok(())
     }
 
@@ -433,9 +392,8 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         begin_timestamp: i64,
         end_timestamp: i64,
     ) -> Result<Option<QueryMessageResult>, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        Ok(owner
-            .store()
+        let store = self.store()?;
+        Ok(store
             .query_message(topic, key, max_num, begin_timestamp, end_timestamp)
             .await)
     }
@@ -455,13 +413,13 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
     }
 
     pub(crate) fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), LegacyStoreError> {
-        let owner = self.owner().map_err(|_| LegacyStoreError::NotStarted)?;
-        owner.set_commitlog_read_mode(read_ahead_mode)
+        let store = self.store().map_err(|_| LegacyStoreError::NotStarted)?;
+        store.set_commitlog_read_mode(read_ahead_mode)
     }
 
     pub(crate) fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> Result<i32, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        Ok(owner.delete_topics(delete_topics))
+        let store = self.store()?;
+        Ok(store.delete_topics(delete_topics))
     }
 
     pub(crate) fn min_offset(&self, topic: &CheetahString, queue_id: i32) -> Result<i64, MessageStoreUnavailable> {
@@ -484,11 +442,8 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         offset: i64,
         nums: i32,
     ) -> Result<Option<GetMessageResult>, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        Ok(owner
-            .store()
-            .get_message(group, topic, queue_id, offset, nums, None)
-            .await)
+        let store = self.store()?;
+        Ok(store.get_message(group, topic, queue_id, offset, nums, None).await)
     }
 
     pub(crate) async fn get_message_with_filter(
@@ -500,9 +455,8 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         nums: i32,
         message_filter: Option<ArcMessageFilter>,
     ) -> Result<Option<GetMessageResult>, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        Ok(owner
-            .store()
+        let store = self.store()?;
+        Ok(store
             .get_message(group, topic, queue_id, offset, nums, message_filter)
             .await)
     }
@@ -518,8 +472,7 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         max_msg_bytes: i32,
         message_filter: ArcMessageFilter,
     ) -> Result<Option<GetMessageResult>, MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let store = owner.store();
+        let store = self.store()?;
         Ok(store
             .get_message_with_size_limit(
                 group,
@@ -545,8 +498,7 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
         &self,
         master_addr: &CheetahString,
     ) -> Result<(), MessageStoreUnavailable> {
-        let owner = self.owner()?;
-        let store = owner.store();
+        let store = self.store()?;
         store.update_ha_master_address(master_addr.as_str()).await;
         store.update_master_address(master_addr);
         Ok(())
@@ -571,9 +523,9 @@ impl<MS: MessageStore> EscapeBridgeStoreCapability<MS> {
 }
 
 impl EscapeBridgeStoreCapability<OwnedMessageStore> {
-    pub(crate) fn bind_owned(&self, owner: &Arc<LegacyEscapeStoreOwner<OwnedMessageStore>>) {
-        self.bind(owner);
-        *self.shared_append.write() = Some(SharedStoreAppendPort::new(owner));
+    pub(crate) fn bind_owned(&self, store: &Arc<OwnedMessageStore>) {
+        self.bind(store);
+        *self.shared_append.write() = Some(SharedStoreAppendPort::new(store));
     }
 }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -284,12 +284,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         // broker config => broker config
         // default message store config => message store config
         let broker_config = self.broker_runtime_inner.broker_config();
-        let message_store_config = self
-            .broker_runtime_inner
-            .message_store()
-            .unwrap()
-            .get_message_store_config()
-            .clone();
+        let message_store_config = self.broker_runtime_inner.message_store_config();
         let broker_config_properties = broker_config.get_properties();
         let message_store_config_properties = message_store_config.get_properties();
         let combine_map = broker_config_properties
@@ -1043,13 +1038,11 @@ mod tests {
             .expect("set commitlog read mode should return response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
-        assert!(
-            admin
-                .message_store()
-                .expect("message store should exist")
-                .get_message_store_config()
-                .data_read_ahead_enable
-        );
+        assert!(admin.message_store_config().data_read_ahead_enable);
+        assert!(admin
+            .message_store()
+            .expect("message store should exist")
+            .data_read_ahead_enabled());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -1064,13 +1057,11 @@ mod tests {
             .expect("set commitlog read mode should return response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
-        assert!(
-            !admin
-                .message_store()
-                .expect("message store should exist")
-                .get_message_store_config()
-                .data_read_ahead_enable
-        );
+        assert!(!admin.message_store_config().data_read_ahead_enable);
+        assert!(!admin
+            .message_store()
+            .expect("message store should exist")
+            .data_read_ahead_enabled());
 
         let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -511,7 +511,7 @@ pub trait MessageStoreInner: Sync + 'static {
     }
 
     /// Delete topic's consume queue file and unused stats.
-    fn delete_topics(&mut self, delete_topics: Vec<&CheetahString>) -> i32;
+    fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> i32;
 
     /// Clean unused topics which not in retain topic name set.
     fn clean_unused_topic(&self, retain_topics: &HashSet<String>) -> i32;
@@ -635,6 +635,19 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Get the message store config
     fn get_message_store_config(&self) -> &MessageStoreConfig;
 
+    /// Return the role currently used by shared Store operations.
+    ///
+    /// Backends that support online role changes override this method with
+    /// their thread-safe runtime state.
+    fn current_broker_role(&self) -> BrokerRole {
+        self.get_message_store_config().broker_role
+    }
+
+    /// Return whether CommitLog sequential read-ahead is currently enabled.
+    fn data_read_ahead_enabled(&self) -> bool {
+        self.get_message_store_config().data_read_ahead_enable
+    }
+
     /// Get the statistics service
     fn get_store_stats_service(&self) -> Arc<StoreStatsService>;
 
@@ -652,7 +665,7 @@ pub trait MessageStoreInner: Sync + 'static {
     fn get_commit_log_mut(&mut self) -> &mut CommitLog;
 
     /// Update commitlog read mode and synchronize any cached store config snapshots.
-    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError>;
+    fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), StoreError>;
 
     /// Get running flags
     fn get_running_flags(&self) -> &RunningFlags;
@@ -731,7 +744,7 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Controller mode changes broker role outside the store. Implementations
     /// that cache `MessageStoreConfig` snapshots should update those copies so
     /// HA and commitlog logic observe the latest role.
-    fn sync_broker_role(&mut self, broker_role: BrokerRole);
+    fn sync_broker_role(&self, broker_role: BrokerRole);
 
     /// Calculate the checksum of a certain range of data.
     fn calc_delta_checksum(&self, from: i64, to: i64) -> Vec<u8>;

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -100,6 +100,7 @@ use crate::log_file::mapped_file::default_mapped_file_impl::LazyMmapStats;
 use crate::log_file::mapped_file::MappedFile;
 use crate::log_file::mapped_file::MappedFileAppend;
 use crate::message_store::local_file_message_store::CommitLogDispatchHandle;
+use crate::message_store::runtime_state::StoreRuntimeState;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
 use crate::store::running_flags::RunningFlags;
@@ -419,6 +420,7 @@ impl CommitLogCleanupHandle {
 pub(crate) struct CommitLogReadHandle {
     mapped_file_queue: MappedFileQueueReadHandle,
     message_store_config: Arc<MessageStoreConfig>,
+    store_runtime_state: Arc<StoreRuntimeState>,
     broker_config: Arc<BrokerConfig>,
     store_context: CommitLogStoreContext,
     runtime_state: Arc<CommitLogRuntimeState>,
@@ -465,6 +467,7 @@ impl CommitLogReadHandle {
     pub(crate) fn get_confirm_offset(&self) -> i64 {
         resolve_commit_log_confirm_offset(
             self.message_store_config.as_ref(),
+            self.store_runtime_state.broker_role(),
             self.broker_config.as_ref(),
             &self.store_context,
             self.runtime_state.confirm_offset(),
@@ -475,7 +478,7 @@ impl CommitLogReadHandle {
 
     pub(crate) fn get_confirm_offset_directly(&self) -> i64 {
         if self.broker_config.enable_controller_mode {
-            if self.message_store_config.broker_role != BrokerRole::Slave
+            if self.store_runtime_state.broker_role() != BrokerRole::Slave
                 && !self.store_context.running_flags.is_fenced()
             {
                 let max_phy_offset = self.get_max_offset();
@@ -540,6 +543,7 @@ impl CommitLogReadHandle {
 pub(crate) struct CommitLogInternalMessageWriteHandle {
     append: MappedFileQueueAppendHandle,
     message_store_config: Arc<MessageStoreConfig>,
+    store_runtime_state: Arc<StoreRuntimeState>,
     enabled_append_prop_crc: bool,
     store_context: CommitLogStoreContext,
     runtime_state: Arc<CommitLogRuntimeState>,
@@ -588,7 +592,7 @@ impl CommitLogInternalMessageWriteHandle {
         let topic_queue_key = generate_key(&msg);
         let mapped_file = self.append.get_last_mapped_file(0, false);
         let need_assign_offset = !(self.message_store_config.duplication_enable
-            && self.message_store_config.broker_role != BrokerRole::Slave);
+            && self.store_runtime_state.broker_role() != BrokerRole::Slave);
         let (put_message_result, encoded_buff) = encode_message_ext(&msg, &self.message_store_config);
         if let Some(result) = put_message_result {
             return result;
@@ -845,6 +849,7 @@ fn publish_confirm_offset(runtime_state: &CommitLogRuntimeState, store_checkpoin
 
 fn resolve_commit_log_confirm_offset(
     message_store_config: &MessageStoreConfig,
+    broker_role: BrokerRole,
     broker_config: &BrokerConfig,
     store_context: &CommitLogStoreContext,
     stored_confirm_offset: i64,
@@ -852,7 +857,7 @@ fn resolve_commit_log_confirm_offset(
     flushed_where: i64,
 ) -> i64 {
     if broker_config.enable_controller_mode {
-        if message_store_config.broker_role == BrokerRole::Slave || store_context.running_flags.is_fenced() {
+        if broker_role == BrokerRole::Slave || store_context.running_flags.is_fenced() {
             return stored_confirm_offset;
         }
 
@@ -884,6 +889,7 @@ mod adapter {
     pub struct CommitLog {
         pub(super) mapped_file_queue: super::MappedFileQueue,
         pub(super) message_store_config: super::Arc<super::MessageStoreConfig>,
+        pub(super) store_runtime_state: super::Arc<super::StoreRuntimeState>,
         pub(super) broker_config: super::Arc<super::BrokerConfig>,
         pub(super) enabled_append_prop_crc: bool,
         pub(super) store_context: super::CommitLogStoreContext,
@@ -920,6 +926,7 @@ impl DerefMut for CommitLog {
 impl CommitLog {
     pub(crate) fn new(
         message_store_config: Arc<MessageStoreConfig>,
+        store_runtime_state: Arc<StoreRuntimeState>,
         broker_config: Arc<BrokerConfig>,
         store_context: CommitLogStoreContext,
         dispatcher: CommitLogDispatchHandle,
@@ -941,6 +948,7 @@ impl CommitLog {
             root: CommitLogRoot::new(CommitLogAdapter {
                 mapped_file_queue,
                 message_store_config: message_store_config.clone(),
+                store_runtime_state,
                 broker_config,
                 enabled_append_prop_crc,
                 store_context,
@@ -980,6 +988,7 @@ impl CommitLog {
         CommitLogReadHandle {
             mapped_file_queue: self.mapped_file_queue.read_handle(),
             message_store_config: self.message_store_config.clone(),
+            store_runtime_state: Arc::clone(&self.store_runtime_state),
             broker_config: self.broker_config.clone(),
             store_context: self.store_context.clone(),
             runtime_state: self.runtime_state.clone(),
@@ -990,6 +999,7 @@ impl CommitLog {
         CommitLogInternalMessageWriteHandle {
             append: self.mapped_file_queue.append_handle(),
             message_store_config: Arc::clone(&self.message_store_config),
+            store_runtime_state: Arc::clone(&self.store_runtime_state),
             enabled_append_prop_crc: self.enabled_append_prop_crc,
             store_context: self.store_context.clone(),
             runtime_state: Arc::clone(&self.runtime_state),
@@ -1688,7 +1698,7 @@ impl CommitLog {
         };
 
         let need_assign_offset = !(self.message_store_config.duplication_enable
-            && self.message_store_config.broker_role != BrokerRole::Slave);
+            && self.store_runtime_state.broker_role() != BrokerRole::Slave);
 
         // Encode message BEFORE acquiring any locks
         let (put_message_result, encoded_buff) = encode_message_ext(&msg, &self.message_store_config);
@@ -1997,7 +2007,7 @@ impl CommitLog {
         if self.message_store_config.duplication_enable {
             return false;
         }
-        if BrokerRole::SyncMaster != self.message_store_config.broker_role {
+        if BrokerRole::SyncMaster != self.store_runtime_state.broker_role() {
             // No need to check ha in async or slave broker
             return false;
         }
@@ -2365,6 +2375,7 @@ impl CommitLog {
     pub fn get_confirm_offset(&self) -> i64 {
         resolve_commit_log_confirm_offset(
             self.message_store_config.as_ref(),
+            self.store_runtime_state.broker_role(),
             self.broker_config.as_ref(),
             &self.store_context,
             self.runtime_state.confirm_offset(),
@@ -2375,7 +2386,7 @@ impl CommitLog {
 
     pub fn get_confirm_offset_directly(&self) -> i64 {
         if self.broker_config.enable_controller_mode {
-            if self.message_store_config.broker_role != BrokerRole::Slave
+            if self.store_runtime_state.broker_role() != BrokerRole::Slave
                 && !self.store_context.running_flags.is_fenced()
             {
                 let max_phy_offset = self.get_max_offset();
@@ -3065,16 +3076,16 @@ impl CommitLog {
             .await
     }
 
-    pub fn sync_broker_role(&mut self, broker_role: BrokerRole) {
-        Arc::make_mut(&mut self.message_store_config).broker_role = broker_role;
+    pub fn sync_broker_role(&self, broker_role: BrokerRole) {
+        self.store_runtime_state.set_broker_role(broker_role);
     }
 
-    pub fn set_data_read_ahead_enable(&mut self, enabled: bool) {
-        Arc::make_mut(&mut self.message_store_config).data_read_ahead_enable = enabled;
+    pub fn set_data_read_ahead_enable(&self, enabled: bool) {
+        self.store_runtime_state.set_data_read_ahead_enable(enabled);
     }
 
     pub fn is_data_read_ahead_enable(&self) -> bool {
-        self.message_store_config.data_read_ahead_enable
+        self.store_runtime_state.data_read_ahead_enable()
     }
 
     pub fn scan_file_and_set_read_mode(&self, read_ahead_mode: i32) -> usize {

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -15,6 +15,7 @@
 pub mod local_file_message_store;
 mod owned_message_store;
 pub mod recovery;
+pub(crate) mod runtime_state;
 
 #[cfg(feature = "rocksdb_store")]
 pub mod rocksdb_message_store;
@@ -425,7 +426,7 @@ macro_rules! message_store_methods {
         delegate_store!(self, slave_fall_behind_much())
     }
 
-    fn delete_topics(&mut self, delete_topics: Vec<&CheetahString>) -> i32 {
+    fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> i32 {
         delegate_store!(self, delete_topics(delete_topics))
     }
 
@@ -565,6 +566,14 @@ macro_rules! message_store_methods {
         }
     }
 
+    fn current_broker_role(&self) -> BrokerRole {
+        delegate_store!(self, current_broker_role())
+    }
+
+    fn data_read_ahead_enabled(&self) -> bool {
+        delegate_store!(self, data_read_ahead_enabled())
+    }
+
     fn get_store_stats_service(&self) -> Arc<StoreStatsService> {
         delegate_store!(self, get_store_stats_service())
     }
@@ -589,7 +598,7 @@ macro_rules! message_store_methods {
         delegate_store!(self, get_commit_log_mut())
     }
 
-    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError> {
+    fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), StoreError> {
         delegate_store!(self, set_commitlog_read_mode(read_ahead_mode))
     }
 
@@ -689,7 +698,7 @@ macro_rules! message_store_methods {
         delegate_store!(self, set_broker_init_max_offset(broker_init_max_offset));
     }
 
-    fn sync_broker_role(&mut self, broker_role: BrokerRole) {
+    fn sync_broker_role(&self, broker_role: BrokerRole) {
         delegate_store!(self, sync_broker_role(broker_role));
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -158,6 +158,7 @@ use crate::message_store::recovery::RecoveryIndexRepairPolicy;
 use crate::message_store::recovery::RecoveryPhase;
 use crate::message_store::recovery::RecoveryPlan;
 use crate::message_store::recovery::RecoveryReport;
+use crate::message_store::runtime_state::StoreRuntimeState;
 use crate::queue::build_consume_queue::CommitLogDispatcherBuildConsumeQueue;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueLookupHandle;
@@ -202,6 +203,7 @@ impl MessageArrivalCapability {
 #[derive(Clone)]
 struct ReputRuntimeContext {
     message_store_config: Arc<MessageStoreConfig>,
+    store_runtime_state: Arc<StoreRuntimeState>,
     max_delay_level: i32,
     delay_level_table: Arc<BTreeMap<i32, i64>>,
     store_stats_service: Arc<StoreStatsService>,
@@ -611,6 +613,7 @@ impl TimerMessageWriteHandle {
 ///Using local files to store message data, which is also the default method.
 pub struct LocalFileMessageStore {
     message_store_config: Arc<MessageStoreConfig>,
+    store_runtime_state: Arc<StoreRuntimeState>,
     composition: LocalStoreComposition,
     broker_config: Arc<BrokerConfig>,
     put_message_hook_list: HookRegistry<dyn PutMessageHook + Send + Sync>,
@@ -815,8 +818,10 @@ impl LocalFileMessageStore {
             max_delay_level,
             delay_level_table.clone(),
         );
+        let store_runtime_state = Arc::new(StoreRuntimeState::new(message_store_config.as_ref()));
         let mut commit_log = CommitLog::new(
             message_store_config.clone(),
+            Arc::clone(&store_runtime_state),
             broker_config.clone(),
             store_context,
             dispatcher.handle(),
@@ -866,6 +871,7 @@ impl LocalFileMessageStore {
         });
         Ok(Self {
             message_store_config: message_store_config.clone(),
+            store_runtime_state,
             composition: LocalStoreComposition::new(local_backend_config),
             broker_config,
             put_message_hook_list: HookRegistry::new(),
@@ -1064,7 +1070,7 @@ impl LocalFileMessageStore {
     pub fn is_transient_store_pool_enable(&self) -> bool {
         self.message_store_config.transient_store_pool_enable
             && (self.broker_config.enable_controller_mode
-                || self.message_store_config().broker_role != BrokerRole::Slave)
+                || self.store_runtime_state.broker_role() != BrokerRole::Slave)
     }
 
     pub fn set_message_store_arc(&mut self, message_store_arc: ArcMut<LocalFileMessageStore>) {
@@ -1287,7 +1293,7 @@ impl LocalFileMessageStore {
     }
 
     fn should_run_timer_dequeue(&self) -> bool {
-        self.message_store_config.is_timer_wheel_enable() && self.message_store_config.broker_role != BrokerRole::Slave
+        self.message_store_config.is_timer_wheel_enable() && self.store_runtime_state.broker_role() != BrokerRole::Slave
     }
 
     fn sync_timer_message_store_role(&self) {
@@ -1296,18 +1302,18 @@ impl LocalFileMessageStore {
         }
     }
 
-    fn refresh_controller_confirm_offset_after_role_change(&mut self) {
+    fn refresh_controller_confirm_offset_after_role_change(&self) {
         if !self.broker_config.enable_controller_mode {
             return;
         }
 
         let min_phy_offset = self.get_min_phy_offset();
         let max_phy_offset = self.get_max_phy_offset().max(min_phy_offset);
-        let next_confirm_offset = match self.message_store_config.broker_role {
+        let next_confirm_offset = match self.store_runtime_state.broker_role() {
             BrokerRole::Slave => self.commit_log.get_confirm_offset_directly(),
             _ => self.commit_log.get_confirm_offset(),
         };
-        self.set_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
+        self.publish_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
     }
 }
 
@@ -1949,7 +1955,8 @@ impl LocalFileMessageStore {
 
     pub fn next_offset_correction(&self, old_offset: i64, new_offset: i64) -> i64 {
         let mut next_offset = old_offset;
-        if self.message_store_config.broker_role != BrokerRole::Slave || self.message_store_config.offset_check_in_slave
+        if self.store_runtime_state.broker_role() != BrokerRole::Slave
+            || self.message_store_config.offset_check_in_slave
         {
             next_offset = new_offset;
         }
@@ -1974,6 +1981,7 @@ impl LocalFileMessageStore {
     fn reput_runtime_context(&self) -> ReputRuntimeContext {
         ReputRuntimeContext {
             message_store_config: self.message_store_config.clone(),
+            store_runtime_state: Arc::clone(&self.store_runtime_state),
             max_delay_level: self.max_delay_level,
             delay_level_table: Arc::new(self.delay_level_table_ref().clone()),
             store_stats_service: self.store_stats_service.clone(),
@@ -3696,7 +3704,7 @@ impl MessageStore for LocalFileMessageStore {
         }
     }
 
-    fn delete_topics(&mut self, delete_topics: Vec<&CheetahString>) -> i32 {
+    fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> i32 {
         let delete_topics = delete_topics.into_iter().cloned().collect::<Vec<_>>();
         self.delete_topics_inner(&delete_topics)
     }
@@ -3901,6 +3909,14 @@ impl MessageStore for LocalFileMessageStore {
         self.message_store_config.as_ref()
     }
 
+    fn current_broker_role(&self) -> BrokerRole {
+        self.store_runtime_state.broker_role()
+    }
+
+    fn data_read_ahead_enabled(&self) -> bool {
+        self.store_runtime_state.data_read_ahead_enable()
+    }
+
     fn get_store_stats_service(&self) -> Arc<StoreStatsService> {
         self.store_stats_service.clone()
     }
@@ -3925,9 +3941,8 @@ impl MessageStore for LocalFileMessageStore {
         &mut self.commit_log
     }
 
-    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError> {
+    fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), StoreError> {
         let data_read_ahead_enable = read_ahead_mode == MADV_NORMAL;
-        Arc::make_mut(&mut self.message_store_config).data_read_ahead_enable = data_read_ahead_enable;
         self.commit_log.set_data_read_ahead_enable(data_read_ahead_enable);
         self.commit_log.scan_file_and_set_read_mode(read_ahead_mode);
         Ok(())
@@ -3966,7 +3981,7 @@ impl MessageStore for LocalFileMessageStore {
     }
 
     fn is_sync_master(&self) -> bool {
-        self.message_store_config.broker_role == BrokerRole::SyncMaster
+        self.store_runtime_state.broker_role() == BrokerRole::SyncMaster
     }
 
     fn assign_offset(&self, msg: &mut MessageExtBrokerInner) -> Result<(), StoreError> {
@@ -4065,8 +4080,7 @@ impl MessageStore for LocalFileMessageStore {
             .store(broker_init_max_offset, Ordering::SeqCst);
     }
 
-    fn sync_broker_role(&mut self, broker_role: BrokerRole) {
-        Arc::make_mut(&mut self.message_store_config).broker_role = broker_role;
+    fn sync_broker_role(&self, broker_role: BrokerRole) {
         self.commit_log.sync_broker_role(broker_role);
         self.refresh_controller_confirm_offset_after_role_change();
         self.sync_timer_message_store_role();
@@ -5298,7 +5312,7 @@ impl ReputMessageServiceInner {
                         std::cmp::Ordering::Greater => {
                             // Update stats before moving dispatch_request
                             if !self.runtime_context.message_store_config.duplication_enable
-                                && self.runtime_context.message_store_config.broker_role == BrokerRole::Slave
+                                && self.runtime_context.store_runtime_state.broker_role() == BrokerRole::Slave
                             {
                                 self.runtime_context
                                     .store_stats_service
@@ -5472,7 +5486,7 @@ impl ReputMessageServiceInner {
                     std::cmp::Ordering::Greater => {
                         // Update stats before moving dispatch_request
                         if !self.runtime_context.message_store_config.duplication_enable
-                            && self.runtime_context.message_store_config.broker_role == BrokerRole::Slave
+                            && self.runtime_context.store_runtime_state.broker_role() == BrokerRole::Slave
                         {
                             self.runtime_context
                                 .store_stats_service
@@ -8265,7 +8279,7 @@ mod tests {
     #[test]
     fn sync_broker_role_updates_timer_dequeue_state() {
         let temp_dir = tempdir().unwrap();
-        let mut store = new_configured_test_store_with_broker(
+        let store = new_configured_test_store_with_broker(
             &temp_dir,
             MessageStoreConfig {
                 timer_wheel_enable: true,
@@ -8282,9 +8296,11 @@ mod tests {
         assert!(!timer_message_store.is_should_running_dequeue());
 
         store.sync_broker_role(BrokerRole::SyncMaster);
+        assert_eq!(store.current_broker_role(), BrokerRole::SyncMaster);
         assert!(timer_message_store.is_should_running_dequeue());
 
         store.sync_broker_role(BrokerRole::Slave);
+        assert_eq!(store.current_broker_role(), BrokerRole::Slave);
         assert!(!timer_message_store.is_should_running_dequeue());
 
         store.sync_broker_role(BrokerRole::AsyncMaster);

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -823,7 +823,7 @@ impl MessageStore for RocksDBMessageStore {
         self.local_file_store.slave_fall_behind_much()
     }
 
-    fn delete_topics(&mut self, delete_topics: Vec<&CheetahString>) -> i32 {
+    fn delete_topics(&self, delete_topics: Vec<&CheetahString>) -> i32 {
         for topic in &delete_topics {
             if let Err(error) = self.root.derived().delete_topic(topic.as_str()) {
                 warn!(topic = %topic, error = %error, "failed to delete RocksDB consume queue topic state");
@@ -985,6 +985,14 @@ impl MessageStore for RocksDBMessageStore {
         self.local_file_store.message_store_config_ref()
     }
 
+    fn current_broker_role(&self) -> BrokerRole {
+        self.local_file_store.current_broker_role()
+    }
+
+    fn data_read_ahead_enabled(&self) -> bool {
+        self.local_file_store.data_read_ahead_enabled()
+    }
+
     fn get_store_stats_service(&self) -> Arc<StoreStatsService> {
         self.local_file_store.get_store_stats_service()
     }
@@ -1009,7 +1017,7 @@ impl MessageStore for RocksDBMessageStore {
         self.local_file_store.get_commit_log_mut()
     }
 
-    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError> {
+    fn set_commitlog_read_mode(&self, read_ahead_mode: i32) -> Result<(), StoreError> {
         self.local_file_store.set_commitlog_read_mode(read_ahead_mode)
     }
 
@@ -1113,7 +1121,7 @@ impl MessageStore for RocksDBMessageStore {
         self.local_file_store.set_broker_init_max_offset(broker_init_max_offset);
     }
 
-    fn sync_broker_role(&mut self, broker_role: BrokerRole) {
+    fn sync_broker_role(&self, broker_role: BrokerRole) {
         self.local_file_store.sync_broker_role(broker_role);
     }
 

--- a/rocketmq-store/src/message_store/runtime_state.rs
+++ b/rocketmq-store/src/message_store/runtime_state.rs
@@ -1,0 +1,74 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use rocketmq_common::common::broker::broker_role::BrokerRole;
+
+use crate::config::message_store_config::MessageStoreConfig;
+
+const ASYNC_MASTER: u8 = 0;
+const SYNC_MASTER: u8 = 1;
+const SLAVE: u8 = 2;
+
+/// Narrow state for Store settings that may change while shared readers are active.
+pub(crate) struct StoreRuntimeState {
+    broker_role: AtomicU8,
+    data_read_ahead_enable: AtomicBool,
+}
+
+impl StoreRuntimeState {
+    pub(crate) fn new(config: &MessageStoreConfig) -> Self {
+        Self {
+            broker_role: AtomicU8::new(Self::encode_role(config.broker_role)),
+            data_read_ahead_enable: AtomicBool::new(config.data_read_ahead_enable),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn broker_role(&self) -> BrokerRole {
+        match self.broker_role.load(Ordering::Acquire) {
+            ASYNC_MASTER => BrokerRole::AsyncMaster,
+            SYNC_MASTER => BrokerRole::SyncMaster,
+            SLAVE => BrokerRole::Slave,
+            _ => unreachable!("Store broker role is written only through the validated encoder"),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn set_broker_role(&self, broker_role: BrokerRole) {
+        self.broker_role
+            .store(Self::encode_role(broker_role), Ordering::Release);
+    }
+
+    #[inline]
+    pub(crate) fn data_read_ahead_enable(&self) -> bool {
+        self.data_read_ahead_enable.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub(crate) fn set_data_read_ahead_enable(&self, enabled: bool) {
+        self.data_read_ahead_enable.store(enabled, Ordering::Release);
+    }
+
+    const fn encode_role(broker_role: BrokerRole) -> u8 {
+        match broker_role {
+            BrokerRole::AsyncMaster => ASYNC_MASTER,
+            BrokerRole::SyncMaster => SYNC_MASTER,
+            BrokerRole::Slave => SLAVE,
+        }
+    }
+}

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -499,44 +499,6 @@
       "adr": "ADR-013"
     },
     {
-      "identity": "5b0ce4895f6edc75d47a6de2",
-      "path": "rocketmq-broker/src/failover/escape_bridge_capability.rs",
-      "symbol": "ArcMut",
-      "kind": "constructor",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "699a02b5525bda62309d1072",
-          "fingerprint": "065faebc51f3b7f1f1ced9c2",
-          "item": "fn new",
-          "line": 131
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
-      "identity": "e460a18e6440058bc50fdca5",
-      "path": "rocketmq-broker/src/failover/escape_bridge_capability.rs",
-      "symbol": "ArcMut",
-      "kind": "type_reference",
-      "category": "production",
-      "occurrences": [
-        {
-          "id": "8cf896d0e7854a3d1ad89efe",
-          "fingerprint": "2aecfa7cb469c22fd22208e2",
-          "item": "struct LegacyEscapeStoreOwner",
-          "line": 127
-        }
-      ],
-      "owner": "broker",
-      "reason": "Legacy shared-mutation type or propagated alias dependency pending ownership migration",
-      "remove_by": "M05",
-      "adr": "ADR-002"
-    },
-    {
       "identity": "9df6be4b83a40eddcebc37be",
       "path": "rocketmq-store/src/message_store/local_file_message_store.rs",
       "symbol": "ArcMut",
@@ -566,7 +528,7 @@
           "id": "2fe46ccfd39fbe3e6291e485",
           "fingerprint": "36bf179549bc6842180b8dfd",
           "item": "fn set_message_store_arc",
-          "line": 1070
+          "line": 1076
         }
       ],
       "owner": "store",
@@ -648,7 +610,7 @@
           "id": "746542483fffcc017c2b2e5b",
           "fingerprint": "f03c49a9cf69fb66e5e947be",
           "item": "mod rocksdb_message_store",
-          "line": 39
+          "line": 40
         }
       ],
       "owner": "store",
@@ -667,25 +629,25 @@
           "id": "36361cc6ccd2b916d08d4dec",
           "fingerprint": "f188643beba2ccecef5f9da0",
           "item": "enum GenericMessageStore",
-          "line": 75
+          "line": 76
         },
         {
           "id": "f6a3c6581db220e1627690d6",
           "fingerprint": "131520c4ce58aed471b5ee64",
           "item": "enum GenericMessageStore",
-          "line": 78
+          "line": 79
         },
         {
           "id": "98f940f936e81a1ad86d929b",
           "fingerprint": "ae926679a6245276015ae367",
           "item": "fn local_file",
-          "line": 82
+          "line": 83
         },
         {
           "id": "3c5132015f64c8e2b0630601",
           "fingerprint": "f19745ebb78552b6636b9aca",
           "item": "fn rocksdb",
-          "line": 87
+          "line": 88
         }
       ],
       "owner": "store",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8635

### Brief Description

Remove the final Broker production `ArcMut` Store owner and let `BrokerRuntimeInner` own `Arc<OwnedMessageStore>` directly. EscapeBridge, Admin reads, and shared append now retain only weak providers and upgrade request-scoped standard Arc leases.

Add a narrow atomic Store runtime state for online broker-role and CommitLog read-ahead changes. Local, RocksDB, owned Store, CommitLog, Timer, offset correction, and Reput paths consume the shared state without a broad synchronous lock or unsafe mutable aliasing. Preserve exclusive lifecycle mutation through provider detach plus `Arc::get_mut`, and keep Broker configuration generations aligned with dynamic Store controls.

Reduce the reviewed ArcMut baseline from 28 identities / 67 occurrences to 26 / 65, close R01 at Broker production 0 / 0, and update the migration checklist to 14 of 31 execution units complete.

### How Did You Test This Change?

- `cargo check -p rocketmq-store --all-targets`
- `cargo check -p rocketmq-broker --all-targets --all-features`
- `cargo check -p rocketmq-proxy-local --all-targets --all-features`
- Focused Store role/controller tests: 2 passed.
- Focused Broker owner, lifecycle, read-mode, role, configuration, append, and source-contract tests: 9 passed.
- `python scripts/arc_mut_guard.py`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- RocksDB specialized Clippy and tests: foundation 82 passed, semantics 9 passed, Broker rocksdb 21 passed, pop consumer 4 passed.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved broker message-store lifecycle and failover handling for greater runtime stability.
  * Broker role changes, commit-log read modes, and read-ahead settings now update more consistently while running.
  * Topic deletion and related store operations can proceed with less disruption.
  * Improved handling of temporarily unavailable message stores during administrative and failover operations.

* **Documentation**
  * Updated architecture migration plans, readiness tracking, and completion metrics to reflect the latest broker improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->