### PR TITLE
[ISSUE #8675]🐛Observe MCP SIGTERM during stdio initialization

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/stdio.rs
@@ -47,10 +47,17 @@ pub async fn serve_typed_with_lifecycle(
     lifecycle: rocketmq_runtime::ServiceLifecycle,
 ) -> Result<(), McpError> {
     let server = RocketmqMcpServer::new(app);
-    let service = server
-        .serve(rmcp::transport::stdio())
-        .await
-        .map_err(|source| McpError::infrastructure("start MCP stdio service", source))?;
+    let startup = server.serve(rmcp::transport::stdio());
+    tokio::pin!(startup);
+    let service = tokio::select! {
+        result = &mut startup => {
+            result.map_err(|source| McpError::infrastructure("start MCP stdio service", source))?
+        }
+        result = lifecycle.wait_for_shutdown_signal() => {
+            result.map_err(|source| McpError::infrastructure("wait for MCP lifecycle shutdown", source))?;
+            return Ok(());
+        }
+    };
     let cancellation = service.cancellation_token();
     let waiting = service.waiting();
     tokio::pin!(waiting);


### PR DESCRIPTION
## Summary

- poll lifecycle shutdown concurrently with RMCP stdio initialization
- return cleanly when SIGTERM arrives before the RMCP service handle exists
- retain explicit cancellation/await after initialization and bounded top-level runtime teardown

Closes #8675

## Validation

- `cargo check -p rocketmq-mcp --bin rocketmq-mcp`
- `cargo clippy -p rocketmq-mcp --bin rocketmq-mcp -- -D warnings`
- `python scripts/container_image_guard.py`
- `cargo fmt -p rocketmq-mcp -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stdio service shutdown handling.
  * The service now exits promptly when a shutdown signal is received during startup.
  * Preserved existing cancellation and shutdown-deadline behavior after startup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->