### PR TITLE
[ISSUE #8661]🐛Move container runtime to a zero-critical pinned base

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -15,16 +15,17 @@
 # limitations under the License.
 
 ARG BUILDER_IMAGE=docker.io/library/rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777
-ARG RUNTIME_IMAGE=docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+ARG RUNTIME_IMAGE=docker.io/library/ubuntu:noble@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 ARG DEBIAN_SNAPSHOT=20260717T000000Z
 ARG ROCKETMQ_RUST_TOOLCHAIN=nightly-2026-07-05
 
-FROM ${BUILDER_IMAGE} AS builder-base
+FROM ${BUILDER_IMAGE} AS ca-bundle
 
 ARG DEBIAN_SNAPSHOT
-ARG ROCKETMQ_RUST_TOOLCHAIN
 
-# The timestamped Debian snapshot makes package resolution immutable for this foundation revision.
+# Bootstrap the CA bundle from signed, immutable Debian snapshot metadata. The lightweight
+# stage is shared by the builder and runtime without making runtime smoke wait for the
+# Rust toolchain or native build dependencies.
 # hadolint ignore=DL3008
 RUN <<EOF
 set -eux
@@ -49,10 +50,20 @@ SOURCES
 apt-get -o Acquire::Check-Valid-Until=false update
 apt-get install -y --no-install-recommends ca-certificates
 sed -i 's#URIs: http://#URIs: https://#' /etc/apt/sources.list.d/rocketmq-snapshot.sources
+rm -rf /var/lib/apt/lists/*
+EOF
+
+FROM ca-bundle AS builder-base
+
+ARG ROCKETMQ_RUST_TOOLCHAIN
+
+# The timestamped Debian snapshot makes package resolution immutable for this foundation revision.
+# hadolint ignore=DL3008
+RUN <<EOF
+set -eux
 apt-get -o Acquire::Check-Valid-Until=false update
 apt-get install -y --no-install-recommends \
     build-essential \
-    ca-certificates \
     clang \
     cmake \
     git \
@@ -77,40 +88,16 @@ WORKDIR /workspace
 
 FROM ${RUNTIME_IMAGE} AS runtime-base
 
-ARG DEBIAN_SNAPSHOT
 ARG SOURCE_REVISION=unknown
 ARG SOURCE_VERSION=0.0.0-dev
 
-# The timestamped Debian snapshot makes package resolution immutable for this foundation revision.
-# hadolint ignore=DL3008
+# Ubuntu noble supplies the shell, runtime libraries, and user-management tools from the
+# pinned manifest. Copy the CA bundle from the lightweight Debian-snapshot stage instead
+# of resolving mutable packages in the runtime stage.
+COPY --from=ca-bundle /etc/ssl/certs/ /etc/ssl/certs/
+
 RUN <<EOF
 set -eux
-rm -f /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources
-cat > /etc/apt/sources.list.d/rocketmq-snapshot.sources <<SOURCES
-Types: deb
-URIs: http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/
-Suites: bookworm bookworm-updates
-Components: main
-Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-Check-Valid-Until: no
-
-Types: deb
-URIs: http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/
-Suites: bookworm-security
-Components: main
-Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
-Check-Valid-Until: no
-SOURCES
-# The slim image has no CA bundle. The bootstrap fetch is still authenticated by the pinned
-# Debian Release signature and package hashes; all remaining packages switch back to HTTPS.
-apt-get -o Acquire::Check-Valid-Until=false update
-apt-get install -y --no-install-recommends ca-certificates
-sed -i 's#URIs: http://#URIs: https://#' /etc/apt/sources.list.d/rocketmq-snapshot.sources
-apt-get -o Acquire::Check-Valid-Until=false update
-apt-get install -y --no-install-recommends \
-    ca-certificates \
-    libssl3
-rm -rf /var/lib/apt/lists/*
 groupadd --gid 10001 rocketmq
 useradd --uid 10001 --gid 10001 --home-dir /home/rocketmq --create-home --shell /usr/sbin/nologin rocketmq
 install -d -o 10001 -g 10001 /opt/rocketmq /var/lib/rocketmq /tmp/rocketmq

--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -10,8 +10,8 @@
       "source": "https://hub.docker.com/_/rust"
     },
     "runtime": {
-      "reference": "docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
-      "source": "https://hub.docker.com/_/debian"
+      "reference": "docker.io/library/ubuntu:noble@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90",
+      "source": "https://hub.docker.com/_/ubuntu"
     }
   },
   "build": {
@@ -32,9 +32,15 @@
       "pkg-config",
       "protobuf-compiler"
     ],
-    "runtime_packages": [
-      "ca-certificates",
-      "libssl3"
+    "runtime_dependency_source": "pinned-base-image-with-snapshot-ca-bundle",
+    "runtime_base_packages": [
+      "coreutils",
+      "dash",
+      "findutils",
+      "libc6",
+      "libgcc-s1",
+      "libssl3t64",
+      "passwd"
     ],
     "builder_target": "builder-base",
     "runtime_target": "runtime-base",

--- a/scripts/container-supply-chain.ps1
+++ b/scripts/container-supply-chain.ps1
@@ -39,6 +39,31 @@ function Invoke-Checked {
     }
 }
 
+function Format-CriticalVulnerabilitySummary {
+    param(
+        [object[]]$Vulnerabilities
+    )
+
+    $summaries = @(
+        $Vulnerabilities |
+            Select-Object -First 10 |
+            ForEach-Object {
+                $fixedVersionProperty = $_.PSObject.Properties["FixedVersion"]
+                $fixedVersion = if (
+                    $null -eq $fixedVersionProperty -or
+                    [string]::IsNullOrWhiteSpace([string]$fixedVersionProperty.Value)
+                ) {
+                    "unfixed"
+                }
+                else {
+                    [string]$fixedVersionProperty.Value
+                }
+                "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
+            }
+    )
+    return $summaries -join "; "
+}
+
 foreach ($command in @("docker", "syft", "trivy", "cosign", "git")) {
     if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
         throw "required command is unavailable: $command"
@@ -115,14 +140,7 @@ $criticalVulnerabilities = @(
 )
 $criticalFindings = $criticalVulnerabilities.Count
 if ($criticalFindings -gt $policy.supply_chain.critical_vulnerability_policy.maximum_findings) {
-    $criticalSummary = @(
-        $criticalVulnerabilities |
-            Select-Object -First 10 |
-            ForEach-Object {
-                $fixedVersion = if ([string]::IsNullOrWhiteSpace($_.FixedVersion)) { "unfixed" } else { $_.FixedVersion }
-                "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
-            }
-    ) -join "; "
+    $criticalSummary = Format-CriticalVulnerabilitySummary -Vulnerabilities $criticalVulnerabilities
     throw "critical vulnerability policy failed: $criticalFindings findings; $criticalSummary"
 }
 

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -124,6 +124,7 @@ def audit_foundation(
         "Acquire::Check-Valid-Until=false",
         "apt-get install -y --no-install-recommends ca-certificates",
         "sed -i 's#URIs: http://#URIs: https://#' /etc/apt/sources.list.d/rocketmq-snapshot.sources",
+        "COPY --from=ca-bundle /etc/ssl/certs/ /etc/ssl/certs/",
         f"USER {policy['runtime']['uid']}:{policy['runtime']['gid']}",
         'CMD ["/bin/true"]',
         "STOPSIGNAL SIGTERM",
@@ -131,9 +132,27 @@ def audit_foundation(
     for fragment in required_dockerfile_fragments:
         if fragment not in dockerfile:
             findings.append(f"foundation Dockerfile missing: {fragment}")
-    for package in policy["build"]["builder_packages"] + policy["build"]["runtime_packages"]:
-        if not re.search(rf"(?m)^\s*{re.escape(package)}(?:\s|\\|$)", dockerfile):
+    for package in policy["build"]["builder_packages"]:
+        package_line = re.search(rf"(?m)^\s*{re.escape(package)}(?:\s|\\|$)", dockerfile)
+        inline_install = re.search(
+            rf"(?m)^\s*apt-get install [^\n]*\b{re.escape(package)}\b",
+            dockerfile,
+        )
+        if package_line is None and inline_install is None:
             findings.append(f"foundation Dockerfile missing pinned-snapshot package: {package}")
+    expected_runtime_packages = {
+        "coreutils",
+        "dash",
+        "findutils",
+        "libc6",
+        "libgcc-s1",
+        "libssl3t64",
+        "passwd",
+    }
+    if policy["build"].get("runtime_dependency_source") != "pinned-base-image-with-snapshot-ca-bundle":
+        findings.append("runtime dependency source must remain the pinned base image plus snapshot CA bundle")
+    if set(policy["build"].get("runtime_base_packages", [])) != expected_runtime_packages:
+        findings.append("runtime pinned-base package contract drifted")
     foundation_only = dockerfile.split("FROM builder-base AS service-builder", maxsplit=1)[0]
     if re.search(r"(?im)^\s*ENTRYPOINT\b", foundation_only):
         findings.append("foundation Dockerfile must not define a shell or service entrypoint")
@@ -168,10 +187,15 @@ def audit_foundation(
         findings.append("container default target drifted")
     if policy.get("build", {}).get("snapshot_bootstrap_transport") != "http-with-signed-release-then-https":
         findings.append("signed snapshot trust-bootstrap transport drifted")
-    if dockerfile.count("URIs: http://snapshot.debian.org/") != 4:
-        findings.append("both foundation stages must bootstrap CA from the signed snapshot over HTTP")
-    if dockerfile.count("sed -i 's#URIs: http://#URIs: https://#'") != 2:
-        findings.append("both foundation stages must switch snapshot transport back to HTTPS")
+    if dockerfile.count("URIs: http://snapshot.debian.org/") != 2:
+        findings.append("builder stage must bootstrap CA from the signed snapshot over HTTP")
+    if dockerfile.count("sed -i 's#URIs: http://#URIs: https://#'") != 1:
+        findings.append("builder stage must switch snapshot transport back to HTTPS")
+    runtime_section = dockerfile.split("FROM ${RUNTIME_IMAGE} AS runtime-base", maxsplit=1)[1].split(
+        "FROM runtime-base AS runtime-base-smoke", maxsplit=1
+    )[0]
+    if re.search(r"(?m)^\s*(?:apt-get|apt)\s", runtime_section):
+        findings.append("runtime stage must not resolve mutable packages")
     for fragment in (
         "FROM builder-base AS service-builder",
         "FROM runtime-base AS service-runtime",
@@ -325,7 +349,7 @@ def audit_foundation(
         "cosign sign --yes $PublishedImageDigest",
         "cosign verify --certificate-identity-regexp",
         "$policy.supply_chain.signature.published_digest_pattern",
-        "FixedVersion",
+        'PSObject.Properties["FixedVersion"]',
     ]
     for fragment in script_fragments:
         if fragment not in supply_script:
@@ -341,6 +365,8 @@ def audit_foundation(
         findings.append("container supply-chain native runner must reserve -c for executable arguments")
     if "--ignore-unfixed" in supply_script:
         findings.append("critical vulnerability gate must not ignore unfixed findings")
+    if "$_.FixedVersion" in supply_script:
+        findings.append("container vulnerability summary must tolerate a missing FixedVersion property")
 
     service_script_fragments = [
         "docker buildx build",
@@ -357,7 +383,7 @@ def audit_foundation(
         "cosign sign-blob",
         "cosign verify-blob",
         "Remove-Item -LiteralPath $privateKey",
-        "FixedVersion",
+        'PSObject.Properties["FixedVersion"]',
     ]
     for fragment in service_script_fragments:
         if fragment not in service_script:
@@ -368,6 +394,8 @@ def audit_foundation(
         findings.append("service image native runners must reserve -c for executable arguments")
     if "--ignore-unfixed" in service_script:
         findings.append("service image CRITICAL vulnerability gate must not ignore unfixed findings")
+    if "$_.FixedVersion" in service_script:
+        findings.append("service vulnerability summary must tolerate a missing FixedVersion property")
     return findings
 
 

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -52,6 +52,31 @@ function Invoke-Captured {
     return $output
 }
 
+function Format-CriticalVulnerabilitySummary {
+    param(
+        [object[]]$Vulnerabilities
+    )
+
+    $summaries = @(
+        $Vulnerabilities |
+            Select-Object -First 10 |
+            ForEach-Object {
+                $fixedVersionProperty = $_.PSObject.Properties["FixedVersion"]
+                $fixedVersion = if (
+                    $null -eq $fixedVersionProperty -or
+                    [string]::IsNullOrWhiteSpace([string]$fixedVersionProperty.Value)
+                ) {
+                    "unfixed"
+                }
+                else {
+                    [string]$fixedVersionProperty.Value
+                }
+                "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
+            }
+    )
+    return $summaries -join "; "
+}
+
 foreach ($command in @("docker", "syft", "trivy", "cosign", "git")) {
     if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
         throw "required command is unavailable: $command"
@@ -200,14 +225,7 @@ try {
         )
         $criticalFindings = $criticalVulnerabilities.Count
         if ($criticalFindings -gt $policy.supply_chain.critical_vulnerability_policy.maximum_findings) {
-            $criticalSummary = @(
-                $criticalVulnerabilities |
-                    Select-Object -First 10 |
-                    ForEach-Object {
-                        $fixedVersion = if ([string]::IsNullOrWhiteSpace($_.FixedVersion)) { "unfixed" } else { $_.FixedVersion }
-                        "$($_.VulnerabilityID) $($_.PkgName) $($_.InstalledVersion) -> $fixedVersion"
-                    }
-            ) -join "; "
+            $criticalSummary = Format-CriticalVulnerabilitySummary -Vulnerabilities $criticalVulnerabilities
             throw "$serviceName critical vulnerability policy failed: $criticalFindings findings; $criticalSummary"
         }
 

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -152,8 +152,21 @@ class ContainerFoundationTests(unittest.TestCase):
         policy["supply_chain"]["signature"]["published_digest_pattern"] = ".*"
         self.assertTrue(any("GHCR service digest" in finding for finding in self.audit(policy=policy)))
 
-        missing_package = self.dockerfile.replace("    libssl3", "    removed-libssl3", 1)
-        self.assertTrue(any("libssl3" in finding for finding in self.audit(dockerfile=missing_package)))
+        policy = copy.deepcopy(self.policy)
+        policy["build"]["runtime_base_packages"].remove("libssl3t64")
+        self.assertTrue(any("pinned-base package" in finding for finding in self.audit(policy=policy)))
+
+        mutable_runtime_install = self.dockerfile.replace(
+            "groupadd --gid 10001 rocketmq",
+            "apt-get install -y curl\ngroupadd --gid 10001 rocketmq",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "must not resolve mutable packages" in finding
+                for finding in self.audit(dockerfile=mutable_runtime_install)
+            )
+        )
 
         no_https_handoff = self.dockerfile.replace(
             "sed -i 's#URIs: http://#URIs: https://#'",
@@ -293,6 +306,75 @@ else {
         service_script = self.service_script.replace("[string]$Executable", "[string]$Command", 1)
         findings = self.audit(service_script=service_script)
         self.assertTrue(any("reserve -c" in finding for finding in findings))
+
+    def test_unfixed_vulnerability_summary_handles_missing_fixed_version(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        self.assertIsNotNone(powershell, "PowerShell is required to validate container scripts")
+        harness = r"""
+param(
+    [string]$SourcePath
+)
+$ErrorActionPreference = "Stop"
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $SourcePath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    throw "failed to parse source helper: $($parseErrors[0].Message)"
+}
+$definition = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Format-CriticalVulnerabilitySummary"
+}, $true)
+if ($null -eq $definition) {
+    throw "missing vulnerability summary helper"
+}
+Invoke-Expression $definition.Extent.Text
+$vulnerability = [pscustomobject]@{
+    VulnerabilityID = "CVE-2099-0001"
+    PkgName = "example"
+    InstalledVersion = "1.0.0"
+    Severity = "CRITICAL"
+}
+Format-CriticalVulnerabilitySummary -Vulnerabilities @($vulnerability)
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            harness_path = Path(directory) / "vulnerability-summary-harness.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            for source_name in ("container-supply-chain.ps1", "service-image-contract.ps1"):
+                with self.subTest(source=source_name):
+                    result = subprocess.run(
+                        [
+                            powershell,
+                            "-NoProfile",
+                            "-File",
+                            str(harness_path),
+                            str(ROOT / "scripts" / source_name),
+                        ],
+                        cwd=ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertEqual(
+                        "CVE-2099-0001 example 1.0.0 -> unfixed",
+                        result.stdout.strip(),
+                    )
+
+    def test_direct_fixed_version_access_is_rejected(self) -> None:
+        safe_access = '$_.PSObject.Properties["FixedVersion"]'
+        supply_script = self.supply_script.replace(safe_access, "$_.FixedVersion", 1)
+        findings = self.audit(supply_script=supply_script)
+        self.assertTrue(any("missing FixedVersion" in finding for finding in findings))
+
+        service_script = self.service_script.replace(safe_access, "$_.FixedVersion", 1)
+        findings = self.audit(service_script=service_script)
+        self.assertTrue(any("missing FixedVersion" in finding for finding in findings))
 
     def test_root_owned_tmpfs_regression_is_rejected(self) -> None:
         ownership = ",uid=$($policy.runtime.uid),gid=$($policy.runtime.gid),mode=0700"


### PR DESCRIPTION
## Summary

- pin the runtime foundation to an Ubuntu 24.04 digest that reports zero CRITICAL findings with the policy Trivy version
- source runtime tools and libraries from the pinned base and copy the CA trust store from a lightweight immutable Debian-snapshot stage
- remove runtime package resolution and preserve the non-root/read-only/tmpfs contract
- render missing Trivy `FixedVersion` values as `unfixed` under PowerShell StrictMode
- add static and executable regressions for the runtime dependency boundary and vulnerability summary

## Validation

- `python -m unittest scripts.tests.test_m11_container_foundation` (15 passed)
- `python scripts/container_image_guard.py`
- PowerShell parser checks for both container scripts
- `git diff --check`
- Trivy v0.72.0 scan of the pinned runtime digest (0 CRITICAL)

Closes #8661