### PR TITLE
[ISSUE #8673]🐛Recognize the owned MCP stdio lifecycle boundary

### DIFF
--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -289,7 +289,10 @@ def audit_foundation(
     if policy.get("signal_sources") != expected_signal_sources:
         findings.append("service signal source registry drifted")
     for name, source in (signal_sources or {}).items():
-        if "wait_for_shutdown_signal" not in source and "wait_for_signal_result" not in source:
+        lifecycle_markers = ["wait_for_shutdown_signal", "wait_for_signal_result"]
+        if name == "mcp_stdio":
+            lifecycle_markers.append("transport::stdio::serve_typed_with_lifecycle")
+        if not any(marker in source for marker in lifecycle_markers):
             findings.append(f"{name} entrypoint must use the shared lifecycle SIGINT/SIGTERM waiter")
         if "tokio::signal::ctrl_c" in source:
             findings.append(f"{name} entrypoint must not use a Ctrl-C-only signal boundary")

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -271,6 +271,15 @@ class ContainerFoundationTests(unittest.TestCase):
         findings = self.audit(signal_sources=signal_sources)
         self.assertTrue(any("Ctrl-C-only" in finding for finding in findings))
 
+        signal_sources = dict(self.signal_sources)
+        signal_sources["mcp_stdio"] = signal_sources["mcp_stdio"].replace(
+            "serve_typed_with_lifecycle",
+            "serve_typed",
+            1,
+        )
+        findings = self.audit(signal_sources=signal_sources)
+        self.assertTrue(any("mcp_stdio entrypoint" in finding for finding in findings))
+
         stop_contract = "docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds)"
         weakened = self.service_script.replace(stop_contract, "docker kill", 1)
         self.assertTrue(


### PR DESCRIPTION
## Summary

- recognize the lifecycle-aware MCP stdio delegate as the shared SIGINT/SIGTERM boundary
- distinguish the stdio delegate from the similarly named HTTP lifecycle function
- keep the guard fail-closed if main falls back to the unowned stdio serve path

Closes #8673

## Validation

- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation -v` (17/17)
- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle validation for signal sources.
  * Added support for the standard MCP stdio lifecycle marker while rejecting weakened stdio entrypoints.

* **Tests**
  * Added coverage to ensure invalid MCP stdio shutdown behavior is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->