### PR TITLE
[ISSUE #8749]♻️Add bounded session execution and request ordering

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -30,6 +30,7 @@ use rocketmq_transport::Channel;
 use rocketmq_transport::ConnectionHandlerContext;
 use rocketmq_transport::RejectRequestResponse;
 use rocketmq_transport::RemotingRequestProcessor as RequestProcessor;
+use rocketmq_transport::RequestOrdering;
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -80,6 +81,7 @@ pub(crate) mod query_assignment_processor;
 pub(crate) mod query_message_processor;
 pub(crate) mod recall_message_processor;
 pub(crate) mod reply_message_processor;
+mod request_ordering;
 pub(crate) mod send_message_processor;
 
 pub enum BrokerProcessorType<MS: MessageStore, TS> {
@@ -242,6 +244,10 @@ where
             BrokerProcessorType::AdminBroker(_) => (false, None),
         }
     }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        request_ordering::broker_request_ordering(request)
+    }
 }
 
 pub(crate) type RequestCodeType = i32;
@@ -380,6 +386,10 @@ where
                 }
             }
         }
+    }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        request_ordering::broker_request_ordering(request)
     }
 }
 
@@ -692,6 +702,16 @@ mod tests {
             true,
             true
         ));
+    }
+
+    #[test]
+    fn broker_request_processor_delegates_session_ordering_policy() {
+        let processor = TestBrokerRequestProcessor::new();
+        let send = RemotingCommand::create_remoting_command(RequestCode::SendMessage);
+        let pull = RemotingCommand::create_remoting_command(RequestCode::PullMessage);
+
+        assert!(matches!(processor.request_ordering(&send), RequestOrdering::Ordered(_)));
+        assert_eq!(processor.request_ordering(&pull), RequestOrdering::Concurrent);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/request_ordering.rs
+++ b/rocketmq-broker/src/processor/request_ordering.rs
@@ -1,0 +1,150 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::RequestOrdering;
+use rocketmq_transport::RequestOrderingKey;
+
+const CLIENT_LIFECYCLE_KEY: u64 = 0x434c_4945_4e54;
+const SEND_NAMESPACE: u64 = 0x5345_4e44;
+const OFFSET_NAMESPACE: u64 = 0x4f46_4653_4554;
+const TRANSACTION_NAMESPACE: u64 = 0x0054_584e;
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+pub(super) fn broker_request_ordering(request: &RemotingCommand) -> RequestOrdering {
+    match RequestCode::from(request.code()) {
+        RequestCode::HeartBeat | RequestCode::UnregisterClient | RequestCode::CheckClientConfig => {
+            RequestOrdering::Ordered(RequestOrderingKey::new(CLIENT_LIFECYCLE_KEY))
+        }
+        RequestCode::SendMessage
+        | RequestCode::SendMessageV2
+        | RequestCode::SendBatchMessage
+        | RequestCode::SendReplyMessage
+        | RequestCode::SendReplyMessageV2 => ordered_by_fields(
+            request,
+            SEND_NAMESPACE,
+            &[&["producerGroup", "a"], &["topic", "b"], &["queueId", "e"]],
+        ),
+        RequestCode::UpdateConsumerOffset | RequestCode::QueryConsumerOffset => ordered_by_fields(
+            request,
+            OFFSET_NAMESPACE,
+            &[&["consumerGroup"], &["topic"], &["queueId"]],
+        ),
+        RequestCode::EndTransaction => ordered_by_fields(
+            request,
+            TRANSACTION_NAMESPACE,
+            &[
+                &["producerGroup"],
+                &["topic"],
+                &["transactionId", "msgId"],
+                &["commitLogOffset"],
+            ],
+        ),
+        // Other broker operations already own their required domain locks or
+        // are read-only. They remain concurrent within the transport session.
+        _ => RequestOrdering::Concurrent,
+    }
+}
+
+fn ordered_by_fields(request: &RemotingCommand, namespace: u64, fields: &[&[&str]]) -> RequestOrdering {
+    let mut hash = FNV_OFFSET_BASIS;
+    hash_u64(&mut hash, namespace);
+    let ext_fields = request.ext_fields();
+    for aliases in fields {
+        let value = aliases
+            .iter()
+            .find_map(|name| ext_fields.and_then(|fields| fields.get(*name)));
+        match value {
+            Some(value) => hash_bytes(&mut hash, value.as_bytes()),
+            None => hash_bytes(&mut hash, []),
+        }
+        hash_u64(&mut hash, u64::MAX);
+    }
+    RequestOrdering::Ordered(RequestOrderingKey::new(hash))
+}
+
+fn hash_u64(hash: &mut u64, value: u64) {
+    hash_bytes(hash, value.to_le_bytes());
+}
+
+fn hash_bytes(hash: &mut u64, value: impl AsRef<[u8]>) {
+    for byte in value.as_ref() {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    fn command(code: RequestCode, fields: &[(&str, &str)]) -> RemotingCommand {
+        let ext_fields = fields
+            .iter()
+            .map(|(key, value)| (CheetahString::from(*key), CheetahString::from(*value)))
+            .collect::<HashMap<_, _>>();
+        RemotingCommand::create_remoting_command(code).set_ext_fields(ext_fields)
+    }
+
+    #[test]
+    fn client_lifecycle_requests_share_one_session_ordering_key() {
+        let heartbeat = command(RequestCode::HeartBeat, &[]);
+        let unregister = command(RequestCode::UnregisterClient, &[]);
+
+        assert_eq!(
+            broker_request_ordering(&heartbeat),
+            broker_request_ordering(&unregister)
+        );
+    }
+
+    #[test]
+    fn sends_are_ordered_per_topic_queue_and_v2_aliases_match_v1_fields() {
+        let v1 = command(
+            RequestCode::SendMessage,
+            &[("producerGroup", "producer-a"), ("topic", "topic-a"), ("queueId", "1")],
+        );
+        let v2 = command(
+            RequestCode::SendMessageV2,
+            &[("a", "producer-a"), ("b", "topic-a"), ("e", "1")],
+        );
+        let other_queue = command(
+            RequestCode::SendMessage,
+            &[("producerGroup", "producer-a"), ("topic", "topic-a"), ("queueId", "2")],
+        );
+
+        assert_eq!(broker_request_ordering(&v1), broker_request_ordering(&v2));
+        assert_ne!(broker_request_ordering(&v1), broker_request_ordering(&other_queue));
+    }
+
+    #[test]
+    fn offset_update_and_query_share_the_same_resource_key() {
+        let fields = [("consumerGroup", "group-a"), ("topic", "topic-a"), ("queueId", "3")];
+        let update = command(RequestCode::UpdateConsumerOffset, &fields);
+        let query = command(RequestCode::QueryConsumerOffset, &fields);
+
+        assert_eq!(broker_request_ordering(&update), broker_request_ordering(&query));
+    }
+
+    #[test]
+    fn unrelated_read_requests_remain_concurrent() {
+        let pull = command(RequestCode::PullMessage, &[]);
+        assert_eq!(broker_request_ordering(&pull), RequestOrdering::Concurrent);
+    }
+}

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -144,48 +144,6 @@ fn record_transport_write(bytes: usize) {
     TRANSPORT_ENCODED_BYTES_WRITTEN.fetch_add(bytes as u64, Ordering::Relaxed);
 }
 
-pub(crate) struct SessionConnection {
-    outbound_sink: SplitSink<SessionConnectionFramed, Bytes>,
-    inbound_stream: SplitStream<SessionConnectionFramed>,
-    state_tx: watch::Sender<ConnectionState>,
-    encode_buffer: BytesMut,
-}
-
-impl SessionConnection {
-    pub(crate) async fn receive_command_with_retained_bytes(
-        &mut self,
-    ) -> Option<rocketmq_error::RocketMQResult<(RemotingCommand, usize)>> {
-        self.inbound_stream
-            .next()
-            .await
-            .map(|result| result.map(|decoded| (decoded.command, decoded.retained_frame_bytes)))
-    }
-
-    pub(crate) async fn send_command(&mut self, mut command: RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
-        command.fast_header_encode(&mut self.encode_buffer);
-        if let Some(body) = command.take_body() {
-            self.encode_buffer.put(body);
-        }
-        let len = self.encode_buffer.len();
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
-        let bytes = self.encode_buffer.split_to(len).freeze();
-        let result = self.outbound_sink.send(bytes).await;
-        if result.is_ok() {
-            record_transport_write(len);
-        } else {
-            let _ = self.state_tx.send(ConnectionState::Degraded);
-        }
-        result
-    }
-
-    pub(crate) async fn shutdown(&mut self) -> rocketmq_error::RocketMQResult<()> {
-        let result = self.outbound_sink.close().await;
-        let _ = self.state_tx.send(ConnectionState::Closed);
-        result
-    }
-}
-
 /// Connection health state
 ///
 /// Represents the current health status of a connection.
@@ -453,22 +411,11 @@ impl Connection {
         SplitSink<SessionConnectionFramed, Bytes>,
         SplitStream<SessionConnectionFramed>,
     ) {
-        let session = self.into_session_connection();
-        (session.outbound_sink, session.inbound_stream)
-    }
-
-    pub(crate) fn into_session_connection(self) -> SessionConnection {
         let framed = self
             .outbound_sink
             .reunite(self.inbound_stream)
             .unwrap_or_else(|_| unreachable!("connection split halves always originate from the same framed I/O"));
-        let (outbound_sink, inbound_stream) = framed.map_codec(SessionCodec::from).split();
-        SessionConnection {
-            outbound_sink,
-            inbound_stream,
-            state_tx: self.state_tx,
-            encode_buffer: self.encode_buffer,
-        }
+        framed.map_codec(SessionCodec::from).split()
     }
 
     /// Gets a reference to the inbound stream for receiving messages

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -33,11 +33,13 @@ mod local;
 mod net;
 mod remoting;
 mod remoting_server;
+mod request_ordering;
 mod request_processor;
 mod rpc;
 mod runtime;
 mod security;
 mod server;
+mod session_executor;
 mod tls;
 
 pub use admission::AdmissionClass;
@@ -103,6 +105,8 @@ pub use remoting_server::rocketmq_tokio_server::run_with_report as run_remoting_
 pub use remoting_server::rocketmq_tokio_server::run_with_report_with_service_context as run_remoting_server_with_report_with_service_context;
 pub use remoting_server::rocketmq_tokio_server::RocketMQServer;
 pub use remoting_server::RemotingServer;
+pub use request_ordering::RequestOrdering;
+pub use request_ordering::RequestOrderingKey;
 pub use request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 pub use rocketmq_protocol::protocol::RemotingDeserializable;
 pub use rocketmq_protocol::protocol::RemotingSerializable;

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -80,11 +80,11 @@ type TestRequestHook =
     Arc<dyn Fn(i32, i32, Channel, TaskGroup, TestDeferredResponse) -> TestRequestHookResult + Send + Sync>;
 
 trait SessionCommandInterceptor: Send + Sync + 'static {
-    fn intercept(&self, code: i32, opaque: i32, channel: Channel, session_task_group: TaskGroup) -> bool;
+    fn intercept(&self, code: i32, opaque: i32, channel: Channel, request_executor_group: TaskGroup) -> bool;
 }
 
 impl SessionCommandInterceptor for () {
-    fn intercept(&self, _code: i32, _opaque: i32, _channel: Channel, _session_task_group: TaskGroup) -> bool {
+    fn intercept(&self, _code: i32, _opaque: i32, _channel: Channel, _request_executor_group: TaskGroup) -> bool {
         false
     }
 }
@@ -295,16 +295,11 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                 self.cmd_handler.response_table.clone(),
                 session.task_group().clone(),
             ),
-            RemotingSessionAction::Command(_) => {
-                let Ok(task_group_lease) = session.task_group().try_child_lease("rocketmq.remoting.command") else {
-                    return;
-                };
-                ChannelInner::new_transport_session_with_task_group(
-                    session.connection(),
-                    self.cmd_handler.response_table.clone(),
-                    task_group_lease.group().clone(),
-                )
-            }
+            RemotingSessionAction::Command(_) => ChannelInner::new_transport_session_with_task_group(
+                session.connection(),
+                self.cmd_handler.response_table.clone(),
+                session.task_group().clone(),
+            ),
         };
         let Ok(channel_inner) = channel_inner else {
             return;
@@ -330,7 +325,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                         command.code(),
                         command.opaque(),
                         remoting_session.context.channel().clone(),
-                        session.task_group().clone(),
+                        session.request_executor_group().clone(),
                     ) {
                         return;
                     }
@@ -349,6 +344,13 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
         Box::pin(async move {
             self.run(session, RemotingSessionAction::Connect, None).await;
         })
+    }
+
+    fn request_ordering(
+        &self,
+        command: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    ) -> crate::request_ordering::RequestOrdering {
+        self.cmd_handler.request_processor.request_ordering(command)
     }
 
     fn command(
@@ -389,6 +391,13 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
 impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler for InterceptingConnectionHandler<RP> {
     fn connected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         self.inner.connected(session)
+    }
+
+    fn request_ordering(
+        &self,
+        command: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    ) -> crate::request_ordering::RequestOrdering {
+        self.inner.request_ordering(command)
     }
 
     fn command(
@@ -830,7 +839,7 @@ mod tests {
     use crate::runtime::config::client_config::TokioClientConfig;
 
     impl SessionCommandInterceptor for Option<TestRequestHook> {
-        fn intercept(&self, code: i32, opaque: i32, channel: Channel, session_task_group: TaskGroup) -> bool {
+        fn intercept(&self, code: i32, opaque: i32, channel: Channel, request_executor_group: TaskGroup) -> bool {
             let Some(hook) = self.as_ref() else {
                 return false;
             };
@@ -841,7 +850,7 @@ mod tests {
                 })
             });
             matches!(
-                hook(code, opaque, channel, session_task_group, deferred_response),
+                hook(code, opaque, channel, request_executor_group, deferred_response),
                 TestRequestHookResult::Intercept
             )
         }
@@ -1225,10 +1234,12 @@ mod tests {
         let reserved = TcpListener::bind("127.0.0.1:0").await.expect("reserve port");
         let addr = reserved.local_addr().unwrap();
         drop(reserved);
-        let session_task_group = Arc::new(std::sync::Mutex::new(None::<TaskGroup>));
-        let session_task_group_for_hook = session_task_group.clone();
+        let request_executor_group = Arc::new(std::sync::Mutex::new(None::<TaskGroup>));
+        let request_executor_group_for_hook = request_executor_group.clone();
         let hook: TestRequestHook = Arc::new(move |_code, _opaque, _channel, task_group, _deferred_response| {
-            let mut captured = session_task_group_for_hook.lock().expect("session task group lock");
+            let mut captured = request_executor_group_for_hook
+                .lock()
+                .expect("request executor group lock");
             if captured.is_none() {
                 *captured = Some(task_group);
             }
@@ -1274,19 +1285,19 @@ mod tests {
             assert_eq!(response.opaque(), opaque);
         }
 
-        let session_task_group = session_task_group
+        let request_executor_group = request_executor_group
             .lock()
-            .expect("session task group lock")
+            .expect("request executor group lock")
             .clone()
-            .expect("session task group");
-        let stats = session_task_group.child_stats();
+            .expect("request executor group");
+        let stats = request_executor_group.child_stats();
         assert_eq!(stats.active, 0);
         assert_eq!(stats.created, COMMAND_COUNT);
         assert_eq!(stats.pruned, COMMAND_COUNT);
         assert_eq!(
-            session_task_group.child_count(),
-            1,
-            "only the connect-time child remains"
+            request_executor_group.child_count(),
+            0,
+            "completed request groups must be pruned"
         );
 
         let _ = shutdown_tx.send(());
@@ -1309,11 +1320,11 @@ mod tests {
         let delayed: Arc<std::sync::Mutex<Option<DelayedResponse>>> = Arc::new(std::sync::Mutex::new(None));
         let first_seen = Arc::new(tokio::sync::Notify::new());
         let second_seen = Arc::new(tokio::sync::Notify::new());
-        let session_task_group = Arc::new(std::sync::Mutex::new(None::<TaskGroup>));
+        let request_executor_group = Arc::new(std::sync::Mutex::new(None::<TaskGroup>));
         let delayed_for_hook = delayed.clone();
         let first_seen_for_hook = first_seen.clone();
         let second_seen_for_hook = second_seen.clone();
-        let session_task_group_for_hook = session_task_group.clone();
+        let request_executor_group_for_hook = request_executor_group.clone();
         let hook: TestRequestHook = Arc::new(
             move |code, opaque, channel, task_group, deferred_response| match opaque {
                 81 => {
@@ -1321,7 +1332,9 @@ mod tests {
                         code,
                         rocketmq_protocol::code::request_code::RequestCode::SendMessage as i32
                     );
-                    *session_task_group_for_hook.lock().expect("session task group lock") = Some(task_group);
+                    *request_executor_group_for_hook
+                        .lock()
+                        .expect("request executor group lock") = Some(task_group);
                     *delayed_for_hook.lock().expect("delayed response lock") =
                         Some((channel.channel_id().to_owned(), deferred_response));
                     first_seen_for_hook.notify_one();
@@ -1397,12 +1410,12 @@ mod tests {
             .expect("control response frame")
             .expect("control response command");
         assert_eq!(control_response.opaque(), 82);
-        let retained_session_task_group = session_task_group
+        let retained_request_executor_group = request_executor_group
             .lock()
-            .expect("session task group lock")
+            .expect("request executor group lock")
             .clone()
-            .expect("session task group");
-        let retained_stats = retained_session_task_group.child_stats();
+            .expect("request executor group");
+        let retained_stats = retained_request_executor_group.child_stats();
         assert_eq!(retained_stats.active, 1);
         assert_eq!(retained_stats.created, 2);
         assert_eq!(retained_stats.pruned, 1);
@@ -1435,7 +1448,7 @@ mod tests {
             ),
         )
         .await;
-        let released_stats = retained_session_task_group.child_stats();
+        let released_stats = retained_request_executor_group.child_stats();
         assert_eq!(released_stats.active, 0);
         assert_eq!(released_stats.created, 2);
         assert_eq!(released_stats.pruned, 2);

--- a/rocketmq-transport/src/request_ordering.rs
+++ b/rocketmq-transport/src/request_ordering.rs
@@ -1,0 +1,179 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::Weak;
+
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+
+/// Opaque, low-cost identity for requests that must execute in arrival order.
+///
+/// Ordering is scoped to one transport session. A hash collision can only
+/// serialize additional work; it cannot allow ordered work to overlap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RequestOrderingKey(u64);
+
+impl RequestOrderingKey {
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Declares whether a request can execute concurrently within its session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RequestOrdering {
+    #[default]
+    Concurrent,
+    Ordered(RequestOrderingKey),
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct RequestSequencer {
+    locks: Arc<DashMap<RequestOrderingKey, Weak<tokio::sync::Mutex<()>>>>,
+}
+
+impl RequestSequencer {
+    pub(crate) async fn acquire(&self, ordering: RequestOrdering) -> RequestOrderingGuard {
+        let RequestOrdering::Ordered(key) = ordering else {
+            return RequestOrderingGuard::concurrent();
+        };
+
+        let lock = match self.locks.entry(key) {
+            Entry::Occupied(mut entry) => {
+                if let Some(lock) = entry.get().upgrade() {
+                    lock
+                } else {
+                    let lock = Arc::new(tokio::sync::Mutex::new(()));
+                    entry.insert(Arc::downgrade(&lock));
+                    lock
+                }
+            }
+            Entry::Vacant(entry) => {
+                let lock = Arc::new(tokio::sync::Mutex::new(()));
+                entry.insert(Arc::downgrade(&lock));
+                lock
+            }
+        };
+        let guard = lock.clone().lock_owned().await;
+        RequestOrderingGuard {
+            key: Some(key),
+            lock: Some(lock),
+            guard: Some(guard),
+            locks: Some(self.locks.clone()),
+        }
+    }
+
+    #[cfg(test)]
+    fn retained_key_count(&self) -> usize {
+        self.locks.len()
+    }
+}
+
+pub(crate) struct RequestOrderingGuard {
+    key: Option<RequestOrderingKey>,
+    lock: Option<Arc<tokio::sync::Mutex<()>>>,
+    guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    locks: Option<Arc<DashMap<RequestOrderingKey, Weak<tokio::sync::Mutex<()>>>>>,
+}
+
+impl RequestOrderingGuard {
+    fn concurrent() -> Self {
+        Self {
+            key: None,
+            lock: None,
+            guard: None,
+            locks: None,
+        }
+    }
+}
+
+impl Drop for RequestOrderingGuard {
+    fn drop(&mut self) {
+        self.guard.take();
+        let Some(lock) = self.lock.take() else {
+            return;
+        };
+        let Some(key) = self.key else {
+            return;
+        };
+        let Some(locks) = self.locks.as_ref() else {
+            return;
+        };
+        let owned_lock = Arc::downgrade(&lock);
+        drop(lock);
+        locks.remove_if(&key, |_, current| {
+            Weak::ptr_eq(current, &owned_lock) && current.strong_count() == 0
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn equal_keys_are_serialized_and_unrelated_keys_are_independent() {
+        let sequencer = RequestSequencer::default();
+        let key = RequestOrderingKey::new(7);
+        let first = sequencer.acquire(RequestOrdering::Ordered(key)).await;
+
+        let same_key_entered = Arc::new(tokio::sync::Notify::new());
+        let same_key_sequencer = sequencer.clone();
+        let same_key_signal = same_key_entered.clone();
+        let same_key = tokio::spawn(async move {
+            let _guard = same_key_sequencer.acquire(RequestOrdering::Ordered(key)).await;
+            same_key_signal.notify_one();
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), same_key_entered.notified())
+                .await
+                .is_err()
+        );
+
+        let unrelated = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            sequencer.acquire(RequestOrdering::Ordered(RequestOrderingKey::new(8))),
+        )
+        .await
+        .expect("unrelated key must not wait");
+        drop(unrelated);
+
+        drop(first);
+        tokio::time::timeout(std::time::Duration::from_secs(1), same_key_entered.notified())
+            .await
+            .expect("same key proceeds after predecessor");
+        same_key.await.expect("same-key task");
+    }
+
+    #[tokio::test]
+    async fn completed_keys_do_not_accumulate_in_the_sequencer() {
+        let sequencer = RequestSequencer::default();
+        let completed = AtomicUsize::new(0);
+        for key in 0..128 {
+            let guard = sequencer
+                .acquire(RequestOrdering::Ordered(RequestOrderingKey::new(key)))
+                .await;
+            completed.fetch_add(1, Ordering::Relaxed);
+            drop(guard);
+        }
+
+        assert_eq!(completed.load(Ordering::Relaxed), 128);
+        assert_eq!(sequencer.retained_key_count(), 0);
+    }
+}

--- a/rocketmq-transport/src/runtime/processor.rs
+++ b/rocketmq-transport/src/runtime/processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::net::channel::Channel;
+use crate::request_ordering::RequestOrdering;
 use crate::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
@@ -31,5 +32,13 @@ pub trait LocalRequestProcessor {
 
     fn reject_request(&self, _code: i32) -> RejectRequestResponse {
         (false, None)
+    }
+
+    /// Declares the per-session execution ordering required by this request.
+    ///
+    /// Requests are concurrent by default. Implementations should return an
+    /// ordered key only when their domain contract requires arrival ordering.
+    fn request_ordering(&self, _request: &RemotingCommand) -> RequestOrdering {
+        RequestOrdering::Concurrent
     }
 }

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -47,8 +48,6 @@ use rocketmq_security_api::ResourceKind;
 
 use crate::admission::AdmissionClass;
 use crate::admission::AdmissionController;
-use crate::admission::AdmissionError;
-use crate::admission::AdmissionPermit;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
 use crate::admission::FullPolicy;
@@ -59,7 +58,10 @@ use crate::connection::ConnectionId;
 use crate::connection::ConnectionState;
 use crate::connection::QueuedWrite;
 use crate::connection::SessionLifecycle;
+use crate::request_ordering::RequestOrdering;
 use crate::security::TransportSecurity;
+use crate::session_executor::SessionDispatchError;
+use crate::session_executor::SessionExecutor;
 use crate::tls::TlsServerRuntime;
 
 const SESSION_WRITER_QUEUE_CAPACITY: usize = 1024;
@@ -70,6 +72,10 @@ pub trait RequestProcessor: Send + Sync + 'static {
         &self,
         request: RemotingCommand,
     ) -> Pin<Box<dyn Future<Output = RocketMQResult<RemotingCommand>> + Send + '_>>;
+
+    fn request_ordering(&self, _request: &RemotingCommand) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
 }
 
 #[derive(Clone)]
@@ -84,6 +90,7 @@ pub struct SessionHandle {
     state_tx: tokio::sync::watch::Sender<ConnectionState>,
     state_rx: tokio::sync::watch::Receiver<ConnectionState>,
     task_group: TaskGroup,
+    request_executor_group: TaskGroup,
     response_class: Option<AdmissionClass>,
     lifecycle: Arc<SessionLifecycle>,
     writer_task_id: TaskId,
@@ -119,8 +126,17 @@ impl SessionHandle {
         &self.task_group
     }
 
+    pub(crate) fn request_executor_group(&self) -> &TaskGroup {
+        &self.request_executor_group
+    }
+
     fn with_response_class(mut self, class: AdmissionClass) -> Self {
         self.response_class = Some(class);
+        self
+    }
+
+    pub(crate) fn with_task_group(mut self, task_group: TaskGroup) -> Self {
+        self.task_group = task_group;
         self
     }
 
@@ -211,6 +227,10 @@ impl SessionHandle {
 
 pub trait ConnectionHandler: Send + Sync + 'static {
     fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+    fn request_ordering(&self, _command: &RemotingCommand) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
 
     fn command(
         &self,
@@ -374,27 +394,26 @@ async fn run_framed_session<H>(
 {
     let connection_id = connection.connection_id().clone();
     let (mut sink, mut stream) = connection.into_framed_parts();
+    let executor = match SessionExecutor::try_new(&task_group, admission.clone(), scope) {
+        Ok(executor) => executor,
+        Err(_) => return,
+    };
     let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
     let lifecycle = Arc::new(SessionLifecycle::new());
     let (writer, mut writes) = tokio::sync::mpsc::channel(SESSION_WRITER_QUEUE_CAPACITY);
-    let writer_cancellation = task_group.cancellation_token();
     let writer_state = state_tx.clone();
     let writer_group = task_group.clone();
     let writer_task_id = match writer_group.spawn("rocketmq.transport.session.writer", TaskKind::Worker, async move {
-        loop {
-            let next = tokio::select! {
-                () = writer_cancellation.cancelled() => break,
-                next = writes.recv() => next,
-            };
+        while let Some(next) = writes.recv().await {
             match next {
-                Some(QueuedWrite::Data {
+                QueuedWrite::Data {
                     bytes,
                     completion,
                     _permit,
                     deadline,
                     target,
                     progress,
-                }) => {
+                } => {
                     let result = match deadline {
                         Some(deadline) if deadline.is_expired() => {
                             Err(RocketMQError::network_deadline_exceeded_before_send(target))
@@ -420,12 +439,11 @@ async fn run_framed_session<H>(
                         break;
                     }
                 }
-                Some(QueuedWrite::Close { completion }) => {
+                QueuedWrite::Close { completion } => {
                     let result = sink.close().await;
                     let _ = completion.send(result);
                     break;
                 }
-                None => break,
             }
         }
     }) {
@@ -443,6 +461,7 @@ async fn run_framed_session<H>(
         state_tx: state_tx.clone(),
         state_rx,
         task_group: task_group.clone(),
+        request_executor_group: executor.task_group().clone(),
         response_class: None,
         lifecycle,
         writer_task_id,
@@ -482,10 +501,35 @@ async fn run_framed_session<H>(
                 .await;
             continue;
         }
-        let admission_permits = acquire_framed_request(&admission, scope, bytes, class);
-        let _admission_permits = match admission_permits {
-            Ok(permits) => permits,
-            Err(error) if error.policy() == FullPolicy::Reject => {
+        let ordering = handler.request_ordering(&command);
+        let opaque = command.opaque();
+        let request_handler = handler.clone();
+        let request_session = session.clone().with_response_class(class);
+        let rejection_session = session.clone().with_response_class(class);
+        match executor.try_execute(
+            bytes,
+            class,
+            ordering,
+            move |request_group| async move {
+                request_handler
+                    .command(request_session.with_task_group(request_group), command)
+                    .await;
+            },
+            move |_request_group, error| async move {
+                let mut connection = rejection_session.connection();
+                let _ = connection
+                    .send_command(
+                        RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SystemBusy,
+                            error.to_string(),
+                        )
+                        .set_opaque(opaque),
+                    )
+                    .await;
+            },
+        ) {
+            Ok(_) => {}
+            Err(SessionDispatchError::Admission(error)) if error.policy() == FullPolicy::Reject => {
                 let mut connection = session.clone().with_response_class(class).connection();
                 let _ = connection
                     .send_command(
@@ -493,17 +537,18 @@ async fn run_framed_session<H>(
                             ResponseCode::SystemBusy,
                             error.to_string(),
                         )
-                        .set_opaque(command.opaque()),
+                        .set_opaque(opaque),
                     )
                     .await;
                 continue;
             }
-            Err(_) => break,
-        };
-        handler
-            .command(session.clone().with_response_class(class), command)
-            .await;
+            Err(SessionDispatchError::Admission(_)) | Err(SessionDispatchError::Closing(_)) => break,
+        }
     }
+    let request_deadline = task_group
+        .shutdown_deadline()
+        .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
+    executor.drain_until(request_deadline).await.log_if_unhealthy();
     handler.disconnected(session.clone()).await;
     let (completion, closed) = tokio::sync::oneshot::channel();
     let _ = writer.send(QueuedWrite::Close { completion }).await;
@@ -546,25 +591,6 @@ pub async fn run_connected_session<H>(
     .await;
 }
 
-struct FramedRequestAdmission {
-    _inflight: AdmissionPermit,
-    _processor: AdmissionPermit,
-}
-
-fn acquire_framed_request(
-    admission: &AdmissionController,
-    scope: AdmissionScope,
-    bytes: usize,
-    class: AdmissionClass,
-) -> Result<FramedRequestAdmission, AdmissionError> {
-    let inflight = admission.try_acquire(AdmissionResource::Inflight, scope, bytes, class)?;
-    let processor = admission.try_acquire(AdmissionResource::Processor, scope, bytes, class)?;
-    Ok(FramedRequestAdmission {
-        _inflight: inflight,
-        _processor: processor,
-    })
-}
-
 async fn accept_transport_connection(
     listener: &tokio::net::TcpListener,
 ) -> RocketMQResult<(tokio::net::TcpStream, SocketAddr)> {
@@ -602,13 +628,63 @@ pub struct TransportServer {
     tls: TlsServerRuntime,
     started: AtomicBool,
     next_session: AtomicU64,
+    active_sessions: AtomicUsize,
     security: Arc<TransportSecurity>,
     principal: Option<Principal>,
 }
 
-struct RequestAdmission {
-    _inflight: AdmissionPermit,
-    _processor: AdmissionPermit,
+struct ActiveSessionGuard {
+    server: Arc<TransportServer>,
+}
+
+impl ActiveSessionGuard {
+    fn new(server: Arc<TransportServer>) -> Self {
+        server.active_sessions.fetch_add(1, Ordering::AcqRel);
+        Self { server }
+    }
+}
+
+impl Drop for ActiveSessionGuard {
+    fn drop(&mut self) {
+        self.server.active_sessions.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct ProcessorSessionHandler {
+    processor: Arc<dyn RequestProcessor>,
+    request_timeout: Duration,
+    session_group: TaskGroup,
+}
+
+impl ConnectionHandler for ProcessorSessionHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        self.processor.request_ordering(request)
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let processor = self.processor.clone();
+        let request_timeout = self.request_timeout;
+        let session_group = self.session_group.clone();
+        Box::pin(async move {
+            let response = match tokio::time::timeout(request_timeout, processor.process(request)).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(_)) | Err(_) => {
+                    session_group.cancel();
+                    return;
+                }
+            };
+            let mut connection = session.connection();
+            let _ = connection.send_command(response).await;
+        })
+    }
 }
 
 impl TransportServer {
@@ -650,6 +726,7 @@ impl TransportServer {
             tls,
             started: AtomicBool::new(false),
             next_session: AtomicU64::new(1),
+            active_sessions: AtomicUsize::new(0),
             security,
             principal,
         }))
@@ -694,14 +771,25 @@ impl TransportServer {
                     drop(stream);
                     continue;
                 };
+                let session_lease = match server
+                    .service_context
+                    .task_group()
+                    .try_child_lease("rocketmq.transport.session")
+                {
+                    Ok(lease) => lease,
+                    Err(_) => break,
+                };
+                let session_group = session_lease.group().clone();
                 let session = server.clone();
-                let session_context = server.service_context.clone();
-                let session_task_context = session_context.clone();
-                if session_context
-                    .spawn_service("transport.session", async move {
+                let active_session = ActiveSessionGuard::new(server.clone());
+                let spawn_group = session_group.clone();
+                if spawn_group
+                    .spawn("rocketmq.transport.session", TaskKind::Service, async move {
+                        let _active_session = active_session;
+                        let _session_lease = session_lease;
                         let _connection_permit = connection_permit;
                         session
-                            .run_session(stream, remote_addr, session_id, session_task_context)
+                            .run_session(stream, remote_addr, session_id, session_group)
                             .await;
                     })
                     .is_err()
@@ -718,7 +806,7 @@ impl TransportServer {
         stream: tokio::net::TcpStream,
         remote_addr: SocketAddr,
         session_id: u64,
-        session_context: ChildServiceContext,
+        session_group: TaskGroup,
     ) {
         let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
         let Ok(_handshake_permit) = self.admission.try_acquire(
@@ -730,120 +818,46 @@ impl TransportServer {
             return;
         };
         let handshake_deadline = tokio::time::Instant::now() + self.config.handshake_timeout;
-        let Ok(Some(negotiated)) =
-            tokio::time::timeout_at(handshake_deadline, self.tls.negotiate_connection(stream, remote_addr)).await
-        else {
+        let handshake_cancellation = session_group.cancellation_token();
+        let negotiated = tokio::select! {
+            () = handshake_cancellation.cancelled() => return,
+            negotiated =
+                tokio::time::timeout_at(handshake_deadline, self.tls.negotiate_connection(stream, remote_addr)) =>
+                negotiated,
+        };
+        let Ok(Some(negotiated)) = negotiated else {
             return;
         };
         let (connection, peer_is_tls) = negotiated.into_parts();
-        let mut connection = connection.into_session_connection();
         drop(_handshake_permit);
-
-        loop {
-            let request_deadline = tokio::time::Instant::now() + self.config.request_timeout;
-            let (request, bytes) =
-                match tokio::time::timeout_at(request_deadline, connection.receive_command_with_retained_bytes()).await
-                {
-                    Ok(Some(Ok(request))) => request,
-                    Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
-                };
-            let peer = PeerInfo::new(remote_addr, peer_is_tls);
-            let decision = self.security.authorize(
-                &request,
-                Some(&peer),
-                self.principal.as_ref(),
-                Resource::new(ResourceKind::Other, request.code().to_string()),
-                Action::Manage,
-            );
-            if let Decision::Deny { reason } = decision {
-                let denied = RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::NoPermission,
-                    reason.to_string(),
-                )
-                .set_opaque(request.opaque());
-                if tokio::time::timeout_at(request_deadline, connection.send_command(denied))
-                    .await
-                    .ok()
-                    .and_then(Result::ok)
-                    .is_none()
-                {
-                    break;
-                }
-                continue;
-            }
-            let class = AdmissionClass::for_request_code(request.code());
-            let _admission = match self.acquire_request(scope, bytes, class) {
-                Ok(admission) => admission,
-                Err(error) => {
-                    if error.policy() == FullPolicy::CloseSlowConsumer {
-                        break;
-                    }
-                    let rejection = RemotingCommand::create_response_command_with_code_remark(
-                        ResponseCode::SystemBusy,
-                        error.to_string(),
-                    )
-                    .set_opaque(request.opaque());
-                    if tokio::time::timeout_at(request_deadline, connection.send_command(rejection))
-                        .await
-                        .ok()
-                        .and_then(Result::ok)
-                        .is_none()
-                    {
-                        break;
-                    }
-                    continue;
-                }
-            };
-            let (sender, receiver) = tokio::sync::oneshot::channel();
-            let processor = self.processor.clone();
-            let processor_context = session_context.clone();
-            let processor_task = match processor_context.spawn_service("transport.processor", async move {
-                let _ = sender.send(processor.process(request).await);
-            }) {
-                Ok(task_id) => task_id,
-                Err(_) => break,
-            };
-            let response = match tokio::time::timeout_at(request_deadline, receiver).await {
-                Ok(Ok(Ok(response))) => response,
-                Ok(Ok(Err(_))) | Ok(Err(_)) | Err(_) => {
-                    processor_context.task_group().abort_task(processor_task);
-                    break;
-                }
-            };
-            if tokio::time::timeout_at(request_deadline, connection.send_command(response))
-                .await
-                .ok()
-                .and_then(Result::ok)
-                .is_none()
-            {
-                break;
-            }
-        }
-        let _ = connection.shutdown().await;
+        run_framed_session(
+            connection,
+            self.local_addr,
+            remote_addr,
+            session_id,
+            scope,
+            session_group.clone(),
+            self.admission.clone(),
+            self.security.clone(),
+            self.principal.clone(),
+            peer_is_tls,
+            self.config.request_timeout,
+            Arc::new(ProcessorSessionHandler {
+                processor: self.processor.clone(),
+                request_timeout: self.config.request_timeout,
+                session_group,
+            }),
+        )
+        .await;
     }
 
-    fn acquire_request(
-        &self,
-        scope: AdmissionScope,
-        bytes: usize,
-        class: AdmissionClass,
-    ) -> Result<RequestAdmission, AdmissionError> {
-        let inflight = self
-            .admission
-            .try_acquire(AdmissionResource::Inflight, scope, bytes, class)?;
-        let processor = self
-            .admission
-            .try_acquire(AdmissionResource::Processor, scope, bytes, class)?;
-        Ok(RequestAdmission {
-            _inflight: inflight,
-            _processor: processor,
-        })
-    }
-
-    /// Returns the number of currently owned accept, session, and processor tasks.
+    /// Returns the number of top-level tasks and active session owners.
     #[must_use]
     pub fn live_task_count(&self) -> usize {
-        self.service_context.task_group().task_count()
+        self.service_context
+            .task_group()
+            .task_count()
+            .saturating_add(self.active_sessions.load(Ordering::Acquire))
     }
 
     /// Returns the number of child ownership groups retained by the server.

--- a/rocketmq-transport/src/session_executor.rs
+++ b/rocketmq-transport/src/session_executor.rs
@@ -1,0 +1,175 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::RuntimeResult;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskGroupChildLease;
+use rocketmq_runtime::TaskId;
+use rocketmq_runtime::TaskKind;
+
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionError;
+use crate::admission::AdmissionResource;
+use crate::admission::AdmissionScope;
+use crate::request_ordering::RequestOrdering;
+use crate::request_ordering::RequestSequencer;
+
+/// Error returned before a request can enter its session-owned execution task.
+#[derive(Debug)]
+pub(crate) enum SessionDispatchError {
+    Admission(AdmissionError),
+    Closing(RuntimeError),
+}
+
+impl fmt::Display for SessionDispatchError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Admission(error) => error.fmt(formatter),
+            Self::Closing(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SessionDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Admission(error) => Some(error),
+            Self::Closing(error) => Some(error),
+        }
+    }
+}
+
+impl From<AdmissionError> for SessionDispatchError {
+    fn from(error: AdmissionError) -> Self {
+        Self::Admission(error)
+    }
+}
+
+impl From<RuntimeError> for SessionDispatchError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Closing(error)
+    }
+}
+
+/// Owns bounded request tasks for one transport session.
+///
+/// A request first reserves queued and in-flight capacity. Its task then waits
+/// for any declared ordering predecessor, converts queued capacity into a
+/// processor permit, and runs under a dynamically registered child task group.
+pub(crate) struct SessionExecutor {
+    admission: Arc<AdmissionController>,
+    scope: AdmissionScope,
+    request_group: TaskGroup,
+    _request_group_lease: TaskGroupChildLease,
+    sequencer: RequestSequencer,
+    accepting: AtomicBool,
+}
+
+impl SessionExecutor {
+    pub(crate) fn try_new(
+        session_group: &TaskGroup,
+        admission: Arc<AdmissionController>,
+        scope: AdmissionScope,
+    ) -> RuntimeResult<Self> {
+        let request_group_lease = session_group.try_child_lease("rocketmq.transport.session.request-executor")?;
+        Ok(Self {
+            admission,
+            scope,
+            request_group: request_group_lease.group().clone(),
+            _request_group_lease: request_group_lease,
+            sequencer: RequestSequencer::default(),
+            accepting: AtomicBool::new(true),
+        })
+    }
+
+    pub(crate) fn try_execute<F, Fut, R, Rejected>(
+        &self,
+        retained_bytes: usize,
+        class: AdmissionClass,
+        ordering: RequestOrdering,
+        execute: F,
+        reject: R,
+    ) -> Result<TaskId, SessionDispatchError>
+    where
+        F: FnOnce(TaskGroup) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+        R: FnOnce(TaskGroup, AdmissionError) -> Rejected + Send + 'static,
+        Rejected: Future<Output = ()> + Send + 'static,
+    {
+        if !self.accepting.load(Ordering::Acquire) {
+            return Err(SessionDispatchError::Closing(RuntimeError::TaskGroupClosing {
+                group_id: self.request_group.id(),
+                group_name: self.request_group.name().into(),
+            }));
+        }
+        let request_lease = self
+            .request_group
+            .try_child_lease("rocketmq.transport.session.request")?;
+        let queued = self
+            .admission
+            .try_acquire(AdmissionResource::Queued, self.scope, retained_bytes, class)?;
+        let inflight = self
+            .admission
+            .try_acquire(AdmissionResource::Inflight, self.scope, retained_bytes, class)?;
+        let admission = self.admission.clone();
+        let scope = self.scope;
+        let sequencer = self.sequencer.clone();
+        let request_group = request_lease.group().clone();
+        let spawn_group = request_group.clone();
+        spawn_group
+            .spawn("rocketmq.transport.session.request", TaskKind::Worker, async move {
+                let _request_lease = request_lease;
+                let ordering_guard = sequencer.acquire(ordering).await;
+                let processor = match admission.try_acquire(AdmissionResource::Processor, scope, retained_bytes, class)
+                {
+                    Ok(processor) => processor,
+                    Err(error) => {
+                        drop(ordering_guard);
+                        drop(queued);
+                        reject(request_group, error).await;
+                        return;
+                    }
+                };
+                drop(queued);
+                let _inflight = inflight;
+                let _processor = processor;
+                let _ordering_guard = ordering_guard;
+                execute(request_group).await;
+            })
+            .map_err(SessionDispatchError::Closing)
+    }
+
+    fn stop_admission(&self) {
+        self.accepting.store(false, Ordering::Release);
+    }
+
+    pub(crate) fn task_group(&self) -> &TaskGroup {
+        &self.request_group
+    }
+
+    pub(crate) async fn drain_until(&self, deadline: ShutdownDeadline) -> ShutdownReport {
+        self.stop_admission();
+        self.request_group.shutdown_until(deadline).await
+    }
+}

--- a/rocketmq-transport/tests/session_concurrency.rs
+++ b/rocketmq-transport/tests/session_concurrency.rs
@@ -1,0 +1,426 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_transport::run_connected_session;
+use rocketmq_transport::AdmissionController;
+use rocketmq_transport::AdmissionLimits;
+use rocketmq_transport::Connection;
+use rocketmq_transport::ConnectionHandler;
+use rocketmq_transport::RequestOrdering;
+use rocketmq_transport::RequestOrderingKey;
+use rocketmq_transport::ResourceLimit;
+use rocketmq_transport::SessionHandle;
+use rocketmq_transport::TransportSecurity;
+use tokio::sync::mpsc;
+use tokio::sync::Notify;
+use tokio::sync::Semaphore;
+
+const ORDERED_FIRST: i32 = 40_001;
+const ORDERED_SECOND: i32 = 40_002;
+const UNRELATED: i32 = 40_003;
+const ORDERING_KEY: RequestOrderingKey = RequestOrderingKey::new(17);
+
+type SessionRunner = tokio::task::JoinHandle<()>;
+
+async fn start_session<H>(
+    name: &'static str,
+    limits: AdmissionLimits,
+    handler: Arc<H>,
+) -> (RuntimeContext, ChildServiceContext, Connection, SessionRunner)
+where
+    H: ConnectionHandler,
+{
+    let runtime = RuntimeContext::from_current(name);
+    let service = runtime.service_context(name);
+    let (transport, peer) = tokio::io::duplex(64 * 1024);
+    let local_addr: SocketAddr = "127.0.0.1:19101".parse().expect("local address");
+    let remote_addr: SocketAddr = "127.0.0.1:19102".parse().expect("remote address");
+    let runner = tokio::spawn(run_connected_session(
+        Connection::new_with_stream(transport),
+        local_addr,
+        remote_addr,
+        service.task_group().clone(),
+        Arc::new(AdmissionController::new(limits)),
+        Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        None,
+        Duration::from_secs(30),
+        handler,
+    ));
+    (runtime, service, Connection::new_with_stream(peer), runner)
+}
+
+async fn finish_session(
+    runtime: RuntimeContext,
+    service: ChildServiceContext,
+    peer: Connection,
+    runner: SessionRunner,
+) {
+    drop(peer);
+    tokio::time::timeout(Duration::from_secs(1), runner)
+        .await
+        .expect("session runner should observe peer closure")
+        .expect("session runner should complete");
+    drop(service);
+    let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+async fn send_success(session: SessionHandle, request: RemotingCommand) {
+    let mut connection = session.connection();
+    connection
+        .send_command(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(request.opaque()),
+        )
+        .await
+        .expect("response should reach the session writer");
+}
+
+struct SlowDataHandler {
+    entered: Arc<Notify>,
+    release: Arc<Semaphore>,
+}
+
+impl ConnectionHandler for SlowDataHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let entered = self.entered.clone();
+        let release = self.release.clone();
+        Box::pin(async move {
+            if request.code() == RequestCode::SendMessage.to_i32() {
+                entered.notify_one();
+                release
+                    .acquire()
+                    .await
+                    .expect("test release semaphore remains open")
+                    .forget();
+            }
+            send_success(session, request).await;
+        })
+    }
+}
+
+#[tokio::test]
+async fn reader_dispatches_control_while_a_data_request_is_running() {
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Semaphore::new(0));
+    let handler = Arc::new(SlowDataHandler {
+        entered: entered.clone(),
+        release: release.clone(),
+    });
+    let limits = AdmissionLimits {
+        processors: ResourceLimit {
+            count: 2,
+            bytes: 1024 * 1024,
+        },
+        control_reserve: ResourceLimit {
+            count: 1,
+            bytes: 1024 * 1024,
+        },
+        ..AdmissionLimits::default()
+    };
+    let (runtime, service, mut peer, runner) = start_session("session-control-progress", limits, handler).await;
+
+    peer.send_command(RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(1))
+        .await
+        .expect("send slow data request");
+    tokio::time::timeout(Duration::from_secs(1), entered.notified())
+        .await
+        .expect("data request should enter its processor");
+
+    peer.send_command(RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_opaque(2))
+        .await
+        .expect("send control request");
+    let control = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+        .await
+        .expect("control request should not wait for data")
+        .expect("session should remain open")
+        .expect("control response should decode");
+    assert_eq!(control.opaque(), 2);
+    assert_eq!(control.code(), ResponseCode::Success.to_i32());
+
+    release.add_permits(1);
+    let data = peer
+        .receive_command()
+        .await
+        .expect("session should remain open")
+        .expect("data response should decode");
+    assert_eq!(data.opaque(), 1);
+
+    finish_session(runtime, service, peer, runner).await;
+}
+
+struct BoundedDataHandler {
+    entered: mpsc::UnboundedSender<i32>,
+    release: Arc<Semaphore>,
+    active_data: AtomicUsize,
+    max_active_data: AtomicUsize,
+}
+
+impl ConnectionHandler for BoundedDataHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let entered = self.entered.clone();
+        let release = self.release.clone();
+        Box::pin(async move {
+            if request.code() == RequestCode::SendMessage.to_i32() {
+                let active = self.active_data.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_active_data.fetch_max(active, Ordering::SeqCst);
+                entered.send(request.opaque()).expect("test observer remains open");
+                release
+                    .acquire()
+                    .await
+                    .expect("test release semaphore remains open")
+                    .forget();
+                self.active_data.fetch_sub(1, Ordering::SeqCst);
+            }
+            send_success(session, request).await;
+        })
+    }
+}
+
+#[tokio::test]
+async fn processor_limit_rejects_excess_data_without_closing_the_session() {
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+    let release = Arc::new(Semaphore::new(0));
+    let handler = Arc::new(BoundedDataHandler {
+        entered: entered_tx,
+        release: release.clone(),
+        active_data: AtomicUsize::new(0),
+        max_active_data: AtomicUsize::new(0),
+    });
+    let limits = AdmissionLimits {
+        processors: ResourceLimit {
+            count: 3,
+            bytes: 1024 * 1024,
+        },
+        control_reserve: ResourceLimit {
+            count: 1,
+            bytes: 1024 * 1024,
+        },
+        ..AdmissionLimits::default()
+    };
+    let (runtime, service, mut peer, runner) = start_session("session-processor-bound", limits, handler.clone()).await;
+
+    for opaque in 1..=2 {
+        peer.send_command(RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(opaque))
+            .await
+            .expect("send admitted data request");
+    }
+    let first = entered_rx.recv().await.expect("first request should enter");
+    let second = entered_rx.recv().await.expect("second request should enter");
+    assert_eq!(HashSet::from([first, second]), HashSet::from([1, 2]));
+
+    peer.send_command(RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(3))
+        .await
+        .expect("send overloaded data request");
+    let rejection = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+        .await
+        .expect("overload should return a bounded response")
+        .expect("overload should not close the session")
+        .expect("overload response should decode");
+    assert_eq!(rejection.opaque(), 3);
+    assert_eq!(rejection.code(), ResponseCode::SystemBusy.to_i32());
+
+    peer.send_command(RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_opaque(4))
+        .await
+        .expect("send reserved control request");
+    let control = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+        .await
+        .expect("control reserve should remain responsive")
+        .expect("session should remain open")
+        .expect("control response should decode");
+    assert_eq!(control.opaque(), 4);
+    assert_eq!(control.code(), ResponseCode::Success.to_i32());
+
+    release.add_permits(2);
+    let mut completed = HashSet::new();
+    for _ in 0..2 {
+        let response = peer
+            .receive_command()
+            .await
+            .expect("session should remain open")
+            .expect("data response should decode");
+        completed.insert(response.opaque());
+    }
+    assert_eq!(completed, HashSet::from([1, 2]));
+    assert_eq!(handler.max_active_data.load(Ordering::SeqCst), 2);
+
+    finish_session(runtime, service, peer, runner).await;
+}
+
+struct OrderingHandler {
+    entered: mpsc::UnboundedSender<i32>,
+    release_first: Arc<Semaphore>,
+}
+
+impl ConnectionHandler for OrderingHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        match request.code() {
+            ORDERED_FIRST | ORDERED_SECOND => RequestOrdering::Ordered(ORDERING_KEY),
+            _ => RequestOrdering::Concurrent,
+        }
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let entered = self.entered.clone();
+        let release_first = self.release_first.clone();
+        Box::pin(async move {
+            entered.send(request.code()).expect("test observer remains open");
+            if request.code() == ORDERED_FIRST {
+                release_first
+                    .acquire()
+                    .await
+                    .expect("test release semaphore remains open")
+                    .forget();
+            }
+            send_success(session, request).await;
+        })
+    }
+}
+
+#[tokio::test]
+async fn explicit_ordering_serializes_one_key_without_blocking_unrelated_work() {
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+    let release_first = Arc::new(Semaphore::new(0));
+    let handler = Arc::new(OrderingHandler {
+        entered: entered_tx,
+        release_first: release_first.clone(),
+    });
+    let (runtime, service, mut peer, runner) =
+        start_session("session-request-ordering", AdmissionLimits::default(), handler).await;
+
+    peer.send_command(RemotingCommand::create_remoting_command(ORDERED_FIRST).set_opaque(1))
+        .await
+        .expect("send first ordered request");
+    assert_eq!(entered_rx.recv().await, Some(ORDERED_FIRST));
+
+    peer.send_command(RemotingCommand::create_remoting_command(ORDERED_SECOND).set_opaque(2))
+        .await
+        .expect("send second ordered request");
+    peer.send_command(RemotingCommand::create_remoting_command(UNRELATED).set_opaque(3))
+        .await
+        .expect("send unrelated request");
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), entered_rx.recv())
+            .await
+            .expect("unrelated work should enter"),
+        Some(UNRELATED)
+    );
+    let unrelated = peer
+        .receive_command()
+        .await
+        .expect("session should remain open")
+        .expect("unrelated response should decode");
+    assert_eq!(unrelated.opaque(), 3);
+
+    release_first.add_permits(1);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), entered_rx.recv())
+            .await
+            .expect("second ordered request should follow its predecessor"),
+        Some(ORDERED_SECOND)
+    );
+    let first = peer
+        .receive_command()
+        .await
+        .expect("session should remain open")
+        .expect("first ordered response should decode");
+    let second = peer
+        .receive_command()
+        .await
+        .expect("session should remain open")
+        .expect("second ordered response should decode");
+    assert_eq!((first.opaque(), second.opaque()), (1, 2));
+
+    finish_session(runtime, service, peer, runner).await;
+}
+
+#[tokio::test]
+async fn shutdown_drains_accepted_requests_before_flushing_and_closing_writer() {
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Semaphore::new(0));
+    let handler = Arc::new(SlowDataHandler {
+        entered: entered.clone(),
+        release: release.clone(),
+    });
+    let (runtime, service, mut peer, runner) =
+        start_session("session-graceful-drain", AdmissionLimits::default(), handler).await;
+
+    peer.send_command(RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(9))
+        .await
+        .expect("send request before shutdown");
+    tokio::time::timeout(Duration::from_secs(1), entered.notified())
+        .await
+        .expect("accepted request should enter");
+
+    service.task_group().cancel();
+    release.add_permits(1);
+
+    let response = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+        .await
+        .expect("accepted request should drain")
+        .expect("writer should remain open while draining")
+        .expect("drained response should decode");
+    assert_eq!(response.opaque(), 9);
+    assert!(tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+        .await
+        .expect("writer should close after its queue is flushed")
+        .is_none());
+    tokio::time::timeout(Duration::from_secs(1), runner)
+        .await
+        .expect("session runner should complete after writer closure")
+        .expect("session runner should not panic");
+
+    drop(peer);
+    drop(service);
+    let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8749

### Brief Description

- Add a session-owned executor that bounds queued, in-flight, and processor work without making the socket reader await request handlers.
- Preserve a single serialized writer, drain accepted request tasks before closing it, and give compatibility server connections independent task-group ownership.
- Add explicit per-session request ordering keys and Broker policies for client lifecycle, sends, offsets, and transactions while keeping unrelated requests concurrent.
- Remove the duplicate sequential session connection path and align remoting task-group diagnostics with the new request executor hierarchy.
- Add deterministic concurrency, overload, ordering, shutdown, and Broker policy coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --lib` (147 passed)
- `cargo test -p rocketmq-transport --test session_concurrency` (4 passed)
- `cargo test -p rocketmq-transport --test client_server_lifecycle` (10 passed)
- `CARGO_PROFILE_TEST_DEBUG=1 cargo test -p rocketmq-broker --lib request_ordering` (4 passed)
- `CARGO_PROFILE_TEST_DEBUG=1 cargo test -p rocketmq-broker --lib broker_request_processor_delegates_session_ordering_policy` (1 passed)
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- Package-batched `cargo fmt ... -- --check` for all 29 root workspace packages; the one-shot `cargo fmt --all -- --check` is blocked by Windows error 206.
- Standalone local format and Clippy validation for `rocketmq-example`, `rocketmq-dashboard/rocketmq-dashboard-web/backend`, and `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`; the Web backend build also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request ordering to ensure related broker operations are processed sequentially while independent operations can run concurrently.
  - Improved request execution controls to support bounded processing and responsive control requests during busy periods.

- **Bug Fixes**
  - Enhanced session shutdown so accepted requests finish gracefully before connections close.
  - Improved handling of overloaded requests without unnecessarily terminating active sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->