### PR TITLE
[ISSUE #8653]🐛Avoid reserved PowerShell platform variable in Kubernetes validation

### DIFF
--- a/scripts/kubernetes-assets-contract.ps1
+++ b/scripts/kubernetes-assets-contract.ps1
@@ -28,7 +28,7 @@ $artifactsRoot = Join-Path $repoRoot $ArtifactsDirectory
 $cacheRoot = Join-Path $toolsRoot "archives"
 New-Item -ItemType Directory -Force -Path $toolsRoot, $artifactsRoot, $cacheRoot | Out-Null
 
-$isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+$hostIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
     [System.Runtime.InteropServices.OSPlatform]::Windows
 )
 if (-not [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.Equals(
@@ -36,9 +36,9 @@ if (-not [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.Equ
     )) {
     throw "M11-09 validation supports only amd64 hosts"
 }
-$platform = if ($isWindows) { "windows_amd64" } else { "linux_amd64" }
-$archiveSuffix = if ($isWindows) { ".zip" } else { ".tar.gz" }
-$executableSuffix = if ($isWindows) { ".exe" } else { "" }
+$platform = if ($hostIsWindows) { "windows_amd64" } else { "linux_amd64" }
+$archiveSuffix = if ($hostIsWindows) { ".zip" } else { ".tar.gz" }
+$executableSuffix = if ($hostIsWindows) { ".exe" } else { "" }
 
 function Get-ToolSpec {
     param([Parameter(Mandatory)][string]$Name)
@@ -97,7 +97,7 @@ function Install-PinnedTool {
         Remove-Item -LiteralPath $extractRoot -Recurse -Force
     }
     New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
-    if ($isWindows) {
+    if ($hostIsWindows) {
         Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
     } else {
         & tar -xzf $archive -C $extractRoot
@@ -112,7 +112,7 @@ function Install-PinnedTool {
         throw "$($Spec.Name) executable was not present in the verified archive"
     }
     Copy-Item -LiteralPath $candidate.FullName -Destination $destination -Force
-    if (-not $isWindows) {
+    if (-not $hostIsWindows) {
         & chmod 0755 $destination
         if ($LASTEXITCODE -ne 0) {
             throw "failed to mark $($Spec.Name) executable"

--- a/scripts/kubernetes_assets_guard.py
+++ b/scripts/kubernetes_assets_guard.py
@@ -348,6 +348,13 @@ def validate_source_assets(guard: Guard) -> None:
     for relative in required:
         guard.read(relative)
 
+    contract_script = guard.read("scripts/kubernetes-assets-contract.ps1")
+    guard.require("$hostIsWindows" in contract_script, "asset contract must use a script-owned host platform flag")
+    guard.require(
+        re.search(r"(?i)\$iswindows\b", contract_script) is None,
+        "asset contract must not assign or reference reserved $IsWindows",
+    )
+
     chart_sources = "\n".join(
         guard.read(f"distribution/helm/rocketmq-rust/templates/{name}")
         for name in (

--- a/scripts/tests/test_m11_kubernetes_assets.py
+++ b/scripts/tests/test_m11_kubernetes_assets.py
@@ -135,6 +135,14 @@ class KubernetesAssetsGuardTests(unittest.TestCase):
         result = self.run_guard(expect_success=False)
         self.assertIn("stateless", result.stderr)
 
+    def test_reserved_powershell_platform_variable_is_rejected(self) -> None:
+        path = self.root / "scripts" / "kubernetes-assets-contract.ps1"
+        source = path.read_text(encoding="utf-8")
+        self.assertIn("$hostIsWindows", source)
+        path.write_text(source.replace("$hostIsWindows", "$isWindows"), encoding="utf-8")
+        result = self.run_guard(expect_success=False)
+        self.assertIn("reserved $IsWindows", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8653

### Brief Description

- replace the case-insensitive `$isWindows` collision with a script-owned `$hostIsWindows` platform flag
- update archive selection, executable suffix, extraction, and chmod branches consistently
- make the Kubernetes assets guard reject any future reference to the reserved PowerShell Core `$IsWindows` variable
- add a deliberate-violation regression test

### How Did You Test This Change?

- `python -m py_compile scripts/kubernetes_assets_guard.py scripts/tests/test_m11_kubernetes_assets.py`
- `python scripts/kubernetes_assets_guard.py`
- `python -m unittest scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_service_lifecycle scripts.tests.test_m11_fault_matrix -v` (24 passed)
- parsed `scripts/kubernetes-assets-contract.ps1` with the PowerShell AST parser
- `git diff --check`

The Docker/Helm-backed Kubernetes deployment assets workflow will be rerun on the merged `main` revision to collect dynamic R21 evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection for Kubernetes asset installation across Windows and non-Windows environments.
  * Ensured extraction and permission handling consistently use the detected host platform.

* **Tests**
  * Added validation to prevent use of a reserved PowerShell platform variable.
  * Added coverage confirming invalid platform-variable usage is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->