### PR TITLE
[ISSUE #8684]✨Prefer native async trait methods in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@
   only when intentionally grouping future or irrelevant cases.
 - Any new `#[allow(...)]` must be scoped to the narrowest item and include a reason. Do not add crate- or
   module-wide `allow(warnings)` or broad Clippy-group suppression.
+- Prefer native `async fn` methods in traits. `#[allow(async_fn_in_trait)]` is permitted when required by the
+  lint for an intentional public async trait API; do not add `#[async_trait]`.
 - Treat roughly 500 lines as a module review signal and avoid extending high-touch modules beyond roughly 800
   lines without a strong local reason. Do not split unrelated legacy modules solely to meet a number.
 - Keep comments focused on invariants, ordering, error handling, protocol compatibility, or concurrency assumptions; do not restate the code.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8684

### Brief Description

- Adds a root Rust engineering guardrail that prefers native `async fn` trait methods.
- Permits narrowly scoped `#[allow(async_fn_in_trait)]` only for an intentional public async trait API.
- Prevents automated changes from introducing `#[async_trait]`.

### How Did You Test This Change?

- `.\scripts\check-agents-routing.ps1` - passed with 4 standalone Cargo projects, 3 Node projects, and 8 routes.
- `git diff --check -- AGENTS.md` - passed.
- Verified the change is additive-only: 2 additions, 0 deletions, and exactly one native async trait guidance rule.
- Cargo validation was not run because this PR changes repository agent guidance only and does not modify Rust, Cargo configuration, dependencies, or executable examples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance recommending native asynchronous trait methods.
  * Clarified when public async trait exceptions are acceptable and discouraged unnecessary compatibility macros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->