### PR TITLE
[ISSUE #8680]♻️Start ArcMut compatibility deprecation window

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -8276,7 +8276,7 @@ accounts:
             timer_wheel_enable: true,
             ..MessageStoreConfig::default()
         });
-        let timer_message_store = TimerMessageStore::new_with_config(None, timer_config);
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(timer_config);
         assert!(timer_message_store.load());
         runtime.inner_for_test().set_timer_message_store(timer_message_store);
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -1004,7 +1004,7 @@ mod tests {
         });
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config.clone());
 
-        let timer_message_store = TimerMessageStore::new_with_config(None, message_store_config);
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(message_store_config);
         assert!(timer_message_store.load());
         runtime.inner_for_test().set_timer_message_store(timer_message_store);
 

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -1115,7 +1115,7 @@ pub mod bench_support {
             timer_precision_ms: 100,
             ..MessageStoreConfig::default()
         });
-        let timer_store = Arc::new(TimerMessageStore::new_with_config(None, config));
+        let timer_store = Arc::new(TimerMessageStore::new_with_message_store_config(config));
 
         assert!(timer_store.load(), "timer store should load for lifecycle probe");
         timer_store.start();

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -37,6 +37,10 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::system_clock::SystemClock;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
+#[allow(
+    deprecated,
+    reason = "GenericMessageStore preserves the public ArcMut signature during its deprecation window"
+)]
 use rocketmq_rust::ArcMut;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
@@ -72,6 +76,14 @@ use crate::store::running_flags::RunningFlags;
 use crate::store_error::StoreError;
 use crate::timer::timer_message_store::TimerMessageStore;
 
+#[allow(
+    deprecated,
+    reason = "this enum is the deprecated GenericMessageStore compatibility surface"
+)]
+#[deprecated(
+    since = "1.0.0",
+    note = "use OwnedMessageStore and inject narrow Store capabilities into shared consumers"
+)]
 pub enum GenericMessageStore {
     LocalFileStore(ArcMut<local_file_message_store::LocalFileMessageStore>),
 
@@ -79,6 +91,10 @@ pub enum GenericMessageStore {
     RocksDBStore(ArcMut<rocksdb_message_store::RocksDBMessageStore>),
 }
 
+#[allow(
+    deprecated,
+    reason = "this impl preserves deprecated GenericMessageStore constructors until removal"
+)]
 impl GenericMessageStore {
     pub fn local_file(store: ArcMut<local_file_message_store::LocalFileMessageStore>) -> Self {
         Self::LocalFileStore(store)
@@ -90,64 +106,69 @@ impl GenericMessageStore {
     }
 }
 
-macro_rules! impl_store_composition {
-    ($store:ty) => {
-        impl $store {
-            pub fn set_message_arriving_listener(
-                &mut self,
-                message_arriving_listener: Option<Arc<Box<dyn MessageArrivingListener + Sync + Send + 'static>>>,
-            ) {
-                match self {
-                    Self::LocalFileStore(store) => store.set_message_arriving_listener(message_arriving_listener),
-                    #[cfg(feature = "rocksdb_store")]
-                    Self::RocksDBStore(store) => store
-                        .local_file_store_mut()
-                        .set_message_arriving_listener(message_arriving_listener),
-                }
+macro_rules! store_composition_methods {
+    () => {
+        pub fn set_message_arriving_listener(
+            &mut self,
+            message_arriving_listener: Option<Arc<Box<dyn MessageArrivingListener + Sync + Send + 'static>>>,
+        ) {
+            match self {
+                Self::LocalFileStore(store) => store.set_message_arriving_listener(message_arriving_listener),
+                #[cfg(feature = "rocksdb_store")]
+                Self::RocksDBStore(store) => store
+                    .local_file_store_mut()
+                    .set_message_arriving_listener(message_arriving_listener),
             }
+        }
 
-            pub async fn reput_once(&mut self) {
-                match self {
-                    Self::LocalFileStore(store) => store.reput_once().await,
-                    #[cfg(feature = "rocksdb_store")]
-                    Self::RocksDBStore(store) => store.local_file_store_mut().reput_once().await,
-                }
+        pub async fn reput_once(&mut self) {
+            match self {
+                Self::LocalFileStore(store) => store.reput_once().await,
+                #[cfg(feature = "rocksdb_store")]
+                Self::RocksDBStore(store) => store.local_file_store_mut().reput_once().await,
             }
+        }
 
-            pub fn consume_queue_store_mut(&mut self) -> &mut ConsumeQueueStore {
-                match self {
-                    Self::LocalFileStore(store) => store.consume_queue_store_mut(),
-                    #[cfg(feature = "rocksdb_store")]
-                    Self::RocksDBStore(store) => store.local_file_store_mut().consume_queue_store_mut(),
-                }
+        pub fn consume_queue_store_mut(&mut self) -> &mut ConsumeQueueStore {
+            match self {
+                Self::LocalFileStore(store) => store.consume_queue_store_mut(),
+                #[cfg(feature = "rocksdb_store")]
+                Self::RocksDBStore(store) => store.local_file_store_mut().consume_queue_store_mut(),
             }
+        }
 
-            #[cfg(feature = "rocksdb_store")]
-            pub fn rocksdb_ticker_metrics(
-                &self,
-            ) -> Option<rocketmq_observability::metrics::rocksdb::RocksDbTickerMetrics> {
-                match self {
-                    Self::LocalFileStore(_) => None,
-                    Self::RocksDBStore(store) => Some(store.rocksdb_store().ticker_metrics()),
-                }
+        #[cfg(feature = "rocksdb_store")]
+        pub fn rocksdb_ticker_metrics(&self) -> Option<rocketmq_observability::metrics::rocksdb::RocksDbTickerMetrics> {
+            match self {
+                Self::LocalFileStore(_) => None,
+                Self::RocksDBStore(store) => Some(store.rocksdb_store().ticker_metrics()),
             }
+        }
 
-            #[cfg(feature = "tieredstore")]
-            pub fn tiered_store_metrics(
-                &self,
-            ) -> Option<Arc<rocketmq_observability::metrics::tiered_store::TieredStoreMetrics>> {
-                match self {
-                    Self::LocalFileStore(store) => store.tiered_store_metrics(),
-                    #[cfg(feature = "rocksdb_store")]
-                    Self::RocksDBStore(store) => store.local_file_store().tiered_store_metrics(),
-                }
+        #[cfg(feature = "tieredstore")]
+        pub fn tiered_store_metrics(
+            &self,
+        ) -> Option<Arc<rocketmq_observability::metrics::tiered_store::TieredStoreMetrics>> {
+            match self {
+                Self::LocalFileStore(store) => store.tiered_store_metrics(),
+                #[cfg(feature = "rocksdb_store")]
+                Self::RocksDBStore(store) => store.local_file_store().tiered_store_metrics(),
             }
         }
     };
 }
 
-impl_store_composition!(GenericMessageStore);
-impl_store_composition!(OwnedMessageStore);
+#[allow(
+    deprecated,
+    reason = "this impl preserves the deprecated GenericMessageStore composition helpers"
+)]
+impl GenericMessageStore {
+    store_composition_methods!();
+}
+
+impl OwnedMessageStore {
+    store_composition_methods!();
+}
 
 macro_rules! delegate_store {
     ($self:expr, $method:ident($($arg:expr),* $(,)?)) => {
@@ -812,6 +833,10 @@ macro_rules! message_store_methods {
     };
 }
 
+#[allow(
+    deprecated,
+    reason = "this impl preserves the deprecated GenericMessageStore adapter contract"
+)]
 impl MessageStore for GenericMessageStore {
     message_store_methods!();
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -83,6 +83,10 @@ use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
+#[allow(
+    deprecated,
+    reason = "set_message_store_arc preserves its public ArcMut signature during the deprecation window"
+)]
 use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
@@ -1073,6 +1077,11 @@ impl LocalFileMessageStore {
                 || self.store_runtime_state.broker_role() != BrokerRole::Slave)
     }
 
+    #[allow(
+        deprecated,
+        reason = "this method preserves the deprecated ArcMut wiring signature until removal"
+    )]
+    #[deprecated(since = "1.0.0", note = "use LocalFileMessageStore::wire_owned_root_dependencies")]
     pub fn set_message_store_arc(&mut self, message_store_arc: ArcMut<LocalFileMessageStore>) {
         drop(message_store_arc);
         self.consume_queue_store.set_context(self.consume_queue_context());

--- a/rocketmq-store/src/message_store/owned_message_store.rs
+++ b/rocketmq-store/src/message_store/owned_message_store.rs
@@ -26,7 +26,6 @@ use crate::base::message_result::PutMessageResult;
 /// shared-mutation wrapper around the concrete backend. Shared consumers should
 /// receive narrow Store capabilities while the application lifecycle retains the
 /// only mutable root owner.
-#[doc(hidden)]
 #[non_exhaustive]
 pub enum OwnedMessageStore {
     LocalFileStore(Box<LocalFileMessageStore>),

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -37,6 +37,10 @@ use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
 use rocketmq_runtime::ShutdownReport;
+#[allow(
+    deprecated,
+    reason = "TimerMessageStore preserves legacy full-Store signatures during the deprecation window"
+)]
 use rocketmq_rust::ArcMut;
 use rocketmq_store_local::timer::service::clamp_queue_offset;
 use rocketmq_store_local::timer::service::recover_timer_log_len as plan_recovered_timer_log_len;
@@ -143,11 +147,19 @@ impl TimerStoreContext {
     }
 }
 
+#[allow(
+    deprecated,
+    reason = "the deprecated field preserves the legacy full-Store carrier until removal"
+)]
 pub struct TimerMessageStore {
     pub curr_read_time_ms: AtomicI64,
     pub curr_queue_offset: AtomicI64,
     pub last_enqueue_but_expired_time: u64,
     pub last_enqueue_but_expired_store_time: u64,
+    #[deprecated(
+        since = "1.0.0",
+        note = "use new_with_message_store_config or wire_owned_root_dependencies"
+    )]
     pub default_message_store: Option<ArcMut<LocalFileMessageStore>>,
     pub timer_metrics: TimerMetrics,
     store_context: Option<TimerStoreContext>,
@@ -358,6 +370,14 @@ impl TimerMessageStore {
         Ok(true)
     }
 
+    #[allow(
+        deprecated,
+        reason = "this constructor preserves the deprecated full-Store signature until removal"
+    )]
+    #[deprecated(
+        since = "1.0.0",
+        note = "use new_with_message_store_config or wire_owned_root_dependencies"
+    )]
     pub fn new(default_message_store: Option<ArcMut<LocalFileMessageStore>>) -> Self {
         let message_store_config = default_message_store
             .as_ref()
@@ -366,17 +386,40 @@ impl TimerMessageStore {
         Self::new_with_config(default_message_store, message_store_config)
     }
 
+    #[allow(
+        deprecated,
+        reason = "this constructor preserves the deprecated full-Store signature until removal"
+    )]
+    #[deprecated(
+        since = "1.0.0",
+        note = "use new_with_message_store_config or wire_owned_root_dependencies"
+    )]
     pub fn new_with_config(
         default_message_store: Option<ArcMut<LocalFileMessageStore>>,
         message_store_config: Arc<MessageStoreConfig>,
     ) -> Self {
+        let mut store = Self::new_with_message_store_config(message_store_config);
+        store.default_message_store = default_message_store;
+        store
+    }
+
+    /// Creates a standalone Timer store from immutable configuration.
+    ///
+    /// Store-owned Timer instances should instead be created by
+    /// [`LocalFileMessageStore::wire_owned_root_dependencies`], which injects
+    /// narrow queue, CommitLog-read, and message-write capabilities.
+    #[allow(
+        deprecated,
+        reason = "initialize the retained legacy field to None for the canonical constructor"
+    )]
+    pub fn new_with_message_store_config(message_store_config: Arc<MessageStoreConfig>) -> Self {
         let timer_metrics_path = get_timer_metrics_path(message_store_config.store_path_root_dir.as_str());
         Self {
             curr_read_time_ms: AtomicI64::new(0),
             curr_queue_offset: AtomicI64::new(0),
             last_enqueue_but_expired_time: 0,
             last_enqueue_but_expired_store_time: 0,
-            default_message_store,
+            default_message_store: None,
             timer_metrics: TimerMetrics::new(Some(timer_metrics_path)),
             store_context: None,
             message_store_config,
@@ -397,15 +440,23 @@ impl TimerMessageStore {
         store_context: TimerStoreContext,
         message_store_config: Arc<MessageStoreConfig>,
     ) -> Self {
-        let mut store = Self::new_with_config(None, message_store_config);
+        let mut store = Self::new_with_message_store_config(message_store_config);
         store.store_context = Some(store_context);
         store
     }
 
     pub fn new_empty() -> Self {
-        Self::new_with_config(None, Arc::new(MessageStoreConfig::default()))
+        Self::new_with_message_store_config(Arc::new(MessageStoreConfig::default()))
     }
 
+    #[allow(
+        deprecated,
+        reason = "this setter preserves the deprecated full-Store signature until removal"
+    )]
+    #[deprecated(
+        since = "1.0.0",
+        note = "use new_with_message_store_config or wire_owned_root_dependencies"
+    )]
     pub fn set_default_message_store(&mut self, default_message_store: Option<ArcMut<LocalFileMessageStore>>) {
         if let Some(message_store) = default_message_store.as_ref() {
             self.message_store_config = message_store.message_store_config();
@@ -417,6 +468,10 @@ impl TimerMessageStore {
         self.default_message_store = default_message_store;
     }
 
+    #[allow(
+        deprecated,
+        reason = "read the legacy full-Store fallback only for compatibility instances"
+    )]
     fn find_store_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue> {
         if let Some(context) = self.store_context.as_ref() {
             return context.find_consume_queue(topic, queue_id);
@@ -426,6 +481,10 @@ impl TimerMessageStore {
             .and_then(|message_store| message_store.find_consume_queue(topic, queue_id))
     }
 
+    #[allow(
+        deprecated,
+        reason = "read the legacy full-Store fallback only for compatibility instances"
+    )]
     fn look_store_message(&self, commit_log_offset: i64, size: i32) -> Option<MessageExt> {
         if let Some(context) = self.store_context.as_ref() {
             return context.look_message_by_offset_with_size(commit_log_offset, size);
@@ -435,6 +494,10 @@ impl TimerMessageStore {
             .and_then(|message_store| message_store.look_message_by_offset_with_size(commit_log_offset, size))
     }
 
+    #[allow(
+        deprecated,
+        reason = "read the legacy full-Store fallback only for compatibility instances"
+    )]
     async fn put_store_message(&self, message: MessageExtBrokerInner) -> PutMessageResult {
         if let Some(context) = self.store_context.as_ref() {
             return context.put_message(message).await;
@@ -1449,6 +1512,31 @@ mod tests {
         })
     }
 
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "verify the deprecated config-only constructor remains equivalent during its release window"
+    )]
+    fn canonical_and_deprecated_config_constructors_preserve_standalone_state() {
+        let root = tempfile::tempdir().expect("Timer constructor test root should be created");
+        let config = config_with_root(root.path().to_string_lossy().as_ref());
+        let canonical = TimerMessageStore::new_with_message_store_config(Arc::clone(&config));
+        let deprecated = TimerMessageStore::new_with_config(None, Arc::clone(&config));
+
+        assert!(canonical.default_message_store.is_none());
+        assert!(deprecated.default_message_store.is_none());
+        assert!(canonical.store_context.is_none());
+        assert!(deprecated.store_context.is_none());
+        assert_eq!(
+            canonical.message_store_config.store_path_root_dir,
+            config.store_path_root_dir
+        );
+        assert_eq!(
+            deprecated.message_store_config.store_path_root_dir,
+            config.store_path_root_dir
+        );
+    }
+
     fn build_store_with_timer(root_dir: &str) -> (LocalFileMessageStore, Arc<TimerMessageStore>, CheetahString) {
         build_store_with_timer_and_config(config_with_root(root_dir))
     }
@@ -1530,7 +1618,7 @@ mod tests {
         let root_dir = temp_dir.path().to_string_lossy().to_string();
         let config = config_with_root(root_dir.as_str());
 
-        let timer_message_store = TimerMessageStore::new_with_config(None, config.clone());
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(config.clone());
         assert!(timer_message_store.load());
         assert!(Path::new(get_timer_check_path(root_dir.as_str()).as_str()).exists());
         assert!(Path::new(get_timer_log_path(root_dir.as_str()).as_str()).exists());
@@ -1544,7 +1632,7 @@ mod tests {
         timer_message_store.sync_last_read_time_ms();
         timer_message_store.shutdown();
 
-        let reloaded_store = TimerMessageStore::new_with_config(None, config);
+        let reloaded_store = TimerMessageStore::new_with_message_store_config(config);
         assert!(reloaded_store.load());
         assert_eq!(reloaded_store.curr_read_time_ms.load(Ordering::Relaxed), read_time_ms);
         assert_eq!(reloaded_store.curr_queue_offset.load(Ordering::Relaxed), 9);
@@ -1555,7 +1643,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let root_dir = temp_dir.path().to_string_lossy().to_string();
         let config = config_with_root(root_dir.as_str());
-        let timer_message_store = Arc::new(TimerMessageStore::new_with_config(None, config));
+        let timer_message_store = Arc::new(TimerMessageStore::new_with_message_store_config(config));
 
         assert!(timer_message_store.load());
         timer_message_store.start();
@@ -1579,7 +1667,7 @@ mod tests {
         let config = config_with_root(root_dir.as_str());
         let deliver_time_ms = 30_000;
 
-        let timer_message_store = TimerMessageStore::new_with_config(None, config.clone());
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(config.clone());
         assert!(timer_message_store.load());
 
         let record = TimerLogRecord {
@@ -1596,7 +1684,7 @@ mod tests {
             .unwrap();
         timer_message_store.shutdown();
 
-        let reloaded_store = TimerMessageStore::new_with_config(None, config);
+        let reloaded_store = TimerMessageStore::new_with_message_store_config(config);
         assert!(reloaded_store.load());
         assert_eq!(
             reloaded_store.read_timer_log(log_offset, TimerLogRecord::SIZE).unwrap(),
@@ -1613,7 +1701,7 @@ mod tests {
         let valid_time_ms = 10_000;
         let invalid_time_ms = 20_000;
 
-        let timer_message_store = TimerMessageStore::new_with_config(None, config.clone());
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(config.clone());
         assert!(timer_message_store.load());
         let first_record = TimerLogRecord {
             deliver_time_ms: valid_time_ms,
@@ -1665,7 +1753,7 @@ mod tests {
             .unwrap();
         timer_wheel.flush().unwrap();
 
-        let reloaded_store = TimerMessageStore::new_with_config(None, config);
+        let reloaded_store = TimerMessageStore::new_with_message_store_config(config);
         assert!(reloaded_store.load());
         assert_eq!(
             reloaded_store.timer_log.lock().as_ref().unwrap().len().unwrap(),
@@ -1680,7 +1768,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let root_dir = temp_dir.path().to_string_lossy().to_string();
         let config = config_with_root(root_dir.as_str());
-        let timer_message_store = TimerMessageStore::new_with_config(None, config);
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(config);
         assert!(timer_message_store.load());
         let local_read_time = timer_message_store.curr_read_time_ms.load(Ordering::Relaxed);
 
@@ -1947,7 +2035,7 @@ mod tests {
     fn set_should_running_dequeue_clamps_future_read_cursor_on_resume() {
         let temp_dir = tempdir().unwrap();
         let root_dir = temp_dir.path().to_string_lossy().to_string();
-        let timer_message_store = TimerMessageStore::new_with_config(None, config_with_root(root_dir.as_str()));
+        let timer_message_store = TimerMessageStore::new_with_message_store_config(config_with_root(root_dir.as_str()));
 
         assert!(timer_message_store.load());
         let now_floor = timer_message_store.floor_time_ms(current_millis() as i64);

--- a/rocketmq-store/tests/rocksdb_foundation_tests.rs
+++ b/rocketmq-store/tests/rocksdb_foundation_tests.rs
@@ -26,6 +26,10 @@ use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::base::store_enum::StoreType;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::message_store::rocksdb_message_store::RocksDBMessageStore;
+#[allow(
+    deprecated,
+    reason = "this boundary test verifies the deprecated GenericMessageStore adapter until removal"
+)]
 use rocketmq_store::message_store::GenericMessageStore;
 use rocketmq_store::rocksdb::column_family::RocksDbColumnFamily;
 use rocketmq_store::rocksdb::config::RocksDbColumnFamilyConfig;
@@ -538,6 +542,10 @@ fn rocksdb_message_store_implements_message_store_trait_boundary() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "this boundary test verifies the deprecated GenericMessageStore adapter until removal"
+)]
 fn generic_message_store_implements_message_store_trait_boundary() {
     fn assert_message_store<MS: MessageStore>() {}
 

--- a/rocketmq-store/tests/store_api_legacy_adapter.rs
+++ b/rocketmq-store/tests/store_api_legacy_adapter.rs
@@ -17,6 +17,10 @@ use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::AppendMessageStatus;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+#[allow(
+    deprecated,
+    reason = "this compile fixture verifies the deprecated GenericMessageStore adapter until removal"
+)]
 use rocketmq_store::message_store::GenericMessageStore;
 use rocketmq_store::message_store::OwnedMessageStore;
 use rocketmq_store::store_api_adapter::legacy_append_receipt;
@@ -280,6 +284,10 @@ where
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "this compile fixture verifies the deprecated GenericMessageStore adapter until removal"
+)]
 fn legacy_adapter_compile_fixture_is_monomorphized() {
     assert_adapter_contract::<GenericMessageStore>();
     assert_adapter_contract::<OwnedMessageStore>();

--- a/rocketmq/src/arc_mut.rs
+++ b/rocketmq/src/arc_mut.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #![allow(dead_code)]
+#![allow(
+    deprecated,
+    reason = "this module implements the deprecated compatibility facade until its removal gate"
+)]
 
 use core::fmt;
 use std::fmt::Debug;
@@ -35,6 +39,10 @@ use serde::Serializer;
 /// # Safety
 /// The legacy compatibility accessors bypass the backing `RwLock` guards. Callers must ensure
 /// that no conflicting references or data races occur when using this type across threads.
+#[deprecated(
+    since = "1.0.0",
+    note = "use std::sync::Weak with an explicit lock or immutable state"
+)]
 pub struct WeakArcMut<T: ?Sized> {
     inner: Weak<RwLock<T>>,
 }
@@ -88,6 +96,10 @@ impl<T: ?Sized> WeakArcMut<T> {
 /// The legacy compatibility accessors bypass the backing `RwLock` guards. Callers must ensure
 /// that no conflicting references or data races occur when using this type across threads.
 #[derive(Default)]
+#[deprecated(
+    since = "1.0.0",
+    note = "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner"
+)]
 pub struct ArcMut<T: ?Sized> {
     inner: Arc<RwLock<T>>,
 }
@@ -213,6 +225,7 @@ impl<T: ?Sized> DerefMut for ArcMut<T> {
 /// # Safety
 /// `mut_from_ref` and `AsRef` bypass lock guards for compatibility. Callers must ensure that no
 /// conflicting references or data races occur.
+#[deprecated(since = "1.0.0", note = "use parking_lot::RwLock or an exclusive owner")]
 pub struct SyncUnsafeCellWrapper<T: ?Sized> {
     inner: RwLock<T>,
 }

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -24,8 +24,29 @@ pub mod task;
 
 pub mod schedule;
 
+#[allow(
+    deprecated,
+    reason = "retain the deprecated public re-export for the compatibility release window"
+)]
+#[deprecated(
+    since = "1.0.0",
+    note = "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner"
+)]
 pub use arc_mut::ArcMut;
+#[allow(
+    deprecated,
+    reason = "retain the deprecated public re-export for the compatibility release window"
+)]
+#[deprecated(since = "1.0.0", note = "use parking_lot::RwLock or an exclusive owner")]
 pub use arc_mut::SyncUnsafeCellWrapper;
+#[allow(
+    deprecated,
+    reason = "retain the deprecated public re-export for the compatibility release window"
+)]
+#[deprecated(
+    since = "1.0.0",
+    note = "use std::sync::Weak with an explicit lock or immutable state"
+)]
 pub use arc_mut::WeakArcMut;
 pub use blocking_queue::BlockingQueue as RocketMQBlockingQueue;
 pub use count_down_latch::CountDownLatch;

--- a/scripts/arc-mut-baseline.json
+++ b/scripts/arc-mut-baseline.json
@@ -13,7 +13,7 @@
           "id": "742a110d6365535945f5a493",
           "fingerprint": "c81c9fcda8aacd07ba8d38aa",
           "item": "fn deserialize",
-          "line": 273
+          "line": 314
         }
       ],
       "owner": "runtime-foundation",
@@ -32,43 +32,43 @@
           "id": "92707fb69873d90005bf683d",
           "fingerprint": "2ad9cdad29a7fa743b039494",
           "item": "fn new_creates_arc_cell_wrapper_with_provided_value",
-          "line": 285
+          "line": 326
         },
         {
           "id": "6b42479dc202bcedcc7414b2",
           "fingerprint": "c37930ca2abeeace6e68b6d1",
           "item": "fn clone_creates_a_new_instance_with_same_value",
-          "line": 291
+          "line": 332
         },
         {
           "id": "02278a31f39ff7d9d0585bc6",
           "fingerprint": "275e756073bd9bbe5e6ecec9",
           "item": "fn as_ref_returns_immutable_reference_to_value",
-          "line": 298
+          "line": 339
         },
         {
           "id": "19888c5d6555a658b4c0d05f",
           "fingerprint": "99fee606655f8db08399dee1",
           "item": "fn as_mut_returns_mutable_reference_to_value",
-          "line": 304
+          "line": 345
         },
         {
           "id": "c7a8600dbf55ae8c7063777c",
           "fingerprint": "600b99c212e0fde410d85836",
           "item": "fn deref_returns_reference_to_inner_value",
-          "line": 311
+          "line": 352
         },
         {
           "id": "61a06c576a81a313f8a4776e",
           "fingerprint": "69ae2f27e70e3e1561a990e4",
           "item": "fn deref_mut_allows_modification_of_inner_value",
-          "line": 317
+          "line": 358
         },
         {
           "id": "1a57c29aa5712c52ec526d8a",
           "fingerprint": "13b59716ed2eea1aa627f4f4",
           "item": "fn multiple_clones_share_the_same_underlying_data",
-          "line": 324
+          "line": 365
         }
       ],
       "owner": "runtime-foundation",
@@ -87,7 +87,7 @@
           "id": "1eba97e12f9a9ab198baa839",
           "fingerprint": "f61ef173913849c47b6177c5",
           "item": "impl T",
-          "line": 171
+          "line": 198
         }
       ],
       "owner": "runtime-foundation",
@@ -106,7 +106,7 @@
           "id": "62b6cb745efa1d3ae6610e09",
           "fingerprint": "25f3cedc2b8ecb4b98920ab5",
           "item": "impl T",
-          "line": 187
+          "line": 216
         }
       ],
       "owner": "runtime-foundation",
@@ -125,85 +125,85 @@
           "id": "d80969477975ea537cb95714",
           "fingerprint": "050e621e5db5f4feee36cc04",
           "item": "fn upgrade",
-          "line": 76
+          "line": 88
         },
         {
           "id": "7459244afaa2bcf423c1b804",
           "fingerprint": "46b9feb352ae3739ad6a2e62",
           "item": "fn upgrade",
-          "line": 77
+          "line": 89
         },
         {
-          "id": "65456a537c534b55102638ba",
-          "fingerprint": "70e2473d7353c7a875fa9d38",
+          "id": "2585a834504cb60408a7521a",
+          "fingerprint": "f0e2f67955a7b3423369b4a3",
           "item": "struct ArcMut",
-          "line": 87
+          "line": 103
         },
         {
           "id": "7a15cb26f654e4c8b49cf86d",
           "fingerprint": "cb463c7c3e58dc88b5e155d9",
           "item": "impl T",
-          "line": 92
+          "line": 108
         },
         {
           "id": "a56340a6d89d10cf9b91749b",
           "fingerprint": "437df753e21acc4c1b31243a",
           "item": "impl T",
-          "line": 98
+          "line": 116
         },
         {
           "id": "9df7e890b1c98eaf7593e539",
           "fingerprint": "284bf9eb8fe03a9ccae981da",
           "item": "impl T",
-          "line": 100
+          "line": 118
         },
         {
           "id": "18da2c00bb61376ecbb0c1f6",
           "fingerprint": "a987616ecd8dd5634f82520f",
           "item": "impl T",
-          "line": 108
+          "line": 128
         },
         {
           "id": "c0fbed00f56e012f7a9ec272",
           "fingerprint": "c15112d3b5f3e5ddf472b5e0",
           "item": "impl T",
-          "line": 155
+          "line": 180
         },
         {
           "id": "7ae400833ab8df57b750eec3",
           "fingerprint": "8ed1aa4d9b6d7cc236010ebf",
           "item": "fn clone",
-          "line": 158
+          "line": 183
         },
         {
           "id": "880df078c86d981ad8030ebe",
           "fingerprint": "0a409e3235deb446e841003a",
           "item": "impl T",
-          "line": 164
+          "line": 189
         },
         {
           "id": "70a57941c75971bd7a131913",
           "fingerprint": "1125c5be270beb1e69f68afc",
           "item": "impl T",
-          "line": 178
+          "line": 207
         },
         {
           "id": "0daacef3fe97047da951ec00",
           "fingerprint": "1baaac59e83673b5fa70c6e5",
           "item": "impl T",
-          "line": 245
+          "line": 284
         },
         {
           "id": "44fcbec661d9f1d4ff75d377",
           "fingerprint": "8676a3a688a8cf764704e886",
           "item": "impl T",
-          "line": 251
+          "line": 290
         },
         {
           "id": "9e06065543594cb3bb2bdcaf",
           "fingerprint": "66d0200d401f15edc2938a4b",
           "item": "impl de",
-          "line": 264
+          "line": 305
         }
       ],
       "owner": "runtime-foundation",
@@ -222,7 +222,7 @@
           "id": "5db571eaef41901539e74f65",
           "fingerprint": "5701ec6da60fc50f3ae41537",
           "item": "impl T",
-          "line": 222
+          "line": 261
         }
       ],
       "owner": "runtime-foundation",
@@ -241,7 +241,7 @@
           "id": "63e96522c58ee5f239456ce2",
           "fingerprint": "0650d8ee9d6664094f0f5404",
           "item": "impl T",
-          "line": 238
+          "line": 277
         }
       ],
       "owner": "runtime-foundation",
@@ -257,34 +257,34 @@
       "category": "compatibility",
       "occurrences": [
         {
-          "id": "db04db873f2527b05f1da604",
-          "fingerprint": "a744d15147a565be7566f7f1",
+          "id": "34a3a1df2288b900841b1de7",
+          "fingerprint": "b22358e57e62d937f99ceb18",
           "item": "struct SyncUnsafeCellWrapper",
-          "line": 194
+          "line": 229
         },
         {
           "id": "0f8d03f9de1035c5d36c207d",
           "fingerprint": "a32d4a9aef53d970ce53d889",
           "item": "impl T",
-          "line": 198
+          "line": 233
         },
         {
           "id": "f2ea67473ecad266d2b8a62a",
           "fingerprint": "b4469e217060bb7ed9282f00",
           "item": "impl T",
-          "line": 207
+          "line": 242
         },
         {
           "id": "1178a4b7943a1876a44afd73",
           "fingerprint": "485c2ea32d5b8d9602a433bd",
           "item": "impl T",
-          "line": 215
+          "line": 252
         },
         {
           "id": "6273f98113278fe577f4904c",
           "fingerprint": "6cb79d116c1962aa1633975a",
           "item": "impl T",
-          "line": 229
+          "line": 268
         }
       ],
       "owner": "runtime-foundation",
@@ -300,52 +300,52 @@
       "category": "compatibility",
       "occurrences": [
         {
-          "id": "813243861ba77e53dcc4b02e",
-          "fingerprint": "cc56d0955a6c147fc72af03a",
+          "id": "56987f5bacacad808f3915fb",
+          "fingerprint": "17309aa6dfa40992a933103f",
           "item": "struct WeakArcMut",
-          "line": 38
+          "line": 46
         },
         {
           "id": "2c2c5a769ec2638b9f60bee2",
           "fingerprint": "19a9989d65fd33adf9af38f7",
           "item": "impl T",
-          "line": 43
+          "line": 51
         },
         {
           "id": "77169b88c05d209e9d13d0a4",
           "fingerprint": "7fba2df25ccbe5645492d489",
           "item": "impl T",
-          "line": 54
+          "line": 64
         },
         {
           "id": "9b927576c54e36a1704b43d5",
           "fingerprint": "fc73dd99015ddedb9a0db2ef",
           "item": "impl T",
-          "line": 58
+          "line": 68
         },
         {
           "id": "50ccdc8db7d3055a387faae9",
           "fingerprint": "d642d4749f6567740de9e3b4",
           "item": "impl T",
-          "line": 66
+          "line": 78
         },
         {
           "id": "6ff1b8b3515b243d1969c0ee",
           "fingerprint": "1de8b8e33e8649c6447d8343",
           "item": "impl T",
-          "line": 74
+          "line": 86
         },
         {
           "id": "0e50e9723b4bdbdabca2dd10",
           "fingerprint": "dedc80dcd8cb3b2ad35df8a8",
           "item": "fn downgrade",
-          "line": 128
+          "line": 150
         },
         {
           "id": "9a41fb8cef8e4f8539a6056c",
           "fingerprint": "dda7662c017745fa3a2e33ee",
           "item": "fn downgrade",
-          "line": 129
+          "line": 151
         }
       ],
       "owner": "runtime-foundation",
@@ -364,13 +364,13 @@
           "id": "9b2656ea02aef4270be49fcd",
           "fingerprint": "899d7e475a899bf5bb7173ed",
           "item": "fn new",
-          "line": 122
+          "line": 142
         },
         {
           "id": "609e6f37cecf9245bd1b7c51",
           "fingerprint": "a8cb42b4767c313bf138d831",
           "item": "impl T",
-          "line": 209
+          "line": 244
         }
       ],
       "owner": "runtime-foundation",
@@ -389,13 +389,13 @@
           "id": "52d5db03f3424f078d2731aa",
           "fingerprint": "374b8ec38e16d9efb4973346",
           "item": "fn mut_from_ref",
-          "line": 123
+          "line": 143
         },
         {
           "id": "028bf83090da8df7b3e1ca16",
           "fingerprint": "374b8ec38e16d9efb4973346",
           "item": "fn mut_from_ref",
-          "line": 210
+          "line": 245
         }
       ],
       "owner": "runtime-foundation",
@@ -411,10 +411,10 @@
       "category": "compatibility",
       "occurrences": [
         {
-          "id": "c4de3f11cf2c6814e89c1cc7",
-          "fingerprint": "5edc64c5be9388581b1a13c9",
+          "id": "603e5d7ed7671c2e2d6e56b3",
+          "fingerprint": "b84e48eaea4ff4e574ff761f",
           "item": "mod schedule",
-          "line": 27
+          "line": 35
         }
       ],
       "owner": "runtime-foundation",
@@ -430,10 +430,10 @@
       "category": "compatibility",
       "occurrences": [
         {
-          "id": "9712d81a72a0f2df77faf112",
-          "fingerprint": "843e8a2fd089f913717d13f1",
+          "id": "8289b0607ff9ede4585eeadc",
+          "fingerprint": "1398850d3142ed7b123fabb4",
           "item": "mod schedule",
-          "line": 28
+          "line": 41
         }
       ],
       "owner": "runtime-foundation",
@@ -449,10 +449,10 @@
       "category": "compatibility",
       "occurrences": [
         {
-          "id": "04eed240a8b71eb693c91690",
-          "fingerprint": "248f5f80abd496abd4be9b88",
+          "id": "3a0eef0133646b8a231a627b",
+          "fingerprint": "fccac5c16379cb93e1873244",
           "item": "mod schedule",
-          "line": 29
+          "line": 50
         }
       ],
       "owner": "runtime-foundation",
@@ -468,10 +468,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "ef5ed7a2fb3cfd78bc28e148",
-          "fingerprint": "79d7934245cbc8a78d433cb3",
+          "id": "27af12865a298c62b16135b0",
+          "fingerprint": "60305e98f790eadd708c1990",
           "item": "<module>",
-          "line": 86
+          "line": 90
         }
       ],
       "owner": "store",
@@ -487,10 +487,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "2fe46ccfd39fbe3e6291e485",
-          "fingerprint": "36bf179549bc6842180b8dfd",
+          "id": "7479d3bee96c4b30cc5f9437",
+          "fingerprint": "a7c3689a723703690f8d958f",
           "item": "fn set_message_store_arc",
-          "line": 1076
+          "line": 1085
         }
       ],
       "owner": "store",
@@ -506,10 +506,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "746542483fffcc017c2b2e5b",
-          "fingerprint": "f03c49a9cf69fb66e5e947be",
+          "id": "32f45d77d26aacb74f5a7de5",
+          "fingerprint": "3a82c532a0c21e0fd13f51a3",
           "item": "mod rocksdb_message_store",
-          "line": 40
+          "line": 44
         }
       ],
       "owner": "store",
@@ -525,28 +525,28 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "36361cc6ccd2b916d08d4dec",
-          "fingerprint": "f188643beba2ccecef5f9da0",
+          "id": "e534ff3b3fe9f567ee47c649",
+          "fingerprint": "0538579d1bd58175d6e47759",
           "item": "enum GenericMessageStore",
-          "line": 76
+          "line": 88
         },
         {
-          "id": "f6a3c6581db220e1627690d6",
-          "fingerprint": "131520c4ce58aed471b5ee64",
+          "id": "0246721faa7251f8829bd6bc",
+          "fingerprint": "6c7d4dc577e0e6cf15fa5348",
           "item": "enum GenericMessageStore",
-          "line": 79
+          "line": 91
         },
         {
-          "id": "98f940f936e81a1ad86d929b",
-          "fingerprint": "ae926679a6245276015ae367",
+          "id": "cc38530a2199810daf1d5abe",
+          "fingerprint": "fc1f714b4a27504e21bbb396",
           "item": "fn local_file",
-          "line": 83
+          "line": 99
         },
         {
           "id": "3c5132015f64c8e2b0630601",
           "fingerprint": "f19745ebb78552b6636b9aca",
           "item": "fn rocksdb",
-          "line": 88
+          "line": 104
         }
       ],
       "owner": "store",
@@ -562,10 +562,10 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "59690fe43b7e20d5c5b0b4ce",
-          "fingerprint": "86afd2fcada016a20ef11e69",
+          "id": "14bed5f0eb0004978a17e275",
+          "fingerprint": "dfb3e08f0b0ce50e90f12535",
           "item": "<module>",
-          "line": 40
+          "line": 44
         }
       ],
       "owner": "store",
@@ -581,28 +581,28 @@
       "category": "production",
       "occurrences": [
         {
-          "id": "af0fcd31eef971bc6f63e598",
-          "fingerprint": "86d104ca58d9a6dd7b7ef375",
+          "id": "e38c48cb2a1a487c9e0f5f68",
+          "fingerprint": "c3db569f8c46bbf7ccf82349",
           "item": "struct TimerMessageStore",
-          "line": 151
+          "line": 163
         },
         {
-          "id": "64375a083f99666818770b37",
-          "fingerprint": "74d7f955ebf55205899de652",
+          "id": "e2d2720bc4bddd1beb0bf467",
+          "fingerprint": "4abd74901af4a2a72f373b6f",
           "item": "fn new",
-          "line": 361
+          "line": 381
         },
         {
-          "id": "747bcf58098dd1ea8ed4efe3",
-          "fingerprint": "95753dce076ef08c0a080058",
+          "id": "c21ecee6b38b405535901d18",
+          "fingerprint": "00091e792564d0d977b610d6",
           "item": "fn new_with_config",
-          "line": 370
+          "line": 398
         },
         {
           "id": "a604b46790ddd1f7e32a25a1",
           "fingerprint": "726df4d5d9d742ff563f9a10",
           "item": "fn set_default_message_store",
-          "line": 409
+          "line": 460
         }
       ],
       "owner": "store",

--- a/scripts/arc-mut-relocation-approvals.json
+++ b/scripts/arc-mut-relocation-approvals.json
@@ -910,6 +910,102 @@
       "from": "3868a2990574ade766ffcdc8",
       "to": "63278d5eba087cd7f1369da9",
       "reason": "M10-02 guarded the existing retry-delete mutation with the minimum derived WAL pin without adding a mut_from_ref occurrence"
+    },
+    {
+      "identity": "4d90f667e8966a75f78769f4",
+      "from": "65456a537c534b55102638ba",
+      "to": "2585a834504cb60408a7521a",
+      "reason": "Adding the compiler-visible ArcMut deprecation marker changed the existing type declaration fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "0bd2a9cf20621cfa4ed1cf5e",
+      "from": "db04db873f2527b05f1da604",
+      "to": "34a3a1df2288b900841b1de7",
+      "reason": "Adding the compiler-visible SyncUnsafeCellWrapper deprecation marker changed the existing type declaration fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "cd00e2a1556ea95f83450e28",
+      "from": "813243861ba77e53dcc4b02e",
+      "to": "56987f5bacacad808f3915fb",
+      "reason": "Adding the compiler-visible WeakArcMut deprecation marker changed the existing type declaration fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "2093ebe6ec0c89a444eba617",
+      "from": "c4de3f11cf2c6814e89c1cc7",
+      "to": "603e5d7ed7671c2e2d6e56b3",
+      "reason": "Adding the ArcMut root re-export deprecation marker changed the existing re-export fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "378773746445866290a41dea",
+      "from": "9712d81a72a0f2df77faf112",
+      "to": "8289b0607ff9ede4585eeadc",
+      "reason": "Adding the SyncUnsafeCellWrapper root re-export deprecation marker changed the existing re-export fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "a5632591cff2155105bfd5ed",
+      "from": "04eed240a8b71eb693c91690",
+      "to": "3a0eef0133646b8a231a627b",
+      "reason": "Adding the WeakArcMut root re-export deprecation marker changed the existing re-export fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "9df6be4b83a40eddcebc37be",
+      "from": "ef5ed7a2fb3cfd78bc28e148",
+      "to": "27af12865a298c62b16135b0",
+      "reason": "Adding the scoped deprecation allowance changed the existing LocalFile ArcMut import fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "3642ffbf2d028a63f43d1340",
+      "from": "2fe46ccfd39fbe3e6291e485",
+      "to": "7479d3bee96c4b30cc5f9437",
+      "reason": "Adding the set_message_store_arc deprecation marker changed its existing ArcMut parameter fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "54faa711f0305e782b819cb0",
+      "from": "746542483fffcc017c2b2e5b",
+      "to": "32f45d77d26aacb74f5a7de5",
+      "reason": "Adding the scoped deprecation allowance changed the existing GenericMessageStore ArcMut import fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "ec0a1d513dcd0a4ad320e84f",
+      "from": "36361cc6ccd2b916d08d4dec",
+      "to": "e534ff3b3fe9f567ee47c649",
+      "reason": "Adding GenericMessageStore deprecation metadata changed the existing LocalFile variant fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "ec0a1d513dcd0a4ad320e84f",
+      "from": "f6a3c6581db220e1627690d6",
+      "to": "0246721faa7251f8829bd6bc",
+      "reason": "Adding GenericMessageStore deprecation metadata changed the existing RocksDB variant fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "ec0a1d513dcd0a4ad320e84f",
+      "from": "98f940f936e81a1ad86d929b",
+      "to": "cc38530a2199810daf1d5abe",
+      "reason": "Adding GenericMessageStore deprecation metadata changed the existing LocalFile constructor fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "85875520c1f74ec05bf38d10",
+      "from": "59690fe43b7e20d5c5b0b4ce",
+      "to": "14bed5f0eb0004978a17e275",
+      "reason": "Adding the scoped deprecation allowance changed the existing Timer ArcMut import fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "37153ae40c27a8e9b5acefa9",
+      "from": "af0fcd31eef971bc6f63e598",
+      "to": "e38c48cb2a1a487c9e0f5f68",
+      "reason": "Adding TimerMessageStore deprecation metadata changed the existing full-Store field fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "37153ae40c27a8e9b5acefa9",
+      "from": "64375a083f99666818770b37",
+      "to": "e2d2720bc4bddd1beb0bf467",
+      "reason": "Adding TimerMessageStore deprecation metadata changed the existing full-Store constructor fingerprint without adding an occurrence"
+    },
+    {
+      "identity": "37153ae40c27a8e9b5acefa9",
+      "from": "747bcf58098dd1ea8ed4efe3",
+      "to": "c21ecee6b38b405535901d18",
+      "reason": "Adding TimerMessageStore deprecation metadata changed the existing config constructor fingerprint without adding an occurrence"
     }
   ]
 }

--- a/scripts/architecture-release-plan.json
+++ b/scripts/architecture-release-plan.json
@@ -9,6 +9,103 @@
     "destructive_removal": "pending-next-major-evidence-gate",
     "constraint": "Approval of the release package does not authorize early removal of compatibility paths or early activation of Proxy mode features."
   },
+  "arc_mut_deprecation": {
+    "since": "1.0.0",
+    "minimum_deprecation_releases": 2,
+    "minimum_major_boundaries": 1,
+    "destructive_removal": "pending-next-major-evidence-gate",
+    "canonical_replacements": [
+      {
+        "id": "owned-message-store",
+        "path": "rocketmq-store/src/message_store/owned_message_store.rs",
+        "declaration": "pub enum OwnedMessageStore"
+      },
+      {
+        "id": "owned-root-wiring",
+        "path": "rocketmq-store/src/message_store/local_file_message_store.rs",
+        "declaration": "pub fn wire_owned_root_dependencies("
+      },
+      {
+        "id": "timer-config-constructor",
+        "path": "rocketmq-store/src/timer/timer_message_store.rs",
+        "declaration": "pub fn new_with_message_store_config("
+      }
+    ],
+    "surfaces": [
+      {
+        "id": "arc-mut-type",
+        "path": "rocketmq/src/arc_mut.rs",
+        "declaration": "pub struct ArcMut",
+        "note": "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner"
+      },
+      {
+        "id": "weak-arc-mut-type",
+        "path": "rocketmq/src/arc_mut.rs",
+        "declaration": "pub struct WeakArcMut",
+        "note": "use std::sync::Weak with an explicit lock or immutable state"
+      },
+      {
+        "id": "sync-unsafe-cell-wrapper-type",
+        "path": "rocketmq/src/arc_mut.rs",
+        "declaration": "pub struct SyncUnsafeCellWrapper",
+        "note": "use parking_lot::RwLock or an exclusive owner"
+      },
+      {
+        "id": "arc-mut-root-reexport",
+        "path": "rocketmq/src/lib.rs",
+        "declaration": "pub use arc_mut::ArcMut;",
+        "note": "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner"
+      },
+      {
+        "id": "weak-arc-mut-root-reexport",
+        "path": "rocketmq/src/lib.rs",
+        "declaration": "pub use arc_mut::WeakArcMut;",
+        "note": "use std::sync::Weak with an explicit lock or immutable state"
+      },
+      {
+        "id": "sync-unsafe-cell-wrapper-root-reexport",
+        "path": "rocketmq/src/lib.rs",
+        "declaration": "pub use arc_mut::SyncUnsafeCellWrapper;",
+        "note": "use parking_lot::RwLock or an exclusive owner"
+      },
+      {
+        "id": "generic-message-store",
+        "path": "rocketmq-store/src/message_store.rs",
+        "declaration": "pub enum GenericMessageStore",
+        "note": "use OwnedMessageStore and inject narrow Store capabilities into shared consumers"
+      },
+      {
+        "id": "local-file-shared-root-wiring",
+        "path": "rocketmq-store/src/message_store/local_file_message_store.rs",
+        "declaration": "pub fn set_message_store_arc(",
+        "note": "use LocalFileMessageStore::wire_owned_root_dependencies"
+      },
+      {
+        "id": "timer-full-store-field",
+        "path": "rocketmq-store/src/timer/timer_message_store.rs",
+        "declaration": "pub default_message_store:",
+        "note": "use new_with_message_store_config or wire_owned_root_dependencies"
+      },
+      {
+        "id": "timer-full-store-constructor",
+        "path": "rocketmq-store/src/timer/timer_message_store.rs",
+        "declaration": "pub fn new(default_message_store:",
+        "note": "use new_with_message_store_config or wire_owned_root_dependencies"
+      },
+      {
+        "id": "timer-full-store-config-constructor",
+        "path": "rocketmq-store/src/timer/timer_message_store.rs",
+        "declaration": "pub fn new_with_config(",
+        "note": "use new_with_message_store_config or wire_owned_root_dependencies"
+      },
+      {
+        "id": "timer-full-store-setter",
+        "path": "rocketmq-store/src/timer/timer_message_store.rs",
+        "declaration": "pub fn set_default_message_store(",
+        "note": "use new_with_message_store_config or wire_owned_root_dependencies"
+      }
+    ]
+  },
   "release_topology": {
     "required_chain": [
       "model/error/runtime/security/store-api",

--- a/scripts/architecture_release_guard.py
+++ b/scripts/architecture_release_guard.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 import tomllib
 from pathlib import Path
@@ -52,6 +53,82 @@ NEW_CRATES = {
     "rocketmq-proxy-local",
 }
 EDGE_FIELDS = ("caller", "target", "kind", "path", "alias")
+REQUIRED_ARC_MUT_DEPRECATIONS = {
+    "arc-mut-type": (
+        "rocketmq/src/arc_mut.rs",
+        "pub struct ArcMut",
+        "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner",
+    ),
+    "weak-arc-mut-type": (
+        "rocketmq/src/arc_mut.rs",
+        "pub struct WeakArcMut",
+        "use std::sync::Weak with an explicit lock or immutable state",
+    ),
+    "sync-unsafe-cell-wrapper-type": (
+        "rocketmq/src/arc_mut.rs",
+        "pub struct SyncUnsafeCellWrapper",
+        "use parking_lot::RwLock or an exclusive owner",
+    ),
+    "arc-mut-root-reexport": (
+        "rocketmq/src/lib.rs",
+        "pub use arc_mut::ArcMut;",
+        "use std::sync::Arc with RwLock, Mutex, atomics, or an exclusive owner",
+    ),
+    "weak-arc-mut-root-reexport": (
+        "rocketmq/src/lib.rs",
+        "pub use arc_mut::WeakArcMut;",
+        "use std::sync::Weak with an explicit lock or immutable state",
+    ),
+    "sync-unsafe-cell-wrapper-root-reexport": (
+        "rocketmq/src/lib.rs",
+        "pub use arc_mut::SyncUnsafeCellWrapper;",
+        "use parking_lot::RwLock or an exclusive owner",
+    ),
+    "generic-message-store": (
+        "rocketmq-store/src/message_store.rs",
+        "pub enum GenericMessageStore",
+        "use OwnedMessageStore and inject narrow Store capabilities into shared consumers",
+    ),
+    "local-file-shared-root-wiring": (
+        "rocketmq-store/src/message_store/local_file_message_store.rs",
+        "pub fn set_message_store_arc(",
+        "use LocalFileMessageStore::wire_owned_root_dependencies",
+    ),
+    "timer-full-store-field": (
+        "rocketmq-store/src/timer/timer_message_store.rs",
+        "pub default_message_store:",
+        "use new_with_message_store_config or wire_owned_root_dependencies",
+    ),
+    "timer-full-store-constructor": (
+        "rocketmq-store/src/timer/timer_message_store.rs",
+        "pub fn new(default_message_store:",
+        "use new_with_message_store_config or wire_owned_root_dependencies",
+    ),
+    "timer-full-store-config-constructor": (
+        "rocketmq-store/src/timer/timer_message_store.rs",
+        "pub fn new_with_config(",
+        "use new_with_message_store_config or wire_owned_root_dependencies",
+    ),
+    "timer-full-store-setter": (
+        "rocketmq-store/src/timer/timer_message_store.rs",
+        "pub fn set_default_message_store(",
+        "use new_with_message_store_config or wire_owned_root_dependencies",
+    ),
+}
+REQUIRED_ARC_MUT_REPLACEMENTS = {
+    "owned-message-store": (
+        "rocketmq-store/src/message_store/owned_message_store.rs",
+        "pub enum OwnedMessageStore",
+    ),
+    "owned-root-wiring": (
+        "rocketmq-store/src/message_store/local_file_message_store.rs",
+        "pub fn wire_owned_root_dependencies(",
+    ),
+    "timer-config-constructor": (
+        "rocketmq-store/src/timer/timer_message_store.rs",
+        "pub fn new_with_message_store_config(",
+    ),
+}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -213,6 +290,108 @@ def check_usage_and_approval(plan: dict[str, Any], findings: list[str]) -> None:
         findings.append("external notification plan must contain at least four channels")
 
 
+def deprecation_attribute_pattern(since: str, note: str) -> re.Pattern[str]:
+    return re.compile(
+        r"#\[\s*deprecated\s*\(\s*since\s*=\s*"
+        + re.escape(f'"{since}"')
+        + r"\s*,\s*note\s*=\s*"
+        + re.escape(f'"{note}"')
+        + r"\s*,?\s*\)\s*\]"
+    )
+
+
+def check_arc_mut_deprecations(
+    plan: dict[str, Any],
+    findings: list[str],
+    source_overrides: dict[str, str] | None = None,
+) -> None:
+    policy = plan.get("arc_mut_deprecation", {})
+    if policy.get("since") != "1.0.0":
+        findings.append("ArcMut compatibility deprecation must start in 1.0.0")
+    if policy.get("minimum_deprecation_releases") != 2:
+        findings.append("ArcMut removal must retain two deprecation releases")
+    if policy.get("minimum_major_boundaries") != 1:
+        findings.append("ArcMut removal must retain one major-version boundary")
+    if policy.get("destructive_removal") != "pending-next-major-evidence-gate":
+        findings.append("ArcMut destructive removal must remain pending the evidence gate")
+
+    surfaces = policy.get("surfaces", [])
+    observed = {
+        surface.get("id"): (
+            surface.get("path"),
+            surface.get("declaration"),
+            surface.get("note"),
+        )
+        for surface in surfaces
+        if isinstance(surface, dict)
+    }
+    if observed != REQUIRED_ARC_MUT_DEPRECATIONS or len(surfaces) != len(observed):
+        findings.append("ArcMut deprecation inventory differs from the approved 12-surface contract")
+
+    replacements = policy.get("canonical_replacements", [])
+    observed_replacements = {
+        replacement.get("id"): (
+            replacement.get("path"),
+            replacement.get("declaration"),
+        )
+        for replacement in replacements
+        if isinstance(replacement, dict)
+    }
+    if (
+        observed_replacements != REQUIRED_ARC_MUT_REPLACEMENTS
+        or len(replacements) != len(observed_replacements)
+    ):
+        findings.append("ArcMut canonical replacement inventory differs from the approved contract")
+
+    since = str(policy.get("since", ""))
+    for surface_id, (relative_path, declaration, note) in REQUIRED_ARC_MUT_DEPRECATIONS.items():
+        path = ROOT / relative_path
+        if source_overrides is not None and relative_path in source_overrides:
+            content = source_overrides[relative_path]
+        elif path.is_file():
+            content = path.read_text(encoding="utf-8")
+        else:
+            findings.append(f"ArcMut deprecation source is missing: {relative_path}")
+            continue
+
+        if content.count(declaration) != 1:
+            findings.append(
+                f"ArcMut deprecation declaration must be unique: {surface_id}"
+            )
+            continue
+        declaration_index = content.index(declaration)
+        matches = list(
+            deprecation_attribute_pattern(since, note).finditer(
+                content[:declaration_index]
+            )
+        )
+        if not matches or content[matches[-1].end() : declaration_index].strip():
+            findings.append(
+                f"ArcMut deprecation marker is missing or detached: {surface_id}"
+            )
+
+    for replacement_id, (relative_path, declaration) in REQUIRED_ARC_MUT_REPLACEMENTS.items():
+        path = ROOT / relative_path
+        if source_overrides is not None and relative_path in source_overrides:
+            content = source_overrides[relative_path]
+        elif path.is_file():
+            content = path.read_text(encoding="utf-8")
+        else:
+            findings.append(f"ArcMut replacement source is missing: {relative_path}")
+            continue
+
+        if content.count(declaration) != 1:
+            findings.append(f"ArcMut replacement declaration must be unique: {replacement_id}")
+            continue
+        declaration_index = content.index(declaration)
+        prefix = content[:declaration_index]
+        attribute_block = prefix[prefix.rfind("\n\n") + 2 :]
+        if re.search(r"#\[\s*deprecated(?:\s*\(|\s*\])", attribute_block):
+            findings.append(f"ArcMut canonical replacement is deprecated: {replacement_id}")
+        if replacement_id == "owned-message-store" and "#[doc(hidden)]" in attribute_block:
+            findings.append("OwnedMessageStore canonical replacement is hidden from Rustdoc")
+
+
 def check_ci_and_documents(plan: dict[str, Any], findings: list[str]) -> None:
     workflow = CI_PATH.read_text(encoding="utf-8")
     for command in (
@@ -259,6 +438,7 @@ def validate() -> list[str]:
     check_release_windows(plan, baseline, findings)
     check_proxy_activation(plan, findings)
     check_usage_and_approval(plan, findings)
+    check_arc_mut_deprecations(plan, findings)
     check_ci_and_documents(plan, findings)
     return findings
 
@@ -276,6 +456,7 @@ def main() -> int:
     print("- compatibility windows: R1 29, next-major 4, long-term 2")
     print("- early removals/Proxy feature activation: 0")
     print("- external usage and notification gates: approved and enforced")
+    print("- ArcMut deprecation contract: 12/12 public surfaces, 3/3 canonical replacements")
     return 0
 
 

--- a/scripts/tests/test_architecture_release_guard.py
+++ b/scripts/tests/test_architecture_release_guard.py
@@ -48,6 +48,7 @@ class ArchitectureReleaseGuardTest(unittest.TestCase):
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         self.assertIn("R1 29, next-major 4, long-term 2", result.stdout)
+        self.assertIn("12/12 public surfaces, 3/3 canonical replacements", result.stdout)
 
     def test_publish_order_covers_target_dag_and_respects_dependencies(self) -> None:
         findings: list[str] = []
@@ -101,6 +102,83 @@ class ArchitectureReleaseGuardTest(unittest.TestCase):
         self.assertEqual(
             "pending-next-major-evidence-gate",
             self.plan["human_approval"]["destructive_removal"],
+        )
+
+    def test_arc_mut_deprecation_inventory_and_markers_are_complete(self) -> None:
+        findings: list[str] = []
+        guard.check_arc_mut_deprecations(self.plan, findings)
+        self.assertEqual([], findings)
+        self.assertEqual(
+            guard.REQUIRED_ARC_MUT_DEPRECATIONS,
+            {
+                surface["id"]: (
+                    surface["path"],
+                    surface["declaration"],
+                    surface["note"],
+                )
+                for surface in self.plan["arc_mut_deprecation"]["surfaces"]
+            },
+        )
+        self.assertEqual(
+            guard.REQUIRED_ARC_MUT_REPLACEMENTS,
+            {
+                replacement["id"]: (
+                    replacement["path"],
+                    replacement["declaration"],
+                )
+                for replacement in self.plan["arc_mut_deprecation"]["canonical_replacements"]
+            },
+        )
+
+    def test_arc_mut_deprecation_contract_fails_closed(self) -> None:
+        invalid = copy.deepcopy(self.plan)
+        invalid["arc_mut_deprecation"]["surfaces"].pop()
+        findings: list[str] = []
+        guard.check_arc_mut_deprecations(invalid, findings)
+        self.assertIn(
+            "ArcMut deprecation inventory differs from the approved 12-surface contract",
+            findings,
+        )
+
+        surface_id = "arc-mut-type"
+        relative_path, declaration, note = guard.REQUIRED_ARC_MUT_DEPRECATIONS[surface_id]
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        declaration_index = source.index(declaration)
+        marker = list(
+            guard.deprecation_attribute_pattern("1.0.0", note).finditer(
+                source[:declaration_index]
+            )
+        )[-1]
+        without_marker = source[: marker.start()] + source[marker.end() :]
+        findings = []
+        guard.check_arc_mut_deprecations(
+            self.plan,
+            findings,
+            source_overrides={relative_path: without_marker},
+        )
+        self.assertIn(
+            f"ArcMut deprecation marker is missing or detached: {surface_id}",
+            findings,
+        )
+
+        replacement_id = "timer-config-constructor"
+        replacement_path, replacement_declaration = guard.REQUIRED_ARC_MUT_REPLACEMENTS[replacement_id]
+        replacement_source = (ROOT / replacement_path).read_text(encoding="utf-8")
+        replacement_index = replacement_source.index(replacement_declaration)
+        deprecated_replacement = (
+            replacement_source[:replacement_index]
+            + '#[deprecated(since = "1.0.0", note = "invalid canonical replacement")]\n    '
+            + replacement_source[replacement_index:]
+        )
+        findings = []
+        guard.check_arc_mut_deprecations(
+            self.plan,
+            findings,
+            source_overrides={replacement_path: deprecated_replacement},
+        )
+        self.assertIn(
+            f"ArcMut canonical replacement is deprecated: {replacement_id}",
+            findings,
         )
 
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8680

### Brief Description

- Marks the 12 remaining ArcMut and Store compatibility surfaces as deprecated since 1.0.0 without removing behavior.
- Exposes three canonical replacements and migrates config-only Timer callers to the non-deprecated constructor.
- Extends the release guard with an exact positive and negative deprecation contract while preserving the reviewed ArcMut baseline at 20 uses and 58 operations.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo check -p rocketmq-rust -p rocketmq-store --all-targets`
- `cargo check -p rocketmq-store --all-targets --all-features`
- `cargo clippy -p rocketmq-rust -p rocketmq-store --all-targets --all-features -- -D warnings`
- Focused ArcMut, Store adapter, Timer constructor, and Broker Timer admin tests
- `python scripts/arc_mut_guard.py`
- `python -m unittest scripts.tests.test_arc_mut_guard -v`
- `python scripts/arc_mut_guard.py --fixtures`
- `python scripts/architecture_release_guard.py`
- `python -m unittest scripts.tests.test_architecture_release_guard -v`
- `python scripts/architecture_dependency_guard.py --mode target`
- `cargo doc -p rocketmq-store --no-deps --all-features` (passed with four pre-existing Rustdoc HTML warnings in untouched files)
- The repository-wide public API check reported review-required against its older baseline because of pre-existing cross-package drift. A focused branch-versus-main Rustdoc path comparison for the two affected packages confirmed zero removed paths: `rocketmq-rust` remained 12 to 12, and `rocketmq-store` changed from 377 to 379 with only `OwnedMessageStore` and its variant added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Made the recommended message-store API visible in generated documentation.
  * Added migration guidance for legacy message-store, timer, and shared-mutation APIs.

* **Refactor**
  * Unified message-store composition and compatibility handling while preserving existing behavior.
  * Updated timer-store construction paths to use the current configuration-based API.

* **Bug Fixes**
  * Preserved compatibility for legacy constructors and adapters during the deprecation period.
  * Added validation to ensure deprecation markers and replacement APIs remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->