### PR TITLE
[ISSUE #8671]🐛Ensure MCP stdio exits after SIGTERM with open stdin

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/main.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/main.rs
@@ -24,8 +24,31 @@ use rocketmq_runtime::ServiceLifecycle;
 use rocketmq_runtime::ServiceLifecycleState;
 use rocketmq_runtime::ShutdownReason;
 
-#[tokio::main]
-async fn main() -> Result<(), McpError> {
+const RUNTIME_TEARDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+fn main() -> Result<(), McpError> {
+    let runtime = build_runtime()?;
+    let result = runtime.block_on(run());
+    shutdown_runtime(runtime, RUNTIME_TEARDOWN_TIMEOUT);
+    result
+}
+
+fn build_runtime() -> Result<tokio::runtime::Runtime, McpError> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("rocketmq-mcp")
+        .build()
+        .map_err(|source| McpError::Infrastructure {
+            operation: "create MCP Tokio runtime",
+            source: Box::new(source),
+        })
+}
+
+fn shutdown_runtime(runtime: tokio::runtime::Runtime, timeout: std::time::Duration) {
+    runtime.shutdown_timeout(timeout);
+}
+
+async fn run() -> Result<(), McpError> {
     let args = Args::parse();
     let lifecycle = ServiceLifecycle::from_env("rocketmq-mcp")
         .map_err(|error| McpError::InvalidConfig(format!("invalid MCP lifecycle configuration: {error}")))?;
@@ -86,13 +109,7 @@ async fn serve_stdio(app: McpApp, lifecycle: ServiceLifecycle) -> Result<(), Mcp
     lifecycle
         .mark_ready()
         .map_err(|error| McpError::InvalidConfig(format!("failed to publish MCP readiness: {error}")))?;
-    tokio::select! {
-        result = transport::stdio::serve_typed(app) => result,
-        result = lifecycle.wait_for_shutdown_signal() => result.map(|_| ()).map_err(|source| McpError::Infrastructure {
-            operation: "wait for MCP lifecycle shutdown",
-            source: Box::new(source),
-        }),
-    }
+    transport::stdio::serve_typed_with_lifecycle(app, lifecycle).await
 }
 
 async fn serve_streamable_http(app: McpApp, lifecycle: ServiceLifecycle) -> Result<(), McpError> {
@@ -108,5 +125,34 @@ async fn serve_streamable_http(app: McpApp, lifecycle: ServiceLifecycle) -> Resu
             transport: "streamable-http",
             feature: "streamable-http",
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use super::build_runtime;
+    use super::shutdown_runtime;
+
+    #[test]
+    fn runtime_teardown_is_bounded_when_blocking_work_is_still_open() {
+        let runtime = build_runtime().expect("test runtime should build");
+        let (started_tx, started_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        runtime.spawn_blocking(move || {
+            started_tx.send(()).expect("test should observe blocking work");
+            let _ = release_rx.recv();
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("blocking work should start");
+
+        let started_at = Instant::now();
+        shutdown_runtime(runtime, Duration::from_millis(10));
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+        release_tx.send(()).expect("blocking work should still be releasable");
     }
 }

--- a/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
@@ -31,6 +31,53 @@ pub async fn serve_typed(app: McpApp) -> Result<(), McpError> {
     Ok(())
 }
 
+/// Serves stdio until the transport closes or the process lifecycle requests shutdown.
+///
+/// The RMCP service is explicitly cancelled and awaited before application-owned runtime
+/// shutdown begins. Tokio's stdin reader itself may still have an uncancellable blocking read;
+/// the binary's bounded top-level runtime teardown owns that final process-level boundary.
+///
+/// # Errors
+///
+/// Returns an infrastructure error when the stdio service cannot start, the lifecycle signal
+/// cannot be observed, the service task fails, or transport cleanup exceeds the shared shutdown
+/// deadline.
+pub async fn serve_typed_with_lifecycle(
+    app: McpApp,
+    lifecycle: rocketmq_runtime::ServiceLifecycle,
+) -> Result<(), McpError> {
+    let server = RocketmqMcpServer::new(app);
+    let service = server
+        .serve(rmcp::transport::stdio())
+        .await
+        .map_err(|source| McpError::infrastructure("start MCP stdio service", source))?;
+    let cancellation = service.cancellation_token();
+    let waiting = service.waiting();
+    tokio::pin!(waiting);
+
+    let shutdown_request = tokio::select! {
+        result = &mut waiting => {
+            result.map_err(|source| McpError::infrastructure("wait for MCP stdio service", source))?;
+            return Ok(());
+        }
+        result = lifecycle.wait_for_shutdown_signal() => {
+            result.map_err(|source| McpError::infrastructure("wait for MCP lifecycle shutdown", source))?
+        }
+    };
+
+    cancellation.cancel();
+    match tokio::time::timeout(shutdown_request.deadline.remaining(), &mut waiting).await {
+        Ok(result) => {
+            result.map_err(|source| McpError::infrastructure("stop MCP stdio service", source))?;
+            Ok(())
+        }
+        Err(source) => Err(McpError::infrastructure(
+            "stop MCP stdio service before shutdown deadline",
+            source,
+        )),
+    }
+}
+
 #[deprecated(since = "1.0.0", note = "use serve_typed")]
 pub async fn serve(app: McpApp) -> anyhow::Result<()> {
     serve_typed(app).await.map_err(anyhow::Error::new)


### PR DESCRIPTION
## Summary

- explicitly cancel and await the RMCP stdio service inside the shared lifecycle deadline
- replace the macro-owned Tokio runtime with an explicit runtime whose final teardown is bounded
- preserve audit, owned-task, and telemetry shutdown before runtime teardown
- add focused coverage for an uncancellable blocking-runtime task

Closes #8671

## Validation

- `cargo check -p rocketmq-mcp --bin rocketmq-mcp`
- `cargo test -p rocketmq-mcp --bin rocketmq-mcp runtime_teardown_is_bounded_when_blocking_work_is_still_open`
- `cargo clippy -p rocketmq-mcp --bin rocketmq-mcp -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo fmt -p rocketmq-mcp -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved service shutdown handling for the standard input/output transport.
  * Added bounded runtime teardown to help prevent shutdowns from hanging indefinitely.
  * Ensured services are cancelled and stopped within the configured shutdown deadline.

* **Bug Fixes**
  * Improved handling of shutdown failures and timeouts with clearer infrastructure errors.

* **Tests**
  * Added coverage verifying that runtime shutdown remains bounded even when blocking work is still active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->