### PR TITLE
[ISSUE #8663]🐛Preserve explicit Cargo test targets in service image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,9 +28,8 @@ CHANGELOG.md
 LICENSE
 docs/
 
-# Testing
-tests/
-**/tests/
+# Cargo parses explicit [[test]] targets in workspace manifests during production builds,
+# so their source files must remain in the build context.
 # Cargo.lock
 
 # CI/CD

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -85,6 +85,7 @@ def audit_foundation(
     dockerfiles: set[str],
     service_script: str = "",
     signal_sources: dict[str, str] | None = None,
+    dockerignore: str = "",
 ) -> list[str]:
     findings: list[str] = []
     if policy.get("schema_version") != 1:
@@ -103,6 +104,8 @@ def audit_foundation(
         findings.append(f"unregistered Dockerfile: {path}")
     for path in sorted(registered - dockerfiles):
         findings.append(f"registered Dockerfile does not exist: {path}")
+    if re.search(r"(?m)^\s*(?:tests/|\*\*/tests/)\s*$", dockerignore):
+        findings.append("Docker build context must preserve explicit Cargo test targets")
 
     builder_ref = policy["base_images"]["builder"]["reference"]
     runtime_ref = policy["base_images"]["runtime"]["reference"]
@@ -417,6 +420,7 @@ def main() -> int:
         signal_sources = {
             name: (ROOT / path).read_text(encoding="utf-8") for name, path in policy["signal_sources"].items()
         }
+        dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
         findings = audit_foundation(
             policy,
             dockerfile,
@@ -425,6 +429,7 @@ def main() -> int:
             repository_dockerfiles(),
             service_script,
             signal_sources,
+            dockerignore,
         )
     except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
         print(f"CONTAINER_IMAGE_GUARD_FAILED {error}", file=sys.stderr)

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -50,6 +50,7 @@ class ContainerFoundationTests(unittest.TestCase):
         cls.workflow = (ROOT / cls.policy["workflow"]["path"]).read_text(encoding="utf-8")
         cls.supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
         cls.service_script = (ROOT / cls.policy["service_contract_script"]).read_text(encoding="utf-8")
+        cls.dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
         cls.signal_sources = {
             name: (ROOT / path).read_text(encoding="utf-8")
             for name, path in cls.policy["signal_sources"].items()
@@ -66,6 +67,7 @@ class ContainerFoundationTests(unittest.TestCase):
         service_script=None,
         signal_sources=None,
         dockerfiles=None,
+        dockerignore=None,
     ):
         return GUARD.audit_foundation(
             policy or self.policy,
@@ -75,6 +77,7 @@ class ContainerFoundationTests(unittest.TestCase):
             dockerfiles if dockerfiles is not None else self.dockerfiles,
             service_script if service_script is not None else self.service_script,
             signal_sources if signal_sources is not None else self.signal_sources,
+            dockerignore if dockerignore is not None else self.dockerignore,
         )
 
     def test_repository_foundation_contract_passes(self) -> None:
@@ -135,6 +138,13 @@ class ContainerFoundationTests(unittest.TestCase):
         )
         findings = self.audit(policy=policy, dockerfiles=dockerfiles | {"docker/Dockerfile"})
         self.assertTrue(any("retire all legacy" in finding for finding in findings))
+
+    def test_explicit_cargo_test_targets_must_remain_in_build_context(self) -> None:
+        for exclusion in ("tests/", "**/tests/"):
+            with self.subTest(exclusion=exclusion):
+                dockerignore = f"{self.dockerignore.rstrip()}\n{exclusion}\n"
+                findings = self.audit(dockerignore=dockerignore)
+                self.assertTrue(any("explicit Cargo test targets" in finding for finding in findings))
 
     def test_missing_read_only_or_signature_verification_is_rejected(self) -> None:
         no_read_only = self.supply_script.replace("--read-only", "--read-write", 1)


### PR DESCRIPTION
## Summary

- keep Cargo test target sources in the Docker build context so workspace manifests remain valid during production binary builds
- add a static container guard for both root and recursive tests-directory exclusions
- add a focused regression for the invalid `.dockerignore` rules

## Validation

- `python -m unittest scripts.tests.test_m11_container_foundation` (16 passed)
- `python scripts/container_image_guard.py`
- `git diff --check`

Closes #8663