### PR TITLE
[ISSUE #8751]♻️Add segmented frame encoding and bounded transport writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,6 +5121,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "cheetah-string",
+ "criterion",
  "dashmap",
  "flate2",
  "flume",

--- a/rocketmq-protocol/src/lib.rs
+++ b/rocketmq-protocol/src/lib.rs
@@ -26,6 +26,7 @@ pub use code::request_code::RequestCode;
 pub use code::response_code::RemotingSysResponseCode;
 pub use protocol::command_custom_header::CommandCustomHeader;
 pub use protocol::command_custom_header::FromMap;
+pub use protocol::encoded_frame::EncodedFrame;
 pub use protocol::remoting_command::RemotingCommand;
 pub use protocol::rocketmq_serializable;
 pub use rpc::rpc_request_header::RpcRequestHeader;

--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -33,6 +33,7 @@ pub mod bodies;
 pub mod body;
 pub mod broker_sync_info;
 pub mod command_custom_header;
+pub mod encoded_frame;
 pub mod filter;
 pub mod forbidden_type;
 pub mod header;
@@ -56,6 +57,7 @@ pub mod topic;
 pub use command_custom_header::CommandCustomHeader;
 pub use command_custom_header::FromMap;
 pub use data_version_compat as data_version_facade;
+pub use encoded_frame::EncodedFrame;
 pub use remoting_command::RemotingCommand;
 pub use remoting_command_compat as remoting_command_facade;
 

--- a/rocketmq-protocol/src/protocol/encoded_frame.rs
+++ b/rocketmq-protocol/src/protocol/encoded_frame.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
+
+use super::remoting_command::RemotingCommand;
+
+const FRAME_PREFIX_BYTES: usize = 8;
+const SERIALIZE_TYPE_BYTES: usize = 4;
+const MAX_HEADER_BYTES: usize = 0x00ff_ffff;
+
+/// Immutable RocketMQ wire frame split into prefix, serialized header, and body segments.
+///
+/// Keeping the body in its existing [`Bytes`] allocation lets plaintext transports use vectored
+/// writes without first copying the complete frame into a second contiguous buffer. The frame's
+/// exact [`Self::encoded_len`] is also available before transport staging or TLS aggregation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EncodedFrame {
+    prefix: [u8; FRAME_PREFIX_BYTES],
+    header: Bytes,
+    body: Bytes,
+}
+
+impl EncodedFrame {
+    /// Encodes a command into immutable wire segments.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error when the command header cannot be encoded, the header exceeds
+    /// RocketMQ's 24-bit header-length field, or the complete frame exceeds its signed 32-bit
+    /// length field.
+    pub fn from_command(mut command: RemotingCommand) -> RocketMQResult<Self> {
+        let mut encoded_header = BytesMut::new();
+        command.fast_header_encode(&mut encoded_header);
+        let body = command.take_body().unwrap_or_default();
+        if encoded_header.len() < FRAME_PREFIX_BYTES {
+            return Err(SerializationError::encode_failed(
+                "remoting-command",
+                "encoded header omitted the RocketMQ frame prefix",
+            )
+            .into());
+        }
+        let prefix_bytes = encoded_header.split_to(FRAME_PREFIX_BYTES);
+        let header = encoded_header.freeze();
+        if header.len() > MAX_HEADER_BYTES {
+            return Err(SerializationError::encode_failed(
+                "remoting-command",
+                format!(
+                    "encoded header is {} bytes, exceeding the 24-bit wire limit",
+                    header.len()
+                ),
+            )
+            .into());
+        }
+        let payload_len = SERIALIZE_TYPE_BYTES
+            .checked_add(header.len())
+            .and_then(|length| length.checked_add(body.len()))
+            .ok_or_else(|| SerializationError::encode_failed("remoting-command", "encoded frame length overflow"))?;
+        let total_len = i32::try_from(payload_len).map_err(|_| {
+            SerializationError::encode_failed(
+                "remoting-command",
+                format!("encoded payload is {payload_len} bytes, exceeding the signed 32-bit wire limit"),
+            )
+        })?;
+        let mut prefix = [0_u8; FRAME_PREFIX_BYTES];
+        prefix.copy_from_slice(&prefix_bytes);
+        let announced_total = i32::from_be_bytes([prefix[0], prefix[1], prefix[2], prefix[3]]);
+        let announced_header =
+            u32::from_be_bytes([prefix[4], prefix[5], prefix[6], prefix[7]]) & MAX_HEADER_BYTES as u32;
+        if announced_total != total_len || announced_header as usize != header.len() {
+            return Err(SerializationError::encode_failed(
+                "remoting-command",
+                "fast header encoder produced inconsistent wire lengths",
+            )
+            .into());
+        }
+        Ok(Self { prefix, header, body })
+    }
+
+    /// Returns the complete encoded wire size, including the four-byte total-length prefix.
+    #[inline]
+    #[must_use]
+    pub fn encoded_len(&self) -> usize {
+        FRAME_PREFIX_BYTES + self.header.len() + self.body.len()
+    }
+
+    /// Returns the immutable prefix, header, and body slices in wire order.
+    #[inline]
+    #[must_use]
+    pub fn segments(&self) -> [&[u8]; 3] {
+        [&self.prefix, self.header.as_ref(), self.body.as_ref()]
+    }
+
+    /// Appends the wire frame to a caller-owned contiguous buffer.
+    ///
+    /// This is intended for TLS record input and compatibility codecs. Plaintext transports should
+    /// preserve [`Self::segments`] through to vectored socket writes.
+    pub fn copy_to(&self, destination: &mut BytesMut) {
+        destination.reserve(self.encoded_len());
+        destination.put_slice(&self.prefix);
+        destination.put_slice(&self.header);
+        destination.put_slice(&self.body);
+    }
+
+    /// Materializes the complete frame as contiguous immutable bytes.
+    ///
+    /// Prefer [`Self::segments`] when the destination accepts vectored writes.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        let mut contiguous = BytesMut::with_capacity(self.encoded_len());
+        self.copy_to(&mut contiguous);
+        contiguous.freeze()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BufMut;
+    use bytes::Bytes;
+    use bytes::BytesMut;
+
+    use super::EncodedFrame;
+    use crate::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+    use crate::protocol::remoting_command::RemotingCommand;
+    use crate::protocol::SerializeType;
+
+    fn legacy_contiguous(mut command: RemotingCommand) -> Bytes {
+        let mut bytes = BytesMut::new();
+        command.fast_header_encode(&mut bytes);
+        if let Some(body) = command.take_body() {
+            bytes.put(body);
+        }
+        bytes.freeze()
+    }
+
+    #[test]
+    fn encoded_frame_matches_json_contiguous_encoding_byte_for_byte() {
+        let command = RemotingCommand::create_remoting_command(105)
+            .set_opaque(73)
+            .set_remark("segmented-json")
+            .set_command_custom_header(GetRouteInfoRequestHeader::new("json-topic", None))
+            .set_body(Bytes::from_static(b"json-body"));
+        let expected = legacy_contiguous(command.clone());
+        let frame = EncodedFrame::from_command(command).expect("JSON command should encode");
+
+        assert_eq!(frame.encoded_len(), expected.len());
+        assert_eq!(frame.into_bytes(), expected);
+    }
+
+    #[test]
+    fn encoded_frame_matches_rocketmq_contiguous_encoding_byte_for_byte() {
+        let command = RemotingCommand::create_remoting_command(106)
+            .set_opaque(74)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_command_custom_header(GetRouteInfoRequestHeader::new("binary-topic", Some(false)))
+            .set_body(Bytes::from_static(b"binary-body"));
+        let expected = legacy_contiguous(command.clone());
+        let frame = EncodedFrame::from_command(command).expect("RocketMQ command should encode");
+
+        assert_eq!(frame.encoded_len(), expected.len());
+        assert_eq!(frame.into_bytes(), expected);
+    }
+
+    #[test]
+    fn encoded_frame_exposes_prefix_header_and_body_without_coalescing() {
+        let body = Bytes::from_static(b"owned-body");
+        let frame = EncodedFrame::from_command(
+            RemotingCommand::create_remoting_command(107)
+                .set_opaque(75)
+                .set_body(body.clone()),
+        )
+        .expect("command should encode");
+        let [prefix, header, encoded_body] = frame.segments();
+
+        assert_eq!(prefix.len(), 8);
+        assert!(!header.is_empty());
+        assert_eq!(encoded_body, body.as_ref());
+        assert_eq!(frame.encoded_len(), prefix.len() + header.len() + encoded_body.len());
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -494,8 +494,9 @@ impl RemotingCommand {
         let estimated_header_size = self.estimate_json_header_size();
         let body_length = self.body.as_ref().map_or(0, |b| b.len());
 
-        // Reserve space upfront: 4 (total_length) + 4 (serialize_type) + estimated_header + body
-        dst.reserve(8 + estimated_header_size + body_length);
+        // Reserve only prefix + header. The body remains an independent `Bytes` segment for
+        // plaintext vectored writes and is coalesced later only by the TLS writer.
+        dst.reserve(8 + estimated_header_size);
 
         // Encode header using simd-json for better performance when available
         #[cfg(feature = "simd")]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_admin_cli::rocketmq_cli::RocketMQCli;
 use rocketmq_admin_core::client_adapter::ClientRuntime;
 use rocketmq_admin_core::client_adapter::ClientRuntimeConfig;

--- a/rocketmq-transport/Cargo.toml
+++ b/rocketmq-transport/Cargo.toml
@@ -71,9 +71,14 @@ tokio-rustls = { version = "0.26", optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
+criterion = { version = "0.8.2", features = ["async_tokio"] }
 serde_json.workspace = true
 tempfile = "3.27.0"
 tokio = { workspace = true, features = ["test-util"] }
+
+[[bench]]
+name = "frame_write"
+harness = false
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.186"

--- a/rocketmq-transport/benches/frame_write.rs
+++ b/rocketmq-transport/benches/frame_write.rs
@@ -1,0 +1,113 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::io;
+use std::io::IoSlice;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::FrameWriteMode;
+use rocketmq_transport::FrameWriter;
+use tokio::io::AsyncWrite;
+
+struct DiscardWriter;
+
+impl AsyncWrite for DiscardWriter {
+    fn poll_write(self: Pin<&mut Self>, _context: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buffer.len()))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum()))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn frame_with_body(body_bytes: usize) -> EncodedFrame {
+    EncodedFrame::from_command(
+        RemotingCommand::create_remoting_command(10_100)
+            .set_opaque(101)
+            .set_body(vec![0x5a; body_bytes]),
+    )
+    .expect("benchmark command should encode")
+}
+
+fn benchmark_frame_write(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime");
+    let mut group = c.benchmark_group("transport_frame_write");
+    for body_bytes in [128, 4 * 1024, 64 * 1024] {
+        let frame = frame_with_body(body_bytes);
+        group.throughput(Throughput::Bytes(frame.encoded_len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("plain_vectored", body_bytes),
+            &frame,
+            |benchmark, frame| {
+                benchmark.to_async(&runtime).iter(|| async {
+                    let mut writer = FrameWriter::plaintext(DiscardWriter);
+                    writer
+                        .write_frame(black_box(frame))
+                        .await
+                        .expect("discard plaintext write");
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("tls_coalesced", body_bytes),
+            &frame,
+            |benchmark, frame| {
+                benchmark.to_async(&runtime).iter(|| async {
+                    let mut writer = FrameWriter::new(
+                        DiscardWriter,
+                        FrameWriteMode::TlsCoalesced {
+                            max_plaintext_frame_bytes: frame.encoded_len(),
+                        },
+                    )
+                    .expect("bounded TLS writer");
+                    writer.write_frame(black_box(frame)).await.expect("discard TLS write");
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_frame_write);
+criterion_main!(benches);

--- a/rocketmq-transport/src/client.rs
+++ b/rocketmq-transport/src/client.rs
@@ -91,7 +91,7 @@ pub async fn connect_with_config(
                 .timeout(connect_tls_stream(stream, &server_name, tls_config))
                 .await
                 .map_err(|_| RocketMQError::network_connection_timeout(address, deadline.budget_millis()))??;
-            Connection::new_with_stream_and_limits(tls_stream, frame_limits)
+            Connection::new_with_tls_stream_and_limits(tls_stream, frame_limits)
         }
         #[cfg(not(feature = "tls"))]
         {

--- a/rocketmq-transport/src/codec/remoting_command_codec.rs
+++ b/rocketmq-transport/src/codec/remoting_command_codec.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::BufMut;
-use bytes::Bytes;
 use bytes::BytesMut;
-use tokio_util::codec::BytesCodec;
 use tokio_util::codec::Decoder;
 use tokio_util::codec::Encoder;
 
-use crate::error_helpers::encoder_error;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 /// A decoded command together with the complete frame size retained while processing it.
@@ -217,81 +214,28 @@ impl Encoder<RemotingCommand> for RemotingCommandCodec {
     ///
     /// This function will return an error if the encoding process fails.
     fn encode(&mut self, item: RemotingCommand, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let mut item = item;
-        item.fast_header_encode(dst);
-        if let Some(body_inner) = item.take_body() {
-            dst.put(body_inner);
-        }
+        EncodedFrame::from_command(item)?.copy_to(dst);
         Ok(())
     }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct CompositeCodec {
-    bytes_codec: BytesCodec,
-    remoting_command_codec: RemotingCommandCodec,
+pub(crate) struct SessionCommandDecoder {
+    inner: RemotingCommandCodec,
 }
 
-impl CompositeCodec {
-    pub fn new() -> Self {
-        Self {
-            bytes_codec: BytesCodec::new(),
-            remoting_command_codec: RemotingCommandCodec::new(),
-        }
-    }
-
-    pub fn with_limits(limits: FrameLimits) -> Self {
-        Self {
-            bytes_codec: BytesCodec::new(),
-            remoting_command_codec: RemotingCommandCodec::with_limits(limits),
-        }
-    }
-}
-
-impl Decoder for CompositeCodec {
-    type Error = rocketmq_error::RocketMQError;
-    type Item = RemotingCommand;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, rocketmq_error::RocketMQError> {
-        self.remoting_command_codec.decode(src)
-    }
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub(crate) struct SessionCodec {
-    inner: CompositeCodec,
-}
-
-impl From<CompositeCodec> for SessionCodec {
-    fn from(inner: CompositeCodec) -> Self {
+impl From<RemotingCommandCodec> for SessionCommandDecoder {
+    fn from(inner: RemotingCommandCodec) -> Self {
         Self { inner }
     }
 }
 
-impl Decoder for SessionCodec {
+impl Decoder for SessionCommandDecoder {
     type Error = rocketmq_error::RocketMQError;
     type Item = DecodedCommand;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        self.inner.remoting_command_codec.decode_with_metadata(src)
-    }
-}
-
-impl Encoder<Bytes> for SessionCodec {
-    type Error = rocketmq_error::RocketMQError;
-
-    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.inner.encode(item, dst)
-    }
-}
-
-impl Encoder<Bytes> for CompositeCodec {
-    type Error = rocketmq_error::RocketMQError;
-
-    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.bytes_codec
-            .encode(item, dst)
-            .map_err(|error| encoder_error(format!("Error encoding bytes: {error}")))
+        self.inner.decode_with_metadata(src)
     }
 }
 

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -15,70 +15,38 @@
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::atomic::AtomicU64;
-use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 
-use bytes::BufMut;
 use bytes::Bytes;
-use bytes::BytesMut;
 use cheetah_string::CheetahString;
-use futures_util::stream::SplitSink;
-use futures_util::stream::SplitStream;
-use futures_util::SinkExt;
 use futures_util::StreamExt;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
-use tokio_util::codec::Framed;
+use tokio_util::codec::FramedRead;
 use uuid::Uuid;
 
 use crate::admission::AdmissionClass;
 use crate::admission::AdmissionController;
-use crate::admission::AdmissionPermit;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
-use crate::codec::remoting_command_codec::CompositeCodec;
 use crate::codec::remoting_command_codec::FrameLimits;
-use crate::codec::remoting_command_codec::SessionCodec;
+use crate::codec::remoting_command_codec::RemotingCommandCodec;
+use crate::codec::remoting_command_codec::SessionCommandDecoder;
 use crate::deadline::RequestDeadline;
+use crate::write_strategy::FrameWriteMode;
+use crate::write_strategy::FrameWriter;
+use crate::write_strategy::OutboundPayload;
+use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::QueuedWriteProgress;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use std::sync::Arc;
-
-const QUEUED_WRITE_WAITING: u8 = 0;
-const QUEUED_WRITE_STARTED: u8 = 1;
-
-pub(crate) struct QueuedWriteProgress(AtomicU8);
-
-impl QueuedWriteProgress {
-    fn waiting() -> Self {
-        Self(AtomicU8::new(QUEUED_WRITE_WAITING))
-    }
-
-    pub(crate) fn start_write(&self) {
-        self.0.store(QUEUED_WRITE_STARTED, Ordering::Release);
-    }
-
-    fn write_started(&self) -> bool {
-        self.0.load(Ordering::Acquire) == QUEUED_WRITE_STARTED
-    }
-}
-
-pub(crate) enum QueuedWrite {
-    Data {
-        bytes: Bytes,
-        completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
-        _permit: AdmissionPermit,
-        deadline: Option<RequestDeadline>,
-        target: String,
-        progress: Option<Arc<QueuedWriteProgress>>,
-    },
-    Close {
-        completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
-    },
-}
 
 pub(crate) struct SessionLifecycle {
     gate: tokio::sync::RwLock<()>,
@@ -116,8 +84,14 @@ pub trait ConnectionTransport: AsyncRead + AsyncWrite + Send + Unpin {}
 impl<T> ConnectionTransport for T where T: AsyncRead + AsyncWrite + Send + Unpin {}
 
 pub type BoxedConnectionTransport = Box<dyn ConnectionTransport>;
-pub type ConnectionFramed = Framed<BoxedConnectionTransport, CompositeCodec>;
-type SessionConnectionFramed = Framed<BoxedConnectionTransport, SessionCodec>;
+type ConnectionReadHalf = FramedRead<ReadHalf<BoxedConnectionTransport>, RemotingCommandCodec>;
+pub(crate) type SessionConnectionReadHalf = FramedRead<ReadHalf<BoxedConnectionTransport>, SessionCommandDecoder>;
+pub(crate) type ConnectionFrameWriter = FrameWriter<WriteHalf<BoxedConnectionTransport>>;
+
+enum ConnectionWriter {
+    Direct(ConnectionFrameWriter),
+    Queued(QueuedConnection),
+}
 
 static TRANSPORT_ENCODED_BYTES_WRITTEN: AtomicU64 = AtomicU64::new(0);
 
@@ -140,7 +114,7 @@ pub fn transport_io_snapshot() -> TransportIoSnapshot {
     }
 }
 
-fn record_transport_write(bytes: usize) {
+pub(crate) fn record_transport_write(bytes: usize) {
     TRANSPORT_ENCODED_BYTES_WRITTEN.fetch_add(bytes as u64, Ordering::Relaxed);
 }
 
@@ -241,16 +215,11 @@ impl ConnectionStateHandle {
 /// - **Fail-fast**: I/O errors immediately update state and return error
 /// - **Zero polling**: Subscribers notified automatically on state change
 pub struct Connection {
-    // === I/O Transport ===
-    /// Outbound message sink (sends encoded frames to peer)
-    ///
-    /// Handles outbound data flow with automatic framing
-    outbound_sink: SplitSink<ConnectionFramed, Bytes>,
+    /// Inbound command stream. Session response capabilities have no read half.
+    inbound: Option<ConnectionReadHalf>,
 
-    /// Inbound message stream (receives decoded frames from peer)
-    ///
-    /// Handles inbound data flow with automatic frame decoding
-    inbound_stream: SplitStream<ConnectionFramed>,
+    /// Direct socket writer or a capability to the canonical session writer actor.
+    outbound: ConnectionWriter,
 
     // === State Management (Tokio Watch Channel) ===
     /// Broadcast channel for connection state changes
@@ -272,20 +241,12 @@ pub struct Connection {
     /// Used for fast `state()` queries without creating new receivers
     state_rx: watch::Receiver<ConnectionState>,
 
-    // === Buffers ===
-    /// Reusable encoding buffer to avoid repeated allocations
-    ///
-    /// Used for staging `RemotingCommand` serialization before sending.
-    /// Split pattern automatically clears buffer after each send.
-    encode_buffer: BytesMut,
-
     // === Identification ===
     /// Unique identifier for this connection instance
     ///
     /// Generated via UUID, stable across the connection lifetime
     connection_id: ConnectionId,
 
-    queued: Option<QueuedConnection>,
     #[cfg(test)]
     enqueue_gate: Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
 }
@@ -331,44 +292,78 @@ impl Connection {
     /// });
     /// ```
     pub fn new(tcp_stream: TcpStream) -> Connection {
-        Self::new_with_stream(tcp_stream)
+        Self::new_with_plaintext_stream(tcp_stream)
     }
 
     pub fn new_with_limits(tcp_stream: TcpStream, limits: FrameLimits) -> Connection {
-        Self::new_with_stream_and_limits(tcp_stream, limits)
+        Self::new_with_plaintext_stream_and_limits(tcp_stream, limits)
     }
 
-    /// Creates a new `Connection` over any async stream implementing RocketMQ framing.
-    pub fn new_with_stream<S>(stream: S) -> Connection
+    /// Creates a plaintext connection over any compatible async stream.
+    pub fn new_with_plaintext_stream<S>(stream: S) -> Connection
     where
         S: ConnectionTransport + 'static,
     {
-        Self::new_with_stream_and_limits(stream, FrameLimits::default())
+        Self::new_with_plaintext_stream_and_limits(stream, FrameLimits::default())
     }
 
-    pub fn new_with_stream_and_limits<S>(stream: S, limits: FrameLimits) -> Connection
+    /// Creates a bounded plaintext connection over any compatible async stream.
+    pub fn new_with_plaintext_stream_and_limits<S>(stream: S, limits: FrameLimits) -> Connection
     where
         S: ConnectionTransport + 'static,
     {
-        const BUFFER_SIZE: usize = 8 * 1024; // 8 KB
-        let framed = Framed::with_capacity(
-            Box::new(stream) as BoxedConnectionTransport,
-            CompositeCodec::with_limits(limits),
+        Self::new_with_stream_limits_and_write_mode(stream, limits, FrameWriteMode::PlainVectored)
+    }
+
+    /// Creates a connection over a negotiated TLS stream with bounded plaintext aggregation.
+    pub fn new_with_tls_stream<S>(stream: S) -> Connection
+    where
+        S: ConnectionTransport + 'static,
+    {
+        Self::new_with_tls_stream_and_limits(stream, FrameLimits::default())
+    }
+
+    /// Creates a TLS connection using the configured maximum wire frame as its aggregation bound.
+    pub fn new_with_tls_stream_and_limits<S>(stream: S, limits: FrameLimits) -> Connection
+    where
+        S: ConnectionTransport + 'static,
+    {
+        let max_plaintext_frame_bytes = limits.max_frame_bytes.saturating_add(4);
+        Self::new_with_stream_limits_and_write_mode(
+            stream,
+            limits,
+            FrameWriteMode::TlsCoalesced {
+                max_plaintext_frame_bytes,
+            },
+        )
+    }
+
+    fn new_with_stream_limits_and_write_mode<S>(
+        stream: S,
+        limits: FrameLimits,
+        write_mode: FrameWriteMode,
+    ) -> Connection
+    where
+        S: ConnectionTransport + 'static,
+    {
+        let transport = Box::new(stream) as BoxedConnectionTransport;
+        let (read_half, write_half) = tokio::io::split(transport);
+        let inbound = FramedRead::with_capacity(
+            read_half,
+            RemotingCommandCodec::with_limits(limits),
             limits.initial_read_bytes.max(4),
         );
-        let (outbound_sink, inbound_stream) = framed.split();
-
+        let outbound = FrameWriter::new(write_half, write_mode)
+            .unwrap_or_else(|_| unreachable!("connection frame limits always produce a non-zero writer bound"));
         // Initialize watch channel with Healthy state
         let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
 
         Self {
-            outbound_sink,
-            inbound_stream,
+            inbound: Some(inbound),
+            outbound: ConnectionWriter::Direct(outbound),
             state_tx,
             state_rx,
-            encode_buffer: BytesMut::with_capacity(BUFFER_SIZE),
             connection_id: CheetahString::from_string(Uuid::new_v4().to_string()),
-            queued: None,
             #[cfg(test)]
             enqueue_gate: None,
         }
@@ -384,20 +379,21 @@ impl Connection {
         response_class: Option<AdmissionClass>,
         lifecycle: Arc<SessionLifecycle>,
     ) -> Self {
-        let (stream, peer) = tokio::io::duplex(1);
-        drop(peer);
-        let mut connection = Self::new_with_stream(stream);
-        connection.state_tx = state_tx;
-        connection.state_rx = state_rx;
-        connection.connection_id = connection_id;
-        connection.queued = Some(QueuedConnection {
-            writer,
-            admission,
-            scope,
-            response_class,
-            lifecycle,
-        });
-        connection
+        Self {
+            inbound: None,
+            outbound: ConnectionWriter::Queued(QueuedConnection {
+                writer,
+                admission,
+                scope,
+                response_class,
+                lifecycle,
+            }),
+            state_tx,
+            state_rx,
+            connection_id,
+            #[cfg(test)]
+            enqueue_gate: None,
+        }
     }
 
     #[cfg(test)]
@@ -405,37 +401,16 @@ impl Connection {
         self.enqueue_gate = Some((checked, resume));
     }
 
-    pub(crate) fn into_framed_parts(
-        self,
-    ) -> (
-        SplitSink<SessionConnectionFramed, Bytes>,
-        SplitStream<SessionConnectionFramed>,
-    ) {
-        let framed = self
-            .outbound_sink
-            .reunite(self.inbound_stream)
-            .unwrap_or_else(|_| unreachable!("connection split halves always originate from the same framed I/O"));
-        framed.map_codec(SessionCodec::from).split()
-    }
-
-    /// Gets a reference to the inbound stream for receiving messages
-    ///
-    /// # Returns
-    ///
-    /// Immutable reference to the inbound message stream
-    #[inline]
-    pub fn inbound_stream(&self) -> &SplitStream<ConnectionFramed> {
-        &self.inbound_stream
-    }
-
-    /// Gets a reference to the outbound sink for sending messages
-    ///
-    /// # Returns
-    ///
-    /// Immutable reference to the outbound message sink
-    #[inline]
-    pub fn outbound_sink(&self) -> &SplitSink<ConnectionFramed, Bytes> {
-        &self.outbound_sink
+    pub(crate) fn into_session_io(self) -> (ConnectionFrameWriter, SessionConnectionReadHalf) {
+        let writer = match self.outbound {
+            ConnectionWriter::Direct(writer) => writer,
+            ConnectionWriter::Queued(_) => unreachable!("session runtime requires an owned transport writer"),
+        };
+        let reader = self
+            .inbound
+            .unwrap_or_else(|| unreachable!("session runtime requires an owned transport reader"))
+            .map_decoder(SessionCommandDecoder::from);
+        (writer, reader)
     }
 
     /// Receives the next `RemotingCommand` from the peer.
@@ -460,24 +435,35 @@ impl Connection {
     /// // Connection closed
     /// ```
     pub async fn receive_command(&mut self) -> Option<rocketmq_error::RocketMQResult<RemotingCommand>> {
-        if self.queued.is_some() {
-            return None;
+        match self.inbound.as_mut() {
+            Some(inbound) => inbound.next().await,
+            None => None,
         }
-        self.inbound_stream.next().await
     }
 
-    async fn send_encoded(
+    fn queued_writer(&self) -> Option<&QueuedConnection> {
+        match &self.outbound {
+            ConnectionWriter::Queued(queued) => Some(queued),
+            ConnectionWriter::Direct(_) => None,
+        }
+    }
+
+    fn response_class(&self) -> Option<AdmissionClass> {
+        self.queued_writer().and_then(|queued| queued.response_class)
+    }
+
+    async fn send_payload(
         &mut self,
-        bytes: Bytes,
+        payload: OutboundPayload,
         class: AdmissionClass,
         deadline: Option<RequestDeadline>,
         target: String,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let encoded_len = bytes.len();
+        let encoded_len = payload.encoded_len();
         if let Some(deadline) = deadline {
             deadline.ensure_before_send(target.clone())?;
         }
-        if let Some(queued) = self.queued.as_ref() {
+        if let Some(queued) = self.queued_writer() {
             let _lifecycle_guard = if let Some(deadline) = deadline {
                 deadline
                     .timeout(queued.lifecycle.begin_send())
@@ -505,7 +491,7 @@ impl Connection {
             }
             let permit = queued
                 .admission
-                .try_acquire(AdmissionResource::Queued, queued.scope, bytes.len(), class)
+                .try_acquire(AdmissionResource::Queued, queued.scope, encoded_len, class)
                 .map_err(|_| rocketmq_error::RocketMQError::network_queue_full(target.clone()))?;
             if let Some(deadline) = deadline {
                 deadline.ensure_before_send(target.clone())?;
@@ -514,14 +500,14 @@ impl Connection {
             let progress = deadline.map(|_| Arc::new(QueuedWriteProgress::waiting()));
             queued
                 .writer
-                .try_send(QueuedWrite::Data {
-                    bytes,
+                .try_send(QueuedWrite::data(
+                    payload,
                     completion,
-                    _permit: permit,
+                    permit,
                     deadline,
-                    target: target.clone(),
-                    progress: progress.clone(),
-                })
+                    target.clone(),
+                    progress.clone(),
+                ))
                 .map_err(|error| match error {
                     tokio::sync::mpsc::error::TrySendError::Full(_) => {
                         rocketmq_error::RocketMQError::network_queue_full(target.clone())
@@ -544,9 +530,6 @@ impl Connection {
             .map_err(|_| {
                 rocketmq_error::RocketMQError::network_connection_failed(target.clone(), "writer completion dropped")
             })?;
-            if outcome.is_ok() {
-                record_transport_write(encoded_len);
-            }
             return outcome;
         }
         if self.state() == ConnectionState::Closed {
@@ -555,12 +538,25 @@ impl Connection {
                 "connection is closed",
             ));
         }
+        let writer = match &mut self.outbound {
+            ConnectionWriter::Direct(writer) => writer,
+            ConnectionWriter::Queued(_) => unreachable!("queued writer returned above"),
+        };
         let send_result = if let Some(deadline) = deadline {
-            deadline.timeout(self.outbound_sink.send(bytes)).await.map_err(|_| {
-                rocketmq_error::RocketMQError::network_write_timeout(target.clone(), deadline.budget_millis())
-            })?
+            match deadline.timeout(payload.write_to(writer)).await {
+                Ok(result) => result,
+                Err(_) => {
+                    let _ = self.state_tx.send(ConnectionState::Degraded);
+                    let _ = writer.shutdown().await;
+                    let _ = self.state_tx.send(ConnectionState::Closed);
+                    return Err(rocketmq_error::RocketMQError::network_write_timeout(
+                        target,
+                        deadline.budget_millis(),
+                    ));
+                }
+            }
         } else {
-            self.outbound_sink.send(bytes).await
+            payload.write_to(writer).await
         };
         match send_result {
             Ok(()) => {
@@ -568,15 +564,21 @@ impl Connection {
                 Ok(())
             }
             Err(error) => {
-                self.mark_degraded();
-                Err(error)
+                let _ = self.state_tx.send(ConnectionState::Degraded);
+                let _ = writer.shutdown().await;
+                let _ = self.state_tx.send(ConnectionState::Closed);
+                Err(rocketmq_error::RocketMQError::network_connection_failed(
+                    target,
+                    error.to_string(),
+                ))
             }
         }
     }
 
     /// Sends a `RemotingCommand` to the peer (consumes command).
     ///
-    /// Encodes the command into the internal buffer, then flushes to the network.
+    /// Encodes the command into immutable prefix/header/body segments, then flushes it to the
+    /// negotiated plaintext or TLS writer.
     /// **Automatically marks connection as Degraded on I/O errors.**
     ///
     /// # Arguments
@@ -600,37 +602,28 @@ impl Connection {
     ///
     /// # Lifecycle
     ///
-    /// 1. Encode command header + body into reusable buffer
-    /// 2. Use zero-copy `split_to()` to extract buffer contents as `Bytes`
-    /// 3. Send extracted bytes via outbound sink
-    /// 4. Buffer is now empty and ready for next command (no clear() needed)
+    /// 1. Encode the prefix and header while preserving the existing body allocation.
+    /// 2. Reserve the exact frame-byte cost before queued staging.
+    /// 3. Transfer the immutable frame to the single writer owner.
     ///
     /// # Performance Optimization
     ///
-    /// - Uses `split_to(len)` instead of `split()` for better performance
-    /// - `split_to()` returns all data and leaves buffer empty, eliminating need for clear()
-    /// - `freeze()` converts BytesMut to Bytes with zero-copy (just refcount increment)
-    pub async fn send_command(&mut self, mut command: RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
-        // Encode command into buffer (buffer might have capacity from previous use)
-        command.fast_header_encode(&mut self.encode_buffer);
-        if let Some(body_inner) = command.take_body() {
-            self.encode_buffer.put(body_inner);
-        }
-
-        // Zero-copy extraction: split_to(len) returns all data, leaves buffer empty
-        // This is more efficient than split() + clear() pattern
-        let len = self.encode_buffer.len();
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
-        let bytes = self.encode_buffer.split_to(len).freeze();
-
+    /// - Plaintext retains three segments through `write_vectored`.
+    /// - TLS uses one writer-owned, bounded coalescing buffer.
+    pub async fn send_command(&mut self, command: RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
         let class = self
-            .queued
-            .as_ref()
-            .and_then(|queued| queued.response_class)
+            .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        self.send_encoded(bytes, class, None, "transport-session-writer".to_string())
-            .await
+        let frame = EncodedFrame::from_command(command)?;
+        #[cfg(feature = "observability")]
+        rocketmq_observability::metrics::remoting::record_network_bytes(frame.encoded_len() as u64);
+        self.send_payload(
+            OutboundPayload::Frame(frame),
+            class,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
     }
 
     /// Sends one command under a caller-owned immutable request deadline.
@@ -644,28 +637,22 @@ impl Connection {
     /// Returns a typed queue, before-send, write-timeout, or transport error.
     pub async fn send_command_with_deadline(
         &mut self,
-        mut command: RemotingCommand,
+        command: RemotingCommand,
         deadline: RequestDeadline,
         target: impl Into<String>,
     ) -> rocketmq_error::RocketMQResult<()> {
         let target = target.into();
         deadline.ensure_before_send(target.clone())?;
-        command.fast_header_encode(&mut self.encode_buffer);
-        if let Some(body_inner) = command.take_body() {
-            self.encode_buffer.put(body_inner);
-        }
+        let class = self
+            .response_class()
+            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
+        let frame = EncodedFrame::from_command(command)?;
         deadline.ensure_before_send(target.clone())?;
 
-        let len = self.encode_buffer.len();
         #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
-        let bytes = self.encode_buffer.split_to(len).freeze();
-        let class = self
-            .queued
-            .as_ref()
-            .and_then(|queued| queued.response_class)
-            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        self.send_encoded(bytes, class, Some(deadline), target).await
+        rocketmq_observability::metrics::remoting::record_network_bytes(frame.encoded_len() as u64);
+        self.send_payload(OutboundPayload::Frame(frame), class, Some(deadline), target)
+            .await
     }
 
     /// Sends a `RemotingCommand` to the peer (borrows command).
@@ -688,44 +675,29 @@ impl Connection {
     /// This method may consume the command's body (`take_body()`), modifying
     /// the original command.
     pub async fn send_command_ref(&mut self, command: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
-        // Encode command into buffer
-        command.fast_header_encode(&mut self.encode_buffer);
-        if let Some(body_inner) = command.take_body() {
-            self.encode_buffer.put(body_inner);
-        }
-
-        // Zero-copy extraction using split_to() pattern
-        let len = self.encode_buffer.len();
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
-        let bytes = self.encode_buffer.split_to(len).freeze();
-
         let class = self
-            .queued
-            .as_ref()
-            .and_then(|queued| queued.response_class)
+            .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        self.send_encoded(bytes, class, None, "transport-session-writer".to_string())
-            .await
+        let owned = command.clone();
+        let _ = command.take_body();
+        let frame = EncodedFrame::from_command(owned)?;
+        #[cfg(feature = "observability")]
+        rocketmq_observability::metrics::remoting::record_network_bytes(frame.encoded_len() as u64);
+        self.send_payload(
+            OutboundPayload::Frame(frame),
+            class,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
     }
 
-    /// Sends multiple `RemotingCommand`s in a single batch (optimized for throughput).
+    /// Sends multiple `RemotingCommand`s under one ordered writer-queue admission.
     ///
     /// **Automatically marks connection as Degraded on I/O errors.**
     ///
-    /// # Performance Benefits
-    ///
-    /// - **Reduced system calls**: Multiple commands sent in one syscall
-    /// - **Better CPU cache**: Encoding loop stays hot
-    /// - **Lower latency**: No network round-trips between commands
-    ///
-    /// # Benchmarks
-    ///
-    /// ```text
-    /// send_command() x 100:  ~50ms  (100 syscalls)
-    /// send_batch() x 100:    ~15ms  (1 syscall)
-    /// Improvement: 3.3x faster
-    /// ```
+    /// Each command remains an independently delimited immutable frame. This preserves plaintext
+    /// vectored writes and TLS per-frame aggregation while avoiding a second full-batch copy.
     ///
     /// # Arguments
     ///
@@ -742,27 +714,19 @@ impl Connection {
     /// let batch = vec![cmd1, cmd2, cmd3];
     /// connection.send_batch(batch).await?;
     /// ```
-    pub async fn send_batch(&mut self, mut commands: Vec<RemotingCommand>) -> rocketmq_error::RocketMQResult<()> {
+    pub async fn send_batch(&mut self, commands: Vec<RemotingCommand>) -> rocketmq_error::RocketMQResult<()> {
         if commands.is_empty() {
             return Ok(());
         }
-
-        // Encode all commands into a single buffer
-        for command in &mut commands {
-            command.fast_header_encode(&mut self.encode_buffer);
-            if let Some(body_inner) = command.take_body() {
-                self.encode_buffer.put(body_inner);
-            }
-        }
-
-        // Send entire batch as one Bytes chunk
-        let len = self.encode_buffer.len();
+        let frames = commands
+            .into_iter()
+            .map(EncodedFrame::from_command)
+            .collect::<rocketmq_error::RocketMQResult<Vec<_>>>()?;
+        let payload = OutboundPayload::batch(frames)?;
         #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::remoting::record_network_bytes(len as u64);
-        let bytes = self.encode_buffer.split_to(len).freeze();
-
-        self.send_encoded(
-            bytes,
+        rocketmq_observability::metrics::remoting::record_network_bytes(payload.encoded_len() as u64);
+        self.send_payload(
+            payload,
             AdmissionClass::Data,
             None,
             "transport-session-writer".to_string(),
@@ -792,8 +756,8 @@ impl Connection {
     pub async fn send_bytes(&mut self, bytes: Bytes) -> rocketmq_error::RocketMQResult<()> {
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::remoting::record_network_bytes(bytes.len() as u64);
-        self.send_encoded(
-            bytes,
+        self.send_payload(
+            OutboundPayload::Contiguous(bytes),
             AdmissionClass::Data,
             None,
             "transport-session-writer".to_string(),
@@ -825,9 +789,9 @@ impl Connection {
     pub async fn send_slice(&mut self, slice: &'static [u8]) -> rocketmq_error::RocketMQResult<()> {
         #[cfg(feature = "observability")]
         rocketmq_observability::metrics::remoting::record_network_bytes(slice.len() as u64);
-        let bytes = slice.into();
-        self.send_encoded(
-            bytes,
+        let bytes = Bytes::from_static(slice);
+        self.send_payload(
+            OutboundPayload::Contiguous(bytes),
             AdmissionClass::Control,
             None,
             "transport-session-writer".to_string(),
@@ -949,20 +913,6 @@ impl Connection {
         }
     }
 
-    /// Marks the connection as degraded (internal use).
-    ///
-    /// Called automatically when I/O errors occur. Broadcasts state change
-    /// to all subscribers.
-    ///
-    /// # Note
-    ///
-    /// This is an internal method. Users should rely on automatic state
-    /// management via I/O operation results.
-    #[inline]
-    fn mark_degraded(&self) {
-        let _ = self.state_tx.send(ConnectionState::Degraded);
-    }
-
     /// Marks the connection as closed (internal use).
     ///
     /// Called when connection is explicitly closed. Broadcasts final state.
@@ -985,28 +935,29 @@ impl Connection {
 
     /// Flushes and actively shuts down the socket write half before marking the connection closed.
     pub async fn shutdown(&mut self) -> rocketmq_error::RocketMQResult<()> {
-        if let Some(queued) = self.queued.as_ref() {
-            let (completion, result) = oneshot::channel();
-            queued
-                .writer
-                .send(QueuedWrite::Close { completion })
-                .await
-                .map_err(|_| {
+        let result = match &mut self.outbound {
+            ConnectionWriter::Queued(queued) => {
+                let (completion, result) = oneshot::channel();
+                queued.writer.send(QueuedWrite::close(completion)).await.map_err(|_| {
                     rocketmq_error::RocketMQError::network_connection_failed(
                         "transport-session-writer",
                         "writer queue closed",
                     )
                 })?;
-            let result = result.await.map_err(|_| {
+                result.await.map_err(|_| {
+                    rocketmq_error::RocketMQError::network_connection_failed(
+                        "transport-session-writer",
+                        "writer completion dropped",
+                    )
+                })?
+            }
+            ConnectionWriter::Direct(writer) => writer.shutdown().await.map_err(|error| {
                 rocketmq_error::RocketMQError::network_connection_failed(
-                    "transport-session-writer",
-                    "writer completion dropped",
+                    "transport-connection-writer",
+                    error.to_string(),
                 )
-            })?;
-            self.mark_closed();
-            return result;
-        }
-        let result = self.outbound_sink.close().await;
+            }),
+        };
         self.mark_closed();
         result
     }

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -41,6 +41,7 @@ mod security;
 mod server;
 mod session_executor;
 mod tls;
+mod write_strategy;
 
 pub use admission::AdmissionClass;
 pub use admission::AdmissionConfigError;
@@ -149,6 +150,8 @@ pub use tls::tls_disabled_error;
 #[cfg(feature = "tls")]
 pub use tls::TlsReloadReport;
 pub use tls::TlsServerRuntime;
+pub use write_strategy::FrameWriteMode;
+pub use write_strategy::FrameWriter;
 
 pub use error_helpers::abort_process_error;
 pub use error_helpers::channel_recv_failed;

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -1184,7 +1184,7 @@ mod tests {
         let pending_requests = PendingRequestTable::new();
         let channel = Arc::new(
             ChannelInner::try_new_with_pending_requests(
-                Connection::new_with_stream(transport),
+                Connection::new_with_plaintext_stream(transport),
                 pending_requests.clone(),
                 test_parent("channel-writer-deadline-test"),
             )
@@ -1232,7 +1232,7 @@ mod tests {
         let (transport, mut peer) = tokio::io::duplex(4096);
         let channel = Arc::new(
             ChannelInner::try_new_with_pending_requests(
-                Connection::new_with_stream(transport),
+                Connection::new_with_plaintext_stream(transport),
                 PendingRequestTable::new(),
                 test_parent("channel-oneway-deadline-test"),
             )

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use futures_util::SinkExt;
 use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
@@ -53,16 +52,18 @@ use crate::admission::AdmissionScope;
 use crate::admission::FullPolicy;
 use crate::config::TlsConfig;
 use crate::config::TlsMode;
+use crate::connection::record_transport_write;
 use crate::connection::Connection;
 use crate::connection::ConnectionId;
 use crate::connection::ConnectionState;
-use crate::connection::QueuedWrite;
 use crate::connection::SessionLifecycle;
 use crate::request_ordering::RequestOrdering;
 use crate::security::TransportSecurity;
 use crate::session_executor::SessionDispatchError;
 use crate::session_executor::SessionExecutor;
 use crate::tls::TlsServerRuntime;
+use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::WriterOperation;
 
 const SESSION_WRITER_QUEUE_CAPACITY: usize = 1024;
 const SESSION_RETIREMENT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -179,7 +180,7 @@ impl SessionHandle {
         }
         let _retirement_guard = self.lifecycle.begin_retirement().await;
         let (completion, result) = tokio::sync::oneshot::channel();
-        let send_result = self.writer.send(QueuedWrite::Close { completion }).await;
+        let send_result = self.writer.send(QueuedWrite::close(completion)).await;
         if send_result.is_err() {
             let _ = self.state_tx.send(ConnectionState::Closed);
             self.task_group.cancel();
@@ -393,55 +394,67 @@ async fn run_framed_session<H>(
     H: ConnectionHandler,
 {
     let connection_id = connection.connection_id().clone();
-    let (mut sink, mut stream) = connection.into_framed_parts();
+    let (mut frame_writer, mut stream) = connection.into_session_io();
     let executor = match SessionExecutor::try_new(&task_group, admission.clone(), scope) {
         Ok(executor) => executor,
         Err(_) => return,
     };
     let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
     let lifecycle = Arc::new(SessionLifecycle::new());
-    let (writer, mut writes) = tokio::sync::mpsc::channel(SESSION_WRITER_QUEUE_CAPACITY);
+    let (writer, mut writes) = tokio::sync::mpsc::channel::<QueuedWrite>(SESSION_WRITER_QUEUE_CAPACITY);
     let writer_state = state_tx.clone();
     let writer_group = task_group.clone();
+    let writer_shutdown_group = writer_group.clone();
     let writer_task_id = match writer_group.spawn("rocketmq.transport.session.writer", TaskKind::Worker, async move {
         while let Some(next) = writes.recv().await {
-            match next {
-                QueuedWrite::Data {
-                    bytes,
-                    completion,
-                    _permit,
-                    deadline,
-                    target,
-                    progress,
-                } => {
-                    let result = match deadline {
-                        Some(deadline) if deadline.is_expired() => {
-                            Err(RocketMQError::network_deadline_exceeded_before_send(target))
+            match next.operation {
+                WriterOperation::Send(payload) => {
+                    let completion = next.completion;
+                    let deadline = next.deadline;
+                    let target = next.target;
+                    let progress = next.progress;
+                    let result = if deadline.is_some_and(|deadline| deadline.is_expired()) {
+                        Err(RocketMQError::network_deadline_exceeded_before_send(target))
+                    } else {
+                        if let Some(progress) = progress.as_ref() {
+                            progress.start_write();
                         }
-                        Some(deadline) => {
-                            if let Some(progress) = progress.as_ref() {
-                                progress.start_write();
-                            }
-                            match deadline.timeout(sink.send(bytes)).await {
-                                Ok(result) => result,
-                                Err(_) => Err(RocketMQError::network_write_timeout(target, deadline.budget_millis())),
-                            }
-                        }
-                        None => sink.send(bytes).await,
+                        payload
+                            .write_to(&mut frame_writer)
+                            .await
+                            .map_err(|error| RocketMQError::network_connection_failed(target, error.to_string()))
                     };
-                    if result.is_err() {
+                    if result.is_ok() {
+                        record_transport_write(payload.encoded_len());
+                    }
+                    let poisoned = frame_writer.is_poisoned();
+                    if poisoned {
                         let _ = writer_state.send(ConnectionState::Degraded);
                     }
-                    let failed = result.is_err();
+                    drop(next.permit);
                     let _ = completion.send(result);
-                    drop(_permit);
-                    if failed {
+                    if poisoned {
+                        writes.close();
+                        let _ = frame_writer.shutdown().await;
+                        while let Some(pending) = writes.recv().await {
+                            let target = match pending.operation {
+                                WriterOperation::Send(_) => pending.target,
+                                WriterOperation::Close => "transport-session-writer".to_string(),
+                            };
+                            drop(pending.permit);
+                            let _ = pending.completion.send(Err(RocketMQError::network_connection_failed(
+                                target,
+                                "connection writer is poisoned by a previous frame failure",
+                            )));
+                        }
+                        let _ = writer_state.send(ConnectionState::Closed);
+                        writer_shutdown_group.cancel();
                         break;
                     }
                 }
-                QueuedWrite::Close { completion } => {
-                    let result = sink.close().await;
-                    let _ = completion.send(result);
+                WriterOperation::Close => {
+                    let result = frame_writer.shutdown().await.map_err(Into::into);
+                    let _ = next.completion.send(result);
                     break;
                 }
             }
@@ -550,10 +563,7 @@ async fn run_framed_session<H>(
         .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
     executor.drain_until(request_deadline).await.log_if_unhealthy();
     handler.disconnected(session.clone()).await;
-    let (completion, closed) = tokio::sync::oneshot::channel();
-    let _ = writer.send(QueuedWrite::Close { completion }).await;
-    let _ = closed.await;
-    let _ = state_tx.send(ConnectionState::Closed);
+    let _ = session.retire().await;
 }
 
 /// Runs an already-connected client or compatibility socket through the canonical framed session
@@ -930,7 +940,7 @@ mod retirement_tests {
         let local_addr: SocketAddr = "127.0.0.1:19001".parse().unwrap();
         let remote_addr: SocketAddr = "127.0.0.1:19002".parse().unwrap();
         let runner = tokio::spawn(super::run_connected_session(
-            Connection::new_with_stream(transport),
+            Connection::new_with_plaintext_stream(transport),
             local_addr,
             remote_addr,
             service.task_group().clone(),
@@ -972,7 +982,7 @@ mod retirement_tests {
             .send_command(RemotingCommand::create_remoting_command(2))
             .await
             .is_err());
-        let mut peer = Connection::new_with_stream(peer_stream);
+        let mut peer = Connection::new_with_plaintext_stream(peer_stream);
         let first = peer.receive_command().await.unwrap().unwrap();
         assert_eq!(first.code(), 1);
         assert!(peer.receive_command().await.is_none());
@@ -991,7 +1001,7 @@ mod retirement_tests {
         let local_addr: SocketAddr = "127.0.0.1:19003".parse().unwrap();
         let remote_addr: SocketAddr = "127.0.0.1:19004".parse().unwrap();
         let runner = tokio::spawn(super::run_connected_session(
-            Connection::new_with_stream(transport),
+            Connection::new_with_plaintext_stream(transport),
             local_addr,
             remote_addr,
             service.task_group().clone(),
@@ -1038,7 +1048,7 @@ mod retirement_tests {
         let local_addr: SocketAddr = "127.0.0.1:19005".parse().unwrap();
         let remote_addr: SocketAddr = "127.0.0.1:19006".parse().unwrap();
         let runner = tokio::spawn(super::run_connected_session(
-            Connection::new_with_stream(transport),
+            Connection::new_with_plaintext_stream(transport),
             local_addr,
             remote_addr,
             service.task_group().clone(),

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -353,7 +353,7 @@ impl TlsServerRuntime {
     async fn accept_tls(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
         self.accept_stream(stream, remote_addr)
             .await
-            .map(Connection::new_with_stream)
+            .map(Connection::new_with_tls_stream)
     }
 
     /// Performs a server-side TLS handshake with the atomically published acceptor generation.

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -1,0 +1,421 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::IoSlice;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_error::SerializationError;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
+
+use crate::admission::AdmissionPermit;
+use crate::deadline::RequestDeadline;
+
+const QUEUED_WRITE_WAITING: u8 = 0;
+const QUEUED_WRITE_STARTED: u8 = 1;
+
+pub(crate) struct QueuedWriteProgress(AtomicU8);
+
+impl QueuedWriteProgress {
+    pub(crate) fn waiting() -> Self {
+        Self(AtomicU8::new(QUEUED_WRITE_WAITING))
+    }
+
+    pub(crate) fn start_write(&self) {
+        self.0.store(QUEUED_WRITE_STARTED, Ordering::Release);
+    }
+
+    pub(crate) fn write_started(&self) -> bool {
+        self.0.load(Ordering::Acquire) == QUEUED_WRITE_STARTED
+    }
+}
+
+pub(crate) struct QueuedWrite {
+    pub(crate) operation: WriterOperation,
+    pub(crate) completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
+    pub(crate) permit: Option<AdmissionPermit>,
+    pub(crate) deadline: Option<RequestDeadline>,
+    pub(crate) target: String,
+    pub(crate) progress: Option<Arc<QueuedWriteProgress>>,
+}
+
+impl QueuedWrite {
+    pub(crate) fn data(
+        payload: OutboundPayload,
+        completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
+        permit: AdmissionPermit,
+        deadline: Option<RequestDeadline>,
+        target: String,
+        progress: Option<Arc<QueuedWriteProgress>>,
+    ) -> Self {
+        Self {
+            operation: WriterOperation::Send(payload),
+            completion,
+            permit: Some(permit),
+            deadline,
+            target,
+            progress,
+        }
+    }
+
+    pub(crate) fn close(completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>) -> Self {
+        Self {
+            operation: WriterOperation::Close,
+            completion,
+            permit: None,
+            deadline: None,
+            target: String::new(),
+            progress: None,
+        }
+    }
+}
+
+pub(crate) enum WriterOperation {
+    Send(OutboundPayload),
+    Close,
+}
+
+pub(crate) enum OutboundPayload {
+    Frame(EncodedFrame),
+    Batch {
+        frames: Vec<EncodedFrame>,
+        encoded_len: usize,
+    },
+    Contiguous(Bytes),
+}
+
+impl OutboundPayload {
+    pub(crate) fn batch(frames: Vec<EncodedFrame>) -> rocketmq_error::RocketMQResult<Self> {
+        let encoded_len = frames.iter().try_fold(0_usize, |total, frame| {
+            total.checked_add(frame.encoded_len()).ok_or_else(|| {
+                SerializationError::encode_failed("remoting-command-batch", "encoded batch length overflow")
+            })
+        })?;
+        Ok(Self::Batch { frames, encoded_len })
+    }
+
+    pub(crate) fn encoded_len(&self) -> usize {
+        match self {
+            Self::Frame(frame) => frame.encoded_len(),
+            Self::Batch { encoded_len, .. } => *encoded_len,
+            Self::Contiguous(bytes) => bytes.len(),
+        }
+    }
+
+    pub(crate) async fn write_to<W>(&self, writer: &mut FrameWriter<W>) -> io::Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        match self {
+            Self::Frame(frame) => writer.write_frame(frame).await,
+            Self::Batch { frames, .. } => {
+                for frame in frames {
+                    writer.write_frame(frame).await?;
+                }
+                Ok(())
+            }
+            Self::Contiguous(bytes) => writer.write_bytes(bytes).await,
+        }
+    }
+}
+
+/// Socket-write representation selected after TCP/TLS negotiation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameWriteMode {
+    /// Preserve prefix, header, and body through to vectored plaintext writes.
+    PlainVectored,
+    /// Coalesce one frame at a time for TLS, rejecting frames above the configured plaintext bound.
+    TlsCoalesced {
+        /// Maximum encoded RocketMQ plaintext bytes accepted for one TLS write.
+        max_plaintext_frame_bytes: usize,
+    },
+}
+
+/// Single-owner frame writer with fail-closed poisoning after socket I/O failure.
+///
+/// `FrameWriter` never retains an `EncodedFrame`; the caller or owning writer actor keeps the
+/// immutable frame alive until completion. TLS aggregation is private to this writer and therefore
+/// cannot share mutable backing between queued frames.
+pub struct FrameWriter<W> {
+    io: W,
+    mode: FrameWriteMode,
+    tls_buffer: BytesMut,
+    poisoned: bool,
+}
+
+struct WriteCancellationGuard<'a> {
+    poisoned: &'a mut bool,
+    armed: bool,
+}
+
+impl<'a> WriteCancellationGuard<'a> {
+    fn new(poisoned: &'a mut bool) -> Self {
+        Self { poisoned, armed: true }
+    }
+
+    fn complete(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for WriteCancellationGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            *self.poisoned = true;
+        }
+    }
+}
+
+impl<W> FrameWriter<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    /// Creates a writer for the negotiated transport mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidInput` when the TLS coalescing bound is zero.
+    pub fn new(io: W, mode: FrameWriteMode) -> io::Result<Self> {
+        if matches!(
+            mode,
+            FrameWriteMode::TlsCoalesced {
+                max_plaintext_frame_bytes: 0
+            }
+        ) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TLS coalescing requires a non-zero frame-byte bound",
+            ));
+        }
+        Ok(Self {
+            io,
+            mode,
+            tls_buffer: BytesMut::new(),
+            poisoned: false,
+        })
+    }
+
+    /// Creates a plaintext vectored writer.
+    #[must_use]
+    pub fn plaintext(io: W) -> Self {
+        Self {
+            io,
+            mode: FrameWriteMode::PlainVectored,
+            tls_buffer: BytesMut::new(),
+            poisoned: false,
+        }
+    }
+
+    /// Returns the selected immutable write mode.
+    #[inline]
+    #[must_use]
+    pub const fn mode(&self) -> FrameWriteMode {
+        self.mode
+    }
+
+    /// Returns whether a prior socket write or flush failure poisoned this writer.
+    #[inline]
+    #[must_use]
+    pub const fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    /// Returns ownership of the underlying I/O object.
+    #[must_use]
+    pub fn into_inner(self) -> W {
+        self.io
+    }
+
+    /// Writes and flushes one immutable RocketMQ frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BrokenPipe` without touching the socket after a prior failure. Plaintext writes
+    /// propagate socket errors and `WriteZero`; TLS writes additionally reject frames larger than
+    /// their configured coalescing bound.
+    pub async fn write_frame(&mut self, frame: &EncodedFrame) -> io::Result<()> {
+        self.ensure_healthy()?;
+        let mode = self.mode;
+        if let FrameWriteMode::TlsCoalesced {
+            max_plaintext_frame_bytes,
+        } = mode
+        {
+            if frame.encoded_len() > max_plaintext_frame_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "encoded frame is {} bytes, exceeding TLS plaintext coalescing limit \
+                         {max_plaintext_frame_bytes}",
+                        frame.encoded_len()
+                    ),
+                ));
+            }
+        }
+        let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
+        let result = match mode {
+            FrameWriteMode::PlainVectored => write_vectored_frame(&mut self.io, frame).await,
+            FrameWriteMode::TlsCoalesced { .. } => {
+                self.tls_buffer.clear();
+                frame.copy_to(&mut self.tls_buffer);
+                let result = write_contiguous(&mut self.io, self.tls_buffer.as_ref()).await;
+                self.tls_buffer.clear();
+                result
+            }
+        };
+        result?;
+        self.io.flush().await?;
+        cancellation.complete();
+        Ok(())
+    }
+
+    /// Writes and flushes caller-provided contiguous wire bytes.
+    ///
+    /// This compatibility path is intended for bytes that are already framed. New
+    /// `RemotingCommand` writes should use [`Self::write_frame`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying socket or flush error and poisons the writer.
+    pub async fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.ensure_healthy()?;
+        let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
+        write_contiguous(&mut self.io, bytes).await?;
+        self.io.flush().await?;
+        cancellation.complete();
+        Ok(())
+    }
+
+    /// Flushes buffered transport data.
+    ///
+    /// # Errors
+    ///
+    /// Returns and records the underlying flush failure.
+    pub async fn flush(&mut self) -> io::Result<()> {
+        self.ensure_healthy()?;
+        let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
+        self.io.flush().await?;
+        cancellation.complete();
+        Ok(())
+    }
+
+    /// Actively shuts down the underlying write half.
+    ///
+    /// Shutdown remains available after poisoning so the owner can close a partially written
+    /// byte stream without attempting another frame.
+    pub async fn shutdown(&mut self) -> io::Result<()> {
+        self.io.shutdown().await
+    }
+
+    fn ensure_healthy(&self) -> io::Result<()> {
+        if self.poisoned {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "frame writer is poisoned by a previous transport failure",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+async fn write_vectored_frame<W>(io: &mut W, frame: &EncodedFrame) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let segments = frame.segments();
+    let mut segment_index = 0;
+    let mut segment_offset = 0;
+    skip_empty_segments(&segments, &mut segment_index, &mut segment_offset);
+    while segment_index < segments.len() {
+        let current = &segments[segment_index][segment_offset..];
+        let second = segments.get(segment_index + 1).copied().unwrap_or_default();
+        let third = segments.get(segment_index + 2).copied().unwrap_or_default();
+        let slices = [IoSlice::new(current), IoSlice::new(second), IoSlice::new(third)];
+        let slice_count = segments.len() - segment_index;
+        let written = io.write_vectored(&slices[..slice_count]).await?;
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "vectored frame write made no progress",
+            ));
+        }
+        advance_segments(&segments, &mut segment_index, &mut segment_offset, written)?;
+    }
+    Ok(())
+}
+
+async fn write_contiguous<W>(io: &mut W, mut bytes: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    while !bytes.is_empty() {
+        let written = io.write(bytes).await?;
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "contiguous frame write made no progress",
+            ));
+        }
+        if written > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "AsyncWrite reported more bytes than supplied",
+            ));
+        }
+        bytes = &bytes[written..];
+    }
+    Ok(())
+}
+
+fn skip_empty_segments(segments: &[&[u8]], segment_index: &mut usize, segment_offset: &mut usize) {
+    while *segment_index < segments.len() && *segment_offset == segments[*segment_index].len() {
+        *segment_index += 1;
+        *segment_offset = 0;
+    }
+}
+
+fn advance_segments(
+    segments: &[&[u8]],
+    segment_index: &mut usize,
+    segment_offset: &mut usize,
+    mut written: usize,
+) -> io::Result<()> {
+    while written > 0 && *segment_index < segments.len() {
+        let remaining = segments[*segment_index].len() - *segment_offset;
+        if written < remaining {
+            *segment_offset += written;
+            written = 0;
+        } else {
+            written -= remaining;
+            *segment_index += 1;
+            *segment_offset = 0;
+            skip_empty_segments(segments, segment_index, segment_offset);
+        }
+    }
+    if written == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "AsyncWrite reported more vectored bytes than supplied",
+        ))
+    }
+}

--- a/rocketmq-transport/tests/end_to_end_deadline.rs
+++ b/rocketmq-transport/tests/end_to_end_deadline.rs
@@ -89,7 +89,7 @@ async fn connected_session_with_limits(
     let remote_addr: SocketAddr = "127.0.0.1:19012".parse().expect("remote address");
     let admission = Arc::new(AdmissionController::new(limits));
     let runner = tokio::spawn(run_connected_session(
-        Connection::new_with_stream(transport),
+        Connection::new_with_plaintext_stream(transport),
         local_addr,
         remote_addr,
         service.task_group().clone(),
@@ -125,7 +125,7 @@ async fn expired_before_send_has_zero_remote_side_effects() {
     let side_effects = Arc::new(AtomicUsize::new(0));
     let remote_effects = side_effects.clone();
     let remote = tokio::spawn(async move {
-        let mut peer = Connection::new_with_stream(peer);
+        let mut peer = Connection::new_with_plaintext_stream(peer);
         if peer.receive_command().await.is_some() {
             remote_effects.fetch_add(1, Ordering::SeqCst);
         }

--- a/rocketmq-transport/tests/session_concurrency.rs
+++ b/rocketmq-transport/tests/session_concurrency.rs
@@ -61,7 +61,7 @@ where
     let local_addr: SocketAddr = "127.0.0.1:19101".parse().expect("local address");
     let remote_addr: SocketAddr = "127.0.0.1:19102".parse().expect("remote address");
     let runner = tokio::spawn(run_connected_session(
-        Connection::new_with_stream(transport),
+        Connection::new_with_plaintext_stream(transport),
         local_addr,
         remote_addr,
         service.task_group().clone(),
@@ -71,7 +71,7 @@ where
         Duration::from_secs(30),
         handler,
     ));
-    (runtime, service, Connection::new_with_stream(peer), runner)
+    (runtime, service, Connection::new_with_plaintext_stream(peer), runner)
 }
 
 async fn finish_session(

--- a/rocketmq-transport/tests/write_strategy.rs
+++ b/rocketmq-transport/tests/write_strategy.rs
@@ -1,0 +1,640 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::io;
+use std::io::IoSlice;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+use std::time::Duration;
+
+use bytes::Bytes;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_transport::run_connected_session;
+use rocketmq_transport::AdmissionController;
+use rocketmq_transport::AdmissionLimits;
+use rocketmq_transport::Connection;
+use rocketmq_transport::ConnectionHandler;
+use rocketmq_transport::FrameWriteMode;
+use rocketmq_transport::FrameWriter;
+use rocketmq_transport::RequestDeadline;
+use rocketmq_transport::SessionHandle;
+use rocketmq_transport::TransportSecurity;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+use tokio::sync::mpsc;
+use tokio::sync::Notify;
+
+#[derive(Clone, Copy)]
+enum StopBehavior {
+    Never,
+    ErrorAfter(usize),
+    WriteZeroAfter(usize),
+}
+
+#[derive(Default)]
+struct WriteRecord {
+    bytes: Vec<u8>,
+    scalar_calls: usize,
+    vectored_calls: usize,
+    largest_vector: usize,
+    flushes: usize,
+    shutdowns: usize,
+}
+
+struct ScriptedWriter {
+    record: Arc<Mutex<WriteRecord>>,
+    max_chunk: usize,
+    stop: StopBehavior,
+}
+
+impl ScriptedWriter {
+    fn new(max_chunk: usize, stop: StopBehavior) -> (Self, Arc<Mutex<WriteRecord>>) {
+        let record = Arc::new(Mutex::new(WriteRecord::default()));
+        (
+            Self {
+                record: record.clone(),
+                max_chunk,
+                stop,
+            },
+            record,
+        )
+    }
+
+    fn allowed_bytes(&self, already_written: usize, offered: usize) -> io::Result<usize> {
+        let available = match self.stop {
+            StopBehavior::Never => offered,
+            StopBehavior::ErrorAfter(limit) if already_written >= limit => {
+                return Err(io::Error::other("injected partial-write failure"));
+            }
+            StopBehavior::WriteZeroAfter(limit) if already_written >= limit => return Ok(0),
+            StopBehavior::ErrorAfter(limit) | StopBehavior::WriteZeroAfter(limit) => {
+                offered.min(limit - already_written)
+            }
+        };
+        Ok(available.min(self.max_chunk))
+    }
+}
+
+impl AsyncWrite for ScriptedWriter {
+    fn poll_write(self: Pin<&mut Self>, _context: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let mut record = self.record.lock().expect("write record lock");
+        record.scalar_calls += 1;
+        let allowed = match self.allowed_bytes(record.bytes.len(), buffer.len()) {
+            Ok(allowed) => allowed,
+            Err(error) => return Poll::Ready(Err(error)),
+        };
+        record.bytes.extend_from_slice(&buffer[..allowed]);
+        Poll::Ready(Ok(allowed))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let offered = buffers.iter().map(|buffer| buffer.len()).sum();
+        let mut record = self.record.lock().expect("write record lock");
+        record.vectored_calls += 1;
+        record.largest_vector = record.largest_vector.max(buffers.len());
+        let allowed = match self.allowed_bytes(record.bytes.len(), offered) {
+            Ok(allowed) => allowed,
+            Err(error) => return Poll::Ready(Err(error)),
+        };
+        let mut remaining = allowed;
+        for buffer in buffers {
+            let copied = remaining.min(buffer.len());
+            record.bytes.extend_from_slice(&buffer[..copied]);
+            remaining -= copied;
+            if remaining == 0 {
+                break;
+            }
+        }
+        Poll::Ready(Ok(allowed))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.record.lock().expect("write record lock").flushes += 1;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.record.lock().expect("write record lock").shutdowns += 1;
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn encoded_frame(code: i32, body: &'static [u8]) -> EncodedFrame {
+    EncodedFrame::from_command(
+        RemotingCommand::create_remoting_command(code)
+            .set_opaque(code)
+            .set_body(Bytes::from_static(body)),
+    )
+    .expect("test command should encode")
+}
+
+#[tokio::test]
+async fn plaintext_advances_partial_vectored_writes_across_all_frame_segments() {
+    let frame = encoded_frame(10_001, b"segmented-plaintext-body");
+    let expected = frame.clone().into_bytes();
+    let (io, record) = ScriptedWriter::new(5, StopBehavior::Never);
+    let mut writer = FrameWriter::plaintext(io);
+
+    writer
+        .write_frame(&frame)
+        .await
+        .expect("vectored write should complete");
+
+    let record = record.lock().expect("write record lock");
+    assert_eq!(record.bytes, expected.as_ref());
+    assert!(record.vectored_calls > 1);
+    assert!(
+        record.largest_vector >= 2,
+        "prefix/header/body should reach one vectored call"
+    );
+    assert_eq!(record.scalar_calls, 0);
+    assert_eq!(record.flushes, 1);
+}
+
+#[tokio::test]
+async fn tls_coalescing_enforces_its_plaintext_bound_and_uses_scalar_writes() {
+    let first = encoded_frame(10_002, b"first-tls-body");
+    let second = encoded_frame(10_003, b"second-tls-body");
+    let expected = [first.clone().into_bytes(), second.clone().into_bytes()].concat();
+    let limit = first.encoded_len().max(second.encoded_len());
+    let (io, record) = ScriptedWriter::new(7, StopBehavior::Never);
+    let mut writer = FrameWriter::new(
+        io,
+        FrameWriteMode::TlsCoalesced {
+            max_plaintext_frame_bytes: limit,
+        },
+    )
+    .expect("non-zero TLS bound");
+
+    writer.write_frame(&first).await.expect("first TLS frame");
+    writer.write_frame(&second).await.expect("second TLS frame");
+
+    {
+        let record = record.lock().expect("write record lock");
+        assert_eq!(record.bytes, expected);
+        assert_eq!(record.vectored_calls, 0);
+        assert!(record.scalar_calls > 1);
+    }
+
+    let (small_io, small_record) = ScriptedWriter::new(usize::MAX, StopBehavior::Never);
+    let mut bounded = FrameWriter::new(
+        small_io,
+        FrameWriteMode::TlsCoalesced {
+            max_plaintext_frame_bytes: first.encoded_len() - 1,
+        },
+    )
+    .expect("non-zero TLS bound");
+    let error = bounded
+        .write_frame(&first)
+        .await
+        .expect_err("oversized TLS plaintext must be rejected before writing");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert!(!bounded.is_poisoned());
+    assert!(small_record.lock().expect("write record lock").bytes.is_empty());
+}
+
+#[tokio::test]
+async fn partial_io_error_poisons_writer_and_blocks_later_frames_without_socket_access() {
+    let frame = encoded_frame(10_004, b"partial-error-body");
+    let (io, record) = ScriptedWriter::new(4, StopBehavior::ErrorAfter(10));
+    let mut writer = FrameWriter::plaintext(io);
+
+    let first_error = writer
+        .write_frame(&frame)
+        .await
+        .expect_err("injected error should fail the partial frame");
+    assert_eq!(first_error.kind(), io::ErrorKind::Other);
+    assert!(writer.is_poisoned());
+    let bytes_after_failure = record.lock().expect("write record lock").bytes.len();
+    assert_eq!(bytes_after_failure, 10);
+
+    let second_error = writer
+        .write_frame(&frame)
+        .await
+        .expect_err("poisoned writer must reject a later frame");
+    assert_eq!(second_error.kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(
+        record.lock().expect("write record lock").bytes.len(),
+        bytes_after_failure
+    );
+}
+
+#[tokio::test]
+async fn write_zero_after_partial_progress_poisons_writer() {
+    let frame = encoded_frame(10_005, b"write-zero-body");
+    let (io, record) = ScriptedWriter::new(3, StopBehavior::WriteZeroAfter(7));
+    let mut writer = FrameWriter::plaintext(io);
+
+    let error = writer
+        .write_frame(&frame)
+        .await
+        .expect_err("WriteZero should fail the frame");
+
+    assert_eq!(error.kind(), io::ErrorKind::WriteZero);
+    assert!(writer.is_poisoned());
+    assert_eq!(record.lock().expect("write record lock").bytes.len(), 7);
+}
+
+struct SuspendedWriter {
+    started: Arc<Notify>,
+    written: Arc<AtomicUsize>,
+}
+
+impl AsyncWrite for SuspendedWriter {
+    fn poll_write(self: Pin<&mut Self>, _context: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        if self.written.load(Ordering::Acquire) == 0 {
+            let written = buffer.len().min(4);
+            self.written.store(written, Ordering::Release);
+            self.started.notify_one();
+            Poll::Ready(Ok(written))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let first = buffers
+            .iter()
+            .find(|buffer| !buffer.is_empty())
+            .map_or(&[][..], |buffer| buffer.as_ref());
+        self.poll_write(context, first)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn dropping_an_active_low_level_write_poisons_the_writer() {
+    let frame = encoded_frame(10_009, b"cancelled-low-level-write");
+    let started = Arc::new(Notify::new());
+    let written = Arc::new(AtomicUsize::new(0));
+    let mut writer = FrameWriter::plaintext(SuspendedWriter {
+        started: started.clone(),
+        written: written.clone(),
+    });
+    let mut active_write = Box::pin(writer.write_frame(&frame));
+
+    tokio::select! {
+        () = started.notified() => {}
+        result = &mut active_write => panic!("write unexpectedly completed: {result:?}"),
+    }
+    drop(active_write);
+
+    assert_eq!(written.load(Ordering::Acquire), 4);
+    assert!(writer.is_poisoned());
+    let error = writer
+        .write_frame(&frame)
+        .await
+        .expect_err("cancelled low-level writer must reject later frames");
+    assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+}
+
+struct DeadlineResponseHandler {
+    completion: mpsc::Sender<Result<(), String>>,
+    response_bytes: usize,
+}
+
+impl ConnectionHandler for DeadlineResponseHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let completion = self.completion.clone();
+        let response_bytes = self.response_bytes;
+        Box::pin(async move {
+            let mut connection = session.connection();
+            let result = connection
+                .send_command_with_deadline(
+                    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                        .set_opaque(request.opaque())
+                        .set_body(vec![0x5a; response_bytes]),
+                    RequestDeadline::after(Duration::from_millis(20)),
+                    "cancellation-test-peer",
+                )
+                .await
+                .map_err(|error| error.to_string());
+            let _ = completion.send(result).await;
+        })
+    }
+}
+
+#[tokio::test]
+async fn caller_deadline_drops_only_waiter_after_writer_owns_frame() {
+    let runtime = RuntimeContext::from_current("frame-writer-caller-cancellation");
+    let service = runtime.service_context("frame-writer-caller-cancellation");
+    let (transport, peer_stream) = tokio::io::duplex(64);
+    let (completion_tx, mut completion_rx) = mpsc::channel(1);
+    let local_addr: SocketAddr = "127.0.0.1:19201".parse().expect("local address");
+    let remote_addr: SocketAddr = "127.0.0.1:19202".parse().expect("remote address");
+    let runner = tokio::spawn(run_connected_session(
+        Connection::new_with_plaintext_stream(transport),
+        local_addr,
+        remote_addr,
+        service.task_group().clone(),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        None,
+        Duration::from_secs(30),
+        Arc::new(DeadlineResponseHandler {
+            completion: completion_tx,
+            response_bytes: 64 * 1024,
+        }),
+    ));
+    let mut peer = Connection::new_with_plaintext_stream(peer_stream);
+    peer.send_command(RemotingCommand::create_remoting_command(10_006).set_opaque(76))
+        .await
+        .expect("request should reach session");
+
+    let completion = tokio::time::timeout(Duration::from_secs(1), completion_rx.recv())
+        .await
+        .expect("caller deadline should finish")
+        .expect("handler should report its send result");
+    assert!(completion.is_err(), "caller should stop waiting at its deadline");
+
+    let response = tokio::time::timeout(Duration::from_secs(2), peer.receive_command())
+        .await
+        .expect("writer should finish after peer resumes reading")
+        .expect("writer should keep the connection open")
+        .expect("complete response should decode");
+    assert_eq!(response.opaque(), 76);
+    assert_eq!(response.body().map(Bytes::len), Some(64 * 1024));
+
+    drop(peer);
+    tokio::time::timeout(Duration::from_secs(1), runner)
+        .await
+        .expect("session should observe peer closure")
+        .expect("session task should finish");
+    drop(service);
+    let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+struct FailureControl {
+    release_error: AtomicBool,
+    partial_written: Notify,
+    parked_writer: Mutex<Option<Waker>>,
+    write_polls: AtomicUsize,
+    failure_poll: AtomicUsize,
+}
+
+impl FailureControl {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            release_error: AtomicBool::new(false),
+            partial_written: Notify::new(),
+            parked_writer: Mutex::new(None),
+            write_polls: AtomicUsize::new(0),
+            failure_poll: AtomicUsize::new(0),
+        })
+    }
+
+    fn release(&self) {
+        self.release_error.store(true, Ordering::Release);
+        if let Some(waker) = self.parked_writer.lock().expect("writer waker lock").take() {
+            waker.wake();
+        }
+    }
+}
+
+struct PartialFailureTransport {
+    inner: tokio::io::DuplexStream,
+    control: Arc<FailureControl>,
+    wrote_partial: bool,
+}
+
+impl AsyncRead for PartialFailureTransport {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(context, buffer)
+    }
+}
+
+impl AsyncWrite for PartialFailureTransport {
+    fn poll_write(mut self: Pin<&mut Self>, context: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let write_poll = self.control.write_polls.fetch_add(1, Ordering::AcqRel) + 1;
+        if !self.wrote_partial {
+            let limit = buffer.len().min(5);
+            match Pin::new(&mut self.inner).poll_write(context, &buffer[..limit]) {
+                Poll::Ready(Ok(written)) if written > 0 => {
+                    self.wrote_partial = true;
+                    self.control.partial_written.notify_one();
+                    Poll::Ready(Ok(written))
+                }
+                result => result,
+            }
+        } else if self.control.release_error.load(Ordering::Acquire) {
+            self.control.failure_poll.store(write_poll, Ordering::Release);
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "injected connection failure after partial frame",
+            )))
+        } else {
+            *self.control.parked_writer.lock().expect("writer waker lock") = Some(context.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let first = buffers
+            .iter()
+            .find(|buffer| !buffer.is_empty())
+            .map_or(&[][..], |buffer| buffer.as_ref());
+        self.poll_write(context, first)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(context)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(context)
+    }
+}
+
+struct ConcurrentResponseHandler {
+    queued: mpsc::Sender<i32>,
+    results: mpsc::Sender<(i32, Result<(), String>)>,
+}
+
+impl ConnectionHandler for ConcurrentResponseHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        request: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let queued = self.queued.clone();
+        let results = self.results.clone();
+        Box::pin(async move {
+            let opaque = request.opaque();
+            let _ = queued.send(opaque).await;
+            let mut connection = session.connection();
+            let result = connection
+                .send_command(
+                    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                        .set_opaque(opaque)
+                        .set_body(vec![opaque as u8; 128]),
+                )
+                .await
+                .map_err(|error| error.to_string());
+            let _ = results.send((opaque, result)).await;
+        })
+    }
+}
+
+#[tokio::test]
+async fn partial_failure_closes_session_and_fails_every_already_queued_frame() {
+    let runtime = RuntimeContext::from_current("frame-writer-poisoned-queue");
+    let service = runtime.service_context("frame-writer-poisoned-queue");
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let (inner, peer_stream) = tokio::io::duplex(4096);
+    let control = FailureControl::new();
+    let transport = PartialFailureTransport {
+        inner,
+        control: control.clone(),
+        wrote_partial: false,
+    };
+    let (queued_tx, mut queued_rx) = mpsc::channel(2);
+    let (result_tx, mut result_rx) = mpsc::channel(2);
+    let local_addr: SocketAddr = "127.0.0.1:19203".parse().expect("local address");
+    let remote_addr: SocketAddr = "127.0.0.1:19204".parse().expect("remote address");
+    let runner = tokio::spawn(run_connected_session(
+        Connection::new_with_plaintext_stream(transport),
+        local_addr,
+        remote_addr,
+        service.task_group().clone(),
+        admission.clone(),
+        Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        None,
+        Duration::from_secs(30),
+        Arc::new(ConcurrentResponseHandler {
+            queued: queued_tx,
+            results: result_tx,
+        }),
+    ));
+    let mut peer = Connection::new_with_plaintext_stream(peer_stream);
+    peer.send_command(RemotingCommand::create_remoting_command(10_007).set_opaque(77))
+        .await
+        .expect("first request");
+    peer.send_command(RemotingCommand::create_remoting_command(10_008).set_opaque(78))
+        .await
+        .expect("second request");
+
+    tokio::time::timeout(Duration::from_secs(1), queued_rx.recv())
+        .await
+        .expect("first handler should enqueue")
+        .expect("first queued signal");
+    tokio::time::timeout(Duration::from_secs(1), queued_rx.recv())
+        .await
+        .expect("second handler should enqueue")
+        .expect("second queued signal");
+    tokio::time::timeout(Duration::from_secs(1), control.partial_written.notified())
+        .await
+        .expect("writer should make partial progress");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while admission.snapshot().queued.current_count < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("both frames should own queued-byte permits");
+
+    control.release();
+
+    let first = tokio::time::timeout(Duration::from_secs(1), result_rx.recv())
+        .await
+        .expect("first send should finish")
+        .expect("first send result");
+    let second = tokio::time::timeout(Duration::from_secs(1), result_rx.recv())
+        .await
+        .expect("second send should finish")
+        .expect("second send result");
+    let errors = [
+        first.1.expect_err("first queued frame should fail"),
+        second.1.expect_err("second queued frame should fail"),
+    ];
+    assert!(errors.iter().any(|error| error.contains("injected connection failure")));
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("poisoned by a previous frame failure")));
+    assert!(control.failure_poll.load(Ordering::Acquire) >= 2);
+    assert_eq!(
+        control.write_polls.load(Ordering::Acquire),
+        control.failure_poll.load(Ordering::Acquire),
+        "queued frames must not touch the socket after the poisoning failure"
+    );
+
+    drop(peer);
+    tokio::time::timeout(Duration::from_secs(1), runner)
+        .await
+        .expect("poisoned session should close")
+        .expect("session task should finish");
+    drop(service);
+    let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8751

### Brief Description

- Add an immutable `EncodedFrame` that preserves the RocketMQ prefix, serialized header, and body as independently owned wire segments while remaining byte-for-byte compatible with JSON and ROCKETMQ encodings.
- Replace full-frame transport staging with plaintext vectored writes and a bounded, reusable TLS coalescing buffer. Exact encoded bytes are admitted before queue staging, and partial I/O failures poison and close the writer while explicitly failing queued frames.
- Preserve single-writer request ordering while making caller deadline expiry drop only the completion waiter after a writer owns a frame.
- Use explicit plaintext and TLS connection constructors, add the existing repository-standard compiler recursion limit to the admin CLI binary entry point, and cover partial writes, `WriteZero`, cancellation, poisoning, queue failure, and frame-write performance.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol`: passed.
- `cargo test -p rocketmq-transport`: passed.
- `cargo test -p rocketmq-protocol encoded_frame`: 3 passed.
- `cargo test -p rocketmq-transport --test write_strategy`: 7 passed.
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy -p rocketmq-admin-cli --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo bench -p rocketmq-transport --bench frame_write --no-run`: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `.\scripts\check-agents-routing.ps1`: passed.
- `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings` in both standalone dashboard Rust backends: passed.
- `cargo build --all-targets --all-features` in the standalone Web Dashboard backend: passed.
- Windows rejected the aggregate `cargo fmt --all -- --check` command with `os error 206`; package-by-package `cargo fmt -p <workspace-package> -- --check` passed for all 29 root workspace packages, and each standalone Cargo project passed its package-level format check.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encoding RocketMQ frames as separate prefix, header, and body segments.
  * Added configurable plaintext and TLS frame-writing modes.
  * Improved frame writing for partial writes, batching, and TLS coalescing.
* **Bug Fixes**
  * Improved connection handling after write failures, timeouts, and shutdowns.
  * TLS connections now use the appropriate TLS-aware transport path.
* **Tests**
  * Added coverage for frame writing, partial I/O, deadlines, failures, and queued session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->