### PR TITLE
[ISSUE #8717]♻️Enforce end-to-end absolute request deadlines

### DIFF
--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -668,6 +668,36 @@ impl RocketMQError {
         Self::Network(NetworkError::request_timeout(addr, timeout.as_millis() as u64))
     }
 
+    /// Create a connection-stage timeout error.
+    #[inline]
+    pub fn network_connection_timeout(addr: impl Into<String>, timeout_millis: u64) -> Self {
+        Self::Network(NetworkError::connection_timeout(addr, timeout_millis))
+    }
+
+    /// Create an outbound queue capacity error.
+    #[inline]
+    pub fn network_queue_full(addr: impl Into<String>) -> Self {
+        Self::Network(NetworkError::queue_full(addr))
+    }
+
+    /// Create a request-expired-before-send error.
+    #[inline]
+    pub fn network_deadline_exceeded_before_send(addr: impl Into<String>) -> Self {
+        Self::Network(NetworkError::deadline_exceeded_before_send(addr))
+    }
+
+    /// Create a socket write timeout error.
+    #[inline]
+    pub fn network_write_timeout(addr: impl Into<String>, timeout_millis: u64) -> Self {
+        Self::Network(NetworkError::write_timeout(addr, timeout_millis))
+    }
+
+    /// Create a response-stage timeout error.
+    #[inline]
+    pub fn network_response_timeout(addr: impl Into<String>, timeout_millis: u64) -> Self {
+        Self::Network(NetworkError::response_timeout(addr, timeout_millis))
+    }
+
     /// Create a network request failed error
     #[inline]
     pub fn network_request_failed(addr: impl Into<String>, reason: impl Into<String>) -> Self {

--- a/rocketmq-error/src/unified/network.rs
+++ b/rocketmq-error/src/unified/network.rs
@@ -51,6 +51,22 @@ pub enum NetworkError {
     #[error("Too many requests to {addr}, limit: {limit}")]
     TooManyRequests { addr: String, limit: usize },
 
+    /// Outbound queue cannot admit another request.
+    #[error("Outbound queue is full for {addr}")]
+    QueueFull { addr: String },
+
+    /// The request expired before its first socket write.
+    #[error("Request deadline exceeded before send to {addr}")]
+    DeadlineExceededBeforeSend { addr: String },
+
+    /// A socket write did not complete inside the request deadline.
+    #[error("Write timeout to {addr} after {timeout_ms}ms")]
+    WriteTimeout { addr: String, timeout_ms: u64 },
+
+    /// A sent request did not receive its response inside the request deadline.
+    #[error("Response timeout from {addr} after {timeout_ms}ms")]
+    ResponseTimeout { addr: String, timeout_ms: u64 },
+
     /// Request timeout
     #[error("Request timeout to {addr} after {timeout_ms}ms")]
     RequestTimeout { addr: String, timeout_ms: u64 },
@@ -93,6 +109,36 @@ impl NetworkError {
         }
     }
 
+    /// Create a bounded outbound queue rejection.
+    #[inline]
+    pub fn queue_full(addr: impl Into<String>) -> Self {
+        Self::QueueFull { addr: addr.into() }
+    }
+
+    /// Create a before-send deadline failure.
+    #[inline]
+    pub fn deadline_exceeded_before_send(addr: impl Into<String>) -> Self {
+        Self::DeadlineExceededBeforeSend { addr: addr.into() }
+    }
+
+    /// Create a socket write timeout.
+    #[inline]
+    pub fn write_timeout(addr: impl Into<String>, timeout_ms: u64) -> Self {
+        Self::WriteTimeout {
+            addr: addr.into(),
+            timeout_ms,
+        }
+    }
+
+    /// Create a response timeout.
+    #[inline]
+    pub fn response_timeout(addr: impl Into<String>, timeout_ms: u64) -> Self {
+        Self::ResponseTimeout {
+            addr: addr.into(),
+            timeout_ms,
+        }
+    }
+
     /// Get the associated address if available
     pub fn addr(&self) -> &str {
         match self {
@@ -103,6 +149,10 @@ impl NetworkError {
             | Self::ReceiveFailed { addr, .. }
             | Self::InvalidAddress { addr }
             | Self::TooManyRequests { addr, .. }
+            | Self::QueueFull { addr }
+            | Self::DeadlineExceededBeforeSend { addr }
+            | Self::WriteTimeout { addr, .. }
+            | Self::ResponseTimeout { addr, .. }
             | Self::RequestTimeout { addr, .. } => addr,
             Self::DnsResolutionFailed { host, .. } => host,
         }
@@ -179,6 +229,26 @@ mod tests {
             timeout_ms: 100,
         };
         assert_eq!(err.to_string(), "Request timeout to localhost:10911 after 100ms");
+    }
+
+    #[test]
+    fn request_deadline_stages_have_stable_variants() {
+        assert!(matches!(
+            NetworkError::queue_full("localhost:10911"),
+            NetworkError::QueueFull { .. }
+        ));
+        assert!(matches!(
+            NetworkError::deadline_exceeded_before_send("localhost:10911"),
+            NetworkError::DeadlineExceededBeforeSend { .. }
+        ));
+        assert!(matches!(
+            NetworkError::write_timeout("localhost:10911", 100),
+            NetworkError::WriteTimeout { timeout_ms: 100, .. }
+        ));
+        assert!(matches!(
+            NetworkError::response_timeout("localhost:10911", 100),
+            NetworkError::ResponseTimeout { timeout_ms: 100, .. }
+        ));
     }
 
     #[test]

--- a/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
+++ b/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
@@ -36,6 +36,7 @@ use rocketmq_runtime::TaskGroup;
 use rocketmq_transport::admission::AdmissionController;
 use rocketmq_transport::admission::AdmissionLimits;
 use rocketmq_transport::client::TransportClient;
+use rocketmq_transport::deadline::RequestDeadline;
 
 const ROUTE_LOOKUP_TIMEOUT: Duration = Duration::from_secs(3);
 const ROUTE_LOOKUP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -53,7 +54,7 @@ pub(crate) trait ClusterTestRouteLookup: Send + Sync {
 }
 
 trait ClusterTestEndpointResolver: Send + Sync {
-    fn resolve(&self, deadline: ShutdownDeadline) -> EndpointResolveFuture<'_>;
+    fn resolve(&self, deadline: RequestDeadline) -> EndpointResolveFuture<'_>;
 }
 
 struct ProductEnvironmentEndpointResolver {
@@ -72,16 +73,15 @@ impl ProductEnvironmentEndpointResolver {
 }
 
 impl ClusterTestEndpointResolver for ProductEnvironmentEndpointResolver {
-    fn resolve(&self, deadline: ShutdownDeadline) -> EndpointResolveFuture<'_> {
+    fn resolve(&self, deadline: RequestDeadline) -> EndpointResolveFuture<'_> {
         Box::pin(async move {
             if deadline.is_expired() {
                 return Err(route_lookup_timeout(deadline));
             }
 
-            let timeout_at = tokio::time::Instant::from_std(deadline.instant());
             let timeout_millis = deadline.remaining().as_millis().min(u128::from(u64::MAX)).max(1) as u64;
             let address_list = tokio::time::timeout_at(
-                timeout_at,
+                deadline.instant(),
                 self.addressing.fetch_ns_addr_inner_async(true, timeout_millis),
             )
             .await
@@ -137,7 +137,7 @@ impl TransportClusterTestRouteLookup {
     async fn lookup_topic_route_until(
         &self,
         topic: &CheetahString,
-        deadline: ShutdownDeadline,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<Option<TopicRouteData>> {
         let endpoints = self.resolve_endpoints(deadline).await?;
         let mut last_error = None;
@@ -159,7 +159,7 @@ impl TransportClusterTestRouteLookup {
         }))
     }
 
-    async fn resolve_endpoints(&self, deadline: ShutdownDeadline) -> RocketMQResult<Vec<SocketAddr>> {
+    async fn resolve_endpoints(&self, deadline: RequestDeadline) -> RocketMQResult<Vec<SocketAddr>> {
         let cached = self.cached_endpoints.read().clone();
         if !cached.is_empty() {
             return Ok(cached);
@@ -190,7 +190,7 @@ impl ClusterTestRouteLookup for TransportClusterTestRouteLookup {
     fn lookup_topic_route(&self, topic: &CheetahString) -> ClusterTestLookupFuture<'_, Option<TopicRouteData>> {
         let topic = topic.clone();
         Box::pin(async move {
-            let deadline = ShutdownDeadline::after(self.request_timeout);
+            let deadline = RequestDeadline::after(self.request_timeout);
             let cancellation = self.task_group.cancellation_token();
             tokio::select! {
                 biased;
@@ -240,8 +240,7 @@ fn decode_route_response(response: RemotingCommand) -> RocketMQResult<Option<Top
     }
 }
 
-async fn resolve_socket_addresses(address_list: &str, deadline: ShutdownDeadline) -> RocketMQResult<Vec<SocketAddr>> {
-    let timeout_at = tokio::time::Instant::from_std(deadline.instant());
+async fn resolve_socket_addresses(address_list: &str, deadline: RequestDeadline) -> RocketMQResult<Vec<SocketAddr>> {
     let mut resolved = Vec::new();
     let mut last_error = None;
 
@@ -253,7 +252,7 @@ async fn resolve_socket_addresses(address_list: &str, deadline: ShutdownDeadline
             continue;
         }
 
-        match tokio::time::timeout_at(timeout_at, tokio::net::lookup_host(endpoint)).await {
+        match tokio::time::timeout_at(deadline.instant(), tokio::net::lookup_host(endpoint)).await {
             Ok(Ok(addresses)) => {
                 for address in addresses {
                     if !resolved.contains(&address) {
@@ -275,8 +274,8 @@ async fn resolve_socket_addresses(address_list: &str, deadline: ShutdownDeadline
     Ok(resolved)
 }
 
-fn route_lookup_timeout(deadline: ShutdownDeadline) -> RocketMQError {
-    RocketMQError::network_timeout(LOOKUP_OWNER, deadline.remaining())
+fn route_lookup_timeout(deadline: RequestDeadline) -> RocketMQError {
+    RocketMQError::network_connection_timeout(LOOKUP_OWNER, deadline.budget_millis())
 }
 
 fn route_lookup_cancelled() -> RocketMQError {
@@ -317,7 +316,7 @@ mod tests {
     }
 
     impl ClusterTestEndpointResolver for FixedEndpointResolver {
-        fn resolve(&self, _deadline: ShutdownDeadline) -> EndpointResolveFuture<'_> {
+        fn resolve(&self, _deadline: RequestDeadline) -> EndpointResolveFuture<'_> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let endpoints = self.endpoints.clone();
             Box::pin(async move { Ok(endpoints) })
@@ -372,7 +371,7 @@ mod tests {
     }
 
     impl ClusterTestEndpointResolver for BlockingResolver {
-        fn resolve(&self, _deadline: ShutdownDeadline) -> EndpointResolveFuture<'_> {
+        fn resolve(&self, _deadline: RequestDeadline) -> EndpointResolveFuture<'_> {
             Box::pin(async move {
                 self.entered.notify_one();
                 std::future::pending().await

--- a/rocketmq-remoting/Cargo.toml
+++ b/rocketmq-remoting/Cargo.toml
@@ -84,6 +84,7 @@ observability = ["rocketmq-transport/observability"]
 bytes     = "1.11.1"
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile  = "3.27.0"
+tokio     = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name    = "encode_decode_bench"

--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -22,6 +22,7 @@ use crate::protocol::remoting_command::RemotingCommand;
 use crate::remoting::InvokeCallback;
 use crate::remoting::RemotingService;
 use crate::runtime::processor::RequestProcessor;
+use rocketmq_transport::deadline::RequestDeadline;
 
 mod async_client;
 mod blocking_client;
@@ -72,6 +73,14 @@ pub trait RemotingClient: RemotingService {
         addr: Option<&CheetahString>,
         request: RemotingCommand,
         timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand>;
+
+    /// Invokes a command using an already-frozen end-to-end deadline.
+    async fn invoke_request_with_deadline(
+        &self,
+        addr: Option<&CheetahString>,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand>;
 
     /// Invokes a command on a specified address without waiting for a response.

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -25,7 +25,6 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ServiceContext;
-use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskGroupChildLease;
 use tokio::sync::broadcast;
@@ -33,11 +32,9 @@ use tokio::sync::broadcast;
 use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::pending_request_table::PendingRequestOwner;
 use crate::base::pending_request_table::PendingRequestTable;
-use crate::base::pending_request_table::PendingRequestToken;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::connection::ConnectionStateHandle;
 // Import error helpers for convenient error creation
-use crate::error_helpers::connection_invalid;
 use crate::error_helpers::remote_error;
 use crate::net::channel::Channel;
 use crate::net::channel::ChannelInner;
@@ -48,6 +45,7 @@ use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
 use rocketmq_transport::admission::AdmissionController;
 use rocketmq_transport::admission::AdmissionLimits;
+use rocketmq_transport::deadline::RequestDeadline;
 use rocketmq_transport::security::TransportSecurity;
 use rocketmq_transport::server::ConnectionHandler as TransportConnectionHandler;
 use rocketmq_transport::server::SessionHandle;
@@ -190,6 +188,7 @@ fn connect<PR>(
     _send_notify: broadcast::Receiver<()>,
     tls_config: TlsConfig,
     task_group: TaskGroup,
+    deadline: RequestDeadline,
 ) -> ClientConnectFuture
 where
     PR: RequestProcessor + Sync + Clone + 'static,
@@ -199,7 +198,7 @@ where
             addr.as_str(),
             &tls_config,
             FrameLimits::legacy_compatibility(),
-            ShutdownDeadline::after(Duration::from_secs(10)),
+            deadline,
         )
         .await?;
         let (connection, local_addr, remote_address, negotiated_tls) = connected.into_parts_with_tls();
@@ -226,8 +225,10 @@ where
         task_group
             .spawn_service("rocketmq.transport.client-session", session_runner)
             .map_err(|error| remote_error(format!("failed to spawn transport client session: {error}")))?;
-        let (channel, pending_request_owner, session) = connected_session
+        let (channel, pending_request_owner, session) = deadline
+            .timeout(connected_session)
             .await
+            .map_err(|_| RocketMQError::network_connection_timeout(addr.clone(), deadline.budget_millis()))?
             .map_err(|_| remote_error("transport client session ended before connection setup"))?;
         if let Some(tx) = tx {
             let _ = tx.send(ConnectionNetEvent::CONNECTED(channel.remote_address()));
@@ -255,8 +256,25 @@ where
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         tls_config: TlsConfig,
     ) -> RocketMQResult<Client<PR>> {
+        Self::connect_until(
+            addr,
+            cmd_handler,
+            tx,
+            tls_config,
+            RequestDeadline::after(Duration::from_secs(10)),
+        )
+        .await
+    }
+
+    pub(crate) async fn connect_until(
+        addr: String,
+        cmd_handler: Arc<RemotingGeneralHandler<PR>>,
+        tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        tls_config: TlsConfig,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Client<PR>> {
         let (task_group, child_lease) = new_client_connection_task_group(&addr)?;
-        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group, child_lease).await
+        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group, child_lease, deadline).await
     }
 
     pub(crate) async fn connect_with_service_context(
@@ -266,8 +284,27 @@ where
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         tls_config: TlsConfig,
     ) -> RocketMQResult<Client<PR>> {
+        Self::connect_with_service_context_until(
+            context,
+            addr,
+            cmd_handler,
+            tx,
+            tls_config,
+            RequestDeadline::after(Duration::from_secs(10)),
+        )
+        .await
+    }
+
+    pub(crate) async fn connect_with_service_context_until(
+        context: &ServiceContext,
+        addr: String,
+        cmd_handler: Arc<RemotingGeneralHandler<PR>>,
+        tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        tls_config: TlsConfig,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Client<PR>> {
         let (task_group, child_lease) = new_client_connection_task_group_with_service_context(context, &addr)?;
-        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group, child_lease).await
+        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group, child_lease, deadline).await
     }
 
     async fn connect_with_task_group(
@@ -277,6 +314,7 @@ where
         tls_config: TlsConfig,
         task_group: TaskGroup,
         child_lease: Option<TaskGroupChildLease>,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<Client<PR>> {
         let (notify_shutdown, _) = broadcast::channel(1);
         let receiver = notify_shutdown.subscribe();
@@ -294,6 +332,7 @@ where
             send_receiver,
             tls_config,
             task_group,
+            deadline,
         )
         .await?;
         Ok(Client {
@@ -314,30 +353,16 @@ where
         self
     }
 
-    async fn send_transport(
-        &self,
-        mut request: RemotingCommand,
-        reservation: Option<PendingRequestToken>,
-    ) -> RocketMQResult<()> {
+    async fn send_transport(&self, mut request: RemotingCommand, deadline: RequestDeadline) -> RocketMQResult<()> {
         let transport_security = &self.transport_security;
+        let target = self.peer.address().to_string();
+        deadline.ensure_before_send(target.clone())?;
         transport_security
             .sign(&mut request, Some(&self.peer))
             .map_err(|error| remote_error(format!("request signing failed: {error}")))?;
+        deadline.ensure_before_send(target.clone())?;
         let mut connection = self.session.connection();
-        match connection.send_command(request).await {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                let connection_broken = matches!(error, rocketmq_error::RocketMQError::IO(_));
-                if let Some(reservation) = reservation {
-                    self.pending_requests.complete_token(reservation, Err(error));
-                }
-                if connection_broken {
-                    Err(connection_invalid("connection send failed"))
-                } else {
-                    Err(remote_error("request send failed"))
-                }
-            }
-        }
+        connection.send_command_with_deadline(request, deadline, target).await
     }
 
     /// Invokes a remote operation with the given `RemotingCommand`.
@@ -353,7 +378,7 @@ where
     pub async fn send_read(
         &mut self,
         request: RemotingCommand,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<RemotingCommand> {
         let (tx, rx) = tokio::sync::oneshot::channel::<RocketMQResult<RemotingCommand>>();
         let opaque = request.opaque();
@@ -361,16 +386,16 @@ where
         let guard = self.pending_requests.register_for_owner_with_bytes(
             &self.pending_request_owner,
             opaque,
-            timeout_millis,
+            deadline,
             retained_bytes,
             tx,
         )?;
 
-        self.send_transport(request, Some(guard.token())).await?;
-        match tokio::time::timeout_at(tokio::time::Instant::from_std(guard.deadline()), rx).await {
+        self.send_transport(request, deadline).await?;
+        match deadline.timeout(rx).await {
             Ok(Ok(value)) => value,
             Ok(Err(error)) => Err(remote_error(error.to_string())),
-            Err(_) => Err(guard.expire("remoting_client_response", timeout_millis)),
+            Err(_) => Err(guard.expire(self.peer.address().to_string())),
         }
     }
 
@@ -394,27 +419,24 @@ where
         F: FnMut(),
     {
         let (tx, rx) = tokio::sync::oneshot::channel::<RocketMQResult<RemotingCommand>>();
-        let timeout_millis = timeout.as_millis().min(u128::from(u64::MAX)) as u64;
+        let deadline = RequestDeadline::after(timeout);
         let retained_bytes = request.body().map_or(0, bytes::Bytes::len);
         let guard = match self.pending_requests.register_for_owner_with_bytes(
             &self.pending_request_owner,
             request.opaque(),
-            timeout_millis,
+            deadline,
             retained_bytes,
             tx,
         ) {
             Ok(guard) => guard,
             Err(_) => return,
         };
-        if self.send_transport(request, Some(guard.token())).await.is_err() {
+        if self.send_transport(request, deadline).await.is_err() {
             return;
         }
 
-        if tokio::time::timeout_at(tokio::time::Instant::from_std(guard.deadline()), rx)
-            .await
-            .is_err()
-        {
-            guard.expire("remoting_client_callback_response", timeout_millis);
+        if deadline.timeout(rx).await.is_err() {
+            guard.expire(self.peer.address().to_string());
             self.retire_after_timeout().await;
         }
         func();
@@ -430,7 +452,13 @@ where
     ///
     /// A `Result` indicating success or failure in sending the request.
     pub async fn send(&mut self, request: RemotingCommand) -> RocketMQResult<()> {
-        self.send_transport(request, None).await
+        self.send_transport(request, RequestDeadline::after(DEFAULT_CALLBACK_RESPONSE_TIMEOUT))
+            .await
+    }
+
+    /// Sends a request using the caller's existing immutable deadline.
+    pub async fn send_until(&mut self, request: RemotingCommand, deadline: RequestDeadline) -> RocketMQResult<()> {
+        self.send_transport(request, deadline).await
     }
 
     /// Sends multiple requests in a batch (fire-and-forget, no response expected).
@@ -470,7 +498,8 @@ where
         // Send all commands individually through the channel
         // The underlying connection will buffer them efficiently
         for request in requests {
-            self.send_transport(request, None).await?;
+            self.send_transport(request, RequestDeadline::after(DEFAULT_CALLBACK_RESPONSE_TIMEOUT))
+                .await?;
         }
         Ok(())
     }
@@ -511,6 +540,7 @@ where
         requests: Vec<RemotingCommand>,
         timeout_millis: u64,
     ) -> RocketMQResult<Vec<RocketMQResult<RemotingCommand>>> {
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
         let mut receivers = Vec::with_capacity(requests.len());
 
         // Send all requests and collect oneshot receivers
@@ -520,27 +550,25 @@ where
             let guard = self.pending_requests.register_for_owner_with_bytes(
                 &self.pending_request_owner,
                 request.opaque(),
-                timeout_millis,
+                deadline,
                 retained_bytes,
                 tx,
             )?;
 
-            self.send_transport(request, Some(guard.token())).await?;
-
-            let deadline = guard.deadline();
-            receivers.push((guard, deadline, rx));
+            self.send_transport(request, deadline).await?;
+            receivers.push((guard, rx));
         }
 
         // Collect all responses
         let mut results = Vec::with_capacity(receivers.len());
         let mut timed_out = false;
-        for (guard, deadline, rx) in receivers {
-            let result = match tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), rx).await {
+        for (guard, rx) in receivers {
+            let result = match deadline.timeout(rx).await {
                 Ok(Ok(value)) => value,
                 Ok(Err(error)) => Err(remote_error(error.to_string())),
                 Err(_) => {
                     timed_out = true;
-                    Err(guard.expire("remoting_client_batch_response", timeout_millis))
+                    Err(guard.expire(self.peer.address().to_string()))
                 }
             };
             results.push(result);
@@ -648,7 +676,7 @@ mod lifecycle_tests {
     }
 
     #[tokio::test]
-    async fn close_with_report_stops_connection_tasks() {
+    async fn batch_requests_share_one_absolute_response_deadline() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
         let addr = listener.local_addr().expect("listener addr");
         let server = tokio::spawn(async move {
@@ -680,9 +708,12 @@ mod lifecycle_tests {
             .await
             .expect("batch registration should succeed");
         assert_eq!(results.len(), 3);
-        assert!(results
-            .iter()
-            .all(|result| matches!(result, Err(RocketMQError::Timeout { .. }))));
+        assert!(results.iter().all(|result| matches!(
+            result,
+            Err(RocketMQError::Network(
+                rocketmq_error::NetworkError::ResponseTimeout { .. }
+            ))
+        )));
         assert!(
             time::Instant::now().duration_since(started_at) < Duration::from_millis(200),
             "batch timeout must be one absolute deadline, not one timeout per sequential await"
@@ -735,7 +766,11 @@ mod lifecycle_tests {
 
         let mut retained_client = client.clone();
         let retained_request = RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 4096]);
-        let retained_invocation = tokio::spawn(async move { retained_client.send_read(retained_request, 100).await });
+        let retained_invocation = tokio::spawn(async move {
+            retained_client
+                .send_read(retained_request, RequestDeadline::from_timeout_millis(100))
+                .await
+        });
         time::timeout(Duration::from_secs(1), async {
             while response_table.usage().count == 0 {
                 tokio::task::yield_now().await;

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -22,6 +22,9 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
+use rocketmq_error::NetworkError;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::RuntimeResult;
 use rocketmq_runtime::ServiceContext;
@@ -54,6 +57,7 @@ use crate::runtime::config::client_config::TokioClientConfig;
 use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
 use crate::tls::TlsConfig;
+use rocketmq_transport::deadline::RequestDeadline;
 use rocketmq_transport::security::TransportSecurity;
 
 /// High-performance async RocketMQ client with connection pooling and auto-reconnection.
@@ -550,7 +554,11 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     ///
     /// * `Some(client)` - Connected to healthy nameserver
     /// * `None` - No nameservers available or all unhealthy
-    async fn get_and_create_nameserver_client(&self) -> Option<Client<PR>> {
+    async fn get_and_create_nameserver_client_until(
+        &self,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<Client<PR>>> {
+        deadline.ensure_before_send("<nameserver>")?;
         let cached_addr = self.namesrv_addr_choosed.read().clone();
 
         if let Some(ref addr) = cached_addr {
@@ -558,7 +566,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
             if let Some(client) = self.connection_tables.get(addr) {
                 if client.connection().is_healthy() && self.latency_tracker.is_healthy(addr) {
                     // Fast path: Cached nameserver is healthy
-                    return Some(client.value().clone());
+                    return Ok(Some(client.value().clone()));
                 }
                 debug!("Cached nameserver {} is unhealthy, selecting new one", addr);
             }
@@ -568,7 +576,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
 
         if addr_list.is_empty() {
             warn!("No nameservers configured in namesrv_addr_list");
-            return None;
+            return Ok(None);
         }
 
         // Use latency tracker to select best nameserver
@@ -580,7 +588,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
                     "Failed to select healthy nameserver. Available list: {:?}, Available set: {:?}",
                     addr_list, available
                 );
-                return None;
+                return Ok(None);
             }
         };
 
@@ -596,11 +604,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         // Update cached selection
         self.namesrv_addr_choosed.write().replace(selected_addr.clone());
 
-        self.create_client(
-            selected_addr,
-            Duration::from_millis(self.tokio_client_config.connect_timeout_millis as u64),
-        )
-        .await
+        self.create_client_until(selected_addr, deadline).await
     }
 
     /// Get existing healthy client or create new connection.
@@ -615,29 +619,43 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     /// - **Fast path**: Single lock acquire + HashMap lookup + health check (< 100ns)
     /// - **Slow path**: Lock + TCP handshake + TLS (if enabled) (10-50ms)
     async fn get_and_create_client(&self, addr: Option<&CheetahString>) -> Option<Client<PR>> {
+        let deadline = RequestDeadline::after(Duration::from_millis(
+            self.tokio_client_config.connect_timeout_millis as u64,
+        ));
+        match self.get_and_create_client_until(addr, deadline).await {
+            Ok(client) => client,
+            Err(error) => {
+                warn!(error = ?error, "Failed to get or create remoting client");
+                None
+            }
+        }
+    }
+
+    async fn get_and_create_client_until(
+        &self,
+        addr: Option<&CheetahString>,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<Client<PR>>> {
         // Route empty addresses to nameserver
         let target_addr = match addr {
-            None => return self.get_and_create_nameserver_client().await,
-            Some(addr) if addr.is_empty() => return self.get_and_create_nameserver_client().await,
+            None => return self.get_and_create_nameserver_client_until(deadline).await,
+            Some(addr) if addr.is_empty() => return self.get_and_create_nameserver_client_until(deadline).await,
             Some(addr) => addr,
         };
+        deadline.ensure_before_send(target_addr.to_string())?;
 
         // Fast path: Check connection pool (lock-free with DashMap)
         if let Some(client_ref) = self.connection_tables.get(target_addr) {
             let client = client_ref.value().clone();
             if client.connection().is_healthy() {
-                return Some(client); // Return healthy cached client
+                return Ok(Some(client)); // Return healthy cached client
             }
             // Client unhealthy - will create new connection
             debug!("Cached client for {} is unhealthy, reconnecting...", target_addr);
         }
 
         // Slow path: Create new connection
-        self.create_client(
-            target_addr,
-            Duration::from_millis(self.tokio_client_config.connect_timeout_millis as u64),
-        )
-        .await
+        self.create_client_until(target_addr, deadline).await
     }
 
     /// Create new client connection with double-checked locking pattern.
@@ -678,11 +696,26 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     /// * `Some(client)` - Successfully connected (either new or cached)
     /// * `None` - Connection failed or timed out (or circuit breaker OPEN)
     async fn create_client(&self, addr: &CheetahString, duration: Duration) -> Option<Client<PR>> {
+        match self.create_client_until(addr, RequestDeadline::after(duration)).await {
+            Ok(client) => client,
+            Err(error) => {
+                error!(remote_addr = %addr, error = ?error, "Failed to create remoting client");
+                None
+            }
+        }
+    }
+
+    async fn create_client_until(
+        &self,
+        addr: &CheetahString,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<Client<PR>>> {
+        deadline.ensure_before_send(addr.to_string())?;
         if let Some(ref pool) = self.connection_pool {
             if let Some(pooled_conn) = pool.get(addr) {
                 if pooled_conn.is_healthy() {
                     debug!("Reusing pooled connection to {}", addr);
-                    return Some(pooled_conn.client().clone());
+                    return Ok(Some(pooled_conn.client().clone()));
                 }
                 // Unhealthy connection - remove from pool
                 pool.remove(addr);
@@ -693,7 +726,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         if let Some(client_ref) = self.connection_tables.get(addr) {
             let client = client_ref.value().clone();
             if client.connection().is_healthy() {
-                return Some(client);
+                return Ok(Some(client));
             }
             // Client unhealthy - remove it immediately (DashMap allows concurrent removal)
             drop(client_ref); // Release read guard before removal
@@ -710,7 +743,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         // Check if request allowed (CLOSED or HALF_OPEN)
         if !breaker.allow_request() {
             warn!("Circuit breaker OPEN for {}, rejecting connection attempt", addr);
-            return None;
+            return Ok(None);
         }
 
         let addr_inner = addr.to_string();
@@ -719,28 +752,33 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
 
         let service_context = self.service_context.clone();
         let transport_security = self.transport_security.clone();
-        let connect_result = time::timeout(duration, async move {
-            let result = if let Some(service_context) = service_context.as_ref() {
-                Client::connect_with_service_context(
-                    service_context,
-                    addr_inner,
-                    self.cmd_handler.clone(),
-                    self.tx.as_ref(),
-                    tls_config,
-                )
-                .await
-            } else {
-                Client::connect(addr_inner, self.cmd_handler.clone(), self.tx.as_ref(), tls_config).await
-            };
-            match transport_security {
-                Some(transport_security) => result.map(|client| client.with_transport_security(transport_security)),
-                None => result,
-            }
-        })
-        .await;
+        let connect_result = if let Some(service_context) = service_context.as_ref() {
+            Client::connect_with_service_context_until(
+                service_context,
+                addr_inner,
+                self.cmd_handler.clone(),
+                self.tx.as_ref(),
+                tls_config,
+                deadline,
+            )
+            .await
+        } else {
+            Client::connect_until(
+                addr_inner,
+                self.cmd_handler.clone(),
+                self.tx.as_ref(),
+                tls_config,
+                deadline,
+            )
+            .await
+        };
+        let connect_result = match transport_security {
+            Some(transport_security) => connect_result.map(|client| client.with_transport_security(transport_security)),
+            None => connect_result,
+        };
 
         match connect_result {
-            Ok(Ok(new_client)) => {
+            Ok(new_client) => {
                 // Connection successful - record success in circuit breaker
                 breaker.record_success();
                 self.circuit_breakers.insert(addr.clone(), breaker);
@@ -758,7 +796,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
                         // Check if existing is still healthy
                         if entry.get().connection().is_healthy() {
                             info!("Race condition: {} already connected by another task", addr);
-                            return Some(entry.get().clone());
+                            return Ok(Some(entry.get().clone()));
                         }
                         // Replace unhealthy with new client
                         entry.insert(new_client.clone());
@@ -769,21 +807,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
                 }
 
                 info!("Successfully created client for {}", addr);
-                Some(new_client)
+                Ok(Some(new_client))
             }
-            Ok(Err(e)) => {
+            Err(error) => {
                 // Connection failed - record failure in circuit breaker
-                error!("Failed to connect to {}: {:?}", addr, e);
+                error!(remote_addr = %addr, error = ?error, "Failed to connect");
                 breaker.record_failure();
                 self.circuit_breakers.insert(addr.clone(), breaker);
-                None
-            }
-            Err(_) => {
-                // Timeout - record failure in circuit breaker
-                error!("Connection to {} timed out after {:?}", addr, duration);
-                breaker.record_failure();
-                self.circuit_breakers.insert(addr.clone(), breaker);
-                None
+                Err(error)
             }
         }
     }
@@ -1199,15 +1230,26 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
         request: RemotingCommand,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        self.invoke_request_with_deadline(addr, request, RequestDeadline::from_timeout_millis(timeout_millis))
+            .await
+    }
+
+    async fn invoke_request_with_deadline(
+        &self,
+        addr: Option<&CheetahString>,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         // Record start time for latency tracking
         let start = time::Instant::now();
+        let timeout_millis = deadline.budget_millis();
+        let target = addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string);
+        deadline.ensure_before_send(target.clone())?;
 
         // Determine target address (for metrics recording)
         let target_addr = addr.cloned().or_else(|| self.namesrv_addr_choosed.read().clone());
 
-        let mut client = self.get_and_create_client(addr).await.ok_or_else(|| {
-            let target = addr.map(|a| a.as_str()).unwrap_or("<nameserver>");
-
+        let mut client = self.get_and_create_client_until(addr, deadline).await?.ok_or_else(|| {
             if target == "<nameserver>" {
                 let configured_list = self.namesrv_addr_list.read().clone();
                 let available_set = self.available_namesrv_addr_set.read().clone();
@@ -1229,37 +1271,41 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                 self.latency_tracker.record_error(addr);
             }
 
-            rocketmq_error::RocketMQError::network_connection_failed(target.to_string(), "Failed to connect")
+            RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
         })?;
 
         if self.shutdown_token.is_cancelled() {
-            return Err(rocketmq_error::RocketMQError::ClientNotStarted);
+            return Err(RocketMQError::ClientNotStarted);
         }
 
         let mut request = request;
         let remote_address = client.remote_address();
+        deadline.ensure_before_send(remote_address.to_string())?;
         let request_for_after = if self.cmd_handler.has_rpc_hooks() {
             request.make_custom_header_to_net();
             self.cmd_handler
                 .do_before_rpc_hooks_with_addr(remote_address, Some(&mut request))?;
+            deadline.ensure_before_send(remote_address.to_string())?;
             Some(request.clone())
         } else {
             None
         };
 
-        let send_result = time::timeout(
-            Duration::from_millis(timeout_millis),
-            client.send_read(request, timeout_millis),
-        )
-        .await;
+        let send_result = client.send_read(request, deadline).await;
 
         let latency = start.elapsed();
 
         match send_result {
-            Ok(Ok(mut response)) => {
+            Ok(mut response) => {
                 if let Some(request) = request_for_after.as_ref() {
                     self.cmd_handler
                         .do_after_rpc_hooks_with_addr(remote_address, request, Some(&mut response))?;
+                    if deadline.is_expired() {
+                        return Err(RocketMQError::network_response_timeout(
+                            remote_address.to_string(),
+                            timeout_millis,
+                        ));
+                    }
                 }
 
                 if let Some(ref addr) = target_addr {
@@ -1278,8 +1324,11 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                 }
                 Ok(response)
             }
-            Ok(Err(err)) => {
-                if matches!(err, rocketmq_error::RocketMQError::Timeout { .. }) {
+            Err(err) => {
+                if matches!(
+                    err,
+                    RocketMQError::Network(NetworkError::WriteTimeout { .. } | NetworkError::ResponseTimeout { .. })
+                ) {
                     client.retire_after_timeout().await;
                     if let Some(ref addr) = target_addr {
                         self.connection_tables.remove(addr);
@@ -1304,37 +1353,31 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                 }
                 Err(err)
             }
-            Err(_) => {
-                client.retire_after_timeout().await;
-                if let Some(ref addr) = target_addr {
-                    self.connection_tables.remove(addr);
-                    if let Some(ref pool) = self.connection_pool {
-                        pool.remove(addr);
-                    }
-                    self.latency_tracker.record_error(addr);
-
-                    if let Some(ref pool) = self.connection_pool {
-                        pool.record_error(addr);
-                    }
-                }
-                Err(rocketmq_error::RocketMQError::Timeout {
-                    operation: "send_request",
-                    timeout_ms: timeout_millis,
-                })
-            }
         }
     }
 
     async fn invoke_request_oneway(&self, addr: &CheetahString, request: RemotingCommand, timeout_millis: u64) {
-        let client = self.get_and_create_client(Some(addr)).await;
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
+        let client = self.get_and_create_client_until(Some(addr), deadline).await;
         match client {
-            None => {
+            Ok(None) => {
                 error!(remote_addr = %addr, "invoke oneway client unavailable");
             }
-            Some(mut client) => {
+            Err(error) => {
+                warn!(
+                    remote_addr = %addr,
+                    error = ?error,
+                    "invoke oneway connection failed"
+                );
+            }
+            Ok(Some(mut client)) => {
                 let mut request = request;
                 if self.cmd_handler.has_rpc_hooks() {
                     let remote_address = client.remote_address();
+                    if let Err(error) = deadline.ensure_before_send(remote_address.to_string()) {
+                        warn!(remote_addr = %addr, error = ?error, "invoke oneway deadline expired");
+                        return;
+                    }
                     request.make_custom_header_to_net();
                     if let Err(error) = self
                         .cmd_handler
@@ -1347,6 +1390,10 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                         );
                         return;
                     }
+                    if let Err(error) = deadline.ensure_before_send(remote_address.to_string()) {
+                        warn!(remote_addr = %addr, error = ?error, "invoke oneway hook exceeded deadline");
+                        return;
+                    }
                 }
                 let addr_clone = addr.clone();
                 let Some(task_group) = self.get_or_create_worker_task_group() else {
@@ -1354,26 +1401,15 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                     return;
                 };
                 if let Err(error) = task_group.spawn_service("remoting.client.oneway-send", async move {
-                    match time::timeout(Duration::from_millis(timeout_millis), async move {
-                        let mut request = request;
-                        request.mark_oneway_rpc_ref();
-                        client.send(request).await
-                    })
-                    .await
-                    {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
+                    let mut request = request;
+                    request.mark_oneway_rpc_ref();
+                    match client.send_until(request, deadline).await {
+                        Ok(()) => {}
+                        Err(error) => {
                             warn!(
                                 remote_addr = %addr_clone,
-                                error = ?e,
+                                error = ?error,
                                 "invoke oneway send failed"
-                            );
-                        }
-                        Err(_) => {
-                            warn!(
-                                remote_addr = %addr_clone,
-                                timeout_ms = timeout_millis,
-                                "invoke oneway send timed out"
                             );
                         }
                     }

--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -18,6 +18,8 @@ use std::fmt::Display;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -41,6 +43,7 @@ use crate::base::response_future::ResponseFuture;
 use crate::connection::Connection;
 use crate::connection::ConnectionStateHandle;
 use crate::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::deadline::RequestDeadline;
 
 pub type ChannelId = CheetahString;
 
@@ -330,7 +333,7 @@ enum ResponseReservation {
     Pending(PendingRequestToken),
     Legacy {
         opaque: i32,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         sender: tokio::sync::oneshot::Sender<rocketmq_error::RocketMQResult<RemotingCommand>>,
     },
     LegacyRegistered {
@@ -338,7 +341,40 @@ enum ResponseReservation {
     },
 }
 
-type ChannelMessage = (RemotingCommand, Option<ResponseReservation>);
+const OUTBOUND_QUEUED: u8 = 0;
+const OUTBOUND_WRITING: u8 = 1;
+const OUTBOUND_SENT: u8 = 2;
+const OUTBOUND_FAILED_BEFORE_SEND: u8 = 3;
+
+struct OutboundProgress(AtomicU8);
+
+impl OutboundProgress {
+    fn queued() -> Self {
+        Self(AtomicU8::new(OUTBOUND_QUEUED))
+    }
+
+    fn set(&self, stage: u8) {
+        self.0.store(stage, Ordering::Release);
+    }
+
+    fn deadline_error(&self, deadline: RequestDeadline) -> RocketMQError {
+        match self.0.load(Ordering::Acquire) {
+            OUTBOUND_QUEUED | OUTBOUND_FAILED_BEFORE_SEND => {
+                RocketMQError::network_deadline_exceeded_before_send("channel")
+            }
+            OUTBOUND_WRITING => RocketMQError::network_write_timeout("channel", deadline.budget_millis()),
+            OUTBOUND_SENT => RocketMQError::network_response_timeout("channel", deadline.budget_millis()),
+            _ => RocketMQError::network_response_timeout("channel", deadline.budget_millis()),
+        }
+    }
+}
+
+type ChannelMessage = (
+    RemotingCommand,
+    Option<ResponseReservation>,
+    Option<RequestDeadline>,
+    Option<Arc<OutboundProgress>>,
+);
 pub type LegacyResponseTable = Arc<parking_lot::Mutex<HashMap<i32, ResponseFuture>>>;
 
 /// Shared state for a `Channel` - handles I/O, async message queueing, and response tracking.
@@ -443,11 +479,11 @@ async fn handle_send(
             }
         };
 
-        let (send, mut reservation) = msg;
+        let (send, mut reservation, deadline, progress) = msg;
 
         if let Some(ResponseReservation::Legacy {
             opaque,
-            timeout_millis,
+            deadline,
             sender,
         }) = reservation.take()
         {
@@ -458,38 +494,93 @@ async fn handle_send(
                 )));
                 continue;
             };
-            table
-                .lock()
-                .insert(opaque, ResponseFuture::new(opaque, timeout_millis, true, sender));
+            table.lock().insert(
+                opaque,
+                ResponseFuture::new(
+                    opaque,
+                    deadline.remaining().as_millis().min(u128::from(u64::MAX)) as u64,
+                    true,
+                    sender,
+                ),
+            );
             reservation = Some(ResponseReservation::LegacyRegistered { opaque });
         }
 
         // Send command via connection
-        let send_result = connection.lock().await.send_command(send).await;
-        if let Err(error) = send_result {
-            let connection_broken = matches!(error, rocketmq_error::RocketMQError::IO(_));
-            error!(error = %error, "send request failed");
-            match reservation {
-                Some(ResponseReservation::Pending(reservation)) => {
-                    response_table.complete_token(reservation, Err(error));
+        let send_result = match deadline {
+            Some(deadline) => {
+                let mut connection = match deadline.timeout(connection.lock()).await {
+                    Ok(connection) => connection,
+                    Err(_) => {
+                        complete_send_error(
+                            reservation,
+                            &response_table,
+                            legacy_response_table.as_ref(),
+                            RocketMQError::network_deadline_exceeded_before_send("channel"),
+                        );
+                        continue;
+                    }
+                };
+                if let Err(error) = deadline.ensure_before_send("channel") {
+                    if let Some(progress) = progress.as_ref() {
+                        progress.set(OUTBOUND_FAILED_BEFORE_SEND);
+                    }
+                    complete_send_error(reservation, &response_table, legacy_response_table.as_ref(), error);
+                    continue;
                 }
-                Some(ResponseReservation::LegacyRegistered { opaque }) => {
-                    let future = legacy_response_table
-                        .as_ref()
-                        .and_then(|table| table.lock().remove(&opaque));
-                    if let Some(future) = future {
-                        let _ = future.tx.send(Err(error));
+                if let Some(progress) = progress.as_ref() {
+                    progress.set(OUTBOUND_WRITING);
+                }
+                connection.send_command_with_deadline(send, deadline, "channel").await
+            }
+            None => connection.lock().await.send_command(send).await,
+        };
+        match send_result {
+            Ok(()) => {
+                if let Some(progress) = progress.as_ref() {
+                    progress.set(OUTBOUND_SENT);
+                }
+            }
+            Err(error) => {
+                if matches!(
+                    error,
+                    RocketMQError::Network(rocketmq_error::NetworkError::DeadlineExceededBeforeSend { .. })
+                ) {
+                    if let Some(progress) = progress.as_ref() {
+                        progress.set(OUTBOUND_FAILED_BEFORE_SEND);
                     }
                 }
-                Some(ResponseReservation::Legacy { sender, .. }) => {
-                    let _ = sender.send(Err(error));
+                let connection_broken = matches!(error, rocketmq_error::RocketMQError::IO(_));
+                error!(error = %error, "send request failed");
+                complete_send_error(reservation, &response_table, legacy_response_table.as_ref(), error);
+                if connection_broken {
+                    return;
                 }
-                None => {}
-            }
-            if connection_broken {
-                return;
             }
         }
+    }
+}
+
+fn complete_send_error(
+    reservation: Option<ResponseReservation>,
+    response_table: &PendingRequestTable,
+    legacy_response_table: Option<&LegacyResponseTable>,
+    error: RocketMQError,
+) {
+    match reservation {
+        Some(ResponseReservation::Pending(reservation)) => {
+            response_table.complete_token(reservation, Err(error));
+        }
+        Some(ResponseReservation::LegacyRegistered { opaque }) => {
+            let future = legacy_response_table.and_then(|table| table.lock().remove(&opaque));
+            if let Some(future) = future {
+                let _ = future.tx.send(Err(error));
+            }
+        }
+        Some(ResponseReservation::Legacy { sender, .. }) => {
+            let _ = sender.send(Err(error));
+        }
+        None => {}
     }
 }
 
@@ -784,45 +875,47 @@ impl ChannelInner {
         request: RemotingCommand,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        let (response_tx, response_rx) =
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
+        let progress = Arc::new(OutboundProgress::queued());
+        let (response_tx, mut response_rx) =
             tokio::sync::oneshot::channel::<rocketmq_error::RocketMQResult<RemotingCommand>>();
         let opaque = request.opaque();
-        let (guard, deadline, reservation) = if let Some(owner) = self.pending_request_owner.as_ref() {
+        let (guard, reservation) = if let Some(owner) = self.pending_request_owner.as_ref() {
             let retained_bytes = request.body().map_or(0, bytes::Bytes::len);
             let guard = self.response_table.register_for_owner_with_bytes(
                 owner,
                 opaque,
-                timeout_millis,
+                deadline,
                 retained_bytes,
                 response_tx,
             )?;
-            let deadline = guard.deadline();
             let reservation = ResponseReservation::Pending(guard.token());
-            (Some(guard), deadline, reservation)
+            (Some(guard), reservation)
         } else {
             (
                 None,
-                std::time::Instant::now() + Duration::from_millis(timeout_millis),
                 ResponseReservation::Legacy {
                     opaque,
-                    timeout_millis,
+                    deadline,
                     sender: response_tx,
                 },
             )
         };
 
         // Enqueue request with response tracking
-        // flume sender: use send_async() for async context
         let outbound_queue_tx = self.outbound_queue_sender()?;
-        if let Err(err) = outbound_queue_tx.send_async((request, Some(reservation))).await {
-            return Err(RocketMQError::network_connection_failed(
-                "channel",
-                format!("send failed: {}", err),
-            ));
-        }
+        deadline.ensure_before_send("channel")?;
+        outbound_queue_tx
+            .try_send((request, Some(reservation), Some(deadline), Some(progress.clone())))
+            .map_err(|error| match error {
+                flume::TrySendError::Full(_) => RocketMQError::network_queue_full("channel"),
+                flume::TrySendError::Disconnected(_) => {
+                    RocketMQError::network_connection_failed("channel", "outbound queue is closed")
+                }
+            })?;
 
         // Wait for response with timeout
-        match tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), response_rx).await {
+        match deadline.timeout(&mut response_rx).await {
             Ok(result) => match result {
                 Ok(response) => response,
                 Err(e) => Err(RocketMQError::network_connection_failed(
@@ -831,25 +924,20 @@ impl ChannelInner {
                 )),
             },
             Err(_) => {
+                let stage_error = progress.deadline_error(deadline);
                 // Timeout expired
                 if let Some(guard) = guard {
-                    Err(guard.expire("channel_recv", timeout_millis))
+                    guard.expire("channel");
                 } else {
                     let future = self
                         .legacy_response_table
                         .as_ref()
                         .and_then(|table| table.lock().remove(&opaque));
                     if let Some(future) = future {
-                        let _ = future.tx.send(Err(RocketMQError::Timeout {
-                            operation: "channel_recv",
-                            timeout_ms: timeout_millis,
-                        }));
+                        let _ = future.tx.send(Err(progress.deadline_error(deadline)));
                     }
-                    Err(RocketMQError::Timeout {
-                        operation: "channel_recv",
-                        timeout_ms: timeout_millis,
-                    })
                 }
+                Err(stage_error)
             }
         }
     }
@@ -875,20 +963,21 @@ impl ChannelInner {
     pub async fn send_oneway(
         &self,
         request: RemotingCommand,
-        _timeout_millis: u64,
+        timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
         let request = request.mark_oneway_rpc();
 
-        // flume sender: use send_async() for async context
         let outbound_queue_tx = self.outbound_queue_sender()?;
-        if let Err(err) = outbound_queue_tx.send_async((request, None)).await {
-            error!("send oneway request failed: {}", err);
-            return Err(RocketMQError::network_connection_failed(
-                "channel",
-                format!("send oneway failed: {}", err),
-            ));
-        }
-        Ok(())
+        deadline.ensure_before_send("channel")?;
+        outbound_queue_tx
+            .try_send((request, None, Some(deadline), None))
+            .map_err(|error| match error {
+                flume::TrySendError::Full(_) => RocketMQError::network_queue_full("channel"),
+                flume::TrySendError::Disconnected(_) => {
+                    RocketMQError::network_connection_failed("channel", "outbound queue is closed")
+                }
+            })
     }
 
     /// Sends a request without waiting for response (async enqueue only).
@@ -910,17 +999,19 @@ impl ChannelInner {
         request: RemotingCommand,
         timeout_millis: Option<u64>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        // flume sender: use send_async() for async context
-        let _ = timeout_millis;
-        let outbound_queue_tx = self.outbound_queue_sender()?;
-        if let Err(err) = outbound_queue_tx.send_async((request, None)).await {
-            error!("send request failed: {}", err);
-            return Err(RocketMQError::network_connection_failed(
-                "channel",
-                format!("send failed: {}", err),
-            ));
+        let deadline = timeout_millis.map(RequestDeadline::from_timeout_millis);
+        if let Some(deadline) = deadline {
+            deadline.ensure_before_send("channel")?;
         }
-        Ok(())
+        let outbound_queue_tx = self.outbound_queue_sender()?;
+        outbound_queue_tx
+            .try_send((request, None, deadline, None))
+            .map_err(|error| match error {
+                flume::TrySendError::Full(_) => RocketMQError::network_queue_full("channel"),
+                flume::TrySendError::Disconnected(_) => {
+                    RocketMQError::network_connection_failed("channel", "outbound queue is closed")
+                }
+            })
     }
 
     // === Health Check ===
@@ -952,6 +1043,8 @@ impl ChannelInner {
 mod tests {
     use super::*;
     use crate::base::pending_request_table::PendingRequestTable;
+    use rocketmq_error::NetworkError;
+    use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
     use tokio::net::TcpStream;
 
@@ -1048,7 +1141,12 @@ mod tests {
         let channel_inner =
             ChannelInner::try_new_with_pending_requests(Connection::new(socket), pending_requests.clone()).unwrap();
         let guard = pending_requests
-            .register_for_owner(channel_inner.pending_request_owner().unwrap(), 91, 30_000, sender)
+            .register_for_owner(
+                channel_inner.pending_request_owner().unwrap(),
+                91,
+                RequestDeadline::from_timeout_millis(30_000),
+                sender,
+            )
             .unwrap();
         let report = channel_inner.close_with_report(Duration::from_secs(1)).await;
 
@@ -1084,10 +1182,20 @@ mod tests {
         let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
         let (second_sender, mut second_receiver) = tokio::sync::oneshot::channel();
         let first_guard = pending_requests
-            .register_for_owner(first.pending_request_owner().unwrap(), 51, 30_000, first_sender)
+            .register_for_owner(
+                first.pending_request_owner().unwrap(),
+                51,
+                RequestDeadline::from_timeout_millis(30_000),
+                first_sender,
+            )
             .unwrap();
         let second_guard = pending_requests
-            .register_for_owner(second.pending_request_owner().unwrap(), 51, 30_000, second_sender)
+            .register_for_owner(
+                second.pending_request_owner().unwrap(),
+                51,
+                RequestDeadline::from_timeout_millis(30_000),
+                second_sender,
+            )
             .unwrap();
 
         first.close_with_report(Duration::from_secs(1)).await;
@@ -1096,5 +1204,88 @@ mod tests {
         assert!(second_receiver.try_recv().is_err());
         assert_eq!(pending_requests.len(), 1);
         drop((first_guard, second_guard, second));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn writer_lock_wait_uses_the_request_deadline() {
+        let (transport, mut peer) = tokio::io::duplex(4096);
+        let pending_requests = PendingRequestTable::new();
+        let channel = Arc::new(
+            ChannelInner::try_new_with_pending_requests(
+                Connection::new_with_stream(transport),
+                pending_requests.clone(),
+            )
+            .expect("create channel"),
+        );
+        let locked_connection = channel.connection.clone();
+        let writer_lock = locked_connection.lock().await;
+        let sending = channel.clone();
+        let send = tokio::spawn(async move {
+            sending
+                .send_wait_response(RemotingCommand::create_remoting_command(5), 50)
+                .await
+        });
+        while !channel.outbound_queue_sender().expect("queue").is_empty() || pending_requests.is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        tokio::time::advance(Duration::from_millis(50)).await;
+        let error = match send.await.expect("send task") {
+            Ok(_) => panic!("writer lock wait must time out"),
+            Err(error) => error,
+        };
+
+        assert!(
+            matches!(
+                error,
+                RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { .. })
+            ),
+            "unexpected error: {error:?}"
+        );
+        let mut byte = [0_u8; 1];
+        tokio::select! {
+            biased;
+            read = peer.read(&mut byte) => panic!("unexpected socket read after writer lock timeout: {read:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        drop(writer_lock);
+        let report = channel.close_with_report(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_oneway_request_is_never_sent_after_writer_lock_releases() {
+        let (transport, mut peer) = tokio::io::duplex(4096);
+        let channel = Arc::new(
+            ChannelInner::try_new_with_pending_requests(
+                Connection::new_with_stream(transport),
+                PendingRequestTable::new(),
+            )
+            .expect("create channel"),
+        );
+        let locked_connection = channel.connection.clone();
+        let writer_lock = locked_connection.lock().await;
+
+        channel
+            .send_oneway(RemotingCommand::create_remoting_command(6), 50)
+            .await
+            .expect("enqueue oneway request");
+        while !channel.outbound_queue_sender().expect("queue").is_empty() {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(Duration::from_millis(50)).await;
+        drop(writer_lock);
+        tokio::task::yield_now().await;
+
+        let mut byte = [0_u8; 1];
+        tokio::select! {
+            biased;
+            read = peer.read(&mut byte) => panic!("unexpected expired oneway socket read: {read:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        let report = channel.close_with_report(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 }

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -80,6 +80,7 @@ use crate::rpc::rpc_client_hook::RpcClientHookFn;
 use crate::rpc::rpc_client_utils::RpcClientUtils;
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
+use rocketmq_transport::deadline::RequestDeadline;
 
 /// Configuration for response handling
 struct ResponseConfig {
@@ -205,13 +206,14 @@ impl RpcClientImpl {
         &self,
         addr: &CheetahString,
         request: RpcRequest<H>,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         config: ResponseConfig,
     ) -> Result<RpcResponse, RpcClientError>
     where
         H: CommandCustomHeader + TopicRequestHeaderTrait,
         R: CommandCustomHeader + FromMap<Target = R, Error = rocketmq_error::RocketMQError> + Send + Sync + 'static,
     {
+        let timeout_millis = deadline.budget_millis();
         trace!(
             "Sending RPC request: addr={}, code={}, timeout={}ms",
             addr,
@@ -220,10 +222,18 @@ impl RpcClientImpl {
         );
 
         let (request_code, request_command) = self.create_request_command(addr, request, timeout_millis)?;
+        deadline
+            .ensure_before_send(addr.to_string())
+            .map_err(|err| RpcClientError::RequestFailed {
+                addr: addr.to_string(),
+                request_code,
+                timeout_ms: timeout_millis,
+                source: Box::new(err),
+            })?;
 
         let response = self
             .remoting_client
-            .invoke_request(Some(addr), request_command, timeout_millis)
+            .invoke_request_with_deadline(Some(addr), request_command, deadline)
             .await
             .map_err(|err| {
                 error!(
@@ -267,7 +277,7 @@ impl RpcClientImpl {
         &self,
         addr: &CheetahString,
         request: RpcRequest<H>,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
     ) -> Result<RpcResponse, RpcClientError> {
         const PULL_SUCCESS_CODES: &[ResponseCode] = &[
             ResponseCode::Success,
@@ -279,7 +289,7 @@ impl RpcClientImpl {
         self.handle_request::<H, PullMessageResponseHeader>(
             addr,
             request,
-            timeout_millis,
+            deadline,
             ResponseConfig::new(PULL_SUCCESS_CODES),
         )
         .await
@@ -290,13 +300,22 @@ impl RpcClientImpl {
         &self,
         addr: &CheetahString,
         request: RpcRequest<H>,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
     ) -> Result<RpcResponse, RpcClientError> {
+        let timeout_millis = deadline.budget_millis();
         let (request_code, request_command) = self.create_request_command(addr, request, timeout_millis)?;
+        deadline
+            .ensure_before_send(addr.to_string())
+            .map_err(|err| RpcClientError::RequestFailed {
+                addr: addr.to_string(),
+                request_code,
+                timeout_ms: timeout_millis,
+                source: Box::new(err),
+            })?;
 
         let response = self
             .remoting_client
-            .invoke_request(Some(addr), request_command, timeout_millis)
+            .invoke_request_with_deadline(Some(addr), request_command, deadline)
             .await
             .map_err(|err| RpcClientError::RequestFailed {
                 addr: addr.to_string(),
@@ -342,28 +361,23 @@ impl RpcClientImpl {
         }
         Ok(None)
     }
-}
 
-impl RpcClient for RpcClientImpl {
-    /// Invokes RPC request synchronously
-    ///
-    /// # Flow
-    ///
-    /// 1. Execute client hooks (may short-circuit)
-    /// 2. Resolve broker address
-    /// 3. Dispatch to specific handler based on request code
-    /// 4. Return response or error
-    async fn invoke<H: CommandCustomHeader + TopicRequestHeaderTrait>(
+    async fn invoke_until<H: CommandCustomHeader + TopicRequestHeaderTrait>(
         &self,
         request: RpcRequest<H>,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<RpcResponse> {
-        // Execute hooks
+        let timeout_millis = deadline.budget_millis();
         if let Some(response) = self.execute_hooks(&request)? {
+            if deadline.is_expired() {
+                return Err(rocketmq_error::RocketMQError::network_response_timeout(
+                    "<rpc-hook>",
+                    timeout_millis,
+                ));
+            }
             return Ok(response);
         }
 
-        // Resolve broker address
         let broker_name = request
             .header
             .broker_name()
@@ -371,14 +385,15 @@ impl RpcClient for RpcClientImpl {
                 broker_name: "<missing brokerName>".to_string(),
             })?;
         let addr = self.get_broker_addr_by_name(broker_name.as_ref())?;
+        deadline.ensure_before_send(addr.to_string())?;
 
         let result = match RequestCode::from(request.code) {
-            RequestCode::PullMessage => self.handle_pull_message(&addr, request, timeout_millis).await?,
+            RequestCode::PullMessage => self.handle_pull_message(&addr, request, deadline).await?,
             RequestCode::GetMinOffset => {
                 self.handle_request::<H, GetMinOffsetResponseHeader>(
                     &addr,
                     request,
-                    timeout_millis,
+                    deadline,
                     ResponseConfig::new(&[ResponseCode::Success]),
                 )
                 .await?
@@ -387,7 +402,7 @@ impl RpcClient for RpcClientImpl {
                 self.handle_request::<H, GetMaxOffsetResponseHeader>(
                     &addr,
                     request,
-                    timeout_millis,
+                    deadline,
                     ResponseConfig::new(&[ResponseCode::Success]),
                 )
                 .await?
@@ -396,7 +411,7 @@ impl RpcClient for RpcClientImpl {
                 self.handle_request::<H, SearchOffsetResponseHeader>(
                     &addr,
                     request,
-                    timeout_millis,
+                    deadline,
                     ResponseConfig::new(&[ResponseCode::Success]),
                 )
                 .await?
@@ -405,29 +420,27 @@ impl RpcClient for RpcClientImpl {
                 self.handle_request::<H, GetEarliestMsgStoretimeResponseHeader>(
                     &addr,
                     request,
-                    timeout_millis,
+                    deadline,
                     ResponseConfig::new(&[ResponseCode::Success]),
                 )
                 .await?
             }
-            RequestCode::QueryConsumerOffset => {
-                self.handle_query_consumer_offset(&addr, request, timeout_millis)
-                    .await?
-            }
+            RequestCode::QueryConsumerOffset => self.handle_query_consumer_offset(&addr, request, deadline).await?,
             RequestCode::UpdateConsumerOffset => {
                 self.handle_request::<H, UpdateConsumerOffsetResponseHeader>(
                     &addr,
                     request,
-                    timeout_millis,
+                    deadline,
                     ResponseConfig::new(&[ResponseCode::Success]),
                 )
                 .await?
             }
             RequestCode::GetTopicStatsInfo | RequestCode::GetTopicConfig => {
                 let (request_code, request_command) = self.create_request_command(&addr, request, timeout_millis)?;
+                deadline.ensure_before_send(addr.to_string())?;
                 let response = self
                     .remoting_client
-                    .invoke_request(Some(&addr), request_command, timeout_millis)
+                    .invoke_request_with_deadline(Some(&addr), request_command, deadline)
                     .await
                     .map_err(|err| RpcClientError::RequestFailed {
                         addr: addr.to_string(),
@@ -452,6 +465,25 @@ impl RpcClient for RpcClientImpl {
 
         Ok(result)
     }
+}
+
+impl RpcClient for RpcClientImpl {
+    /// Invokes RPC request synchronously
+    ///
+    /// # Flow
+    ///
+    /// 1. Execute client hooks (may short-circuit)
+    /// 2. Resolve broker address
+    /// 3. Dispatch to specific handler based on request code
+    /// 4. Return response or error
+    async fn invoke<H: CommandCustomHeader + TopicRequestHeaderTrait>(
+        &self,
+        request: RpcRequest<H>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<RpcResponse> {
+        self.invoke_until(request, RequestDeadline::from_timeout_millis(timeout_millis))
+            .await
+    }
 
     /// Invokes RPC request with message queue context
     ///
@@ -462,10 +494,11 @@ impl RpcClient for RpcClientImpl {
         mut request: RpcRequest<H>,
         timeout_millis: u64,
     ) -> RocketMQResult<RpcResponse> {
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
         if let Some(broker_name) = self.client_metadata.get_broker_name_from_message_queue(&mq) {
             request.header.set_broker_name(broker_name);
         }
-        self.invoke(request, timeout_millis).await
+        self.invoke_until(request, deadline).await
     }
 }
 
@@ -498,6 +531,7 @@ impl RpcClientImpl {
         H: CommandCustomHeader + TopicRequestHeaderTrait + Send + 'static,
         F: FnOnce(RocketMQResult<RpcResponse>) + Send + 'static,
     {
+        let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
         let client_metadata = self.client_metadata.clone();
         let remoting_client = self.remoting_client.clone();
         let remoting_client_for_task = remoting_client.clone();
@@ -512,7 +546,7 @@ impl RpcClientImpl {
                     client_hook_list: hooks,
                 };
 
-                let result = temp_client.invoke(request, timeout_millis).await;
+                let result = temp_client.invoke_until(request, deadline).await;
                 callback(result);
             })
             .expect("RPC callback task should be spawned on the remoting worker task group")

--- a/rocketmq-transport/Cargo.toml
+++ b/rocketmq-transport/Cargo.toml
@@ -58,7 +58,7 @@ tokio-rustls = { version = "0.26", optional = true }
 anyhow.workspace = true
 serde_json.workspace = true
 tempfile = "3.27.0"
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.186"

--- a/rocketmq-transport/examples/architecture_network_performance_collector.rs
+++ b/rocketmq-transport/examples/architecture_network_performance_collector.rs
@@ -67,6 +67,7 @@ use rocketmq_transport::config::TlsClientConfig;
 use rocketmq_transport::config::TlsConfig;
 use rocketmq_transport::config::TlsMode;
 use rocketmq_transport::connection::transport_io_snapshot;
+use rocketmq_transport::deadline::RequestDeadline;
 use rocketmq_transport::server::RequestProcessor;
 use rocketmq_transport::server::TransportServer;
 use rocketmq_transport::server::TransportServerConfig;
@@ -674,7 +675,7 @@ async fn collect_connection_soak_inner(spec: RunSpec, harness: &TransportHarness
                 harness.server.local_addr(),
                 data_request(),
                 &tls,
-                ShutdownDeadline::after(spec.request_timeout),
+                RequestDeadline::after(spec.request_timeout),
             )
             .await
             .with_context(|| format!("connection soak request {operation}"))?;
@@ -769,7 +770,7 @@ async fn collect_overload_inner(spec: RunSpec, harness: &TransportHarness) -> Re
                             server_addr,
                             data_request(),
                             &tls,
-                            ShutdownDeadline::after(request_timeout),
+                            RequestDeadline::after(request_timeout),
                         )
                         .await;
                     (request_started.elapsed(), result)
@@ -785,7 +786,7 @@ async fn collect_overload_inner(spec: RunSpec, harness: &TransportHarness) -> Re
                     server_addr,
                     RemotingCommand::create_remoting_command(RequestCode::HeartBeat.to_i32()),
                     &control_tls,
-                    ShutdownDeadline::after(request_timeout),
+                    RequestDeadline::after(request_timeout),
                 )
                 .await
         };

--- a/rocketmq-transport/src/base/pending_request_table.rs
+++ b/rocketmq-transport/src/base/pending_request_table.rs
@@ -29,6 +29,8 @@ use tokio::sync::Semaphore;
 
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
+use crate::deadline::RequestDeadline;
+
 static NEXT_TABLE_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -83,7 +85,7 @@ struct PendingRequest {
     reservation: u64,
     owner: PendingRequestOwner,
     created_at: Instant,
-    deadline: Instant,
+    deadline: RequestDeadline,
     timeout_millis: u64,
     _permit: OwnedSemaphorePermit,
     _byte_permit: PendingBytePermit,
@@ -179,7 +181,7 @@ pub struct PendingRequestTable {
 pub struct PendingRequestGuard {
     table: PendingRequestTable,
     token: Option<PendingRequestToken>,
-    deadline: Instant,
+    deadline: RequestDeadline,
 }
 
 impl Default for PendingRequestTable {
@@ -241,46 +243,41 @@ impl PendingRequestTable {
     pub fn register(
         &self,
         opaque: i32,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         sender: tokio::sync::oneshot::Sender<RocketMQResult<RemotingCommand>>,
     ) -> RocketMQResult<PendingRequestGuard> {
-        self.register_with_bytes(opaque, timeout_millis, 0, sender)
+        self.register_with_bytes(opaque, deadline, 0, sender)
     }
 
     pub fn register_with_bytes(
         &self,
         opaque: i32,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         retained_bytes: usize,
         sender: tokio::sync::oneshot::Sender<RocketMQResult<RemotingCommand>>,
     ) -> RocketMQResult<PendingRequestGuard> {
-        self.register_for_owner_with_bytes(
-            &self.inner.default_owner,
-            opaque,
-            timeout_millis,
-            retained_bytes,
-            sender,
-        )
+        self.register_for_owner_with_bytes(&self.inner.default_owner, opaque, deadline, retained_bytes, sender)
     }
 
     pub fn register_for_owner(
         &self,
         owner: &PendingRequestOwner,
         opaque: i32,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         sender: tokio::sync::oneshot::Sender<RocketMQResult<RemotingCommand>>,
     ) -> RocketMQResult<PendingRequestGuard> {
-        self.register_for_owner_with_bytes(owner, opaque, timeout_millis, 0, sender)
+        self.register_for_owner_with_bytes(owner, opaque, deadline, 0, sender)
     }
 
     pub fn register_for_owner_with_bytes(
         &self,
         owner: &PendingRequestOwner,
         opaque: i32,
-        timeout_millis: u64,
+        deadline: RequestDeadline,
         retained_bytes: usize,
         sender: tokio::sync::oneshot::Sender<RocketMQResult<RemotingCommand>>,
     ) -> RocketMQResult<PendingRequestGuard> {
+        deadline.ensure_before_send("pending_request")?;
         self.validate_owner(owner)?;
         let owner_state = owner.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if !owner_state.accepting {
@@ -291,11 +288,11 @@ impl PendingRequestTable {
         }
         let permit = self.inner.permits.clone().try_acquire_owned().map_err(|_| {
             self.inner.rejected_count.fetch_add(1, Ordering::Relaxed);
-            RocketMQError::network_connection_failed("pending_request", "pending request count capacity exhausted")
+            RocketMQError::network_queue_full("pending_request")
         })?;
         let byte_permit = self.inner.byte_budget.try_acquire(retained_bytes).ok_or_else(|| {
             self.inner.rejected_bytes.fetch_add(1, Ordering::Relaxed);
-            RocketMQError::network_connection_failed("pending_request", "pending request byte capacity exhausted")
+            RocketMQError::network_queue_full("pending_request")
         })?;
         let reservation = self.inner.next_reservation.fetch_add(1, Ordering::Relaxed);
         let key = PendingRequestKey {
@@ -304,7 +301,7 @@ impl PendingRequestTable {
         };
         let token = PendingRequestToken { key, reservation };
         let created_at = Instant::now();
-        let deadline = created_at + Duration::from_millis(timeout_millis);
+        let timeout_millis = deadline.budget_millis();
         let pending = PendingRequest {
             reservation,
             owner: owner.clone(),
@@ -432,7 +429,7 @@ impl PendingRequestTable {
     }
 
     /// Completes every request whose registered absolute response deadline has elapsed.
-    pub fn expire_due(&self, now: Instant) -> usize {
+    pub fn expire_due(&self, now: tokio::time::Instant) -> usize {
         let expired: Vec<(PendingRequestToken, u64, PendingRequestOwner)> = self
             .inner
             .entries
@@ -454,10 +451,10 @@ impl PendingRequestTable {
             owner.retire();
             if self.complete_token(
                 token,
-                Err(RocketMQError::Timeout {
-                    operation: "pending_request_response",
-                    timeout_ms: timeout_millis,
-                }),
+                Err(RocketMQError::network_response_timeout(
+                    "pending_request",
+                    timeout_millis,
+                )),
             ) {
                 completed += 1;
             }
@@ -519,7 +516,7 @@ impl PendingRequestGuard {
     }
 
     #[doc(hidden)]
-    pub fn deadline(&self) -> Instant {
+    pub fn deadline(&self) -> RequestDeadline {
         self.deadline
     }
 
@@ -532,21 +529,19 @@ impl PendingRequestGuard {
     }
 
     #[doc(hidden)]
-    pub fn expire(mut self, operation: &'static str, timeout_millis: u64) -> RocketMQError {
+    pub fn expire(mut self, addr: impl Into<String>) -> RocketMQError {
         let token = self
             .token
             .take()
             .expect("active pending request guard must have a token");
-        let error = RocketMQError::Timeout {
-            operation,
-            timeout_ms: timeout_millis,
-        };
+        let addr = addr.into();
+        let timeout_millis = self.deadline.budget_millis();
+        let error = RocketMQError::network_response_timeout(addr.clone(), timeout_millis);
         if let Some(pending) = self.table.take_token(token) {
             pending.owner.retire();
-            pending.completion.complete(Err(RocketMQError::Timeout {
-                operation,
-                timeout_ms: timeout_millis,
-            }));
+            pending
+                .completion
+                .complete(Err(RocketMQError::network_response_timeout(addr, timeout_millis)));
         }
         error
     }
@@ -571,8 +566,8 @@ impl PendingRequest {
         now.saturating_duration_since(self.created_at)
     }
 
-    fn is_expired(&self, now: Instant) -> bool {
-        now >= self.deadline
+    fn is_expired(&self, now: tokio::time::Instant) -> bool {
+        now >= self.deadline.instant()
     }
 }
 
@@ -594,7 +589,12 @@ mod owner_epoch_tests {
         let registration = std::thread::spawn(move || {
             let (sender, _receiver) = tokio::sync::oneshot::channel();
             started_tx.send(()).unwrap();
-            let result = registering_table.register_for_owner(&registering_owner, 7, 30_000, sender);
+            let result = registering_table.register_for_owner(
+                &registering_owner,
+                7,
+                RequestDeadline::from_timeout_millis(30_000),
+                sender,
+            );
             result_tx.send(result.is_ok()).unwrap();
         });
 

--- a/rocketmq-transport/src/client.rs
+++ b/rocketmq-transport/src/client.rs
@@ -21,7 +21,6 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::ServiceContext;
-use rocketmq_runtime::ShutdownDeadline;
 
 use crate::admission::AdmissionClass;
 use crate::admission::AdmissionController;
@@ -33,6 +32,7 @@ use crate::base::pending_request_table::PendingRequestUsage;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::config::TlsConfig;
 use crate::connection::Connection;
+use crate::deadline::RequestDeadline;
 use crate::security::TransportSecurity;
 #[cfg(feature = "tls")]
 use crate::tls::connect_tls_stream;
@@ -72,12 +72,12 @@ pub async fn connect_with_config(
     address: &str,
     tls_config: &TlsConfig,
     frame_limits: FrameLimits,
-    deadline: ShutdownDeadline,
+    deadline: RequestDeadline,
 ) -> RocketMQResult<ConnectedTransport> {
-    let timeout_at = tokio::time::Instant::from_std(deadline.instant());
-    let stream = tokio::time::timeout_at(timeout_at, tokio::net::TcpStream::connect(address))
+    let stream = deadline
+        .timeout(tokio::net::TcpStream::connect(address))
         .await
-        .map_err(|_| RocketMQError::network_timeout(address, deadline.remaining()))??;
+        .map_err(|_| RocketMQError::network_connection_timeout(address, deadline.budget_millis()))??;
     let local_addr = stream.local_addr()?;
     let remote_addr = stream.peer_addr()?;
     let negotiated_tls = tls_config.enable;
@@ -85,9 +85,10 @@ pub async fn connect_with_config(
         #[cfg(feature = "tls")]
         {
             let server_name = server_name_from_address(address);
-            let tls_stream = tokio::time::timeout_at(timeout_at, connect_tls_stream(stream, &server_name, tls_config))
+            let tls_stream = deadline
+                .timeout(connect_tls_stream(stream, &server_name, tls_config))
                 .await
-                .map_err(|_| RocketMQError::network_timeout(address, deadline.remaining()))??;
+                .map_err(|_| RocketMQError::network_connection_timeout(address, deadline.budget_millis()))??;
             Connection::new_with_stream_and_limits(tls_stream, frame_limits)
         }
         #[cfg(not(feature = "tls"))]
@@ -161,7 +162,7 @@ impl TransportClient {
         &self,
         address: SocketAddr,
         request: RemotingCommand,
-        deadline: ShutdownDeadline,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<RemotingCommand> {
         let tls_config = TlsConfig::default();
         self.invoke_with_config(address, request, &tls_config, deadline).await
@@ -177,16 +178,17 @@ impl TransportClient {
         address: SocketAddr,
         mut request: RemotingCommand,
         tls_config: &TlsConfig,
-        deadline: ShutdownDeadline,
+        deadline: RequestDeadline,
     ) -> RocketMQResult<RemotingCommand> {
-        let timeout_at = tokio::time::Instant::from_std(deadline.instant());
         let connected = connect_with_config(&address.to_string(), tls_config, FrameLimits::default(), deadline).await?;
         let (mut connection, local_addr, remote_addr, negotiated_tls) = connected.into_parts_with_tls();
         let scope = AdmissionScope::new(remote_addr.ip()).with_session(remote_addr.port() as u64);
         let peer = PeerInfo::new(remote_addr, negotiated_tls);
+        deadline.ensure_before_send(address.to_string())?;
         self.security
             .sign(&mut request, Some(&peer))
             .map_err(|error| RocketMQError::network_connection_failed(address.to_string(), error.to_string()))?;
+        deadline.ensure_before_send(address.to_string())?;
         let retained_bytes = request.body().map_or(0, bytes::Bytes::len);
         let _connection_permit = self
             .admission
@@ -206,26 +208,22 @@ impl TransportClient {
         let opaque = self.next_opaque.fetch_add(1, Ordering::Relaxed);
         request.set_opaque_mut(opaque);
         let (sender, receiver) = tokio::sync::oneshot::channel();
-        let guard = self.pending.register_for_owner_with_bytes(
-            &owner,
-            opaque,
-            deadline.remaining().as_millis().min(u128::from(u64::MAX)) as u64,
-            retained_bytes,
-            sender,
-        )?;
+        let guard = self
+            .pending
+            .register_for_owner_with_bytes(&owner, opaque, deadline, retained_bytes, sender)?;
 
-        if let Err(error) = tokio::time::timeout_at(timeout_at, connection.send_command(request))
+        if let Err(error) = connection
+            .send_command_with_deadline(request, deadline, address.to_string())
             .await
-            .map_err(|_| RocketMQError::network_timeout(address.to_string(), deadline.remaining()))?
         {
             guard.complete(Err(error));
-            let _ = connection.shutdown().await;
+            let _ = deadline.timeout(connection.shutdown()).await;
             return receiver.await.map_err(|_| {
                 RocketMQError::network_connection_failed(address.to_string(), "send completion dropped")
             })?;
         }
 
-        match tokio::time::timeout_at(timeout_at, connection.receive_command()).await {
+        match deadline.timeout(connection.receive_command()).await {
             Ok(Some(Ok(response))) => {
                 let response_opaque = response.opaque();
                 if !self
@@ -247,13 +245,10 @@ impl TransportClient {
                 });
             }
             Err(_) => {
-                guard.expire(
-                    "transport_response",
-                    deadline.remaining().as_millis().min(u128::from(u64::MAX)) as u64,
-                );
+                guard.expire(address.to_string());
             }
         }
-        let _ = connection.shutdown().await;
+        let _ = deadline.timeout(connection.shutdown()).await;
         receiver
             .await
             .map_err(|_| RocketMQError::network_connection_failed(address.to_string(), "response completion dropped"))?

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -15,6 +15,7 @@
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 
 use bytes::BufMut;
@@ -42,14 +43,37 @@ use crate::admission::AdmissionScope;
 use crate::codec::remoting_command_codec::CompositeCodec;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::codec::remoting_command_codec::SessionCodec;
+use crate::deadline::RequestDeadline;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use std::sync::Arc;
+
+const QUEUED_WRITE_WAITING: u8 = 0;
+const QUEUED_WRITE_STARTED: u8 = 1;
+
+pub(crate) struct QueuedWriteProgress(AtomicU8);
+
+impl QueuedWriteProgress {
+    fn waiting() -> Self {
+        Self(AtomicU8::new(QUEUED_WRITE_WAITING))
+    }
+
+    pub(crate) fn start_write(&self) {
+        self.0.store(QUEUED_WRITE_STARTED, Ordering::Release);
+    }
+
+    fn write_started(&self) -> bool {
+        self.0.load(Ordering::Acquire) == QUEUED_WRITE_STARTED
+    }
+}
 
 pub(crate) enum QueuedWrite {
     Data {
         bytes: Bytes,
         completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
         _permit: AdmissionPermit,
+        deadline: Option<RequestDeadline>,
+        target: String,
+        progress: Option<Arc<QueuedWriteProgress>>,
     },
     Close {
         completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
@@ -495,50 +519,83 @@ impl Connection {
         self.inbound_stream.next().await
     }
 
-    async fn send_encoded(&mut self, bytes: Bytes, class: AdmissionClass) -> rocketmq_error::RocketMQResult<()> {
+    async fn send_encoded(
+        &mut self,
+        bytes: Bytes,
+        class: AdmissionClass,
+        deadline: Option<RequestDeadline>,
+        target: String,
+    ) -> rocketmq_error::RocketMQResult<()> {
         let encoded_len = bytes.len();
+        if let Some(deadline) = deadline {
+            deadline.ensure_before_send(target.clone())?;
+        }
         if let Some(queued) = self.queued.as_ref() {
-            let _lifecycle_guard = queued.lifecycle.begin_send().await;
+            let _lifecycle_guard = if let Some(deadline) = deadline {
+                deadline
+                    .timeout(queued.lifecycle.begin_send())
+                    .await
+                    .map_err(|_| rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target.clone()))?
+            } else {
+                queued.lifecycle.begin_send().await
+            };
             if self.state() == ConnectionState::Closed {
                 return Err(rocketmq_error::RocketMQError::network_connection_failed(
-                    "transport-session-writer",
+                    target,
                     "connection is closed",
                 ));
             }
             #[cfg(test)]
             if let Some((checked, resume)) = self.enqueue_gate.as_ref() {
                 checked.notify_one();
-                resume.notified().await;
+                if let Some(deadline) = deadline {
+                    deadline.timeout(resume.notified()).await.map_err(|_| {
+                        rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target.clone())
+                    })?;
+                } else {
+                    resume.notified().await;
+                }
             }
             let permit = queued
                 .admission
                 .try_acquire(AdmissionResource::Queued, queued.scope, bytes.len(), class)
-                .map_err(|error| {
-                    rocketmq_error::RocketMQError::network_connection_failed(
-                        "transport-session-writer",
-                        error.to_string(),
-                    )
-                })?;
+                .map_err(|_| rocketmq_error::RocketMQError::network_queue_full(target.clone()))?;
+            if let Some(deadline) = deadline {
+                deadline.ensure_before_send(target.clone())?;
+            }
             let (completion, result) = oneshot::channel();
+            let progress = deadline.map(|_| Arc::new(QueuedWriteProgress::waiting()));
             queued
                 .writer
-                .send(QueuedWrite::Data {
+                .try_send(QueuedWrite::Data {
                     bytes,
                     completion,
                     _permit: permit,
+                    deadline,
+                    target: target.clone(),
+                    progress: progress.clone(),
                 })
-                .await
-                .map_err(|_| {
-                    rocketmq_error::RocketMQError::network_connection_failed(
-                        "transport-session-writer",
-                        "writer queue closed",
-                    )
+                .map_err(|error| match error {
+                    tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                        rocketmq_error::RocketMQError::network_queue_full(target.clone())
+                    }
+                    tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                        rocketmq_error::RocketMQError::network_connection_failed(target.clone(), "writer queue closed")
+                    }
                 })?;
-            let outcome = result.await.map_err(|_| {
-                rocketmq_error::RocketMQError::network_connection_failed(
-                    "transport-session-writer",
-                    "writer completion dropped",
-                )
+            let outcome = if let Some(deadline) = deadline {
+                deadline.timeout(result).await.map_err(|_| {
+                    if progress.as_ref().is_some_and(|progress| !progress.write_started()) {
+                        rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target.clone())
+                    } else {
+                        rocketmq_error::RocketMQError::network_write_timeout(target.clone(), deadline.budget_millis())
+                    }
+                })?
+            } else {
+                result.await
+            }
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::network_connection_failed(target.clone(), "writer completion dropped")
             })?;
             if outcome.is_ok() {
                 record_transport_write(encoded_len);
@@ -547,11 +604,18 @@ impl Connection {
         }
         if self.state() == ConnectionState::Closed {
             return Err(rocketmq_error::RocketMQError::network_connection_failed(
-                "transport-session-writer",
+                target,
                 "connection is closed",
             ));
         }
-        match self.outbound_sink.send(bytes).await {
+        let send_result = if let Some(deadline) = deadline {
+            deadline.timeout(self.outbound_sink.send(bytes)).await.map_err(|_| {
+                rocketmq_error::RocketMQError::network_write_timeout(target.clone(), deadline.budget_millis())
+            })?
+        } else {
+            self.outbound_sink.send(bytes).await
+        };
+        match send_result {
             Ok(()) => {
                 record_transport_write(encoded_len);
                 Ok(())
@@ -618,7 +682,43 @@ impl Connection {
             .as_ref()
             .and_then(|queued| queued.response_class)
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        self.send_encoded(bytes, class).await
+        self.send_encoded(bytes, class, None, "transport-session-writer".to_string())
+            .await
+    }
+
+    /// Sends one command under a caller-owned immutable request deadline.
+    ///
+    /// The deadline is checked before encoding, after encoding, during queue
+    /// admission, immediately before socket write, and while the write is in
+    /// progress.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed queue, before-send, write-timeout, or transport error.
+    pub async fn send_command_with_deadline(
+        &mut self,
+        mut command: RemotingCommand,
+        deadline: RequestDeadline,
+        target: impl Into<String>,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let target = target.into();
+        deadline.ensure_before_send(target.clone())?;
+        command.fast_header_encode(&mut self.encode_buffer);
+        if let Some(body_inner) = command.take_body() {
+            self.encode_buffer.put(body_inner);
+        }
+        deadline.ensure_before_send(target.clone())?;
+
+        let len = self.encode_buffer.len();
+        #[cfg(feature = "observability")]
+        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
+        let bytes = self.encode_buffer.split_to(len).freeze();
+        let class = self
+            .queued
+            .as_ref()
+            .and_then(|queued| queued.response_class)
+            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
+        self.send_encoded(bytes, class, Some(deadline), target).await
     }
 
     /// Sends a `RemotingCommand` to the peer (borrows command).
@@ -658,7 +758,8 @@ impl Connection {
             .as_ref()
             .and_then(|queued| queued.response_class)
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        self.send_encoded(bytes, class).await
+        self.send_encoded(bytes, class, None, "transport-session-writer".to_string())
+            .await
     }
 
     /// Sends multiple `RemotingCommand`s in a single batch (optimized for throughput).
@@ -713,7 +814,13 @@ impl Connection {
         rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
         let bytes = self.encode_buffer.split_to(len).freeze();
 
-        self.send_encoded(bytes, AdmissionClass::Data).await
+        self.send_encoded(
+            bytes,
+            AdmissionClass::Data,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
     }
 
     /// Sends raw `Bytes` directly to the peer (zero-copy).
@@ -738,7 +845,13 @@ impl Connection {
     pub async fn send_bytes(&mut self, bytes: Bytes) -> rocketmq_error::RocketMQResult<()> {
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::remoting::record_network_bytes(bytes.len() as u64);
-        self.send_encoded(bytes, AdmissionClass::Data).await
+        self.send_encoded(
+            bytes,
+            AdmissionClass::Data,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
     }
 
     /// Sends a static byte slice to the peer (zero-copy).
@@ -766,7 +879,13 @@ impl Connection {
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::remoting::record_network_bytes(slice.len() as u64);
         let bytes = slice.into();
-        self.send_encoded(bytes, AdmissionClass::Control).await
+        self.send_encoded(
+            bytes,
+            AdmissionClass::Control,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
     }
 
     /// Gets the unique identifier for this connection.

--- a/rocketmq-transport/src/deadline.rs
+++ b/rocketmq-transport/src/deadline.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Immutable end-to-end request deadline.
+
+use std::future::Future;
+use std::time::Duration;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+
+/// One absolute deadline frozen at the public request boundary.
+///
+/// Copies preserve the same expiry instant and original budget. Downstream
+/// stages can only observe the remaining budget; they cannot extend it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestDeadline {
+    expires_at: tokio::time::Instant,
+    budget: Duration,
+}
+
+impl RequestDeadline {
+    /// Freezes a relative timeout into one absolute Tokio deadline.
+    #[must_use]
+    pub fn after(timeout: Duration) -> Self {
+        let now = tokio::time::Instant::now();
+        let expires_at = now.checked_add(timeout).unwrap_or(now);
+        Self {
+            expires_at,
+            budget: timeout,
+        }
+    }
+
+    /// Freezes a millisecond timeout into one absolute Tokio deadline.
+    #[must_use]
+    pub fn from_timeout_millis(timeout_millis: u64) -> Self {
+        Self::after(Duration::from_millis(timeout_millis))
+    }
+
+    /// Returns the immutable absolute expiry instant.
+    #[must_use]
+    pub const fn instant(self) -> tokio::time::Instant {
+        self.expires_at
+    }
+
+    /// Returns the original caller budget.
+    #[must_use]
+    pub const fn budget(self) -> Duration {
+        self.budget
+    }
+
+    /// Returns the original caller budget, saturated to the public millisecond field.
+    #[must_use]
+    pub fn budget_millis(self) -> u64 {
+        self.budget.as_millis().min(u128::from(u64::MAX)) as u64
+    }
+
+    /// Returns the budget still available at the current Tokio clock instant.
+    #[must_use]
+    pub fn remaining(self) -> Duration {
+        self.expires_at.saturating_duration_since(tokio::time::Instant::now())
+    }
+
+    /// Returns whether the deadline has elapsed.
+    #[must_use]
+    pub fn is_expired(self) -> bool {
+        tokio::time::Instant::now() >= self.expires_at
+    }
+
+    /// Rejects work that has not started its socket write before expiry.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed before-send error once the immutable deadline has elapsed.
+    pub fn ensure_before_send(self, addr: impl Into<String>) -> RocketMQResult<()> {
+        if self.is_expired() {
+            Err(RocketMQError::network_deadline_exceeded_before_send(addr))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Runs a future against this exact absolute deadline.
+    pub async fn timeout<F>(self, future: F) -> Result<F::Output, tokio::time::error::Elapsed>
+    where
+        F: Future,
+    {
+        tokio::time::timeout_at(self.expires_at, future).await
+    }
+}

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -25,6 +25,7 @@ pub mod codec;
 pub mod config;
 pub mod connection;
 pub mod connection_context;
+pub mod deadline;
 pub mod error_helpers;
 pub mod security;
 pub mod server;

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use futures_util::SinkExt;
 use futures_util::StreamExt;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -385,8 +386,25 @@ async fn run_framed_session<H>(
                     bytes,
                     completion,
                     _permit,
+                    deadline,
+                    target,
+                    progress,
                 }) => {
-                    let result = sink.send(bytes).await;
+                    let result = match deadline {
+                        Some(deadline) if deadline.is_expired() => {
+                            Err(RocketMQError::network_deadline_exceeded_before_send(target))
+                        }
+                        Some(deadline) => {
+                            if let Some(progress) = progress.as_ref() {
+                                progress.start_write();
+                            }
+                            match deadline.timeout(sink.send(bytes)).await {
+                                Ok(result) => result,
+                                Err(_) => Err(RocketMQError::network_write_timeout(target, deadline.budget_millis())),
+                            }
+                        }
+                        None => sink.send(bytes).await,
+                    };
                     if result.is_err() {
                         let _ = writer_state.send(ConnectionState::Degraded);
                     }
@@ -848,8 +866,11 @@ mod retirement_tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use rocketmq_error::NetworkError;
+    use rocketmq_error::RocketMQError;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_runtime::RuntimeContext;
+    use tokio::io::AsyncReadExt;
     use tokio::sync::oneshot;
     use tokio::sync::Notify;
 
@@ -858,6 +879,7 @@ mod retirement_tests {
     use crate::admission::AdmissionController;
     use crate::admission::AdmissionLimits;
     use crate::connection::Connection;
+    use crate::deadline::RequestDeadline;
     use crate::security::TransportSecurity;
 
     struct CaptureSession {
@@ -988,5 +1010,64 @@ mod retirement_tests {
             .unwrap()
             .is_err());
         runner.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn request_deadline_wins_the_enqueue_race_without_a_socket_write() {
+        let runtime = RuntimeContext::from_current("transport-request-deadline-race-test");
+        let service = runtime.service_context("transport-request-deadline-race");
+        let (transport, mut peer_stream) = tokio::io::duplex(4096);
+        let (session_tx, session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let local_addr: SocketAddr = "127.0.0.1:19005".parse().unwrap();
+        let remote_addr: SocketAddr = "127.0.0.1:19006".parse().unwrap();
+        let runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_stream(transport),
+            local_addr,
+            remote_addr,
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            handler,
+        ));
+        let session = session_rx.await.expect("session capture");
+        let checked = Arc::new(Notify::new());
+        let resume_enqueue = Arc::new(Notify::new());
+        let mut connection = session.connection_with_enqueue_gate(checked.clone(), resume_enqueue);
+        let deadline = RequestDeadline::after(Duration::from_millis(50));
+        let send = tokio::spawn(async move {
+            connection
+                .send_command_with_deadline(
+                    RemotingCommand::create_remoting_command(4),
+                    deadline,
+                    "127.0.0.1:19006".to_string(),
+                )
+                .await
+        });
+        checked.notified().await;
+
+        tokio::time::advance(Duration::from_millis(50)).await;
+        let error = send
+            .await
+            .expect("send task")
+            .expect_err("deadline must win the enqueue race");
+
+        assert!(matches!(
+            error,
+            RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { .. })
+        ));
+        let mut byte = [0_u8; 1];
+        tokio::select! {
+            biased;
+            read = peer_stream.read(&mut byte) => panic!("unexpected socket read after deadline: {read:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        session.retire().await.expect("retire session");
+        runner.await.expect("session runner");
     }
 }

--- a/rocketmq-transport/tests/client_server_lifecycle.rs
+++ b/rocketmq-transport/tests/client_server_lifecycle.rs
@@ -47,6 +47,7 @@ use rocketmq_transport::config::TlsConfig;
 use rocketmq_transport::config::TlsMode;
 use rocketmq_transport::connection::transport_io_snapshot;
 use rocketmq_transport::connection::Connection;
+use rocketmq_transport::deadline::RequestDeadline;
 use rocketmq_transport::security::TransportSecurity;
 use rocketmq_transport::server::ConnectionHandler;
 use rocketmq_transport::server::RequestProcessor;
@@ -241,7 +242,7 @@ async fn real_request_uses_one_deadline_and_drains_all_owned_tasks() {
         .invoke(
             address,
             RemotingCommand::create_remoting_command(105).set_body("payload"),
-            ShutdownDeadline::after(Duration::from_secs(2)),
+            RequestDeadline::after(Duration::from_secs(2)),
         )
         .await
         .unwrap();
@@ -279,7 +280,7 @@ async fn hung_processor_and_send_failure_complete_without_leaking_pending_or_tas
         .invoke(
             address,
             RemotingCommand::create_remoting_command(105),
-            ShutdownDeadline::after(Duration::from_millis(100)),
+            RequestDeadline::after(Duration::from_millis(100)),
         )
         .await
         .is_err());
@@ -287,7 +288,7 @@ async fn hung_processor_and_send_failure_complete_without_leaking_pending_or_tas
         .invoke(
             "127.0.0.1:1".parse().unwrap(),
             RemotingCommand::create_remoting_command(105),
-            ShutdownDeadline::after(Duration::from_millis(100)),
+            RequestDeadline::after(Duration::from_millis(100)),
         )
         .await
         .is_err());
@@ -321,7 +322,7 @@ async fn wrong_response_opaque_is_rejected_and_cannot_complete_the_request() {
         .invoke(
             address,
             RemotingCommand::create_remoting_command(105),
-            ShutdownDeadline::after(Duration::from_millis(100)),
+            RequestDeadline::after(Duration::from_millis(100)),
         )
         .await;
 
@@ -473,7 +474,7 @@ async fn transport_security_signs_outbound_and_fails_closed_without_a_principal(
         .invoke(
             signed_address,
             RemotingCommand::create_remoting_command(RequestCode::HeartBeat),
-            ShutdownDeadline::after(Duration::from_secs(1)),
+            RequestDeadline::after(Duration::from_secs(1)),
         )
         .await
         .expect("signed request");
@@ -523,7 +524,7 @@ async fn tls_client_invocation_releases_pending_and_server_ownership() {
             address,
             RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_body(vec![7_u8; 1024]),
             &client_tls,
-            ShutdownDeadline::after(Duration::from_secs(2)),
+            RequestDeadline::after(Duration::from_secs(2)),
         )
         .await
         .expect("TLS invocation");

--- a/rocketmq-transport/tests/end_to_end_deadline.rs
+++ b/rocketmq-transport/tests/end_to_end_deadline.rs
@@ -1,0 +1,337 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_error::NetworkError;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_transport::admission::AdmissionController;
+use rocketmq_transport::admission::AdmissionLimits;
+use rocketmq_transport::admission::ResourceLimit;
+use rocketmq_transport::client::TransportClient;
+use rocketmq_transport::connection::Connection;
+use rocketmq_transport::deadline::RequestDeadline;
+use rocketmq_transport::security::TransportSecurity;
+use rocketmq_transport::server::run_connected_session;
+use rocketmq_transport::server::ConnectionHandler;
+use rocketmq_transport::server::SessionHandle;
+use tokio::io::DuplexStream;
+use tokio::sync::oneshot;
+
+struct CaptureSession {
+    sender: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
+}
+
+impl ConnectionHandler for CaptureSession {
+    fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(sender) = self.sender.lock().expect("capture lock").take() {
+                let _ = sender.send(session);
+            }
+        })
+    }
+
+    fn command(
+        &self,
+        _session: SessionHandle,
+        _command: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+async fn connected_session(
+    capacity: usize,
+    name: &'static str,
+) -> (SessionHandle, DuplexStream, tokio::task::JoinHandle<()>) {
+    let (session, peer, runner, _admission) =
+        connected_session_with_limits(capacity, name, AdmissionLimits::default()).await;
+    (session, peer, runner)
+}
+
+async fn connected_session_with_limits(
+    capacity: usize,
+    name: &'static str,
+    limits: AdmissionLimits,
+) -> (
+    SessionHandle,
+    DuplexStream,
+    tokio::task::JoinHandle<()>,
+    Arc<AdmissionController>,
+) {
+    let runtime = RuntimeContext::from_current(name);
+    let service = runtime.service_context(name);
+    let (transport, peer) = tokio::io::duplex(capacity);
+    let (session_tx, session_rx) = oneshot::channel();
+    let handler = Arc::new(CaptureSession {
+        sender: std::sync::Mutex::new(Some(session_tx)),
+    });
+    let local_addr: SocketAddr = "127.0.0.1:19011".parse().expect("local address");
+    let remote_addr: SocketAddr = "127.0.0.1:19012".parse().expect("remote address");
+    let admission = Arc::new(AdmissionController::new(limits));
+    let runner = tokio::spawn(run_connected_session(
+        Connection::new_with_stream(transport),
+        local_addr,
+        remote_addr,
+        service.task_group().clone(),
+        admission.clone(),
+        Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        None,
+        Duration::from_secs(30),
+        handler,
+    ));
+    let session = session_rx.await.expect("capture connected session");
+    (session, peer, runner, admission)
+}
+
+#[tokio::test(start_paused = true)]
+async fn request_deadline_is_frozen_once_at_entry() {
+    let deadline = RequestDeadline::after(Duration::from_millis(100));
+    let expires_at = deadline.instant();
+
+    tokio::time::advance(Duration::from_millis(40)).await;
+
+    assert_eq!(deadline.instant(), expires_at);
+    assert_eq!(deadline.remaining(), Duration::from_millis(60));
+
+    tokio::time::advance(Duration::from_millis(60)).await;
+
+    assert!(deadline.is_expired());
+    assert_eq!(deadline.remaining(), Duration::ZERO);
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_before_send_has_zero_remote_side_effects() {
+    let (session, peer, runner) = connected_session(4096, "deadline-before-send-test").await;
+    let side_effects = Arc::new(AtomicUsize::new(0));
+    let remote_effects = side_effects.clone();
+    let remote = tokio::spawn(async move {
+        let mut peer = Connection::new_with_stream(peer);
+        if peer.receive_command().await.is_some() {
+            remote_effects.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+    let deadline = RequestDeadline::after(Duration::from_millis(10));
+    tokio::time::advance(Duration::from_millis(10)).await;
+
+    let error = session
+        .connection()
+        .send_command_with_deadline(
+            RemotingCommand::create_remoting_command(1),
+            deadline,
+            session.remote_addr().to_string(),
+        )
+        .await
+        .expect_err("expired request must not enter the writer");
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { .. })
+    ));
+    tokio::task::yield_now().await;
+    assert_eq!(side_effects.load(Ordering::SeqCst), 0);
+
+    remote.abort();
+    session.task_group().cancel();
+    runner.await.expect("session runner");
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocked_socket_write_uses_the_original_deadline() {
+    let (session, _peer, runner) = connected_session(64, "deadline-write-timeout-test").await;
+    let deadline = RequestDeadline::after(Duration::from_millis(50));
+    let mut connection = session.connection();
+    let send = tokio::spawn(async move {
+        connection
+            .send_command_with_deadline(
+                RemotingCommand::create_remoting_command(2).set_body(vec![0_u8; 1024 * 1024]),
+                deadline,
+                "127.0.0.1:19012".to_string(),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    tokio::time::advance(Duration::from_millis(50)).await;
+    let error = send
+        .await
+        .expect("send task")
+        .expect_err("blocked socket write must time out");
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::WriteTimeout { timeout_ms: 50, .. })
+    ));
+
+    session.task_group().cancel();
+    runner.await.expect("session runner");
+}
+
+#[tokio::test(start_paused = true)]
+async fn full_outbound_admission_returns_queue_full_without_extending_deadline() {
+    let limits = AdmissionLimits {
+        queued: ResourceLimit {
+            count: 1,
+            bytes: 4 * 1024 * 1024,
+        },
+        ..AdmissionLimits::default()
+    };
+    let (session, _peer, runner, admission) =
+        connected_session_with_limits(64, "deadline-full-queue-test", limits).await;
+    let first_deadline = RequestDeadline::after(Duration::from_secs(10));
+    let mut first_connection = session.connection();
+    let first = tokio::spawn(async move {
+        first_connection
+            .send_command_with_deadline(
+                RemotingCommand::create_remoting_command(9000).set_body(vec![0_u8; 1024 * 1024]),
+                first_deadline,
+                "127.0.0.1:19012".to_string(),
+            )
+            .await
+    });
+    while admission.snapshot().queued.current_count != 1 {
+        if first.is_finished() {
+            let result = first.await.expect("first send task");
+            panic!("first send completed before holding admission: {result:?}");
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let error = session
+        .connection()
+        .send_command_with_deadline(
+            RemotingCommand::create_remoting_command(9001),
+            RequestDeadline::after(Duration::from_secs(1)),
+            "127.0.0.1:19012".to_string(),
+        )
+        .await
+        .expect_err("full admission must reject immediately");
+
+    assert!(
+        matches!(error, RocketMQError::Network(NetworkError::QueueFull { .. })),
+        "unexpected error: {error:?}"
+    );
+
+    session.task_group().cancel();
+    assert!(first.await.expect("first send task").is_err());
+    runner.await.expect("session runner");
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_request_expiry_is_reported_before_send() {
+    let (session, _peer, runner, admission) =
+        connected_session_with_limits(64, "deadline-queue-wait-test", AdmissionLimits::default()).await;
+    let mut first_connection = session.connection();
+    let first = tokio::spawn(async move {
+        first_connection
+            .send_command_with_deadline(
+                RemotingCommand::create_remoting_command(9100).set_body(vec![0_u8; 1024 * 1024]),
+                RequestDeadline::after(Duration::from_secs(10)),
+                "127.0.0.1:19012".to_string(),
+            )
+            .await
+    });
+    while admission.snapshot().queued.current_count != 1 {
+        tokio::task::yield_now().await;
+    }
+
+    let mut queued_connection = session.connection();
+    let queued = tokio::spawn(async move {
+        queued_connection
+            .send_command_with_deadline(
+                RemotingCommand::create_remoting_command(9101),
+                RequestDeadline::after(Duration::from_millis(50)),
+                "127.0.0.1:19012".to_string(),
+            )
+            .await
+    });
+    while admission.snapshot().queued.current_count != 2 {
+        tokio::task::yield_now().await;
+    }
+
+    tokio::time::advance(Duration::from_millis(50)).await;
+    let error = queued
+        .await
+        .expect("queued send task")
+        .expect_err("queued request must expire before socket write");
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { .. })
+    ));
+
+    session.task_group().cancel();
+    assert!(first.await.expect("first send task").is_err());
+    runner.await.expect("session runner");
+}
+
+#[tokio::test(start_paused = true)]
+async fn missing_response_uses_the_same_absolute_response_deadline() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener address");
+    let (request_seen_tx, request_seen_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (socket, _) = listener.accept().await.expect("accept client");
+        let mut connection = Connection::new(socket);
+        let _request = connection
+            .receive_command()
+            .await
+            .expect("request frame")
+            .expect("request command");
+        let _ = request_seen_tx.send(());
+        let _ = release_rx.await;
+    });
+    let runtime = RuntimeContext::from_current("deadline-no-response-test");
+    let service = runtime.service_context("deadline-no-response-client");
+    let client = Arc::new(TransportClient::new(
+        service,
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    ));
+    let invoking = client.clone();
+    let invoke = tokio::spawn(async move {
+        invoking
+            .invoke(
+                address,
+                RemotingCommand::create_remoting_command(3),
+                RequestDeadline::after(Duration::from_millis(100)),
+            )
+            .await
+    });
+    request_seen_rx.await.expect("server observed request");
+
+    tokio::time::advance(Duration::from_millis(100)).await;
+    let error = match invoke.await.expect("invoke task") {
+        Ok(_) => panic!("missing response must time out"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::ResponseTimeout { timeout_ms: 100, .. })
+    ));
+
+    let _ = release_tx.send(());
+    server.await.expect("server task");
+}

--- a/rocketmq-transport/tests/pending_request_table.rs
+++ b/rocketmq-transport/tests/pending_request_table.rs
@@ -17,17 +17,17 @@ use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_transport::base::pending_request_table::PendingRequestLimits;
 use rocketmq_transport::base::pending_request_table::PendingRequestTable;
+use rocketmq_transport::deadline::RequestDeadline;
 use std::sync::Arc;
 use std::sync::Barrier;
 use std::time::Duration;
-use std::time::Instant;
 
 #[tokio::test]
 async fn response_completion_is_exactly_once_and_releases_the_reservation() {
     let table = PendingRequestTable::new();
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let guard = table
-        .register(7, 3_000, sender)
+        .register(7, RequestDeadline::from_timeout_millis(3_000), sender)
         .expect("first reservation should succeed");
 
     assert_eq!(table.len(), 1);
@@ -58,18 +58,23 @@ async fn expiring_ten_thousand_requests_completes_every_waiter_and_releases_ever
         let (sender, receiver) = tokio::sync::oneshot::channel();
         guards.push(
             table
-                .register(opaque, 3_000, sender)
+                .register(opaque, RequestDeadline::from_timeout_millis(3_000), sender)
                 .expect("unique opaque should reserve successfully"),
         );
         receivers.push(receiver);
     }
 
-    assert_eq!(table.expire_due(Instant::now() + Duration::from_secs(4)), REQUESTS);
+    assert_eq!(
+        table.expire_due(tokio::time::Instant::now() + Duration::from_secs(4)),
+        REQUESTS
+    );
     assert_eq!(table.len(), 0);
     for receiver in receivers {
         assert!(matches!(
             receiver.await.expect("timeout should notify every waiter"),
-            Err(RocketMQError::Timeout { .. })
+            Err(RocketMQError::Network(
+                rocketmq_error::NetworkError::ResponseTimeout { .. }
+            ))
         ));
     }
     drop(guards);
@@ -79,7 +84,9 @@ async fn expiring_ten_thousand_requests_completes_every_waiter_and_releases_ever
 async fn dropping_guard_completes_waiter_with_typed_cancellation() {
     let table = PendingRequestTable::new();
     let (sender, receiver) = tokio::sync::oneshot::channel();
-    let guard = table.register(41, 3_000, sender).unwrap();
+    let guard = table
+        .register(41, RequestDeadline::from_timeout_millis(3_000), sender)
+        .unwrap();
 
     drop(guard);
 
@@ -94,16 +101,25 @@ async fn dropping_guard_completes_waiter_with_typed_cancellation() {
 async fn retired_opaque_cannot_be_reused_by_a_late_response() {
     let table = PendingRequestTable::new();
     let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
-    let first = table.register(9, 1, first_sender).unwrap();
-    assert_eq!(table.expire_due(Instant::now() + Duration::from_millis(2)), 1);
+    let first = table
+        .register(9, RequestDeadline::from_timeout_millis(1), first_sender)
+        .unwrap();
+    assert_eq!(
+        table.expire_due(tokio::time::Instant::now() + Duration::from_millis(2)),
+        1
+    );
     assert!(matches!(
         first_receiver.await.unwrap(),
-        Err(RocketMQError::Timeout { .. })
+        Err(RocketMQError::Network(
+            rocketmq_error::NetworkError::ResponseTimeout { .. }
+        ))
     ));
     drop(first);
 
     let (second_sender, _second_receiver) = tokio::sync::oneshot::channel();
-    assert!(table.register(9, 3_000, second_sender).is_err());
+    assert!(table
+        .register(9, RequestDeadline::from_timeout_millis(3_000), second_sender)
+        .is_err());
     assert!(!table.complete_response(
         9,
         RemotingCommand::create_response_command_with_code(ResponseCode::Success),
@@ -114,14 +130,20 @@ async fn retired_opaque_cannot_be_reused_by_a_late_response() {
 async fn admission_permit_is_released_after_completion() {
     let table = PendingRequestTable::with_capacity(1);
     let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
-    let first = table.register(1, 3_000, first_sender).unwrap();
+    let first = table
+        .register(1, RequestDeadline::from_timeout_millis(3_000), first_sender)
+        .unwrap();
     let (blocked_sender, _blocked_receiver) = tokio::sync::oneshot::channel();
-    assert!(table.register(2, 3_000, blocked_sender).is_err());
+    assert!(table
+        .register(2, RequestDeadline::from_timeout_millis(3_000), blocked_sender)
+        .is_err());
 
     assert!(first.complete(Err(RocketMQError::network_connection_failed("test", "done",))));
     assert!(first_receiver.await.unwrap().is_err());
     let (next_sender, _next_receiver) = tokio::sync::oneshot::channel();
-    assert!(table.register(2, 3_000, next_sender).is_ok());
+    assert!(table
+        .register(2, RequestDeadline::from_timeout_millis(3_000), next_sender)
+        .is_ok());
 }
 
 #[tokio::test]
@@ -135,7 +157,7 @@ async fn close_all_completes_every_waiter_with_a_typed_cause() {
         let (sender, receiver) = tokio::sync::oneshot::channel();
         guards.push(
             table
-                .register(opaque, 3_000, sender)
+                .register(opaque, RequestDeadline::from_timeout_millis(3_000), sender)
                 .expect("unique opaque should reserve successfully"),
         );
         receivers.push(receiver);
@@ -163,9 +185,21 @@ async fn closing_one_connection_owner_does_not_complete_another_owners_request()
     let second_owner = table.new_owner();
     let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
     let (second_sender, mut second_receiver) = tokio::sync::oneshot::channel();
-    let first_guard = table.register_for_owner(&first_owner, 17, 3_000, first_sender).unwrap();
+    let first_guard = table
+        .register_for_owner(
+            &first_owner,
+            17,
+            RequestDeadline::from_timeout_millis(3_000),
+            first_sender,
+        )
+        .unwrap();
     let second_guard = table
-        .register_for_owner(&second_owner, 17, 3_000, second_sender)
+        .register_for_owner(
+            &second_owner,
+            17,
+            RequestDeadline::from_timeout_millis(3_000),
+            second_sender,
+        )
         .unwrap();
 
     assert_eq!(
@@ -198,23 +232,45 @@ async fn timed_out_owner_rejects_reuse_but_rotated_owner_is_safe_from_late_respo
     let table = PendingRequestTable::new();
     let retired_owner = table.new_owner();
     let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
-    let first = table.register_for_owner(&retired_owner, 29, 1, first_sender).unwrap();
+    let first = table
+        .register_for_owner(
+            &retired_owner,
+            29,
+            RequestDeadline::from_timeout_millis(1),
+            first_sender,
+        )
+        .unwrap();
 
-    assert_eq!(table.expire_due(Instant::now() + Duration::from_millis(2)), 1);
+    assert_eq!(
+        table.expire_due(tokio::time::Instant::now() + Duration::from_millis(2)),
+        1
+    );
     assert!(matches!(
         first_receiver.await.unwrap(),
-        Err(RocketMQError::Timeout { .. })
+        Err(RocketMQError::Network(
+            rocketmq_error::NetworkError::ResponseTimeout { .. }
+        ))
     ));
     drop(first);
     let (reused_sender, _reused_receiver) = tokio::sync::oneshot::channel();
     assert!(table
-        .register_for_owner(&retired_owner, 29, 3_000, reused_sender)
+        .register_for_owner(
+            &retired_owner,
+            29,
+            RequestDeadline::from_timeout_millis(3_000),
+            reused_sender,
+        )
         .is_err());
 
     let rotated_owner = table.new_owner();
     let (rotated_sender, rotated_receiver) = tokio::sync::oneshot::channel();
     let rotated = table
-        .register_for_owner(&rotated_owner, 29, 3_000, rotated_sender)
+        .register_for_owner(
+            &rotated_owner,
+            29,
+            RequestDeadline::from_timeout_millis(3_000),
+            rotated_sender,
+        )
         .unwrap();
     assert!(!table.complete_response_for_owner(
         &retired_owner,
@@ -241,13 +297,15 @@ async fn count_and_byte_admission_are_observable_and_released_on_every_completio
     });
     let (first_sender, first_receiver) = tokio::sync::oneshot::channel();
     let first = table
-        .register_with_bytes(1, 3_000, 6, first_sender)
+        .register_with_bytes(1, RequestDeadline::from_timeout_millis(3_000), 6, first_sender)
         .expect("first request fits both budgets");
     assert_eq!(table.usage().count, 1);
     assert_eq!(table.usage().bytes, 6);
 
     let (byte_blocked_sender, _byte_blocked_receiver) = tokio::sync::oneshot::channel();
-    assert!(table.register_with_bytes(2, 3_000, 3, byte_blocked_sender).is_err());
+    assert!(table
+        .register_with_bytes(2, RequestDeadline::from_timeout_millis(3_000), 3, byte_blocked_sender,)
+        .is_err());
     assert_eq!(table.usage().rejected_bytes, 1);
 
     assert!(first.complete(Err(RocketMQError::network_connection_failed("test", "send failed",))));
@@ -256,7 +314,9 @@ async fn count_and_byte_admission_are_observable_and_released_on_every_completio
     assert_eq!(table.usage().bytes, 0);
 
     let (next_sender, next_receiver) = tokio::sync::oneshot::channel();
-    let next = table.register_with_bytes(2, 3_000, 8, next_sender).unwrap();
+    let next = table
+        .register_with_bytes(2, RequestDeadline::from_timeout_millis(3_000), 8, next_sender)
+        .unwrap();
     assert_eq!(
         table.close_all(|| { RocketMQError::network_connection_failed("test", "connection closed") }),
         1
@@ -282,7 +342,10 @@ fn close_and_registration_are_one_atomic_owner_epoch() {
         registrations.push(std::thread::spawn(move || {
             let (sender, receiver) = tokio::sync::oneshot::channel();
             barrier.wait();
-            (table.register_for_owner(&owner, opaque, 30_000, sender), receiver)
+            (
+                table.register_for_owner(&owner, opaque, RequestDeadline::from_timeout_millis(30_000), sender),
+                receiver,
+            )
         }));
     }
     let close_table = table.clone();

--- a/rocketmq-transport/tests/production_runtime.rs
+++ b/rocketmq-transport/tests/production_runtime.rs
@@ -20,12 +20,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_runtime::RuntimeContext;
-use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_transport::admission::AdmissionController;
 use rocketmq_transport::admission::AdmissionLimits;
 use rocketmq_transport::client::connect_with_config;
 use rocketmq_transport::codec::remoting_command_codec::FrameLimits;
 use rocketmq_transport::config::TlsConfig;
+use rocketmq_transport::deadline::RequestDeadline;
 use rocketmq_transport::server::ConnectionHandler;
 use rocketmq_transport::server::SessionHandle;
 use rocketmq_transport::server::TransportListener;
@@ -60,7 +60,7 @@ async fn canonical_client_connect_builds_the_framed_transport() {
         &address.to_string(),
         &TlsConfig::default(),
         FrameLimits::legacy_compatibility(),
-        ShutdownDeadline::after(Duration::from_secs(1)),
+        RequestDeadline::after(Duration::from_secs(1)),
     )
     .await
     .unwrap();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8717

### Brief Description

Freeze each request timeout once as an immutable `RequestDeadline` and propagate it through endpoint resolution, connection setup, hooks, signing, encoding, queue admission, socket writes, and response correlation.

Outbound transport work now carries its deadline, retained-byte permit, response reservation, and explicit send progress so queue wait, before-send expiry, write timeout, and response timeout remain distinguishable even when timers race. Pending-request capacity and writer queues reject overload with typed `QueueFull` errors, and expired work is prevented from reaching the socket.

The same deadline contract is used by the remoting client, channel, RPC adapter, and NameServer cluster route lookup. Network failures now expose stable `ConnectionTimeout`, `QueueFull`, `DeadlineExceededBeforeSend`, `WriteTimeout`, and `ResponseTimeout` variants.

### How Did You Test This Change?

- `cargo fmt --all -- --check`: passed.
- `cargo test -p rocketmq-transport --test end_to_end_deadline`: passed, 6 paused-time tests.
- `cargo test -p rocketmq-transport deadline`: passed.
- `cargo test -p rocketmq-remoting deadline`: passed.
- `cargo test -p rocketmq-transport --no-fail-fast`: passed.
- `cargo test -p rocketmq-namesrv route_lookup --no-fail-fast`: passed, 4 tests.
- `cargo test -p rocketmq-error`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `.\scripts\check-agents-routing.ps1`: passed.
- `git diff --check`: passed.

The broader remoting package sweep passed all 125 library tests and all affected suites. Its existing source-layout assertion for asynchronous TLS initialization remains failing on `origin/main`; the referenced remoting server file is unchanged by this pull request. The error hygiene guard likewise reported only the same 11 pre-existing findings from `origin/main`, with no finding in a changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent request deadline handling across connections, queues, writes, and responses.
  * Added detailed network errors for connection, queue, send, write, and response timeouts.
  * Added deadline-aware request and connection APIs.

* **Bug Fixes**
  * Prevented expired requests from being sent or written.
  * Improved timeout accuracy across routing, transport, and RPC operations.
  * Requests now retain their original timeout budget throughout processing.

* **Tests**
  * Added end-to-end coverage for deadline behavior, queue limits, write blocking, and response timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->