### PR TITLE
[ISSUE #8667]🐛Validate controller smoke configuration before service image builds

### DIFF
--- a/docker/smoke-config/controller.toml
+++ b/docker/smoke-config/controller.toml
@@ -28,7 +28,6 @@ metricsInDelta = false
 configBlackList = "configBlackList;configStorePath"
 nodeId = 1
 listenAddr = "0.0.0.0:60109"
-raftPeers = []
 controllerPeers = []
 electionTimeoutMs = 1000
 heartbeatIntervalMs = 300

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -86,6 +87,7 @@ def audit_foundation(
     service_script: str = "",
     signal_sources: dict[str, str] | None = None,
     dockerignore: str = "",
+    smoke_configs: dict[str, str] | None = None,
 ) -> list[str]:
     findings: list[str] = []
     if policy.get("schema_version") != 1:
@@ -106,6 +108,19 @@ def audit_foundation(
         findings.append(f"registered Dockerfile does not exist: {path}")
     if re.search(r"(?m)^\s*(?:tests/|\*\*/tests/)\s*$", dockerignore):
         findings.append("Docker build context must preserve explicit Cargo test targets")
+    parsed_smoke_configs: dict[str, dict[str, Any]] = {}
+    for name, source in (smoke_configs or {}).items():
+        try:
+            parsed_smoke_configs[name] = tomllib.loads(source)
+        except tomllib.TOMLDecodeError as error:
+            findings.append(f"service smoke config is invalid TOML: {name}: {error}")
+    controller_source = (smoke_configs or {}).get("controller.toml")
+    if controller_source is None:
+        findings.append("controller smoke config is missing")
+    elif "controller.toml" in parsed_smoke_configs:
+        expected_peer = [{"id": 1, "addr": "127.0.0.1:60110"}]
+        if parsed_smoke_configs["controller.toml"].get("raftPeers") != expected_peer:
+            findings.append("controller smoke config must retain its single-node Raft peer")
 
     builder_ref = policy["base_images"]["builder"]["reference"]
     runtime_ref = policy["base_images"]["runtime"]["reference"]
@@ -424,6 +439,10 @@ def main() -> int:
             name: (ROOT / path).read_text(encoding="utf-8") for name, path in policy["signal_sources"].items()
         }
         dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+        smoke_config_directory = ROOT / policy["smoke_config_directory"]
+        smoke_configs = {
+            path.name: path.read_text(encoding="utf-8") for path in smoke_config_directory.glob("*.toml")
+        }
         findings = audit_foundation(
             policy,
             dockerfile,
@@ -433,6 +452,7 @@ def main() -> int:
             service_script,
             signal_sources,
             dockerignore,
+            smoke_configs,
         )
     except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
         print(f"CONTAINER_IMAGE_GUARD_FAILED {error}", file=sys.stderr)

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -51,6 +51,10 @@ class ContainerFoundationTests(unittest.TestCase):
         cls.supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
         cls.service_script = (ROOT / cls.policy["service_contract_script"]).read_text(encoding="utf-8")
         cls.dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+        cls.smoke_configs = {
+            path.name: path.read_text(encoding="utf-8")
+            for path in (ROOT / cls.policy["smoke_config_directory"]).glob("*.toml")
+        }
         cls.signal_sources = {
             name: (ROOT / path).read_text(encoding="utf-8")
             for name, path in cls.policy["signal_sources"].items()
@@ -68,6 +72,7 @@ class ContainerFoundationTests(unittest.TestCase):
         signal_sources=None,
         dockerfiles=None,
         dockerignore=None,
+        smoke_configs=None,
     ):
         return GUARD.audit_foundation(
             policy or self.policy,
@@ -78,6 +83,7 @@ class ContainerFoundationTests(unittest.TestCase):
             service_script if service_script is not None else self.service_script,
             signal_sources if signal_sources is not None else self.signal_sources,
             dockerignore if dockerignore is not None else self.dockerignore,
+            smoke_configs if smoke_configs is not None else self.smoke_configs,
         )
 
     def test_repository_foundation_contract_passes(self) -> None:
@@ -145,6 +151,25 @@ class ContainerFoundationTests(unittest.TestCase):
                 dockerignore = f"{self.dockerignore.rstrip()}\n{exclusion}\n"
                 findings = self.audit(dockerignore=dockerignore)
                 self.assertTrue(any("explicit Cargo test targets" in finding for finding in findings))
+
+    def test_smoke_configs_must_parse_and_retain_controller_peer(self) -> None:
+        duplicate_peer = dict(self.smoke_configs)
+        duplicate_peer["controller.toml"] = duplicate_peer["controller.toml"].replace(
+            "controllerPeers = []",
+            "raftPeers = []\ncontrollerPeers = []",
+            1,
+        )
+        findings = self.audit(smoke_configs=duplicate_peer)
+        self.assertTrue(any("invalid TOML" in finding for finding in findings))
+
+        missing_peer = dict(self.smoke_configs)
+        missing_peer["controller.toml"] = missing_peer["controller.toml"].replace(
+            '[[raftPeers]]\nid = 1\naddr = "127.0.0.1:60110"',
+            "raftPeers = []",
+            1,
+        )
+        findings = self.audit(smoke_configs=missing_peer)
+        self.assertTrue(any("single-node Raft peer" in finding for finding in findings))
 
     def test_missing_read_only_or_signature_verification_is_rejected(self) -> None:
         no_read_only = self.supply_script.replace("--read-only", "--read-write", 1)


### PR DESCRIPTION
## Summary

- remove the duplicate empty `raftPeers` declaration from the controller smoke fixture
- parse all six smoke TOML files in the static container guard before image builds
- require the controller fixture to retain its expected single-node Raft peer
- add duplicate-key and missing-peer regressions

## Validation

- `python -m unittest scripts.tests.test_m11_container_foundation` (17 passed)
- `python scripts/container_image_guard.py`
- Python `tomllib` parse of all six smoke fixtures
- `git diff --check`

Closes #8667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image validation for TOML smoke-test configurations.
  * Detects malformed smoke configuration files.
  * Verifies that the controller configuration includes the required single-node Raft peer settings.
  * Corrected configuration handling to preserve explicitly defined Raft peers.

* **Tests**
  * Added coverage for invalid TOML and missing required Raft peer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->