### PR TITLE
[ISSUE #8762]♻️Refactor TLS negotiation to use idle timeout for silent connections and enhance handshake timeout handling

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -3716,9 +3716,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.11"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -4041,7 +4041,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.5",
  "serde",
  "smallvec",
  "zeroize",
@@ -4526,7 +4526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4848,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -4927,9 +4927,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7561,12 +7561,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.11"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.41.0",
+ "quick-xml 0.38.4",
  "quote",
 ]
 
@@ -8659,7 +8659,7 @@ dependencies = [
  "core-graphics-helmer-fork",
  "log",
  "objc",
- "rand 0.8.7",
+ "rand 0.8.5",
  "screencapturekit",
  "screencapturekit-sys",
  "sysinfo 0.31.4",

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -62,6 +62,7 @@ use crate::security::TransportSecurity;
 use crate::session_executor::SessionDispatchError;
 use crate::session_executor::SessionExecutor;
 use crate::telemetry::TransportTelemetry;
+use crate::tls::NegotiatedConnection;
 use crate::tls::TlsServerRuntime;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::WriterOperation;
@@ -247,6 +248,49 @@ pub trait ConnectionHandler: Send + Sync + 'static {
     }
 }
 
+#[derive(Clone, Copy)]
+struct NegotiationTimeouts {
+    protocol_detection: Duration,
+    tls_handshake: Duration,
+}
+
+async fn negotiate_transport_connection(
+    tls: &TlsServerRuntime,
+    admission: &AdmissionController,
+    scope: AdmissionScope,
+    stream: tokio::net::TcpStream,
+    remote_addr: SocketAddr,
+    timeouts: NegotiationTimeouts,
+) -> Option<NegotiatedConnection> {
+    // Protocol detection waits under the connection idle budget. Once TLS is identified, the
+    // narrower handshake budget bounds only the cryptographic negotiation.
+    let is_tls_handshake = tokio::time::timeout(
+        timeouts.protocol_detection,
+        tls.detect_tls_handshake(&stream, remote_addr),
+    )
+    .await
+    .ok()
+    .flatten()?;
+    let _handshake_permit = admission
+        .try_acquire(
+            AdmissionResource::Handshake,
+            scope,
+            crate::admission::estimated_handshake_retained_bytes(),
+            AdmissionClass::Data,
+        )
+        .ok()?;
+    let negotiation = tls.negotiate_detected_connection(stream, remote_addr, is_tls_handshake);
+
+    if is_tls_handshake {
+        tokio::time::timeout(timeouts.tls_handshake, negotiation)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        negotiation.await
+    }
+}
+
 /// Canonical socket accept, admission, TLS handshake, and session ownership runtime.
 pub struct TransportListener {
     listener: tokio::net::TcpListener,
@@ -344,28 +388,26 @@ impl TransportListener {
                 .spawn("rocketmq.transport.session", TaskKind::Service, async move {
                     let _session_lease = session_lease;
                     let _connection_permit = connection_permit;
-                    let Ok(_handshake_permit) = admission.try_acquire(
-                        AdmissionResource::Handshake,
-                        scope,
-                        crate::admission::estimated_handshake_retained_bytes(),
-                        AdmissionClass::Data,
-                    ) else {
-                        return;
-                    };
                     let handshake_cancellation = session_group.cancellation_token();
                     let negotiated = tokio::select! {
                         () = handshake_cancellation.cancelled() => return,
-                        negotiated = tokio::time::timeout(
-                            handshake_timeout,
-                            tls.negotiate_connection(stream, remote_addr),
+                        negotiated = negotiate_transport_connection(
+                            &tls,
+                            &admission,
+                            scope,
+                            stream,
+                            remote_addr,
+                            NegotiationTimeouts {
+                                protocol_detection: idle_timeout,
+                                tls_handshake: handshake_timeout,
+                            },
                         ) => negotiated,
                     };
-                    let Ok(Some(negotiated)) = negotiated else {
+                    let Some(negotiated) = negotiated else {
                         return;
                     };
                     let (connection, peer_is_tls) = negotiated.into_parts();
                     let connection = connection.with_telemetry(telemetry);
-                    drop(_handshake_permit);
                     run_framed_session(
                         connection,
                         local_addr,
@@ -879,28 +921,26 @@ impl TransportServer {
         session_group: TaskGroup,
     ) {
         let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
-        let Ok(_handshake_permit) = self.admission.try_acquire(
-            AdmissionResource::Handshake,
-            scope,
-            crate::admission::estimated_handshake_retained_bytes(),
-            AdmissionClass::Data,
-        ) else {
-            return;
-        };
-        let handshake_deadline = tokio::time::Instant::now() + self.config.handshake_timeout;
         let handshake_cancellation = session_group.cancellation_token();
         let negotiated = tokio::select! {
             () = handshake_cancellation.cancelled() => return,
-            negotiated =
-                tokio::time::timeout_at(handshake_deadline, self.tls.negotiate_connection(stream, remote_addr)) =>
-                negotiated,
+            negotiated = negotiate_transport_connection(
+                &self.tls,
+                &self.admission,
+                scope,
+                stream,
+                remote_addr,
+                NegotiationTimeouts {
+                    protocol_detection: self.config.request_timeout,
+                    tls_handshake: self.config.handshake_timeout,
+                },
+            ) => negotiated,
         };
-        let Ok(Some(negotiated)) = negotiated else {
+        let Some(negotiated) = negotiated else {
             return;
         };
         let (connection, peer_is_tls) = negotiated.into_parts();
         let connection = connection.with_telemetry(self.telemetry.clone());
-        drop(_handshake_permit);
         run_framed_session(
             connection,
             self.local_addr,
@@ -956,16 +996,24 @@ mod retirement_tests {
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_runtime::RuntimeContext;
     use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
     use tokio::sync::oneshot;
     use tokio::sync::Notify;
 
     use super::ConnectionHandler;
     use super::SessionHandle;
+    use super::TransportListener;
     use crate::admission::AdmissionController;
     use crate::admission::AdmissionLimits;
+    use crate::config::TlsConfig;
+    #[cfg(feature = "tls")]
+    use crate::config::TlsMode;
     use crate::connection::Connection;
     use crate::deadline::RequestDeadline;
     use crate::security::TransportSecurity;
+    use crate::tls::TlsServerRuntime;
 
     struct CaptureSession {
         sender: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
@@ -987,6 +1035,143 @@ mod retirement_tests {
         ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
             Box::pin(async {})
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_plaintext_first_byte_uses_idle_timeout_not_tls_handshake_timeout() {
+        let runtime = RuntimeContext::from_current("transport-delayed-plaintext-test");
+        let service = runtime.service_context("transport-delayed-plaintext");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let tls = TlsServerRuntime::initialize_with_service_context(TlsConfig::default(), &service)
+            .await
+            .expect("initialize TLS runtime");
+        let (session_tx, session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let transport = TransportListener::new(
+            listener,
+            service.task_group().clone(),
+            tls,
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Duration::from_millis(20),
+        )
+        .with_idle_timeout(Duration::from_millis(500));
+        let server = tokio::spawn(transport.run(handler));
+
+        let mut client = TcpStream::connect(addr).await.expect("connect client");
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        client.write_all(&[0]).await.expect("write delayed plaintext byte");
+
+        tokio::time::timeout(Duration::from_millis(500), session_rx)
+            .await
+            .expect("plaintext session should outlive TLS handshake timeout")
+            .expect("capture session");
+
+        service.task_group().cancel();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server should stop")
+            .expect("server task")
+            .expect("server result");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_connection_uses_idle_timeout_before_closing() {
+        let runtime = RuntimeContext::from_current("transport-silent-connection-test");
+        let service = runtime.service_context("transport-silent-connection");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let tls = TlsServerRuntime::initialize_with_service_context(TlsConfig::default(), &service)
+            .await
+            .expect("initialize TLS runtime");
+        let (session_tx, _session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let transport = TransportListener::new(
+            listener,
+            service.task_group().clone(),
+            tls,
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Duration::from_millis(20),
+        )
+        .with_idle_timeout(Duration::from_millis(150));
+        let server = tokio::spawn(transport.run(handler));
+
+        let mut client = TcpStream::connect(addr).await.expect("connect client");
+        let mut byte = [0u8; 1];
+        assert!(
+            tokio::time::timeout(Duration::from_millis(60), client.read(&mut byte))
+                .await
+                .is_err(),
+            "silent connection must remain open past the TLS handshake timeout"
+        );
+        let read = tokio::time::timeout(Duration::from_millis(300), client.read(&mut byte))
+            .await
+            .expect("silent connection should reach idle timeout")
+            .expect("read idle close");
+        assert_eq!(read, 0, "idle timeout should close the silent connection");
+
+        service.task_group().cancel();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server should stop")
+            .expect("server task")
+            .expect("server result");
+    }
+
+    #[cfg(feature = "tls")]
+    #[tokio::test(start_paused = true)]
+    async fn detected_tls_handshake_remains_bounded_by_handshake_timeout() {
+        let runtime = RuntimeContext::from_current("transport-stalled-tls-test");
+        let service = runtime.service_context("transport-stalled-tls");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let tls = TlsServerRuntime::initialize_with_service_context(
+            TlsConfig {
+                test_mode_enable: true,
+                server: crate::config::TlsServerConfig {
+                    mode: TlsMode::Permissive,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &service,
+        )
+        .await
+        .expect("initialize TLS runtime");
+        assert_eq!(tls.active_generation(), 1, "test TLS acceptor must be active");
+        let (session_tx, _session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let transport = TransportListener::new(
+            listener,
+            service.task_group().clone(),
+            tls,
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Duration::from_millis(30),
+        )
+        .with_idle_timeout(Duration::from_millis(500));
+        let server = tokio::spawn(transport.run(handler));
+
+        let mut client = TcpStream::connect(addr).await.expect("connect client");
+        client.write_all(&[0x16]).await.expect("write TLS handshake magic");
+        let mut byte = [0u8; 1];
+        let read = tokio::time::timeout(Duration::from_millis(250), client.read(&mut byte))
+            .await
+            .expect("stalled TLS handshake should not reach idle timeout")
+            .expect("read handshake close");
+        assert_eq!(read, 0, "TLS handshake timeout should close the connection");
+
+        service.task_group().cancel();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server should stop")
+            .expect("server task")
+            .expect("server result");
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -221,14 +221,27 @@ impl TlsServerRuntime {
         stream: TcpStream,
         remote_addr: SocketAddr,
     ) -> Option<NegotiatedConnection> {
-        let is_tls_handshake = match peek_tls_handshake(&stream).await {
-            Ok(value) => value,
+        let is_tls_handshake = self.detect_tls_handshake(&stream, remote_addr).await?;
+        self.negotiate_detected_connection(stream, remote_addr, is_tls_handshake)
+            .await
+    }
+
+    pub(crate) async fn detect_tls_handshake(&self, stream: &TcpStream, remote_addr: SocketAddr) -> Option<bool> {
+        match peek_tls_handshake(stream).await {
+            Ok(value) => Some(value),
             Err(error) => {
                 warn!("failed to inspect TLS handshake byte from {remote_addr}: {error}");
-                return None;
+                None
             }
-        };
+        }
+    }
 
+    pub(crate) async fn negotiate_detected_connection(
+        &self,
+        stream: TcpStream,
+        remote_addr: SocketAddr,
+        is_tls_handshake: bool,
+    ) -> Option<NegotiatedConnection> {
         match self.mode {
             TlsMode::Disabled => {
                 if is_tls_handshake {

--- a/rocketmq-transport/tests/production_runtime.rs
+++ b/rocketmq-transport/tests/production_runtime.rs
@@ -30,6 +30,7 @@ use rocketmq_transport::SessionHandle;
 use rocketmq_transport::TlsConfig;
 use rocketmq_transport::TlsServerRuntime;
 use rocketmq_transport::TransportListener;
+use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
 struct CountConnections(AtomicUsize);
@@ -70,8 +71,8 @@ async fn canonical_client_connect_builds_the_framed_transport() {
     accept.await.unwrap();
 }
 
-#[tokio::test]
-async fn canonical_listener_times_out_a_silent_tls_peek() {
+#[tokio::test(start_paused = true)]
+async fn canonical_listener_uses_idle_timeout_for_a_silent_tls_peek() {
     let runtime = RuntimeContext::from_current("transport-listener-test");
     let service = runtime.service_context("listener");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -87,7 +88,8 @@ async fn canonical_listener_times_out_a_silent_tls_peek() {
         tls,
         admission.clone(),
         Duration::from_millis(25),
-    );
+    )
+    .with_idle_timeout(Duration::from_millis(100));
     let handler = handled.clone();
     service
         .spawn_service("listener.run", async move {
@@ -95,10 +97,18 @@ async fn canonical_listener_times_out_a_silent_tls_peek() {
         })
         .unwrap();
 
-    let _silent = tokio::net::TcpStream::connect(address).await.unwrap();
+    let mut silent = tokio::net::TcpStream::connect(address).await.unwrap();
     tokio::time::sleep(Duration::from_millis(75)).await;
 
     assert_eq!(handled.0.load(Ordering::SeqCst), 0);
+    assert_eq!(admission.snapshot().connections.current_count, 1);
+
+    let mut byte = [0u8; 1];
+    let read = tokio::time::timeout(Duration::from_millis(100), silent.read(&mut byte))
+        .await
+        .expect("silent connection should reach the idle timeout")
+        .expect("read idle close");
+    assert_eq!(read, 0);
     assert_eq!(admission.snapshot().connections.current_count, 0);
 
     let mut active = tokio::net::TcpStream::connect(address).await.unwrap();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #8762

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling by separating protocol detection and TLS negotiation timeouts.
  - Delayed plaintext connections are no longer closed prematurely during TLS detection.
  - Silent connections now remain available until the configured idle timeout, then close automatically.
  - Stalled TLS handshakes are closed promptly when the handshake timeout is reached.
  - Improved reliability when detecting and establishing secure or plaintext connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->