### PR TITLE
[ISSUE #8753]♻️Add a bounded CommitLog append sequencer and micro-batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5050,6 +5050,7 @@ version = "1.0.0"
 dependencies = [
  "bytes",
  "cheetah-string",
+ "criterion",
  "dashmap",
  "libc",
  "loom",
@@ -5059,6 +5060,7 @@ dependencies = [
  "rayon",
  "rocketmq-error",
  "rocketmq-observability",
+ "rocketmq-runtime",
  "rocketmq-store-api",
  "serde",
  "serde_json",

--- a/rocketmq-store-local/Cargo.toml
+++ b/rocketmq-store-local/Cargo.toml
@@ -44,6 +44,7 @@ parking_lot.workspace = true
 rayon = "1.12"
 rocketmq-error.workspace = true
 rocketmq-observability = { workspace = true, optional = true }
+rocketmq-runtime.workspace = true
 rocketmq-store-api.workspace = true
 serde.workspace = true
 thiserror.workspace = true
@@ -52,9 +53,15 @@ tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
 loom = "=0.7.2"
 serde_json.workspace = true
 tempfile = "3.27.0"
+tokio = { workspace = true, features = ["test-util"] }
+
+[[bench]]
+name = "commitlog_micro_batch"
+harness = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-uring = { version = "0.5", optional = true }

--- a/rocketmq-store-local/benches/commitlog_micro_batch.rs
+++ b/rocketmq-store-local/benches/commitlog_micro_batch.rs
@@ -1,0 +1,79 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rocketmq_store_local::commit_log::append::micro_batch::MicroBatchPolicy;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencer;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerConfig;
+use tokio_util::sync::CancellationToken;
+
+const REQUESTS_PER_ITERATION: usize = 32;
+const RETAINED_BYTES_PER_REQUEST: usize = 1024;
+
+async fn run_sequencer(policy: MicroBatchPolicy) {
+    let config = AppendSequencerConfig {
+        queue_capacity: REQUESTS_PER_ITERATION,
+        queue_bytes: REQUESTS_PER_ITERATION * RETAINED_BYTES_PER_REQUEST,
+        micro_batch: policy,
+    };
+    let (sender, mut receiver) = AppendSequencer::bounded(config).expect("sequencer");
+    for request in 0..REQUESTS_PER_ITERATION {
+        sender
+            .try_submit(request, RETAINED_BYTES_PER_REQUEST)
+            .expect("admission");
+    }
+    sender.close();
+    let cancellation = CancellationToken::new();
+    let mut completed = 0;
+    while let Some(batch) = receiver.next_batch(&cancellation).await {
+        completed += batch.len();
+    }
+    assert_eq!(completed, REQUESTS_PER_ITERATION);
+}
+
+fn benchmark_commitlog_micro_batch(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("benchmark runtime");
+    let mut group = criterion.benchmark_group("commitlog_append_sequencer");
+    group.bench_function("disabled_32_requests", |bencher| {
+        bencher.iter(|| {
+            runtime.block_on(run_sequencer(
+                MicroBatchPolicy::disabled(REQUESTS_PER_ITERATION * RETAINED_BYTES_PER_REQUEST)
+                    .expect("benchmark policy"),
+            ));
+        });
+    });
+    group.bench_function("enabled_32_requests", |bencher| {
+        bencher.iter(|| {
+            runtime.block_on(run_sequencer(
+                MicroBatchPolicy::try_new(
+                    REQUESTS_PER_ITERATION,
+                    REQUESTS_PER_ITERATION * RETAINED_BYTES_PER_REQUEST,
+                    Duration::ZERO,
+                )
+                .expect("benchmark policy"),
+            ));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_commitlog_micro_batch);
+criterion_main!(benches);

--- a/rocketmq-store-local/src/commit_log/append.rs
+++ b/rocketmq-store-local/src/commit_log/append.rs
@@ -15,6 +15,11 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+pub mod finalized_append;
+pub mod micro_batch;
+pub mod prepared_payload;
+pub mod sequencer;
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum AppendMessageStatus {
     #[default]

--- a/rocketmq-store-local/src/commit_log/append/finalized_append.rs
+++ b/rocketmq-store-local/src/commit_log/append/finalized_append.rs
@@ -1,0 +1,225 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime-field binding for an already validated CommitLog payload.
+
+use crate::commit_log::append_frame::AppendFrameCrcPlan;
+use crate::commit_log::append_frame::AppendFrameKernel;
+
+use super::prepared_payload::PreparedPayload;
+use super::prepared_payload::PreparedPayloadKind;
+
+/// Per-frame runtime fields calculated before mapped-file reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FinalizedFrame {
+    queue_offset: i64,
+    physical_offset: i64,
+}
+
+/// A prepared payload bound to its final queue/physical offsets and Store timestamp.
+///
+/// Construction performs every fallible range and offset calculation. [`Self::write_into`] then
+/// executes only the stable-byte copy, fixed-field patches, and caller-provided checksum write.
+pub struct FinalizedAppend<'a> {
+    prepared: &'a PreparedPayload,
+    frames: Vec<FinalizedFrame>,
+    store_timestamp: i64,
+}
+
+impl<'a> FinalizedAppend<'a> {
+    /// Binds runtime fields for all frames without touching mapped memory.
+    ///
+    /// Batch frame queue offsets advance by one in encoded order. Physical offsets advance by each
+    /// frame's relative byte start.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FinalizeAppendError`] when queue or physical offset arithmetic overflows.
+    pub fn try_new(
+        prepared: &'a PreparedPayload,
+        first_queue_offset: i64,
+        first_physical_offset: i64,
+        store_timestamp: i64,
+    ) -> Result<Self, FinalizeAppendError> {
+        let mut frames = Vec::with_capacity(prepared.frame_count());
+        for (index, prepared_frame) in prepared.frames().iter().copied().enumerate() {
+            let relative_physical_offset =
+                i64::try_from(prepared_frame.start()).map_err(|_| FinalizeAppendError::PhysicalOffsetOverflow {
+                    first_physical_offset,
+                    frame_start: prepared_frame.start(),
+                })?;
+            let physical_offset = first_physical_offset.checked_add(relative_physical_offset).ok_or(
+                FinalizeAppendError::PhysicalOffsetOverflow {
+                    first_physical_offset,
+                    frame_start: prepared_frame.start(),
+                },
+            )?;
+            let queue_offset =
+                match prepared.kind() {
+                    PreparedPayloadKind::Single => first_queue_offset,
+                    PreparedPayloadKind::Batch => first_queue_offset.checked_add(index as i64).ok_or(
+                        FinalizeAppendError::QueueOffsetOverflow {
+                            first_queue_offset,
+                            frame_index: index,
+                        },
+                    )?,
+                };
+            frames.push(FinalizedFrame {
+                queue_offset,
+                physical_offset,
+            });
+        }
+        Ok(Self {
+            prepared,
+            frames,
+            store_timestamp,
+        })
+    }
+
+    /// Returns the exact destination bytes required.
+    #[must_use]
+    pub const fn required_bytes(&self) -> usize {
+        self.prepared.retained_bytes()
+    }
+
+    /// Returns final physical offsets in encoded frame order.
+    #[must_use]
+    pub fn physical_offsets(&self) -> impl ExactSizeIterator<Item = i64> + '_ {
+        self.frames.iter().map(|frame| frame.physical_offset)
+    }
+
+    /// Copies and patches the payload into an exclusive mapped-file staging buffer.
+    ///
+    /// The checksum callback is invoked once per frame when a trailer was reserved. It receives
+    /// that mutable frame and the range plan selected by [`AppendFrameKernel`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FinalizeAppendError::DestinationTooSmall`] without modifying the destination when
+    /// it cannot hold the complete payload.
+    pub fn write_into<F>(&self, destination: &mut [u8], mut finalize_crc: F) -> Result<(), FinalizeAppendError>
+    where
+        F: FnMut(&mut [u8], AppendFrameCrcPlan),
+    {
+        if destination.len() < self.required_bytes() {
+            return Err(FinalizeAppendError::DestinationTooSmall {
+                required: self.required_bytes(),
+                available: destination.len(),
+            });
+        }
+        destination[..self.required_bytes()].copy_from_slice(self.prepared.bytes());
+        for (prepared_frame, finalized_frame) in self.prepared.frames().iter().copied().zip(self.frames.iter().copied())
+        {
+            let frame = &mut destination[prepared_frame.range()];
+            let crc_plan = AppendFrameKernel::finalize_frame(
+                frame,
+                finalized_frame.queue_offset,
+                finalized_frame.physical_offset,
+                self.store_timestamp,
+                prepared_frame.born_host_width(),
+                self.prepared.crc_trailer_bytes() as i32,
+            );
+            if !matches!(crc_plan, AppendFrameCrcPlan::Disabled) {
+                finalize_crc(frame, crc_plan);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Failure to bind or copy final append fields.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FinalizeAppendError {
+    /// A batch queue offset cannot be represented.
+    #[error("queue offset overflow: first offset {first_queue_offset}, frame index {frame_index}")]
+    QueueOffsetOverflow {
+        first_queue_offset: i64,
+        frame_index: usize,
+    },
+    /// A frame's physical offset cannot be represented.
+    #[error("physical offset overflow: first offset {first_physical_offset}, frame start {frame_start}")]
+    PhysicalOffsetOverflow {
+        first_physical_offset: i64,
+        frame_start: usize,
+    },
+    /// The caller supplied a staging buffer smaller than the validated payload.
+    #[error("append destination has {available} bytes but requires {required}")]
+    DestinationTooSmall { required: usize, available: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BufMut;
+    use bytes::Bytes;
+    use bytes::BytesMut;
+
+    use super::*;
+
+    const QUEUE_OFFSET_POSITION: usize = 20;
+    const PHYSICAL_OFFSET_POSITION: usize = 28;
+    const STORE_TIMESTAMP_POSITION: usize = 56;
+
+    fn frame(len: usize) -> Bytes {
+        let mut bytes = BytesMut::zeroed(len);
+        bytes[..4].copy_from_slice(&(len as i32).to_be_bytes());
+        bytes.freeze()
+    }
+
+    fn read_i64(bytes: &[u8], start: usize) -> i64 {
+        i64::from_be_bytes(bytes[start..start + 8].try_into().expect("i64 bytes"))
+    }
+
+    #[test]
+    fn patches_sequential_batch_offsets_and_physical_positions() {
+        let first = frame(80);
+        let second = frame(88);
+        let mut bytes = BytesMut::new();
+        bytes.put(first);
+        bytes.put(second);
+        let prepared = PreparedPayload::try_batch(bytes.freeze(), 0).expect("prepared batch");
+        let finalized = FinalizedAppend::try_new(&prepared, 41, 1024, 77).expect("finalized batch");
+        let mut destination = vec![0; finalized.required_bytes()];
+
+        finalized
+            .write_into(&mut destination, |_, _| unreachable!("CRC disabled"))
+            .expect("write");
+
+        assert_eq!(read_i64(&destination, QUEUE_OFFSET_POSITION), 41);
+        assert_eq!(read_i64(&destination, PHYSICAL_OFFSET_POSITION), 1024);
+        assert_eq!(read_i64(&destination, STORE_TIMESTAMP_POSITION), 77);
+        assert_eq!(read_i64(&destination[80..], QUEUE_OFFSET_POSITION), 42);
+        assert_eq!(read_i64(&destination[80..], PHYSICAL_OFFSET_POSITION), 1104);
+        assert_eq!(finalized.physical_offsets().collect::<Vec<_>>(), vec![1024, 1104]);
+    }
+
+    #[test]
+    fn rejects_small_destination_before_copying() {
+        let prepared = PreparedPayload::try_single(frame(80), 0).expect("prepared");
+        let finalized = FinalizedAppend::try_new(&prepared, 1, 2, 3).expect("finalized");
+        let mut destination = vec![0xA5; 79];
+
+        let error = finalized
+            .write_into(&mut destination, |_, _| {})
+            .expect_err("small destination");
+
+        assert_eq!(
+            error,
+            FinalizeAppendError::DestinationTooSmall {
+                required: 80,
+                available: 79
+            }
+        );
+        assert!(destination.iter().all(|byte| *byte == 0xA5));
+    }
+}

--- a/rocketmq-store-local/src/commit_log/append/micro_batch.rs
+++ b/rocketmq-store-local/src/commit_log/append/micro_batch.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CommitLog micro-batch policy and resource-permit preserving batch container.
+
+use std::time::Duration;
+
+use rocketmq_runtime::resource_budget::BudgetedItem;
+
+/// Limits applied while draining adjacent FIFO append requests.
+///
+/// `max_bytes` is an aggregation limit rather than an admission limit. A single request larger
+/// than that value is still processed as a one-item batch when it fits the sequencer queue budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MicroBatchPolicy {
+    max_items: usize,
+    max_bytes: usize,
+    max_wait: Duration,
+}
+
+impl MicroBatchPolicy {
+    /// Creates an enabled micro-batch policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MicroBatchPolicyError`] when either hard limit is zero.
+    pub const fn try_new(
+        max_items: usize,
+        max_bytes: usize,
+        max_wait: Duration,
+    ) -> Result<Self, MicroBatchPolicyError> {
+        if max_items == 0 {
+            return Err(MicroBatchPolicyError::ZeroMaxItems);
+        }
+        if max_bytes == 0 {
+            return Err(MicroBatchPolicyError::ZeroMaxBytes);
+        }
+        Ok(Self {
+            max_items,
+            max_bytes,
+            max_wait,
+        })
+    }
+
+    /// Creates a policy that preserves sequencer ownership without request aggregation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MicroBatchPolicyError::ZeroMaxBytes`] when the queue has no byte capacity.
+    pub const fn disabled(max_payload_bytes: usize) -> Result<Self, MicroBatchPolicyError> {
+        Self::try_new(1, max_payload_bytes, Duration::ZERO)
+    }
+
+    /// Returns the maximum number of requests in one drain.
+    #[must_use]
+    pub const fn max_items(self) -> usize {
+        self.max_items
+    }
+
+    /// Returns the aggregate-byte target for one drain.
+    #[must_use]
+    pub const fn max_bytes(self) -> usize {
+        self.max_bytes
+    }
+
+    /// Returns how long a non-full drain may wait for adjacent requests.
+    #[must_use]
+    pub const fn max_wait(self) -> Duration {
+        self.max_wait
+    }
+}
+
+/// Invalid micro-batch policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum MicroBatchPolicyError {
+    /// A batch cannot have a zero item limit.
+    #[error("CommitLog micro-batch max-items must be greater than zero")]
+    ZeroMaxItems,
+    /// A batch cannot have a zero byte limit.
+    #[error("CommitLog micro-batch max-bytes must be greater than zero")]
+    ZeroMaxBytes,
+}
+
+/// One FIFO drain whose resource permits remain held until each item is consumed.
+pub struct MicroBatch<T> {
+    items: Vec<BudgetedItem<T>>,
+    retained_bytes: usize,
+}
+
+impl<T> MicroBatch<T> {
+    pub(crate) fn new(items: Vec<BudgetedItem<T>>, retained_bytes: usize) -> Self {
+        Self { items, retained_bytes }
+    }
+
+    /// Returns the number of append requests in this drain.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns whether this drain is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns aggregate bytes retained by all queue permits.
+    #[must_use]
+    pub const fn retained_bytes(&self) -> usize {
+        self.retained_bytes
+    }
+
+    /// Consumes the batch while preserving each permit alongside its request.
+    #[must_use]
+    pub fn into_budgeted_items(self) -> Vec<BudgetedItem<T>> {
+        self.items
+    }
+}

--- a/rocketmq-store-local/src/commit_log/append/prepared_payload.rs
+++ b/rocketmq-store-local/src/commit_log/append/prepared_payload.rs
@@ -1,0 +1,348 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Immutable CommitLog bytes validated before entering the append sequencer.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::commit_log::append_frame::AppendFrameKernel;
+use crate::commit_log::header::HostWidth;
+
+const LENGTH_PREFIX_BYTES: usize = size_of::<i32>();
+const SYS_FLAG_POSITION: usize = 36;
+const SYS_FLAG_END: usize = SYS_FLAG_POSITION + size_of::<i32>();
+
+/// Whether an encoded payload contains one CommitLog frame or a length-prefixed frame batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreparedPayloadKind {
+    /// Exactly one CommitLog frame.
+    Single,
+    /// One or more contiguous CommitLog frames.
+    Batch,
+}
+
+/// Validated immutable metadata for one frame in a [`PreparedPayload`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedFrame {
+    start: usize,
+    len: usize,
+    born_host_width: HostWidth,
+}
+
+impl PreparedFrame {
+    /// Returns this frame's range within the prepared payload.
+    #[must_use]
+    pub fn range(self) -> Range<usize> {
+        self.start..self.start + self.len
+    }
+
+    /// Returns this frame's relative start.
+    #[must_use]
+    pub const fn start(self) -> usize {
+        self.start
+    }
+
+    /// Returns this frame's validated byte length.
+    #[must_use]
+    pub const fn len(self) -> usize {
+        self.len
+    }
+
+    /// Returns whether this descriptor is empty.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the born-host width that selects the Store timestamp position.
+    #[must_use]
+    pub const fn born_host_width(self) -> HostWidth {
+        self.born_host_width
+    }
+}
+
+/// Immutable, structurally validated CommitLog bytes.
+///
+/// Stable fields are encoded before this value is created. Queue offsets, physical offsets,
+/// Store timestamps, and checksums remain placeholders until a sequenced append is finalized.
+#[derive(Debug, Clone)]
+pub struct PreparedPayload {
+    bytes: Bytes,
+    frames: Arc<[PreparedFrame]>,
+    message_count: i16,
+    kind: PreparedPayloadKind,
+    crc_trailer_bytes: usize,
+}
+
+impl PreparedPayload {
+    /// Validates an encoded single-message frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PreparedPayloadError`] when the payload is malformed, contains multiple frames,
+    /// or cannot safely accommodate the runtime fields and configured checksum trailer.
+    pub fn try_single(bytes: Bytes, crc_trailer_bytes: usize) -> Result<Self, PreparedPayloadError> {
+        Self::try_from_encoded(bytes, PreparedPayloadKind::Single, crc_trailer_bytes)
+    }
+
+    /// Validates one or more contiguous encoded batch frames.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PreparedPayloadError`] when any frame is malformed, the frame partition is not
+    /// exact, or a runtime field/checksum trailer would be out of bounds.
+    pub fn try_batch(bytes: Bytes, crc_trailer_bytes: usize) -> Result<Self, PreparedPayloadError> {
+        Self::try_from_encoded(bytes, PreparedPayloadKind::Batch, crc_trailer_bytes)
+    }
+
+    fn try_from_encoded(
+        bytes: Bytes,
+        kind: PreparedPayloadKind,
+        crc_trailer_bytes: usize,
+    ) -> Result<Self, PreparedPayloadError> {
+        if bytes.is_empty() {
+            return Err(PreparedPayloadError::Empty);
+        }
+        if bytes.len() > i32::MAX as usize {
+            return Err(PreparedPayloadError::PayloadTooLarge { len: bytes.len() });
+        }
+
+        let mut frames = Vec::new();
+        let mut start = 0usize;
+        while start < bytes.len() {
+            let prefix_end = start
+                .checked_add(LENGTH_PREFIX_BYTES)
+                .ok_or(PreparedPayloadError::FrameRangeOverflow { start })?;
+            let prefix = bytes
+                .get(start..prefix_end)
+                .ok_or(PreparedPayloadError::MissingLengthPrefix {
+                    start,
+                    remaining: bytes.len().saturating_sub(start),
+                })?;
+            let declared_len = AppendFrameKernel::declared_frame_length(prefix);
+            let len = usize::try_from(declared_len)
+                .map_err(|_| PreparedPayloadError::NonPositiveFrameLength { start, declared_len })?;
+            if len == 0 {
+                return Err(PreparedPayloadError::NonPositiveFrameLength { start, declared_len });
+            }
+            let end = start
+                .checked_add(len)
+                .ok_or(PreparedPayloadError::FrameRangeOverflow { start })?;
+            let frame = bytes.get(start..end).ok_or(PreparedPayloadError::FrameOutOfBounds {
+                start,
+                declared_len,
+                payload_len: bytes.len(),
+            })?;
+            let sys_flag_bytes = frame
+                .get(SYS_FLAG_POSITION..SYS_FLAG_END)
+                .ok_or(PreparedPayloadError::FixedHeaderTooShort { start, frame_len: len })?;
+            let sys_flag = i32::from_be_bytes(
+                sys_flag_bytes
+                    .try_into()
+                    .map_err(|_| PreparedPayloadError::FixedHeaderTooShort { start, frame_len: len })?,
+            );
+            let born_host_width = HostWidth::born(sys_flag);
+            let timestamp_end = born_host_width
+                .store_timestamp_position()
+                .checked_add(size_of::<i64>())
+                .ok_or(PreparedPayloadError::FrameRangeOverflow { start })?;
+            if timestamp_end > len {
+                return Err(PreparedPayloadError::FixedHeaderTooShort { start, frame_len: len });
+            }
+            if crc_trailer_bytes > len {
+                return Err(PreparedPayloadError::CrcTrailerOutOfBounds {
+                    start,
+                    frame_len: len,
+                    crc_trailer_bytes,
+                });
+            }
+            frames.push(PreparedFrame {
+                start,
+                len,
+                born_host_width,
+            });
+            start = end;
+        }
+
+        match (kind, frames.len()) {
+            (PreparedPayloadKind::Single, 1) | (PreparedPayloadKind::Batch, 1..) => {}
+            (PreparedPayloadKind::Single, actual) => {
+                return Err(PreparedPayloadError::SingleFrameCount { actual });
+            }
+            (PreparedPayloadKind::Batch, 0) => return Err(PreparedPayloadError::EmptyBatch),
+        }
+        let message_count =
+            i16::try_from(frames.len()).map_err(|_| PreparedPayloadError::TooManyFrames { actual: frames.len() })?;
+
+        Ok(Self {
+            bytes,
+            frames: frames.into(),
+            message_count,
+            kind,
+            crc_trailer_bytes,
+        })
+    }
+
+    /// Returns the immutable stable bytes.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    /// Returns all validated frame descriptors in FIFO order.
+    #[must_use]
+    pub fn frames(&self) -> &[PreparedFrame] {
+        &self.frames
+    }
+
+    /// Returns whether this is a single frame or an encoded frame batch.
+    #[must_use]
+    pub const fn kind(&self) -> PreparedPayloadKind {
+        self.kind
+    }
+
+    /// Returns the number of encoded CommitLog frames.
+    #[must_use]
+    pub fn frame_count(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Returns the validated message count used by ConsumeQueue offset accounting.
+    #[must_use]
+    pub const fn message_count(&self) -> i16 {
+        self.message_count
+    }
+
+    /// Returns the exact number of payload bytes retained by the sequencer.
+    #[must_use]
+    pub const fn retained_bytes(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Returns the checksum trailer length reserved in every frame.
+    #[must_use]
+    pub const fn crc_trailer_bytes(&self) -> usize {
+        self.crc_trailer_bytes
+    }
+
+    /// Consumes this wrapper and returns the original immutable bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+}
+
+/// Structural validation failure for encoded CommitLog bytes.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PreparedPayloadError {
+    /// No frame bytes were supplied.
+    #[error("prepared CommitLog payload is empty")]
+    Empty,
+    /// The aggregate cannot be represented by the CommitLog signed length domain.
+    #[error("prepared CommitLog payload length {len} exceeds i32::MAX")]
+    PayloadTooLarge { len: usize },
+    /// Fewer than four bytes remain for a frame length.
+    #[error("frame at byte {start} has only {remaining} bytes for its length prefix")]
+    MissingLengthPrefix { start: usize, remaining: usize },
+    /// A signed frame length was zero or negative.
+    #[error("frame at byte {start} declares non-positive length {declared_len}")]
+    NonPositiveFrameLength { start: usize, declared_len: i32 },
+    /// A frame length points beyond the immutable payload.
+    #[error("frame at byte {start} declares length {declared_len}, outside payload length {payload_len}")]
+    FrameOutOfBounds {
+        start: usize,
+        declared_len: i32,
+        payload_len: usize,
+    },
+    /// Offset arithmetic overflowed while validating the frame partition.
+    #[error("frame range starting at byte {start} overflows usize")]
+    FrameRangeOverflow { start: usize },
+    /// A frame cannot contain all fixed runtime fields selected by its system flags.
+    #[error("frame at byte {start} is too short for its fixed header: {frame_len} bytes")]
+    FixedHeaderTooShort { start: usize, frame_len: usize },
+    /// The configured checksum trailer cannot fit inside a frame.
+    #[error("frame at byte {start} has {frame_len} bytes, smaller than checksum trailer {crc_trailer_bytes}")]
+    CrcTrailerOutOfBounds {
+        start: usize,
+        frame_len: usize,
+        crc_trailer_bytes: usize,
+    },
+    /// A single-message payload contained an unexpected frame count.
+    #[error("single-message payload must contain exactly one frame, found {actual}")]
+    SingleFrameCount { actual: usize },
+    /// A batch payload contained no frames.
+    #[error("batch payload must contain at least one frame")]
+    EmptyBatch,
+    /// ConsumeQueue accounting cannot represent the number of encoded frames.
+    #[error("prepared CommitLog payload contains {actual} frames, exceeding i16::MAX")]
+    TooManyFrames { actual: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BufMut;
+    use bytes::BytesMut;
+
+    use super::*;
+
+    fn encoded_frame(len: usize, sys_flag: i32) -> Bytes {
+        let mut bytes = BytesMut::zeroed(len);
+        bytes[..4].copy_from_slice(&(len as i32).to_be_bytes());
+        bytes[SYS_FLAG_POSITION..SYS_FLAG_END].copy_from_slice(&sys_flag.to_be_bytes());
+        bytes.freeze()
+    }
+
+    #[test]
+    fn validates_exact_single_and_batch_partitions() {
+        let first = encoded_frame(80, 0);
+        let second = encoded_frame(96, 0x10);
+        let mut batch = BytesMut::with_capacity(first.len() + second.len());
+        batch.put(first);
+        batch.put(second);
+
+        let prepared = PreparedPayload::try_batch(batch.freeze(), 0).expect("valid batch");
+
+        assert_eq!(prepared.kind(), PreparedPayloadKind::Batch);
+        assert_eq!(prepared.frame_count(), 2);
+        assert_eq!(prepared.frames()[0].range(), 0..80);
+        assert_eq!(prepared.frames()[1].range(), 80..176);
+        assert_eq!(prepared.frames()[1].born_host_width(), HostWidth::Ipv6);
+    }
+
+    #[test]
+    fn rejects_truncated_frame_before_sequencing() {
+        let mut frame = encoded_frame(80, 0).to_vec();
+        frame[..4].copy_from_slice(&81_i32.to_be_bytes());
+
+        let error = PreparedPayload::try_single(Bytes::from(frame), 0).expect_err("truncated frame");
+
+        assert!(matches!(error, PreparedPayloadError::FrameOutOfBounds { .. }));
+    }
+
+    #[test]
+    fn rejects_multiple_frames_in_single_payload() {
+        let first = encoded_frame(80, 0);
+        let second = encoded_frame(80, 0);
+        let mut batch = BytesMut::new();
+        batch.put(first);
+        batch.put(second);
+
+        let error = PreparedPayload::try_single(batch.freeze(), 0).expect_err("multiple frames");
+
+        assert_eq!(error, PreparedPayloadError::SingleFrameCount { actual: 2 });
+    }
+}

--- a/rocketmq-store-local/src/commit_log/append/sequencer.rs
+++ b/rocketmq-store-local/src/commit_log/append/sequencer.rs
@@ -1,0 +1,446 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded FIFO admission and micro-batch draining for CommitLog append requests.
+
+use std::fmt;
+
+use rocketmq_runtime::resource_budget::BudgetConfigError;
+use rocketmq_runtime::resource_budget::BudgetLimit;
+use rocketmq_runtime::resource_budget::BudgetedItem;
+use rocketmq_runtime::resource_budget::BudgetedQueue;
+use rocketmq_runtime::resource_budget::FullPolicy;
+use rocketmq_runtime::resource_budget::QueuePushErrorKind;
+use rocketmq_runtime::resource_budget::QueueSnapshot;
+use rocketmq_runtime::resource_budget::ResourceBudgetTree;
+use tokio_util::sync::CancellationToken;
+
+use super::micro_batch::MicroBatch;
+use super::micro_batch::MicroBatchPolicy;
+
+/// Bounded queue capacities and drain policy for one CommitLog sequencer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppendSequencerConfig {
+    /// Maximum admitted requests whose processing permits have not yet been released.
+    pub queue_capacity: usize,
+    /// Maximum aggregate request bytes retained by queued and in-flight requests.
+    pub queue_bytes: usize,
+    /// Adjacent FIFO drain policy.
+    pub micro_batch: MicroBatchPolicy,
+}
+
+/// Factory namespace for the single-consumer CommitLog append queue.
+pub struct AppendSequencer;
+
+impl AppendSequencer {
+    /// Creates cloneable admission and exclusive drain halves.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BudgetConfigError`] when configured queue capacities are invalid.
+    pub fn bounded<T>(
+        config: AppendSequencerConfig,
+    ) -> Result<(AppendSequencerSender<T>, AppendSequencerReceiver<T>), BudgetConfigError> {
+        let budget = ResourceBudgetTree::new(
+            "commitlog-append",
+            BudgetLimit::new(config.queue_capacity, config.queue_bytes, FullPolicy::Reject),
+        )?;
+        let queue = BudgetedQueue::new(budget.root());
+        Ok((
+            AppendSequencerSender { queue: queue.clone() },
+            AppendSequencerReceiver {
+                queue,
+                policy: config.micro_batch,
+                carry: None,
+            },
+        ))
+    }
+}
+
+/// Cloneable bounded-admission port for append callers.
+pub struct AppendSequencerSender<T> {
+    queue: BudgetedQueue<T>,
+}
+
+impl<T> Clone for AppendSequencerSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for AppendSequencerSender<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AppendSequencerSender")
+            .field("queue", &self.queue.snapshot())
+            .finish()
+    }
+}
+
+impl<T> AppendSequencerSender<T> {
+    /// Attempts to admit one request without waiting for capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original request when the byte/count budget is saturated or the sequencer is
+    /// closed.
+    pub fn try_submit(&self, request: T, retained_bytes: usize) -> Result<(), AppendAdmissionError<T>> {
+        self.queue
+            .try_push_data(request, retained_bytes)
+            .map(|_| ())
+            .map_err(|error| {
+                let kind = match error.kind() {
+                    QueuePushErrorKind::BudgetExhausted(_) => AppendAdmissionErrorKind::Saturated,
+                    QueuePushErrorKind::Closed | QueuePushErrorKind::SlowConsumerClosed => {
+                        AppendAdmissionErrorKind::Closed
+                    }
+                };
+                AppendAdmissionError {
+                    kind,
+                    request: error.into_item(),
+                }
+            })
+    }
+
+    /// Stops new admission and wakes the drain owner. Already admitted requests remain queued.
+    pub fn close(&self) {
+        self.queue.close();
+    }
+
+    /// Closes admission and drops every request that has not reached the exclusive receiver.
+    ///
+    /// This is reserved for terminal consumer failure so producers are released instead of
+    /// waiting forever on work that can no longer be processed.
+    pub fn close_and_discard_pending(&self) -> usize {
+        self.queue.close();
+        let mut discarded = 0;
+        while self.queue.try_pop_budgeted().is_some() {
+            discarded += 1;
+        }
+        discarded
+    }
+
+    /// Returns the current bounded queue state.
+    #[must_use]
+    pub fn snapshot(&self) -> QueueSnapshot {
+        self.queue.snapshot()
+    }
+}
+
+/// Exclusive FIFO drain owner.
+pub struct AppendSequencerReceiver<T> {
+    queue: BudgetedQueue<T>,
+    policy: MicroBatchPolicy,
+    carry: Option<BudgetedItem<T>>,
+}
+
+impl<T> AppendSequencerReceiver<T> {
+    /// Drains the next bounded FIFO micro-batch.
+    ///
+    /// Cancellation closes admission, then preserves and drains already admitted requests. The
+    /// queue receive branch is biased ahead of cancellation and deadline branches so an item is
+    /// never popped by a losing `select!` branch.
+    pub async fn next_batch(&mut self, cancellation: &CancellationToken) -> Option<MicroBatch<T>> {
+        let first = if let Some(item) = self.carry.take() {
+            Some(item)
+        } else {
+            tokio::select! {
+                biased;
+                item = self.queue.recv_budgeted() => item,
+                () = cancellation.cancelled() => {
+                    self.queue.close();
+                    self.queue.recv_budgeted().await
+                }
+            }
+        }?;
+
+        let mut retained_bytes = first.retained_bytes();
+        let mut items = Vec::with_capacity(self.policy.max_items());
+        items.push(first);
+        if self.policy.max_items() == 1 {
+            return Some(MicroBatch::new(items, retained_bytes));
+        }
+
+        let deadline = tokio::time::Instant::now() + self.policy.max_wait();
+        loop {
+            if items.len() >= self.policy.max_items() {
+                break;
+            }
+            if let Some(next) = self.queue.try_pop_budgeted() {
+                if !self.try_include(next, &mut items, &mut retained_bytes) {
+                    break;
+                }
+                continue;
+            }
+            if self.queue.is_closed() || self.policy.max_wait().is_zero() {
+                break;
+            }
+
+            enum WaitOutcome<T> {
+                Item(Option<BudgetedItem<T>>),
+                Cancelled,
+                Deadline,
+            }
+            let outcome = tokio::select! {
+                biased;
+                item = tokio::time::timeout_at(deadline, self.queue.recv_budgeted()) => {
+                    match item {
+                        Ok(item) => WaitOutcome::Item(item),
+                        Err(_) => WaitOutcome::Deadline,
+                    }
+                },
+                () = cancellation.cancelled() => WaitOutcome::Cancelled,
+            };
+            match outcome {
+                WaitOutcome::Item(Some(next)) => {
+                    if !self.try_include(next, &mut items, &mut retained_bytes) {
+                        break;
+                    }
+                }
+                WaitOutcome::Item(None) | WaitOutcome::Deadline => break,
+                WaitOutcome::Cancelled => {
+                    self.queue.close();
+                }
+            }
+        }
+
+        Some(MicroBatch::new(items, retained_bytes))
+    }
+
+    fn try_include(
+        &mut self,
+        next: BudgetedItem<T>,
+        items: &mut Vec<BudgetedItem<T>>,
+        retained_bytes: &mut usize,
+    ) -> bool {
+        let next_bytes = next.retained_bytes();
+        if retained_bytes
+            .checked_add(next_bytes)
+            .is_none_or(|total| total > self.policy.max_bytes())
+        {
+            self.carry = Some(next);
+            return false;
+        }
+        *retained_bytes += next_bytes;
+        items.push(next);
+        true
+    }
+}
+
+/// Admission rejection category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendAdmissionErrorKind {
+    /// Count or byte capacity is exhausted.
+    Saturated,
+    /// The sequencer no longer accepts requests.
+    Closed,
+}
+
+/// Rejected append request, retaining ownership for caller-side error projection.
+pub struct AppendAdmissionError<T> {
+    kind: AppendAdmissionErrorKind,
+    request: T,
+}
+
+impl<T> AppendAdmissionError<T> {
+    /// Returns the rejection category.
+    #[must_use]
+    pub const fn kind(&self) -> AppendAdmissionErrorKind {
+        self.kind
+    }
+
+    /// Recovers the rejected request.
+    #[must_use]
+    pub fn into_request(self) -> T {
+        self.request
+    }
+}
+
+impl<T> fmt::Debug for AppendAdmissionError<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AppendAdmissionError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Display for AppendAdmissionError<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            AppendAdmissionErrorKind::Saturated => formatter.write_str("CommitLog append sequencer is saturated"),
+            AppendAdmissionErrorKind::Closed => formatter.write_str("CommitLog append sequencer is closed"),
+        }
+    }
+}
+
+impl<T: fmt::Debug> std::error::Error for AppendAdmissionError<T> {}
+
+#[cfg(test)]
+mod tests {
+    use std::future::poll_fn;
+    use std::future::Future;
+    use std::task::Poll;
+    use std::time::Duration;
+
+    use super::*;
+
+    fn config(policy: MicroBatchPolicy) -> AppendSequencerConfig {
+        AppendSequencerConfig {
+            queue_capacity: 8,
+            queue_bytes: 1024,
+            micro_batch: policy,
+        }
+    }
+
+    #[tokio::test]
+    async fn drains_fifo_by_item_and_byte_limits() {
+        let policy = MicroBatchPolicy::try_new(3, 5, Duration::ZERO).expect("policy");
+        let (sender, mut receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit(1, 2).expect("first");
+        sender.try_submit(2, 2).expect("second");
+        sender.try_submit(3, 2).expect("third");
+        let cancellation = CancellationToken::new();
+
+        let first = receiver.next_batch(&cancellation).await.expect("first batch");
+        let first_items = first
+            .into_budgeted_items()
+            .into_iter()
+            .map(BudgetedItem::into_item)
+            .collect::<Vec<_>>();
+        let second = receiver.next_batch(&cancellation).await.expect("second batch");
+        let second_items = second
+            .into_budgeted_items()
+            .into_iter()
+            .map(BudgetedItem::into_item)
+            .collect::<Vec<_>>();
+
+        assert_eq!(first_items, vec![1, 2]);
+        assert_eq!(second_items, vec![3]);
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_preserves_single_request_batches() {
+        let policy = MicroBatchPolicy::disabled(1024).expect("policy");
+        let (sender, mut receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit(1, 1).expect("first");
+        sender.try_submit(2, 1).expect("second");
+        let cancellation = CancellationToken::new();
+
+        assert_eq!(receiver.next_batch(&cancellation).await.expect("first").len(), 1);
+        assert_eq!(receiver.next_batch(&cancellation).await.expect("second").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn request_larger_than_batch_target_is_processed_as_a_singleton() {
+        let policy = MicroBatchPolicy::try_new(4, 5, std::time::Duration::ZERO).expect("policy");
+        let (sender, mut receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit("oversized", 8).expect("oversized request fits queue");
+        sender.try_submit("next", 1).expect("next");
+        let cancellation = CancellationToken::new();
+
+        let first = receiver.next_batch(&cancellation).await.expect("first");
+        let second = receiver.next_batch(&cancellation).await.expect("second");
+
+        assert_eq!(first.retained_bytes(), 8);
+        assert_eq!(
+            first.into_budgeted_items().pop().map(BudgetedItem::into_item),
+            Some("oversized")
+        );
+        assert_eq!(
+            second.into_budgeted_items().pop().map(BudgetedItem::into_item),
+            Some("next")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn partial_batch_is_released_at_its_configured_deadline() {
+        let policy = MicroBatchPolicy::try_new(4, 1024, Duration::from_millis(10)).expect("policy");
+        let (sender, mut receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit("first", 1).expect("first");
+        let cancellation = CancellationToken::new();
+        let mut next_batch = Box::pin(receiver.next_batch(&cancellation));
+
+        let first_poll = poll_fn(|context| Poll::Ready(next_batch.as_mut().poll(context))).await;
+        assert!(first_poll.is_pending());
+        tokio::time::advance(Duration::from_millis(9)).await;
+        let before_deadline = poll_fn(|context| Poll::Ready(next_batch.as_mut().poll(context))).await;
+        assert!(before_deadline.is_pending());
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        let batch = next_batch.await.expect("deadline batch");
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch.retained_bytes(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancellation_closes_admission_but_drains_existing_fifo() {
+        let policy = MicroBatchPolicy::try_new(8, 1024, Duration::from_millis(10)).expect("policy");
+        let (sender, mut receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit(1, 1).expect("first");
+        sender.try_submit(2, 1).expect("second");
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        let batch = receiver.next_batch(&cancellation).await.expect("drained batch");
+        let items = batch
+            .into_budgeted_items()
+            .into_iter()
+            .map(BudgetedItem::into_item)
+            .collect::<Vec<_>>();
+
+        assert_eq!(items, vec![1, 2]);
+        assert_eq!(
+            sender.try_submit(3, 1).expect_err("closed").kind(),
+            AppendAdmissionErrorKind::Closed
+        );
+        assert!(receiver.next_batch(&cancellation).await.is_none());
+    }
+
+    #[test]
+    fn rejects_count_and_byte_saturation_without_losing_requests() {
+        let policy = MicroBatchPolicy::disabled(1024).expect("policy");
+        let config = AppendSequencerConfig {
+            queue_capacity: 1,
+            queue_bytes: 4,
+            micro_batch: policy,
+        };
+        let (sender, _receiver) = AppendSequencer::bounded(config).expect("sequencer");
+        sender.try_submit("first", 4).expect("first");
+
+        let error = sender.try_submit("second", 1).expect_err("count saturated");
+
+        assert_eq!(error.kind(), AppendAdmissionErrorKind::Saturated);
+        assert_eq!(error.into_request(), "second");
+    }
+
+    #[test]
+    fn terminal_consumer_failure_releases_pending_queue_budget() {
+        let policy = MicroBatchPolicy::disabled(1024).expect("policy");
+        let (sender, _receiver) = AppendSequencer::bounded(config(policy)).expect("sequencer");
+        sender.try_submit("first", 4).expect("first");
+        sender.try_submit("second", 8).expect("second");
+
+        assert_eq!(sender.close_and_discard_pending(), 2);
+
+        let snapshot = sender.snapshot();
+        assert!(snapshot.closed);
+        assert_eq!(snapshot.depth, 0);
+        assert_eq!(snapshot.reserved_count, 0);
+        assert_eq!(snapshot.retained_bytes, 0);
+    }
+}

--- a/rocketmq-store-local/tests/commitlog_micro_batch.rs
+++ b/rocketmq-store-local/tests/commitlog_micro_batch.rs
@@ -1,0 +1,175 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_runtime::resource_budget::BudgetedItem;
+use rocketmq_store_local::commit_log::append::finalized_append::FinalizedAppend;
+use rocketmq_store_local::commit_log::append::micro_batch::MicroBatchPolicy;
+use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayload;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencer;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerConfig;
+use rocketmq_store_local::commit_log::append_frame::AppendFrameCrcPlan;
+use rocketmq_store_local::commit_log::append_frame::AppendFrameKernel;
+use rocketmq_store_local::commit_log::append_frame::SegmentAppendDecision;
+use tokio_util::sync::CancellationToken;
+
+const QUEUE_OFFSET_POSITION: usize = 20;
+const PHYSICAL_OFFSET_POSITION: usize = 28;
+const STORE_TIMESTAMP_POSITION: usize = 56;
+
+fn encoded_frame(len: usize, crc_trailer_bytes: usize) -> Bytes {
+    assert!(len >= 80 + crc_trailer_bytes);
+    let mut frame = BytesMut::zeroed(len);
+    frame[..4].copy_from_slice(&(len as i32).to_be_bytes());
+    frame.freeze()
+}
+
+fn encoded_batch(frame_lengths: &[usize], crc_trailer_bytes: usize) -> Bytes {
+    let mut payload = BytesMut::new();
+    for len in frame_lengths {
+        payload.put(encoded_frame(*len, crc_trailer_bytes));
+    }
+    payload.freeze()
+}
+
+fn read_i64(bytes: &[u8], start: usize) -> i64 {
+    i64::from_be_bytes(bytes[start..start + 8].try_into().expect("i64 bytes"))
+}
+
+fn sequencer_config(policy: MicroBatchPolicy) -> AppendSequencerConfig {
+    AppendSequencerConfig {
+        queue_capacity: 16,
+        queue_bytes: 4096,
+        micro_batch: policy,
+    }
+}
+
+#[tokio::test]
+async fn enabled_micro_batch_preserves_fifo_and_both_drain_limits() {
+    let policy = MicroBatchPolicy::try_new(3, 240, Duration::ZERO).expect("policy");
+    let (sender, mut receiver) = AppendSequencer::bounded(sequencer_config(policy)).expect("sequencer");
+    for id in 0..5 {
+        sender.try_submit(id, 80).expect("admit request");
+    }
+    let cancellation = CancellationToken::new();
+
+    let first = receiver.next_batch(&cancellation).await.expect("first batch");
+    let second = receiver.next_batch(&cancellation).await.expect("second batch");
+    let first_ids = first
+        .into_budgeted_items()
+        .into_iter()
+        .map(BudgetedItem::into_item)
+        .collect::<Vec<_>>();
+    let second_ids = second
+        .into_budgeted_items()
+        .into_iter()
+        .map(BudgetedItem::into_item)
+        .collect::<Vec<_>>();
+
+    assert_eq!(first_ids, vec![0, 1, 2]);
+    assert_eq!(second_ids, vec![3, 4]);
+}
+
+#[tokio::test]
+async fn disabled_micro_batch_keeps_single_writer_and_one_result_per_drain() {
+    let policy = MicroBatchPolicy::disabled(4096).expect("policy");
+    let (sender, mut receiver) = AppendSequencer::bounded(sequencer_config(policy)).expect("sequencer");
+    sender.try_submit("first", 80).expect("first");
+    sender.try_submit("second", 80).expect("second");
+    let cancellation = CancellationToken::new();
+
+    let first = receiver.next_batch(&cancellation).await.expect("first drain");
+    let second = receiver.next_batch(&cancellation).await.expect("second drain");
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(
+        first.into_budgeted_items().pop().map(BudgetedItem::into_item),
+        Some("first")
+    );
+    assert_eq!(
+        second.into_budgeted_items().pop().map(BudgetedItem::into_item),
+        Some("second")
+    );
+}
+
+#[test]
+fn finalized_batch_assigns_contiguous_offsets_and_finalizes_each_checksum() {
+    const CRC_TRAILER_BYTES: usize = 4;
+    let prepared =
+        PreparedPayload::try_batch(encoded_batch(&[84, 92], CRC_TRAILER_BYTES), CRC_TRAILER_BYTES).expect("prepare");
+    let finalized = FinalizedAppend::try_new(&prepared, 70, 4096, 123_456).expect("finalize");
+    let mut destination = vec![0; finalized.required_bytes()];
+    let mut checksum_calls = 0;
+
+    finalized
+        .write_into(&mut destination, |frame, plan| {
+            let AppendFrameCrcPlan::Trailer {
+                covered_end,
+                trailer_start,
+                trailer_end,
+            } = plan
+            else {
+                panic!("checksum trailer expected");
+            };
+            checksum_calls += 1;
+            let checksum = frame[..covered_end]
+                .iter()
+                .fold(0_u32, |sum, byte| sum.wrapping_add(u32::from(*byte)));
+            frame[trailer_start..trailer_end].copy_from_slice(&checksum.to_be_bytes());
+        })
+        .expect("write finalized payload");
+
+    assert_eq!(checksum_calls, 2);
+    assert_eq!(read_i64(&destination, QUEUE_OFFSET_POSITION), 70);
+    assert_eq!(read_i64(&destination, PHYSICAL_OFFSET_POSITION), 4096);
+    assert_eq!(read_i64(&destination, STORE_TIMESTAMP_POSITION), 123_456);
+    assert_eq!(read_i64(&destination[84..], QUEUE_OFFSET_POSITION), 71);
+    assert_eq!(read_i64(&destination[84..], PHYSICAL_OFFSET_POSITION), 4180);
+}
+
+#[test]
+fn malformed_encoded_batch_fails_before_any_reservation() {
+    let reservation_count = AtomicUsize::new(0);
+    let mut malformed = encoded_frame(80, 0).to_vec();
+    malformed[..4].copy_from_slice(&81_i32.to_be_bytes());
+
+    let prepared = PreparedPayload::try_batch(Bytes::from(malformed), 0);
+    if prepared.is_ok() {
+        reservation_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    assert!(prepared.is_err());
+    assert_eq!(reservation_count.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn rollover_is_decided_before_runtime_patch_or_copy() {
+    let prepared = PreparedPayload::try_single(encoded_frame(96, 0), 0).expect("prepare");
+
+    assert_eq!(
+        AppendFrameKernel::segment_append_decision(prepared.retained_bytes() as i32, 103),
+        SegmentAppendDecision::Roll
+    );
+    assert_eq!(
+        AppendFrameKernel::segment_append_decision(prepared.retained_bytes() as i32, 104),
+        SegmentAppendDecision::Append
+    );
+}

--- a/rocketmq-store/src/base/append_message_callback.rs
+++ b/rocketmq-store/src/base/append_message_callback.rs
@@ -17,6 +17,9 @@ use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use rocketmq_store_local::commit_log::append::finalized_append::FinalizedAppend;
+use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayload;
+use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayloadKind;
 use rocketmq_store_local::commit_log::append_frame::AppendBatchFrameCursor;
 use rocketmq_store_local::commit_log::append_frame::AppendFrameCrcPlan;
 use rocketmq_store_local::commit_log::append_frame::AppendFrameKernel;
@@ -102,6 +105,240 @@ impl DefaultAppendMessageCallback {
             crc32_reserved_length,
             message_store_config,
             topic_config_table,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn message_num(&self, message: &MessageExtBrokerInner) -> i16 {
+        get_message_num(&self.topic_config_table, message)
+    }
+
+    /// Appends one structurally validated immutable payload.
+    ///
+    /// All fallible offset calculations complete before mapped-file reservation. The reservation
+    /// path then performs only rollover publication or stable-byte copy, runtime-field patching,
+    /// checksum finalization, and lease commit.
+    pub(crate) fn append_prepared_message<MF: MappedFile>(
+        &self,
+        file_from_offset: i64,
+        mapped_file: &MF,
+        msg_inner: &MessageExtBrokerInner,
+        prepared: &PreparedPayload,
+        queue_offset: i64,
+        message_num: i32,
+    ) -> AppendMessageResult {
+        if prepared.kind() != PreparedPayloadKind::Single {
+            error!("Single-message append received a batch PreparedPayload");
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        }
+        self.append_prepared(
+            file_from_offset,
+            mapped_file,
+            prepared,
+            queue_offset,
+            msg_inner.store_timestamp(),
+            message_num,
+            |wrote_offset, _| {
+                let address = msg_inner.message_ext_inner.store_host;
+                Arc::new(move || message_utils::build_message_id(address, wrote_offset))
+            },
+            |_| {},
+        )
+    }
+
+    /// Appends a structurally validated immutable payload containing one or more batch frames.
+    pub(crate) fn append_prepared_batch<MF: MappedFile>(
+        &self,
+        file_from_offset: i64,
+        mapped_file: &MF,
+        msg_batch: &MessageExtBatch,
+        prepared: &PreparedPayload,
+        put_message_context: &mut PutMessageContext,
+    ) -> AppendMessageResult {
+        if prepared.kind() != PreparedPayloadKind::Batch {
+            error!("Batch append received a single-frame PreparedPayload");
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        }
+        let queue_offset = msg_batch.message_ext_broker_inner.queue_offset();
+        let address = msg_batch.message_ext_broker_inner.store_host();
+        let store_host_length =
+            if msg_batch.message_ext_broker_inner.sys_flag() & MessageSysFlag::STOREHOSTADDRESS_V6_FLAG == 0 {
+                4 + 4
+            } else {
+                16 + 4
+            };
+        self.append_prepared(
+            file_from_offset,
+            mapped_file,
+            prepared,
+            queue_offset,
+            msg_batch.message_ext_broker_inner.store_timestamp(),
+            i32::from(prepared.message_count()),
+            move |_, physical_offsets| {
+                let physical_offsets = physical_offsets.to_vec();
+                Arc::new(move || {
+                    build_batch_message_id(address, store_host_length, physical_offsets.len(), &physical_offsets)
+                })
+            },
+            |physical_offsets| {
+                put_message_context.set_batch_size(physical_offsets.len() as i32);
+                put_message_context.set_phy_pos(physical_offsets.to_vec());
+            },
+        )
+    }
+
+    fn append_prepared<MF, I, C>(
+        &self,
+        file_from_offset: i64,
+        mapped_file: &MF,
+        prepared: &PreparedPayload,
+        queue_offset: i64,
+        store_timestamp: i64,
+        message_num: i32,
+        message_id_supplier: I,
+        mut publish_physical_offsets: C,
+    ) -> AppendMessageResult
+    where
+        MF: MappedFile,
+        I: FnOnce(i64, &[i64]) -> Arc<dyn Fn() -> String + Send + Sync>,
+        C: FnMut(&[i64]),
+    {
+        let encoded_len = prepared.retained_bytes();
+        let Ok(encoded_len_i32) = i32::try_from(encoded_len) else {
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        };
+        let current_position = mapped_file.get_wrote_position().max(0) as usize;
+        let remaining = mapped_file.get_file_size().saturating_sub(current_position as u64) as usize;
+        let max_blank = i32::try_from(remaining).unwrap_or(i32::MAX);
+        let Some(wrote_offset) = file_from_offset.checked_add(current_position as i64) else {
+            error!("CommitLog physical offset overflow before mapped-file reservation");
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        };
+        let Some(reservation_size) = encoded_len.checked_add(BLANK_MARKER_LENGTH) else {
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        };
+
+        if AppendFrameKernel::segment_append_decision(encoded_len_i32, max_blank) == SegmentAppendDecision::Roll {
+            let mut lease = match mapped_file.reserve_write(reservation_size) {
+                Ok(lease) => lease,
+                Err(error) => {
+                    error!(%error, "Failed to reserve mapped-file rollover marker");
+                    return AppendMessageResult {
+                        status: AppendMessageStatus::UnknownError,
+                        ..Default::default()
+                    };
+                }
+            };
+            let marker = AppendFrameKernel::blank_marker(max_blank);
+            let started = Instant::now();
+            if lease.capacity() >= BLANK_MARKER_LENGTH {
+                lease.buffer_mut()[..BLANK_MARKER_LENGTH].copy_from_slice(marker.bytes());
+            }
+            let committed_bytes = lease.capacity();
+            if let Err(error) = lease.commit(committed_bytes, Some(store_timestamp as u64)) {
+                error!(%error, "Failed to publish mapped-file rollover marker");
+                return AppendMessageResult {
+                    status: AppendMessageStatus::UnknownError,
+                    ..Default::default()
+                };
+            }
+            return AppendMessageResult {
+                status: AppendMessageStatus::EndOfFile,
+                wrote_offset,
+                wrote_bytes: marker.declared_wrote_bytes(),
+                store_timestamp,
+                logics_offset: queue_offset,
+                msg_num: message_num,
+                msg_id_supplier: Some(message_id_supplier(wrote_offset, &[])),
+                page_cache_rt: started.elapsed().as_millis() as i64,
+                ..Default::default()
+            };
+        }
+
+        let finalized = match FinalizedAppend::try_new(prepared, queue_offset, wrote_offset, store_timestamp) {
+            Ok(finalized) => finalized,
+            Err(error) => {
+                error!(%error, "Failed to finalize PreparedPayload before mapped-file reservation");
+                return AppendMessageResult {
+                    status: AppendMessageStatus::UnknownError,
+                    ..Default::default()
+                };
+            }
+        };
+        let physical_offsets = finalized.physical_offsets().collect::<Vec<_>>();
+        let mut lease = match mapped_file.reserve_write(reservation_size) {
+            Ok(lease) => lease,
+            Err(error) => {
+                error!(%error, "Failed to reserve mapped-file prepared append");
+                return AppendMessageResult {
+                    status: AppendMessageStatus::UnknownError,
+                    ..Default::default()
+                };
+            }
+        };
+        if lease.start_position() != current_position {
+            error!(
+                expected = current_position,
+                actual = lease.start_position(),
+                "Mapped-file position changed between append finalization and reservation"
+            );
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        }
+        let started = Instant::now();
+        let write_result = finalized.write_into(&mut lease.buffer_mut()[..encoded_len], |frame, crc_plan| {
+            if let AppendFrameCrcPlan::Trailer {
+                covered_end,
+                trailer_start,
+                trailer_end,
+            } = crc_plan
+            {
+                let checksum = crc32(&frame[..covered_end]);
+                create_crc32(&mut frame[trailer_start..trailer_end], checksum);
+            }
+        });
+        if let Err(error) = write_result {
+            error!(%error, "Prepared append staging buffer rejected a preflighted payload");
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        }
+        if let Err(error) = lease.commit(encoded_len, Some(store_timestamp as u64)) {
+            error!(%error, "Failed to commit mapped-file prepared append");
+            return AppendMessageResult {
+                status: AppendMessageStatus::UnknownError,
+                ..Default::default()
+            };
+        }
+        publish_physical_offsets(&physical_offsets);
+        AppendMessageResult {
+            status: AppendMessageStatus::PutOk,
+            wrote_offset,
+            wrote_bytes: encoded_len_i32,
+            store_timestamp,
+            logics_offset: queue_offset,
+            msg_num: message_num,
+            msg_id_supplier: Some(message_id_supplier(wrote_offset, &physical_offsets)),
+            page_cache_rt: started.elapsed().as_millis() as i64,
+            ..Default::default()
         }
     }
 }

--- a/rocketmq-store/src/base/message_encoder_pool.rs
+++ b/rocketmq-store/src/base/message_encoder_pool.rs
@@ -32,10 +32,13 @@ use std::sync::Arc;
 use bytes::BytesMut;
 use rocketmq_model::common::message::message_batch::MessageExtBatch;
 use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayload;
+use tracing::error;
 
 use crate::base::message_result::PutMessageResult;
 use crate::base::put_message_context::PutMessageContext;
 use crate::config::message_store_config::MessageStoreConfig;
+use crate::log_file::commit_log::CRC32_RESERVED_LEN;
 use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
 
 /// Thread-local pool for MessageExtEncoder instances
@@ -77,6 +80,30 @@ impl MessageEncoderPool {
         (result, bytes)
     }
 
+    /// Encodes and structurally validates one immutable CommitLog payload.
+    pub fn prepare_message(
+        &self,
+        message: &MessageExtBrokerInner,
+        config: &Arc<MessageStoreConfig>,
+    ) -> Result<PreparedPayload, PutMessageResult> {
+        let (encode_result, bytes) = self.encode_message(message, config);
+        if let Some(result) = encode_result {
+            return Err(result);
+        }
+        let crc_trailer_bytes = if config.enabled_append_prop_crc {
+            CRC32_RESERVED_LEN as usize
+        } else {
+            0
+        };
+        PreparedPayload::try_single(bytes.freeze(), crc_trailer_bytes).map_err(|validation_error| {
+            error!(
+                error = %validation_error,
+                "Message encoder produced an invalid CommitLog frame"
+            );
+            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
+        })
+    }
+
     /// Encode a batch of messages using pooled encoder
     pub fn encode_message_batch(
         &self,
@@ -86,6 +113,30 @@ impl MessageEncoderPool {
     ) -> Option<BytesMut> {
         let mut encoder = self.get_or_create_encoder(config);
         encoder.encode_batch(batch, context)
+    }
+
+    /// Encodes and structurally validates one immutable CommitLog frame batch.
+    pub fn prepare_message_batch(
+        &self,
+        batch: &MessageExtBatch,
+        context: &mut PutMessageContext,
+        config: &Arc<MessageStoreConfig>,
+    ) -> Result<PreparedPayload, PutMessageResult> {
+        let bytes = self.encode_message_batch(batch, context, config).ok_or_else(|| {
+            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
+        })?;
+        let crc_trailer_bytes = if config.enabled_append_prop_crc {
+            CRC32_RESERVED_LEN as usize
+        } else {
+            0
+        };
+        PreparedPayload::try_batch(bytes.freeze(), crc_trailer_bytes).map_err(|validation_error| {
+            error!(
+                error = %validation_error,
+                "Batch encoder produced an invalid CommitLog frame partition"
+            );
+            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
+        })
     }
 
     /// Generate topic-queue key using pooled string buffer
@@ -118,6 +169,15 @@ pub fn encode_message_with_pool(
     ENCODER_POOL.with(|pool| pool.encode_message(message, config))
 }
 
+/// Encode and validate one immutable payload using the thread-local encoder pool.
+#[inline]
+pub fn prepare_message_with_pool(
+    message: &MessageExtBrokerInner,
+    config: &Arc<MessageStoreConfig>,
+) -> Result<PreparedPayload, PutMessageResult> {
+    ENCODER_POOL.with(|pool| pool.prepare_message(message, config))
+}
+
 /// Encode a batch of messages using the thread-local encoder pool
 #[inline]
 pub fn encode_message_batch_with_pool(
@@ -126,6 +186,16 @@ pub fn encode_message_batch_with_pool(
     config: &Arc<MessageStoreConfig>,
 ) -> Option<BytesMut> {
     ENCODER_POOL.with(|pool| pool.encode_message_batch(batch, context, config))
+}
+
+/// Encode and validate one immutable frame batch using the thread-local encoder pool.
+#[inline]
+pub fn prepare_message_batch_with_pool(
+    batch: &MessageExtBatch,
+    context: &mut PutMessageContext,
+    config: &Arc<MessageStoreConfig>,
+) -> Result<PreparedPayload, PutMessageResult> {
+    ENCODER_POOL.with(|pool| pool.prepare_message_batch(batch, context, config))
 }
 
 /// Generate topic-queue key using pooled buffer

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -344,6 +344,30 @@ mod defaults {
         32
     }
 
+    pub const fn commit_log_append_queue_capacity() -> usize {
+        1024
+    }
+
+    pub const fn commit_log_append_queue_bytes() -> usize {
+        64 * 1024 * 1024
+    }
+
+    pub const fn commit_log_micro_batch_enabled() -> bool {
+        true
+    }
+
+    pub const fn commit_log_micro_batch_max_items() -> usize {
+        32
+    }
+
+    pub const fn commit_log_micro_batch_max_bytes() -> usize {
+        1024 * 1024
+    }
+
+    pub const fn commit_log_micro_batch_max_wait_micros() -> u64 {
+        50
+    }
+
     pub const fn max_ha_transfer_byte_in_second() -> usize {
         100 * 1024 * 1024
     }
@@ -1208,6 +1232,24 @@ pub struct MessageStoreConfig {
     #[serde(default = "defaults::topic_queue_lock_num")]
     pub topic_queue_lock_num: usize,
 
+    #[serde(default = "defaults::commit_log_append_queue_capacity")]
+    pub commit_log_append_queue_capacity: usize,
+
+    #[serde(default = "defaults::commit_log_append_queue_bytes")]
+    pub commit_log_append_queue_bytes: usize,
+
+    #[serde(default = "defaults::commit_log_micro_batch_enabled")]
+    pub commit_log_micro_batch_enabled: bool,
+
+    #[serde(default = "defaults::commit_log_micro_batch_max_items")]
+    pub commit_log_micro_batch_max_items: usize,
+
+    #[serde(default = "defaults::commit_log_micro_batch_max_bytes")]
+    pub commit_log_micro_batch_max_bytes: usize,
+
+    #[serde(default = "defaults::commit_log_micro_batch_max_wait_micros")]
+    pub commit_log_micro_batch_max_wait_micros: u64,
+
     #[serde(default = "defaults::max_filter_message_size")]
     pub max_filter_message_size: i32,
 
@@ -1452,6 +1494,12 @@ impl Default for MessageStoreConfig {
             real_time_persist_rocksdb_config: false,
             enable_rocksdb_log: false,
             topic_queue_lock_num: 32,
+            commit_log_append_queue_capacity: defaults::commit_log_append_queue_capacity(),
+            commit_log_append_queue_bytes: defaults::commit_log_append_queue_bytes(),
+            commit_log_micro_batch_enabled: defaults::commit_log_micro_batch_enabled(),
+            commit_log_micro_batch_max_items: defaults::commit_log_micro_batch_max_items(),
+            commit_log_micro_batch_max_bytes: defaults::commit_log_micro_batch_max_bytes(),
+            commit_log_micro_batch_max_wait_micros: defaults::commit_log_micro_batch_max_wait_micros(),
             max_filter_message_size: 16000,
             enable_dleger_commit_log: false,
             rocksdb_cq_double_write_enable: false,
@@ -2168,6 +2216,30 @@ impl MessageStoreConfig {
             self.max_slave_resend_length.to_string(),
         );
         properties.insert("syncFromLastFile".to_string(), self.sync_from_last_file.to_string());
+        properties.insert(
+            "commitLogAppendQueueCapacity".to_string(),
+            self.commit_log_append_queue_capacity.to_string(),
+        );
+        properties.insert(
+            "commitLogAppendQueueBytes".to_string(),
+            self.commit_log_append_queue_bytes.to_string(),
+        );
+        properties.insert(
+            "commitLogMicroBatchEnabled".to_string(),
+            self.commit_log_micro_batch_enabled.to_string(),
+        );
+        properties.insert(
+            "commitLogMicroBatchMaxItems".to_string(),
+            self.commit_log_micro_batch_max_items.to_string(),
+        );
+        properties.insert(
+            "commitLogMicroBatchMaxBytes".to_string(),
+            self.commit_log_micro_batch_max_bytes.to_string(),
+        );
+        properties.insert(
+            "commitLogMicroBatchMaxWaitMicros".to_string(),
+            self.commit_log_micro_batch_max_wait_micros.to_string(),
+        );
         properties.insert("asyncLearner".to_string(), self.async_learner.to_string());
         properties.insert(
             "maxConsumeQueueScan".to_string(),
@@ -2299,6 +2371,48 @@ mod tests {
     #[test]
     fn default_max_checksum_range_matches_java_default() {
         assert_eq!(MessageStoreConfig::default().max_checksum_range, 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn commit_log_append_sequencer_has_bounded_production_defaults() {
+        let config = MessageStoreConfig::default();
+
+        assert_eq!(config.commit_log_append_queue_capacity, 1024);
+        assert_eq!(config.commit_log_append_queue_bytes, 64 * 1024 * 1024);
+        assert!(config.commit_log_micro_batch_enabled);
+        assert_eq!(config.commit_log_micro_batch_max_items, 32);
+        assert_eq!(config.commit_log_micro_batch_max_bytes, 1024 * 1024);
+        assert_eq!(config.commit_log_micro_batch_max_wait_micros, 50);
+
+        let properties = config.get_properties();
+        assert_eq!(properties["commitLogAppendQueueCapacity"], "1024");
+        assert_eq!(properties["commitLogAppendQueueBytes"], (64 * 1024 * 1024).to_string());
+        assert_eq!(properties["commitLogMicroBatchEnabled"], "true");
+        assert_eq!(properties["commitLogMicroBatchMaxItems"], "32");
+        assert_eq!(properties["commitLogMicroBatchMaxBytes"], (1024 * 1024).to_string());
+        assert_eq!(properties["commitLogMicroBatchMaxWaitMicros"], "50");
+    }
+
+    #[test]
+    fn serde_loads_commit_log_append_sequencer_settings() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str(
+            r#"{
+                "commitLogAppendQueueCapacity": 64,
+                "commitLogAppendQueueBytes": 8388608,
+                "commitLogMicroBatchEnabled": false,
+                "commitLogMicroBatchMaxItems": 8,
+                "commitLogMicroBatchMaxBytes": 524288,
+                "commitLogMicroBatchMaxWaitMicros": 125
+            }"#,
+        )?;
+
+        assert_eq!(config.commit_log_append_queue_capacity, 64);
+        assert_eq!(config.commit_log_append_queue_bytes, 8 * 1024 * 1024);
+        assert!(!config.commit_log_micro_batch_enabled);
+        assert_eq!(config.commit_log_micro_batch_max_items, 8);
+        assert_eq!(config.commit_log_micro_batch_max_bytes, 512 * 1024);
+        assert_eq!(config.commit_log_micro_batch_max_wait_micros, 125);
+        Ok(())
     }
 
     #[test]

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -221,6 +221,19 @@ pub(crate) struct MappedFileQueueAppendHandle {
 }
 
 impl MappedFileQueueAppendHandle {
+    /// Returns the current absolute append position without exposing the mapped-file generation.
+    pub(crate) fn current_append_offset(&self) -> u64 {
+        self.mapped_files
+            .load()
+            .last()
+            .map(|mapped_file| {
+                mapped_file
+                    .get_file_from_offset()
+                    .saturating_add(mapped_file.get_wrote_position().max(0) as u64)
+            })
+            .unwrap_or_default()
+    }
+
     pub(crate) fn get_last_mapped_file(&self, start_offset: u64, need_create: bool) -> Option<Arc<DefaultMappedFile>> {
         get_last_mapped_file_for_append(
             &self.mapped_files,

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod append_sequencer;
+
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -49,8 +51,8 @@ use rocketmq_model::utils::queue_type_utils::QueueTypeUtils;
 use rocketmq_protocol::common::message::message_decoder::cheetah_from_utf8_lossy;
 use rocketmq_protocol::common::message::message_decoder::string_to_message_properties;
 use rocketmq_runtime::common::system_clock::SystemClock;
-use rocketmq_runtime::common::time_utils;
-use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::resource_budget::QueueSnapshot;
+#[cfg(feature = "observability")]
 use tokio::time::Instant;
 use tracing::error;
 use tracing::info;
@@ -73,7 +75,6 @@ use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
 use crate::base::store_stats_service::StoreStatsService;
 use crate::base::swappable::Swappable;
-use crate::base::topic_queue_lock::TopicQueueLock;
 use crate::config::flush_disk_type::FlushDiskType;
 use crate::config::message_store_config::LinuxMemoryLockMode;
 use crate::config::message_store_config::LinuxRecoveryFadviseMode;
@@ -93,13 +94,12 @@ use crate::log_file::commit_log_loader::CommitLogLoader;
 use crate::log_file::commit_log_loader::LoadStatistics;
 use crate::log_file::commit_log_loader::RecoveryFilePrefetch;
 use crate::log_file::commit_log_loader::RecoveryMmapAdvice;
+use crate::log_file::flush_manager_impl::default_flush_manager::CommitLogFlushWakeup;
 use crate::log_file::flush_manager_impl::default_flush_manager::DefaultFlushManager;
-use crate::log_file::flush_manager_impl::default_flush_manager::InternalMessageFlushHandle;
 use crate::log_file::group_commit_request::GroupCommitRequest;
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::default_mapped_file_impl::LazyMmapStats;
 use crate::log_file::mapped_file::MappedFile;
-use crate::log_file::mapped_file::MappedFileAppend;
 use crate::message_store::local_file_message_store::CommitLogDispatchHandle;
 use crate::message_store::runtime_state::StoreRuntimeState;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
@@ -116,9 +116,8 @@ use crate::utils::ffi::MADV_RANDOM;
 use rocketmq_store_local::commit_log::abnormal_recovery::AbnormalRecoveryObservation;
 use rocketmq_store_local::commit_log::abnormal_recovery::AbnormalRecoveryRecord;
 use rocketmq_store_local::commit_log::abnormal_recovery::AbnormalRecoverySegmentOutcome;
-use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendAttempt;
-use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendFailure;
-use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendResolution;
+use rocketmq_store_local::commit_log::append::micro_batch::MicroBatchPolicy;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerConfig;
 use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendStatus;
 use rocketmq_store_local::commit_log::load_orchestration::drive_commit_log_load;
 use rocketmq_store_local::commit_log::load_orchestration::parallel_commit_log_load_enabled;
@@ -149,6 +148,11 @@ use rocketmq_store_local::commit_log::recovery::NormalRecoveryState;
 use rocketmq_store_local::commit_log::root::CommitLogRoot;
 use rocketmq_store_local::commit_log::runtime_state::CommitLogActiveMemoryLock;
 use rocketmq_store_local::commit_log::runtime_state::CommitLogRuntimeState;
+
+use self::append_sequencer::CommitLogAppendDependencies;
+use self::append_sequencer::CommitLogAppendPort;
+use self::append_sequencer::CommitLogAppendProcessor;
+use self::append_sequencer::CommitLogAppendRuntime;
 
 pub use rocketmq_store_local::commit_log::record::BLANK_MAGIC_CODE;
 pub use rocketmq_store_local::commit_log::record::MESSAGE_MAGIC_CODE;
@@ -284,18 +288,6 @@ fn encode_message_ext(
     message_store_config: &Arc<MessageStoreConfig>,
 ) -> (Option<PutMessageResult>, BytesMut) {
     message_encoder_pool::encode_message_with_pool(message_ext, message_store_config)
-}
-
-fn encode_message_ext_batch(
-    message_ext_batch: &MessageExtBatch,
-    put_message_context: &mut PutMessageContext,
-    message_store_config: &Arc<MessageStoreConfig>,
-) -> Option<BytesMut> {
-    message_encoder_pool::encode_message_batch_with_pool(message_ext_batch, put_message_context, message_store_config)
-}
-
-fn generate_key(msg: &MessageExtBrokerInner) -> String {
-    message_encoder_pool::generate_key_with_pool(msg)
 }
 
 fn parse_property_crc(properties_map: &HashMap<CheetahString, CheetahString>) -> Result<Option<u32>, ()> {
@@ -542,18 +534,10 @@ impl CommitLogReadHandle {
 /// by that invariant; recovery and CommitLog lifecycle remain exclusively owned by `CommitLog`.
 #[derive(Clone)]
 pub(crate) struct CommitLogInternalMessageWriteHandle {
-    append: MappedFileQueueAppendHandle,
     message_store_config: Arc<MessageStoreConfig>,
     store_runtime_state: Arc<StoreRuntimeState>,
     enabled_append_prop_crc: bool,
-    store_context: CommitLogStoreContext,
-    runtime_state: Arc<CommitLogRuntimeState>,
-    append_message_callback: Arc<DefaultAppendMessageCallback>,
-    put_message_lock: Arc<tokio::sync::Mutex<()>>,
-    topic_queue_lock: Arc<TopicQueueLock>,
-    topic_config_table: Arc<DashMap<CheetahString, Arc<TopicConfig>>>,
-    consume_queue_store: ConsumeQueueStore,
-    flush: InternalMessageFlushHandle,
+    append_port: CommitLogAppendPort,
 }
 
 impl CommitLogInternalMessageWriteHandle {
@@ -590,183 +574,16 @@ impl CommitLogInternalMessageWriteHandle {
             msg.with_store_host_v6_flag();
         }
 
-        let topic_queue_key = generate_key(&msg);
-        let mapped_file = self.append.get_last_mapped_file(0, false);
         let need_assign_offset = !(self.message_store_config.duplication_enable
             && self.store_runtime_state.broker_role() != BrokerRole::Slave);
-        let (put_message_result, encoded_buff) = encode_message_ext(&msg, &self.message_store_config);
-        if let Some(result) = put_message_result {
-            return result;
-        }
-        msg.encoded_buff = Some(encoded_buff);
-        let put_message_context = PutMessageContext::new(topic_queue_key.clone());
-
-        let topic_queue_lock = need_assign_offset.then(|| Arc::clone(&self.topic_queue_lock));
-        let _topic_queue_guard = if let Some(topic_queue_lock) = topic_queue_lock.as_ref() {
-            let guard = topic_queue_lock.lock(topic_queue_key.as_str()).await;
-            self.assign_offset(&mut msg);
-            Some(guard)
-        } else {
-            None
+        let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
+            Ok(prepared) => prepared,
+            Err(result) => return result,
         };
-
-        let lock_wait_start = Instant::now();
-        let _put_message_lock = self.put_message_lock.lock().await;
-        let lock_wait_millis = lock_wait_start.elapsed().as_millis() as u64;
-        let begin_lock_timestamp = time_utils::current_millis();
-        self.runtime_state.set_begin_time_in_lock(begin_lock_timestamp);
-        let start_time = Instant::now();
-        if !self.message_store_config.duplication_enable {
-            msg.message_ext_inner.store_timestamp = begin_lock_timestamp as i64;
-        }
-
-        let append_attempt = {
-            let (active_memory_lock, active_memory_lock_present) = self.runtime_state.active_memory_lock_parts();
-            CommitLogAppendAttempt::run(
-                mapped_file,
-                |mapped_file| mapped_file.is_full(),
-                || self.append.get_last_mapped_file(0, true),
-                |mapped_file| {
-                    let target = CommitLog::active_memory_lock_target_for_config(
-                        self.message_store_config.as_ref(),
-                        mapped_file.get_wrote_position().max(0) as u64,
-                        mapped_file.get_file_size(),
-                    );
-                    lock_active_mapped_file_parts!(
-                        active_memory_lock,
-                        active_memory_lock_present,
-                        mapped_file,
-                        target,
-                        crate::utils::ffi::mlock,
-                        crate::utils::ffi::munlock,
-                    )
-                },
-                |mapped_file| {
-                    mapped_file.append_message(&mut msg, self.append_message_callback.as_ref(), &put_message_context)
-                },
-            )
-        };
-        let (put_message_result, unlock_mapped_file) = match append_attempt.resolve() {
-            CommitLogAppendResolution::Continue {
-                status,
-                result,
-                unlock_segment,
-            } => (
-                PutMessageResult::new_append_result(CommitLog::put_message_status(status), Some(result)),
-                unlock_segment,
-            ),
-            CommitLogAppendResolution::Return {
-                status,
-                append_result,
-                abandoned_segment,
-                failure,
-            } => {
-                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-                drop(_topic_queue_guard);
-                match failure {
-                    CommitLogAppendFailure::InitialSegmentUnavailable
-                    | CommitLogAppendFailure::RolledSegmentUnavailable => {
-                        error!(
-                            "create mapped file error, topic: {} clientAddr: {}",
-                            msg.topic(),
-                            msg.born_host()
-                        );
-                    }
-                    CommitLogAppendFailure::InitialActiveLockFailed { error } => {
-                        error!(
-                            "lock active commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg.topic(),
-                            msg.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::RolledActiveLockFailed { error } => {
-                        error!(
-                            "lock rolled commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg.topic(),
-                            msg.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::InitialMessageIllegal | CommitLogAppendFailure::InitialUnknown => {}
-                }
-                drop(abandoned_segment);
-                return PutMessageResult::new_append_result(CommitLog::put_message_status(status), append_result);
-            }
-        };
-        let elapsed_time_in_lock = self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::store::record_append_latency(elapsed_time_in_lock);
-        if elapsed_time_in_lock > 500 {
-            warn!(
-                "[NOTIFYME]internal putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}",
-                elapsed_time_in_lock,
-                msg.body_len(),
-                put_message_result.append_message_result().as_ref().unwrap(),
-            );
-        }
-
-        if let (Some(unlock_mf), true) = (unlock_mapped_file, self.message_store_config.warm_mapped_file_enable) {
-            unlock_mf.munlock();
-        }
-
-        if put_message_result.put_message_status() == PutMessageStatus::PutOk {
-            let message_num = get_message_num(&self.topic_config_table, &msg);
-            self.increase_offset(&msg, message_num);
-            if let Some(append_result) = put_message_result.append_message_result() {
-                self.record_put_message_stats(msg.topic(), append_result);
-            }
-            drop(_topic_queue_guard);
-            self.flush.wakeup();
-            put_message_result
-        } else {
-            drop(_topic_queue_guard);
-            warn!(
-                "Failed to append internal message to CommitLog, offset hole created for topic={} queue={}, will be \
-                 recovered",
-                msg.topic(),
-                msg.queue_id()
-            );
-            put_message_result
-        }
-    }
-
-    fn release_put_message_lock(
-        &self,
-        put_message_lock: tokio::sync::MutexGuard<'_, ()>,
-        lock_wait_millis: u64,
-        lock_hold_start: Instant,
-    ) -> u64 {
-        let elapsed_time_in_lock = lock_hold_start.elapsed().as_millis() as u64;
-        self.runtime_state
-            .record_put_message_lock(lock_wait_millis, elapsed_time_in_lock);
-        drop(put_message_lock);
-        self.runtime_state.clear_begin_time_in_lock();
-        elapsed_time_in_lock
-    }
-
-    fn increase_offset(&self, msg: &MessageExtBrokerInner, message_num: i16) {
-        let tran_type = MessageSysFlag::get_transaction_value(msg.sys_flag());
-        if MessageSysFlag::TRANSACTION_NOT_TYPE == tran_type || MessageSysFlag::TRANSACTION_COMMIT_TYPE == tran_type {
-            self.consume_queue_store.increase_queue_offset(msg, message_num);
-        }
-    }
-
-    fn assign_offset(&self, msg: &mut MessageExtBrokerInner) {
-        let tran_type = MessageSysFlag::get_transaction_value(msg.sys_flag());
-        if MessageSysFlag::TRANSACTION_NOT_TYPE == tran_type || MessageSysFlag::TRANSACTION_COMMIT_TYPE == tran_type {
-            self.consume_queue_store.assign_queue_offset(msg);
-        }
-    }
-
-    fn record_put_message_stats(&self, topic: &CheetahString, append_result: &AppendMessageResult) {
-        let stats = &self.store_context.store_stats_service;
-        if append_result.msg_num > 0 {
-            stats.add_single_put_message_topic_times_total(topic.as_str(), append_result.msg_num as usize);
-        }
-        if append_result.wrote_bytes > 0 {
-            stats.add_single_put_message_topic_size_total(topic.as_str(), append_result.wrote_bytes as usize);
-        }
+        self.append_port
+            .append_message(msg, prepared, need_assign_offset)
+            .await
+            .result
     }
 }
 
@@ -897,10 +714,8 @@ mod adapter {
         pub(super) dispatcher: super::CommitLogDispatchHandle,
         pub(super) runtime_state: super::Arc<super::CommitLogRuntimeState>,
         pub(super) store_checkpoint: super::Arc<super::StoreCheckpoint>,
-        pub(super) append_message_callback: super::Arc<super::DefaultAppendMessageCallback>,
+        pub(super) append_runtime: super::CommitLogAppendRuntime,
         pub(super) put_message_lock: super::Arc<tokio::sync::Mutex<()>>,
-        pub(super) topic_queue_lock: super::Arc<super::TopicQueueLock>,
-        pub(super) topic_config_table: super::Arc<super::DashMap<super::CheetahString, super::Arc<super::TopicConfig>>>,
         pub(super) consume_queue_store: super::ConsumeQueueStore,
         pub(super) flush_manager: super::DefaultFlushManager,
         pub(super) cold_data_check_service: super::Arc<super::ColdDataCheckService>,
@@ -925,7 +740,7 @@ impl DerefMut for CommitLog {
 }
 
 impl CommitLog {
-    pub(crate) fn new(
+    pub(crate) fn try_new(
         runtime_scope: crate::runtime::StoreRuntimeScope,
         message_store_config: Arc<MessageStoreConfig>,
         store_runtime_state: Arc<StoreRuntimeState>,
@@ -936,7 +751,7 @@ impl CommitLog {
         topic_config_table: Arc<DashMap<CheetahString, Arc<TopicConfig>>>,
         consume_queue_store: ConsumeQueueStore,
         allocate_mapped_file_service: AllocateMappedFileService,
-    ) -> Self {
+    ) -> Result<Self, StoreError> {
         let enabled_append_prop_crc = message_store_config.enabled_append_prop_crc;
         let store_path = message_store_config.get_store_path_commit_log();
         let mapped_file_size = message_store_config.mapped_file_size_commit_log;
@@ -946,7 +761,62 @@ impl CommitLog {
         let mapped_file_queue =
             MappedFileQueue::new(store_path, mapped_file_size as u64, Some(allocate_mapped_file_service));
         let mapped_file_flush = mapped_file_queue.flush_handle();
-        Self {
+        let runtime_state = Arc::new(CommitLogRuntimeState::new(
+            message_store_config.linux_memory_lock_warn_only,
+            memory_lock_budget_bytes,
+        ));
+        let append_message_callback = Arc::new(DefaultAppendMessageCallback::new(
+            message_store_config.clone(),
+            topic_config_table.clone(),
+        ));
+        let put_message_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let flush_manager = DefaultFlushManager::new(
+            runtime_scope.clone(),
+            message_store_config.clone(),
+            mapped_file_flush,
+            store_checkpoint.clone(),
+        );
+        let micro_batch = if message_store_config.commit_log_micro_batch_enabled {
+            MicroBatchPolicy::try_new(
+                message_store_config.commit_log_micro_batch_max_items,
+                message_store_config.commit_log_micro_batch_max_bytes,
+                std::time::Duration::from_micros(message_store_config.commit_log_micro_batch_max_wait_micros),
+            )
+        } else {
+            MicroBatchPolicy::disabled(message_store_config.commit_log_append_queue_bytes)
+        }
+        .map_err(|error| {
+            StoreError::storage(
+                StoreOperation::Start,
+                format!("invalid CommitLog micro-batch policy: {error}"),
+            )
+        })?;
+        let append_processor = CommitLogAppendProcessor::new(CommitLogAppendDependencies {
+            append: mapped_file_queue.append_handle(),
+            message_store_config: Arc::clone(&message_store_config),
+            store_context: store_context.clone(),
+            runtime_state: Arc::clone(&runtime_state),
+            append_callback: Arc::clone(&append_message_callback),
+            put_message_lock: Arc::clone(&put_message_lock),
+            consume_queue_store: consume_queue_store.clone(),
+            flush: flush_manager.commit_log_flush_wakeup(),
+        });
+        let append_runtime = CommitLogAppendRuntime::start(
+            runtime_scope,
+            AppendSequencerConfig {
+                queue_capacity: message_store_config.commit_log_append_queue_capacity,
+                queue_bytes: message_store_config.commit_log_append_queue_bytes,
+                micro_batch,
+            },
+            append_processor,
+        )
+        .map_err(|error| {
+            StoreError::storage(
+                StoreOperation::Start,
+                format!("failed to initialize CommitLog append sequencer: {error}"),
+            )
+        })?;
+        Ok(Self {
             root: CommitLogRoot::new(CommitLogAdapter {
                 mapped_file_queue,
                 message_store_config: message_store_config.clone(),
@@ -955,28 +825,15 @@ impl CommitLog {
                 enabled_append_prop_crc,
                 store_context,
                 dispatcher,
-                runtime_state: Arc::new(CommitLogRuntimeState::new(
-                    message_store_config.linux_memory_lock_warn_only,
-                    memory_lock_budget_bytes,
-                )),
+                runtime_state,
                 store_checkpoint: store_checkpoint.clone(),
-                append_message_callback: Arc::new(DefaultAppendMessageCallback::new(
-                    message_store_config.clone(),
-                    topic_config_table.clone(),
-                )),
-                put_message_lock: Arc::new(Default::default()),
-                topic_queue_lock: Arc::new(TopicQueueLock::with_size(message_store_config.topic_queue_lock_num)),
-                topic_config_table,
+                append_runtime,
+                put_message_lock,
                 consume_queue_store,
-                flush_manager: DefaultFlushManager::new(
-                    runtime_scope,
-                    message_store_config.clone(),
-                    mapped_file_flush,
-                    store_checkpoint,
-                ),
+                flush_manager,
                 cold_data_check_service: Arc::new(Default::default()),
             }),
-        }
+        })
     }
 
     #[inline]
@@ -1000,18 +857,10 @@ impl CommitLog {
 
     pub(crate) fn internal_message_write_handle(&self) -> CommitLogInternalMessageWriteHandle {
         CommitLogInternalMessageWriteHandle {
-            append: self.mapped_file_queue.append_handle(),
             message_store_config: Arc::clone(&self.message_store_config),
             store_runtime_state: Arc::clone(&self.store_runtime_state),
             enabled_append_prop_crc: self.enabled_append_prop_crc,
-            store_context: self.store_context.clone(),
-            runtime_state: Arc::clone(&self.runtime_state),
-            append_message_callback: Arc::clone(&self.append_message_callback),
-            put_message_lock: Arc::clone(&self.put_message_lock),
-            topic_queue_lock: Arc::clone(&self.topic_queue_lock),
-            topic_config_table: Arc::clone(&self.topic_config_table),
-            consume_queue_store: self.consume_queue_store.clone(),
-            flush: self.flush_manager.internal_message_flush_handle(),
+            append_port: self.append_runtime.port(),
         }
     }
 
@@ -1304,6 +1153,7 @@ impl CommitLog {
     }
 
     pub fn shutdown(&mut self) {
+        self.append_runtime.close();
         self.flush_manager.shutdown();
     }
 
@@ -1315,23 +1165,15 @@ impl CommitLog {
         self.runtime_state.put_message_lock_runtime_info()
     }
 
-    fn release_put_message_lock(
-        &self,
-        put_message_lock: tokio::sync::MutexGuard<'_, ()>,
-        lock_wait_millis: u64,
-        lock_hold_start: Instant,
-    ) -> u64 {
-        let elapsed_time_in_lock = lock_hold_start.elapsed().as_millis() as u64;
-        self.runtime_state
-            .record_put_message_lock(lock_wait_millis, elapsed_time_in_lock);
-        drop(put_message_lock);
-        self.runtime_state.clear_begin_time_in_lock();
-        elapsed_time_in_lock
+    /// Returns bounded admission and saturation state for the CommitLog append sequencer.
+    pub fn append_sequencer_runtime_info(&self) -> QueueSnapshot {
+        self.append_runtime.port().snapshot()
     }
 
     pub async fn shutdown_gracefully(
         &mut self,
     ) -> Result<crate::consume_queue::mapped_file_queue::FlushProgress, StoreError> {
+        self.append_runtime.shutdown_gracefully().await;
         self.flush_manager.shutdown_gracefully().await
     }
 
@@ -1453,7 +1295,6 @@ impl CommitLog {
             msg_batch.message_ext_broker_inner.get_properties(),
             msg_batch.message_ext_broker_inner.get_body().map(|body| body.len()),
         );
-        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = current_millis() as i64;
         let tran_type = MessageSysFlag::get_transaction_value(msg_batch.message_ext_broker_inner.sys_flag());
         if MessageSysFlag::TRANSACTION_NOT_TYPE != tran_type {
             return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
@@ -1479,12 +1320,7 @@ impl CommitLog {
             msg_batch.message_ext_broker_inner.with_store_host_v6_flag();
         }
 
-        let mapped_file = self.mapped_file_queue.get_last_mapped_file();
-        let curr_offset = if let Some(ref mapped_file_inner) = mapped_file {
-            mapped_file_inner.get_wrote_position() as u64 + mapped_file_inner.get_file_from_offset()
-        } else {
-            0
-        };
+        let curr_offset = self.mapped_file_queue.append_handle().current_append_offset();
         let need_handle_ha = self.need_handle_ha(&msg_batch.message_ext_broker_inner);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
@@ -1496,150 +1332,29 @@ impl CommitLog {
             msg_batch.message_ext_broker_inner.version = MessageVersion::V2;
         }
         let mut put_message_context = PutMessageContext::default();
-        let encoded_buff = encode_message_ext_batch(&msg_batch, &mut put_message_context, &self.message_store_config);
-
-        let topic_queue_key = generate_key(&msg_batch.message_ext_broker_inner);
-        put_message_context.set_topic_queue_table_key(topic_queue_key.clone());
-        msg_batch.encoded_buff = encoded_buff;
-
-        let topic_queue_lock = self.topic_queue_lock.clone();
-        let _topic_queue_guard = topic_queue_lock.lock(topic_queue_key.as_str()).await;
-        self.assign_offset(&mut msg_batch.message_ext_broker_inner);
-
-        let lock_wait_start = Instant::now();
-        let put_message_lock = self.put_message_lock.clone();
-        let _put_message_lock = put_message_lock.lock().await;
-        let lock_wait_millis = lock_wait_start.elapsed().as_millis() as u64;
-        self.runtime_state.set_begin_time_in_lock(time_utils::current_millis());
-        let start_time = Instant::now();
-        // Here settings are stored timestamp, in order to ensure an orderly global
-        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = time_utils::current_millis() as i64;
-
-        let append_attempt = {
-            let adapter = self.root.adapter();
-            let mapped_file_queue = &adapter.mapped_file_queue;
-            let message_store_config = adapter.message_store_config.as_ref();
-            let (active_memory_lock, active_memory_lock_present) = adapter.runtime_state.active_memory_lock_parts();
-            let append_message_callback = adapter.append_message_callback.as_ref();
-            let enabled_append_prop_crc = adapter.enabled_append_prop_crc;
-            CommitLogAppendAttempt::run(
-                mapped_file,
-                |mapped_file| mapped_file.is_full(),
-                || mapped_file_queue.get_last_mapped_file_mut_start_offset(0, true),
-                |mapped_file| {
-                    let target = Self::active_memory_lock_target_for_config(
-                        message_store_config,
-                        mapped_file.get_wrote_position().max(0) as u64,
-                        mapped_file.get_file_size(),
-                    );
-                    lock_active_mapped_file_parts!(
-                        active_memory_lock,
-                        active_memory_lock_present,
-                        mapped_file,
-                        target,
-                        crate::utils::ffi::mlock,
-                        crate::utils::ffi::munlock,
-                    )
-                },
-                |mapped_file| {
-                    mapped_file.append_messages(
-                        &mut msg_batch,
-                        append_message_callback,
-                        &mut put_message_context,
-                        enabled_append_prop_crc,
-                    )
-                },
-            )
+        let prepared = match message_encoder_pool::prepare_message_batch_with_pool(
+            &msg_batch,
+            &mut put_message_context,
+            &self.message_store_config,
+        ) {
+            Ok(prepared) => prepared,
+            Err(result) => return result,
         };
-        let (put_message_result, unlock_mapped_file) = match append_attempt.resolve() {
-            CommitLogAppendResolution::Continue {
-                status,
-                result,
-                unlock_segment,
-            } => (
-                PutMessageResult::new_append_result(Self::put_message_status(status), Some(result)),
-                unlock_segment,
-            ),
-            CommitLogAppendResolution::Return {
-                status,
-                append_result,
-                abandoned_segment,
-                failure,
-            } => {
-                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-                drop(_topic_queue_guard);
-                match failure {
-                    CommitLogAppendFailure::InitialSegmentUnavailable
-                    | CommitLogAppendFailure::RolledSegmentUnavailable => {
-                        error!(
-                            "create mapped file error, topic: {}  clientAddr: {}",
-                            msg_batch.message_ext_broker_inner.topic(),
-                            msg_batch.message_ext_broker_inner.born_host()
-                        );
-                    }
-                    CommitLogAppendFailure::InitialActiveLockFailed { error } => {
-                        error!(
-                            "lock active commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg_batch.message_ext_broker_inner.topic(),
-                            msg_batch.message_ext_broker_inner.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::RolledActiveLockFailed { error } => {
-                        error!(
-                            "lock rolled commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg_batch.message_ext_broker_inner.topic(),
-                            msg_batch.message_ext_broker_inner.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::InitialMessageIllegal | CommitLogAppendFailure::InitialUnknown => {}
-                }
-                drop(abandoned_segment);
-                return PutMessageResult::new_append_result(Self::put_message_status(status), append_result);
-            }
-        };
-        let elapsed_time_in_lock = self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::store::record_append_latency(elapsed_time_in_lock);
-        if elapsed_time_in_lock > 500 {
-            warn!(
-                "[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}",
-                elapsed_time_in_lock,
-                msg_batch.message_ext_broker_inner.body_len(),
-                put_message_result.append_message_result().as_ref().unwrap(),
-            );
+        let sequenced = self
+            .append_runtime
+            .port()
+            .append_batch(msg_batch, prepared, put_message_context)
+            .await;
+        if sequenced.result.put_message_status() != PutMessageStatus::PutOk {
+            return sequenced.result;
         }
-        if let (Some(unlock_mf), true) = (unlock_mapped_file, self.message_store_config.warm_mapped_file_enable) {
-            unlock_mf.munlock();
-        }
-        if put_message_result.put_message_status() == PutMessageStatus::PutOk {
-            self.increase_offset(
-                &msg_batch.message_ext_broker_inner,
-                put_message_context.get_batch_size() as i16,
-            );
-            if let Some(append_result) = put_message_result.append_message_result() {
-                self.record_put_message_stats(msg_batch.message_ext_broker_inner.topic(), append_result);
-            }
-            // Topic-queue lock released here after successful write
-            drop(_topic_queue_guard);
-            self.handle_disk_flush_and_ha(
-                put_message_result,
-                msg_batch.message_ext_broker_inner,
-                need_ack_nums,
-                need_handle_ha,
-            )
-            .await
-        } else {
-            // Write failed - topic_queue_lock will be released, but offset is already assigned
-            drop(_topic_queue_guard);
-            warn!(
-                "Failed to append batch messages to CommitLog, offset hole created for topic={} queue={}",
-                msg_batch.message_ext_broker_inner.topic(),
-                msg_batch.message_ext_broker_inner.queue_id()
-            );
-            put_message_result
-        }
+        self.handle_disk_flush_and_ha(
+            sequenced.result,
+            sequenced.batch.message_ext_broker_inner,
+            need_ack_nums,
+            need_handle_ha,
+        )
+        .await
     }
 
     #[tracing::instrument(
@@ -1684,16 +1399,9 @@ impl CommitLog {
             msg.with_store_host_v6_flag();
         }
 
-        let topic_queue_key = generate_key(&msg);
-
         //get last mapped file from mapped file queue
-        let mapped_file = self.mapped_file_queue.get_last_mapped_file();
         // current offset is physical offset
-        let curr_offset = if let Some(ref mapped_file_inner) = mapped_file {
-            mapped_file_inner.get_wrote_position() as u64 + mapped_file_inner.get_file_from_offset()
-        } else {
-            0
-        };
+        let curr_offset = self.mapped_file_queue.append_handle().current_append_offset();
         let need_handle_ha = self.need_handle_ha(&msg);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
@@ -1703,164 +1411,20 @@ impl CommitLog {
         let need_assign_offset = !(self.message_store_config.duplication_enable
             && self.store_runtime_state.broker_role() != BrokerRole::Slave);
 
-        // Encode message BEFORE acquiring any locks
-        let (put_message_result, encoded_buff) = encode_message_ext(&msg, &self.message_store_config);
-        if let Some(result) = put_message_result {
-            return result;
-        }
-        msg.encoded_buff = Some(encoded_buff);
-        let put_message_context = PutMessageContext::new(topic_queue_key.clone());
-
-        let topic_queue_lock = need_assign_offset.then(|| self.topic_queue_lock.clone());
-        let _topic_queue_guard = if let Some(topic_queue_lock) = topic_queue_lock.as_ref() {
-            let guard = topic_queue_lock.lock(topic_queue_key.as_str()).await;
-            self.assign_offset(&mut msg);
-            Some(guard)
-        } else {
-            None
+        let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
+            Ok(prepared) => prepared,
+            Err(result) => return result,
         };
-
-        let lock_wait_start = Instant::now();
-        let put_message_lock = self.put_message_lock.clone();
-        let _put_message_lock = put_message_lock.lock().await;
-        let lock_wait_millis = lock_wait_start.elapsed().as_millis() as u64;
-        let begin_lock_timestamp = time_utils::current_millis();
-        self.runtime_state.set_begin_time_in_lock(begin_lock_timestamp);
-        let start_time = Instant::now();
-        // Here settings are stored timestamp, in order to ensure an orderly global
-        if !self.message_store_config.duplication_enable {
-            msg.message_ext_inner.store_timestamp = begin_lock_timestamp as i64;
+        let sequenced = self
+            .append_runtime
+            .port()
+            .append_message(msg, prepared, need_assign_offset)
+            .await;
+        if sequenced.result.put_message_status() != PutMessageStatus::PutOk {
+            return sequenced.result;
         }
-
-        let append_attempt = {
-            let adapter = self.root.adapter();
-            let mapped_file_queue = &adapter.mapped_file_queue;
-            let message_store_config = adapter.message_store_config.as_ref();
-            let (active_memory_lock, active_memory_lock_present) = adapter.runtime_state.active_memory_lock_parts();
-            let append_message_callback = adapter.append_message_callback.as_ref();
-            CommitLogAppendAttempt::run(
-                mapped_file,
-                |mapped_file| mapped_file.is_full(),
-                || mapped_file_queue.get_last_mapped_file_mut_start_offset(0, true),
-                |mapped_file| {
-                    let target = Self::active_memory_lock_target_for_config(
-                        message_store_config,
-                        mapped_file.get_wrote_position().max(0) as u64,
-                        mapped_file.get_file_size(),
-                    );
-                    lock_active_mapped_file_parts!(
-                        active_memory_lock,
-                        active_memory_lock_present,
-                        mapped_file,
-                        target,
-                        crate::utils::ffi::mlock,
-                        crate::utils::ffi::munlock,
-                    )
-                },
-                |mapped_file| mapped_file.append_message(&mut msg, append_message_callback, &put_message_context),
-            )
-        };
-        let (put_message_result, unlock_mapped_file) = match append_attempt.resolve() {
-            CommitLogAppendResolution::Continue {
-                status,
-                result,
-                unlock_segment,
-            } => (
-                PutMessageResult::new_append_result(Self::put_message_status(status), Some(result)),
-                unlock_segment,
-            ),
-            CommitLogAppendResolution::Return {
-                status,
-                append_result,
-                abandoned_segment,
-                failure,
-            } => {
-                self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-                drop(_topic_queue_guard);
-                match failure {
-                    CommitLogAppendFailure::InitialSegmentUnavailable
-                    | CommitLogAppendFailure::RolledSegmentUnavailable => {
-                        error!(
-                            "create mapped file error, topic: {}  clientAddr: {}",
-                            msg.topic(),
-                            msg.born_host()
-                        );
-                    }
-                    CommitLogAppendFailure::InitialActiveLockFailed { error } => {
-                        error!(
-                            "lock active commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg.topic(),
-                            msg.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::RolledActiveLockFailed { error } => {
-                        error!(
-                            "lock rolled commitlog mapped file error, topic: {} clientAddr: {} error: {}",
-                            msg.topic(),
-                            msg.born_host(),
-                            error
-                        );
-                    }
-                    CommitLogAppendFailure::InitialMessageIllegal | CommitLogAppendFailure::InitialUnknown => {}
-                }
-                drop(abandoned_segment);
-                return PutMessageResult::new_append_result(Self::put_message_status(status), append_result);
-            }
-        };
-        let elapsed_time_in_lock = self.release_put_message_lock(_put_message_lock, lock_wait_millis, start_time);
-        #[cfg(feature = "observability")]
-        rocketmq_observability::metrics::store::record_append_latency(elapsed_time_in_lock);
-        if elapsed_time_in_lock > 500 {
-            warn!(
-                "[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}",
-                elapsed_time_in_lock,
-                msg.body_len(),
-                put_message_result.append_message_result().as_ref().unwrap(),
-            );
-        }
-
-        if let (Some(unlock_mf), true) = (unlock_mapped_file, self.message_store_config.warm_mapped_file_enable) {
-            unlock_mf.munlock();
-        }
-
-        if put_message_result.put_message_status() == PutMessageStatus::PutOk {
-            let message_num = get_message_num(&self.topic_config_table, &msg);
-            self.increase_offset(&msg, message_num);
-            if let Some(append_result) = put_message_result.append_message_result() {
-                self.record_put_message_stats(msg.topic(), append_result);
-            }
-            // Topic-queue lock released here after successful write
-            drop(_topic_queue_guard);
-            self.handle_disk_flush_and_ha(put_message_result, msg, need_ack_nums, need_handle_ha)
-                .await
-        } else {
-            // Write failed - topic_queue_lock will be released, but offset is already assigned
-            // This creates a hole in ConsumeQueue that will be filled by recovery process
-            drop(_topic_queue_guard);
-            warn!(
-                "Failed to append message to CommitLog, offset hole created for topic={} queue={}, will be recovered",
-                msg.topic(),
-                msg.queue_id()
-            );
-            put_message_result
-        }
-    }
-
-    fn increase_offset(&self, msg: &MessageExtBrokerInner, message_num: i16) {
-        let tran_type = MessageSysFlag::get_transaction_value(msg.sys_flag());
-        if MessageSysFlag::TRANSACTION_NOT_TYPE == tran_type || MessageSysFlag::TRANSACTION_COMMIT_TYPE == tran_type {
-            self.consume_queue_store.increase_queue_offset(msg, message_num);
-        }
-    }
-
-    #[inline]
-    fn assign_offset(&self, msg: &mut MessageExtBrokerInner) {
-        let tran_type = MessageSysFlag::get_transaction_value(msg.sys_flag());
-        // if the message is not transaction message or transaction commit message
-        if MessageSysFlag::TRANSACTION_NOT_TYPE == tran_type || MessageSysFlag::TRANSACTION_COMMIT_TYPE == tran_type {
-            self.consume_queue_store.assign_queue_offset(msg);
-        }
+        self.handle_disk_flush_and_ha(sequenced.result, sequenced.message, need_ack_nums, need_handle_ha)
+            .await
     }
 
     #[inline]
@@ -1921,35 +1485,17 @@ impl CommitLog {
                     put_message_result.set_put_message_status(flush_status);
                 }
             }
-            // Async flush + HA: Only wait for HA, flush happens asynchronously
+            // The sequencer already issued one aggregate async-flush wake-up for this micro-batch.
             (FlushDiskType::AsyncFlush, true) => {
-                // Trigger async flush (no waiting)
-                let _ = self.handle_disk_flush(append_message_result, &msg).await;
-                // Wait for HA replication
                 let replica_status = self.handle_ha(append_message_result, need_ack_nums).await;
                 if replica_status != PutMessageStatus::PutOk {
                     put_message_result.set_put_message_status(replica_status);
                 }
             }
-            // Async flush only: Don't wait for anything (fastest path)
-            (FlushDiskType::AsyncFlush, false) => {
-                // Trigger async flush and return immediately
-                let _ = self.handle_disk_flush(append_message_result, &msg).await;
-                // No waiting needed - this is the hot path for high-throughput scenarios
-            }
+            (FlushDiskType::AsyncFlush, false) => {}
         }
 
         put_message_result
-    }
-
-    fn record_put_message_stats(&self, topic: &CheetahString, append_result: &AppendMessageResult) {
-        let stats = &self.store_context.store_stats_service;
-        if append_result.msg_num > 0 {
-            stats.add_single_put_message_topic_times_total(topic.as_str(), append_result.msg_num as usize);
-        }
-        if append_result.wrote_bytes > 0 {
-            stats.add_single_put_message_topic_size_total(topic.as_str(), append_result.wrote_bytes as usize);
-        }
     }
 
     async fn handle_ha(&self, put_message_result: &AppendMessageResult, need_ack_nums: i32) -> PutMessageStatus {
@@ -3413,6 +2959,7 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use super::*;
     use crate::base::memory_lock_manager::MemoryLockCategory;
@@ -3498,6 +3045,15 @@ mod tests {
         fs::create_dir_all(root).expect("create mapped file dir");
         let file_path = root.join(format!("{offset:020}"));
         DefaultMappedFile::new(CheetahString::from(file_path.to_string_lossy().as_ref()), file_size)
+    }
+
+    fn append_test_message(topic: &'static str, body: &'static [u8]) -> MessageExtBrokerInner {
+        let mut message = MessageExtBrokerInner::default();
+        message.set_topic(CheetahString::from_static_str(topic));
+        message.message_ext_inner.set_queue_id(0);
+        message.set_body(Bytes::from_static(body));
+        message.set_wait_store_msg_ok(false);
+        message
     }
 
     fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -3928,6 +3484,160 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn append_sequencer_projects_fifo_offsets_across_segment_rollover() {
+        let temp_dir = tempfile::tempdir().expect("create append sequencer temp dir");
+        let mut store = new_test_message_store_with_config(
+            temp_dir.path(),
+            MessageStoreConfig {
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                mapped_file_size_commit_log: 256,
+                ha_listen_port: 0,
+                commit_log_micro_batch_max_items: 4,
+                commit_log_micro_batch_max_bytes: 4096,
+                commit_log_micro_batch_max_wait_micros: 1000,
+                ..MessageStoreConfig::default()
+            },
+            BrokerRole::AsyncMaster,
+            false,
+        );
+        store.init().await.expect("init append sequencer store");
+        assert!(store.load().await, "load append sequencer store");
+        store.start().await.expect("start append sequencer store");
+
+        let commit_log = store.get_commit_log();
+        let (first, second, third) = tokio::join!(
+            commit_log.put_message(append_test_message("append-sequencer-rollover", b"first-message-body")),
+            commit_log.put_message(append_test_message("append-sequencer-rollover", b"second-message-body")),
+            commit_log.put_message(append_test_message("append-sequencer-rollover", b"third-message-body")),
+        );
+        let results = [first, second, third];
+
+        assert!(results
+            .iter()
+            .all(|result| result.put_message_status() == PutMessageStatus::PutOk));
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| {
+                    result
+                        .append_message_result()
+                        .expect("successful append result")
+                        .logics_offset
+                })
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        let physical_offsets = results
+            .iter()
+            .map(|result| {
+                result
+                    .append_message_result()
+                    .expect("successful append result")
+                    .wrote_offset
+            })
+            .collect::<Vec<_>>();
+        assert!(physical_offsets.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(
+            physical_offsets
+                .iter()
+                .map(|offset| offset / 256)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+                >= 2,
+            "three appends should cross the configured CommitLog segment boundary"
+        );
+
+        let queue = commit_log.append_sequencer_runtime_info();
+        assert_eq!(queue.depth, 0);
+        assert_eq!(queue.reserved_count, 0);
+        assert_eq!(commit_log.put_message_lock_runtime_info().acquire_total, 1);
+
+        store.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn caller_drop_does_not_cancel_admitted_append_and_capacity_stays_bounded() {
+        let temp_dir = tempfile::tempdir().expect("create caller-drop temp dir");
+        let mut store = new_test_message_store_with_config(
+            temp_dir.path(),
+            MessageStoreConfig {
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                mapped_file_size_commit_log: 4096,
+                ha_listen_port: 0,
+                commit_log_append_queue_capacity: 1,
+                commit_log_append_queue_bytes: 4096,
+                commit_log_micro_batch_max_items: 1,
+                commit_log_micro_batch_max_bytes: 4096,
+                commit_log_micro_batch_max_wait_micros: 0,
+                ..MessageStoreConfig::default()
+            },
+            BrokerRole::AsyncMaster,
+            false,
+        );
+        store.init().await.expect("init caller-drop store");
+        assert!(store.load().await, "load caller-drop store");
+        store.start().await.expect("start caller-drop store");
+        let store = Arc::new(store);
+
+        let writer_lock = Arc::clone(&store.get_commit_log().put_message_lock).lock_owned().await;
+        let caller_store = Arc::clone(&store);
+        let caller = tokio::spawn(async move {
+            caller_store
+                .get_commit_log()
+                .put_message(append_test_message(
+                    "append-sequencer-caller-drop",
+                    b"admitted-before-caller-drop",
+                ))
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if store.get_commit_log().append_sequencer_runtime_info().reserved_count == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first append should retain one bounded queue permit");
+
+        let saturated = store
+            .get_commit_log()
+            .put_message(append_test_message(
+                "append-sequencer-caller-drop",
+                b"rejected-while-capacity-is-held",
+            ))
+            .await;
+        assert_eq!(saturated.put_message_status(), PutMessageStatus::OsPageCacheBusy);
+
+        caller.abort();
+        let caller_error = match caller.await {
+            Ok(_) => panic!("caller task should be cancelled"),
+            Err(error) => error,
+        };
+        assert!(caller_error.is_cancelled());
+        drop(writer_lock);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let commit_log = store.get_commit_log();
+                if commit_log.get_max_offset() > 0 && commit_log.append_sequencer_runtime_info().reserved_count == 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("admitted append should finish after its caller is dropped");
+
+        let mut store = match Arc::try_unwrap(store) {
+            Ok(store) => store,
+            Err(_) => panic!("caller-drop test should release every LocalFileMessageStore owner"),
+        };
+        store.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
+++ b/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
@@ -1,0 +1,736 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Store-owned CommitLog append worker and per-request result projection.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_error::RocketMQResult;
+use rocketmq_model::common::message::message_batch::MessageExtBatch;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_runtime::resource_budget::BudgetConfigError;
+use rocketmq_runtime::resource_budget::QueueSnapshot;
+use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
+use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayload;
+use rocketmq_store_local::commit_log::append::sequencer::AppendAdmissionErrorKind;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencer;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerConfig;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerReceiver;
+use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerSender;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendAttempt;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendFailure;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendResolution;
+use tokio::sync::oneshot;
+use tracing::error;
+use tracing::warn;
+
+use super::CommitLog;
+use super::CommitLogFlushWakeup;
+use super::CommitLogRuntimeState;
+use super::CommitLogStoreContext;
+use super::ConsumeQueueStore;
+use super::ConsumeQueueStoreTrait;
+use super::DefaultAppendMessageCallback;
+use super::DefaultMappedFile;
+use super::MappedFile;
+use super::MappedFileQueueAppendHandle;
+use super::MessageStoreConfig;
+use super::PutMessageContext;
+use super::PutMessageResult;
+use super::PutMessageStatus;
+use crate::base::message_result::AppendMessageResult;
+
+const APPEND_WORKER_NAME: &str = "commitlog-append-sequencer";
+const APPEND_WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Failure to construct the bounded queue or start its lifecycle-owned worker.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CommitLogAppendStartError {
+    #[error("invalid append queue budget: {0}")]
+    InvalidBudget(#[from] BudgetConfigError),
+    #[error("failed to start append worker: {0}")]
+    WorkerStart(#[from] RuntimeError),
+}
+
+/// Result returned to a single-message caller after the worker finishes durable-memory append.
+pub(super) struct SequencedMessageAppend {
+    pub(super) message: MessageExtBrokerInner,
+    pub(super) result: PutMessageResult,
+}
+
+/// Result returned to an encoded-message-batch caller.
+pub(super) struct SequencedBatchAppend {
+    pub(super) batch: MessageExtBatch,
+    pub(super) result: PutMessageResult,
+}
+
+/// Cloneable admission port shared by normal and internal CommitLog producers.
+#[derive(Clone)]
+pub(super) struct CommitLogAppendPort {
+    sender: AppendSequencerSender<AppendRequest>,
+}
+
+impl CommitLogAppendPort {
+    pub(super) async fn append_message(
+        &self,
+        message: MessageExtBrokerInner,
+        prepared: PreparedPayload,
+        assign_queue_offset: bool,
+    ) -> SequencedMessageAppend {
+        let (completion, response) = oneshot::channel();
+        let request = AppendRequest::Message {
+            message,
+            prepared,
+            assign_queue_offset,
+            completion,
+        };
+        let retained_bytes = request.retained_bytes();
+        if let Err(error) = self.sender.try_submit(request, retained_bytes) {
+            let kind = error.kind();
+            error
+                .into_request()
+                .reject(PutMessageResult::new_default(Self::admission_status(kind)));
+        }
+        response.await.unwrap_or_else(|response_error| {
+            error!(error = %response_error, "CommitLog append worker dropped a message response");
+            SequencedMessageAppend {
+                message: MessageExtBrokerInner::default(),
+                result: PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+            }
+        })
+    }
+
+    pub(super) async fn append_batch(
+        &self,
+        batch: MessageExtBatch,
+        prepared: PreparedPayload,
+        context: PutMessageContext,
+    ) -> SequencedBatchAppend {
+        let (completion, response) = oneshot::channel();
+        let request = AppendRequest::Batch {
+            batch,
+            prepared,
+            context,
+            completion,
+        };
+        let retained_bytes = request.retained_bytes();
+        if let Err(error) = self.sender.try_submit(request, retained_bytes) {
+            let kind = error.kind();
+            error
+                .into_request()
+                .reject(PutMessageResult::new_default(Self::admission_status(kind)));
+        }
+        response.await.unwrap_or_else(|response_error| {
+            error!(error = %response_error, "CommitLog append worker dropped a batch response");
+            SequencedBatchAppend {
+                batch: MessageExtBatch::default(),
+                result: PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+            }
+        })
+    }
+
+    pub(super) fn close(&self) {
+        self.sender.close();
+    }
+
+    fn close_and_discard_pending(&self) -> usize {
+        self.sender.close_and_discard_pending()
+    }
+
+    pub(super) fn snapshot(&self) -> QueueSnapshot {
+        self.sender.snapshot()
+    }
+
+    fn admission_status(kind: AppendAdmissionErrorKind) -> PutMessageStatus {
+        match kind {
+            AppendAdmissionErrorKind::Saturated => PutMessageStatus::OsPageCacheBusy,
+            AppendAdmissionErrorKind::Closed => PutMessageStatus::ServiceNotAvailable,
+        }
+    }
+}
+
+/// Lifecycle owner for the append worker.
+pub(super) struct CommitLogAppendRuntime {
+    port: CommitLogAppendPort,
+    task_group: TaskGroup,
+}
+
+impl CommitLogAppendRuntime {
+    pub(super) fn start(
+        runtime_scope: crate::runtime::StoreRuntimeScope,
+        config: AppendSequencerConfig,
+        processor: CommitLogAppendProcessor,
+    ) -> Result<Self, CommitLogAppendStartError> {
+        let (sender, receiver) = AppendSequencer::bounded(config)?;
+        let port = CommitLogAppendPort { sender };
+        let task_group = runtime_scope.task_group(APPEND_WORKER_NAME);
+        let cancellation = task_group.cancellation_token();
+        let worker_port = port.clone();
+        task_group.spawn(
+            APPEND_WORKER_NAME,
+            TaskKind::Worker,
+            run_append_worker(receiver, processor, cancellation, worker_port),
+        )?;
+        Ok(Self { port, task_group })
+    }
+
+    pub(super) fn port(&self) -> CommitLogAppendPort {
+        self.port.clone()
+    }
+
+    pub(super) fn close(&self) {
+        self.port.close();
+    }
+
+    pub(super) async fn shutdown_gracefully(&self) {
+        self.port.close();
+        let report = self.task_group.shutdown(APPEND_WORKER_SHUTDOWN_TIMEOUT).await;
+        if let Err(shutdown_error) = report.assert_no_task_leak() {
+            error!(error = %shutdown_error, "CommitLog append sequencer did not stop cleanly");
+        }
+    }
+}
+
+enum AppendRequest {
+    Message {
+        message: MessageExtBrokerInner,
+        prepared: PreparedPayload,
+        assign_queue_offset: bool,
+        completion: oneshot::Sender<SequencedMessageAppend>,
+    },
+    Batch {
+        batch: MessageExtBatch,
+        prepared: PreparedPayload,
+        context: PutMessageContext,
+        completion: oneshot::Sender<SequencedBatchAppend>,
+    },
+}
+
+impl AppendRequest {
+    fn retained_bytes(&self) -> usize {
+        match self {
+            Self::Message { message, prepared, .. } => prepared.retained_bytes().saturating_add(message.body_len()),
+            Self::Batch { batch, prepared, .. } => prepared
+                .retained_bytes()
+                .saturating_add(batch.message_ext_broker_inner.body_len()),
+        }
+    }
+
+    fn reject(self, result: PutMessageResult) {
+        match self {
+            Self::Message {
+                message, completion, ..
+            } => {
+                let _ = completion.send(SequencedMessageAppend { message, result });
+            }
+            Self::Batch { batch, completion, .. } => {
+                let _ = completion.send(SequencedBatchAppend { batch, result });
+            }
+        }
+    }
+
+    fn bind_sequencer_fields(
+        self,
+        append_callback: &DefaultAppendMessageCallback,
+        duplication_enable: bool,
+    ) -> ReadyAppend {
+        match self {
+            Self::Message {
+                mut message,
+                prepared,
+                assign_queue_offset,
+                completion,
+            } => {
+                if !duplication_enable {
+                    message.message_ext_inner.store_timestamp =
+                        rocketmq_runtime::common::time_utils::current_millis() as i64;
+                }
+                let message_count = append_callback.message_num(&message);
+                ReadyAppend::Message {
+                    message,
+                    prepared,
+                    assign_queue_offset,
+                    message_count,
+                    completion,
+                }
+            }
+            Self::Batch {
+                mut batch,
+                prepared,
+                context,
+                completion,
+            } => {
+                batch.message_ext_broker_inner.message_ext_inner.store_timestamp =
+                    rocketmq_runtime::common::time_utils::current_millis() as i64;
+                let message_count = prepared.message_count();
+                ReadyAppend::Batch {
+                    batch,
+                    prepared,
+                    context,
+                    message_count,
+                    completion,
+                }
+            }
+        }
+    }
+}
+
+/// An admitted append whose stable encoding and sequencer-owned runtime fields are ready.
+enum ReadyAppend {
+    Message {
+        message: MessageExtBrokerInner,
+        prepared: PreparedPayload,
+        assign_queue_offset: bool,
+        message_count: i16,
+        completion: oneshot::Sender<SequencedMessageAppend>,
+    },
+    Batch {
+        batch: MessageExtBatch,
+        prepared: PreparedPayload,
+        context: PutMessageContext,
+        message_count: i16,
+        completion: oneshot::Sender<SequencedBatchAppend>,
+    },
+}
+
+enum CompletedAppend {
+    Message {
+        message: MessageExtBrokerInner,
+        result: PutMessageResult,
+        completion: oneshot::Sender<SequencedMessageAppend>,
+        unlock_segment: Option<Arc<DefaultMappedFile>>,
+    },
+    Batch {
+        batch: MessageExtBatch,
+        result: PutMessageResult,
+        completion: oneshot::Sender<SequencedBatchAppend>,
+        unlock_segment: Option<Arc<DefaultMappedFile>>,
+    },
+}
+
+impl CompletedAppend {
+    fn committed(&self) -> bool {
+        match self {
+            Self::Message { result, .. } | Self::Batch { result, .. } => {
+                result.put_message_status() == PutMessageStatus::PutOk
+            }
+        }
+    }
+
+    fn finish_post_lock(&mut self, processor: &CommitLogAppendProcessor) {
+        match self {
+            Self::Message {
+                message,
+                result,
+                unlock_segment,
+                ..
+            } => {
+                if processor.message_store_config.warm_mapped_file_enable {
+                    if let Some(mapped_file) = unlock_segment.take() {
+                        mapped_file.munlock();
+                    }
+                }
+                if result.put_message_status() == PutMessageStatus::PutOk {
+                    if let Some(append_result) = result.append_message_result() {
+                        processor.record_put_message_stats(message.topic(), append_result);
+                    }
+                }
+            }
+            Self::Batch {
+                batch,
+                result,
+                unlock_segment,
+                ..
+            } => {
+                if processor.message_store_config.warm_mapped_file_enable {
+                    if let Some(mapped_file) = unlock_segment.take() {
+                        mapped_file.munlock();
+                    }
+                }
+                if result.put_message_status() == PutMessageStatus::PutOk {
+                    if let Some(append_result) = result.append_message_result() {
+                        processor.record_put_message_stats(batch.message_ext_broker_inner.topic(), append_result);
+                    }
+                }
+            }
+        }
+    }
+
+    fn complete(self) {
+        match self {
+            Self::Message {
+                message,
+                result,
+                completion,
+                ..
+            } => {
+                let _ = completion.send(SequencedMessageAppend { message, result });
+            }
+            Self::Batch {
+                batch,
+                result,
+                completion,
+                ..
+            } => {
+                let _ = completion.send(SequencedBatchAppend { batch, result });
+            }
+        }
+    }
+}
+
+/// Dependencies captured by the single CommitLog append worker.
+pub(super) struct CommitLogAppendDependencies {
+    pub(super) append: MappedFileQueueAppendHandle,
+    pub(super) message_store_config: Arc<MessageStoreConfig>,
+    pub(super) store_context: CommitLogStoreContext,
+    pub(super) runtime_state: Arc<CommitLogRuntimeState>,
+    pub(super) append_callback: Arc<DefaultAppendMessageCallback>,
+    pub(super) put_message_lock: Arc<tokio::sync::Mutex<()>>,
+    pub(super) consume_queue_store: ConsumeQueueStore,
+    pub(super) flush: CommitLogFlushWakeup,
+}
+
+pub(super) struct CommitLogAppendProcessor {
+    append: MappedFileQueueAppendHandle,
+    message_store_config: Arc<MessageStoreConfig>,
+    store_context: CommitLogStoreContext,
+    runtime_state: Arc<CommitLogRuntimeState>,
+    append_callback: Arc<DefaultAppendMessageCallback>,
+    put_message_lock: Arc<tokio::sync::Mutex<()>>,
+    consume_queue_store: ConsumeQueueStore,
+    flush: CommitLogFlushWakeup,
+}
+
+impl CommitLogAppendProcessor {
+    pub(super) fn new(dependencies: CommitLogAppendDependencies) -> Self {
+        let CommitLogAppendDependencies {
+            append,
+            message_store_config,
+            store_context,
+            runtime_state,
+            append_callback,
+            put_message_lock,
+            consume_queue_store,
+            flush,
+        } = dependencies;
+        Self {
+            append,
+            message_store_config,
+            store_context,
+            runtime_state,
+            append_callback,
+            put_message_lock,
+            consume_queue_store,
+            flush,
+        }
+    }
+
+    async fn process_batch(
+        &self,
+        batch: rocketmq_store_local::commit_log::append::micro_batch::MicroBatch<AppendRequest>,
+    ) {
+        let request_count = batch.len();
+        let retained_bytes = batch.retained_bytes();
+        let mut requests = Vec::with_capacity(request_count);
+        let mut permits = Vec::with_capacity(request_count);
+        for budgeted_request in batch.into_budgeted_items() {
+            let (request, permit, _) = budgeted_request.into_parts();
+            requests.push(request.bind_sequencer_fields(
+                self.append_callback.as_ref(),
+                self.message_store_config.duplication_enable,
+            ));
+            permits.push(permit);
+        }
+
+        let wait_started = std::time::Instant::now();
+        let guard = self.put_message_lock.lock().await;
+        let lock_wait_millis = wait_started.elapsed().as_millis() as u64;
+        let lock_started = std::time::Instant::now();
+        self.runtime_state
+            .set_begin_time_in_lock(rocketmq_runtime::common::time_utils::current_millis());
+
+        let mut completions = Vec::with_capacity(request_count);
+        for request in requests {
+            completions.push(self.append_ready(request));
+        }
+
+        let lock_hold_millis = lock_started.elapsed().as_millis() as u64;
+        self.runtime_state
+            .record_put_message_lock(lock_wait_millis, lock_hold_millis);
+        drop(guard);
+        self.runtime_state.clear_begin_time_in_lock();
+        #[cfg(feature = "observability")]
+        rocketmq_observability::metrics::store::record_append_latency(lock_hold_millis);
+        if lock_hold_millis > 500 {
+            warn!(
+                lock_hold_millis,
+                request_count, retained_bytes, "CommitLog append micro-batch held the writer lock for too long"
+            );
+        }
+
+        for completion in &mut completions {
+            completion.finish_post_lock(self);
+        }
+        let committed_requests = completions.iter().filter(|completion| completion.committed()).count();
+        self.flush.wakeup_after_append_batch(committed_requests);
+        for (completion, permit) in completions.into_iter().zip(permits) {
+            completion.complete();
+            drop(permit);
+        }
+    }
+
+    /// Performs only logical-offset reservation and mapped CommitLog writes while the global
+    /// writer lock is held. Encoding, timestamp binding, stats, segment unlock, flush wake-up, and
+    /// result delivery stay outside this critical section.
+    fn append_ready(&self, request: ReadyAppend) -> CompletedAppend {
+        match request {
+            ReadyAppend::Message {
+                mut message,
+                prepared,
+                assign_queue_offset,
+                message_count,
+                completion,
+            } => {
+                if assign_queue_offset {
+                    self.assign_offset(&mut message);
+                }
+                let mut queue_offset = message.queue_offset();
+                if matches!(
+                    MessageSysFlag::get_transaction_value(message.sys_flag()),
+                    MessageSysFlag::TRANSACTION_PREPARED_TYPE | MessageSysFlag::TRANSACTION_ROLLBACK_TYPE
+                ) {
+                    queue_offset = 0;
+                }
+                let (result, unlock_segment) =
+                    self.append_message(&mut message, &prepared, queue_offset, i32::from(message_count));
+                if result.put_message_status() == PutMessageStatus::PutOk {
+                    self.increase_offset(&message, message_count);
+                }
+                CompletedAppend::Message {
+                    message,
+                    result,
+                    completion,
+                    unlock_segment,
+                }
+            }
+            ReadyAppend::Batch {
+                mut batch,
+                prepared,
+                mut context,
+                message_count,
+                completion,
+            } => {
+                self.assign_offset(&mut batch.message_ext_broker_inner);
+                let (result, unlock_segment) = self.append_batch(&mut batch, &prepared, &mut context);
+                if result.put_message_status() == PutMessageStatus::PutOk {
+                    self.increase_offset(&batch.message_ext_broker_inner, message_count);
+                }
+                CompletedAppend::Batch {
+                    batch,
+                    result,
+                    completion,
+                    unlock_segment,
+                }
+            }
+        }
+    }
+
+    fn append_message(
+        &self,
+        message: &mut MessageExtBrokerInner,
+        prepared: &PreparedPayload,
+        queue_offset: i64,
+        message_num: i32,
+    ) -> (PutMessageResult, Option<Arc<DefaultMappedFile>>) {
+        let initial = self.append.get_last_mapped_file(0, false);
+        let outcome = CommitLogAppendAttempt::run(
+            initial,
+            |mapped_file| mapped_file.is_full(),
+            || self.append.get_last_mapped_file(0, true),
+            |mapped_file| self.prepare_active_segment(mapped_file),
+            |mapped_file| {
+                self.append_callback.append_prepared_message(
+                    mapped_file.get_file_from_offset() as i64,
+                    mapped_file.as_ref(),
+                    message,
+                    prepared,
+                    queue_offset,
+                    message_num,
+                )
+            },
+        );
+        self.resolve_append(outcome, message.topic(), message.born_host().to_string())
+    }
+
+    fn append_batch(
+        &self,
+        batch: &mut MessageExtBatch,
+        prepared: &PreparedPayload,
+        context: &mut PutMessageContext,
+    ) -> (PutMessageResult, Option<Arc<DefaultMappedFile>>) {
+        let initial = self.append.get_last_mapped_file(0, false);
+        let outcome = CommitLogAppendAttempt::run(
+            initial,
+            |mapped_file| mapped_file.is_full(),
+            || self.append.get_last_mapped_file(0, true),
+            |mapped_file| self.prepare_active_segment(mapped_file),
+            |mapped_file| {
+                self.append_callback.append_prepared_batch(
+                    mapped_file.get_file_from_offset() as i64,
+                    mapped_file.as_ref(),
+                    batch,
+                    prepared,
+                    context,
+                )
+            },
+        );
+        self.resolve_append(
+            outcome,
+            batch.message_ext_broker_inner.topic(),
+            batch.message_ext_broker_inner.born_host().to_string(),
+        )
+    }
+
+    fn resolve_append(
+        &self,
+        outcome: rocketmq_store_local::commit_log::append_attempt::CommitLogAppendOutcome<
+            Arc<DefaultMappedFile>,
+            rocketmq_error::RocketMQError,
+        >,
+        topic: &str,
+        born_host: String,
+    ) -> (PutMessageResult, Option<Arc<DefaultMappedFile>>) {
+        match outcome.resolve() {
+            CommitLogAppendResolution::Continue {
+                status,
+                result,
+                unlock_segment,
+            } => (
+                PutMessageResult::new_append_result(CommitLog::put_message_status(status), Some(result)),
+                unlock_segment,
+            ),
+            CommitLogAppendResolution::Return {
+                status,
+                append_result,
+                abandoned_segment,
+                failure,
+            } => {
+                match failure {
+                    CommitLogAppendFailure::InitialSegmentUnavailable
+                    | CommitLogAppendFailure::RolledSegmentUnavailable => {
+                        error!(topic, born_host, "Failed to create CommitLog mapped segment");
+                    }
+                    CommitLogAppendFailure::InitialActiveLockFailed { error }
+                    | CommitLogAppendFailure::RolledActiveLockFailed { error } => {
+                        error!(%error, topic, born_host, "Failed to lock active CommitLog mapped segment");
+                    }
+                    CommitLogAppendFailure::InitialMessageIllegal | CommitLogAppendFailure::InitialUnknown => {}
+                }
+                drop(abandoned_segment);
+                (
+                    PutMessageResult::new_append_result(CommitLog::put_message_status(status), append_result),
+                    None,
+                )
+            }
+        }
+    }
+
+    fn prepare_active_segment(&self, mapped_file: &Arc<DefaultMappedFile>) -> RocketMQResult<()> {
+        let target = CommitLog::active_memory_lock_target_for_config(
+            self.message_store_config.as_ref(),
+            mapped_file.get_wrote_position().max(0) as u64,
+            mapped_file.get_file_size(),
+        );
+        let (active_memory_lock, active_memory_lock_present) = self.runtime_state.active_memory_lock_parts();
+        CommitLog::ensure_active_mapped_file_locked_parts(
+            active_memory_lock,
+            active_memory_lock_present,
+            target,
+            mapped_file.get_file_from_offset(),
+            |manager, target| {
+                mapped_file.lock_region_with(
+                    manager,
+                    target.category,
+                    target.offset,
+                    target.len,
+                    crate::utils::ffi::mlock,
+                )
+            },
+            crate::utils::ffi::munlock,
+        )
+    }
+
+    fn assign_offset(&self, message: &mut MessageExtBrokerInner) {
+        let transaction = MessageSysFlag::get_transaction_value(message.sys_flag());
+        if matches!(
+            transaction,
+            MessageSysFlag::TRANSACTION_NOT_TYPE | MessageSysFlag::TRANSACTION_COMMIT_TYPE
+        ) {
+            self.consume_queue_store.assign_queue_offset(message);
+        }
+    }
+
+    fn increase_offset(&self, message: &MessageExtBrokerInner, message_count: i16) {
+        let transaction = MessageSysFlag::get_transaction_value(message.sys_flag());
+        if matches!(
+            transaction,
+            MessageSysFlag::TRANSACTION_NOT_TYPE | MessageSysFlag::TRANSACTION_COMMIT_TYPE
+        ) {
+            self.consume_queue_store.increase_queue_offset(message, message_count);
+        }
+    }
+
+    fn record_put_message_stats(&self, topic: &str, append_result: &AppendMessageResult) {
+        if append_result.msg_num > 0 {
+            self.store_context
+                .store_stats_service
+                .add_single_put_message_topic_times_total(topic, append_result.msg_num as usize);
+        }
+        if append_result.wrote_bytes > 0 {
+            self.store_context
+                .store_stats_service
+                .add_single_put_message_topic_size_total(topic, append_result.wrote_bytes as usize);
+        }
+    }
+}
+
+async fn run_append_worker(
+    mut receiver: AppendSequencerReceiver<AppendRequest>,
+    processor: CommitLogAppendProcessor,
+    cancellation: tokio_util::sync::CancellationToken,
+    port: CommitLogAppendPort,
+) {
+    struct WorkerExitGuard(CommitLogAppendPort);
+
+    impl Drop for WorkerExitGuard {
+        fn drop(&mut self) {
+            let discarded_requests = self.0.close_and_discard_pending();
+            if discarded_requests > 0 {
+                warn!(
+                    discarded_requests,
+                    "CommitLog append worker exited before processing every admitted request"
+                );
+            }
+        }
+    }
+
+    let _exit_guard = WorkerExitGuard(port);
+    while let Some(batch) = receiver.next_batch(&cancellation).await {
+        processor.process_batch(batch).await;
+    }
+}

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -60,9 +60,9 @@ pub struct DefaultFlushManager {
     root: FlushManagerRoot<DefaultFlushManagerAdapter>,
 }
 
-/// Narrow wake-up capability for internal messages that never wait for durable acknowledgement.
+/// Narrow wake-up capability shared by sequenced CommitLog append requests.
 #[derive(Clone)]
-pub(crate) struct InternalMessageFlushHandle {
+pub(crate) struct CommitLogFlushWakeup {
     flush_disk_type: FlushDiskType,
     transient_store_pool_enable: bool,
     group_commit_notified: Option<Arc<Notify>>,
@@ -70,28 +70,32 @@ pub(crate) struct InternalMessageFlushHandle {
     commit_real_time_notified: Option<Arc<Notify>>,
 }
 
-impl InternalMessageFlushHandle {
-    pub(crate) fn wakeup(&self) {
+impl CommitLogFlushWakeup {
+    /// Wakes the owning flush service once after a sequencer batch commits one or more requests.
+    pub(crate) fn wakeup_after_append_batch(&self, committed_requests: usize) {
+        if committed_requests == 0 {
+            return;
+        }
         match self.flush_disk_type {
             FlushDiskType::SyncFlush => {
                 if let Some(notified) = &self.group_commit_notified {
                     notified.notify_one();
                 } else {
-                    warn!("sync flush wake-up is unavailable for internal message");
+                    warn!("sync flush wake-up is unavailable after CommitLog append");
                 }
             }
             FlushDiskType::AsyncFlush if self.transient_store_pool_enable => {
                 if let Some(notified) = &self.commit_real_time_notified {
                     notified.notify_one();
                 } else {
-                    warn!("commit wake-up is unavailable for internal message");
+                    warn!("commit wake-up is unavailable after CommitLog append");
                 }
             }
             FlushDiskType::AsyncFlush => {
                 if let Some(notified) = &self.flush_real_time_notified {
                     notified.notify_one();
                 } else {
-                    warn!("flush wake-up is unavailable for internal message");
+                    warn!("flush wake-up is unavailable after CommitLog append");
                 }
             }
         }
@@ -216,8 +220,8 @@ impl DefaultFlushManager {
         self.store_health_recorder = store_health_recorder;
     }
 
-    pub(crate) fn internal_message_flush_handle(&self) -> InternalMessageFlushHandle {
-        InternalMessageFlushHandle {
+    pub(crate) fn commit_log_flush_wakeup(&self) -> CommitLogFlushWakeup {
+        CommitLogFlushWakeup {
             flush_disk_type: self.message_store_config.flush_disk_type,
             transient_store_pool_enable: self.message_store_config.transient_store_pool_enable,
             group_commit_notified: self

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -123,7 +123,7 @@ impl LocalFileMessageStore {
             delay_level_table.clone(),
         );
         let store_runtime_state = Arc::new(StoreRuntimeState::new(message_store_config.as_ref()));
-        let mut commit_log = CommitLog::new(
+        let mut commit_log = CommitLog::try_new(
             runtime_scope.clone(),
             message_store_config.clone(),
             Arc::clone(&store_runtime_state),
@@ -134,7 +134,7 @@ impl LocalFileMessageStore {
             topic_config_table.clone(),
             consume_queue_store.clone(),
             (*allocate_mapped_file_service).clone(),
-        );
+        )?;
         commit_log.set_store_health_recorder(store_health_recorder.clone());
         let commit_log_read = commit_log.read_handle();
         let commit_log_cleanup = commit_log.cleanup_handle();

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -1638,6 +1638,7 @@ async fn started_store_reput_dispatches_schedule_topic_messages_after_normal_mes
         &temp_dir,
         MessageStoreConfig {
             flush_disk_type: FlushDiskType::AsyncFlush,
+            ha_listen_port: allocate_local_test_port() as usize,
             ..MessageStoreConfig::default()
         },
     );
@@ -2951,7 +2952,7 @@ async fn store_stats_records_batch_put_append_totals() {
 }
 
 #[tokio::test]
-async fn shared_put_message_serializes_concurrent_appends() {
+async fn shared_put_message_micro_batches_concurrent_appends() {
     let temp_dir = tempdir().unwrap();
     let store = new_async_flush_test_store(&temp_dir);
     let topic = CheetahString::from_static_str("shared-put-message-topic");
@@ -2966,7 +2967,7 @@ async fn shared_put_message_serializes_concurrent_appends() {
         first.append_message_result().expect("first append").wrote_offset,
         second.append_message_result().expect("second append").wrote_offset
     );
-    assert_eq!(store.get_runtime_info()["putMessageLockAcquireTotal"], "2");
+    assert_eq!(store.get_runtime_info()["putMessageLockAcquireTotal"], "1");
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8753

### Brief Description

- Add immutable `PreparedPayload` and `FinalizedAppend` stages so stable encoding and structural validation happen before sequencer admission, while offsets, timestamps, and checksums are finalized in FIFO append order.
- Add a Store-owned, count-and-byte bounded CommitLog append sequencer with configurable max-items, max-bytes, and max-wait micro-batching.
- Keep mapped-file reservation, rollover, runtime-field patching, mapped copy, and lease commit under one global writer lock, then project statistics, flush wake-up, HA waits, and per-request results after the critical section.
- Preserve admitted writes when a caller is dropped, drain admitted requests during graceful shutdown, and expose bounded queue runtime state.
- Add enabled/disabled, FIFO, offset, checksum, rollover, failure, cancellation, saturation, lifecycle, and Criterion benchmark coverage.

### How Did You Test This Change?

- `cargo fmt --all -- --check` could not start on Windows because the workspace command exceeded the OS command-line length limit (error 206); the equivalent format check passed for all 29 workspace packages in batches of eight.
- `cargo test -p rocketmq-store-local --test commitlog_micro_batch` - passed, 5 tests.
- `cargo test -p rocketmq-store-local commit_log` - passed.
- `cargo test -p rocketmq-store --lib` - passed, 545 tests.
- `cargo clippy -p rocketmq-store-local --all-targets --all-features -- -D warnings` - passed.
- `cargo clippy -p rocketmq-store --all-targets -- -D warnings` - passed.
- `cargo bench -p rocketmq-store-local --no-run` - passed.
- `cargo bench -p rocketmq-store-local --bench commitlog_micro_batch -- --sample-size 20 --measurement-time 2 --warm-up-time 1` - passed; enabled micro-batching measured an 8.8755 us median versus 9.4882 us disabled on this local run.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `git diff --check` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded, FIFO commit-log append processing with configurable micro-batching limits.
  * Added configuration for append queue capacity, byte limits, batch size, and wait time.
  * Added runtime append queue status information.
  * Added support for validated single-message and batch payload appends.

* **Bug Fixes**
  * Improved queue and physical offset assignment, checksum finalization, and segment rollover handling.
  * Invalid or incomplete payloads are now rejected before storage changes occur.
  * Graceful shutdown now completes admitted append operations safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->