### PR TITLE
[ISSUE #8669]🐛Align service image stop grace with the application shutdown deadline

### DIFF
--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -54,6 +54,8 @@
     "uid": 10001,
     "gid": 10001,
     "read_only_rootfs_required": true,
+    "shutdown_timeout_seconds": 45,
+    "stop_grace_period_seconds": 60,
     "writable_data_path": "/var/lib/rocketmq",
     "tmpfs_path": "/tmp/rocketmq",
     "default_command": [

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -147,6 +147,7 @@ def audit_foundation(
         "protoc --version",
         "COPY --from=ca-bundle /etc/ssl/certs/ /etc/ssl/certs/",
         f"USER {policy['runtime']['uid']}:{policy['runtime']['gid']}",
+        f"ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS={policy['runtime']['shutdown_timeout_seconds']}",
         'CMD ["/bin/true"]',
         "STOPSIGNAL SIGTERM",
     ]
@@ -190,6 +191,12 @@ def audit_foundation(
         findings.append("container runtime identity must be non-root")
     if runtime.get("read_only_rootfs_required") is not True:
         findings.append("container policy must require a read-only rootfs")
+    if runtime.get("shutdown_timeout_seconds") != 45:
+        findings.append("service application shutdown deadline must remain 45 seconds")
+    if runtime.get("stop_grace_period_seconds") != 60:
+        findings.append("service container stop grace period must remain 60 seconds")
+    if runtime.get("stop_grace_period_seconds", 0) <= runtime.get("shutdown_timeout_seconds", 0):
+        findings.append("service container stop grace must exceed the application shutdown deadline")
     if runtime.get("default_command") != ["/bin/true"]:
         findings.append("container foundation default command must remain /bin/true")
 
@@ -394,7 +401,7 @@ def audit_foundation(
         "--target $service.target",
         "--read-only",
         "must fail closed when its required config mount is absent",
-        "docker stop --signal SIGTERM --timeout 30",
+        "docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds)",
         "{{.State.ExitCode}}",
         "$service.data_path",
         "find /usr/local/bin",

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -185,7 +185,7 @@ try {
                 $logs = Invoke-Captured docker logs $containerId
                 throw "$serviceName exited before SIGTERM smoke: $logs"
             }
-            Invoke-Checked docker stop --signal SIGTERM --timeout 30 $containerId
+            Invoke-Checked docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds) $containerId
             $exitCode = [int](Invoke-Captured docker inspect --format "{{.State.ExitCode}}" $containerId).Trim()
             if ($exitCode -ne 0) {
                 $logs = Invoke-Captured docker logs $containerId

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -188,6 +188,10 @@ class ContainerFoundationTests(unittest.TestCase):
         self.assertTrue(any("GHCR service digest" in finding for finding in self.audit(policy=policy)))
 
         policy = copy.deepcopy(self.policy)
+        policy["runtime"]["stop_grace_period_seconds"] = policy["runtime"]["shutdown_timeout_seconds"]
+        self.assertTrue(any("must exceed" in finding for finding in self.audit(policy=policy)))
+
+        policy = copy.deepcopy(self.policy)
         policy["build"]["runtime_base_packages"].remove("libssl3t64")
         self.assertTrue(any("pinned-base package" in finding for finding in self.audit(policy=policy)))
 
@@ -267,8 +271,11 @@ class ContainerFoundationTests(unittest.TestCase):
         findings = self.audit(signal_sources=signal_sources)
         self.assertTrue(any("Ctrl-C-only" in finding for finding in findings))
 
-        weakened = self.service_script.replace("docker stop --signal SIGTERM --timeout 30", "docker kill", 1)
-        self.assertTrue(any("docker stop --signal SIGTERM" in finding for finding in self.audit(service_script=weakened)))
+        stop_contract = "docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds)"
+        weakened = self.service_script.replace(stop_contract, "docker kill", 1)
+        self.assertTrue(
+            any("docker stop --signal SIGTERM" in finding for finding in self.audit(service_script=weakened))
+        )
 
     def test_native_dash_c_arguments_are_preserved_by_real_script_helpers(self) -> None:
         powershell = shutil.which("pwsh") or shutil.which("powershell")


### PR DESCRIPTION
## Summary

- record the 45-second application shutdown deadline and 60-second outer stop grace in container policy
- drive `docker stop` from the policy grace period instead of a conflicting hard-coded 30 seconds
- guard the Dockerfile environment, policy relationship, and service validation command against drift

## Validation

- `python -m unittest scripts.tests.test_m11_container_foundation` (17 passed)
- `python scripts/container_image_guard.py`
- PowerShell parser check for `scripts/service-image-contract.ps1`
- `git diff --check`

Closes #8669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable container shutdown timing, including a 45-second shutdown timeout and a 60-second stop grace period.
  - Containerized services now use the configured grace period when stopping, supporting more reliable graceful termination.

- **Bug Fixes**
  - Improved runtime validation to prevent invalid or insufficient shutdown timing configurations.
  - Updated service termination checks to consistently honor the configured stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->