### PR TITLE
[ISSUE #8657]🐛Own container tmpfs mounts with the non-root runtime identity

### DIFF
--- a/scripts/container-supply-chain.ps1
+++ b/scripts/container-supply-chain.ps1
@@ -51,6 +51,7 @@ $outputPath = Join-Path $root $OutputDirectory
 New-Item -ItemType Directory -Force -Path $outputPath | Out-Null
 
 $policy = Get-Content -Raw -LiteralPath (Join-Path $root "docker/container-policy.json") | ConvertFrom-Json
+$tmpfsOptions = "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m,uid=$($policy.runtime.uid),gid=$($policy.runtime.gid),mode=0700"
 $sourceCommit = (& git -C $root rev-parse HEAD).Trim()
 $sourceEpoch = (& git -C $root show -s --format=%ct HEAD).Trim()
 if ($LASTEXITCODE -ne 0) {
@@ -84,7 +85,7 @@ $smoke = @(
     "touch $($policy.runtime.writable_data_path)/data-write",
     "touch $($policy.runtime.tmpfs_path)/tmp-write"
 ) -join "; "
-Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m" $ImageRef /bin/sh -c $smoke
+Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs $tmpfsOptions $ImageRef /bin/sh -c $smoke
 
 $sbomPath = Join-Path $outputPath "runtime-base.cdx.json"
 $trivyPath = Join-Path $outputPath "runtime-base.trivy.json"

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -328,6 +328,13 @@ def audit_foundation(
     for fragment in script_fragments:
         if fragment not in supply_script:
             findings.append(f"container supply-chain script missing: {fragment}")
+    tmpfs_ownership = (
+        "uid=$($policy.runtime.uid)",
+        "gid=$($policy.runtime.gid)",
+        "mode=0700",
+    )
+    if any(fragment not in supply_script for fragment in tmpfs_ownership):
+        findings.append("container supply-chain tmpfs must be owned by the non-root runtime identity")
     if supply_script.count("[string]$Executable") < 1 or "[string]$Command" in supply_script:
         findings.append("container supply-chain native runner must reserve -c for executable arguments")
     if "--ignore-unfixed" in supply_script:
@@ -351,6 +358,8 @@ def audit_foundation(
     for fragment in service_script_fragments:
         if fragment not in service_script:
             findings.append(f"service image contract script missing: {fragment}")
+    if any(fragment not in service_script for fragment in tmpfs_ownership):
+        findings.append("service image tmpfs must be owned by the non-root runtime identity")
     if service_script.count("[string]$Executable") < 2 or "[string]$Command" in service_script:
         findings.append("service image native runners must reserve -c for executable arguments")
     if "--ignore-unfixed" in service_script:

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -61,6 +61,7 @@ foreach ($command in @("docker", "syft", "trivy", "cosign", "git")) {
 $root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $policyPath = Join-Path $root "docker/container-policy.json"
 $policy = Get-Content -Raw -LiteralPath $policyPath | ConvertFrom-Json
+$tmpfsOptions = "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m,uid=$($policy.runtime.uid),gid=$($policy.runtime.gid),mode=0700"
 $dockerfilePath = (Resolve-Path (Join-Path $root $policy.foundation_dockerfile)).Path
 $smokeConfigPath = (Resolve-Path (Join-Path $root $policy.smoke_config_directory)).Path
 $outputPath = Join-Path $root $OutputDirectory
@@ -135,7 +136,7 @@ try {
             throw "$serviceName runtime image contains binaries outside its owner boundary: $($ownedBinaries -join ',')"
         }
 
-        & docker run --rm --network none --read-only --tmpfs "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m" $imageRef *> $null
+        & docker run --rm --network none --read-only --tmpfs $tmpfsOptions $imageRef *> $null
         if ($LASTEXITCODE -eq 0) {
             throw "$serviceName must fail closed when its required config mount is absent"
         }
@@ -148,11 +149,11 @@ try {
             "touch $($service.data_path)/data-write",
             "touch $($policy.runtime.tmpfs_path)/tmp-write"
         ) -join "; "
-        Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m" --entrypoint /bin/sh $imageRef -c $permissionSmoke
+        Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs $tmpfsOptions --entrypoint /bin/sh $imageRef -c $permissionSmoke
 
         $containerId = ""
         try {
-            $containerId = (Invoke-Captured docker run --detach --interactive --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --mount "type=bind,source=$smokeConfigPath,target=/etc/rocketmq,readonly" --tmpfs "$($policy.runtime.tmpfs_path):rw,noexec,nosuid,size=16m" $imageRef).Trim()
+            $containerId = (Invoke-Captured docker run --detach --interactive --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --mount "type=bind,source=$smokeConfigPath,target=/etc/rocketmq,readonly" --tmpfs $tmpfsOptions $imageRef).Trim()
             Start-Sleep -Seconds 5
             $running = (Invoke-Captured docker inspect --format "{{.State.Running}}" $containerId).Trim()
             if ($running -ne "true") {

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -286,6 +286,16 @@ else {
         findings = self.audit(service_script=service_script)
         self.assertTrue(any("reserve -c" in finding for finding in findings))
 
+    def test_root_owned_tmpfs_regression_is_rejected(self) -> None:
+        ownership = ",uid=$($policy.runtime.uid),gid=$($policy.runtime.gid),mode=0700"
+        supply_script = self.supply_script.replace(ownership, "", 1)
+        findings = self.audit(supply_script=supply_script)
+        self.assertTrue(any("tmpfs must be owned" in finding for finding in findings))
+
+        service_script = self.service_script.replace(ownership, "", 1)
+        findings = self.audit(service_script=service_script)
+        self.assertTrue(any("tmpfs must be owned" in finding for finding in findings))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8657

### Brief Description

- give every Docker verification tmpfs the runtime UID/GID and restrictive mode 0700
- apply the same option set to runtime foundation, missing-config fail-closed, permission, and detached SIGTERM paths
- make the container guard reject root-owned tmpfs regressions
- add deliberate-violation coverage for both production scripts

### How Did You Test This Change?

- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation -v` (12 passed)
- parsed both container PowerShell scripts with the PowerShell AST parser
- `git diff --check`

The Docker-backed Container Foundation workflow will be rerun on merged `main` for dynamic evidence.