### PR TITLE
[ISSUE #8659]🐛Preserve Trivy evidence before enforcing container vulnerability policy

### DIFF
--- a/.github/workflows/container-foundation-ci.yml
+++ b/.github/workflows/container-foundation-ci.yml
@@ -73,6 +73,7 @@ jobs:
           ./scripts/service-image-contract.ps1 -OutputDirectory target/service-images
 
       - name: Upload supply-chain evidence
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-foundation

--- a/scripts/container-supply-chain.ps1
+++ b/scripts/container-supply-chain.ps1
@@ -95,13 +95,13 @@ $privateKey = "$keyPrefix.key"
 $publicKey = "$keyPrefix.pub"
 
 Invoke-Checked syft scan "docker:$ImageRef" --scope all-layers --output "cyclonedx-json=$sbomPath"
-Invoke-Checked trivy image --scanners vuln --severity CRITICAL --exit-code 1 --format json --output $trivyPath $ImageRef
+Invoke-Checked trivy image --scanners vuln --severity CRITICAL --exit-code 0 --format json --output $trivyPath $ImageRef
 $sbom = Get-Content -Raw -LiteralPath $sbomPath | ConvertFrom-Json
 if ($sbom.bomFormat -ne "CycloneDX") {
     throw "Syft output is not a CycloneDX SBOM"
 }
 $trivyReport = Get-Content -Raw -LiteralPath $trivyPath | ConvertFrom-Json
-$criticalFindings = @(
+$criticalVulnerabilities = @(
     foreach ($result in @($trivyReport.Results)) {
         $vulnerabilities = $result.PSObject.Properties["Vulnerabilities"]
         if ($null -ne $vulnerabilities) {
@@ -112,9 +112,18 @@ $criticalFindings = @(
             }
         }
     }
-).Count
+)
+$criticalFindings = $criticalVulnerabilities.Count
 if ($criticalFindings -gt $policy.supply_chain.critical_vulnerability_policy.maximum_findings) {
-    throw "critical vulnerability policy failed: $criticalFindings findings"
+    $criticalSummary = @(
+        $criticalVulnerabilities |
+            Select-Object -First 10 |
+            ForEach-Object {
+                $fixedVersion = if ([string]::IsNullOrWhiteSpace($_.FixedVersion)) { "unfixed" } else { $_.FixedVersion }
+                "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
+            }
+    ) -join "; "
+    throw "critical vulnerability policy failed: $criticalFindings findings; $criticalSummary"
 }
 
 $oldPassword = $env:COSIGN_PASSWORD

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -300,6 +300,7 @@ def audit_foundation(
         "scripts/service-image-contract.ps1",
         "target/container-foundation",
         "target/service-images",
+        "if: always()",
     ):
         if fragment not in workflow:
             findings.append(f"container workflow missing: {fragment}")
@@ -315,7 +316,7 @@ def audit_foundation(
         "cyclonedx-json",
         "--severity",
         "CRITICAL",
-        "--exit-code",
+        "--exit-code 0",
         "cosign",
         "sign-blob",
         "verify-blob",
@@ -324,6 +325,7 @@ def audit_foundation(
         "cosign sign --yes $PublishedImageDigest",
         "cosign verify --certificate-identity-regexp",
         "$policy.supply_chain.signature.published_digest_pattern",
+        "FixedVersion",
     ]
     for fragment in script_fragments:
         if fragment not in supply_script:
@@ -351,9 +353,11 @@ def audit_foundation(
         "find /usr/local/bin",
         "cyclonedx-json",
         "--severity CRITICAL",
+        "--exit-code 0",
         "cosign sign-blob",
         "cosign verify-blob",
         "Remove-Item -LiteralPath $privateKey",
+        "FixedVersion",
     ]
     for fragment in service_script_fragments:
         if fragment not in service_script:

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -177,7 +177,7 @@ try {
         $trivyPath = Join-Path $outputPath "$serviceName.trivy.json"
         $bundlePath = Join-Path $outputPath "$serviceName.sbom.sigstore.json"
         Invoke-Checked syft scan "docker:$imageRef" --scope all-layers --output "cyclonedx-json=$sbomPath"
-        Invoke-Checked trivy image --scanners vuln --severity CRITICAL --exit-code 1 --format json --output $trivyPath $imageRef
+        Invoke-Checked trivy image --scanners vuln --severity CRITICAL --exit-code 0 --format json --output $trivyPath $imageRef
         Invoke-Checked cosign sign-blob --yes --key $privateKey --bundle $bundlePath $sbomPath
         Invoke-Checked cosign verify-blob --key $publicKey --bundle $bundlePath $sbomPath
 
@@ -186,7 +186,7 @@ try {
             throw "$serviceName Syft output is not a CycloneDX SBOM"
         }
         $trivyReport = Get-Content -Raw -LiteralPath $trivyPath | ConvertFrom-Json
-        $criticalFindings = @(
+        $criticalVulnerabilities = @(
             foreach ($result in @($trivyReport.Results)) {
                 $vulnerabilities = $result.PSObject.Properties["Vulnerabilities"]
                 if ($null -ne $vulnerabilities) {
@@ -197,9 +197,18 @@ try {
                     }
                 }
             }
-        ).Count
+        )
+        $criticalFindings = $criticalVulnerabilities.Count
         if ($criticalFindings -gt $policy.supply_chain.critical_vulnerability_policy.maximum_findings) {
-            throw "$serviceName critical vulnerability policy failed: $criticalFindings findings"
+            $criticalSummary = @(
+                $criticalVulnerabilities |
+                    Select-Object -First 10 |
+                    ForEach-Object {
+                        $fixedVersion = if ([string]::IsNullOrWhiteSpace($_.FixedVersion)) { "unfixed" } else { $_.FixedVersion }
+                        "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
+                    }
+            ) -join "; "
+            throw "$serviceName critical vulnerability policy failed: $criticalFindings findings; $criticalSummary"
         }
 
         $evidence.Add([ordered]@{

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -112,6 +112,14 @@ class ContainerFoundationTests(unittest.TestCase):
         weakened = self.supply_script.replace("--severity", "--ignore-unfixed --severity", 1)
         self.assertTrue(any("must not ignore unfixed" in finding for finding in self.audit(supply_script=weakened)))
 
+        premature_exit = self.supply_script.replace("--exit-code 0", "--exit-code 1", 1)
+        self.assertTrue(any("--exit-code 0" in finding for finding in self.audit(supply_script=premature_exit)))
+
+    def test_partial_scan_evidence_upload_is_required(self) -> None:
+        workflow = self.workflow.replace("if: always()", "if: success()", 1)
+        findings = self.audit(workflow=workflow)
+        self.assertTrue(any("if: always()" in finding for finding in findings))
+
     def test_unregistered_dockerfile_or_restored_legacy_exception_is_rejected(self) -> None:
         dockerfiles = set(self.dockerfiles)
         dockerfiles.add("docker/Dockerfile.unreviewed")


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8659

### Brief Description

- make Trivy produce JSON with exit code zero, then enforce the unchanged zero-CRITICAL repository policy
- report CVE, package, installed version, and fixed version for actionable failures
- retain the same evidence-first behavior for the runtime foundation and all five services
- upload partial supply-chain evidence even when a preceding policy step fails
- guard against restoring premature scanner exits or success-only uploads

### How Did You Test This Change?

- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation -v` (13 passed)
- parsed both container PowerShell scripts with the PowerShell AST parser
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`

The Docker-backed workflow will be rerun on merged `main`; any CRITICAL finding remains a hard failure and will now be actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supply-chain evidence is now uploaded even when earlier verification steps fail or are cancelled.
  * Security scans continue through vulnerability findings so complete reports can be generated.
  * Critical vulnerability policy errors now include clearer details, including affected packages, versions, and fix availability.

* **Tests**
  * Added coverage to verify that partial scan evidence uploads remain required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->