### PR TITLE
[ISSUE #8655]🐛Normalize SLO text artifact hashes across platforms

### DIFF
--- a/distribution/config/architecture-production-readiness-policy.json
+++ b/distribution/config/architecture-production-readiness-policy.json
@@ -107,6 +107,7 @@
     "production_requires_dynamic_execution": true,
     "production_requires_current_commit": true,
     "fixture_requires_explicit_opt_in": true,
-    "artifact_hash_algorithm": "sha256"
+    "artifact_hash_algorithm": "sha256",
+    "artifact_text_normalization": "lf"
   }
 }

--- a/scripts/architecture_slo_guard.py
+++ b/scripts/architecture_slo_guard.py
@@ -118,12 +118,13 @@ class Guard:
         return path.read_text(encoding="utf-8")
 
 
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as source:
-        for chunk in iter(lambda: source.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+def canonical_text_sha256(path: Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
 def canonical_json_sha256(value: dict[str, Any]) -> str:
@@ -255,6 +256,14 @@ def validate_policy(
         evidence.get("fixture_requires_explicit_opt_in") is True,
         "fixture evidence must require explicit opt-in",
     )
+    guard.require(
+        evidence.get("artifact_hash_algorithm") == "sha256",
+        "artifact hash algorithm must remain sha256",
+    )
+    guard.require(
+        evidence.get("artifact_text_normalization") == "lf",
+        "artifact text normalization must remain lf",
+    )
 
 
 def validate_release_assets(
@@ -331,6 +340,7 @@ def validate_release_assets(
         "architecture_slo_guard.py",
         "dynamic_execution",
         "candidate_commit",
+        "Get-CanonicalTextSha256",
     ):
         guard.require(marker in runner, f"SLO runner contract marker missing: {marker}")
     guard.require(
@@ -542,7 +552,7 @@ def validate_evidence(
         )
         if path.is_file() and isinstance(expected_hash, str):
             guard.require(
-                sha256_file(path) == expected_hash,
+                canonical_text_sha256(path) == expected_hash,
                 f"artifact hash mismatch: {relative}",
             )
         indexed[relative] = str(expected_hash)
@@ -642,7 +652,7 @@ def validate_evidence(
             guard.require(
                 isinstance(expected_hash, str)
                 and path.is_file()
-                and sha256_file(path) == expected_hash,
+                and canonical_text_sha256(path) == expected_hash,
                 f"release artifact hash mismatch: {relative}",
             )
 

--- a/scripts/run-architecture-slo-evidence.ps1
+++ b/scripts/run-architecture-slo-evidence.ps1
@@ -50,9 +50,18 @@ function Assert-True {
     }
 }
 
-function Get-Sha256 {
+function Get-CanonicalTextSha256 {
     param([Parameter(Mandatory)][string]$Path)
-    (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+    $text = [IO.File]::ReadAllText($Path, [Text.UTF8Encoding]::new($false))
+    $normalized = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+    $bytes = [Text.UTF8Encoding]::new($false).GetBytes($normalized)
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try {
+        ([BitConverter]::ToString($sha256.ComputeHash($bytes))).Replace("-", "").ToLowerInvariant()
+    }
+    finally {
+        $sha256.Dispose()
+    }
 }
 
 function Write-Utf8 {
@@ -117,6 +126,7 @@ if ($Mode -eq "Validate") {
     Write-Output "Validate mode completed without dynamic execution or PASS evidence."
     exit 0
 }
+Invoke-Native python @($Guard, '--root', $Root, '--policy-only') | Out-Null
 
 Assert-True (-not [string]::IsNullOrWhiteSpace($CandidateCommit)) "CandidateCommit is required"
 Assert-True (-not [string]::IsNullOrWhiteSpace($CandidateImageMap)) "CandidateImageMap is required"
@@ -205,7 +215,7 @@ try {
     function Add-Artifact {
         param([Parameter(Mandatory)][string]$Path)
         $relative = [IO.Path]::GetRelativePath($RunDirectory, $Path).Replace('\', '/')
-        $ArtifactRecords.Add([ordered]@{ path = $relative; sha256 = Get-Sha256 $Path })
+        $ArtifactRecords.Add([ordered]@{ path = $relative; sha256 = Get-CanonicalTextSha256 $Path })
         $relative
     }
     Add-Artifact $SamplesPath | Out-Null
@@ -270,7 +280,7 @@ try {
     $ReleaseArtifacts = [ordered]@{}
     foreach ($property in $Policy.release_artifacts.PSObject.Properties) {
         $path = Join-Path $Root ([string]$property.Value)
-        $ReleaseArtifacts[[string]$property.Value] = Get-Sha256 $path
+        $ReleaseArtifacts[[string]$property.Value] = Get-CanonicalTextSha256 $path
     }
     $Rollback = [ordered]@{
         baseline_images_restored = [bool]$FaultRun.global_assertions.rollback_verified
@@ -302,7 +312,7 @@ try {
         missing_sample_ratio = $MissingSampleRatio
         dynamic_execution = $true
         fixture = $false
-        fault_evidence = [ordered]@{ path = $FaultRelative; sha256 = Get-Sha256 $FaultSnapshotPath }
+        fault_evidence = [ordered]@{ path = $FaultRelative; sha256 = Get-CanonicalTextSha256 $FaultSnapshotPath }
         objectives = @($ObjectiveRecords)
         rollback_assertions = $Rollback
         unresolved_alerts = @()

--- a/scripts/tests/fixtures/m11-slo/pass/run.json
+++ b/scripts/tests/fixtures/m11-slo/pass/run.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "milestone": "M11-12",
   "execution_unit": "R24",
-  "policy_sha256": "861dfd1228cf2ffdde988b1543daa93b3827240d3cb3ca0f8d6c1ab3b9ed96cc",
+  "policy_sha256": "0a56c4d1d1e4907a251673e4fe589313602e953dca740e765435c330a1304b1e",
   "candidate_commit": "0123456789abcdef0123456789abcdef01234567",
   "candidate_images": {
     "broker": "registry.example.invalid/rocketmq/broker@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
@@ -98,7 +98,7 @@
     "distribution/config/prometheus-architecture-production-readiness-alerts.yaml": "53e35ad621710dd8c2cbac5eff6012a631ec7215e019d4e533ae35efb0cd1a1f",
     "rocketmq-doc/en/architecture-production-readiness-runbook.md": "a3252fcc7243e92fa02ae9205f5450958cd9387db8ee73d315c0cd2606314eb1",
     "distribution/kubernetes/fault-matrix-policy.json": "771b3abf35213a4b6fbb3626d7822e11e6a17d9609ae7587d309bcaf2a5cdd37",
-    "scripts/telemetry-semantic-registry.json": "798e6e381ea03ce896027b69423101124b0cec17c20c2068bda39c36021333b6"
+    "scripts/telemetry-semantic-registry.json": "5211cf7882663b4220236facaa14a68c507fef60a5b1081de1be1867cd5ce277"
   },
   "artifacts": [
     {

--- a/scripts/tests/test_architecture_slo_guard.py
+++ b/scripts/tests/test_architecture_slo_guard.py
@@ -144,6 +144,21 @@ class ArchitectureSloGuardTests(unittest.TestCase):
         )
         self.assertIn("artifact hash mismatch", result.stderr)
 
+    def test_text_hashes_are_stable_across_line_endings(self) -> None:
+        paths = (
+            self.root / "scripts" / "telemetry-semantic-registry.json",
+            self.root / FIXTURE / "artifacts" / "fault-run.json",
+            self.root / FIXTURE / "artifacts" / "objectives.txt",
+        )
+        for path in paths:
+            normalized = (
+                path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            )
+            path.write_bytes(normalized.replace(b"\n", b"\r\n"))
+        self.run_guard(
+            "--evidence", str(FIXTURE), "--allow-fixture", expect_success=True
+        )
+
     def test_unregistered_dashboard_metric_is_rejected(self) -> None:
         dashboard = (
             self.root


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8655

### Brief Description

- define LF normalization as part of the R24 text-artifact SHA-256 policy
- use the same canonical text hash in the PowerShell producer and Python validator
- bind dynamic execution to a policy-only guard before the six-hour soak starts
- update the fixture policy/registry hashes
- prove CRLF/LF equivalence while retaining fail-closed content-tamper checks

### How Did You Test This Change?

- `python -m py_compile scripts/architecture_slo_guard.py scripts/tests/test_architecture_slo_guard.py`
- `python scripts/architecture_slo_guard.py --policy-only`
- `python scripts/architecture_slo_guard.py --evidence scripts/tests/fixtures/m11-slo/pass --allow-fixture`
- `python -m unittest scripts.tests.test_architecture_slo_guard -v` (10 passed)
- `.\scripts\run-architecture-slo-evidence.ps1 -Mode Validate`
- parsed `scripts/run-architecture-slo-evidence.ps1` with the PowerShell AST parser
- `git diff --check`