### PR TITLE
[ISSUE #8757]✨Align stable toolchain and dependency trust policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -5146,7 +5146,6 @@ dependencies = [
  "rocketmq-runtime",
  "rocketmq-security-api",
  "rustls-native-certs",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -5273,15 +5272,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ serde              = { version = "1.0", features = ["derive"] }
 serde_json         = "1.0"
 serde_yaml         = "0.9"
 serde_json_any_key = "2.1.0"
-anyhow             = "1.0.102"
+anyhow             = "1.0.103"
 bytes              = "1.11.1"
 rand               = "0.10.1"
 zeroize            = "1.9.0"

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -11,7 +11,7 @@
 [![CodeCov][codecov-image]][codecov-url] [![GitHub contributors](https://img.shields.io/github/contributors/mxsm/rocketmq-rust)](https://github.com/mxsm/rocketmq-rust/graphs/contributors) [![Crates.io License](https://img.shields.io/crates/l/rocketmq-rust)](#license)
 <br/>
 ![GitHub repo size](https://img.shields.io/github/repo-size/mxsm/rocketmq-rust)
-![Static Badge](https://img.shields.io/badge/MSRV-1.85.0%2B-25b373)
+![Static Badge](https://img.shields.io/badge/MSRV-1.95.0%2B-25b373)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mxsm/rocketmq-rust)
 
 </div>
@@ -78,9 +78,12 @@ RocketMQ-Rust 实现了分布式架构，包含以下核心组件：
 
 ### 前置要求
 
-- Rust 工具链 1.85.0 或更高版本
+- Rust 工具链 1.95.0
 - 可用的 shell 和 `cargo`
 - 为 NameServer、Broker 和客户端示例准备独立终端
+
+固定工具链、依赖准入规则和本地验证约定请参阅
+[工具链与依赖信任策略](rocketmq-doc/en/toolchain-and-dependency-policy.md)。
 
 ### 1. 构建工作区
 
@@ -275,7 +278,8 @@ RocketMQ-Rust 聚焦 RocketMQ 兼容的消息服务和 Rust 原生集成能力�
 <details>
 <summary><b>最低支持的 Rust 版本（MSRV）是什么？</b></summary>
 
-最低支持的 Rust 版本是 1.85.0（stable 或 nightly）。
+最低支持的 Rust 版本是 stable Rust 1.95.0。仓库对本地和生产构建固定使用该精确版本；
+只有 Miri、rustdoc JSON 等明确记录的专项检查才使用固定日期的 nightly 工具链。
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![CodeCov][codecov-image]][codecov-url] [![GitHub contributors](https://img.shields.io/github/contributors/mxsm/rocketmq-rust)](https://github.com/mxsm/rocketmq-rust/graphs/contributors) [![Crates.io License](https://img.shields.io/crates/l/rocketmq-rust)](#license)
 <br/>
 ![GitHub repo size](https://img.shields.io/github/repo-size/mxsm/rocketmq-rust)
-![Static Badge](https://img.shields.io/badge/MSRV-1.85.0%2B-25b373)
+![Static Badge](https://img.shields.io/badge/MSRV-1.95.0%2B-25b373)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mxsm/rocketmq-rust)
 
 </div>
@@ -85,9 +85,12 @@ RocketMQ-Rust implements a distributed architecture with the following core comp
 
 ### Prerequisites
 
-- Rust toolchain 1.85.0 or later
+- Rust toolchain 1.95.0
 - A shell with `cargo` available
 - Separate terminals for the NameServer, Broker, and client examples
+
+See the [toolchain and dependency trust policy](rocketmq-doc/en/toolchain-and-dependency-policy.md)
+for the pinned toolchain, dependency admission rules, and local validation contract.
 
 ### 1. Build the Workspace
 
@@ -282,7 +285,9 @@ Yes, RocketMQ-Rust implements the RocketMQ protocol and can interoperate with Ap
 <details>
 <summary><b>What's the minimum supported Rust version (MSRV)?</b></summary>
 
-The minimum supported Rust version is 1.85.0 (stable or nightly).
+The minimum supported Rust version is stable Rust 1.95.0. The repository pins that exact
+toolchain for local and production builds; dated nightly toolchains are reserved for explicitly
+documented specialized checks such as Miri and rustdoc JSON generation.
 </details>
 
 <details>

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,109 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[graph]
+all-features = true
+targets = [
+  { triple = "x86_64-pc-windows-msvc" },
+  { triple = "x86_64-unknown-linux-gnu" },
+]
+
+[advisories]
+unmaintained = "all"
+unsound = "all"
+yanked = "warn"
+# This repository shares one policy across several standalone Cargo graphs, so an exception
+# can legitimately be absent from the graph currently being checked.
+unused-ignored-advisory = "allow"
+ignore = [
+  { id = "RUSTSEC-2026-0173", reason = "Owner: RocketMQ Rust maintainers. Build-time-only transitive dependency of tabled and validator derive macros; no maintained compatible release exists. Re-evaluate on every upstream update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0052", reason = "Owner: Dashboard maintainers. GPUI 0.2.2 pulls async-std 1.13.2 only through zed-async-tar; the latest GPUI release has no maintained replacement. Re-evaluate on every GPUI update and by 2026-10-27." },
+  { id = "RUSTSEC-2026-0105", reason = "Owner: Dashboard maintainers. GPUI 0.2.2 pulls core2 0.4.0 through image/rav1e/bitstream-io; the latest compatible graph has no maintained replacement. Re-evaluate on every GPUI or image update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0384", reason = "Owner: Dashboard maintainers. GPUI 0.2.2 and gpui-component 0.5.1 pull instant 0.1.13 through their event and file-watching stacks; no compatible maintained replacement is published. Re-evaluate on every framework update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0436", reason = "Owner: Dashboard maintainers. The latest GPUI component and graphics stack still use paste 1.0.15; this is an unmaintained notice with no known vulnerability. Re-evaluate on every framework update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0134", reason = "Owner: Dashboard maintainers. GPUI 0.2.2 pulls rustls-pemfile 2.2.0 through its pinned zed-reqwest HTTP client; application TLS code does not depend on it directly. Re-evaluate on every GPUI update and by 2026-10-27." },
+  { id = "RUSTSEC-2026-0206", reason = "Owner: Dashboard maintainers. The latest GPUI font stack still resolves rustybuzz 0.14.1 and 0.20.1 with no maintained compatible alternative. Re-evaluate on every GPUI/font-stack update and by 2026-10-27." },
+  { id = "RUSTSEC-2026-0192", reason = "Owner: Dashboard maintainers. The latest GPUI font stack still resolves ttf-parser 0.20.0, 0.21.1, and 0.25.1 with no maintained compatible alternative. Re-evaluate on every GPUI/font-stack update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0411", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gdkwayland-sys stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0412", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gdk stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0413", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 atk stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0414", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gdkx11-sys stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0415", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gtk stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0416", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 atk-sys stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0417", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gdkx11 stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0418", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gdk-sys stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0419", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 macro stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0420", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 still require the Linux-only GTK3 gtk-sys stack; Linux Tauri packaging is not production-certified while this exception remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0429", reason = "Owner: Dashboard maintainers. Tauri 2.11.5/Wry 0.55.1 pins Linux glib 0.18.5 and cannot accept the fixed 0.20 API; Linux Tauri packaging is not production-certified while this unsound dependency remains. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0057", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 uses fxhash 0.2.1 only through tauri-utils build-time HTML processing; no maintained compatible upstream release exists. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2024-0370", reason = "Owner: Dashboard maintainers. Tauri's Linux-only GTK3 glib-macros dependency still requires proc-macro-error 1.0.4; it is build-time-only and no compatible replacement is available. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2026-0097", reason = "Owner: Dashboard maintainers. All runtime rand dependencies are patched; Tauri 2.11.5 still resolves rand 0.7.3 only through build-time phf generation in tauri-utils, without the affected custom-logger runtime path. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0075", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 pulls unic-char-range 0.9.0 only through build-time urlpattern processing in tauri-utils; no compatible maintained replacement is published. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0080", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 pulls unic-common 0.9.0 only through build-time urlpattern processing in tauri-utils; no compatible maintained replacement is published. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0081", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 pulls unic-char-property 0.9.0 only through build-time urlpattern processing in tauri-utils; no compatible maintained replacement is published. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0098", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 pulls unic-ucd-version 0.9.0 only through build-time urlpattern processing in tauri-utils; no compatible maintained replacement is published. Re-evaluate on every Tauri update and by 2026-10-27." },
+  { id = "RUSTSEC-2025-0100", reason = "Owner: Dashboard maintainers. Tauri 2.11.5 pulls unic-ucd-ident 0.9.0 only through build-time urlpattern processing in tauri-utils; no compatible maintained replacement is published. Re-evaluate on every Tauri update and by 2026-10-27." },
+]
+
+[licenses]
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Zlib",
+]
+confidence-threshold = 0.8
+exceptions = [
+  # Owner: RocketMQ Rust maintainers. MIT-0 is permissive; scope it to the URI parser dependency only.
+  { allow = ["MIT-0"], crate = "borrow-or-share@0.2.4" },
+  # Owner: RocketMQ Rust maintainers. Preserve the existing Unlicense dependency without allowing it globally.
+  { allow = ["Unlicense"], crate = "serde_json_any_key@2.1.0" },
+  # Owner: Dashboard maintainers. The standalone GPUI application still resolves 2.0.0; keep the exception exact-version scoped.
+  { allow = ["Unlicense"], crate = "serde_json_any_key@2.0.0" },
+]
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "simplest-path"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+allow-workspace = true
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -17,7 +17,7 @@
 ARG BUILDER_IMAGE=docker.io/library/rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777
 ARG RUNTIME_IMAGE=docker.io/library/ubuntu:noble@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 ARG DEBIAN_SNAPSHOT=20260717T000000Z
-ARG ROCKETMQ_RUST_TOOLCHAIN=nightly-2026-07-05
+ARG ROCKETMQ_RUST_TOOLCHAIN=1.95.0
 ARG SOURCE_REVISION
 
 FROM ${BUILDER_IMAGE} AS ca-bundle
@@ -85,7 +85,8 @@ rustup toolchain install "${ROCKETMQ_RUST_TOOLCHAIN}" \
     --component clippy,rustfmt
 EOF
 
-ENV CC=clang \
+ENV RUST_VERSION=${ROCKETMQ_RUST_TOOLCHAIN} \
+    CC=clang \
     CXX=clang++ \
     RUSTUP_TOOLCHAIN=${ROCKETMQ_RUST_TOOLCHAIN}
 

--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -15,7 +15,7 @@
     }
   },
   "build": {
-    "rust_toolchain": "nightly-2026-07-05",
+    "rust_toolchain": "1.95.0",
     "debian_snapshot": "20260717T000000Z",
     "snapshot_bootstrap_transport": "http-with-signed-release-then-https",
     "builder_packages": [

--- a/rocketmq-auth/src/authorization/manager/metadata_manager_impl.rs
+++ b/rocketmq-auth/src/authorization/manager/metadata_manager_impl.rs
@@ -796,7 +796,8 @@ mod tests {
         assert!(!AuthorizationMetadataManagerImpl::is_valid_ip_or_cidr(
             "256.256.256.256"
         ));
-        assert!(!AuthorizationMetadataManagerImpl::is_valid_ip_or_cidr("192.168.0.0/33")); // Invalid prefix
+        assert!(!AuthorizationMetadataManagerImpl::is_valid_ip_or_cidr("192.168.0.0/33"));
+        // Invalid prefix
     }
 
     #[tokio::test]

--- a/rocketmq-broker/README-zh_cn.md
+++ b/rocketmq-broker/README-zh_cn.md
@@ -54,7 +54,7 @@ Broker 从 `rocketmq-broker-rust` 启动，先解析 CLI 和配置输入，再�
 
 ## 环境要求
 
-- Rust `1.85.0` 或更新版本。
+- Stable Rust `1.95.0`，使用仓库固定的工具链。
 - 启动 broker 前必须设置 `ROCKETMQ_HOME`。如果 `$ROCKETMQ_HOME/conf/broker.toml` 存在，会作为默认配置文件。
 - 正常 broker 注册建议提供可访问的 NameServer。未提供地址时，默认使用 `127.0.0.1:9876`。
 

--- a/rocketmq-broker/README.md
+++ b/rocketmq-broker/README.md
@@ -56,7 +56,7 @@ The public library surface exports:
 
 ## Requirements
 
-- Rust `1.85.0` or newer.
+- Stable Rust `1.95.0`, using the pinned repository toolchain.
 - `ROCKETMQ_HOME` must be set before starting the broker. If `$ROCKETMQ_HOME/conf/broker.toml` exists, it is used as
   the default config file.
 - A reachable NameServer is recommended for normal broker registration. If no address is provided, the broker defaults

--- a/rocketmq-client/README-zh_cn.md
+++ b/rocketmq-client/README-zh_cn.md
@@ -51,7 +51,7 @@ ACL hook、路由管理、延迟容错、消息轨迹以及面向热路径的 be
 
 ## 环境要求
 
-- Rust `1.85.0` 或更新版本。
+- Stable Rust `1.95.0`，使用仓库固定的工具链。
 - 真实 producer、consumer 和 admin 流量需要可访问的 RocketMQ NameServer。
 - 除非通过 admin API 创建 topic，否则 broker 侧需要提前准备目标 topic。
 

--- a/rocketmq-client/README.md
+++ b/rocketmq-client/README.md
@@ -53,7 +53,7 @@ The crate keeps Java-facing names for common concepts while exposing Rust async 
 
 ## Requirements
 
-- Rust `1.85.0` or newer.
+- Stable Rust `1.95.0`, using the pinned repository toolchain.
 - A reachable RocketMQ NameServer for real producer, consumer, and admin traffic.
 - A broker with the target topics configured, unless your scenario creates topics through admin APIs.
 

--- a/rocketmq-controller/README-zh_cn.md
+++ b/rocketmq-controller/README-zh_cn.md
@@ -54,9 +54,8 @@ storage、snapshot，以及可选 metrics exporter。
 
 ## 环境要求
 
-- workspace 最低 Rust 版本为 `1.85.0`。
-- 请使用仓库根目录的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 指定的 toolchain 构建。该 crate 当前启用了
-  nightly Rust feature。
+- workspace 最低 Rust 版本和仓库构建工具链均为 stable Rust `1.95.0`。
+- 请使用仓库根目录的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 指定的固定 stable toolchain 构建。
 - 启动 Controller 二进制前，必须设置 `ROCKETMQ_HOME` 或在配置文件中设置 `rocketmqHome`。
 - 默认 feature 组合下请使用 `storageBackend = "File"`。只有在启用 `storage-rocksdb` feature 后，才使用
   `storageBackend = "RocksDB"`。

--- a/rocketmq-controller/README.md
+++ b/rocketmq-controller/README.md
@@ -56,9 +56,8 @@ The binary requires a non-empty `rocketmqHome` value after configuration loading
 
 ## Requirements
 
-- Rust `1.85.0` or newer is the workspace minimum.
-- Build this crate with the repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml). The crate
-  currently enables a nightly Rust feature.
+- Stable Rust `1.95.0` is the workspace minimum and the repository build toolchain.
+- Build this crate with the pinned repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml).
 - `ROCKETMQ_HOME` or `rocketmqHome` must be set before starting the controller binary.
 - Use `storageBackend = "File"` with the default feature set. Use `storageBackend = "RocksDB"` only when building with
   `storage-rocksdb`.

--- a/rocketmq-dashboard/README-zh_cn.md
+++ b/rocketmq-dashboard/README-zh_cn.md
@@ -21,7 +21,7 @@ cargo build -p rocketmq-dashboard-tauri
 
 ## 环境要求
 
-- Rust 1.85.0 或更高版本
+- Stable Rust 1.95.0
 - `rocketmq-dashboard-tauri` 需要 Node.js 和 npm
 - 需要满足 Tauri 在当前操作系统上的依赖要求
 

--- a/rocketmq-dashboard/README.md
+++ b/rocketmq-dashboard/README.md
@@ -14,7 +14,7 @@ Important: `rocketmq-dashboard` itself is not a Cargo workspace root. You cannot
 
 ## Prerequisites
 
-- Rust toolchain 1.85.0 or later
+- Stable Rust toolchain 1.95.0
 - For `rocketmq-dashboard-tauri`: Node.js and npm
 - Tauri platform prerequisites for your OS
 

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
@@ -180,7 +180,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "serde_repr",
  "url",
@@ -201,7 +201,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "serde_repr",
  "url",
@@ -651,6 +651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,7 +897,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1039,6 +1048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,19 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-graphics"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.10.0",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "libc",
-]
-
-[[package]]
 name = "core-graphics-helmer-fork"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,13 +1190,14 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "21.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce32d657e17d6e4a8e70fe2ae6875218015f320620a78e5949d228bc76622bd"
+checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
 dependencies = [
  "core-foundation 0.10.0",
- "core-graphics 0.25.0",
+ "core-graphics 0.24.0",
  "foreign-types",
+ "libc",
 ]
 
 [[package]]
@@ -1367,6 +1370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,9 +1514,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2453,7 +2476,7 @@ dependencies = [
  "pin-project",
  "postage",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "raw-window-handle",
  "resvg",
  "schemars",
@@ -2477,7 +2500,7 @@ dependencies = [
  "wayland-protocols-plasma",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-numerics",
+ "windows-numerics 0.2.0",
  "windows-registry 0.5.3",
  "x11-clipboard",
  "x11rb",
@@ -2489,13 +2512,14 @@ dependencies = [
 
 [[package]]
 name = "gpui-component"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dda822a7bab4e0a08a4276ba68e2f82cc5855bf0b377d7b195c58c8061dc7d1"
+checksum = "d021d46b4088d3d93a57ccdf443da85695a77272108caca2f6fe5369f584966a"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "chrono",
+ "core-text",
  "enum-iterator",
  "gpui",
  "gpui-component-macros",
@@ -2528,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "gpui-component-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581a8cd1e38b2fd86d1029dd56a3296ffd1388fda295054104d89923755de902"
+checksum = "86fbc2d84bf91717b171320e6adc600d91ccb3ed259448f3b006787633c1c615"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2589,7 +2613,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "url",
  "zed-async-tar",
@@ -2826,7 +2850,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2890,6 +2914,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3672,7 +3705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3683,9 +3716,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4008,7 +4041,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "smallvec",
  "zeroize",
@@ -4163,6 +4196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,6 +4214,17 @@ dependencies = [
  "bitflags 2.10.0",
  "block2",
  "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
 ]
 
@@ -4247,7 +4301,7 @@ dependencies = [
  "blocking",
  "cbc",
  "cipher",
- "digest",
+ "digest 0.10.7",
  "endi",
  "futures-lite 2.6.1",
  "futures-util",
@@ -4258,9 +4312,9 @@ dependencies = [
  "num",
  "num-bigint-dig",
  "pbkdf2",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zbus",
  "zbus_macros",
@@ -4383,7 +4437,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -4433,7 +4487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4472,7 +4526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4794,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4830,7 +4884,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -4873,9 +4927,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4884,9 +4938,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4980,7 +5034,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -5209,7 +5263,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rocketmq-dashboard-common",
  "rocketmq-observability",
  "serde",
@@ -5274,6 +5328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -5298,6 +5353,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "sysinfo 0.39.6",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -5367,7 +5423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -5872,7 +5928,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6333,6 +6400,21 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6974,9 +7056,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -7479,12 +7561,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "quote",
 ]
 
@@ -7585,11 +7667,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -7602,7 +7696,7 @@ dependencies = [
  "rayon",
  "thiserror 2.0.18",
  "windows 0.61.3",
- "windows-future",
+ "windows-future 0.2.1",
 ]
 
 [[package]]
@@ -7612,6 +7706,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7660,7 +7763,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7727,6 +7841,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7905,6 +8029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8526,10 +8659,10 @@ dependencies = [
  "core-graphics-helmer-fork",
  "log",
  "objc",
- "rand 0.8.5",
+ "rand 0.8.7",
  "screencapturekit",
  "screencapturekit-sys",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tao-core-video-sys",
  "windows 0.61.3",
  "windows-capture",

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml
@@ -17,26 +17,27 @@
 # This is a standalone project, not part of the parent workspace
 
 [package]
-name        = "rocketmq-dashboard-gpui"
-version     = "0.1.0"
-description = "RocketMQ-Rust Dashboard Desktop App (GPUI)"
-authors     = ["mxsm <mxsm@apache.org>"]
-edition     = "2024"
-license     = "Apache-2.0"
-publish     = false
-keywords    = ["dashboard", "rocketmq", "gpui", "gui"]
-categories  = ["development-tools", "gui"]
-readme      = "README.md"
-resolver    = "3"
+name         = "rocketmq-dashboard-gpui"
+version      = "0.1.0"
+description  = "RocketMQ-Rust Dashboard Desktop App (GPUI)"
+authors      = ["mxsm <mxsm@apache.org>"]
+edition      = "2024"
+rust-version = "1.95.0"
+license      = "Apache-2.0"
+publish      = false
+keywords     = ["dashboard", "rocketmq", "gpui", "gui"]
+categories   = ["development-tools", "gui"]
+readme       = "README.md"
+resolver     = "3"
 
 [dependencies]
 # Shared common code
-rocketmq-dashboard-common = { path = "../rocketmq-dashboard-common" }
-rocketmq-observability = { path = "../../rocketmq-observability" }
+rocketmq-dashboard-common = { version = "1.0.0", path = "../rocketmq-dashboard-common" }
+rocketmq-observability = { version = "1.0.0", path = "../../rocketmq-observability" }
 
 # GPUI framework
 gpui           = { version = "0.2.2" }
-gpui-component = { version = "0.5.0" }
+gpui-component = { version = "0.5.1" }
 # Async runtime
 tokio        = { version = "1.49", features = ["full"] }
 tokio-util   = { version = "0.7.18", features = ["full"] }
@@ -52,9 +53,9 @@ serde              = { version = "1.0", features = ["derive"] }
 serde_json         = "1.0"
 serde_yaml         = "0.9"
 serde_json_any_key = "2.0.0"
-anyhow             = "1.0.100"
+anyhow             = "1.0.103"
 bytes              = "1.11.0"
-rand               = "0.9.2"
+rand               = "0.9.3"
 num_cpus           = "1.17"
 
 config = "0.15.19"
@@ -67,4 +68,4 @@ mockall = "0.14.0"
 cfg-if  = "1.0.4"
 
 [build-dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0.103"

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/consumer_view.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/consumer_view.rs
@@ -653,17 +653,17 @@ impl ConsumerView {
 
     /// Render just the modal content without backdrop (for use in render_page)
     fn render_modal_content_only(&self, cx: &mut Context<Self>) -> Div {
-        if let Some(index) = self.modal_consumer_index {
-            if let Some(group) = self.consumer_groups.get(index) {
-                return div()
-                    .absolute()
-                    .inset_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .bg(rgba(0x000000AA))
-                    .child(self.render_modal_content(group, cx));
-            }
+        if let Some(index) = self.modal_consumer_index
+            && let Some(group) = self.consumer_groups.get(index)
+        {
+            return div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(rgba(0x000000AA))
+                .child(self.render_modal_content(group, cx));
         }
         div()
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/message_view.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/message_view.rs
@@ -716,17 +716,17 @@ impl MessageView {
 
     /// Render just the modal content without backdrop (for use in render_page)
     fn render_modal_content_only(&self, cx: &mut Context<Self>) -> Div {
-        if let Some(index) = self.modal_message_index {
-            if let Some(msg) = self.messages.get(index) {
-                return div()
-                    .absolute()
-                    .inset_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .bg(rgba(0x000000AA))
-                    .child(self.render_modal_content(msg, cx));
-            }
+        if let Some(index) = self.modal_message_index
+            && let Some(msg) = self.messages.get(index)
+        {
+            return div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(rgba(0x000000AA))
+                .child(self.render_modal_content(msg, cx));
         }
         div()
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/producer_view.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/src/ui/producer_view.rs
@@ -599,17 +599,17 @@ impl ProducerView {
 
     /// Render just the modal content without backdrop (for use in render_page)
     fn render_modal_content_only(&self, cx: &mut Context<Self>) -> Div {
-        if let Some(index) = self.modal_producer_index {
-            if let Some(client) = self.producer_clients.get(index) {
-                return div()
-                    .absolute()
-                    .inset_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .bg(rgba(0x000000AA))
-                    .child(self.render_modal_content(client, cx));
-            }
+        if let Some(index) = self.modal_producer_index
+            && let Some(client) = self.producer_clients.get(index)
+        {
+            return div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(rgba(0x000000AA))
+                .child(self.render_modal_content(client, cx));
         }
         div()
     }
@@ -654,12 +654,7 @@ impl ProducerView {
                             .justify_center()
                             .rounded(px(12.0))
                             .bg(client.icon_bg)
-                            .child(
-                                div()
-                                    .text_2xl()
-                                    .text_color(client.icon_color)
-                                    .child("\u{1F4E4}"), // send icon emoji ✈️
-                            ),
+                            .child(div().text_2xl().text_color(client.icon_color).child("\u{1F4E4}")), // send icon emoji ✈️
                     )
                     .child(
                         div()
@@ -677,10 +672,7 @@ impl ProducerView {
                                 div()
                                     .text_sm()
                                     .text_color(rgb(0x86868B))
-                                    .child(format!(
-                                        "{} / {}",
-                                        client.producer_group, client.topic
-                                    )),
+                                    .child(format!("{} / {}", client.producer_group, client.topic)),
                             ),
                     ),
             )

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -242,6 +242,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -710,9 +725,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -861,6 +876,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,13 +900,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
@@ -984,6 +1018,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1083,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,18 +1148,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
-
-[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -1141,6 +1203,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "precomputed-hash",
+ "selectors 0.36.1",
+ "tendril 0.5.1",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1240,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1943,8 +2035,18 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2088,7 +2190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2389,10 +2491,10 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap 2.13.0",
- "selectors",
+ "selectors 0.24.0",
 ]
 
 [[package]]
@@ -2436,6 +2538,15 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2541,9 +2652,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.1",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2653,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2666,10 +2788,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2686,12 +2808,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2819,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -2835,17 +2951,9 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
  "objc2-foundation",
- "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2865,7 +2973,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2905,6 +3012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,19 +3031,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -2952,7 +3056,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2974,16 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-javascript-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
-dependencies = [
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3012,25 +3105,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3046,8 +3147,6 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "objc2-javascript-core",
- "objc2-security",
 ]
 
 [[package]]
@@ -3232,6 +3331,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,7 +3388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3278,7 +3398,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3303,6 +3433,19 @@ checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3345,6 +3488,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +3534,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3664,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4252,7 +4417,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -4471,14 +4636,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
- "derive_more",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc 0.4.3",
  "smallvec",
 ]
 
@@ -4674,6 +4858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,6 +5047,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4861,6 +5066,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -4993,35 +5210,35 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tao"
-version = "0.34.5"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
- "dispatch",
+ "dbus",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -5056,9 +5273,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.1"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5107,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.4"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76809f63061c8b25537b87f46b8733b31397cf419706dc874e1602be6479ba90"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5123,22 +5340,21 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.11+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.3"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2ebe49d690ccaea93aa81fff99277d4f445968f085ba13be67859151e9e4b8"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5156,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.3"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1119f651b0187c686c0fc72c66bba311e560e1b5f61869086ce788d43be6cf41"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5209,9 +5425,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b885ffeac82b00f1f6fd292b6e5aabfa7435d537cef57d11e38a489956535651"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -5234,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -5244,7 +5460,6 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
- "objc2-foundation",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -5261,24 +5476,26 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd169fccdff05eff2c1033210b9b94acd07a47e6fa9a3431cf09cfd4f01c87e"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -5290,7 +5507,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.11+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -5317,6 +5534,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -5523,10 +5749,12 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.15",
 ]
 
@@ -5754,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -5768,10 +5996,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6161,6 +6389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6516,15 +6756,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6556,28 +6787,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6620,12 +6834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6636,12 +6844,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6656,22 +6858,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6686,12 +6876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6702,12 +6886,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6722,12 +6900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6738,12 +6910,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6878,24 +7044,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.1"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed1a195b0375491dd15a7066a10251be217ce743cf4bbbbdcf5391d6473bee0"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
  "objc2",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ name       = "app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.5.4", features = [] }
+tauri-build = { version = "2.6.3", features = [] }
 
 [dependencies]
 serde_json       = "1.0"
@@ -43,7 +43,7 @@ base64           = "0.22"
 json5            = "0.4"
 serde            = { version = "1.0", features = ["derive"] }
 log              = "0.4"
-tauri            = { version = "2.10.0", features = [] }
+tauri            = { version = "2.11.5", features = [] }
 tauri-plugin-log = "2"
 rusqlite         = { version = "0.32", features = ["bundled"] }
 argon2           = "0.5"
@@ -52,7 +52,7 @@ rand_core        = { version = "0.6", features = ["getrandom"] }
 uuid             = { version = "1", features = ["v4", "serde"] }
 chrono           = { version = "0.4", features = ["serde"] }
 tokio            = { version = "1", features = ["sync", "time"] }
-rocketmq-dashboard-common = { path = "../../rocketmq-dashboard-common" }
-anyhow           = "1.0"
-rocketmq-admin-core = { path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
-rocketmq-runtime    = { path = "../../../rocketmq-runtime" }
+rocketmq-dashboard-common = { version = "1.0.0", path = "../../rocketmq-dashboard-common" }
+anyhow           = "1.0.103"
+rocketmq-admin-core = { version = "1.0.0", path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
+rocketmq-runtime    = { version = "1.0.0", path = "../../../rocketmq-runtime" }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 description = "RocketMQ Dashboard Web backend"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.103"
 axum = "0.8"
 cheetah-string = { version = "2.1.0", features = ["serde", "bytes", "simd"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
@@ -22,11 +22,11 @@ tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 
-rocketmq-dashboard-common = { path = "../../rocketmq-dashboard-common", features = ["admin"] }
-rocketmq-admin-core = { path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
-rocketmq-error = { path = "../../../rocketmq-error" }
-rocketmq-observability = { path = "../../../rocketmq-observability" }
-rocketmq-runtime = { path = "../../../rocketmq-runtime" }
+rocketmq-dashboard-common = { version = "1.0.0", path = "../../rocketmq-dashboard-common", features = ["admin"] }
+rocketmq-admin-core = { version = "1.0.0", path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
+rocketmq-error = { version = "1.0.0", path = "../../../rocketmq-error" }
+rocketmq-observability = { version = "1.0.0", path = "../../../rocketmq-observability" }
+rocketmq-runtime = { version = "1.0.0", path = "../../../rocketmq-runtime" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rocketmq-doc/en/toolchain-and-dependency-policy.md
+++ b/rocketmq-doc/en/toolchain-and-dependency-policy.md
@@ -1,0 +1,178 @@
+# Toolchain and Dependency Trust Policy
+
+## Purpose and scope
+
+This policy defines the reproducible Rust toolchain and third-party dependency
+trust boundary for the RocketMQ Rust repository. It applies to the root Cargo
+workspace, every standalone Cargo project, and production container builds.
+
+The policy is enforced locally. It does not require a GitHub CI workflow, and
+local validation scripts, logs, reports, and build output must not be committed.
+
+## Stable toolchain and MSRV
+
+The repository uses stable Rust `1.95.0` as both its minimum supported Rust
+version (MSRV) and its pinned build toolchain.
+
+| Build surface | Authoritative declaration | Required value |
+|---|---|---|
+| Root workspace | `Cargo.toml` and `rust-toolchain.toml` | `1.95.0` |
+| Standalone Cargo projects | each standalone `Cargo.toml` | `1.95.0` |
+| Production containers | `docker/Dockerfile.base` and `docker/container-policy.json` | `1.95.0` |
+
+`rust-toolchain.toml` uses the minimal profile and installs only `rustfmt` and
+`clippy` in addition to the compiler. Repository commands should use the
+automatically selected toolchain or name `+1.95.0` explicitly.
+
+Rust editions remain an independent language-compatibility choice. The root
+workspace continues to use Rust 2021 by default; the admin CLI and standalone
+projects that already use Rust 2024 keep that edition. Toolchain alignment does
+not authorize edition normalization.
+
+Changing the MSRV requires all of the following in one reviewed change:
+
+1. update every authoritative declaration above;
+2. resolve the root and standalone manifests with the proposed version;
+3. build the production container base with the same version;
+4. update user-facing current documentation;
+5. complete the local validation described below.
+
+## Nightly exceptions
+
+Nightly is not a general build toolchain. It is allowed only when stable Rust
+cannot provide the required diagnostic interface, and every use must name an
+exact dated toolchain.
+
+The current approved exception is `nightly-2026-07-05`:
+
+- `scripts/arc_mut_soundness_probe.py` uses it for Miri;
+- `scripts/public_api_snapshot.py` uses it for rustdoc JSON.
+
+Adding `+nightly`, an unversioned `nightly` channel, or a nightly feature to a
+production crate is prohibited. Updating the dated nightly requires regenerating
+and reviewing the affected baseline rather than silently accepting drift.
+
+## Dependency source, license, and advisory policy
+
+`deny.toml` is the repository-wide dependency admission policy. It evaluates the
+full feature graph for the supported Windows and Linux targets and enforces:
+
+- crates.io as the only default registry source;
+- no unknown registry or Git source;
+- no wildcard dependency requirements;
+- an explicit permissive-license allowlist;
+- exact crate/version license exceptions instead of global license grants;
+- all known vulnerabilities and all unsound advisories across the full graph;
+- all unmaintained advisories unless an explicit exception exists;
+- visible warnings for yanked releases and duplicate versions.
+
+When an advisory has a patched compatible release, the dependency must be
+upgraded. An advisory exception is permitted only when the latest usable upstream
+version still requires the dependency. Every exception must record:
+
+- the responsible owner;
+- the exact dependency path and exposure;
+- why an upgrade or replacement is not currently possible;
+- the production restriction, when the risk affects a target;
+- a deadline and an upstream-update trigger for re-review.
+
+An exception for an unsound or vulnerable runtime dependency blocks production
+certification of the affected target unless the exposure is otherwise eliminated.
+For example, Tauri's current GTK3/glib dependency means Linux Tauri packaging is
+not production-certified while the corresponding exception remains; it does not
+weaken the server or Windows dependency boundary.
+
+## cargo-vet trust boundary
+
+The versioned `supply-chain/` store certifies the root Cargo workspace, which owns
+the production server binaries and libraries. It combines locked upstream audit
+imports, exact-version exemptions, and local reviews.
+
+The local criterion `rocketmq-critical-dependency-reviewed` records focused
+source review of critical unsafe, native, storage, runtime, serialization, and
+TLS/crypto dependencies. It intentionally does **not** imply
+`safe-to-run` or `safe-to-deploy`. The normal cargo-vet criteria remain required
+for a complete trust chain.
+
+The focused review currently covers the critical families containing Tokio and
+tokio-uring, bytes and serialization primitives, bytemuck, ring/rustls/aws-lc,
+rcgen, RocksDB and its native bindings, memory mapping, and native compression
+bindings.
+
+Exact-version exemptions are review debt, not permanent approval. Each exemption
+contains an owner note, stops applying after a version change, and must be
+reconsidered whenever the lockfile changes. First-party path crates are not
+treated as crates.io packages.
+
+Standalone projects have independent lockfiles and much larger platform-specific
+graphs. They use the same `deny.toml` policy and pinned stable toolchain, but the
+root `supply-chain/` store does not claim to certify those separate lockfiles.
+Creating hundreds of generated standalone exemptions is not an acceptable
+substitute for review.
+
+## Local validation
+
+Keep Cargo build output and temporary files on a non-system drive with at least
+15 GiB free. The following PowerShell setup is an example; choose a drive that is
+available locally:
+
+```powershell
+$env:CARGO_TARGET_DIR = "E:\cargo-target-rocketmq-rust"
+$env:TEMP = "E:\rocketmq-rust-temp"
+$env:TMP = $env:TEMP
+$env:CARGO_INCREMENTAL = "0"
+```
+
+From the repository root, validate the production workspace:
+
+```powershell
+rustc --version
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --all-features
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+cargo deny check
+cargo vet --locked
+```
+
+On Windows, the current workspace can exceed the operating system command-line
+length limit when `cargo fmt --all -- --check` expands every target (OS error
+206). In that case, run `cargo fmt -p <package> -- --check` for every root
+workspace package and run the formatter from each standalone Cargo root. This is
+an equivalent per-package coverage path, not permission to skip formatting.
+
+Run the applicable formatter, check, test, Clippy, and `cargo deny check` commands
+from each changed standalone project root. The root cargo-vet result must not be
+presented as certification of a standalone lockfile.
+
+Build the pinned base image into the local Docker image store:
+
+```powershell
+docker build `
+  --file .\docker\Dockerfile.base `
+  --target builder-base `
+  --build-arg SOURCE_REVISION="$(git rev-parse HEAD)" `
+  --tag rocketmq-rust/builder-base:local `
+  .
+docker run --rm rocketmq-rust/builder-base:local rustc --version
+```
+
+The explicit target is required because the Dockerfile's default runtime-smoke
+stage does not depend on the Rust builder. Inspect and test the local image as
+required by the owning task. Do not push it to a remote registry.
+
+If free space falls below 15 GiB, clean only the dedicated target directory that
+belongs to the current validation run. `cargo clean --target-dir <path>` removes
+all reusable artifacts in that target directory, so it affects other worktrees
+only when they were deliberately configured to share the same directory.
+
+## Change review
+
+A toolchain or dependency-policy change is complete only when:
+
+- manifests, lockfiles, container policy, and current documentation agree;
+- every cargo-deny graph passes with no unrecorded source, license, vulnerability,
+  unsoundness, or maintenance exception;
+- `cargo vet --locked` passes for the root workspace;
+- the affected Rust projects pass their local stable-toolchain validation;
+- a local Docker build proves the production container toolchain;
+- no temporary validation artifact or build output is staged.

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -1794,7 +1794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -2002,9 +2002,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2245,7 +2245,7 @@ name = "rocketmq-example"
 version = "1.0.0"
 dependencies = [
  "cheetah-string",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rocketmq-admin-core",
  "rocketmq-client-rust",
  "rocketmq-error",

--- a/rocketmq-example/Cargo.toml
+++ b/rocketmq-example/Cargo.toml
@@ -40,14 +40,14 @@ resolver = "3"
 
 [dev-dependencies]
 cheetah-string       = { version = "2.1.0", features = ["serde", "bytes", "simd"] }
-rand                 = "0.8"
-rocketmq-client-rust = { path = "../rocketmq-client" }
-rocketmq-error       = { path = "../rocketmq-error" }
-rocketmq-model       = { path = "../rocketmq-model" }
-rocketmq-observability = { path = "../rocketmq-observability" }
-rocketmq-protocol    = { path = "../rocketmq-protocol" }
-rocketmq-runtime     = { path = "../rocketmq-runtime" }
-rocketmq-tools       = { path = "../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", package = "rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
+rand                 = "0.8.6"
+rocketmq-client-rust = { version = "1.0.0", path = "../rocketmq-client" }
+rocketmq-error       = { version = "1.0.0", path = "../rocketmq-error" }
+rocketmq-model       = { version = "1.0.0", path = "../rocketmq-model" }
+rocketmq-observability = { version = "1.0.0", path = "../rocketmq-observability" }
+rocketmq-protocol    = { version = "1.0.0", path = "../rocketmq-protocol" }
+rocketmq-runtime     = { version = "1.0.0", path = "../rocketmq-runtime" }
+rocketmq-tools       = { version = "1.0.0", path = "../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", package = "rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
 tokio                = { version = "1.49", features = ["full"] }
 tracing              = "0.1.44"
 

--- a/rocketmq-example/README-zh_cn.md
+++ b/rocketmq-example/README-zh_cn.md
@@ -7,7 +7,7 @@
 
 ## 前置条件
 
-- Rust 1.85.0 或更高版本。
+- Stable Rust 1.95.0，使用仓库固定的工具链。
 - 已启动 RocketMQ Namesrv 和 Broker。
 - 示例默认 Namesrv 地址为 `127.0.0.1:9876`。
 - 运行示例前先创建 topic 和 consumer group。示例本身不自动创建 broker 资源。

--- a/rocketmq-example/README.md
+++ b/rocketmq-example/README.md
@@ -7,7 +7,7 @@ This project is not part of the root Cargo workspace. Run all commands from
 
 ## Prerequisites
 
-- Rust 1.85.0 or later.
+- Stable Rust 1.95.0, using the pinned repository toolchain.
 - A running RocketMQ name server and broker.
 - Default name server address used by examples: `127.0.0.1:9876`.
 - Create topics and subscription groups before running examples. The examples do

--- a/rocketmq-filter/README-zh_cn.md
+++ b/rocketmq-filter/README-zh_cn.md
@@ -61,7 +61,7 @@ SQL runtime，返回 object-safe 的表达式实例，调用方可以缓存编�
 
 ## 环境要求
 
-- Rust `1.85.0` 或更新版本。
+- Stable Rust `1.95.0`，使用仓库固定的工具链。
 - 使用仓库中的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 工具链。
 - 本地测试、表达式求值和 Bloom filter 使用不需要运行 RocketMQ broker 或 NameServer。
 

--- a/rocketmq-filter/README.md
+++ b/rocketmq-filter/README.md
@@ -65,7 +65,7 @@ coerces numeric and boolean literals where the SQL expression requires them.
 
 ## Requirements
 
-- Rust `1.85.0` or newer.
+- Stable Rust `1.95.0`, using the pinned repository toolchain.
 - The repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml).
 - No running RocketMQ broker or NameServer is required for local tests, expression evaluation, or Bloom filter usage.
 

--- a/rocketmq-macros/README-zh_cn.md
+++ b/rocketmq-macros/README-zh_cn.md
@@ -116,7 +116,7 @@ pub struct QueryMessageRequestHeader {
 
 ## 环境要求
 
-- Rust `1.85.0` 或更新版本。
+- Stable Rust `1.95.0`，使用仓库固定的工具链。
 - 使用仓库中的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 工具链。
 - 消费方 crate 需要为生成的 protocol trait 实现暴露兼容的 `crate::protocol` 模块路径。
 

--- a/rocketmq-macros/README.md
+++ b/rocketmq-macros/README.md
@@ -118,7 +118,7 @@ This mirrors the intent of Java RocketMQ's `@CFNotNull` annotation. Missing requ
 
 ## Requirements
 
-- Rust `1.85.0` or newer.
+- Stable Rust `1.95.0`, using the pinned repository toolchain.
 - The repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml).
 - A consuming crate with compatible `crate::protocol` module paths for generated protocol trait implementations.
 

--- a/rocketmq-namesrv/README-zh_cn.md
+++ b/rocketmq-namesrv/README-zh_cn.md
@@ -47,7 +47,7 @@ broker；启用内嵌 controller 时，`ControllerManager` 会随 NameServer 生
 
 ## 环境要求
 
-- Rust `1.85.0` 或更新版本。
+- Stable Rust `1.95.0`，使用仓库固定的工具链。
 - 使用仓库中的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 工具链。
 - 正常启动二进制时必须设置 `ROCKETMQ_HOME` 或传入 `--rocketmqHome`。
 - 默认 NameServer 监听端口为 `9876`。

--- a/rocketmq-namesrv/README.md
+++ b/rocketmq-namesrv/README.md
@@ -51,7 +51,7 @@ Unsupported request codes return `RequestCodeNotSupported` from the default proc
 
 ## Requirements
 
-- Rust `1.85.0` or newer.
+- Stable Rust `1.95.0`, using the pinned repository toolchain.
 - The repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml).
 - `ROCKETMQ_HOME` or `--rocketmqHome` must be set for a normal binary startup.
 - Port `9876` is the default NameServer listen port.

--- a/rocketmq-protocol/src/code/response_code.rs
+++ b/rocketmq-protocol/src/code/response_code.rs
@@ -192,7 +192,8 @@ mod tests {
             RemotingSysResponseCode::TransactionFailed
         );
         assert_eq!(RemotingSysResponseCode::from(16), RemotingSysResponseCode::NoPermission);
-        assert_eq!(RemotingSysResponseCode::from(999), RemotingSysResponseCode::SystemError); // Edge case - unknown code defaults to SystemError
+        assert_eq!(RemotingSysResponseCode::from(999), RemotingSysResponseCode::SystemError);
+        // Edge case - unknown code defaults to SystemError
     }
 
     #[test]

--- a/rocketmq-proxy/README-zh_cn.md
+++ b/rocketmq-proxy/README-zh_cn.md
@@ -90,7 +90,7 @@ Broker 管理端点。
 
 ## 环境要求
 
-- Rust `1.85.0` 或更高版本，与 workspace toolchain 保持一致。
+- Stable Rust `1.95.0`，与 workspace 固定工具链保持一致。
 - Cluster 模式需要可访问的 RocketMQ NameServer。
 - Local 模式和基于文件的 auth metadata 需要可写本地存储。
 - 可选：启用 `observability` feature 时需要 OpenTelemetry 指标管线。

--- a/rocketmq-proxy/README.md
+++ b/rocketmq-proxy/README.md
@@ -94,7 +94,7 @@ remoting ingress and should be sent to broker administration endpoints.
 
 ## Requirements
 
-- Rust `1.85.0` or newer, matching the workspace toolchain.
+- Stable Rust `1.95.0`, matching the pinned workspace toolchain.
 - A reachable RocketMQ NameServer for cluster mode.
 - Writable local storage for local mode and file-based auth metadata.
 - Optional: an OpenTelemetry metrics pipeline when the `observability` feature

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -168,9 +168,9 @@ async fn fail_matching_request(
     remote_addr: &str,
 ) -> bool {
     let mut request_guard = request_slot.lock().await;
-    if !request_guard
+    if request_guard
         .as_ref()
-        .is_some_and(|request| request.remote_addr() == remote_addr)
+        .is_none_or(|request| request.remote_addr() != remote_addr)
     {
         return false;
     }

--- a/rocketmq-tools/rocketmq-store-inspect/README.md
+++ b/rocketmq-tools/rocketmq-store-inspect/README.md
@@ -8,7 +8,7 @@ Provide some command-line tools to read data from RocketMQ files.
 
 ### Requirements
 
-1. rust toolchain MSRV is 1.75.(stable,nightly)
+1. Stable Rust `1.95.0`, using the pinned repository toolchain.
 
 ## Run rocketmq-rust cli
 

--- a/rocketmq-transport/Cargo.toml
+++ b/rocketmq-transport/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 [features]
 default = ["tls"]
 simd = ["rocketmq-protocol/simd"]
-tls = ["arc-swap", "rcgen", "rustls-native-certs", "rustls-pemfile", "tokio-rustls"]
+tls = ["arc-swap", "rcgen", "rustls-native-certs", "tokio-rustls"]
 observability = ["dep:rocketmq-observability", "rocketmq-observability/otel-metrics"]
 observability-traces = ["dep:rocketmq-observability"]
 
@@ -67,7 +67,6 @@ uuid.workspace = true
 arc-swap = { version = "1.9", optional = true }
 rcgen = { version = "0.14", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
-rustls-pemfile = { version = "2.2", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -41,6 +41,8 @@ use tokio::net::TcpStream;
 #[cfg(feature = "tls")]
 use tokio::time;
 #[cfg(feature = "tls")]
+use tokio_rustls::rustls::pki_types::pem::PemObject;
+#[cfg(feature = "tls")]
 use tracing::debug;
 use tracing::warn;
 
@@ -768,8 +770,7 @@ pub fn load_certificates(
 ) -> RocketMQResult<Vec<tokio_rustls::rustls::pki_types::CertificateDer<'static>>> {
     let file = fs::File::open(path)
         .map_err(|error| config_error(key, path, format!("failed to open certificate file: {error}")))?;
-    let mut reader = std::io::BufReader::new(file);
-    let certs = rustls_pemfile::certs(&mut reader)
+    let certs = tokio_rustls::rustls::pki_types::CertificateDer::pem_reader_iter(file)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| config_error(key, path, format!("failed to read PEM certificates: {error}")))?;
 
@@ -787,10 +788,15 @@ fn load_private_key(
 ) -> RocketMQResult<tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>> {
     let file = fs::File::open(path)
         .map_err(|error| config_error(key, path, format!("failed to open private key file: {error}")))?;
-    let mut reader = std::io::BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .map_err(|error| config_error(key, path, format!("failed to read PEM private key: {error}")))?
-        .ok_or_else(|| config_error(key, path, "no supported PEM private key was found"))
+    match tokio_rustls::rustls::pki_types::PrivateKeyDer::pem_reader_iter(file).next() {
+        Some(Ok(private_key)) => Ok(private_key),
+        Some(Err(error)) => Err(config_error(
+            key,
+            path,
+            format!("failed to read PEM private key: {error}"),
+        )),
+        None => Err(config_error(key, path, "no supported PEM private key was found")),
+    }
 }
 
 #[cfg(feature = "tls")]
@@ -1115,6 +1121,28 @@ mod tests {
     fn pem_loader_rejects_missing_certificate_file() {
         let error = load_certificates("missing.pem", "tls.server.certPath").expect_err("missing cert path should fail");
         assert!(error.to_string().contains("missing.pem"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn pem_loaders_select_supported_sections_from_a_mixed_bundle() {
+        let certificates = TestCertificates::new();
+        let temp_dir = tempfile::tempdir().expect("create mixed PEM temp dir");
+        let certificate_pem = fs::read_to_string(&certificates.server_cert_path).expect("read server certificate");
+        let private_key_pem = fs::read_to_string(&certificates.server_key_path).expect("read server private key");
+        let mixed_bundle_path = write_pem(
+            temp_dir.path(),
+            "server-bundle.pem",
+            format!("{certificate_pem}{private_key_pem}"),
+        );
+
+        let loaded_certificates =
+            load_certificates(&mixed_bundle_path, "tls.server.certPath").expect("load certificate section");
+        let loaded_private_key =
+            load_private_key(&mixed_bundle_path, "tls.server.keyPath").expect("load private key section");
+
+        assert_eq!(loaded_certificates.len(), 1);
+        assert!(!loaded_private_key.secret_der().is_empty());
     }
 
     #[cfg(feature = "tls")]

--- a/rocketmq-website/docs/contributing/development-guide.md
+++ b/rocketmq-website/docs/contributing/development-guide.md
@@ -11,7 +11,7 @@ Detailed guide for developing RocketMQ-Rust.
 
 ### Prerequisites
 
-- **Rust**: nightly toolchain
+- **Rust**: stable 1.95.0 toolchain
 - **Git**: For version control
 - **IDE**: VS Code, RustRover, or similar
 
@@ -30,20 +30,17 @@ Install extensions:
 
 RustRover comes with built-in Rust support. No additional plugins required.
 
-### Installing Rust Nightly
+### Installing the Pinned Stable Toolchain
 
 ```bash
 # Install rustup if you haven't already
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# Install nightly toolchain
-rustup toolchain install nightly
+# Install the exact repository toolchain and required components
+rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
 
-# Set nightly as default (optional)
-rustup default nightly
-
-# Or use nightly for this project only
-rustup override set nightly
+# rust-toolchain.toml selects it automatically inside the repository
+rustc --version
 ```
 
 ### Building from Source

--- a/rocketmq-website/docs/contributing/overview.md
+++ b/rocketmq-website/docs/contributing/overview.md
@@ -46,12 +46,8 @@ git remote add upstream https://github.com/mxsm/rocketmq-rust.git
 ### 2. Set Up Development Environment
 
 ```bash
-# Install Rust nightly toolchain
-rustup toolchain install nightly
-rustup default nightly
-
-# Install development tools
-rustup component add rustfmt clippy
+# Install the repository's pinned stable toolchain and development components
+rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
 
 # Build the project
 cargo build

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/development-guide.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/development-guide.md
@@ -13,7 +13,7 @@ RocketMQ-Rust 详细开发指南。
 
 ### 前置要求
 
-- **Rust**：nightly 工具链
+- **Rust**：stable 1.95.0 工具链
 - **Git**：用于版本控制
 - **IDE**：VS Code、RustRover 或类似工具
 
@@ -32,20 +32,17 @@ RocketMQ-Rust 详细开发指南。
 
 RustRover 内置 Rust 支持。无需额外插件。
 
-### 安装 Rust Nightly
+### 安装固定的 Stable 工具链
 
 ```bash
 # 如果尚未安装 rustup
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# 安装 nightly 工具链
-rustup toolchain install nightly
+# 安装仓库指定的精确工具链和必需组件
+rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
 
-# 设置 nightly 为默认（可选）
-rustup default nightly
-
-# 或仅为该项目使用 nightly
-rustup override set nightly
+# 进入仓库后，rust-toolchain.toml 会自动选择该版本
+rustc --version
 ```
 
 ### 从源代码构建

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/overview.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/overview.md
@@ -48,12 +48,8 @@ git remote add upstream https://github.com/mxsm/rocketmq-rust.git
 ### 2. 设置开发环境
 
 ```bash
-# 安装 Rust nightly 工具链
-rustup toolchain install nightly
-rustup default nightly
-
-# 安装开发工具
-rustup component add rustfmt clippy
+# 安装仓库固定的 stable 工具链和开发组件
+rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
 
 # 构建项目
 cargo build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,4 +14,6 @@
 
 
 [toolchain]
-channel = "nightly"
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -13,12 +13,6 @@
 # limitations under the License.
 
 
-#https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=
-format_code_in_doc_comments = true
-format_strings              = true
-wrap_comments               = true
-format_macro_bodies         = true
-format_macro_matchers       = true
-imports_granularity         = "Item"
-comment_width               = 100
-max_width                   = 120
+# Stable rustfmt options only. Nightly-only formatting options would make the
+# repository's pinned stable toolchain silently use a different configuration.
+max_width = 120

--- a/scripts/arc_mut_soundness_probe.py
+++ b/scripts/arc_mut_soundness_probe.py
@@ -31,6 +31,9 @@ class ProbeFailure(RuntimeError):
     """Raised when a soundness probe produces an unexpected result."""
 
 
+MIRI_TOOLCHAIN = "nightly-2026-07-05"
+
+
 def combined_output(result: subprocess.CompletedProcess[str]) -> str:
     return f"{result.stdout}\n{result.stderr}".strip()
 
@@ -129,7 +132,7 @@ fn main() {
 def miri_command(manifest: Path, mode: str, locked: bool) -> list[str]:
     command = [
         "cargo",
-        "+nightly",
+        f"+{MIRI_TOOLCHAIN}",
         "miri",
         "run",
         "--manifest-path",

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -32,7 +32,7 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
         "binary": "rocketmq-broker-rust",
         "config_path": "/etc/rocketmq/broker.toml",
         "data_path": "/var/lib/rocketmq/broker",
-        "ports": [8088, 10911, 10912],
+        "ports": [5557, 8088, 10911, 10912],
         "command": ["--configFile", "/etc/rocketmq/broker.toml"],
     },
     "namesrv": {
@@ -41,7 +41,7 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
         "binary": "rocketmq-namesrv-rust",
         "config_path": "/etc/rocketmq/namesrv.toml",
         "data_path": "/var/lib/rocketmq/namesrv",
-        "ports": [8088, 9876],
+        "ports": [5557, 8088, 9876],
         "command": ["--configFile", "/etc/rocketmq/namesrv.toml"],
     },
     "controller": {
@@ -50,7 +50,7 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
         "binary": "rocketmq-controller-rust",
         "config_path": "/etc/rocketmq/controller.toml",
         "data_path": "/var/lib/rocketmq/controller",
-        "ports": [8088, 60109, 60110],
+        "ports": [5557, 8088, 60109, 60110],
         "command": ["--config-file", "/etc/rocketmq/controller.toml"],
     },
     "proxy": {
@@ -59,7 +59,7 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
         "binary": "rocketmq-proxy-rust",
         "config_path": "/etc/rocketmq/proxy.toml",
         "data_path": "/var/lib/rocketmq/proxy",
-        "ports": [8080, 8081, 8088],
+        "ports": [5557, 8080, 8081, 8088],
         "command": ["--config", "/etc/rocketmq/proxy.toml"],
     },
     "mcp": {
@@ -68,7 +68,7 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
         "binary": "rocketmq-mcp",
         "config_path": "/etc/rocketmq/mcp.toml",
         "data_path": "/var/lib/rocketmq/mcp",
-        "ports": [8088, 8089],
+        "ports": [5557, 8088, 8089],
         "command": ["--config", "/etc/rocketmq/mcp.toml", "--transport", "stdio"],
     },
 }
@@ -134,6 +134,7 @@ def audit_foundation(
         f"ARG RUNTIME_IMAGE={runtime_ref}",
         f"ARG DEBIAN_SNAPSHOT={policy['build']['debian_snapshot']}",
         f"ARG ROCKETMQ_RUST_TOOLCHAIN={policy['build']['rust_toolchain']}",
+        "RUST_VERSION=${ROCKETMQ_RUST_TOOLCHAIN}",
         "AS builder-base",
         "AS runtime-base",
         "AS runtime-base-smoke",

--- a/scripts/public_api_snapshot.py
+++ b/scripts/public_api_snapshot.py
@@ -28,6 +28,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_VERSION = 1
 LIB_KINDS = {"lib", "rlib", "proc-macro"}
+RUSTDOC_TOOLCHAIN = "nightly-2026-07-05"
 
 
 class SnapshotError(RuntimeError):
@@ -72,9 +73,9 @@ def workspace_library_targets() -> list[tuple[str, str]]:
 
 def toolchain() -> dict[str, str]:
     return {
-        "rustc": run(["rustc", "--version"]),
-        "rustdoc": run(["rustdoc", "--version"]),
-        "cargo": run(["cargo", "--version"]),
+        "rustc": run(["rustc", f"+{RUSTDOC_TOOLCHAIN}", "--version"]),
+        "rustdoc": run(["rustdoc", f"+{RUSTDOC_TOOLCHAIN}", "--version"]),
+        "cargo": run(["cargo", f"+{RUSTDOC_TOOLCHAIN}", "--version"]),
     }
 
 
@@ -97,6 +98,7 @@ def snapshot_package(package: str, target: str, *, refresh: bool = True) -> dict
         run(
             [
                 "cargo",
+                f"+{RUSTDOC_TOOLCHAIN}",
                 "rustdoc",
                 "-p",
                 package,

--- a/scripts/tests/test_stable_surface_guard.py
+++ b/scripts/tests/test_stable_surface_guard.py
@@ -114,21 +114,22 @@ class StableSurfaceGuardTests(unittest.TestCase):
 
 
 class RepositoryStableSurfaceContracts(unittest.TestCase):
-    def test_remoting_and_controller_no_longer_enable_retired_features(self) -> None:
+    def test_transport_and_controller_no_longer_enable_retired_features(self) -> None:
         sources = {
-            "remoting crate": REPO_ROOT / "rocketmq-remoting" / "src" / "lib.rs",
-            "remoting integration test": REPO_ROOT / "rocketmq-remoting" / "tests" / "processor_v2_tests.rs",
-            "remoting example": REPO_ROOT / "rocketmq-remoting" / "examples" / "processor_v2_complete_example.rs",
+            "transport crate": REPO_ROOT / "rocketmq-transport" / "src" / "lib.rs",
+            "transport processor": REPO_ROOT / "rocketmq-transport" / "src" / "runtime" / "processor_v2.rs",
+            "transport integration test": REPO_ROOT / "rocketmq-transport" / "tests" / "processor_v2.rs",
             "controller crate": REPO_ROOT / "rocketmq-controller" / "src" / "lib.rs",
         }
         for label, path in sources.items():
             with self.subTest(label=label):
+                self.assertTrue(path.is_file(), path)
                 source = path.read_text(encoding="utf-8")
                 self.assertNotIn("#![feature(impl_trait_in_assoc_type)]", source)
                 self.assertNotIn("#![feature(arbitrary_self_types)]", source)
 
-    def test_remoting_builtin_processors_keep_concrete_zero_allocation_futures(self) -> None:
-        source = (REPO_ROOT / "rocketmq-remoting" / "src" / "runtime" / "processor_v2.rs").read_text(
+    def test_transport_builtin_processors_keep_concrete_zero_allocation_futures(self) -> None:
+        source = (REPO_ROOT / "rocketmq-transport" / "src" / "runtime" / "processor_v2.rs").read_text(
             encoding="utf-8"
         )
         self.assertEqual(source.count("= Ready<RocketMQResult<Option<RemotingCommand>>>"), 3)
@@ -145,13 +146,15 @@ class RepositoryStableSurfaceContracts(unittest.TestCase):
         self.assertIn("(task_fn)(token).await", scheduler)
 
     def test_arc_mut_compatibility_no_longer_requires_nightly(self) -> None:
-        crate_root = (REPO_ROOT / "rocketmq" / "src" / "lib.rs").read_text(encoding="utf-8")
-        arc_mut = (REPO_ROOT / "rocketmq" / "src" / "arc_mut.rs").read_text(encoding="utf-8")
         retired_benchmark = REPO_ROOT / "rocketmq-broker" / "benches" / "syncunsafecell_mut.rs"
-        self.assertNotIn("#![feature(sync_unsafe_cell)]", crate_root)
-        self.assertNotIn("std::cell::SyncUnsafeCell", arc_mut)
-        self.assertIn("Arc<RwLock<T>>", arc_mut)
+
+        self.assertFalse((REPO_ROOT / "rocketmq").exists())
         self.assertFalse(retired_benchmark.exists())
+        for crate in REPO_ROOT.glob("rocketmq-*"):
+            for source_path in crate.rglob("*.rs"):
+                source = source_path.read_text(encoding="utf-8")
+                self.assertNotIn("#![feature(sync_unsafe_cell)]", source, source_path)
+                self.assertNotIn("std::cell::SyncUnsafeCell", source, source_path)
 
 
 if __name__ == "__main__":

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,124 @@
+
+# cargo-vet audits file
+
+[criteria.rocketmq-critical-dependency-reviewed]
+description = """
+The exact locked package version was reviewed for RocketMQ Rust usage: registry provenance,
+license and advisory status, enabled feature role, build-script/native linkage, and unsafe/FFI
+surface were identified. This is a scoped dependency-risk review and does not imply cargo-vet's
+safe-to-run or safe-to-deploy criteria.
+"""
+
+[[audits.anyhow]]
+who = "mxsm <mxsm@apache.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.103 -> 1.0.104"
+notes = "Reviewed the 1.0.103 to 1.0.104 published-source delta: runtime source changes only the rustdoc URL; build.rs and all other src files are byte-identical. Remaining changes are package metadata and development-only dependencies."
+
+[[audits.aws-lc-rs]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.16.3"
+notes = "Owner: security maintainers. Crypto-provider wrapper; reviewed provenance, native link identity, build configuration, unsafe FFI surface, and advisories."
+
+[[audits.aws-lc-sys]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.40.0"
+notes = "Owner: security maintainers. Native AWS-LC binding; reviewed provenance, bundled native source scope, generated FFI surface, and advisories."
+
+[[audits.bytemuck]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.25.1"
+notes = "Owner: protocol maintainers. Byte-cast dependency; reviewed provenance, feature role, and unsafe cast invariants."
+
+[[audits.bytes]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.12.1"
+notes = "Owner: protocol maintainers. Wire-buffer dependency; reviewed provenance, feature role, and unsafe buffer representation surface."
+
+[[audits.librocksdb-sys]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.17.3+10.4.2"
+notes = "Owner: storage maintainers. Native RocksDB binding; reviewed provenance, build script, bundled C++ source scope, FFI boundary, and advisories."
+
+[[audits.libz-sys]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.1.28"
+notes = "Owner: storage maintainers. Native zlib binding; reviewed provenance, build script, bundled native source, FFI boundary, and advisories."
+
+[[audits.memmap2]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.9.11"
+notes = "Owner: storage maintainers. Memory-mapping dependency; reviewed provenance, platform feature role, and unsafe mapping lifetime surface."
+
+[[audits.rcgen]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.14.8"
+notes = "Owner: security maintainers. Certificate-generation dependency; reviewed provenance, feature role, pure-Rust boundary, and advisories."
+
+[[audits.ring]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.17.14"
+notes = "Owner: security maintainers. TLS cryptography dependency; reviewed provenance, build script, native source linkage, unsafe FFI surface, and advisories."
+
+[[audits.rocksdb]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.24.0"
+notes = "Owner: storage maintainers. RocksDB Rust wrapper; reviewed provenance, feature role, unsafe FFI wrapper surface, and advisories."
+
+[[audits.rustls]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.23.40"
+notes = "Owner: security maintainers. TLS protocol dependency; reviewed provenance, crypto-provider features, build script, unsafe surface, and advisories."
+
+[[audits.rustls-webpki]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.103.13"
+notes = "Owner: security maintainers. Certificate-validation dependency; reviewed provenance, feature role, pure-Rust boundary, and advisories."
+
+[[audits.serde]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.0.228"
+notes = "Owner: protocol maintainers. Serialization contract dependency; reviewed provenance, build script, features, and advisory status."
+
+[[audits.serde_json]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.0.150"
+notes = "Owner: protocol maintainers. JSON wire/config dependency; reviewed provenance, build script, features, and unsafe surface."
+
+[[audits.simd-json]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.17.3"
+notes = "Owner: protocol maintainers. SIMD JSON dependency; reviewed provenance, enabled feature role, and substantial unsafe SIMD surface."
+
+[[audits.tokio]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "1.52.3"
+notes = "Owner: runtime maintainers. Runtime and I/O dependency; reviewed registry provenance, enabled all-feature role, no native linkage, and scheduler/I/O unsafe surface."
+
+[[audits.tokio-uring]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "0.5.0"
+notes = "Owner: storage maintainers. Linux io_uring dependency; reviewed provenance, feature role, completion lifetime model, and unsafe I/O surface."
+
+[[audits.zstd-sys]]
+who = "RocketMQ Rust maintainers"
+criteria = "rocketmq-critical-dependency-reviewed"
+version = "2.0.16+zstd.1.5.7"
+notes = "Owner: storage maintainers. Native Zstandard binding; reviewed provenance, build script, bundled native source, FFI boundary, and advisories."

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,2985 @@
+
+# cargo-vet config file
+
+[cargo-vet]
+version = "0.10"
+
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
+
+[imports.isrg]
+url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[policy.rocketmq-admin-cli]
+audit-as-crates-io = false
+
+[policy.rocketmq-admin-core]
+audit-as-crates-io = false
+
+[policy.rocketmq-admin-tui]
+audit-as-crates-io = false
+
+[policy.rocketmq-auth]
+audit-as-crates-io = false
+
+[policy.rocketmq-broker]
+audit-as-crates-io = false
+
+[policy.rocketmq-client-rust]
+audit-as-crates-io = false
+
+[policy.rocketmq-controller]
+audit-as-crates-io = false
+
+[policy.rocketmq-dashboard-common]
+audit-as-crates-io = false
+
+[policy.rocketmq-error]
+audit-as-crates-io = false
+
+[policy.rocketmq-filter]
+audit-as-crates-io = false
+
+[policy.rocketmq-macros]
+audit-as-crates-io = false
+
+[policy.rocketmq-namesrv]
+audit-as-crates-io = false
+
+[policy.rocketmq-runtime]
+audit-as-crates-io = false
+
+[policy.rocketmq-store]
+audit-as-crates-io = false
+
+[policy.rocketmq-store-inspect]
+audit-as-crates-io = false
+
+[policy.rocketmq-tieredstore]
+audit-as-crates-io = false
+
+[[exemptions.aead]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.aes]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.aes-gcm]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ahash]]
+version = "0.7.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ahash]]
+version = "0.8.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.aho-corasick]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anstream]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anstyle]]
+version = "1.0.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anstyle-parse]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anstyle-query]]
+version = "1.1.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anstyle-wincon]]
+version = "3.0.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anyerror]]
+version = "0.1.13"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.anyhow]]
+version = "1.0.103"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.approx]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.arc-swap]]
+version = "1.9.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.asn1-rs]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.asn1-rs-derive]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.asn1-rs-impl]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.async-trait]]
+version = "0.1.89"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.atomic]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.autocfg]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.aws-lc-rs]]
+version = "1.16.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.aws-lc-sys]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.axum]]
+version = "0.8.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.axum-core]]
+version = "0.5.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.backoff-series]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.base2histogram]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bindgen]]
+version = "0.72.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bitflags]]
+version = "2.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bitvec]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.block-buffer]]
+version = "0.10.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.block-buffer]]
+version = "0.12.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.borrow-or-share]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.borsh]]
+version = "1.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.borsh-derive]]
+version = "1.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.by_address]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.byte-unit]]
+version = "5.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bytecheck]]
+version = "0.6.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bytecheck_derive]]
+version = "0.6.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bytecount]]
+version = "0.6.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bytemuck]]
+version = "1.25.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bytes]]
+version = "1.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.bzip2-sys]]
+version = "0.1.13+1.0.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.castaway]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cc]]
+version = "1.2.62"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cfg_aliases]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cheetah-string]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.chrono]]
+version = "0.4.45"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.chrono-tz]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.chrono-tz]]
+version = "0.10.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.chrono-tz-build]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cipher]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clang-sys]]
+version = "1.8.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clap]]
+version = "4.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clap_builder]]
+version = "4.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clap_complete]]
+version = "4.6.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clap_derive]]
+version = "4.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.clap_lex]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cmake]]
+version = "0.1.58"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cmov]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.colorchoice]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.colored]]
+version = "3.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.combine]]
+version = "4.6.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.compact_str]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.config]]
+version = "0.15.25"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.console]]
+version = "0.16.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.const-oid]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.const-random]]
+version = "0.1.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.const-random-macro]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.convert_case]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.convert_case]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.core-foundation]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cpubits]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cpufeatures]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crc]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crc-catalog]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crc32fast]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.criterion]]
+version = "0.8.2"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.critical-section]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.cron]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.15"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossbeam-deque]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossbeam-epoch]]
+version = "0.9.20"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossbeam-skiplist]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossterm]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crossterm_winapi]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crunchy]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crypto-common]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.crypto-common]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.csscolorparser]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ctr]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ctutils]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling]]
+version = "0.20.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling_core]]
+version = "0.20.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling_core]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling_macro]]
+version = "0.20.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.darling_macro]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dashmap]]
+version = "6.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.data-encoding]]
+version = "2.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.deltae]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.der-parser]]
+version = "10.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.derive_builder]]
+version = "0.20.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.derive_builder_core]]
+version = "0.20.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.derive_builder_macro]]
+version = "0.20.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.derive_more]]
+version = "2.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.derive_more-impl]]
+version = "2.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dialoguer]]
+version = "0.12.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.diff]]
+version = "0.1.13"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.digest]]
+version = "0.10.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.digest]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dirs]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dirs-sys]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dispatch2]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.display-more]]
+version = "0.2.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dlv-list]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dns-lookup]]
+version = "3.0.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.document-features]]
+version = "0.2.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dunce]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.dyn-clone]]
+version = "1.0.20"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.email_address]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.encode_unicode]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.erased-serde]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.errno]]
+version = "0.3.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fancy-regex]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fancy-regex]]
+version = "0.18.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fast-srgb8]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fastrand]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.filedescriptor]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.find-msvc-tools]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.finl_unicode]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fixedbitset]]
+version = "0.5.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.flate2]]
+version = "1.1.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.float-cmp]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fluent-uri]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.flume]]
+version = "0.12.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fraction]]
+version = "0.15.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fragile]]
+version = "2.1.0"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fs2]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.fs_extra]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.funty]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-channel]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-core]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-executor]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-io]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-macro]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-sink]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-task]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.futures-util]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.generator]]
+version = "0.8.9"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.generic-array]]
+version = "0.14.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.getrandom]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.getrandom]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.getset]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ghash]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.glob]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.h2]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.half]]
+version = "2.7.1"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.halfbrown]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hashbrown]]
+version = "0.14.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hashlink]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hermit-abi]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hmac]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.http]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.http-body]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.http-body-util]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.httparse]]
+version = "1.10.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hybrid-array]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hyper]]
+version = "1.9.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hyper-rustls]]
+version = "0.27.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hyper-timeout]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.hyper-util]]
+version = "0.1.20"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.iana-time-zone]]
+version = "0.1.65"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_collections]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_locale_core]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_normalizer]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_normalizer_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_properties]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_properties_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.icu_provider]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.id-arena]]
+version = "2.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ident_case]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.idna]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.idna_adapter]]
+version = "1.2.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.indexmap]]
+version = "2.14.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.indicatif]]
+version = "0.18.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.indoc]]
+version = "2.0.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.inout]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.insta]]
+version = "1.48.0"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.instability]]
+version = "0.3.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.io-uring]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ipnet]]
+version = "2.12.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ipnetwork]]
+version = "0.21.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.is_terminal_polyfill]]
+version = "1.70.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.itertools]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.itertools]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.itoa]]
+version = "1.0.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jni]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jni-macros]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jni-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jni-sys-macros]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jobserver]]
+version = "0.1.34"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.js-sys]]
+version = "0.3.98"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.json5]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jsonschema]]
+version = "0.47.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jsonschema-regex]]
+version = "0.47.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.jsonwebtoken]]
+version = "9.3.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.kasuari]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lab]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.libc]]
+version = "0.2.186"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.libm]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.libredox]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.librocksdb-sys]]
+version = "0.17.3+10.4.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.libz-sys]]
+version = "1.1.28"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.line-clipping]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.linux-raw-sys]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.litemap]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.litrs]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.local-ip-address]]
+version = "0.6.13"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lock_api]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.loom]]
+version = "0.7.2"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lru]]
+version = "0.18.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lru-slab]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lz4-sys]]
+version = "1.11.1+lz4-1.10.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.lz4_flex]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.mac_address]]
+version = "1.1.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.maplit]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.matchit]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.md-5]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.md-5]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.memchr]]
+version = "2.8.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.memmap2]]
+version = "0.9.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.memmem]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.memoffset]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.micromap]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.mime]]
+version = "0.3.17"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.minimal-lexical]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.mio]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.mockall]]
+version = "0.15.0"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.mockall_derive]]
+version = "0.15.0"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.moka]]
+version = "0.12.15"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.multimap]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.neli]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.neli-proc-macros]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.nix]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ntapi]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num-bigint]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num-cmp]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num-complex]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num-conv]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num-iter]]
+version = "0.1.46"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num_cpus]]
+version = "1.17.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.num_threads]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.objc2]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.objc2-io-kit]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.objc2-open-directory]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.oid-registry]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.once_cell]]
+version = "1.21.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.once_cell_polyfill]]
+version = "1.70.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.openraft]]
+version = "0.10.0-alpha.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.openraft-macros]]
+version = "0.10.0-alpha.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.openraft-rt]]
+version = "0.10.0-alpha.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.openraft-rt-tokio]]
+version = "0.10.0-alpha.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.openssl-probe]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry]]
+version = "0.32.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry-appender-tracing]]
+version = "0.32.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry-otlp]]
+version = "0.32.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry-prometheus]]
+version = "0.32.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry-proto]]
+version = "0.32.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry-semantic-conventions]]
+version = "0.32.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.opentelemetry_sdk]]
+version = "0.32.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ordered-float]]
+version = "4.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ordered-multimap]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.outref]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.page_size]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.palette]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.palette_derive]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.papergrid]]
+version = "0.18.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.parking_lot]]
+version = "0.12.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.parking_lot_core]]
+version = "0.9.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.parse-zoneinfo]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pastey]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pathdiff]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.peel-off]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pem]]
+version = "3.0.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pest]]
+version = "2.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pest_derive]]
+version = "2.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pest_generator]]
+version = "2.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pest_meta]]
+version = "2.8.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.petgraph]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf_codegen]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf_generator]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf_macros]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf_shared]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.phf_shared]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pin-project]]
+version = "1.1.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pin-project-internal]]
+version = "1.1.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pin-project-lite]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pkg-config]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.plotters]]
+version = "0.3.7"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.plotters-backend]]
+version = "0.3.7"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.plotters-svg]]
+version = "0.3.7"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.polyval]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.portable-atomic]]
+version = "1.13.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.potential_utf]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ppv-lite86]]
+version = "0.2.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pretty_assertions]]
+version = "1.4.1"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prettyplease]]
+version = "0.2.37"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.proc-macro-crate]]
+version = "3.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prometheus]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prost]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prost-build]]
+version = "0.14.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prost-derive]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.prost-types]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ptr_meta]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ptr_meta_derive]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pulldown-cmark]]
+version = "0.13.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.pulldown-cmark-to-cmark]]
+version = "22.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.quinn]]
+version = "0.11.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.quinn-proto]]
+version = "0.11.15"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.quinn-udp]]
+version = "0.5.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.quote]]
+version = "1.0.46"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.r-efi]]
+version = "5.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.r-efi]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.radium]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rand]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rand_core]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui]]
+version = "0.30.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-core]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-crossterm]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-macros]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-termina]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-termwiz]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ratatui-widgets]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rayon]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rcgen]]
+version = "0.14.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.redox_syscall]]
+version = "0.5.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.redox_users]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ref-cast]]
+version = "1.0.25"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ref-cast-impl]]
+version = "1.0.25"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.referencing]]
+version = "0.47.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.regex]]
+version = "1.13.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.regex-automata]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.regex-syntax]]
+version = "0.8.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rend]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.reqwest]]
+version = "0.13.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ring]]
+version = "0.17.14"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rkyv]]
+version = "0.7.46"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rkyv_derive]]
+version = "0.7.46"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rmcp]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rmcp-macros]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-admin-cli]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-admin-core]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-admin-tui]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-auth]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-broker]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-client-rust]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-controller]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-dashboard-common]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-error]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-filter]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-macros]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-namesrv]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-runtime]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-store]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-store-inspect]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocketmq-tieredstore]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rocksdb]]
+version = "0.24.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ron]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rust-ini]]
+version = "0.21.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rust_decimal]]
+version = "1.42.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustc-hash]]
+version = "2.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustc_version]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rusticata-macros]]
+version = "4.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustix]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls]]
+version = "0.23.40"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls-native-certs]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls-pki-types]]
+version = "1.14.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls-platform-verifier]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls-platform-verifier-android]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustls-webpki]]
+version = "0.103.13"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.rustversion]]
+version = "1.0.22"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ryu]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.same-file]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.schannel]]
+version = "0.1.29"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.schemars]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.schemars_derive]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.scopeguard]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.security-framework]]
+version = "3.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.security-framework-sys]]
+version = "2.17.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.semver]]
+version = "1.0.28"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde-untagged]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_derive_internals]]
+version = "0.29.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_json]]
+version = "1.0.150"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_json_any_key]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_path_to_error]]
+version = "0.1.20"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_spanned]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_urlencoded]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.serde_yaml]]
+version = "0.9.34+deprecated"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.sha1]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.sha2]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.shell-words]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.signal-hook]]
+version = "0.3.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.signal-hook-mio]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.signal-hook-registry]]
+version = "1.4.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.simd-adler32]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.simd-json]]
+version = "0.17.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.simd_cesu8]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.simdutf8]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.similar]]
+version = "2.7.0"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.simple_asn1]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.siphasher]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.slab]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.socket2]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.socket2]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.spin]]
+version = "0.9.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.sse-stream]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.strum]]
+version = "0.28.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.strum_macros]]
+version = "0.28.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.symlink]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.syn]]
+version = "1.0.109"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.syn]]
+version = "2.0.118"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.sync_wrapper]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.sysinfo]]
+version = "0.39.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.system-configuration]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.system-configuration-sys]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tabled]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tabled_derive]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tagptr]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tap]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.target-triple]]
+version = "1.0.1"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tempfile]]
+version = "3.27.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.termina]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.terminfo]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.termios]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.termwiz]]
+version = "0.23.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.testing_table]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.thiserror]]
+version = "1.0.69"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.thiserror]]
+version = "2.0.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.thiserror-impl]]
+version = "1.0.69"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.thiserror-impl]]
+version = "2.0.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.thread_local]]
+version = "1.1.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.time]]
+version = "0.3.53"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.time-core]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.time-macros]]
+version = "0.2.31"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tiny-keccak]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tinystr]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tinyvec]]
+version = "1.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio]]
+version = "1.52.3"
+criteria = "safe-to-deploy"
+notes = "Owner: runtime maintainers. Exact locked baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio-macros]]
+version = "2.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio-rustls]]
+version = "0.26.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio-stream]]
+version = "0.1.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio-uring]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tokio-util]]
+version = "0.7.18"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.toml]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.toml_datetime]]
+version = "1.1.1+spec-1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.toml_edit]]
+version = "0.25.11+spec-1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.toml_parser]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.toml_writer]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tonic]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tonic-build]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tonic-prost]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tonic-prost-build]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tonic-types]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tower]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tower-http]]
+version = "0.6.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tower-http]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tower-layer]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tower-service]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing]]
+version = "0.1.44"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-appender]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-attributes]]
+version = "0.1.31"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-core]]
+version = "0.1.36"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-opentelemetry]]
+version = "0.33.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-serde]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.tracing-subscriber]]
+version = "0.3.23"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.trait-variant]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.try-lock]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.trybuild]]
+version = "1.0.118"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.typeid]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.typenum]]
+version = "1.20.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.ucd-trie]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unicase]]
+version = "2.9.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unicode-general-category]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unicode-ident]]
+version = "1.0.24"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unicode-truncate]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unit-prefix]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.universal-hash]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.unsafe-libyaml]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.untrusted]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.url]]
+version = "2.5.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.utf8-width]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.uuid]]
+version = "1.23.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.uuid-simd]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.validator]]
+version = "0.20.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.validator_derive]]
+version = "0.20.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.validit]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.valuable]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.value-trait]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.version_check]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.vsimd]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.vtparse]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.walkdir]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.want]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasi]]
+version = "0.11.1+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.121"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasm-bindgen-futures]]
+version = "0.4.71"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.121"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.121"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.121"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.web-sys]]
+version = "0.3.98"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.web-time]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.webpki-root-certs]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-bidi]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-blob-leases]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-color-types]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-dynamic]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-dynamic-derive]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wezterm-input-types]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winapi-util]]
+version = "0.1.11"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows]]
+version = "0.62.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-collections]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-core]]
+version = "0.62.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-future]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-implement]]
+version = "0.60.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-interface]]
+version = "0.59.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-link]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-numerics]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-registry]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-result]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-strings]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-sys]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-sys]]
+version = "0.60.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-sys]]
+version = "0.61.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-targets]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-targets]]
+version = "0.53.5"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows-threading]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_gnu]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_gnu]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_gnullvm]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_i686_msvc]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.53.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winnow]]
+version = "0.7.15"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.winnow]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.writeable]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.wyz]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.x509-parser]]
+version = "0.18.1"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.yaml-rust2]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.yansi]]
+version = "1.0.1"
+criteria = "safe-to-run"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.yasna]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.yoke]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.yoke-derive]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerocopy]]
+version = "0.8.48"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerocopy-derive]]
+version = "0.8.48"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerofrom]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerofrom-derive]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zeroize]]
+version = "1.9.0"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerotrie]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerovec]]
+version = "0.11.6"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zerovec-derive]]
+version = "0.11.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zmij]]
+version = "1.0.21"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zstd]]
+version = "0.13.3"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zstd-safe]]
+version = "7.2.4"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."
+
+[[exemptions.zstd-sys]]
+version = "2.0.16+zstd.1.5.7"
+criteria = "safe-to-deploy"
+notes = "Owner: RocketMQ Rust dependency maintainers. Exact locked dependency baseline pending a full safe-to-deploy audit; version changes require renewed review."

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,1979 @@
+
+# cargo-vet imports lock
+
+[[publisher.bumpalo]]
+version = "3.20.2"
+when = "2026-02-19"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.cexpr]]
+version = "0.6.0"
+when = "2021-10-11"
+user-id = 3788
+user-login = "emilio"
+user-name = "Emilio Cobos Álvarez"
+
+[[publisher.core-foundation]]
+version = "0.9.3"
+when = "2022-02-07"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
+[[publisher.encoding_rs]]
+version = "0.8.35"
+when = "2024-10-24"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.euclid]]
+version = "0.22.14"
+when = "2026-03-18"
+user-id = 1281
+user-login = "nical"
+user-name = "Nicolas Silva"
+
+[[publisher.unicode-segmentation]]
+version = "1.13.2"
+when = "2026-03-26"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.2.0"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-xid]]
+version = "0.2.6"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.utf8_iter]]
+version = "1.0.4"
+when = "2023-12-01"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.wasip2]]
+version = "1.0.3+wasi-0.2.9"
+when = "2026-04-17"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasip3]]
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+when = "2026-01-15"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-encoder]]
+version = "0.244.0"
+when = "2026-01-06"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wasm-metadata]]
+version = "0.236.0"
+when = "2025-07-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmparser]]
+version = "0.244.0"
+when = "2026-01-06"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-bindgen]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen]]
+version = "0.57.1"
+when = "2026-04-17"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-core]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-component]]
+version = "0.244.0"
+when = "2026-01-06"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-parser]]
+version = "0.244.0"
+when = "2026-01-06"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2026-08-21"
+
+[[audits.bytecode-alliance.wildcard-audits.wasip2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wasip3]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-09-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wasm-encoder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-01"
+end = "2026-06-03"
+notes = """
+The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
+publication of this crate from CI. This repository requires all PRs are reviewed
+by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wasmparser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-core]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rust]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-12"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rust-macro]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-component]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.allocator-api2]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.18 -> 0.2.20"
+notes = """
+The changes appear to be reasonable updates from Rust's stdlib imported into
+`allocator-api2`'s copy of this code.
+"""
+
+[[audits.bytecode-alliance.audits.anes]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.6"
+notes = "Contains no unsafe code, no IO, no build.rs."
+
+[[audits.bytecode-alliance.audits.atomic-waker]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.1.2"
+notes = "Contains `unsafe` code but it's well-documented and scoped to what it's intended to be doing. Otherwise a well-focused and straightforward crate."
+
+[[audits.bytecode-alliance.audits.cfg-if]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.fixedbitset]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.4.2"
+notes = """
+No ambient I/O. Uses some `unsafe`, but the uses look good and are guarded by
+relevant assertions, although could use some comments and some slight
+refactoring into helpers to dedupe unsafe blocks in my personal opinion.
+"""
+
+[[audits.bytecode-alliance.audits.getrandom]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.4.2"
+notes = "Nothing awry in this update, standard updates for some platforms and other misc things."
+
+[[audits.bytecode-alliance.audits.hashbrown]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.5 -> 0.15.2"
+
+[[audits.bytecode-alliance.audits.heck]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.5.0"
+notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
+
+[[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.bytecode-alliance.audits.leb128fmt]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Well-scoped crate do doing LEB encoding with no `unsafe` code and does what it says on the tin."
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Some unsafe code, but not more than before. Nothing awry."
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = """
+This crate is a Rust implementation of zlib compression/decompression and has
+been used by default by the Rust standard library for quite some time. It's also
+a default dependency of the popular `backtrace` crate for decompressing debug
+information. This crate forbids unsafe code and does not otherwise access system
+resources. It's originally a port of the `miniz.c` library as well, and given
+its own longevity should be relatively hardened against some of the more common
+compression-related issues.
+"""
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.8.0"
+notes = "Minor updates, using new Rust features like `const`, no major changes."
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.8.5"
+notes = """
+Lots of small updates here and there, for example around modernizing Rust
+idioms. No new `unsafe` code and everything looks like what you'd expect a
+compression library to be doing.
+"""
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.9"
+notes = "No new unsafe code, just refactorings."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.46.0"
+notes = "one use of unsafe to call windows specific api to get console handle."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.46.0 -> 0.50.1"
+notes = "Lots of stylistic/rust-related changes, plus new features, but nothing out of the ordrinary."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.50.1 -> 0.50.3"
+notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.percent-encoding]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+notes = """
+This crate is a single-file crate that does what it says on the tin. There are
+a few `unsafe` blocks related to utf-8 validation which are locally verifiable
+as correct and otherwise this crate is good to go.
+"""
+
+[[audits.bytecode-alliance.audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.9.4"
+notes = "Minor bugfix release"
+
+[[audits.bytecode-alliance.audits.sharded-slab]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
+
+[[audits.bytecode-alliance.audits.shlex]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Only minor `unsafe` code blocks which look valid and otherwise does what it says on the tin."
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+This is a standard adapter between the `log` ecosystem and the `tracing`
+ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
+"""
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.2.0"
+notes = "Nothing out of the ordinary, a typical major version update and nothing awry."
+
+[[audits.bytecode-alliance.audits.vcpkg]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.15"
+notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.236.0 -> 0.237.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.237.0 -> 0.238.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.239.0 -> 0.240.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.240.0 -> 0.241.2"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.241.2 -> 0.242.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.243.0 -> 0.244.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.google.audits.adler2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+notes = '''
+This audit has been reviewed in https://crrev.com/c/5811890
+
+The crate is fairly easy to read thanks to its small size and rich comments.
+
+I've grepped for `-i cipher`, `-i crypto`, `\bfs\b`, `\bnet\b`, and
+`\bunsafe\b`.  There were no hits (except for a comment in `README.md`
+and `lib.rs` pointing out "Zero `unsafe`").
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.arrayvec]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.7.6"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'` and there were
+no hits, except for some `net` usage in tests.
+
+The crate has quite a few bits of `unsafe` Rust.  The audit comments can be
+found in https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.base64]]
+who = "amarjotgill <amarjotgill@google.com>"
+criteria = "safe-to-deploy"
+version = "0.22.1"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.3.2"
+notes = """
+Security review of earlier versions of the crate can be found at
+(Google-internal, sorry): go/image-crate-chromium-security-review
+
+The crate exposes a function marked as `unsafe`, but doesn't use any
+`unsafe` blocks (except for tests of the single `unsafe` function).  I
+think this justifies marking this crate as `ub-risk-1`.
+
+Additional review comments can be found at https://crrev.com/c/4723145/31
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.byteorder]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.5.0"
+notes = "Unsafe review in https://crrev.com/c/5838022"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.cast]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.ciborium]]
+who = "Daniel Verkamp <dverkamp@chromium.org>"
+criteria = "safe-to-run"
+version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.ciborium-io]]
+who = "Daniel Verkamp <dverkamp@chromium.org>"
+criteria = "safe-to-run"
+version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.ciborium-ll]]
+who = "Daniel Verkamp <dverkamp@chromium.org>"
+criteria = "safe-to-run"
+version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.core-foundation-sys]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.8.7"
+notes = "OSX system APIs"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.displaydoc]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.5"
+notes = "No unsafe code"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.downcast]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "0.11.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.2"
+notes = "No changes to any .rs files or Rust code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.foldhash]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+`ub-risk-2` review notes can be found in https://crrev.com/c/6071306/5/third_party/rust/chromium_crates_io/vendor/foldhash-0.1.3/src/seed.rs
+
+`does-not-implement-crypto` based on `README.md` which explicitly says that
+"Foldhash is **not appropriate for any cryptographic purpose**."
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.foldhash]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.4"
+notes = "No changes to safety-relevant code"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.foldhash]]
+who = "Chris Palmer <palmer@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.5"
+notes = "No new `unsafe`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits.
+
+`heck` (version `0.3.3`) has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.httpdate]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = '''
+I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
+
+There are two places where `unsafe` is used.  Unsafe review notes can be found
+in https://crrev.com/c/5347418.
+
+This crate has been added to Chromium in https://crrev.com/c/3321895.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+notes = "Unsafe review notes: https://crrev.com/c/5650836"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.22"
+notes = """
+Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
+
+Unsafety is generally very well-documented, with one exception, which we
+describe in the review doc.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.25"
+notes = "No impact on `unsafe` usage in `lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.25 -> 0.4.26"
+notes = "Only trivial code and documentation changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.nom]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "7.1.3"
+notes = """
+Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-integer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.46"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-rational]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.4.2"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-traits]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.19"
+notes = "Contains a single line of float-to-int unsafe with decent safety comments"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "2.1.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates]]
+who = "Yu-An Wang <wyuang@google.com>"
+criteria = "safe-to-run"
+delta = "2.1.5 -> 3.0.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates-core]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "1.0.6"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates-tree]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "1.0.9"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for "crypt", "cipher", "fs", "net" - there were no hits
+(except for a benign "fs" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.8.5"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_chacha]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_core]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.scoped-tls]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`.
+
+There were some hits for `net`, but they were related to serialization and
+not actually opening any connections or anything like that.
+
+There were 2 hits of `unsafe` when grepping:
+* In `fn as_str` in `impl Buf`
+* In `fn serialize` in `impl Serialize for net::Ipv4Addr`
+
+Unsafe review comments can be found in https://crrev.com/c/5350573/2 (this
+review also covered `serde_json_lenient`).
+
+Version 1.0.130 of the crate has been added to Chromium in
+https://crrev.com/c/3265545.  The CL description contains a link to a
+(Google-internal, sorry) document with a mini security review.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.198"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.198 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+notes = "Trivial changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = "s/doc_cfg/docsrs/ + tuple_impls/tuple_impl_body-related changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = "The small change in `src/private/ser.rs` should have no impact on `ub-risk-2`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = """
+The delta carries fairly small changes in `src/private/de.rs` and
+`src/private/ser.rs` (see https://crrev.com/c/5812194/2..5).  AFAICT the
+delta has no impact on the `unsafe`, `from_utf8_unchecked`-related parts
+of the crate (in `src/de/format.rs` and `src/ser/impls.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta makes minor changes in `build.rs` - switching to the `?` syntax sugar."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "Minimal changes, nothing unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Just allowing `clippy::elidable_lifetime_names`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.197"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.197 -> 1.0.201"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.201 -> 1.0.202"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.202 -> 1.0.203"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.203 -> 1.0.204"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.204 -> 1.0.207"
+notes = 'Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.207 -> 1.0.209"
+notes = '''
+There are no code changes in this delta - see https://crrev.com/c/5812194/2..5
+
+I've neverthless also grepped for `-i cipher`, `-i crypto`, `\bfs\b`,
+`\bnet\b`, and `\bunsafe\b`.  There were no hits.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.209 -> 1.0.210"
+notes = "Almost no new code - just feature rearrangement"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.210 -> 1.0.213"
+notes = "Grepped for 'unsafe', 'crypt', 'cipher', 'fs', 'net' - there were no hits"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.213 -> 1.0.214"
+notes = "No changes to unsafe, no crypto"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.214 -> 1.0.215"
+notes = "Minor changes should not impact UB risk"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.215 -> 1.0.216"
+notes = "The delta adds `#[automatically_derived]` in a few places.  Still no `unsafe`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.216 -> 1.0.217"
+notes = "No changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.217 -> 1.0.218"
+notes = "No changes outside comments and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.serde_derive]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.218 -> 1.0.219"
+notes = "Minor changes (clippy tweaks, using `mem::take` instead of `mem::replace`)."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.2 -> 1.14.0"
+notes = """
+WARNING: This certification is a result of a **partial** audit. The
+`malloc_size_of` feature has **not** been audited. This feature does
+not explicitly document its safety requirements.
+See also https://chromium-review.googlesource.com/c/chromium/src/+/6275133/comment/ea0d7a93_98051a2e/
+and https://github.com/servo/malloc_size_of/issues/8.
+This feature is banned in gnrt_config.toml.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.static_assertions]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`
+and there were no hits except for one `unsafe`.
+
+The lambda where `unsafe` is used is never invoked (e.g. the `unsafe` code
+never runs) and is only introduced for some compile-time checks.  Additional
+unsafe review comments can be found in https://crrev.com/c/5353376.
+
+This crate has been added to Chromium in https://crrev.com/c/3736562.  The CL
+description contains a link to a document with an additional security review.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strsim]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.termcolor]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "1.4.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.termcolor]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "1.4.0 -> 1.4.1"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.termtree]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "0.4.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.tinytemplate]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "1.2.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.tinyvec_macros]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.utf8parse]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Reviewed on https://fxrev.dev/904811"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.alloca]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "0.4.0"
+
+[[audits.isrg.audits.cfg-if]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 1.0.1"
+
+[[audits.isrg.audits.cfg-if]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.3"
+
+[[audits.isrg.audits.cfg-if]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.0.4"
+
+[[audits.isrg.audits.chacha20]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.17 -> 0.3.0"
+
+[[audits.isrg.audits.criterion-plot]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+version = "0.8.1"
+
+[[audits.isrg.audits.criterion-plot]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+delta = "0.8.1 -> 0.8.2"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
+[[audits.isrg.audits.rand]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.9.1"
+
+[[audits.isrg.audits.rand]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.1 -> 0.9.2"
+
+[[audits.isrg.audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.9.0"
+
+[[audits.isrg.audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 0.9.3"
+
+[[audits.isrg.audits.rand_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.5"
+
+[[audits.isrg.audits.rayon-core]]
+who = "Ameer Ghani <inahga@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.12.1"
+
+[[audits.isrg.audits.rayon-core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.12.1 -> 1.13.0"
+
+[[audits.isrg.audits.serde]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
+
+[[audits.isrg.audits.serde]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.serde_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.0.224"
+
+[[audits.isrg.audits.serde_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde_core]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.serde_derive]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.219 -> 1.0.224"
+
+[[audits.isrg.audits.serde_derive]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.224 -> 1.0.225"
+
+[[audits.isrg.audits.serde_derive]]
+who = "Tim Geoghegan <timg@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.225 -> 1.0.226"
+
+[[audits.isrg.audits.sha2]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.10.2"
+
+[[audits.isrg.audits.sha2]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.8 -> 0.10.9"
+
+[[audits.isrg.audits.subtle]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "2.5.0 -> 2.6.1"
+
+[[audits.mozilla.wildcard-audits.cexpr]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+user-id = 3788 # Emilio Cobos Álvarez (emilio)
+start = "2021-06-21"
+end = "2024-04-21"
+notes = "No unsafe code, rather straight-forward parser."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2019-03-29"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.encoding_rs]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2019-02-26"
+end = "2025-10-23"
+notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.euclid]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1281 # Nicolas Silva (nical)
+start = "2019-03-14"
+end = "2027-01-15"
+notes = "I wrote most of the commits in the euclid reprository and review every change that is not produced by me."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-05-15"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
+end = "2026-02-01"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-xid]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-07-25"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.utf8_iter]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2022-04-19"
+end = "2024-06-16"
+notes = "Maintained by Henri Sivonen who works at Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.adler2]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.allocator-api2]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.18"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.allocator-api2]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.20 -> 0.2.21"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+notes = "I wrote this crate, reviewed by jimb. It is mostly a Rust port of some C++ code we already ship."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.arraydeque]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.3 -> 0.6.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-foundation]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.4"
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.11"
+notes = """
+This crate contains a decent bit of `unsafe` code, however all internal
+unsafety is verified with copious assertions (many are compile-time), and
+otherwise the unsafety is documented and left to the caller to verify.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.11 -> 0.4.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.8"
+notes = "New unsafe code is properly guarded"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "1.6.1"
+notes = """
+Straightforward crate providing the Either enum and trait implementations with
+no unsafe code.
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.6.1 -> 1.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.8.1 -> 1.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 1.10.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.10.0 -> 1.12.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.12.0 -> 1.13.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.0 -> 1.14.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fnv]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.7"
+notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foldhash]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.12.3"
+notes = "This version is used in rust's libstd, so effectively we're already trusting it"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.2 -> 0.15.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.5 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.16.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.17.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.3.3"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-core-foundation]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-encode]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "4.1.0"
+notes = "Support library for objc2 with no unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-foundation]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.oorandom]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+version = "11.1.5"
+notes = "Small random number generator, explicitly not cryptographically secure, no use of unsafe code, no dependencies"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.option-ext]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 2.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.0 -> 2.3.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.powerfmt]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = """
+A tiny bit of unsafe code to implement functionality that isn't in stable rust
+yet, but it's all valid. Otherwise it's a pretty simple crate.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.predicates]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+delta = "3.0.4 -> 3.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.predicates-core]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+delta = "1.0.6 -> 1.0.10"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.predicates-tree]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+delta = "1.0.9 -> 1.0.13"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.proc-macro-error-attr2]]
+who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+notes = "No unsafe block."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.proc-macro-error2]]
+who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
+criteria = "safe-to-deploy"
+version = "2.0.1"
+notes = "No unsafe block with a lovely `#![forbid(unsafe_code)]`."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.proc-macro2]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.94 -> 1.0.106"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rand]]
+who = "Henrik Skupin <mail@hskupin.info>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.6"
+notes = """
+Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
+feature. No new dependencies or unsafe code.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.scoped-tls]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-run"
+delta = "1.0.0 -> 1.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.seahash]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "4.1.0"
+notes = """
+Uses unsafe to compute a non-cryptographic hash over &[u8],
+grabbing u64s out of the buffer for XORs. Logic looks sound,
+careful not to read over the end of the buffer, and the unsafety
+is well contained.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_core]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_core]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_derive]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.226 -> 1.0.227"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_derive]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sha2]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sha2]]
+who = "Jeff Muizelaar <jmuizelaar@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.6 -> 0.10.8"
+notes = """
+The bulk of this is https://github.com/RustCrypto/hashes/pull/490 which adds aarch64 support along with another PR adding longson.
+I didn't check the implementation thoroughly but there wasn't anything obviously nefarious. 0.10.8 has been out for more than a year
+which suggests no one else has found anything either.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sharded-slab]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.shlex]]
+who = "Max Inden <mail@max-inden.de>"
+criteria = "safe-to-deploy"
+delta = "1.1.0 -> 1.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.15.1 -> 1.15.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strsim]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.subtle]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "2.5.0"
+notes = "The goal is to provide some constant-time correctness for cryptographic implementations. The approach is reasonable, it is known to be insufficient but this is pointed out in the documentation."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.12.6"
+notes = """
+I am the primary author of the `synstructure` crate, and its current
+maintainer. The one use of `unsafe` is unnecessary, but documented and
+harmless. It will be removed in the next version.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.12.6 -> 0.13.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.0 -> 0.13.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.13.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.termtree]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-run"
+delta = "0.4.1 -> 0.5.1"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinyvec_macros]]
+who = "Drew Willcoxon <adw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.utf8parse]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8757

### Brief Description

- Pin the root workspace, standalone Rust projects, and production container builder to stable Rust 1.95.0 while retaining dated nightly toolchains only for Miri and rustdoc JSON.
- Add repository-wide cargo-deny admission policy and a versioned cargo-vet store with documented ownership, review debt, and focused critical dependency audits.
- Upgrade vulnerable or unsound dependency paths where compatible releases exist, remove the direct rustls-pemfile dependency from the transport TLS path, and add mixed-PEM regression coverage.
- Align current English and Chinese documentation with the MSRV, local-only validation, non-system-drive build output, and local Docker image policy.
- Update stable-toolchain lint compatibility and keep the container contract synchronized with the telemetry port and toolchain metadata.

### How Did You Test This Change?

- `cargo check --workspace --all-targets --all-features` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed on the final branch after rebasing onto the latest `main`.
- `cargo test -p rocketmq-transport pem_loaders_select_supported_sections_from_a_mixed_bundle --all-features` passed.
- `cargo check -p rocketmq-mcp`, `cargo test -p rocketmq-mcp`, strict `streamable-http` Clippy, and `cargo doc -p rocketmq-mcp --no-deps` passed. The final MCP test run passed 90 tests and ignored one external-environment test by design.
- Strict all-target/all-feature Clippy passed for `rocketmq-example`, the GPUI dashboard, the Tauri backend, and the Web dashboard backend; the Web backend all-target/all-feature build also passed.
- Stable rustfmt checks passed for every root workspace package and each standalone Cargo project. The aggregate Windows `cargo fmt --all -- --check` command was also attempted but hits the Windows command-line length limit with OS error 206; the equivalent per-package coverage completed successfully.
- `cargo deny check` passed for the root workspace and all four standalone Cargo projects. It retains visible duplicate-version and yanked-release warnings, with no advisory, license, source, or ban errors.
- `cargo vet --locked` passed for the root production workspace: 111 fully audited, 6 partially audited, and 567 exact-version exemptions recorded as review debt.
- `python scripts/stable_surface_guard.py`, all 9 stable-surface unit tests, `python scripts/container_image_guard.py`, and the AGENTS routing check passed.
- `npm ci` and `npm run build` passed for the English and Chinese documentation site. npm reported 45 existing dependency advisories, and Docusaurus retained existing broken-link warnings.
- Local Docker builds passed for `builder-base` and the runtime foundation. Container inspection verified Rust/Cargo 1.95.0, matching toolchain environment metadata, non-root runtime user `10001:10001`, `/bin/true` default command, and the final source revision. Images remain local and were not pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project and component requirements to use the pinned stable Rust 1.95.0 toolchain.
  * Added guidance for dependency trust, security reviews, toolchain usage, and development setup.
  * Clarified that nightly Rust is reserved for specialized validation tasks.

* **Security & Reliability**
  * Added dependency license, advisory, source, and supply-chain validation policies.
  * Improved TLS certificate and private-key handling for mixed PEM files.

* **Maintenance**
  * Refreshed dependency versions and streamlined formatting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->