### PR TITLE
[ISSUE #8651]🐛Preserve native command arguments in container verification

### DIFF
--- a/scripts/container-supply-chain.ps1
+++ b/scripts/container-supply-chain.ps1
@@ -26,14 +26,16 @@ Set-StrictMode -Version Latest
 function Invoke-Checked {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Command,
+        # PowerShell abbreviates named parameters, so `Command` would consume
+        # native `-c` arguments intended for tools such as /bin/sh.
+        [string]$Executable,
         [Parameter(ValueFromRemainingArguments = $true)]
         [string[]]$Arguments
     )
 
-    & $Command @Arguments
+    & $Executable @Arguments
     if ($LASTEXITCODE -ne 0) {
-        throw "$Command failed with exit code $LASTEXITCODE"
+        throw "$Executable failed with exit code $LASTEXITCODE"
     }
 }
 

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -328,6 +328,8 @@ def audit_foundation(
     for fragment in script_fragments:
         if fragment not in supply_script:
             findings.append(f"container supply-chain script missing: {fragment}")
+    if supply_script.count("[string]$Executable") < 1 or "[string]$Command" in supply_script:
+        findings.append("container supply-chain native runner must reserve -c for executable arguments")
     if "--ignore-unfixed" in supply_script:
         findings.append("critical vulnerability gate must not ignore unfixed findings")
 
@@ -349,6 +351,8 @@ def audit_foundation(
     for fragment in service_script_fragments:
         if fragment not in service_script:
             findings.append(f"service image contract script missing: {fragment}")
+    if service_script.count("[string]$Executable") < 2 or "[string]$Command" in service_script:
+        findings.append("service image native runners must reserve -c for executable arguments")
     if "--ignore-unfixed" in service_script:
         findings.append("service image CRITICAL vulnerability gate must not ignore unfixed findings")
     return findings

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -23,28 +23,31 @@ Set-StrictMode -Version Latest
 function Invoke-Checked {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Command,
+        # PowerShell abbreviates named parameters, so `Command` would consume
+        # native `-c` arguments intended for tools such as /bin/sh.
+        [string]$Executable,
         [Parameter(ValueFromRemainingArguments = $true)]
         [string[]]$Arguments
     )
 
-    & $Command @Arguments
+    & $Executable @Arguments
     if ($LASTEXITCODE -ne 0) {
-        throw "$Command failed with exit code $LASTEXITCODE"
+        throw "$Executable failed with exit code $LASTEXITCODE"
     }
 }
 
 function Invoke-Captured {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Command,
+        # Keep native switches distinct from this wrapper's named parameters.
+        [string]$Executable,
         [Parameter(ValueFromRemainingArguments = $true)]
         [string[]]$Arguments
     )
 
-    $output = (& $Command @Arguments | Out-String).Trim()
+    $output = (& $Executable @Arguments | Out-String).Trim()
     if ($LASTEXITCODE -ne 0) {
-        throw "$Command failed with exit code $LASTEXITCODE"
+        throw "$Executable failed with exit code $LASTEXITCODE"
     }
     return $output
 }

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -16,8 +16,11 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -191,6 +194,97 @@ class ContainerFoundationTests(unittest.TestCase):
 
         weakened = self.service_script.replace("docker stop --signal SIGTERM --timeout 30", "docker kill", 1)
         self.assertTrue(any("docker stop --signal SIGTERM" in finding for finding in self.audit(service_script=weakened)))
+
+    def test_native_dash_c_arguments_are_preserved_by_real_script_helpers(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        self.assertIsNotNone(powershell, "PowerShell is required to validate container scripts")
+        payload = "set -eu; test native-argument-preserved = native-argument-preserved"
+        harness = r"""
+param(
+    [string]$SourcePath,
+    [string]$FunctionName,
+    [string]$PythonPath,
+    [string]$OutputPath,
+    [string]$Payload
+)
+$ErrorActionPreference = "Stop"
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $SourcePath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    throw "failed to parse source helper: $($parseErrors[0].Message)"
+}
+$definition = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq $FunctionName
+}, $true)
+if ($null -eq $definition) {
+    throw "missing helper: $FunctionName"
+}
+Invoke-Expression $definition.Extent.Text
+if ($FunctionName -eq "Invoke-Checked") {
+    Invoke-Checked $PythonPath -c `
+        'import json,pathlib,sys; pathlib.Path(sys.argv[2]).write_text(json.dumps(sys.argv[1:2]))' `
+        $Payload $OutputPath
+}
+elseif ($FunctionName -eq "Invoke-Captured") {
+    $captured = Invoke-Captured $PythonPath -c 'import sys; sys.stdout.write(sys.argv[1])' $Payload
+    [System.IO.File]::WriteAllText($OutputPath, $captured)
+}
+else {
+    throw "unsupported helper: $FunctionName"
+}
+"""
+        cases = (
+            ("container-supply-chain.ps1", "Invoke-Checked", [payload]),
+            ("service-image-contract.ps1", "Invoke-Checked", [payload]),
+            ("service-image-contract.ps1", "Invoke-Captured", payload),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            harness_path = temporary / "native-argument-harness.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            for index, (source_name, function_name, expected) in enumerate(cases):
+                with self.subTest(source=source_name, helper=function_name):
+                    output_path = temporary / f"result-{index}.json"
+                    result = subprocess.run(
+                        [
+                            powershell,
+                            "-NoProfile",
+                            "-File",
+                            str(harness_path),
+                            str(ROOT / "scripts" / source_name),
+                            function_name,
+                            sys.executable,
+                            str(output_path),
+                            payload,
+                        ],
+                        cwd=ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    actual = (
+                        json.loads(output_path.read_text(encoding="utf-8"))
+                        if isinstance(expected, list)
+                        else output_path.read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(expected, actual)
+
+    def test_native_runner_parameter_collision_is_rejected(self) -> None:
+        supply_script = self.supply_script.replace("[string]$Executable", "[string]$Command", 1)
+        findings = self.audit(supply_script=supply_script)
+        self.assertTrue(any("reserve -c" in finding for finding in findings))
+
+        service_script = self.service_script.replace("[string]$Executable", "[string]$Command", 1)
+        findings = self.audit(service_script=service_script)
+        self.assertTrue(any("reserve -c" in finding for finding in findings))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8651

### Brief Description

- rename the native command wrapper parameter so PowerShell cannot abbreviate native `-c` as the wrapper's `Command` parameter
- cover both checked and captured invocations used by the runtime-base and five service-image verification paths
- make the container guard reject reintroduction of the collision
- execute the real PowerShell helper ASTs in a focused regression test with a native `-c` payload

### How Did You Test This Change?

- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation -v` (11 passed)
- parsed `scripts/container-supply-chain.ps1` and `scripts/service-image-contract.ps1` with the PowerShell AST parser
- `git diff --check`

The Docker-backed Container Foundation workflow will be rerun on the merged `main` revision to collect the dynamic R20 evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved native runner arguments, including `-c`, when executing container-related scripts.
  * Improved validation to detect and reject parameter collisions that could alter command-line behavior.
  * Updated error reporting to clearly identify the executable that failed.

* **Tests**
  * Added coverage for command argument preservation and detection of conflicting runner parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->