### PR TITLE
[ISSUE #8713]♻️Add Controller-aware production Helm HA profiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,26 @@
 # Cargo build artifacts
 target/
 **/target/
+target-*/
+**/target-*/
+.codex-target/
+**/.codex-target/
+
+# Node and website build artifacts
+node_modules/
+**/node_modules/
+dist/
+**/dist/
+build/
+**/build/
+.docusaurus/
+**/.docusaurus/
+.cache/
+**/.cache/
+.npm/
+**/.npm/
+.pnpm-store/
+**/.pnpm-store/
 
 # IDE and editor files
 .vscode/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 distribution/kubernetes/fault-matrix-policy.json text eol=lf
 scripts/tests/fixtures/m11-fault-matrix/pass/** text eol=lf
+docker/Dockerfile* text eol=lf

--- a/distribution/helm/rocketmq-rust/Chart.yaml
+++ b/distribution/helm/rocketmq-rust/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: rocketmq-rust
-description: Secure digest-only deployment assets for the five RocketMQ Rust services
+description: Controller-aware development and production HA deployment assets for RocketMQ Rust
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
 kubeVersion: ">=1.32.0-0"
 annotations:
-  rocketmq.apache.org/architecture-milestone: M11-09
-  rocketmq.apache.org/image-policy: signed-digest-only
+  rocketmq.apache.org/architecture-milestone: P0-04
+  rocketmq.apache.org/image-policy: local-tag-or-immutable-digest

--- a/distribution/helm/rocketmq-rust/templates/_helpers.tpl
+++ b/distribution/helm/rocketmq-rust/templates/_helpers.tpl
@@ -7,6 +7,47 @@ rocketmq-rust
 rocketmq-{{ .service }}
 {{- end -}}
 
+{{/* Fail early when cross-field topology invariants cannot be expressed by JSON Schema. */}}
+{{- define "rocketmq.validateValues" -}}
+{{- $profile := .Values.deploymentProfile -}}
+{{- if eq $profile "production-controller-ha" -}}
+  {{- $controllerReplicas := int .Values.services.controller.replicas -}}
+  {{- $controllerQuorum := add (div $controllerReplicas 2) 1 -}}
+  {{- if or (lt $controllerReplicas 3) (eq (mod $controllerReplicas 2) 0) -}}
+    {{- fail "production-controller-ha requires an odd Controller replica count of at least 3" -}}
+  {{- end -}}
+  {{- if ne (len .Values.services.controller.peerServiceClusterIPs) $controllerReplicas -}}
+    {{- fail "production-controller-ha requires one unique Controller peer Service IP per Controller replica" -}}
+  {{- end -}}
+  {{- if lt (int .Values.services.broker.replicas) 3 -}}
+    {{- fail "production-controller-ha requires at least 3 Broker replicas in the Controller-managed replica group" -}}
+  {{- end -}}
+  {{- if ne .Values.services.controller.storageBackend "RocksDB" -}}
+    {{- fail "production-controller-ha requires Controller RocksDB storage" -}}
+  {{- end -}}
+  {{- range $service := list "broker" "namesrv" "controller" -}}
+    {{- $config := index $.Values.services $service -}}
+    {{- if not $config.persistence.enabled -}}
+      {{- fail (printf "production-controller-ha requires services.%s.persistence.enabled=true" $service) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if lt (int .Values.services.controller.pdb.minAvailable) (int $controllerQuorum) -}}
+    {{- fail (printf "Controller PDB minAvailable must preserve quorum (%d)" $controllerQuorum) -}}
+  {{- end -}}
+{{- else if eq $profile "dev-single" -}}
+  {{- if or (ne (int .Values.services.broker.replicas) 1) (ne (int .Values.services.controller.replicas) 1) -}}
+    {{- fail "dev-single requires exactly one Broker and one Controller" -}}
+  {{- end -}}
+{{- else -}}
+  {{- fail (printf "unsupported deploymentProfile %q" $profile) -}}
+{{- end -}}
+{{- range $service, $config := .Values.services -}}
+  {{- if and $config.pdb.enabled (gt (int $config.pdb.minAvailable) (int $config.replicas)) -}}
+    {{- fail (printf "services.%s.pdb.minAvailable cannot exceed replicas" $service) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "rocketmq.labels" -}}
 app.kubernetes.io/name: {{ include "rocketmq.serviceName" . }}
 app.kubernetes.io/instance: {{ .root.Release.Name }}
@@ -14,7 +55,7 @@ app.kubernetes.io/part-of: {{ include "rocketmq.partOf" . }}
 app.kubernetes.io/managed-by: {{ .root.Release.Service }}
 app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
 rocketmq.apache.org/service: {{ .service }}
-rocketmq.apache.org/architecture-milestone: M11-10
+rocketmq.apache.org/architecture-milestone: P0-04
 {{- end -}}
 
 {{/* Shared process lifecycle contract. The health port is kubelet-only and is not exposed by Services. */}}
@@ -57,20 +98,33 @@ rocketmq.apache.org/service: {{ .service }}
 {{- end -}}
 
 {{- define "rocketmq.image" -}}
-{{- $placeholder := "sha256:0000000000000000000000000000000000000000000000000000000000000000" -}}
-{{- $digest := required (printf "services.%s.image.digest is required" .service) .digest -}}
-{{- if eq $digest $placeholder -}}
-{{- fail (printf "services.%s.image.digest is unpublished; inject a verified signed digest" .service) -}}
+{{- $repository := required (printf "services.%s.image.repository is required" .service) .image.repository -}}
+{{- if .image.digest -}}
+{{ printf "%s@%s" $repository .image.digest }}
+{{- else -}}
+{{- $tag := required (printf "services.%s.image.tag is required when digest is empty" .service) .image.tag -}}
+{{ printf "%s:%s" $repository $tag }}
 {{- end -}}
-{{ printf "%s/%s@%s" .root.Values.global.imageRegistry .service $digest }}
 {{- end -}}
 
-{{- define "rocketmq.controllerServiceIP" -}}
-{{- $address := required "three explicit Controller peer Service IPs are required" .address -}}
-{{- if hasPrefix "192.0.2." $address -}}
-{{- fail "Controller peer Service IP is an unpublished documentation sentinel; inject an unused address from the cluster Service CIDR" -}}
+{{- define "rocketmq.namesrvAddresses" -}}
+{{- $addresses := list -}}
+{{- range $ordinal := until (int .Values.services.namesrv.replicas) -}}
+  {{- $addresses = append $addresses (printf "rocketmq-namesrv-%d.rocketmq-namesrv-headless.%s.svc.cluster.local:9876" $ordinal $.Release.Namespace) -}}
 {{- end -}}
-{{- $address -}}
+{{ join ";" $addresses }}
+{{- end -}}
+
+{{- define "rocketmq.controllerAddresses" -}}
+{{- if eq .Values.deploymentProfile "dev-single" -}}
+rocketmq-controller.{{ .Release.Namespace }}.svc.cluster.local:60109
+{{- else -}}
+{{- $addresses := list -}}
+{{- range $address := .Values.services.controller.peerServiceClusterIPs -}}
+  {{- $addresses = append $addresses (printf "%s:60109" $address) -}}
+{{- end -}}
+{{ join ";" $addresses }}
+{{- end -}}
 {{- end -}}
 
 {{- define "rocketmq.podSecurityContext" -}}
@@ -111,6 +165,14 @@ csi:
 {{- end -}}
 
 {{- define "rocketmq.topology" -}}
+{{- if and (eq .root.Values.deploymentProfile "production-controller-ha") (gt (int (index .root.Values.services .service).replicas) 1) }}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+{{ include "rocketmq.selectorLabels" . | indent 12 }}
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname
@@ -121,9 +183,10 @@ topologySpreadConstraints:
 {{- if eq .service "controller" }}
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: DoNotSchedule
+    whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:
 {{ include "rocketmq.selectorLabels" . | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/distribution/helm/rocketmq-rust/templates/configmaps.yaml
+++ b/distribution/helm/rocketmq-rust/templates/configmaps.yaml
@@ -1,3 +1,4 @@
+{{- include "rocketmq.validateValues" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,12 +7,17 @@ metadata:
   labels:
 {{ include "rocketmq.labels" (dict "root" . "service" "broker") | indent 4 }}
 data:
-  broker.toml: |-
+{{- range $ordinal := until (int .Values.services.broker.replicas) }}
+  rocketmq-broker-{{ $ordinal }}.toml: |-
     listenPort = 10911
-    brokerIp1 = "rocketmq-broker-0.rocketmq-broker-headless.{{ .Release.Namespace }}.svc.cluster.local"
+    brokerIp1 = "rocketmq-broker-{{ $ordinal }}.rocketmq-broker-headless.{{ $.Release.Namespace }}.svc.cluster.local"
+    brokerIp2 = "rocketmq-broker-{{ $ordinal }}.rocketmq-broker-headless.{{ $.Release.Namespace }}.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/broker"
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876"
-    autoCreateTopicEnable = {{ .Values.services.broker.autoCreateTopicEnable }}
+    storePathBrokerIdentity = "/var/lib/rocketmq/broker/brokerIdentity.json"
+    namesrvAddr = "{{ include "rocketmq.namesrvAddresses" $ }}"
+    autoCreateTopicEnable = {{ $.Values.services.broker.autoCreateTopicEnable }}
+    enableControllerMode = {{ eq $.Values.deploymentProfile "production-controller-ha" }}
+    controllerAddr = "{{ include "rocketmq.controllerAddresses" $ }}"
     authConfigPath = "/var/lib/rocketmq/broker/auth"
     aclFile = "/var/run/secrets/rocketmq/broker-acl.yml"
     aclFileWatchEnabled = true
@@ -20,9 +26,10 @@ data:
     signatureAlgorithm = "HmacSHA256"
 
     [brokerIdentity]
-    brokerName = "rocketmq-broker"
+    brokerName = {{ $.Values.services.broker.replicaGroupName | quote }}
     brokerClusterName = "RocketmqRust"
     brokerId = 0
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -47,7 +54,7 @@ metadata:
   labels:
 {{ include "rocketmq.labels" (dict "root" . "service" "controller") | indent 4 }}
 data:
-{{- range $ordinal := until 3 }}
+{{- range $ordinal := until (int .Values.services.controller.replicas) }}
   controller-{{ $ordinal }}.toml: |-
     rocketmqHome = "/var/lib/rocketmq/controller"
     configStorePath = "/var/lib/rocketmq/controller/controller.properties"
@@ -79,17 +86,28 @@ data:
     electionTimeoutMs = 1000
     heartbeatIntervalMs = 300
     storagePath = "/var/lib/rocketmq/controller/node-{{ add $ordinal 1 }}"
-    storageBackend = "File"
+    storageBackend = {{ $.Values.services.controller.storageBackend | quote }}
     enableElectUncleanMasterLocal = false
-{{- range $peer := until 3 }}
+{{- if eq $.Values.deploymentProfile "dev-single" }}
+
+    [[raftPeers]]
+    id = 1
+    addr = "127.0.0.1:60110"
+
+    [[controllerPeers]]
+    id = 1
+    addr = "127.0.0.1:60109"
+{{- else }}
+{{- range $peer := until (int $.Values.services.controller.replicas) }}
 
     [[raftPeers]]
     id = {{ add $peer 1 }}
-    addr = "{{ include "rocketmq.controllerServiceIP" (dict "address" (index $.Values.services.controller.peerServiceClusterIPs $peer)) }}:60110"
+    addr = "{{ index $.Values.services.controller.peerServiceClusterIPs $peer }}:60110"
 
     [[controllerPeers]]
     id = {{ add $peer 1 }}
-    addr = "{{ include "rocketmq.controllerServiceIP" (dict "address" (index $.Values.services.controller.peerServiceClusterIPs $peer)) }}:60109"
+    addr = "{{ index $.Values.services.controller.peerServiceClusterIPs $peer }}:60109"
+{{- end }}
 {{- end }}
 {{- end }}
 ---
@@ -113,7 +131,7 @@ data:
     listenAddr = "0.0.0.0:8080"
 
     [cluster]
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876"
+    namesrvAddr = "{{ include "rocketmq.namesrvAddresses" . }}"
 
     [auth]
     authenticationEnabled = true
@@ -166,7 +184,7 @@ data:
 
     [[clusters]]
     name = "rocketmq-rust"
-    namesrv_addr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.{{ .Release.Namespace }}.svc.cluster.local:9876"
+    namesrv_addr = "{{ include "rocketmq.namesrvAddresses" . }}"
     default = true
 
     [security]

--- a/distribution/helm/rocketmq-rust/templates/namespace.yaml
+++ b/distribution/helm/rocketmq-rust/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- include "rocketmq.validateValues" . -}}
 {{- if .Values.namespace.create }}
 apiVersion: v1
 kind: Namespace

--- a/distribution/helm/rocketmq-rust/templates/networkpolicies.yaml
+++ b/distribution/helm/rocketmq-rust/templates/networkpolicies.yaml
@@ -6,53 +6,17 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/part-of: rocketmq-rust
-    rocketmq.apache.org/architecture-milestone: M11-09
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: rocketmq-rust
-  policyTypes:
-    - Ingress
-    - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: rocketmq-intra-cluster
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/part-of: rocketmq-rust
   policyTypes: [Ingress, Egress]
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: rocketmq-rust
-      ports:
-{{- range $port := list 10911 10912 9876 60109 60110 8080 8081 8089 }}
-        - {protocol: TCP, port: {{ $port }}}
-{{- end }}
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: rocketmq-rust
-      ports:
-{{- range $port := list 10911 10912 9876 60109 60110 8080 8081 8089 }}
-        - {protocol: TCP, port: {{ $port }}}
-{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: rocketmq-dns-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
@@ -75,8 +39,6 @@ kind: NetworkPolicy
 metadata:
   name: rocketmq-otel-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
@@ -93,50 +55,187 @@ spec:
       ports:
         - {protocol: TCP, port: 4317}
 ---
-{{- range $service := list "broker" "proxy" "mcp" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rocketmq-{{ $service }}-client-ingress
-  namespace: {{ $.Release.Namespace }}
-  labels:
-{{ include "rocketmq.labels" (dict "root" $ "service" $service) | indent 4 }}
+  name: rocketmq-controller
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-{{ include "rocketmq.selectorLabels" (dict "root" $ "service" $service) | indent 6 }}
+      rocketmq.apache.org/service: controller
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60110}
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.clientNamespaceLabel }}: "true"
+      ports:
+        - {protocol: TCP, port: 60109}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60110}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10911}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rocketmq-broker
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      rocketmq.apache.org/service: broker
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10912}
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: proxy
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: mcp
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.clientNamespaceLabel }}: "true"
+      ports:
+        - {protocol: TCP, port: 10911}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10912}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
+      ports:
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60109}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rocketmq-namesrv
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      rocketmq.apache.org/service: namesrv
   policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: proxy
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: mcp
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.clientNamespaceLabel }}: "true"
+      ports:
+        - {protocol: TCP, port: 9876}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rocketmq-proxy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      rocketmq.apache.org/service: proxy
+  policyTypes: [Ingress, Egress]
   ingress:
     - from:
         - namespaceSelector:
             matchLabels:
-              {{ $.Values.networkPolicy.clientNamespaceLabel }}: "true"
-{{- if eq $service "broker" }}
-      ports:
-        - {protocol: TCP, port: 10911}
-{{- else if eq $service "proxy" }}
+              {{ .Values.networkPolicy.clientNamespaceLabel }}: "true"
       ports:
         - {protocol: TCP, port: 8080}
         - {protocol: TCP, port: 8081}
-{{- else }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
       ports:
-        - {protocol: TCP, port: 8089}
-{{- end }}
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10911}
 ---
-{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rocketmq-mcp-jwks-egress
+  name: rocketmq-mcp
   namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "rocketmq.labels" (dict "root" . "service" "mcp") | indent 4 }}
 spec:
   podSelector:
     matchLabels:
-{{ include "rocketmq.selectorLabels" (dict "root" . "service" "mcp") | indent 6 }}
-  policyTypes: [Egress]
+      rocketmq.apache.org/service: mcp
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.clientNamespaceLabel }}: "true"
+      ports:
+        - {protocol: TCP, port: 8089}
   egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
+      ports:
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10911}
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/distribution/helm/rocketmq-rust/templates/pdbs.yaml
+++ b/distribution/helm/rocketmq-rust/templates/pdbs.yaml
@@ -1,5 +1,6 @@
 {{- $root := . -}}
-{{- range $service, $minAvailable := dict "broker" 1 "namesrv" 2 "controller" 2 "proxy" 1 "mcp" 1 }}
+{{- range $service, $config := .Values.services }}
+{{- if $config.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,9 +9,10 @@ metadata:
   labels:
 {{ include "rocketmq.labels" (dict "root" $root "service" $service) | indent 4 }}
 spec:
-  minAvailable: {{ $minAvailable }}
+  minAvailable: {{ $config.pdb.minAvailable }}
   selector:
     matchLabels:
 {{ include "rocketmq.selectorLabels" (dict "root" $root "service" $service) | indent 6 }}
 ---
+{{- end }}
 {{- end }}

--- a/distribution/helm/rocketmq-rust/templates/serviceaccount.yaml
+++ b/distribution/helm/rocketmq-rust/templates/serviceaccount.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/part-of: rocketmq-rust
-    rocketmq.apache.org/architecture-milestone: M11-09
+    rocketmq.apache.org/architecture-milestone: P0-04
 automountServiceAccountToken: false

--- a/distribution/helm/rocketmq-rust/templates/services.yaml
+++ b/distribution/helm/rocketmq-rust/templates/services.yaml
@@ -1,3 +1,4 @@
+{{- include "rocketmq.validateValues" . -}}
 {{- $root := . -}}
 {{- range $service, $ports := dict "broker" (list 10911 10912) "namesrv" (list 9876) "controller" (list 60109 60110) }}
 apiVersion: v1
@@ -40,7 +41,8 @@ spec:
 {{- end }}
 ---
 {{- end }}
-{{- range $ordinal := until 3 }}
+{{- if eq .Values.deploymentProfile "production-controller-ha" }}
+{{- range $ordinal := until (int .Values.services.controller.replicas) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -51,13 +53,15 @@ metadata:
     rocketmq.apache.org/controller-ordinal: {{ $ordinal | quote }}
 spec:
   type: ClusterIP
-  clusterIP: {{ include "rocketmq.controllerServiceIP" (dict "address" (index $root.Values.services.controller.peerServiceClusterIPs $ordinal)) }}
+  clusterIP: {{ index $root.Values.services.controller.peerServiceClusterIPs $ordinal }}
+  publishNotReadyAddresses: true
   selector:
     statefulset.kubernetes.io/pod-name: rocketmq-controller-{{ $ordinal }}
   ports:
     - {name: remoting, port: 60109, targetPort: 60109, protocol: TCP}
     - {name: raft, port: 60110, targetPort: 60110, protocol: TCP}
 ---
+{{- end }}
 {{- end }}
 {{- range $service, $ports := dict "proxy" (list 8080 8081) "mcp" (list 8089) }}
 apiVersion: v1

--- a/distribution/helm/rocketmq-rust/templates/workloads.yaml
+++ b/distribution/helm/rocketmq-rust/templates/workloads.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   serviceName: rocketmq-broker-headless
   replicas: {{ .Values.services.broker.replicas }}
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate
   persistentVolumeClaimRetentionPolicy:
@@ -33,14 +33,20 @@ spec:
 {{- end }}
       securityContext:
 {{ include "rocketmq.podSecurityContext" . | indent 8 }}
-{{ include "rocketmq.topology" (dict "root" . "service" "broker") | indent 6 }}
+{{- with (include "rocketmq.topology" (dict "root" . "service" "broker") | trim) }}
+{{ . | nindent 6 }}
+{{- end }}
       containers:
         - name: broker
-          image: {{ include "rocketmq.image" (dict "root" . "service" "broker" "digest" .Values.services.broker.image.digest) | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "rocketmq.image" (dict "service" "broker" "image" .Values.services.broker.image) | quote }}
+          imagePullPolicy: {{ .Values.services.broker.image.pullPolicy }}
           args: ["--configFile", "/etc/rocketmq/broker.toml"]
           env:
 {{ include "rocketmq.lifecycleEnv" . | indent 12 }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - {name: ROCKETMQ_HOME, value: /var/lib/rocketmq/broker}
             - {name: OTEL_SERVICE_NAME, value: rocketmq-broker}
             - {name: OTEL_EXPORTER_OTLP_ENDPOINT, value: {{ .Values.global.otelEndpoint | quote }}}
@@ -55,7 +61,10 @@ spec:
           securityContext:
 {{ include "rocketmq.containerSecurityContext" . | indent 12 }}
           volumeMounts:
-            - {name: config, mountPath: /etc/rocketmq/broker.toml, subPath: broker.toml, readOnly: true}
+            - name: config
+              mountPath: /etc/rocketmq/broker.toml
+              subPathExpr: $(POD_NAME).toml
+              readOnly: true
             - {name: data, mountPath: /var/lib/rocketmq/broker}
             - {name: runtime-secrets, mountPath: /var/run/secrets/rocketmq, readOnly: true}
             - {name: tmp, mountPath: /tmp/rocketmq}
@@ -63,12 +72,18 @@ spec:
         - name: config
           configMap:
             name: rocketmq-broker-config
+{{- if not .Values.services.broker.persistence.enabled }}
+        - name: data
+          emptyDir:
+            sizeLimit: {{ .Values.services.broker.persistence.size }}
+{{- end }}
         - name: runtime-secrets
 {{- include "rocketmq.secretVolume" . | nindent 10 }}
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
+{{- if .Values.services.broker.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -80,6 +95,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.services.broker.persistence.size }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -116,11 +132,13 @@ spec:
 {{- end }}
       securityContext:
 {{ include "rocketmq.podSecurityContext" . | indent 8 }}
-{{ include "rocketmq.topology" (dict "root" . "service" "namesrv") | indent 6 }}
+{{- with (include "rocketmq.topology" (dict "root" . "service" "namesrv") | trim) }}
+{{ . | nindent 6 }}
+{{- end }}
       containers:
         - name: namesrv
-          image: {{ include "rocketmq.image" (dict "root" . "service" "namesrv" "digest" .Values.services.namesrv.image.digest) | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "rocketmq.image" (dict "service" "namesrv" "image" .Values.services.namesrv.image) | quote }}
+          imagePullPolicy: {{ .Values.services.namesrv.image.pullPolicy }}
           args: ["--configFile", "/etc/rocketmq/namesrv.toml"]
           env:
 {{ include "rocketmq.lifecycleEnv" . | indent 12 }}
@@ -145,12 +163,18 @@ spec:
         - name: config
           configMap:
             name: rocketmq-namesrv-config
+{{- if not .Values.services.namesrv.persistence.enabled }}
+        - name: data
+          emptyDir:
+            sizeLimit: {{ .Values.services.namesrv.persistence.size }}
+{{- end }}
         - name: runtime-secrets
 {{- include "rocketmq.secretVolume" . | nindent 10 }}
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: 256Mi
+{{- if .Values.services.namesrv.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -162,6 +186,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.services.namesrv.persistence.size }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -198,11 +223,13 @@ spec:
 {{- end }}
       securityContext:
 {{ include "rocketmq.podSecurityContext" . | indent 8 }}
-{{ include "rocketmq.topology" (dict "root" . "service" "controller") | indent 6 }}
+{{- with (include "rocketmq.topology" (dict "root" . "service" "controller") | trim) }}
+{{ . | nindent 6 }}
+{{- end }}
       containers:
         - name: controller
-          image: {{ include "rocketmq.image" (dict "root" . "service" "controller" "digest" .Values.services.controller.image.digest) | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "rocketmq.image" (dict "service" "controller" "image" .Values.services.controller.image) | quote }}
+          imagePullPolicy: {{ .Values.services.controller.image.pullPolicy }}
           args: ["--config-file", "/etc/rocketmq/controller.toml"]
           env:
 {{ include "rocketmq.lifecycleEnv" . | indent 12 }}
@@ -212,7 +239,7 @@ spec:
                   fieldPath: metadata.name
             - {name: ROCKETMQ_HOME, value: /var/lib/rocketmq/controller}
             - {name: ROCKETMQ_CONTROLLER_RAFT_BIND_ADDR, value: "0.0.0.0:60110"}
-            - {name: ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER, value: "true"}
+            - {name: ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER, value: {{ .Values.services.controller.autoInitializeCluster | quote }}}
             - {name: OTEL_SERVICE_NAME, value: rocketmq-controller}
             - {name: OTEL_EXPORTER_OTLP_ENDPOINT, value: {{ .Values.global.otelEndpoint | quote }}}
             - {name: OTEL_EXPORTER_OTLP_PROTOCOL, value: grpc}
@@ -237,12 +264,18 @@ spec:
         - name: config
           configMap:
             name: rocketmq-controller-config
+{{- if not .Values.services.controller.persistence.enabled }}
+        - name: data
+          emptyDir:
+            sizeLimit: {{ .Values.services.controller.persistence.size }}
+{{- end }}
         - name: runtime-secrets
 {{- include "rocketmq.secretVolume" . | nindent 10 }}
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: 512Mi
+{{- if .Values.services.controller.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -254,6 +287,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.services.controller.persistence.size }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -286,11 +320,13 @@ spec:
 {{- end }}
       securityContext:
 {{ include "rocketmq.podSecurityContext" . | indent 8 }}
-{{ include "rocketmq.topology" (dict "root" . "service" "proxy") | indent 6 }}
+{{- with (include "rocketmq.topology" (dict "root" . "service" "proxy") | trim) }}
+{{ . | nindent 6 }}
+{{- end }}
       containers:
         - name: proxy
-          image: {{ include "rocketmq.image" (dict "root" . "service" "proxy" "digest" .Values.services.proxy.image.digest) | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "rocketmq.image" (dict "service" "proxy" "image" .Values.services.proxy.image) | quote }}
+          imagePullPolicy: {{ .Values.services.proxy.image.pullPolicy }}
           args: ["--config", "/etc/rocketmq/proxy.toml"]
           env:
 {{ include "rocketmq.lifecycleEnv" . | indent 12 }}
@@ -326,6 +362,7 @@ spec:
             medium: Memory
             sizeLimit: 512Mi
 ---
+{{- if .Values.services.mcp.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -343,6 +380,7 @@ spec:
     requests:
       storage: {{ .Values.services.mcp.persistence.size }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -373,11 +411,13 @@ spec:
 {{- end }}
       securityContext:
 {{ include "rocketmq.podSecurityContext" . | indent 8 }}
-{{ include "rocketmq.topology" (dict "root" . "service" "mcp") | indent 6 }}
+{{- with (include "rocketmq.topology" (dict "root" . "service" "mcp") | trim) }}
+{{ . | nindent 6 }}
+{{- end }}
       containers:
         - name: mcp
-          image: {{ include "rocketmq.image" (dict "root" . "service" "mcp" "digest" .Values.services.mcp.image.digest) | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "rocketmq.image" (dict "service" "mcp" "image" .Values.services.mcp.image) | quote }}
+          imagePullPolicy: {{ .Values.services.mcp.image.pullPolicy }}
           args: ["--config", "/etc/rocketmq/mcp.toml", "--transport", "streamable-http"]
           env:
 {{ include "rocketmq.lifecycleEnv" . | indent 12 }}
@@ -404,8 +444,13 @@ spec:
           configMap:
             name: rocketmq-mcp-config
         - name: audit
+{{- if .Values.services.mcp.persistence.enabled }}
           persistentVolumeClaim:
             claimName: rocketmq-mcp-audit
+{{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.services.mcp.persistence.size }}
+{{- end }}
         - name: runtime-secrets
 {{- include "rocketmq.secretVolume" . | nindent 10 }}
         - name: tmp

--- a/distribution/helm/rocketmq-rust/values-dev-single.yaml
+++ b/distribution/helm/rocketmq-rust/values-dev-single.yaml
@@ -1,0 +1,76 @@
+deploymentProfile: dev-single
+
+networkPolicy:
+  enabled: false
+
+services:
+  broker:
+    replicas: 1
+    replicaGroupName: rocketmq-dev-broker
+    image:
+      repository: rocketmq-rust/broker
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    persistence:
+      enabled: false
+      storageClassName: ""
+      size: 10Gi
+    pdb:
+      enabled: false
+      minAvailable: 1
+  namesrv:
+    replicas: 1
+    image:
+      repository: rocketmq-rust/namesrv
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    persistence:
+      enabled: false
+      storageClassName: ""
+      size: 1Gi
+    pdb:
+      enabled: false
+      minAvailable: 1
+  controller:
+    replicas: 1
+    peerServiceClusterIPs: []
+    autoInitializeCluster: true
+    storageBackend: Memory
+    image:
+      repository: rocketmq-rust/controller
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    persistence:
+      enabled: false
+      storageClassName: ""
+      size: 1Gi
+    pdb:
+      enabled: false
+      minAvailable: 1
+  proxy:
+    replicas: 1
+    image:
+      repository: rocketmq-rust/proxy
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    pdb:
+      enabled: false
+      minAvailable: 1
+  mcp:
+    replicas: 1
+    image:
+      repository: rocketmq-rust/mcp
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    persistence:
+      enabled: false
+      storageClassName: ""
+      size: 1Gi
+    pdb:
+      enabled: false
+      minAvailable: 1

--- a/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
+++ b/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
@@ -1,0 +1,47 @@
+deploymentProfile: production-controller-ha
+
+# These tags are loaded into the local cluster and are never pulled. Build them
+# with `docker buildx build --load`, then use the cluster-specific image-load command.
+services:
+  broker:
+    replicas: 3
+    replicaGroupName: rocketmq-broker
+    image:
+      repository: rocketmq-rust/broker
+      tag: local
+      digest: ""
+      pullPolicy: Never
+  namesrv:
+    replicas: 3
+    image:
+      repository: rocketmq-rust/namesrv
+      tag: local
+      digest: ""
+      pullPolicy: Never
+  controller:
+    replicas: 3
+    peerServiceClusterIPs:
+      - 10.96.0.201
+      - 10.96.0.202
+      - 10.96.0.203
+    autoInitializeCluster: true
+    storageBackend: RocksDB
+    image:
+      repository: rocketmq-rust/controller
+      tag: local
+      digest: ""
+      pullPolicy: Never
+  proxy:
+    replicas: 2
+    image:
+      repository: rocketmq-rust/proxy
+      tag: local
+      digest: ""
+      pullPolicy: Never
+  mcp:
+    replicas: 1
+    image:
+      repository: rocketmq-rust/mcp
+      tag: local
+      digest: ""
+      pullPolicy: Never

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -1,30 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/mxsm/rocketmq-rust/distribution/helm/rocketmq-rust/values.schema.json",
-  "title": "RocketMQ Rust secure deployment values",
+  "title": "RocketMQ Rust deployment values",
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "deploymentProfile",
     "global",
     "namespace",
     "networkPolicy",
     "services"
   ],
   "properties": {
+    "deploymentProfile": {
+      "type": "string",
+      "enum": [
+        "dev-single",
+        "production-controller-ha"
+      ]
+    },
     "global": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "imageRegistry",
         "imagePullSecrets",
         "otelEndpoint",
         "secretRefs",
         "podSecurity"
       ],
       "properties": {
-        "imageRegistry": {
-          "const": "ghcr.io/mxsm/rocketmq-rust"
-        },
         "imagePullSecrets": {
           "type": "array",
           "items": {
@@ -85,13 +89,16 @@
           ],
           "properties": {
             "runAsUser": {
-              "const": 10001
+              "type": "integer",
+              "minimum": 1
             },
             "runAsGroup": {
-              "const": 10001
+              "type": "integer",
+              "minimum": 1
             },
             "fsGroup": {
-              "const": 10001
+              "type": "integer",
+              "minimum": 1
             }
           }
         }
@@ -105,7 +112,7 @@
       ],
       "properties": {
         "create": {
-          "const": true
+          "type": "boolean"
         }
       }
     },
@@ -119,13 +126,15 @@
       ],
       "properties": {
         "enabled": {
-          "const": true
+          "type": "boolean"
         },
         "clientNamespaceLabel": {
-          "const": "rocketmq.apache.org/client-access"
+          "type": "string",
+          "minLength": 1
         },
         "observabilityNamespaceLabel": {
-          "const": "rocketmq.apache.org/observability"
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -159,18 +168,53 @@
     }
   },
   "definitions": {
-    "digest": {
+    "image": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "digest"
+        "repository",
+        "tag",
+        "digest",
+        "pullPolicy"
       ],
       "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^\\s:@]+(?::[0-9]+)?(?:/[^\\s:@]+)*$"
+        },
+        "tag": {
+          "type": "string"
+        },
         "digest": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^(?:|sha256:[0-9a-f]{64})$"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
         }
-      }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "tag": {
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "properties": {
+            "digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        }
+      ]
     },
     "resources": {
       "type": "object",
@@ -198,11 +242,11 @@
       "properties": {
         "cpu": {
           "type": "string",
-          "pattern": "^[1-9][0-9]*(m)?$"
+          "pattern": "^[1-9][0-9]*(?:m)?$"
         },
         "memory": {
           "type": "string",
-          "pattern": "^[1-9][0-9]*(Mi|Gi)$"
+          "pattern": "^[1-9][0-9]*(?:Mi|Gi)$"
         }
       }
     },
@@ -210,17 +254,55 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "enabled",
         "storageClassName",
         "size"
       ],
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "storageClassName": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "size": {
           "type": "string",
-          "pattern": "^[1-9][0-9]*Gi$"
+          "pattern": "^[1-9][0-9]*(?:Mi|Gi|Ti)$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "storageClassName": {
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "minAvailable"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },
@@ -229,23 +311,34 @@
       "additionalProperties": false,
       "required": [
         "replicas",
+        "replicaGroupName",
         "autoCreateTopicEnable",
         "image",
         "persistence",
+        "pdb",
         "resources"
       ],
       "properties": {
         "replicas": {
-          "const": 1
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
+        },
+        "replicaGroupName": {
+          "type": "string",
+          "minLength": 1
         },
         "autoCreateTopicEnable": {
           "type": "boolean"
         },
         "image": {
-          "$ref": "#/definitions/digest"
+          "$ref": "#/definitions/image"
         },
         "persistence": {
           "$ref": "#/definitions/persistence"
+        },
+        "pdb": {
+          "$ref": "#/definitions/pdb"
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -259,17 +352,23 @@
         "replicas",
         "image",
         "persistence",
+        "pdb",
         "resources"
       ],
       "properties": {
         "replicas": {
-          "const": 3
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
         },
         "image": {
-          "$ref": "#/definitions/digest"
+          "$ref": "#/definitions/image"
         },
         "persistence": {
           "$ref": "#/definitions/persistence"
+        },
+        "pdb": {
+          "$ref": "#/definitions/pdb"
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -282,29 +381,46 @@
       "required": [
         "replicas",
         "peerServiceClusterIPs",
+        "autoInitializeCluster",
+        "storageBackend",
         "image",
         "persistence",
+        "pdb",
         "resources"
       ],
       "properties": {
         "replicas": {
-          "const": 3
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
         },
         "peerServiceClusterIPs": {
           "type": "array",
-          "minItems": 3,
-          "maxItems": 3,
+          "maxItems": 9,
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"
+            "format": "ipv4"
           }
         },
+        "autoInitializeCluster": {
+          "type": "boolean"
+        },
+        "storageBackend": {
+          "type": "string",
+          "enum": [
+            "Memory",
+            "RocksDB"
+          ]
+        },
         "image": {
-          "$ref": "#/definitions/digest"
+          "$ref": "#/definitions/image"
         },
         "persistence": {
           "$ref": "#/definitions/persistence"
+        },
+        "pdb": {
+          "$ref": "#/definitions/pdb"
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -317,14 +433,20 @@
       "required": [
         "replicas",
         "image",
+        "pdb",
         "resources"
       ],
       "properties": {
         "replicas": {
-          "const": 2
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
         },
         "image": {
-          "$ref": "#/definitions/digest"
+          "$ref": "#/definitions/image"
+        },
+        "pdb": {
+          "$ref": "#/definitions/pdb"
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -340,14 +462,17 @@
         "publicBaseUrl",
         "oauth",
         "persistence",
+        "pdb",
         "resources"
       ],
       "properties": {
         "replicas": {
-          "const": 1
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1
         },
         "image": {
-          "$ref": "#/definitions/digest"
+          "$ref": "#/definitions/image"
         },
         "publicBaseUrl": {
           "type": "string",
@@ -379,10 +504,184 @@
         "persistence": {
           "$ref": "#/definitions/persistence"
         },
+        "pdb": {
+          "$ref": "#/definitions/pdb"
+        },
         "resources": {
           "$ref": "#/definitions/resources"
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "deploymentProfile": {
+            "const": "production-controller-ha"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "networkPolicy": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "services": {
+            "properties": {
+              "broker": {
+                "properties": {
+                  "replicas": {
+                    "minimum": 3
+                  },
+                  "persistence": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "pdb": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      },
+                      "minAvailable": {
+                        "minimum": 2
+                      }
+                    }
+                  }
+                }
+              },
+              "namesrv": {
+                "properties": {
+                  "replicas": {
+                    "minimum": 3
+                  },
+                  "persistence": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "pdb": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      },
+                      "minAvailable": {
+                        "minimum": 2
+                      }
+                    }
+                  }
+                }
+              },
+              "controller": {
+                "properties": {
+                  "replicas": {
+                    "enum": [
+                      3,
+                      5,
+                      7,
+                      9
+                    ]
+                  },
+                  "peerServiceClusterIPs": {
+                    "minItems": 3
+                  },
+                  "storageBackend": {
+                    "const": "RocksDB"
+                  },
+                  "persistence": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "pdb": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      },
+                      "minAvailable": {
+                        "minimum": 2
+                      }
+                    }
+                  }
+                }
+              },
+              "proxy": {
+                "properties": {
+                  "replicas": {
+                    "minimum": 2
+                  },
+                  "pdb": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "deploymentProfile": {
+            "const": "dev-single"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "services": {
+            "properties": {
+              "broker": {
+                "properties": {
+                  "replicas": {
+                    "const": 1
+                  }
+                }
+              },
+              "namesrv": {
+                "properties": {
+                  "replicas": {
+                    "const": 1
+                  }
+                }
+              },
+              "controller": {
+                "properties": {
+                  "replicas": {
+                    "const": 1
+                  },
+                  "peerServiceClusterIPs": {
+                    "maxItems": 0
+                  }
+                }
+              },
+              "proxy": {
+                "properties": {
+                  "replicas": {
+                    "const": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -1,5 +1,6 @@
+deploymentProfile: production-controller-ha
+
 global:
-  imageRegistry: ghcr.io/mxsm/rocketmq-rust
   imagePullSecrets: []
   otelEndpoint: http://otel-collector.observability.svc.cluster.local:4317
   secretRefs:
@@ -20,59 +21,96 @@ networkPolicy:
 
 services:
   broker:
-    replicas: 1
+    replicas: 3
+    replicaGroupName: rocketmq-broker
     autoCreateTopicEnable: false
     image:
-      digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      repository: rocketmq-rust/broker
+      tag: local
+      digest: ""
+      pullPolicy: Never
     persistence:
+      enabled: true
       storageClassName: rocketmq-retain
       size: 100Gi
+    pdb:
+      enabled: true
+      minAvailable: 2
     resources:
       requests: {cpu: 1000m, memory: 2Gi}
       limits: {cpu: 4000m, memory: 8Gi}
   namesrv:
     replicas: 3
     image:
-      digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      repository: rocketmq-rust/namesrv
+      tag: local
+      digest: ""
+      pullPolicy: Never
     persistence:
+      enabled: true
       storageClassName: rocketmq-retain
       size: 2Gi
+    pdb:
+      enabled: true
+      minAvailable: 2
     resources:
       requests: {cpu: 250m, memory: 256Mi}
       limits: {cpu: 1000m, memory: 1Gi}
   controller:
     replicas: 3
     peerServiceClusterIPs:
-      - 192.0.2.1
-      - 192.0.2.2
-      - 192.0.2.3
+      - 10.96.0.201
+      - 10.96.0.202
+      - 10.96.0.203
+    autoInitializeCluster: true
+    storageBackend: RocksDB
     image:
-      digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      repository: rocketmq-rust/controller
+      tag: local
+      digest: ""
+      pullPolicy: Never
     persistence:
+      enabled: true
       storageClassName: rocketmq-retain
       size: 10Gi
+    pdb:
+      enabled: true
+      minAvailable: 2
     resources:
       requests: {cpu: 500m, memory: 512Mi}
       limits: {cpu: 2000m, memory: 2Gi}
   proxy:
     replicas: 2
     image:
-      digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      repository: rocketmq-rust/proxy
+      tag: local
+      digest: ""
+      pullPolicy: Never
+    pdb:
+      enabled: true
+      minAvailable: 1
     resources:
       requests: {cpu: 500m, memory: 512Mi}
       limits: {cpu: 2000m, memory: 2Gi}
   mcp:
     replicas: 1
     image:
-      digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      repository: rocketmq-rust/mcp
+      tag: local
+      digest: ""
+      pullPolicy: Never
     publicBaseUrl: https://mcp.example.invalid
     oauth:
       issuer: https://issuer.example.invalid
       audience: rocketmq-mcp
       jwksUrl: https://issuer.example.invalid/.well-known/jwks.json
     persistence:
+      enabled: true
       storageClassName: rocketmq-retain
       size: 10Gi
+    pdb:
+      enabled: true
+      minAvailable: 1
     resources:
       requests: {cpu: 250m, memory: 256Mi}
       limits: {cpu: 1000m, memory: 1Gi}

--- a/distribution/kubernetes/README.md
+++ b/distribution/kubernetes/README.md
@@ -1,63 +1,75 @@
 # RocketMQ Rust Kubernetes assets
 
-`base/manifest.yaml` is the deterministic output of the canonical Helm chart with the non-publishable secure rendering
-fixture. The base Kustomization replaces every image with an all-zero digest, so applying the base directly fails closed.
-The `overlays/secure` digests are also non-publishable test fixtures; a release process must replace all five with
-verified, signed `ghcr.io/mxsm/rocketmq-rust/<service>@sha256:<64 hex>` references. The three `10.96.0.20x`
-Controller ClusterIPs are validation fixtures as well. A production overlay must replace them with unused, reserved
-addresses from that cluster's Service CIDR in both the ordinal Services and the three Controller config entries.
+`base/manifest.yaml` is the rendered `production-controller-ha` profile from
+the canonical Helm chart. The base uses five locally loaded images:
 
-The chart and Kustomize assets use the shared M11-10 HTTP lifecycle contract: `/readyz` rejects new work before drain,
-`/livez` reports progress, `/drainz` initiates the same absolute 45-second shutdown deadline as SIGTERM, and the Pod
-termination grace is 60 seconds. TCP-open and startup probes remain forbidden because they do not prove service
-readiness or durable drain completion.
-
-## State and security boundaries
-
-- Broker, NameServer, and Controller are StatefulSets with explicit storage classes and retained PVCs.
-- Controller has three ordinal-specific configs, a two-member PDB quorum, hostname/zone spread, and stable peer
-  endpoints.
-  Because the current Controller peer contract is a typed socket address, each ordinal gets a stable ClusterIP with
-  separate remoting `60109` and Raft `60110` ports. Only the lowest node ID may run the explicit multi-member bootstrap;
-  replicas/configuration alone are still not recorded as proof that a quorum was formed.
-- Proxy is a stateless Deployment with bounded `emptyDir` data. MCP is a single-replica Deployment with a retained audit
-  PVC; its file-audit writer is not horizontally shared.
-- All Pods use UID/GID 10001, restricted Pod Security, read-only root filesystems, dropped capabilities, no service-account
-  token, default-deny networking, explicit DNS/OTel/client/JWKS paths, and an existing Secret or SecretProviderClass mount.
-- No Kubernetes Secret object is generated. Operators provide `broker-acl.yml`, `proxy-acl.yml`, `tls.crt`, and `tls.key`
-  through the selected external secret reference.
-
-## Validation
-
-```powershell
-.\scripts\kubernetes-assets-contract.ps1
-python -m unittest scripts.tests.test_m11_kubernetes_assets -v
-python scripts/fault_matrix_guard.py --policy-only
-python scripts/fault_matrix_guard.py --evidence scripts/tests/fixtures/m11-fault-matrix/pass --allow-fixture
-python -m unittest scripts.tests.test_m11_fault_matrix -v
-.\scripts\kind-architecture-refactor-e2e.ps1 -Mode Validate
+```text
+rocketmq-rust/broker:local
+rocketmq-rust/namesrv:local
+rocketmq-rust/controller:local
+rocketmq-rust/proxy:local
+rocketmq-rust/mcp:local
 ```
 
-To regenerate the committed Kustomize base after an intentional chart change:
+Every workload sets `imagePullPolicy: Never`. Build with
+`docker buildx build --load` and, when the Kubernetes nodes do not share the
+host Docker image store, load the images with the cluster-specific `kind` or
+`k3d` command. No registry login or remote push is part of this deployment
+mode.
+
+The three `10.96.0.20x` Controller ClusterIPs are example reservations. Replace
+them with unused addresses from the target cluster's Service CIDR before
+deployment.
+
+## Profiles
+
+- `values-dev-single.yaml` runs one ephemeral Controller, Broker, NameServer,
+  Proxy, and MCP instance for development.
+- `values-production-controller-ha.yaml` runs an odd Controller quorum backed
+  by RocksDB PVCs, a Controller-managed three-member Broker replica group,
+  persistent NameServers, two Proxies, and persistent MCP audit storage.
+
+The production schema rejects unsafe replica counts, missing Controller
+endpoints, disabled required persistence, and a non-RocksDB Controller backend.
+
+## State, readiness, and security
+
+- Broker, NameServer, and Controller are StatefulSets with retained PVCs.
+- Stable Controller ordinals own stable Raft/remoting endpoints and RocksDB
+  paths. Stable Broker ordinals own separate message-store and identity PVCs.
+- Controller readiness requires an observed Raft leader and applied committed
+  state. Broker readiness requires Store, registration, assigned role,
+  listeners, processors, and security. Proxy performs its Cluster
+  route/security metadata preflight before binding listeners.
+- PDBs, host anti-affinity, topology spread constraints, rolling updates, and
+  default-deny NetworkPolicies follow the production replica model.
+- Pods run as UID/GID 10001 with a read-only root filesystem, dropped
+  capabilities, no privilege escalation, and no mounted service-account token.
+- No Kubernetes Secret is generated. Operators supply `broker-acl.yml`,
+  `proxy-acl.yml`, `tls.crt`, and `tls.key` through an existing Secret or a
+  Secrets Store CSI provider.
+
+## Local validation
+
+Run from the repository root:
 
 ```powershell
-.\scripts\kubernetes-assets-contract.ps1 -UpdateGeneratedBase
+helm lint .\distribution\helm\rocketmq-rust --strict
+helm lint .\distribution\helm\rocketmq-rust --strict `
+  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml
+helm lint .\distribution\helm\rocketmq-rust --strict `
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml
+
+helm template rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml > $null
+helm template rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml > $null
 ```
 
-The script downloads Helm, Kustomize, and Kubeconform only from pinned upstream releases, verifies their SHA-256 hashes,
-requires the default chart to reject unpublished digests, checks deterministic chart/base parity, validates both secure
-renders against Kubernetes 1.32 schemas, and runs the deployment policy guard.
+To update `base/manifest.yaml`, render the production profile as UTF-8 and
+replace the file only after the local lint and schema checks pass.
 
-## Dynamic fault evidence
-
-`scripts/kind-architecture-refactor-e2e.ps1 -Mode Run` is the only path that may emit M11-11 dynamic PASS evidence. It
-requires Docker plus Kind or K3d, five baseline and candidate `image@sha256` references, an explicitly pinned collector
-image, and operator-supplied baseline/rotated runtime and fault-driver Secret manifests. It executes rolling upgrade,
-node eviction, collector outage, scheduling-level disk pressure, Controller leader loss, credential rotation, and
-acknowledged-message recovery. Its evidence includes cluster/tool profiles, chart/overlay hashes, events, exact Queue and
-CommitLog offsets, PVC UIDs, rollback results, and artifact hashes. Missing prerequisites or any failed durability,
-drain, SLO, quorum, secret-redaction, cleanup, or rollback assertion fails closed and leaves no `run.json` PASS record.
-
-The committed positive fixture is intentionally marked `fixture=true` and `dynamic_execution=false`; it is accepted only
-with `--allow-fixture` and can test the evidence parser but can never satisfy the real Kind/K3d Gate. The dynamic workflow
-is manually dispatched with protected secret inputs and uploads the immutable evidence directory for independent review.
+See `rocketmq-doc/en/01-run-rocketmq-rust-k8s.md` for local image builds,
+installation, upgrade, and recovery procedures.

--- a/distribution/kubernetes/base/kustomization.yaml
+++ b/distribution/kubernetes/base/kustomization.yaml
@@ -4,18 +4,18 @@ namespace: rocketmq
 resources:
   - manifest.yaml
 images:
-  - name: ghcr.io/mxsm/rocketmq-rust/broker
-    newName: ghcr.io/mxsm/rocketmq-rust/broker
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-  - name: ghcr.io/mxsm/rocketmq-rust/namesrv
-    newName: ghcr.io/mxsm/rocketmq-rust/namesrv
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-  - name: ghcr.io/mxsm/rocketmq-rust/controller
-    newName: ghcr.io/mxsm/rocketmq-rust/controller
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-  - name: ghcr.io/mxsm/rocketmq-rust/proxy
-    newName: ghcr.io/mxsm/rocketmq-rust/proxy
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-  - name: ghcr.io/mxsm/rocketmq-rust/mcp
-    newName: ghcr.io/mxsm/rocketmq-rust/mcp
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+  - name: rocketmq-rust/broker
+    newName: rocketmq-rust/broker
+    newTag: local
+  - name: rocketmq-rust/namesrv
+    newName: rocketmq-rust/namesrv
+    newTag: local
+  - name: rocketmq-rust/controller
+    newName: rocketmq-rust/controller
+    newTag: local
+  - name: rocketmq-rust/proxy
+    newName: rocketmq-rust/proxy
+    newTag: local
+  - name: rocketmq-rust/mcp
+    newName: rocketmq-rust/mcp
+    newTag: local

--- a/distribution/kubernetes/base/manifest.yaml
+++ b/distribution/kubernetes/base/manifest.yaml
@@ -20,56 +20,11 @@ metadata:
   namespace: rocketmq
   labels:
     app.kubernetes.io/part-of: rocketmq-rust
-    rocketmq.apache.org/architecture-milestone: M11-09
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: rocketmq-rust
-  policyTypes:
-    - Ingress
-    - Egress
----
-# Source: rocketmq-rust/templates/networkpolicies.yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: rocketmq-intra-cluster
-  namespace: rocketmq
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/part-of: rocketmq-rust
   policyTypes: [Ingress, Egress]
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: rocketmq-rust
-      ports:
-        - {protocol: TCP, port: 10911}
-        - {protocol: TCP, port: 10912}
-        - {protocol: TCP, port: 9876}
-        - {protocol: TCP, port: 60109}
-        - {protocol: TCP, port: 60110}
-        - {protocol: TCP, port: 8080}
-        - {protocol: TCP, port: 8081}
-        - {protocol: TCP, port: 8089}
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: rocketmq-rust
-      ports:
-        - {protocol: TCP, port: 10911}
-        - {protocol: TCP, port: 10912}
-        - {protocol: TCP, port: 9876}
-        - {protocol: TCP, port: 60109}
-        - {protocol: TCP, port: 60110}
-        - {protocol: TCP, port: 8080}
-        - {protocol: TCP, port: 8081}
-        - {protocol: TCP, port: 8089}
 ---
 # Source: rocketmq-rust/templates/networkpolicies.yaml
 apiVersion: networking.k8s.io/v1
@@ -77,8 +32,6 @@ kind: NetworkPolicy
 metadata:
   name: rocketmq-dns-egress
   namespace: rocketmq
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
@@ -102,8 +55,6 @@ kind: NetworkPolicy
 metadata:
   name: rocketmq-otel-egress
   namespace: rocketmq
-  labels:
-    app.kubernetes.io/part-of: rocketmq-rust
 spec:
   podSelector:
     matchLabels:
@@ -124,28 +75,40 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rocketmq-broker-client-ingress
+  name: rocketmq-controller
   namespace: rocketmq
-  labels:
-    app.kubernetes.io/name: rocketmq-broker
-    app.kubernetes.io/instance: rocketmq
-    app.kubernetes.io/part-of: rocketmq-rust
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.1.0"
-    rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: rocketmq-broker
-      app.kubernetes.io/instance: rocketmq
-      rocketmq.apache.org/service: broker
-  policyTypes: [Ingress]
+      rocketmq.apache.org/service: controller
+  policyTypes: [Ingress, Egress]
   ingress:
     - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60110}
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
         - namespaceSelector:
             matchLabels:
               rocketmq.apache.org/client-access: "true"
+      ports:
+        - {protocol: TCP, port: 60109}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60110}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
       ports:
         - {protocol: TCP, port: 10911}
 ---
@@ -153,23 +116,94 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rocketmq-proxy-client-ingress
+  name: rocketmq-broker
   namespace: rocketmq
-  labels:
-    app.kubernetes.io/name: rocketmq-proxy
-    app.kubernetes.io/instance: rocketmq
-    app.kubernetes.io/part-of: rocketmq-rust
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.1.0"
-    rocketmq.apache.org/service: proxy
-    rocketmq.apache.org/architecture-milestone: M11-10
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: rocketmq-proxy
-      app.kubernetes.io/instance: rocketmq
-      rocketmq.apache.org/service: proxy
+      rocketmq.apache.org/service: broker
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10912}
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: proxy
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: mcp
+        - namespaceSelector:
+            matchLabels:
+              rocketmq.apache.org/client-access: "true"
+      ports:
+        - {protocol: TCP, port: 10911}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10912}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
+      ports:
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: controller
+      ports:
+        - {protocol: TCP, port: 60109}
+---
+# Source: rocketmq-rust/templates/networkpolicies.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rocketmq-namesrv
+  namespace: rocketmq
+spec:
+  podSelector:
+    matchLabels:
+      rocketmq.apache.org/service: namesrv
   policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: proxy
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: mcp
+        - namespaceSelector:
+            matchLabels:
+              rocketmq.apache.org/client-access: "true"
+      ports:
+        - {protocol: TCP, port: 9876}
+---
+# Source: rocketmq-rust/templates/networkpolicies.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rocketmq-proxy
+  namespace: rocketmq
+spec:
+  podSelector:
+    matchLabels:
+      rocketmq.apache.org/service: proxy
+  policyTypes: [Ingress, Egress]
   ingress:
     - from:
         - namespaceSelector:
@@ -178,28 +212,31 @@ spec:
       ports:
         - {protocol: TCP, port: 8080}
         - {protocol: TCP, port: 8081}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
+      ports:
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10911}
 ---
 # Source: rocketmq-rust/templates/networkpolicies.yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rocketmq-mcp-client-ingress
+  name: rocketmq-mcp
   namespace: rocketmq
-  labels:
-    app.kubernetes.io/name: rocketmq-mcp
-    app.kubernetes.io/instance: rocketmq
-    app.kubernetes.io/part-of: rocketmq-rust
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.1.0"
-    rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: rocketmq-mcp
-      app.kubernetes.io/instance: rocketmq
       rocketmq.apache.org/service: mcp
-  policyTypes: [Ingress]
+  policyTypes: [Ingress, Egress]
   ingress:
     - from:
         - namespaceSelector:
@@ -207,29 +244,19 @@ spec:
               rocketmq.apache.org/client-access: "true"
       ports:
         - {protocol: TCP, port: 8089}
----
-# Source: rocketmq-rust/templates/networkpolicies.yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: rocketmq-mcp-jwks-egress
-  namespace: rocketmq
-  labels:
-    app.kubernetes.io/name: rocketmq-mcp
-    app.kubernetes.io/instance: rocketmq
-    app.kubernetes.io/part-of: rocketmq-rust
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.1.0"
-    rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: rocketmq-mcp
-      app.kubernetes.io/instance: rocketmq
-      rocketmq.apache.org/service: mcp
-  policyTypes: [Egress]
   egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: namesrv
+      ports:
+        - {protocol: TCP, port: 9876}
+    - to:
+        - podSelector:
+            matchLabels:
+              rocketmq.apache.org/service: broker
+      ports:
+        - {protocol: TCP, port: 10911}
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -250,9 +277,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
-  minAvailable: 1
+  minAvailable: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: rocketmq-broker
@@ -272,7 +299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   minAvailable: 2
   selector:
@@ -294,7 +321,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   minAvailable: 1
   selector:
@@ -316,7 +343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: namesrv
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   minAvailable: 2
   selector:
@@ -338,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: proxy
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   minAvailable: 1
   selector:
@@ -355,7 +382,7 @@ metadata:
   namespace: rocketmq
   labels:
     app.kubernetes.io/part-of: rocketmq-rust
-    rocketmq.apache.org/architecture-milestone: M11-09
+    rocketmq.apache.org/architecture-milestone: P0-04
 automountServiceAccountToken: false
 
 ---
@@ -372,14 +399,60 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 data:
-  broker.toml: |-
+  rocketmq-broker-0.toml: |-
     listenPort = 10911
     brokerIp1 = "rocketmq-broker-0.rocketmq-broker-headless.rocketmq.svc.cluster.local"
+    brokerIp2 = "rocketmq-broker-0.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/broker"
+    storePathBrokerIdentity = "/var/lib/rocketmq/broker/brokerIdentity.json"
     namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
     autoCreateTopicEnable = false
+    enableControllerMode = true
+    controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
+    authConfigPath = "/var/lib/rocketmq/broker/auth"
+    aclFile = "/var/run/secrets/rocketmq/broker-acl.yml"
+    aclFileWatchEnabled = true
+    authenticationEnabled = true
+    authorizationEnabled = true
+    signatureAlgorithm = "HmacSHA256"
+
+    [brokerIdentity]
+    brokerName = "rocketmq-broker"
+    brokerClusterName = "RocketmqRust"
+    brokerId = 0
+  rocketmq-broker-1.toml: |-
+    listenPort = 10911
+    brokerIp1 = "rocketmq-broker-1.rocketmq-broker-headless.rocketmq.svc.cluster.local"
+    brokerIp2 = "rocketmq-broker-1.rocketmq-broker-headless.rocketmq.svc.cluster.local"
+    storePathRootDir = "/var/lib/rocketmq/broker"
+    storePathBrokerIdentity = "/var/lib/rocketmq/broker/brokerIdentity.json"
+    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    autoCreateTopicEnable = false
+    enableControllerMode = true
+    controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
+    authConfigPath = "/var/lib/rocketmq/broker/auth"
+    aclFile = "/var/run/secrets/rocketmq/broker-acl.yml"
+    aclFileWatchEnabled = true
+    authenticationEnabled = true
+    authorizationEnabled = true
+    signatureAlgorithm = "HmacSHA256"
+
+    [brokerIdentity]
+    brokerName = "rocketmq-broker"
+    brokerClusterName = "RocketmqRust"
+    brokerId = 0
+  rocketmq-broker-2.toml: |-
+    listenPort = 10911
+    brokerIp1 = "rocketmq-broker-2.rocketmq-broker-headless.rocketmq.svc.cluster.local"
+    brokerIp2 = "rocketmq-broker-2.rocketmq-broker-headless.rocketmq.svc.cluster.local"
+    storePathRootDir = "/var/lib/rocketmq/broker"
+    storePathBrokerIdentity = "/var/lib/rocketmq/broker/brokerIdentity.json"
+    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    autoCreateTopicEnable = false
+    enableControllerMode = true
+    controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
     authConfigPath = "/var/lib/rocketmq/broker/auth"
     aclFile = "/var/run/secrets/rocketmq/broker-acl.yml"
     aclFileWatchEnabled = true
@@ -405,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: namesrv
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 data:
   namesrv.toml: |-
     rocketmqHome = "/var/lib/rocketmq/namesrv"
@@ -427,7 +500,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 data:
   controller-0.toml: |-
     rocketmqHome = "/var/lib/rocketmq/controller"
@@ -460,7 +533,7 @@ data:
     electionTimeoutMs = 1000
     heartbeatIntervalMs = 300
     storagePath = "/var/lib/rocketmq/controller/node-1"
-    storageBackend = "File"
+    storageBackend = "RocksDB"
     enableElectUncleanMasterLocal = false
 
     [[raftPeers]]
@@ -517,7 +590,7 @@ data:
     electionTimeoutMs = 1000
     heartbeatIntervalMs = 300
     storagePath = "/var/lib/rocketmq/controller/node-2"
-    storageBackend = "File"
+    storageBackend = "RocksDB"
     enableElectUncleanMasterLocal = false
 
     [[raftPeers]]
@@ -574,7 +647,7 @@ data:
     electionTimeoutMs = 1000
     heartbeatIntervalMs = 300
     storagePath = "/var/lib/rocketmq/controller/node-3"
-    storageBackend = "File"
+    storageBackend = "RocksDB"
     enableElectUncleanMasterLocal = false
 
     [[raftPeers]]
@@ -614,7 +687,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: proxy
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 data:
   proxy.toml: |-
     mode = "cluster"
@@ -650,7 +723,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 data:
   mcp.toml: |-
     [server]
@@ -754,7 +827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
   annotations:
     helm.sh/resource-policy: keep
     rocketmq.apache.org/persisted-format: mcp-audit-v1
@@ -778,7 +851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -809,7 +882,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   type: ClusterIP
   selector:
@@ -839,7 +912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -870,7 +943,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   type: ClusterIP
   selector:
@@ -900,7 +973,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: namesrv
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -927,7 +1000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: namesrv
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   type: ClusterIP
   selector:
@@ -953,11 +1026,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
     rocketmq.apache.org/controller-ordinal: "0"
 spec:
   type: ClusterIP
   clusterIP: 10.96.0.201
+  publishNotReadyAddresses: true
   selector:
     statefulset.kubernetes.io/pod-name: rocketmq-controller-0
   ports:
@@ -977,11 +1051,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
     rocketmq.apache.org/controller-ordinal: "1"
 spec:
   type: ClusterIP
   clusterIP: 10.96.0.202
+  publishNotReadyAddresses: true
   selector:
     statefulset.kubernetes.io/pod-name: rocketmq-controller-1
   ports:
@@ -1001,11 +1076,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
     rocketmq.apache.org/controller-ordinal: "2"
 spec:
   type: ClusterIP
   clusterIP: 10.96.0.203
+  publishNotReadyAddresses: true
   selector:
     statefulset.kubernetes.io/pod-name: rocketmq-controller-2
   ports:
@@ -1025,7 +1101,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   type: ClusterIP
   selector:
@@ -1051,7 +1127,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: proxy
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   type: ClusterIP
   selector:
@@ -1081,7 +1157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: proxy
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   replicas: 2
   strategy:
@@ -1101,7 +1177,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: "0.1.0"
         rocketmq.apache.org/service: proxy
-        rocketmq.apache.org/architecture-milestone: M11-10
+        rocketmq.apache.org/architecture-milestone: P0-04
     spec:
       serviceAccountName: rocketmq-runtime
       automountServiceAccountToken: false
@@ -1114,6 +1190,16 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: rocketmq-proxy
+                  app.kubernetes.io/instance: rocketmq
+                  rocketmq.apache.org/service: proxy
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -1125,8 +1211,8 @@ spec:
               rocketmq.apache.org/service: proxy
       containers:
         - name: proxy
-          image: "ghcr.io/mxsm/rocketmq-rust/proxy@sha256:4444444444444444444444444444444444444444444444444444444444444444"
-          imagePullPolicy: IfNotPresent
+          image: "rocketmq-rust/proxy:local"
+          imagePullPolicy: Never
           args: ["--config", "/etc/rocketmq/proxy.toml"]
           env:
             - {name: ROCKETMQ_HEALTH_BIND_ADDR, value: "0.0.0.0:8088"}
@@ -1215,7 +1301,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: mcp
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   replicas: 1
   strategy:
@@ -1234,7 +1320,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: "0.1.0"
         rocketmq.apache.org/service: mcp
-        rocketmq.apache.org/architecture-milestone: M11-10
+        rocketmq.apache.org/architecture-milestone: P0-04
     spec:
       serviceAccountName: rocketmq-runtime
       automountServiceAccountToken: false
@@ -1247,19 +1333,10 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: rocketmq-mcp
-              app.kubernetes.io/instance: rocketmq
-              rocketmq.apache.org/service: mcp
       containers:
         - name: mcp
-          image: "ghcr.io/mxsm/rocketmq-rust/mcp@sha256:5555555555555555555555555555555555555555555555555555555555555555"
-          imagePullPolicy: IfNotPresent
+          image: "rocketmq-rust/mcp:local"
+          imagePullPolicy: Never
           args: ["--config", "/etc/rocketmq/mcp.toml", "--transport", "streamable-http"]
           env:
             - {name: ROCKETMQ_HEALTH_BIND_ADDR, value: "0.0.0.0:8088"}
@@ -1349,11 +1426,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: broker
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   serviceName: rocketmq-broker-headless
-  replicas: 1
-  podManagementPolicy: OrderedReady
+  replicas: 3
+  podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate
   persistentVolumeClaimRetentionPolicy:
@@ -1373,7 +1450,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: "0.1.0"
         rocketmq.apache.org/service: broker
-        rocketmq.apache.org/architecture-milestone: M11-10
+        rocketmq.apache.org/architecture-milestone: P0-04
     spec:
       serviceAccountName: rocketmq-runtime
       automountServiceAccountToken: false
@@ -1386,6 +1463,16 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: rocketmq-broker
+                  app.kubernetes.io/instance: rocketmq
+                  rocketmq.apache.org/service: broker
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -1397,13 +1484,17 @@ spec:
               rocketmq.apache.org/service: broker
       containers:
         - name: broker
-          image: "ghcr.io/mxsm/rocketmq-rust/broker@sha256:1111111111111111111111111111111111111111111111111111111111111111"
-          imagePullPolicy: IfNotPresent
+          image: "rocketmq-rust/broker:local"
+          imagePullPolicy: Never
           args: ["--configFile", "/etc/rocketmq/broker.toml"]
           env:
             - {name: ROCKETMQ_HEALTH_BIND_ADDR, value: "0.0.0.0:8088"}
             - {name: ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS, value: "45"}
             - {name: ROCKETMQ_LIVENESS_STALE_SECONDS, value: "30"}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - {name: ROCKETMQ_HOME, value: /var/lib/rocketmq/broker}
             - {name: OTEL_SERVICE_NAME, value: rocketmq-broker}
             - {name: OTEL_EXPORTER_OTLP_ENDPOINT, value: "http://otel-collector.observability.svc.cluster.local:4317"}
@@ -1454,7 +1545,10 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
-            - {name: config, mountPath: /etc/rocketmq/broker.toml, subPath: broker.toml, readOnly: true}
+            - name: config
+              mountPath: /etc/rocketmq/broker.toml
+              subPathExpr: $(POD_NAME).toml
+              readOnly: true
             - {name: data, mountPath: /var/lib/rocketmq/broker}
             - {name: runtime-secrets, mountPath: /var/run/secrets/rocketmq, readOnly: true}
             - {name: tmp, mountPath: /tmp/rocketmq}
@@ -1480,7 +1574,7 @@ spec:
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/version: "0.1.0"
           rocketmq.apache.org/service: broker
-          rocketmq.apache.org/architecture-milestone: M11-10
+          rocketmq.apache.org/architecture-milestone: P0-04
       spec:
         accessModes: [ReadWriteOnce]
         storageClassName: "rocketmq-retain"
@@ -1501,7 +1595,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: namesrv
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   serviceName: rocketmq-namesrv-headless
   replicas: 3
@@ -1525,7 +1619,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: "0.1.0"
         rocketmq.apache.org/service: namesrv
-        rocketmq.apache.org/architecture-milestone: M11-10
+        rocketmq.apache.org/architecture-milestone: P0-04
     spec:
       serviceAccountName: rocketmq-runtime
       automountServiceAccountToken: false
@@ -1538,6 +1632,16 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: rocketmq-namesrv
+                  app.kubernetes.io/instance: rocketmq
+                  rocketmq.apache.org/service: namesrv
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -1549,8 +1653,8 @@ spec:
               rocketmq.apache.org/service: namesrv
       containers:
         - name: namesrv
-          image: "ghcr.io/mxsm/rocketmq-rust/namesrv@sha256:2222222222222222222222222222222222222222222222222222222222222222"
-          imagePullPolicy: IfNotPresent
+          image: "rocketmq-rust/namesrv:local"
+          imagePullPolicy: Never
           args: ["--configFile", "/etc/rocketmq/namesrv.toml"]
           env:
             - {name: ROCKETMQ_HEALTH_BIND_ADDR, value: "0.0.0.0:8088"}
@@ -1631,7 +1735,7 @@ spec:
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/version: "0.1.0"
           rocketmq.apache.org/service: namesrv
-          rocketmq.apache.org/architecture-milestone: M11-10
+          rocketmq.apache.org/architecture-milestone: P0-04
       spec:
         accessModes: [ReadWriteOnce]
         storageClassName: "rocketmq-retain"
@@ -1652,7 +1756,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "0.1.0"
     rocketmq.apache.org/service: controller
-    rocketmq.apache.org/architecture-milestone: M11-10
+    rocketmq.apache.org/architecture-milestone: P0-04
 spec:
   serviceName: rocketmq-controller-headless
   replicas: 3
@@ -1676,7 +1780,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: "0.1.0"
         rocketmq.apache.org/service: controller
-        rocketmq.apache.org/architecture-milestone: M11-10
+        rocketmq.apache.org/architecture-milestone: P0-04
     spec:
       serviceAccountName: rocketmq-runtime
       automountServiceAccountToken: false
@@ -1689,6 +1793,16 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: rocketmq-controller
+                  app.kubernetes.io/instance: rocketmq
+                  rocketmq.apache.org/service: controller
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -1700,7 +1814,7 @@ spec:
               rocketmq.apache.org/service: controller
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: rocketmq-controller
@@ -1708,8 +1822,8 @@ spec:
               rocketmq.apache.org/service: controller
       containers:
         - name: controller
-          image: "ghcr.io/mxsm/rocketmq-rust/controller@sha256:3333333333333333333333333333333333333333333333333333333333333333"
-          imagePullPolicy: IfNotPresent
+          image: "rocketmq-rust/controller:local"
+          imagePullPolicy: Never
           args: ["--config-file", "/etc/rocketmq/controller.toml"]
           env:
             - {name: ROCKETMQ_HEALTH_BIND_ADDR, value: "0.0.0.0:8088"}
@@ -1800,7 +1914,7 @@ spec:
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/version: "0.1.0"
           rocketmq.apache.org/service: controller
-          rocketmq.apache.org/architecture-milestone: M11-10
+          rocketmq.apache.org/architecture-milestone: P0-04
       spec:
         accessModes: [ReadWriteOnce]
         storageClassName: "rocketmq-retain"

--- a/distribution/kubernetes/deployment-policy.json
+++ b/distribution/kubernetes/deployment-policy.json
@@ -1,16 +1,20 @@
 {
   "schema_version": 1,
-  "milestone": "M11-10",
+  "milestone": "P0-04",
   "kubernetes_version": "1.32.0",
   "helm_chart": "distribution/helm/rocketmq-rust",
-  "helm_secure_values": "distribution/helm/rocketmq-rust/ci/secure-values.yaml",
   "kustomize_base": "distribution/kubernetes/base",
   "kustomize_secure_overlay": "distribution/kubernetes/overlays/secure",
+  "profiles": {
+    "development": "dev-single",
+    "production": "production-controller-ha"
+  },
   "image": {
-    "repository_prefix": "ghcr.io/mxsm/rocketmq-rust",
-    "digest_pattern": "^sha256:[0-9a-f]{64}$",
-    "unpublished_placeholder": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "secure_values_are_non_publishable_fixtures": true
+    "mode": "local",
+    "repository_prefix": "rocketmq-rust",
+    "tag": "local",
+    "pull_policy": "Never",
+    "remote_push_enabled": false
   },
   "security": {
     "profile": "restricted",
@@ -71,9 +75,9 @@
   },
   "services": {
     "broker": {
-      "repository": "ghcr.io/mxsm/rocketmq-rust/broker",
+      "repository": "rocketmq-rust/broker",
       "workload_kind": "StatefulSet",
-      "replicas": 1,
+      "replicas": 3,
       "config_path": "/etc/rocketmq/broker.toml",
       "data_path": "/var/lib/rocketmq/broker",
       "ports": [
@@ -88,7 +92,7 @@
         "retention": "Retain"
       },
       "pdb": {
-        "min_available": 1
+        "min_available": 2
       },
       "resources": {
         "requests": {
@@ -102,7 +106,7 @@
       }
     },
     "namesrv": {
-      "repository": "ghcr.io/mxsm/rocketmq-rust/namesrv",
+      "repository": "rocketmq-rust/namesrv",
       "workload_kind": "StatefulSet",
       "replicas": 3,
       "config_path": "/etc/rocketmq/namesrv.toml",
@@ -132,7 +136,7 @@
       }
     },
     "controller": {
-      "repository": "ghcr.io/mxsm/rocketmq-rust/controller",
+      "repository": "rocketmq-rust/controller",
       "workload_kind": "StatefulSet",
       "replicas": 3,
       "quorum": 2,
@@ -145,6 +149,7 @@
       ],
       "raft_bind_address": "0.0.0.0:60110",
       "auto_initialize_cluster": true,
+      "storage_backend": "RocksDB",
       "peer_service_ips_required": 3,
       "peer_service_ip_fixture": [
         "10.96.0.201",
@@ -172,7 +177,7 @@
       }
     },
     "proxy": {
-      "repository": "ghcr.io/mxsm/rocketmq-rust/proxy",
+      "repository": "rocketmq-rust/proxy",
       "workload_kind": "Deployment",
       "replicas": 2,
       "config_path": "/etc/rocketmq/proxy.toml",
@@ -200,7 +205,7 @@
       }
     },
     "mcp": {
-      "repository": "ghcr.io/mxsm/rocketmq-rust/mcp",
+      "repository": "rocketmq-rust/mcp",
       "workload_kind": "Deployment",
       "replicas": 1,
       "horizontal_scaling": false,
@@ -247,13 +252,6 @@
       "version": "v0.8.0",
       "linux_amd64_sha256": "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883",
       "windows_amd64_sha256": "e3f56102bcf4f50b034a567e2482a1c5330799983ddd655952310211aef73d93"
-    }
-  },
-  "workflow": {
-    "path": ".github/workflows/kubernetes-assets-ci.yml",
-    "actions": {
-      "actions/checkout": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-      "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     }
   }
 }

--- a/distribution/kubernetes/overlays/secure/kustomization.yaml
+++ b/distribution/kubernetes/overlays/secure/kustomization.yaml
@@ -1,21 +1,21 @@
-# non-publishable rendering fixture only. Replace every digest with a verified signed production digest before deployment.
+# Keep the hardened overlay on images loaded into the local cluster.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
 images:
-  - name: ghcr.io/mxsm/rocketmq-rust/broker
-    newName: ghcr.io/mxsm/rocketmq-rust/broker
-    digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
-  - name: ghcr.io/mxsm/rocketmq-rust/namesrv
-    newName: ghcr.io/mxsm/rocketmq-rust/namesrv
-    digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
-  - name: ghcr.io/mxsm/rocketmq-rust/controller
-    newName: ghcr.io/mxsm/rocketmq-rust/controller
-    digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
-  - name: ghcr.io/mxsm/rocketmq-rust/proxy
-    newName: ghcr.io/mxsm/rocketmq-rust/proxy
-    digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
-  - name: ghcr.io/mxsm/rocketmq-rust/mcp
-    newName: ghcr.io/mxsm/rocketmq-rust/mcp
-    digest: sha256:5555555555555555555555555555555555555555555555555555555555555555
+  - name: rocketmq-rust/broker
+    newName: rocketmq-rust/broker
+    newTag: local
+  - name: rocketmq-rust/namesrv
+    newName: rocketmq-rust/namesrv
+    newTag: local
+  - name: rocketmq-rust/controller
+    newName: rocketmq-rust/controller
+    newTag: local
+  - name: rocketmq-rust/proxy
+    newName: rocketmq-rust/proxy
+    newTag: local
+  - name: rocketmq-rust/mcp
+    newName: rocketmq-rust/mcp
+    newTag: local

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -217,6 +219,10 @@ async fn run_controller(
         shutdown_controller_after_startup_failure(&controller_manager, &lifecycle).await;
         return Err(error);
     }
+    if let Err(error) = wait_for_cluster_recovery(&controller_manager).await {
+        shutdown_controller_after_startup_failure(&controller_manager, &lifecycle).await;
+        return Err(error);
+    }
     if let Err(error) = lifecycle.mark_ready() {
         shutdown_controller_after_startup_failure(&controller_manager, &lifecycle).await;
         return Err(error.into());
@@ -388,6 +394,30 @@ async fn initialize_cluster_if_configured(controller_manager: &Arc<ControllerMan
 
     Err(ControllerError::Internal(format!(
         "controller node {} did not become leader after bootstrap",
+        config.node_id
+    ))
+    .into())
+}
+
+async fn wait_for_cluster_recovery(controller_manager: &Arc<ControllerManager>) -> Result<()> {
+    let config = controller_manager.controller_config();
+    if config.raft_peers.is_empty() {
+        return Ok(());
+    }
+
+    for _ in 0..300 {
+        if controller_manager.controller().has_recovered_cluster_state() {
+            info!(
+                node_id = config.node_id,
+                "Controller observed a Raft leader and recovered committed state"
+            );
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(ControllerError::Internal(format!(
+        "controller node {} did not recover committed Raft state before the readiness deadline",
         config.node_id
     ))
     .into())

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -296,6 +296,16 @@ impl OpenRaftController {
         metrics.current_leader == Some(self.config.snapshot().node_id)
     }
 
+    pub(crate) fn has_recovered_cluster_state(&self) -> bool {
+        let Some(node) = self.node() else {
+            return false;
+        };
+
+        use openraft::async_runtime::WatchReceiver;
+        let metrics = node.raft().metrics().borrow_watched().clone();
+        metrics.current_leader.is_some() && metrics.last_applied.is_some()
+    }
+
     fn not_leader_response(&self) -> Option<RemotingCommand> {
         Some(RemotingCommand::create_response_command_with_code_remark(
             ResponseCode::ControllerNotLeader,
@@ -1030,8 +1040,10 @@ fn parse_controller_raft_bind_addr(raw: &str) -> std::result::Result<SocketAddr,
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::net::TcpListener as StdTcpListener;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use rocketmq_common::common::controller::controller_config::RaftPeer;
     use rocketmq_common::common::controller::ControllerConfig;
@@ -1042,6 +1054,7 @@ mod tests {
     use super::parse_controller_raft_bind_addr;
     use super::OpenRaftController;
     use crate::config::ControllerConfigReader;
+    use crate::typ::Node;
     use std::net::SocketAddr;
 
     #[test]
@@ -1087,9 +1100,31 @@ mod tests {
         second_start.expect("repeat OpenRaft controller startup");
         assert!(controller.node().is_some(), "startup should publish the Raft node");
         assert!(
+            !controller.has_recovered_cluster_state(),
+            "a bound Raft listener alone must not publish business readiness"
+        );
+        assert!(
             StdTcpListener::bind(addr).is_err(),
             "OpenRaft controller startup should return only after binding the gRPC listener"
         );
+
+        controller
+            .initialize_cluster(BTreeMap::from([(
+                1,
+                Node {
+                    node_id: 1,
+                    rpc_addr: addr.to_string(),
+                },
+            )]))
+            .await
+            .expect("initialize single-node cluster");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !controller.has_recovered_cluster_state() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Controller should observe a leader and committed state");
 
         let (first_shutdown, second_shutdown) =
             tokio::join!(controller.shutdown_shared(), controller.shutdown_shared());

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -122,6 +122,13 @@ impl RaftController {
         self.inner.has_committed_log()
     }
 
+    /// Returns whether this node has observed a Raft leader and applied committed state.
+    ///
+    /// This is the minimum recovery evidence required before publishing process readiness.
+    pub fn has_recovered_cluster_state(&self) -> bool {
+        self.inner.has_recovered_cluster_state()
+    }
+
     pub fn scheduling_enabled(&self) -> bool {
         self.inner.scheduling_enabled()
     }

--- a/rocketmq-doc/en/01-run-rocketmq-rust-k8s.md
+++ b/rocketmq-doc/en/01-run-rocketmq-rust-k8s.md
@@ -2,11 +2,238 @@
 title: "Run RocketMQ Rust with Kubernetes"
 permalink: /docs/run-rocketmq-rust-k8s/
 excerpt: "Run RocketMQ Rust with Kubernetes"
-last_modified_at: 2025-02-01T08:48:05-04:00
+last_modified_at: 2026-07-24T00:00:00+08:00
 redirect_from:
   - /theme-setup/
-toc: false
+toc: true
 classes: wide
 ---
 
-WIP
+# Run RocketMQ Rust with Kubernetes
+
+The Helm chart has two explicit deployment profiles:
+
+- `dev-single` is a one-pod-per-service development topology. Controller state and
+  service data may be ephemeral.
+- `production-controller-ha` is the production topology. It requires three or
+  more Brokers, an odd Controller quorum of at least three members, stable
+  Controller endpoints, and persistent storage.
+
+The examples below use images built into the local Docker image store. They do
+not log in to a registry and do not push images.
+
+## Prerequisites
+
+- Docker with BuildKit/buildx
+- Helm 4.2.3 or a compatible Helm release
+- Kubernetes 1.32 or newer
+- `kubectl` configured for the target cluster
+- a `ReadWriteOnce` StorageClass for the production profile
+
+For production, reserve one unused ClusterIP per Controller member from the
+cluster Service CIDR. The example values use `10.96.0.201` through
+`10.96.0.203`; replace them if the cluster uses another Service CIDR or those
+addresses are already allocated.
+
+## Build local images
+
+Run these commands from the repository root. `--load` writes each result to the
+local Docker image store; there is intentionally no `--push`.
+
+```powershell
+docker buildx build --load --file .\docker\Dockerfile.base --target broker `
+  --tag rocketmq-rust/broker:local .
+docker buildx build --load --file .\docker\Dockerfile.base --target namesrv `
+  --tag rocketmq-rust/namesrv:local .
+docker buildx build --load --file .\docker\Dockerfile.base --target controller `
+  --tag rocketmq-rust/controller:local .
+docker buildx build --load --file .\docker\Dockerfile.base --target proxy `
+  --tag rocketmq-rust/proxy:local .
+docker buildx build --load --file .\docker\Dockerfile.base --target mcp `
+  --tag rocketmq-rust/mcp:local .
+
+docker image inspect `
+  rocketmq-rust/broker:local `
+  rocketmq-rust/namesrv:local `
+  rocketmq-rust/controller:local `
+  rocketmq-rust/proxy:local `
+  rocketmq-rust/mcp:local > $null
+```
+
+Docker Desktop Kubernetes can use the host image store directly. A cluster
+running in containers has a separate image store, so load the images without a
+registry:
+
+```powershell
+# kind
+kind load docker-image --name <cluster-name> `
+  rocketmq-rust/broker:local `
+  rocketmq-rust/namesrv:local `
+  rocketmq-rust/controller:local `
+  rocketmq-rust/proxy:local `
+  rocketmq-rust/mcp:local
+
+# k3d
+k3d image import --cluster <cluster-name> `
+  rocketmq-rust/broker:local `
+  rocketmq-rust/namesrv:local `
+  rocketmq-rust/controller:local `
+  rocketmq-rust/proxy:local `
+  rocketmq-rust/mcp:local
+```
+
+Both profiles set `imagePullPolicy: Never`. An `ErrImageNeverPull` Pod therefore
+means that the image was not loaded into the image store used by that node.
+
+## Prepare storage and secrets
+
+The production values use the placeholder StorageClass
+`rocketmq-retain`. Either create a class with that name and an appropriate
+retention policy, or override all four persistent services:
+
+```yaml
+services:
+  broker:
+    persistence:
+      storageClassName: standard
+  namesrv:
+    persistence:
+      storageClassName: standard
+  controller:
+    persistence:
+      storageClassName: standard
+  mcp:
+    persistence:
+      storageClassName: standard
+```
+
+The chart never generates credentials or private keys. Create the namespace and
+the externally managed Secret before installing. Keep the source files outside
+the repository.
+
+```powershell
+kubectl create namespace rocketmq --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n rocketmq create secret generic rocketmq-runtime-secrets `
+  --from-file=broker-acl.yml=<path-to-broker-acl> `
+  --from-file=proxy-acl.yml=<path-to-proxy-acl> `
+  --from-file=tls.crt=<path-to-tls-certificate> `
+  --from-file=tls.key=<path-to-tls-private-key>
+```
+
+Use a Secrets Store CSI provider instead by clearing
+`global.secretRefs.existingSecret` and setting
+`global.secretRefs.secretProviderClassName`.
+
+## Validate locally
+
+```powershell
+helm lint .\distribution\helm\rocketmq-rust --strict
+helm lint .\distribution\helm\rocketmq-rust --strict `
+  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml
+helm lint .\distribution\helm\rocketmq-rust --strict `
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml
+
+helm template rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml > $null
+helm template rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml > $null
+```
+
+The production schema rejects an even or undersized Controller set, fewer than
+three Brokers, missing Controller endpoints, disabled required persistence, and
+a Controller backend other than RocksDB.
+
+## Install `dev-single`
+
+```powershell
+helm upgrade --install rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml `
+  --wait --timeout 10m
+```
+
+This profile is for local development only. It uses one Controller with the
+in-memory backend and does not promise recovery after Pod or node loss.
+
+## Install `production-controller-ha`
+
+First copy `values-production-controller-ha.yaml` to a local, uncommitted
+override file and set:
+
+- the Controller ClusterIPs reserved for this cluster;
+- the StorageClass used by Broker, NameSrv, Controller, and MCP;
+- production MCP URLs and OAuth values;
+- resource limits appropriate for the nodes.
+
+Then install:
+
+```powershell
+helm upgrade --install rocketmq .\distribution\helm\rocketmq-rust `
+  --namespace rocketmq `
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml `
+  -f <local-production-overrides.yaml> `
+  --atomic --wait --timeout 15m
+```
+
+The profile creates:
+
+- three stable Controller ordinals, stable Raft/Remoting ClusterIPs, RocksDB
+  PVCs, and a two-member disruption quorum;
+- one three-replica Controller-managed Broker group, with stable Pod DNS and an
+  independent retained PVC per ordinal;
+- three persistent NameServers, two Proxies, and one persistent MCP audit
+  instance;
+- required host anti-affinity, topology spread constraints, PDBs, default-deny
+  networking, and service-specific ingress/egress rules.
+
+Broker identity metadata is stored on the Broker PVC. A new ordinal requests a
+Broker ID from Controller and commits it before becoming ready; a restarted
+ordinal recovers the same identity file.
+
+## Readiness and rollout
+
+The HTTP probe on port `8088` is intentionally not exposed by a Service.
+Startup readiness is published only after:
+
+- Controller has observed a Raft leader and applied committed state;
+- Broker has a writable Store, bound listeners, active processors, initialized
+  security, Controller registration, and an assigned runtime role;
+- Proxy has a working NameServer/Broker metadata path, initialized
+  authentication/authorization, and all configured listeners bound.
+
+Use `kubectl rollout status` and inspect `/readyz` through the Pod network when
+diagnosing a rollout:
+
+```powershell
+kubectl -n rocketmq rollout status statefulset/rocketmq-controller --timeout=10m
+kubectl -n rocketmq rollout status statefulset/rocketmq-broker --timeout=10m
+kubectl -n rocketmq rollout status deployment/rocketmq-proxy --timeout=10m
+kubectl -n rocketmq get pods,pvc,pdb
+```
+
+Upgrade one release at a time with the same production override file. Do not
+change Controller node IDs, Controller ClusterIPs, Broker group names, or PVC
+ownership during an ordinary upgrade.
+
+## Recovery
+
+- Keep Controller and Broker PVC retention set to `Retain`. Never replace a
+  failed Pod by deleting its PVC as a first response.
+- Restore a Controller ordinal with its original PVC and the same node ID and
+  ClusterIP. A majority of the configured voters must be available before the
+  cluster can accept writes.
+- Restore a Broker ordinal with its original PVC so that its Controller-issued
+  Broker ID is recovered. Do not attach one ordinal's PVC to another ordinal.
+- If a Controller member is permanently lost, recover quorum first and use an
+  explicit Raft membership operation before changing the Helm replica count or
+  endpoint list.
+- Take storage-provider snapshots of Controller and Broker volumes. Restore a
+  mutually consistent set; do not combine unrelated Controller state,
+  Broker identity, and message-store snapshots.
+- After recovery, wait for Controller, then Broker, then Proxy readiness before
+  reopening client traffic.
+
+Uninstalling the Helm release does not authorize deletion of retained data.
+Review PVCs individually before any manual removal.

--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -126,6 +126,11 @@ pub trait ClusterClient: Send + Sync {
         None
     }
 
+    /// Verifies that NameServer exposes at least one registered Broker route.
+    async fn readiness_check(&self) -> ProxyResult<()> {
+        Ok(())
+    }
+
     async fn query_route(&self, topic: &ResourceIdentity) -> ProxyResult<TopicRouteData>;
 
     async fn query_assignment(
@@ -825,6 +830,10 @@ impl ClusterClient for RocketmqClusterClient {
         Some(format!("{prefix}-{identity}"))
     }
 
+    async fn readiness_check(&self) -> ProxyResult<()> {
+        self.executor.readiness_check().await
+    }
+
     async fn query_route(&self, topic: &ResourceIdentity) -> ProxyResult<TopicRouteData> {
         self.executor.query_route(topic.clone()).await
     }
@@ -969,6 +978,9 @@ struct ClusterTaskExecutor {
 }
 
 enum ClusterCommand {
+    ReadinessCheck {
+        reply: oneshot::Sender<ProxyResult<()>>,
+    },
     QueryRoute {
         topic: ResourceIdentity,
         reply: oneshot::Sender<ProxyResult<TopicRouteData>>,
@@ -1282,6 +1294,10 @@ impl ClusterTaskExecutor {
         Self { sender, startup_error }
     }
 
+    async fn readiness_check(&self) -> ProxyResult<()> {
+        self.execute(|reply| ClusterCommand::ReadinessCheck { reply }).await
+    }
+
     async fn query_route(&self, topic: ResourceIdentity) -> ProxyResult<TopicRouteData> {
         self.execute(|reply| ClusterCommand::QueryRoute { topic, reply }).await
     }
@@ -1573,6 +1589,9 @@ fn cluster_client_config(config: &ClusterConfig) -> RocketmqClientConfig {
 
 async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorkerState, command: ClusterCommand) {
     match command {
+        ClusterCommand::ReadinessCheck { reply } => {
+            let _ = reply.send(cluster_readiness_inner(config, state).await);
+        }
         ClusterCommand::QueryRoute { topic, reply } => {
             let _ = reply.send(query_route_inner(config, state, topic).await);
         }
@@ -1685,6 +1704,30 @@ async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorke
             let _ = reply.send(unlock_batch_mq_inner(config, state, request).await);
         }
     }
+}
+
+async fn cluster_readiness_inner(config: &ClusterConfig, state: &mut ClusterWorkerState) -> ProxyResult<()> {
+    let client = state.client(config).await?;
+    let cluster_info = client.broker_cluster_info(config.mq_client_api_timeout_ms).await?;
+    if cluster_info_has_registered_broker(&cluster_info) {
+        Ok(())
+    } else {
+        Err(ProxyError::Transport {
+            message: "Proxy Cluster readiness found no registered Broker route".to_string(),
+        })
+    }
+}
+
+fn cluster_info_has_registered_broker(cluster_info: &ClusterInfo) -> bool {
+    let has_broker = cluster_info
+        .broker_addr_table
+        .as_ref()
+        .is_some_and(|brokers| !brokers.is_empty());
+    let has_cluster = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .is_some_and(|clusters| !clusters.is_empty());
+    has_broker && has_cluster
 }
 
 async fn lock_batch_mq_inner(
@@ -3096,6 +3139,7 @@ mod tests {
 
     use super::build_send_producer;
     use super::cluster_client_config;
+    use super::cluster_info_has_registered_broker;
     use super::convert_subscription_group;
     use super::convert_topic_message_type;
     use super::select_auth_metadata_broker_addr;
@@ -3187,6 +3231,8 @@ mod tests {
             "127.0.0.1:10911"
         );
         assert!(select_auth_metadata_broker_addr(&cluster_info, "missing").is_none());
+        assert!(cluster_info_has_registered_broker(&cluster_info));
+        assert!(!cluster_info_has_registered_broker(&ClusterInfo::default()));
     }
 
     #[test]

--- a/rocketmq-proxy-cluster/src/service.rs
+++ b/rocketmq-proxy-cluster/src/service.rs
@@ -102,6 +102,10 @@ impl ClusterMetadataService {
 
 #[async_trait]
 impl MetadataService for ClusterMetadataService {
+    async fn readiness_check(&self) -> ProxyResult<()> {
+        self.client.readiness_check().await
+    }
+
     async fn topic_message_type(
         &self,
         _context: &ProxyContext,

--- a/rocketmq-proxy-core/src/service.rs
+++ b/rocketmq-proxy-core/src/service.rs
@@ -85,6 +85,11 @@ pub trait RouteService: Send + Sync {
 
 #[async_trait]
 pub trait MetadataService: Send + Sync {
+    /// Verifies that the backing metadata route is available before listeners publish readiness.
+    async fn readiness_check(&self) -> ProxyResult<()> {
+        Ok(())
+    }
+
     async fn topic_message_type(
         &self,
         context: &ProxyContext,

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -91,6 +91,21 @@ fn publish_listener_ready(readiness: Option<LifecycleReadiness>) -> ProxyResult<
     }
 }
 
+async fn verify_cluster_route_and_security(
+    mode: ProxyMode,
+    metadata_service: Option<&Arc<dyn MetadataService>>,
+) -> ProxyResult<()> {
+    if !matches!(mode, ProxyMode::Cluster) {
+        return Ok(());
+    }
+
+    let metadata_service = metadata_service.ok_or_else(|| ProxyError::Transport {
+        message: "Proxy Cluster readiness requires a metadata service".to_string(),
+    })?;
+    metadata_service.readiness_check().await?;
+    Ok(())
+}
+
 fn require_healthy_grpc_shutdown(report: server::ProxyGrpcServerShutdownReport) -> ProxyResult<()> {
     if report.is_healthy() {
         Ok(())
@@ -370,6 +385,7 @@ where
                      runtime",
                 ));
             }
+            verify_cluster_route_and_security(config.mode, auth_metadata_service.as_ref()).await?;
             let auth_runtime = match auth_runtime {
                 Some(auth_runtime) => Some(auth_runtime),
                 None => {
@@ -557,11 +573,14 @@ mod tests {
     use rocketmq_runtime::ServiceLifecycleConfig;
     use rocketmq_runtime::ServiceLifecycleState;
 
+    use super::verify_cluster_route_and_security;
     use super::LifecycleReadiness;
     use super::ProxyRuntime;
     use super::ProxyRuntimeBuilder;
     use crate::config::ProxyConfig;
     use crate::config::ProxyMode;
+    use crate::service::DefaultMetadataService;
+    use crate::service::MetadataService;
 
     fn lifecycle() -> ServiceLifecycle {
         ServiceLifecycle::new(ServiceLifecycleConfig {
@@ -582,6 +601,24 @@ mod tests {
         readiness.listener_bound().expect("second listener binds");
         assert_eq!(lifecycle.state(), ServiceLifecycleState::Ready);
         assert!(readiness.listener_bound().is_err());
+    }
+
+    #[tokio::test]
+    async fn cluster_readiness_requires_a_healthy_metadata_path() {
+        assert!(
+            verify_cluster_route_and_security(ProxyMode::Cluster, None)
+                .await
+                .is_err(),
+            "Cluster mode must fail closed without a route and security metadata path"
+        );
+
+        let metadata: Arc<dyn MetadataService> = Arc::new(DefaultMetadataService);
+        verify_cluster_route_and_security(ProxyMode::Cluster, Some(&metadata))
+            .await
+            .expect("healthy metadata path should satisfy the readiness preflight");
+        verify_cluster_route_and_security(ProxyMode::Local, None)
+            .await
+            .expect("Local mode does not require a Cluster metadata preflight");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8713

### Brief Description

Adds explicit `dev-single` and `production-controller-ha` Helm profiles with schema-enforced replica, persistence, quorum, image, and disruption invariants. The production profile renders stable Broker and Controller StatefulSet identities, RocksDB-backed Controller storage, durable PVCs, topology constraints, PDBs, and least-open NetworkPolicies.

Controller readiness now waits for observed Raft leadership and applied committed state. Cluster-mode Proxy startup verifies that NameServer exposes a registered Broker route before publishing service readiness. Kubernetes assets and operating documentation use five locally loaded `rocketmq-rust/*:local` images with `imagePullPolicy: Never`; no remote image publication is required.

### How Did You Test This Change?

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- Focused Controller, Proxy, and Proxy Cluster readiness tests: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed locally.
- Helm lint for default, `dev-single`, and `production-controller-ha` values: passed locally.
- Helm/Kustomize renders validated with kubeconform strict Kubernetes 1.32 schemas: 20 development resources and 37 production resources, passed locally.
- Invalid Controller quorum, peer count, Broker replica, Controller persistence, and duplicate endpoint configurations: rejected as expected.
- Five `docker buildx build --load` local images were inspected as non-root and smoke-tested with their `--help` entrypoints: passed; no image was pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm deployment profiles for single-node development and production controller high availability.
  * Added configurable service replicas, images, persistence, storage, disruption budgets, networking, and controller addressing.
  * Added readiness checks for recovered controller state and registered proxy routes.
* **Bug Fixes**
  * Services now wait for recovery and connectivity before reporting readiness.
  * Improved deployment validation and component network access controls.
* **Documentation**
  * Added comprehensive Kubernetes installation, validation, rollout, and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->