### PR TITLE
[ISSUE #8766]♻️Model local production artifacts as complete ReleaseState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ _site
 !.claude/glossary/**
 !.claude/glossary
 .codex
+.rocketmq/
 
 # Tauri
 **/src-tauri/target

--- a/distribution/config/image-provenance.schema.json
+++ b/distribution/config/image-provenance.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/local-image-provenance-v1.json",
+  "title": "RocketMQ Rust local image provenance",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release_id",
+    "generated_at",
+    "source_commit",
+    "rust_toolchain",
+    "cargo_lock_sha256",
+    "feature_profile_sha256",
+    "config_digest",
+    "local_only",
+    "remote_push_performed",
+    "images"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "release_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "rust_toolchain": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "cargo_lock_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "feature_profile_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "config_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "local_only": {
+      "const": true
+    },
+    "remote_push_performed": {
+      "const": false
+    },
+    "images": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "service",
+          "reference",
+          "image_id",
+          "image_config_digest",
+          "binary_sha256",
+          "resolved_features",
+          "sbom_path",
+          "sbom_sha256"
+        ],
+        "properties": {
+          "service": {
+            "enum": [
+              "broker",
+              "namesrv",
+              "controller",
+              "proxy",
+              "mcp"
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "pattern": "^rocketmq-rust/(broker|namesrv|controller|proxy|mcp):[0-9a-f]{7,12}$"
+          },
+          "image_id": {
+            "$ref": "#/$defs/digest"
+          },
+          "image_config_digest": {
+            "$ref": "#/$defs/digest"
+          },
+          "binary_sha256": {
+            "$ref": "#/$defs/sha256"
+          },
+          "resolved_features": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "sbom_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sbom_sha256": {
+            "$ref": "#/$defs/sha256"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/distribution/config/image-sbom.schema.json
+++ b/distribution/config/image-sbom.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/local-image-sbom-v1.json",
+  "title": "RocketMQ Rust local image CycloneDX SBOM subset",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version",
+    "metadata",
+    "components"
+  ],
+  "properties": {
+    "bomFormat": {
+      "const": "CycloneDX"
+    },
+    "specVersion": {
+      "const": "1.6"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "timestamp",
+        "component",
+        "properties"
+      ],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "component": {
+          "type": "object",
+          "required": [
+            "type",
+            "name",
+            "version",
+            "hashes"
+          ]
+        },
+        "properties": {
+          "type": "array",
+          "minItems": 3
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "version"
+        ]
+      }
+    }
+  }
+}

--- a/distribution/config/production-feature-profile.json
+++ b/distribution/config/production-feature-profile.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "profile": "production",
+  "build_mode": {
+    "locked": true,
+    "release": true,
+    "default_features": false,
+    "local_images_only": true,
+    "remote_push_enabled": false,
+    "tag_pattern": "^rocketmq-rust/(broker|namesrv|controller|proxy|mcp):[0-9a-f]{7,12}$"
+  },
+  "config_bundle_files": [
+    "distribution/config/image-provenance.schema.json",
+    "distribution/config/image-sbom.schema.json",
+    "distribution/config/production-feature-profile.json",
+    "distribution/config/release-state.schema.json",
+    "distribution/helm/rocketmq-rust/templates/_helpers.tpl",
+    "distribution/helm/rocketmq-rust/templates/configmaps.yaml",
+    "distribution/helm/rocketmq-rust/templates/networkpolicies.yaml",
+    "distribution/helm/rocketmq-rust/templates/services.yaml",
+    "distribution/helm/rocketmq-rust/templates/servicemonitor.yaml",
+    "distribution/helm/rocketmq-rust/templates/workloads.yaml",
+    "distribution/helm/rocketmq-rust/values-production-controller-ha.yaml",
+    "distribution/helm/rocketmq-rust/values.schema.json",
+    "distribution/helm/rocketmq-rust/values.yaml",
+    "distribution/kubernetes/base/manifest.yaml",
+    "distribution/kubernetes/release-state-transition-policy.json"
+  ],
+  "services": {
+    "broker": {
+      "package": "rocketmq-broker",
+      "manifest": "rocketmq-broker/Cargo.toml",
+      "binary": "rocketmq-broker-rust",
+      "docker_target": "broker",
+      "features": [
+        "production"
+      ],
+      "resolved_features": [
+        "local_file_store",
+        "metrics-prometheus",
+        "otel-logs",
+        "otel-metrics",
+        "otel-traces",
+        "otlp-logs",
+        "otlp-traces",
+        "production",
+        "production-observability",
+        "prometheus"
+      ]
+    },
+    "namesrv": {
+      "package": "rocketmq-namesrv",
+      "manifest": "rocketmq-namesrv/Cargo.toml",
+      "binary": "rocketmq-namesrv-rust",
+      "docker_target": "namesrv",
+      "features": [
+        "production"
+      ],
+      "resolved_features": [
+        "metrics-prometheus",
+        "observability",
+        "otel-logs",
+        "otel-traces",
+        "otlp-logs",
+        "otlp-traces",
+        "production",
+        "production-observability"
+      ]
+    },
+    "controller": {
+      "package": "rocketmq-controller",
+      "manifest": "rocketmq-controller/Cargo.toml",
+      "binary": "rocketmq-controller-rust",
+      "docker_target": "controller",
+      "features": [
+        "production"
+      ],
+      "resolved_features": [
+        "metrics",
+        "metrics-prometheus",
+        "otel-logs",
+        "otel-traces",
+        "otlp-logs",
+        "otlp-traces",
+        "production",
+        "production-observability",
+        "storage-rocksdb"
+      ]
+    },
+    "proxy": {
+      "package": "rocketmq-proxy",
+      "manifest": "rocketmq-proxy/Cargo.toml",
+      "binary": "rocketmq-proxy-rust",
+      "docker_target": "proxy",
+      "features": [
+        "production"
+      ],
+      "resolved_features": [
+        "cluster-mode",
+        "metrics-prometheus",
+        "observability",
+        "otel-logs",
+        "otel-traces",
+        "otlp-logs",
+        "otlp-traces",
+        "production",
+        "production-observability"
+      ]
+    },
+    "mcp": {
+      "package": "rocketmq-mcp",
+      "manifest": "rocketmq-tools/rocketmq-mcp/Cargo.toml",
+      "binary": "rocketmq-mcp",
+      "docker_target": "mcp",
+      "features": [
+        "production"
+      ],
+      "resolved_features": [
+        "auth",
+        "diagnose",
+        "metrics-prometheus",
+        "observability",
+        "otel-logs",
+        "otlp-logs",
+        "otlp-traces",
+        "production",
+        "production-observability",
+        "read-only",
+        "stdio",
+        "streamable-http"
+      ]
+    }
+  }
+}

--- a/distribution/config/release-state.schema.json
+++ b/distribution/config/release-state.schema.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/release-state-v1.json",
+  "title": "RocketMQ Rust ReleaseState",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release_id",
+    "created_at",
+    "source_commit",
+    "images",
+    "config_bundle",
+    "secret_references",
+    "identity",
+    "storage_generation",
+    "cluster_import"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "release_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_commit": {
+      "$ref": "#/$defs/commit"
+    },
+    "images": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "broker",
+        "namesrv",
+        "controller",
+        "proxy",
+        "mcp"
+      ],
+      "properties": {
+        "broker": {
+          "$ref": "#/$defs/image"
+        },
+        "namesrv": {
+          "$ref": "#/$defs/image"
+        },
+        "controller": {
+          "$ref": "#/$defs/image"
+        },
+        "proxy": {
+          "$ref": "#/$defs/image"
+        },
+        "mcp": {
+          "$ref": "#/$defs/image"
+        }
+      }
+    },
+    "config_bundle": {
+      "$ref": "#/$defs/config_bundle"
+    },
+    "secret_references": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/secret_reference"
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commit",
+        "nonce",
+        "config_digest",
+        "secret_version",
+        "storage_generation"
+      ],
+      "properties": {
+        "commit": {
+          "$ref": "#/$defs/commit"
+        },
+        "nonce": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+        },
+        "config_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "secret_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "storage_generation": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "storage_generation": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "cluster_import": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "none",
+            "kind",
+            "k3d"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "not": {
+        "const": "0000000000000000000000000000000000000000"
+      }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?![A-Za-z]:)(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._/-]+$"
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "format": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service",
+        "reference",
+        "image_id",
+        "image_config_digest",
+        "binary_sha256",
+        "source_commit",
+        "rust_toolchain",
+        "cargo_lock_sha256",
+        "feature_profile_sha256",
+        "resolved_features",
+        "config_digest",
+        "sbom",
+        "provenance"
+      ],
+      "properties": {
+        "service": {
+          "enum": [
+            "broker",
+            "namesrv",
+            "controller",
+            "proxy",
+            "mcp"
+          ]
+        },
+        "reference": {
+          "type": "string",
+          "pattern": "^rocketmq-rust/(broker|namesrv|controller|proxy|mcp):[0-9a-f]{7,12}$"
+        },
+        "image_id": {
+          "$ref": "#/$defs/digest"
+        },
+        "image_config_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "binary_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_commit": {
+          "$ref": "#/$defs/commit"
+        },
+        "rust_toolchain": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "cargo_lock_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "feature_profile_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "resolved_features": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          }
+        },
+        "config_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "sbom": {
+          "$ref": "#/$defs/artifact"
+        },
+        "provenance": {
+          "$ref": "#/$defs/artifact"
+        }
+      }
+    },
+    "config_file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "config_bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "digest",
+        "files",
+        "helm_values",
+        "config_map_template",
+        "schema"
+      ],
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/config_file"
+          }
+        },
+        "helm_values": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "config_map_template": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "schema": {
+          "$ref": "#/$defs/relative_path"
+        }
+      }
+    },
+    "secret_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "namespace",
+        "provider",
+        "version",
+        "mount_path"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$"
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+        },
+        "provider": {
+          "enum": [
+            "kubernetes",
+            "external-secrets",
+            "secrets-store-csi"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "mount_path": {
+          "type": "string",
+          "const": "/var/run/secrets/rocketmq"
+        }
+      }
+    }
+  }
+}

--- a/distribution/helm/rocketmq-rust/ci/secure-values.yaml
+++ b/distribution/helm/rocketmq-rust/ci/secure-values.yaml
@@ -3,6 +3,9 @@ releaseIdentity:
   # Real repository revision used only to keep the canonical render non-null.
   commit: "698f053f149784be1be1ddda403270b579607089"
   nonce: render-fixture
+  configDigest: "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+  secretVersion: render-fixture-1
+  storageGeneration: 1
 
 global:
   secretRefs:

--- a/distribution/helm/rocketmq-rust/templates/_helpers.tpl
+++ b/distribution/helm/rocketmq-rust/templates/_helpers.tpl
@@ -34,6 +34,17 @@ rocketmq-{{ .service }}
 {{- if not (regexMatch "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" $releaseNonce) -}}
   {{- fail "releaseIdentity.nonce must be 1..=63 lowercase ASCII letters, digits, or interior hyphens" -}}
 {{- end -}}
+{{- $configDigest := required "releaseIdentity.configDigest is required" .Values.releaseIdentity.configDigest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $configDigest) -}}
+  {{- fail "releaseIdentity.configDigest must be a lowercase SHA-256 digest" -}}
+{{- end -}}
+{{- $secretVersion := required "releaseIdentity.secretVersion is required" .Values.releaseIdentity.secretVersion -}}
+{{- if not (regexMatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$" $secretVersion) -}}
+  {{- fail "releaseIdentity.secretVersion must be an opaque 1..=128 character version identifier" -}}
+{{- end -}}
+{{- if lt (int .Values.releaseIdentity.storageGeneration) 1 -}}
+  {{- fail "releaseIdentity.storageGeneration must be at least 1" -}}
+{{- end -}}
 {{- if eq $profile "production-controller-ha" -}}
   {{- $controllerReplicas := int .Values.services.controller.replicas -}}
   {{- $controllerQuorum := add (div $controllerReplicas 2) 1 -}}
@@ -136,6 +147,9 @@ rocketmq.apache.org/architecture-milestone: P0-05
 {{- define "rocketmq.telemetryEnv" -}}
 - {name: ROCKETMQ_RELEASE_COMMIT, value: {{ required "releaseIdentity.commit is required" .Values.releaseIdentity.commit | quote }}}
 - {name: ROCKETMQ_RELEASE_NONCE, value: {{ required "releaseIdentity.nonce is required" .Values.releaseIdentity.nonce | quote }}}
+- {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: {{ required "releaseIdentity.configDigest is required" .Values.releaseIdentity.configDigest | quote }}}
+- {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: {{ required "releaseIdentity.secretVersion is required" .Values.releaseIdentity.secretVersion | quote }}}
+- {name: ROCKETMQ_STORAGE_GENERATION, value: {{ .Values.releaseIdentity.storageGeneration | quote }}}
 - {name: ROCKETMQ_METRICS_ENABLED, value: {{ .Values.metrics.enabled | quote }}}
 - {name: ROCKETMQ_METRICS_EXPORTER, value: {{ ternary "prometheus" "disable" .Values.metrics.enabled | quote }}}
 - {name: ROCKETMQ_METRICS_BIND_ADDR, value: {{ printf "0.0.0.0:%d" (int .Values.metrics.port) | quote }}}
@@ -145,6 +159,9 @@ rocketmq.apache.org/architecture-milestone: P0-05
 {{- define "rocketmq.releaseAnnotations" -}}
 rocketmq.apache.org/release-commit: {{ .Values.releaseIdentity.commit | quote }}
 rocketmq.apache.org/release-nonce: {{ .Values.releaseIdentity.nonce | quote }}
+rocketmq.apache.org/release-config-digest: {{ .Values.releaseIdentity.configDigest | quote }}
+rocketmq.apache.org/release-secret-version: {{ .Values.releaseIdentity.secretVersion | quote }}
+rocketmq.apache.org/storage-generation: {{ .Values.releaseIdentity.storageGeneration | quote }}
 {{- end -}}
 
 {{- define "rocketmq.lifecycleProbes" -}}

--- a/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
+++ b/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
@@ -1,5 +1,14 @@
 deploymentProfile: production-controller-ha
 
+# Local rendering fixture. The release-state reconciler replaces every value from
+# a validated candidate and never treats this fixture as deployable state.
+releaseIdentity:
+  commit: "1111111111111111111111111111111111111111"
+  nonce: local-validation
+  configDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  secretVersion: local-reference-1
+  storageGeneration: 1
+
 # These tags are loaded into the local cluster and are never pulled. Build them
 # with `docker buildx build --load`, then use the cluster-specific image-load command.
 services:

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -111,7 +111,10 @@
       "additionalProperties": false,
       "required": [
         "commit",
-        "nonce"
+        "nonce",
+        "configDigest",
+        "secretVersion",
+        "storageGeneration"
       ],
       "properties": {
         "commit": {
@@ -128,6 +131,23 @@
           "minLength": 1,
           "maxLength": 63,
           "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+        },
+        "configDigest": {
+          "type": "string",
+          "description": "SHA-256 digest of the complete non-sensitive configuration bundle.",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "secretVersion": {
+          "type": "string",
+          "description": "Opaque version of the referenced Secret; this field must never contain Secret material.",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "storageGeneration": {
+          "type": "integer",
+          "description": "Monotonically increasing generation shared by the persisted release state.",
+          "minimum": 1
         }
       }
     },

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -12,10 +12,12 @@ global:
     fsGroup: 10001
 
 releaseIdentity:
-  # Required: exact non-zero 40-character source revision embedded in all five images.
-  commit: ""
-  # Required: stable 1..=63 character lowercase identifier for this rollout.
-  nonce: ""
+  # Local validation fixture. The reconciler replaces the complete identity from ReleaseState.
+  commit: "1111111111111111111111111111111111111111"
+  nonce: local-validation
+  configDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  secretVersion: local-reference-1
+  storageGeneration: 1
 
 metrics:
   enabled: true

--- a/distribution/kubernetes/README.md
+++ b/distribution/kubernetes/README.md
@@ -11,18 +11,18 @@ rocketmq-rust/proxy:local
 rocketmq-rust/mcp:local
 ```
 
-Every workload sets `imagePullPolicy: Never`. Build with
-`docker buildx build --load` and, when the Kubernetes nodes do not share the
-host Docker image store, load the images with the cluster-specific `kind` or
-`k3d` command. No registry login or remote push is part of this deployment
-mode.
+Every workload sets `imagePullPolicy: Never`. The committed `local` tags are a
+rendering fixture; deployable images use `rocketmq-rust/<service>:<commit>`.
+`scripts/build-production-images.ps1 -Load` builds all five images from a clean
+checkout, records their image and binary digests, and writes a complete local
+`ReleaseState` under `.rocketmq/candidate/`. No registry login or remote push is
+part of this deployment mode.
 
-Service image builds require an explicit non-zero 40-character
-`SOURCE_REVISION`. Capture it once with `git rev-parse HEAD`, use it for every
-Docker build, and pass the same value to Helm as
-`--set-string releaseIdentity.commit=...`. A rollout nonce is also required;
-pass it as `--set-string releaseIdentity.nonce=...`. All five processes reject
-a null or mismatched release identity before readiness.
+`ReleaseState` binds the five images to one configuration digest, Secret
+reference and version, rollout nonce, and storage generation.
+`scripts/set-architecture-release-state.ps1` validates that complete state,
+imports the same image set with Kind or K3d, applies it in policy order, waits
+for readiness, and compensates completed steps in reverse order after failure.
 
 The three `10.96.0.20x` Controller ClusterIPs are example reservations. Replace
 them with unused addresses from the target cluster's Service CIDR before
@@ -63,47 +63,25 @@ endpoints, disabled required persistence, and a non-RocksDB Controller backend.
 
 ## Local validation
 
-Run from the repository root:
+Build and validate a local candidate from the repository root:
 
 ```powershell
-$sourceRevision = (git rev-parse HEAD).Trim()
-$rolloutNonce = $env:ROCKETMQ_ROLLOUT_NONCE
-if (
-  $sourceRevision -notmatch '^[0-9a-f]{40}$' -or
-  $sourceRevision -match '^0{40}$' -or
-  [string]::IsNullOrWhiteSpace($rolloutNonce) -or
-  $rolloutNonce -notmatch '^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$'
-) {
-  throw "A real source revision and canonical ROCKETMQ_ROLLOUT_NONCE are required"
-}
-$releaseIdentityArgs = @(
-  '--set-string', "releaseIdentity.commit=$sourceRevision",
-  '--set-string', "releaseIdentity.nonce=$rolloutNonce"
-)
-
-helm lint .\distribution\helm\rocketmq-rust --strict `
-  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml @releaseIdentityArgs
-helm lint .\distribution\helm\rocketmq-rust --strict `
-  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml @releaseIdentityArgs
-
+.\scripts\build-production-images.ps1 -Load
+.\scripts\set-architecture-release-state.ps1 -ValidateOnly
+helm lint .\distribution\helm\rocketmq-rust --strict
 helm template rocketmq .\distribution\helm\rocketmq-rust `
   --namespace rocketmq `
-  -f .\distribution\helm\rocketmq-rust\values-dev-single.yaml `
-  @releaseIdentityArgs > $null
-helm template rocketmq .\distribution\helm\rocketmq-rust `
-  --namespace rocketmq `
-  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml `
-  @releaseIdentityArgs > $null
+  -f .\distribution\helm\rocketmq-rust\values-production-controller-ha.yaml > $null
 ```
 
-The bare chart defaults intentionally remain fail-closed until deployable
-images, a real release commit, and a rollout nonce are supplied.
+The chart defaults are local validation fixtures. The reconciler replaces the
+complete release identity and every image reference from the validated
+candidate; operators must not deploy the fixture values directly.
 
 To update `base/manifest.yaml`, render the production profile as UTF-8 and
 replace the file only after the local lint and schema checks pass. The committed
-base uses the non-deployable secure rendering fixture's explicit release
-identity; a deployable render must carry the exact revision embedded in its
-service images and a deliberate rollout nonce.
+base remains a non-deployable local rendering fixture. A deployable render must
+come from a complete validated `ReleaseState`.
 
 See `rocketmq-doc/en/01-run-rocketmq-rust-k8s.md` for local image builds,
 installation, upgrade, and recovery procedures.

--- a/distribution/kubernetes/base/manifest.yaml
+++ b/distribution/kubernetes/base/manifest.yaml
@@ -1350,8 +1350,11 @@ spec:
   template:
     metadata:
       annotations:
-        rocketmq.apache.org/release-commit: "698f053f149784be1be1ddda403270b579607089"
-        rocketmq.apache.org/release-nonce: "render-fixture"
+        rocketmq.apache.org/release-commit: "1111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-nonce: "local-validation"
+        rocketmq.apache.org/release-config-digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-secret-version: "local-reference-1"
+        rocketmq.apache.org/storage-generation: "1"
       labels:
         app.kubernetes.io/name: rocketmq-proxy
         app.kubernetes.io/instance: rocketmq
@@ -1407,8 +1410,11 @@ spec:
             - {name: ROCKETMQ_SECURITY_SECRET_PROVIDER, value: "mounted-files"}
             - {name: ROCKETMQ_SECURITY_ADMIN_IDENTITY, value: "/var/run/secrets/rocketmq/admin.identity"}
             - {name: ROCKETMQ_SECURITY_REQUEST_POLICY, value: "/var/run/secrets/rocketmq/request-policy.json"}
-            - {name: ROCKETMQ_RELEASE_COMMIT, value: "698f053f149784be1be1ddda403270b579607089"}
-            - {name: ROCKETMQ_RELEASE_NONCE, value: "render-fixture"}
+            - {name: ROCKETMQ_RELEASE_COMMIT, value: "1111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_NONCE, value: "local-validation"}
+            - {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: "local-reference-1"}
+            - {name: ROCKETMQ_STORAGE_GENERATION, value: "1"}
             - {name: ROCKETMQ_METRICS_ENABLED, value: "true"}
             - {name: ROCKETMQ_METRICS_EXPORTER, value: "prometheus"}
             - {name: ROCKETMQ_METRICS_BIND_ADDR, value: "0.0.0.0:5557"}
@@ -1511,8 +1517,11 @@ spec:
   template:
     metadata:
       annotations:
-        rocketmq.apache.org/release-commit: "698f053f149784be1be1ddda403270b579607089"
-        rocketmq.apache.org/release-nonce: "render-fixture"
+        rocketmq.apache.org/release-commit: "1111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-nonce: "local-validation"
+        rocketmq.apache.org/release-config-digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-secret-version: "local-reference-1"
+        rocketmq.apache.org/storage-generation: "1"
       labels:
         app.kubernetes.io/name: rocketmq-mcp
         app.kubernetes.io/instance: rocketmq
@@ -1549,8 +1558,11 @@ spec:
             - {name: ROCKETMQ_SECURITY_SECRET_PROVIDER, value: "mounted-files"}
             - {name: ROCKETMQ_SECURITY_ADMIN_IDENTITY, value: "/var/run/secrets/rocketmq/admin.identity"}
             - {name: ROCKETMQ_SECURITY_REQUEST_POLICY, value: "/var/run/secrets/rocketmq/request-policy.json"}
-            - {name: ROCKETMQ_RELEASE_COMMIT, value: "698f053f149784be1be1ddda403270b579607089"}
-            - {name: ROCKETMQ_RELEASE_NONCE, value: "render-fixture"}
+            - {name: ROCKETMQ_RELEASE_COMMIT, value: "1111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_NONCE, value: "local-validation"}
+            - {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: "local-reference-1"}
+            - {name: ROCKETMQ_STORAGE_GENERATION, value: "1"}
             - {name: ROCKETMQ_METRICS_ENABLED, value: "true"}
             - {name: ROCKETMQ_METRICS_EXPORTER, value: "prometheus"}
             - {name: ROCKETMQ_METRICS_BIND_ADDR, value: "0.0.0.0:5557"}
@@ -1659,8 +1671,11 @@ spec:
   template:
     metadata:
       annotations:
-        rocketmq.apache.org/release-commit: "698f053f149784be1be1ddda403270b579607089"
-        rocketmq.apache.org/release-nonce: "render-fixture"
+        rocketmq.apache.org/release-commit: "1111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-nonce: "local-validation"
+        rocketmq.apache.org/release-config-digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-secret-version: "local-reference-1"
+        rocketmq.apache.org/storage-generation: "1"
       labels:
         app.kubernetes.io/name: rocketmq-broker
         app.kubernetes.io/instance: rocketmq
@@ -1716,8 +1731,11 @@ spec:
             - {name: ROCKETMQ_SECURITY_SECRET_PROVIDER, value: "mounted-files"}
             - {name: ROCKETMQ_SECURITY_ADMIN_IDENTITY, value: "/var/run/secrets/rocketmq/admin.identity"}
             - {name: ROCKETMQ_SECURITY_REQUEST_POLICY, value: "/var/run/secrets/rocketmq/request-policy.json"}
-            - {name: ROCKETMQ_RELEASE_COMMIT, value: "698f053f149784be1be1ddda403270b579607089"}
-            - {name: ROCKETMQ_RELEASE_NONCE, value: "render-fixture"}
+            - {name: ROCKETMQ_RELEASE_COMMIT, value: "1111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_NONCE, value: "local-validation"}
+            - {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: "local-reference-1"}
+            - {name: ROCKETMQ_STORAGE_GENERATION, value: "1"}
             - {name: ROCKETMQ_METRICS_ENABLED, value: "true"}
             - {name: ROCKETMQ_METRICS_EXPORTER, value: "prometheus"}
             - {name: ROCKETMQ_METRICS_BIND_ADDR, value: "0.0.0.0:5557"}
@@ -1846,8 +1864,11 @@ spec:
   template:
     metadata:
       annotations:
-        rocketmq.apache.org/release-commit: "698f053f149784be1be1ddda403270b579607089"
-        rocketmq.apache.org/release-nonce: "render-fixture"
+        rocketmq.apache.org/release-commit: "1111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-nonce: "local-validation"
+        rocketmq.apache.org/release-config-digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-secret-version: "local-reference-1"
+        rocketmq.apache.org/storage-generation: "1"
       labels:
         app.kubernetes.io/name: rocketmq-namesrv
         app.kubernetes.io/instance: rocketmq
@@ -1903,8 +1924,11 @@ spec:
             - {name: ROCKETMQ_SECURITY_SECRET_PROVIDER, value: "mounted-files"}
             - {name: ROCKETMQ_SECURITY_ADMIN_IDENTITY, value: "/var/run/secrets/rocketmq/admin.identity"}
             - {name: ROCKETMQ_SECURITY_REQUEST_POLICY, value: "/var/run/secrets/rocketmq/request-policy.json"}
-            - {name: ROCKETMQ_RELEASE_COMMIT, value: "698f053f149784be1be1ddda403270b579607089"}
-            - {name: ROCKETMQ_RELEASE_NONCE, value: "render-fixture"}
+            - {name: ROCKETMQ_RELEASE_COMMIT, value: "1111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_NONCE, value: "local-validation"}
+            - {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: "local-reference-1"}
+            - {name: ROCKETMQ_STORAGE_GENERATION, value: "1"}
             - {name: ROCKETMQ_METRICS_ENABLED, value: "true"}
             - {name: ROCKETMQ_METRICS_EXPORTER, value: "prometheus"}
             - {name: ROCKETMQ_METRICS_BIND_ADDR, value: "0.0.0.0:5557"}
@@ -2025,8 +2049,11 @@ spec:
   template:
     metadata:
       annotations:
-        rocketmq.apache.org/release-commit: "698f053f149784be1be1ddda403270b579607089"
-        rocketmq.apache.org/release-nonce: "render-fixture"
+        rocketmq.apache.org/release-commit: "1111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-nonce: "local-validation"
+        rocketmq.apache.org/release-config-digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        rocketmq.apache.org/release-secret-version: "local-reference-1"
+        rocketmq.apache.org/storage-generation: "1"
       labels:
         app.kubernetes.io/name: rocketmq-controller
         app.kubernetes.io/instance: rocketmq
@@ -2090,8 +2117,11 @@ spec:
             - {name: ROCKETMQ_SECURITY_SECRET_PROVIDER, value: "mounted-files"}
             - {name: ROCKETMQ_SECURITY_ADMIN_IDENTITY, value: "/var/run/secrets/rocketmq/admin.identity"}
             - {name: ROCKETMQ_SECURITY_REQUEST_POLICY, value: "/var/run/secrets/rocketmq/request-policy.json"}
-            - {name: ROCKETMQ_RELEASE_COMMIT, value: "698f053f149784be1be1ddda403270b579607089"}
-            - {name: ROCKETMQ_RELEASE_NONCE, value: "render-fixture"}
+            - {name: ROCKETMQ_RELEASE_COMMIT, value: "1111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_NONCE, value: "local-validation"}
+            - {name: ROCKETMQ_RELEASE_CONFIG_DIGEST, value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+            - {name: ROCKETMQ_RELEASE_SECRET_VERSION, value: "local-reference-1"}
+            - {name: ROCKETMQ_STORAGE_GENERATION, value: "1"}
             - {name: ROCKETMQ_METRICS_ENABLED, value: "true"}
             - {name: ROCKETMQ_METRICS_EXPORTER, value: "prometheus"}
             - {name: ROCKETMQ_METRICS_BIND_ADDR, value: "0.0.0.0:5557"}

--- a/distribution/kubernetes/release-state-transition-policy.json
+++ b/distribution/kubernetes/release-state-transition-policy.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "release_state_schema": "distribution/config/release-state.schema.json",
+  "local_images_only": true,
+  "remote_push_enabled": false,
+  "allowed_cluster_kinds": [
+    "kind",
+    "k3d"
+  ],
+  "forbid_image_only_transition": true,
+  "apply_order": [
+    {
+      "step": "validate_complete_state",
+      "compensation": "none"
+    },
+    {
+      "step": "snapshot_before",
+      "compensation": "retain_snapshot"
+    },
+    {
+      "step": "import_local_images",
+      "compensation": "retain_local_images"
+    },
+    {
+      "step": "apply_complete_state",
+      "compensation": "restore_previous_helm_revision"
+    },
+    {
+      "step": "wait_readiness",
+      "compensation": "restore_previous_helm_revision"
+    },
+    {
+      "step": "snapshot_after",
+      "compensation": "retain_snapshot"
+    },
+    {
+      "step": "publish_active_state",
+      "compensation": "restore_previous_active_state"
+    }
+  ],
+  "compensation_order": [
+    "publish_active_state",
+    "snapshot_after",
+    "wait_readiness",
+    "apply_complete_state",
+    "import_local_images",
+    "snapshot_before",
+    "validate_complete_state"
+  ],
+  "readiness": {
+    "timeout": "10m",
+    "workloads": [
+      "statefulset/rocketmq-controller",
+      "statefulset/rocketmq-namesrv",
+      "statefulset/rocketmq-broker",
+      "deployment/rocketmq-proxy",
+      "deployment/rocketmq-mcp"
+    ]
+  },
+  "snapshots": {
+    "include_helm_status": true,
+    "include_workload_status": true,
+    "include_release_state": true,
+    "secret_values_forbidden": true
+  }
+}

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,6 +19,9 @@ ARG RUNTIME_IMAGE=docker.io/library/ubuntu:noble@sha256:4fbb8e6a8395de5a7550b335
 ARG DEBIAN_SNAPSHOT=20260717T000000Z
 ARG ROCKETMQ_RUST_TOOLCHAIN=1.95.0
 ARG SOURCE_REVISION
+ARG CARGO_LOCK_SHA256
+ARG PRODUCTION_FEATURE_PROFILE_SHA256
+ARG RELEASE_CONFIG_SHA256
 
 FROM ${BUILDER_IMAGE} AS ca-bundle
 
@@ -159,11 +162,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/workspace/target,sharing=locked <<EOF
 set -eux
-cargo build --locked --release --package rocketmq-broker --features production-observability --bin rocketmq-broker-rust
-cargo build --locked --release --package rocketmq-namesrv --features production-observability --bin rocketmq-namesrv-rust
-cargo build --locked --release --package rocketmq-controller --features production-observability --bin rocketmq-controller-rust
-cargo build --locked --release --package rocketmq-proxy --features production-observability --bin rocketmq-proxy-rust
-cargo build --locked --release --package rocketmq-mcp --features streamable-http,production-observability --bin rocketmq-mcp
+cargo build --locked --release --package rocketmq-broker --no-default-features --features production --bin rocketmq-broker-rust
+cargo build --locked --release --package rocketmq-namesrv --no-default-features --features production --bin rocketmq-namesrv-rust
+cargo build --locked --release --package rocketmq-controller --no-default-features --features production --bin rocketmq-controller-rust
+cargo build --locked --release --package rocketmq-proxy --no-default-features --features production --bin rocketmq-proxy-rust
+cargo build --locked --release --package rocketmq-mcp --no-default-features --features production --bin rocketmq-mcp
 install -d /opt/rocketmq-binaries
 for binary in \
     rocketmq-broker-rust \
@@ -177,6 +180,12 @@ done
 EOF
 
 FROM runtime-base AS service-runtime
+
+ARG ROCKETMQ_RUST_TOOLCHAIN
+ARG SOURCE_REVISION
+ARG CARGO_LOCK_SHA256
+ARG PRODUCTION_FEATURE_PROFILE_SHA256
+ARG RELEASE_CONFIG_SHA256
 
 USER 0:0
 RUN <<EOF
@@ -195,6 +204,12 @@ ENV HOME=/var/lib/rocketmq \
     ROCKETMQ_HEALTH_BIND_ADDR=0.0.0.0:8088 \
     ROCKETMQ_LIVENESS_STALE_SECONDS=30 \
     ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS=45
+
+LABEL org.opencontainers.image.revision=${SOURCE_REVISION} \
+    io.rocketmq.build.rust-toolchain=${ROCKETMQ_RUST_TOOLCHAIN} \
+    io.rocketmq.build.cargo-lock-sha256=${CARGO_LOCK_SHA256} \
+    io.rocketmq.build.production-feature-profile-sha256=${PRODUCTION_FEATURE_PROFILE_SHA256} \
+    io.rocketmq.release.config-digest=${RELEASE_CONFIG_SHA256}
 
 VOLUME ["/var/lib/rocketmq"]
 USER 10001:10001

--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -52,6 +52,7 @@ otlp-logs        = ["otel-logs", "rocketmq-observability/otlp-logs"]
 prometheus       = ["otel-metrics", "rocketmq-observability/prometheus"]
 metrics-prometheus = ["prometheus"]
 production-observability = ["metrics-prometheus", "otlp-traces", "otlp-logs"]
+production      = ["local_file_store", "production-observability"]
 
 [dependencies]
 rocketmq-store       = { workspace = true }

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -124,6 +124,7 @@ otel-logs = ["rocketmq-observability/otel-logs"]
 otlp-traces = ["otel-traces", "rocketmq-observability/otlp-traces"]
 otlp-logs = ["otel-logs", "rocketmq-observability/otlp-logs"]
 production-observability = ["metrics-prometheus", "otlp-traces", "otlp-logs"]
+production      = ["storage-rocksdb", "production-observability"]
 debug           = []
 
 [[bin]]

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -44,6 +44,7 @@ otel-logs = ["rocketmq-observability/otel-logs"]
 otlp-traces = ["otel-traces", "rocketmq-observability/otlp-traces"]
 otlp-logs = ["otel-logs", "rocketmq-observability/otlp-logs"]
 production-observability = ["metrics-prometheus", "otlp-traces", "otlp-logs"]
+production = ["production-observability"]
 
 [dependencies]
 rocketmq-model         = { workspace = true }

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -48,6 +48,7 @@ otel-logs = ["rocketmq-observability/otel-logs"]
 otlp-traces = ["otel-traces", "rocketmq-observability/otlp-traces"]
 otlp-logs = ["otel-logs", "rocketmq-observability/otlp-logs"]
 production-observability = ["metrics-prometheus", "otlp-traces", "otlp-logs"]
+production = ["cluster-mode", "production-observability"]
 tieredstore = ["local-mode", "rocketmq-proxy-local/tieredstore"]
 
 [dependencies]

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -41,6 +41,7 @@ otel-logs = ["rocketmq-observability/otel-logs"]
 otlp-traces = ["observability", "rocketmq-observability/otlp-traces"]
 otlp-logs = ["otel-logs", "rocketmq-observability/otlp-logs"]
 production-observability = ["metrics-prometheus", "otlp-traces", "otlp-logs"]
+production      = ["read-only", "diagnose", "stdio", "streamable-http", "production-observability"]
 auth            = []
 streamable-http = [
     "rmcp/transport-streamable-http-server",

--- a/scripts/build-production-images.ps1
+++ b/scripts/build-production-images.ps1
@@ -1,0 +1,387 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [switch]$Load,
+    [string]$OutputDirectory = ".rocketmq/candidate",
+    [string]$IdentityNonce = "",
+    [string]$SecretName = "rocketmq-runtime-secrets",
+    [string]$SecretVersion = "local-reference-1",
+    [ValidateRange(1, [long]::MaxValue)]
+    [long]$StorageGeneration = 1,
+    [ValidateSet("none", "kind", "k3d")]
+    [string]$ClusterKind = "none",
+    [string]$ClusterName = "rocketmq"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Executable,
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    & $Executable @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Executable,
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    $output = (& $Executable @Arguments | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+    return $output
+}
+
+function Get-Sha256 {
+    param([Parameter(Mandatory)][string]$Path)
+
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-TextSha256 {
+    param([Parameter(Mandatory)][string]$Text)
+
+    $algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($Text)
+        return [BitConverter]::ToString($algorithm.ComputeHash($bytes)).Replace("-", "").ToLowerInvariant()
+    }
+    finally {
+        $algorithm.Dispose()
+    }
+}
+
+function Write-Json {
+    param(
+        [Parameter(Mandatory)][object]$Value,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 16
+    [System.IO.File]::WriteAllText(
+        $Path,
+        ($json.TrimEnd() + "`n"),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Get-RepositoryRelativePath {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    return [System.IO.Path]::GetRelativePath($Root, $Path).Replace("\", "/")
+}
+
+if (-not $Load) {
+    throw "production images are local-only; invoke this script with -Load"
+}
+
+foreach ($commandName in @("docker", "git")) {
+    if (-not (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+        throw "required command is unavailable: $commandName"
+    }
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$dirty = Invoke-Captured git -C $root status --porcelain --untracked-files=normal
+if (-not [string]::IsNullOrWhiteSpace($dirty)) {
+    throw "production images must be built from a clean checkout"
+}
+
+Invoke-Captured docker info | Out-Null
+Invoke-Captured docker buildx version | Out-Null
+
+$profilePath = Join-Path $root "distribution/config/production-feature-profile.json"
+$containerPolicyPath = Join-Path $root "docker/container-policy.json"
+$dockerfilePath = Join-Path $root "docker/Dockerfile.base"
+$cargoLockPath = Join-Path $root "Cargo.lock"
+$profile = Get-Content -Raw -LiteralPath $profilePath | ConvertFrom-Json
+$containerPolicy = Get-Content -Raw -LiteralPath $containerPolicyPath | ConvertFrom-Json
+
+if ($profile.profile -ne "production" -or -not $profile.build_mode.local_images_only) {
+    throw "production feature profile must require local-only images"
+}
+if ($profile.build_mode.remote_push_enabled) {
+    throw "production feature profile unexpectedly permits a remote push"
+}
+
+$sourceCommit = (Invoke-Captured git -C $root rev-parse HEAD).Trim()
+$shortCommit = (Invoke-Captured git -C $root rev-parse --short HEAD).Trim()
+if ($sourceCommit -notmatch "^[0-9a-f]{40}$" -or $shortCommit -notmatch "^[0-9a-f]{7,12}$") {
+    throw "git returned a non-canonical source revision"
+}
+if ([string]::IsNullOrWhiteSpace($IdentityNonce)) {
+    $IdentityNonce = "local-$shortCommit"
+}
+if ($IdentityNonce -notmatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$") {
+    throw "IdentityNonce must be a canonical 1..=63 character release nonce"
+}
+if ($SecretName -notmatch "^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$") {
+    throw "SecretName must be a canonical Kubernetes object name"
+}
+if ($SecretVersion -notmatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$") {
+    throw "SecretVersion must be an opaque 1..=128 character version identifier"
+}
+if ($ClusterName -notmatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$") {
+    throw "ClusterName must be a canonical local cluster name"
+}
+
+$outputPath = if ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+    [System.IO.Path]::GetFullPath($OutputDirectory)
+}
+else {
+    [System.IO.Path]::GetFullPath((Join-Path $root $OutputDirectory))
+}
+$rootPrefix = $root.TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+if (-not $outputPath.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDirectory must remain inside the repository so artifact paths stay portable"
+}
+New-Item -ItemType Directory -Force -Path $outputPath | Out-Null
+
+$configFiles = @($profile.config_bundle_files)
+$configEntries = [System.Collections.Generic.List[object]]::new()
+foreach ($relativePath in $configFiles) {
+    if (
+        [System.IO.Path]::IsPathRooted($relativePath) -or
+        $relativePath.Replace("\", "/").Split("/") -contains ".."
+    ) {
+        throw "configuration bundle path must be repository-relative: $relativePath"
+    }
+    $absolutePath = Join-Path $root $relativePath
+    if (-not (Test-Path -LiteralPath $absolutePath -PathType Leaf)) {
+        throw "configuration bundle file is missing: $relativePath"
+    }
+    $configEntries.Add([ordered]@{
+        path = $relativePath.Replace("\", "/")
+        sha256 = Get-Sha256 $absolutePath
+    })
+}
+$configManifest = (@($configEntries) | ForEach-Object { "$($_.sha256)  $($_.path)" }) -join "`n"
+$configDigest = "sha256:" + (Get-TextSha256 ($configManifest + "`n"))
+$cargoLockSha256 = Get-Sha256 $cargoLockPath
+$featureProfileSha256 = Get-Sha256 $profilePath
+$rustToolchain = [string]$containerPolicy.build.rust_toolchain
+$releaseId = "$shortCommit-$IdentityNonce"
+$generatedAt = [DateTimeOffset]::UtcNow.ToString("o")
+$sourceVersion = "1.0.0-$shortCommit"
+$imageEvidence = [System.Collections.Generic.List[object]]::new()
+
+foreach ($serviceProperty in $profile.services.PSObject.Properties) {
+    $serviceName = $serviceProperty.Name
+    $service = $serviceProperty.Value
+    $imageReference = "rocketmq-rust/$serviceName`:$shortCommit"
+
+    Write-Host "==> Building local production image $imageReference"
+    Invoke-Checked docker buildx build `
+        --load `
+        --file $dockerfilePath `
+        --target $service.docker_target `
+        --tag $imageReference `
+        --build-arg "SOURCE_REVISION=$sourceCommit" `
+        --build-arg "SOURCE_VERSION=$sourceVersion" `
+        --build-arg "CARGO_LOCK_SHA256=$cargoLockSha256" `
+        --build-arg "PRODUCTION_FEATURE_PROFILE_SHA256=$featureProfileSha256" `
+        --build-arg "RELEASE_CONFIG_SHA256=$configDigest" `
+        $root
+
+    $inspect = Invoke-Captured docker image inspect --format "{{json .}}" $imageReference |
+        ConvertFrom-Json
+    $imageId = [string]$inspect.Id
+    if ($imageId -notmatch "^sha256:[0-9a-f]{64}$") {
+        throw "$serviceName image has a non-canonical image ID: $imageId"
+    }
+    $labels = $inspect.Config.Labels
+    $expectedLabels = [ordered]@{
+        "org.opencontainers.image.revision" = $sourceCommit
+        "io.rocketmq.build.rust-toolchain" = $rustToolchain
+        "io.rocketmq.build.cargo-lock-sha256" = $cargoLockSha256
+        "io.rocketmq.build.production-feature-profile-sha256" = $featureProfileSha256
+        "io.rocketmq.release.config-digest" = $configDigest
+    }
+    foreach ($label in $expectedLabels.GetEnumerator()) {
+        $property = $labels.PSObject.Properties[$label.Key]
+        if ($null -eq $property -or [string]$property.Value -ne $label.Value) {
+            throw "$serviceName image label mismatch: $($label.Key)"
+        }
+    }
+
+    $binaryPath = "/usr/local/bin/$($service.binary)"
+    $binaryHashOutput = Invoke-Captured docker run --rm --entrypoint sha256sum $imageReference $binaryPath
+    $binarySha256 = ($binaryHashOutput -split "\s+")[0].ToLowerInvariant()
+    if ($binarySha256 -notmatch "^[0-9a-f]{64}$") {
+        throw "$serviceName binary returned a non-canonical SHA-256 digest"
+    }
+
+    $packageOutput = Invoke-Captured docker run --rm --entrypoint dpkg-query $imageReference `
+        -W '-f=${Package}\t${Version}\t${Architecture}\n'
+    $components = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in ($packageOutput -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        $fields = $line -split "`t", 3
+        if ($fields.Count -ne 3) {
+            throw "$serviceName returned an invalid dpkg-query row"
+        }
+        $components.Add([ordered]@{
+            type = "library"
+            name = $fields[0]
+            version = $fields[1]
+            purl = "pkg:deb/ubuntu/$($fields[0])@$([Uri]::EscapeDataString($fields[1]))?arch=$($fields[2])"
+        })
+    }
+    $components = @($components | Sort-Object name, version)
+
+    $sbom = [ordered]@{
+        bomFormat = "CycloneDX"
+        specVersion = "1.6"
+        serialNumber = "urn:uuid:$([Guid]::NewGuid())"
+        version = 1
+        metadata = [ordered]@{
+            timestamp = $generatedAt
+            component = [ordered]@{
+                type = "application"
+                name = $service.package
+                version = $sourceVersion
+                hashes = @(
+                    [ordered]@{
+                        alg = "SHA-256"
+                        content = $binarySha256
+                    }
+                )
+            }
+            properties = @(
+                [ordered]@{ name = "rocketmq:source-commit"; value = $sourceCommit }
+                [ordered]@{ name = "rocketmq:image-reference"; value = $imageReference }
+                [ordered]@{ name = "rocketmq:config-digest"; value = $configDigest }
+            )
+        }
+        components = $components
+    }
+    $sbomPath = Join-Path $outputPath "$serviceName.cdx.json"
+    Write-Json -Value $sbom -Path $sbomPath
+
+    $imageEvidence.Add([ordered]@{
+        service = $serviceName
+        reference = $imageReference
+        image_id = $imageId
+        image_config_digest = $imageId
+        binary_sha256 = $binarySha256
+        resolved_features = @($service.resolved_features)
+        sbom_path = Get-RepositoryRelativePath -Root $root -Path $sbomPath
+        sbom_sha256 = Get-Sha256 $sbomPath
+    })
+}
+
+$provenance = [ordered]@{
+    schema_version = 1
+    release_id = $releaseId
+    generated_at = $generatedAt
+    source_commit = $sourceCommit
+    rust_toolchain = $rustToolchain
+    cargo_lock_sha256 = $cargoLockSha256
+    feature_profile_sha256 = $featureProfileSha256
+    config_digest = $configDigest
+    local_only = $true
+    remote_push_performed = $false
+    images = @($imageEvidence)
+}
+$provenancePath = Join-Path $outputPath "provenance.json"
+Write-Json -Value $provenance -Path $provenancePath
+$provenanceSha256 = Get-Sha256 $provenancePath
+$provenanceRelativePath = Get-RepositoryRelativePath -Root $root -Path $provenancePath
+
+$images = [ordered]@{}
+foreach ($evidence in $imageEvidence) {
+    $images[$evidence.service] = [ordered]@{
+        service = $evidence.service
+        reference = $evidence.reference
+        image_id = $evidence.image_id
+        image_config_digest = $evidence.image_config_digest
+        binary_sha256 = $evidence.binary_sha256
+        source_commit = $sourceCommit
+        rust_toolchain = $rustToolchain
+        cargo_lock_sha256 = $cargoLockSha256
+        feature_profile_sha256 = $featureProfileSha256
+        resolved_features = @($evidence.resolved_features)
+        config_digest = $configDigest
+        sbom = [ordered]@{
+            path = $evidence.sbom_path
+            sha256 = $evidence.sbom_sha256
+            format = "cyclonedx-1.6-json"
+        }
+        provenance = [ordered]@{
+            path = $provenanceRelativePath
+            sha256 = $provenanceSha256
+            format = "rocketmq-local-provenance-v1"
+        }
+    }
+}
+
+$releaseState = [ordered]@{
+    schema_version = 1
+    release_id = $releaseId
+    created_at = $generatedAt
+    source_commit = $sourceCommit
+    images = $images
+    config_bundle = [ordered]@{
+        digest = $configDigest
+        files = @($configEntries)
+        helm_values = "distribution/helm/rocketmq-rust/values-production-controller-ha.yaml"
+        config_map_template = "distribution/helm/rocketmq-rust/templates/configmaps.yaml"
+        schema = "distribution/config/release-state.schema.json"
+    }
+    secret_references = @(
+        [ordered]@{
+            name = $SecretName
+            namespace = "rocketmq"
+            provider = "kubernetes"
+            version = $SecretVersion
+            mount_path = "/var/run/secrets/rocketmq"
+        }
+    )
+    identity = [ordered]@{
+        commit = $sourceCommit
+        nonce = $IdentityNonce
+        config_digest = $configDigest
+        secret_version = $SecretVersion
+        storage_generation = $StorageGeneration
+    }
+    storage_generation = $StorageGeneration
+    cluster_import = [ordered]@{
+        kind = $ClusterKind
+        name = $ClusterName
+    }
+}
+$releaseStatePath = Join-Path $outputPath "release-state.json"
+Write-Json -Value $releaseState -Path $releaseStatePath
+
+Write-Host "PRODUCTION_IMAGES_OK services=$($imageEvidence.Count) release_state=$releaseStatePath"

--- a/scripts/build-production-images.ps1
+++ b/scripts/build-production-images.ps1
@@ -97,7 +97,16 @@ function Get-RepositoryRelativePath {
         [Parameter(Mandatory)][string]$Path
     )
 
-    return [System.IO.Path]::GetRelativePath($Root, $Path).Replace("\", "/")
+    $rootPath = [System.IO.Path]::GetFullPath($Root).TrimEnd("\", "/") +
+        [System.IO.Path]::DirectorySeparatorChar
+    $artifactPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not $artifactPath.StartsWith($rootPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "release artifact must remain under the repository root: $artifactPath"
+    }
+
+    $rootUri = [System.Uri]::new($rootPath)
+    $artifactUri = [System.Uri]::new($artifactPath)
+    return [System.Uri]::UnescapeDataString($rootUri.MakeRelativeUri($artifactUri).ToString())
 }
 
 if (-not $Load) {

--- a/scripts/build-production-images.ps1
+++ b/scripts/build-production-images.ps1
@@ -240,8 +240,15 @@ foreach ($serviceProperty in $profile.services.PSObject.Properties) {
         throw "$serviceName binary returned a non-canonical SHA-256 digest"
     }
 
-    $packageOutput = Invoke-Captured docker run --rm --entrypoint dpkg-query $imageReference `
-        -W '-f=${Package}\t${Version}\t${Architecture}\n'
+    $packageOutput = Invoke-Captured -Executable docker -Arguments @(
+        "run",
+        "--rm",
+        "--entrypoint",
+        "dpkg-query",
+        $imageReference,
+        "-W",
+        '-f=${Package}\t${Version}\t${Architecture}\n'
+    )
     $components = [System.Collections.Generic.List[object]]::new()
     foreach ($line in ($packageOutput -split "`r?`n")) {
         if ([string]::IsNullOrWhiteSpace($line)) {

--- a/scripts/set-architecture-release-state.ps1
+++ b/scripts/set-architecture-release-state.ps1
@@ -1,0 +1,709 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding(DefaultParameterSetName = "Validate")]
+param(
+    [string]$StatePath = ".rocketmq/candidate/release-state.json",
+    [Parameter(ParameterSetName = "Validate")]
+    [switch]$ValidateOnly,
+    [Parameter(ParameterSetName = "Validate")]
+    [switch]$SchemaOnly,
+    [Parameter(Mandatory, ParameterSetName = "Apply")]
+    [switch]$Apply,
+    [Parameter(ParameterSetName = "Apply")]
+    [string]$ReleaseName = "rocketmq",
+    [Parameter(ParameterSetName = "Apply")]
+    [string]$Namespace = "rocketmq"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Executable,
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    & $Executable @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Executable,
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Arguments
+    )
+
+    $output = (& $Executable @Arguments | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+    return $output
+}
+
+function Get-Sha256 {
+    param([Parameter(Mandatory)][string]$Path)
+
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-TextSha256 {
+    param([Parameter(Mandatory)][string]$Text)
+
+    $algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($Text)
+        return [BitConverter]::ToString($algorithm.ComputeHash($bytes)).Replace("-", "").ToLowerInvariant()
+    }
+    finally {
+        $algorithm.Dispose()
+    }
+}
+
+function Write-Json {
+    param(
+        [Parameter(Mandatory)][object]$Value,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 20
+    [System.IO.File]::WriteAllText(
+        $Path,
+        ($json.TrimEnd() + "`n"),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Assert-ExactProperties {
+    param(
+        [Parameter(Mandatory)][object]$Value,
+        [Parameter(Mandatory)][string[]]$Names,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    if ($null -eq $Value) {
+        throw "$Context must be an object"
+    }
+    $actual = @($Value.PSObject.Properties.Name | Sort-Object)
+    $expected = @($Names | Sort-Object)
+    if (($actual -join "`n") -ne ($expected -join "`n")) {
+        throw "$Context properties must be exactly: $($expected -join ', ')"
+    }
+}
+
+function Assert-Digest {
+    param(
+        [Parameter(Mandatory)][string]$Value,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    if ($Value -notmatch "^sha256:[0-9a-f]{64}$") {
+        throw "$Context must be a lowercase SHA-256 digest"
+    }
+}
+
+function Assert-Sha256 {
+    param(
+        [Parameter(Mandatory)][string]$Value,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    if ($Value -notmatch "^[0-9a-f]{64}$") {
+        throw "$Context must be a lowercase SHA-256 hash"
+    }
+}
+
+function Resolve-RepositoryPath {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$RelativePath,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    $normalized = $RelativePath.Replace("\", "/")
+    if (
+        [System.IO.Path]::IsPathRooted($RelativePath) -or
+        $normalized.Split("/") -contains ".." -or
+        $normalized -notmatch "^[A-Za-z0-9._/-]+$"
+    ) {
+        throw "$Context must be a safe repository-relative path"
+    }
+    $resolved = [System.IO.Path]::GetFullPath((Join-Path $Root $normalized))
+    $prefix = $Root.TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $resolved.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Context escapes the repository"
+    }
+    return $resolved
+}
+
+function Assert-Artifact {
+    param(
+        [Parameter(Mandatory)][object]$Artifact,
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Context,
+        [switch]$RequireFormat
+    )
+
+    $properties = if ($RequireFormat) { @("path", "sha256", "format") } else { @("path", "sha256") }
+    Assert-ExactProperties -Value $Artifact -Names $properties -Context $Context
+    Assert-Sha256 -Value ([string]$Artifact.sha256) -Context "$Context.sha256"
+    $artifactPath = Resolve-RepositoryPath -Root $Root -RelativePath ([string]$Artifact.path) -Context "$Context.path"
+    if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
+        throw "$Context is missing: $($Artifact.path)"
+    }
+    $actualHash = Get-Sha256 $artifactPath
+    if ($actualHash -ne $Artifact.sha256) {
+        throw "$Context hash mismatch"
+    }
+    return $artifactPath
+}
+
+function Get-OptionalHelmStatus {
+    param(
+        [Parameter(Mandatory)][string]$Helm,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$TargetNamespace
+    )
+
+    $output = & $Helm status $Name --namespace $TargetNamespace --output json 2>$null | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    return $output.Trim() | ConvertFrom-Json
+}
+
+function New-ClusterSnapshot {
+    param(
+        [Parameter(Mandatory)][string]$Helm,
+        [Parameter(Mandatory)][string]$Kubectl,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$TargetNamespace,
+        [Parameter(Mandatory)][string]$Phase,
+        [Parameter(Mandatory)][object]$ReleaseState
+    )
+
+    $helmStatus = Get-OptionalHelmStatus -Helm $Helm -Name $Name -TargetNamespace $TargetNamespace
+    $workloadOutput = & $Kubectl get statefulsets,deployments,pods `
+        --namespace $TargetNamespace `
+        --selector app.kubernetes.io/instance=$Name `
+        --output json 2>$null | Out-String
+    $workloads = if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($workloadOutput)) {
+        $workloadOutput.Trim() | ConvertFrom-Json
+    }
+    else {
+        [ordered]@{
+            apiVersion = "v1"
+            kind = "List"
+            items = @()
+        }
+    }
+    return [ordered]@{
+        schema_version = 1
+        captured_at = [DateTimeOffset]::UtcNow.ToString("o")
+        phase = $Phase
+        release_id = $ReleaseState.release_id
+        helm_status = $helmStatus
+        workloads = $workloads
+    }
+}
+
+if ($SchemaOnly -and -not $ValidateOnly) {
+    throw "-SchemaOnly is valid only with -ValidateOnly"
+}
+if (-not $ValidateOnly -and -not $Apply) {
+    throw "specify -ValidateOnly or the explicit mutating switch -Apply"
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$resolvedStatePath = if ([System.IO.Path]::IsPathRooted($StatePath)) {
+    [System.IO.Path]::GetFullPath($StatePath)
+}
+else {
+    [System.IO.Path]::GetFullPath((Join-Path $root $StatePath))
+}
+if (-not (Test-Path -LiteralPath $resolvedStatePath -PathType Leaf)) {
+    throw "ReleaseState is missing: $resolvedStatePath"
+}
+
+$rawState = Get-Content -Raw -LiteralPath $resolvedStatePath
+if ($rawState -match "(?i)BEGIN [A-Z ]*PRIVATE KEY") {
+    throw "ReleaseState contains private key material"
+}
+if ($rawState -match '(?i)"(?:password|token|secret_value|client_secret|private_key)"\s*:') {
+    throw "ReleaseState contains a forbidden Secret field"
+}
+$state = $rawState | ConvertFrom-Json
+$profilePath = Join-Path $root "distribution/config/production-feature-profile.json"
+$policyPath = Join-Path $root "distribution/kubernetes/release-state-transition-policy.json"
+$profile = Get-Content -Raw -LiteralPath $profilePath | ConvertFrom-Json
+$policy = Get-Content -Raw -LiteralPath $policyPath | ConvertFrom-Json
+
+Assert-ExactProperties -Value $state -Names @(
+    "schema_version",
+    "release_id",
+    "created_at",
+    "source_commit",
+    "images",
+    "config_bundle",
+    "secret_references",
+    "identity",
+    "storage_generation",
+    "cluster_import"
+) -Context "ReleaseState"
+if ($state.schema_version -ne 1) {
+    throw "ReleaseState.schema_version must be 1"
+}
+if ($state.release_id -notmatch "^[a-z0-9][a-z0-9._-]{0,127}$") {
+    throw "ReleaseState.release_id is not canonical"
+}
+$createdAt = [DateTimeOffset]::MinValue
+if (-not [DateTimeOffset]::TryParse([string]$state.created_at, [ref]$createdAt)) {
+    throw "ReleaseState.created_at must be an RFC 3339 timestamp"
+}
+if ($state.source_commit -notmatch "^[0-9a-f]{40}$" -or $state.source_commit -eq ("0" * 40)) {
+    throw "ReleaseState.source_commit must be a non-zero lowercase commit"
+}
+if ([long]$state.storage_generation -lt 1) {
+    throw "ReleaseState.storage_generation must be at least 1"
+}
+
+Assert-ExactProperties -Value $state.identity -Names @(
+    "commit",
+    "nonce",
+    "config_digest",
+    "secret_version",
+    "storage_generation"
+) -Context "ReleaseState.identity"
+if ($state.identity.commit -ne $state.source_commit) {
+    throw "ReleaseState identity commit must match source_commit"
+}
+if ($state.identity.nonce -notmatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$") {
+    throw "ReleaseState identity nonce is not canonical"
+}
+Assert-Digest -Value ([string]$state.identity.config_digest) -Context "ReleaseState.identity.config_digest"
+if ($state.identity.secret_version -notmatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$") {
+    throw "ReleaseState identity Secret version is not canonical"
+}
+if ([long]$state.identity.storage_generation -ne [long]$state.storage_generation) {
+    throw "ReleaseState identity storage generation must match storage_generation"
+}
+
+Assert-ExactProperties -Value $state.cluster_import -Names @("kind", "name") -Context "ReleaseState.cluster_import"
+if ($state.cluster_import.kind -notin @("none", "kind", "k3d")) {
+    throw "ReleaseState cluster import kind must be none, kind, or k3d"
+}
+if ($state.cluster_import.name -notmatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$") {
+    throw "ReleaseState cluster import name is not canonical"
+}
+
+$secretReferences = @($state.secret_references)
+if ($secretReferences.Count -ne 1) {
+    throw "ReleaseState must contain exactly one chart Secret reference"
+}
+$secretReference = $secretReferences[0]
+Assert-ExactProperties -Value $secretReference -Names @(
+    "name",
+    "namespace",
+    "provider",
+    "version",
+    "mount_path"
+) -Context "ReleaseState.secret_references[0]"
+if ($secretReference.name -notmatch "^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$") {
+    throw "Secret reference name is not canonical"
+}
+if ($secretReference.namespace -notmatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$") {
+    throw "Secret reference namespace is not canonical"
+}
+if ($secretReference.provider -notin @("kubernetes", "external-secrets", "secrets-store-csi")) {
+    throw "Secret reference provider is unsupported"
+}
+if ($secretReference.version -ne $state.identity.secret_version) {
+    throw "Secret reference version must match the release identity"
+}
+if ($secretReference.mount_path -ne "/var/run/secrets/rocketmq") {
+    throw "Secret reference mount_path must use the hardened runtime location"
+}
+
+Assert-ExactProperties -Value $state.config_bundle -Names @(
+    "digest",
+    "files",
+    "helm_values",
+    "config_map_template",
+    "schema"
+) -Context "ReleaseState.config_bundle"
+Assert-Digest -Value ([string]$state.config_bundle.digest) -Context "ReleaseState.config_bundle.digest"
+if ($state.config_bundle.digest -ne $state.identity.config_digest) {
+    throw "configuration bundle digest must match release identity"
+}
+$expectedConfigPaths = @($profile.config_bundle_files)
+$configFiles = @($state.config_bundle.files)
+$actualConfigPaths = @($configFiles | ForEach-Object { [string]$_.path })
+if (($actualConfigPaths -join "`n") -ne ($expectedConfigPaths -join "`n")) {
+    throw "ReleaseState configuration bundle must contain the complete production file set"
+}
+$configEntries = [System.Collections.Generic.List[object]]::new()
+foreach ($entry in $configFiles) {
+    Assert-ExactProperties -Value $entry -Names @("path", "sha256") -Context "ReleaseState.config_bundle.files"
+    Assert-Sha256 -Value ([string]$entry.sha256) -Context "configuration file hash"
+    $configPath = Resolve-RepositoryPath -Root $root -RelativePath ([string]$entry.path) -Context "configuration file path"
+    if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        throw "configuration bundle file is missing: $($entry.path)"
+    }
+    $actualHash = Get-Sha256 $configPath
+    if ($actualHash -ne $entry.sha256) {
+        throw "configuration bundle file hash mismatch: $($entry.path)"
+    }
+    $configEntries.Add([ordered]@{
+        path = [string]$entry.path
+        sha256 = $actualHash
+    })
+}
+$configManifest = (@($configEntries) | ForEach-Object { "$($_.sha256)  $($_.path)" }) -join "`n"
+$actualConfigDigest = "sha256:" + (Get-TextSha256 ($configManifest + "`n"))
+if ($actualConfigDigest -ne $state.config_bundle.digest) {
+    throw "configuration bundle aggregate digest mismatch"
+}
+foreach ($pathField in @("helm_values", "config_map_template", "schema")) {
+    $path = Resolve-RepositoryPath `
+        -Root $root `
+        -RelativePath ([string]$state.config_bundle.$pathField) `
+        -Context "ReleaseState.config_bundle.$pathField"
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "ReleaseState.config_bundle.$pathField is missing"
+    }
+}
+
+$services = @("broker", "namesrv", "controller", "proxy", "mcp")
+Assert-ExactProperties -Value $state.images -Names $services -Context "ReleaseState.images"
+$featureProfileSha256 = Get-Sha256 $profilePath
+$provenancePaths = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal
+)
+foreach ($serviceName in $services) {
+    $image = $state.images.$serviceName
+    Assert-ExactProperties -Value $image -Names @(
+        "service",
+        "reference",
+        "image_id",
+        "image_config_digest",
+        "binary_sha256",
+        "source_commit",
+        "rust_toolchain",
+        "cargo_lock_sha256",
+        "feature_profile_sha256",
+        "resolved_features",
+        "config_digest",
+        "sbom",
+        "provenance"
+    ) -Context "ReleaseState.images.$serviceName"
+    if ($image.service -ne $serviceName) {
+        throw "$serviceName image owner mismatch"
+    }
+    if ($image.reference -notmatch "^rocketmq-rust/$serviceName`:[0-9a-f]{7,12}$") {
+        throw "$serviceName image reference must be a local commit tag"
+    }
+    Assert-Digest -Value ([string]$image.image_id) -Context "$serviceName image_id"
+    Assert-Digest -Value ([string]$image.image_config_digest) -Context "$serviceName image_config_digest"
+    Assert-Sha256 -Value ([string]$image.binary_sha256) -Context "$serviceName binary_sha256"
+    Assert-Sha256 -Value ([string]$image.cargo_lock_sha256) -Context "$serviceName cargo_lock_sha256"
+    Assert-Sha256 -Value ([string]$image.feature_profile_sha256) -Context "$serviceName feature_profile_sha256"
+    Assert-Digest -Value ([string]$image.config_digest) -Context "$serviceName config_digest"
+    if (
+        $image.source_commit -ne $state.source_commit -or
+        $image.config_digest -ne $state.config_bundle.digest -or
+        $image.feature_profile_sha256 -ne $featureProfileSha256
+    ) {
+        throw "$serviceName image metadata is not bound to the complete ReleaseState"
+    }
+    $expectedFeatures = @($profile.services.$serviceName.resolved_features | Sort-Object)
+    $actualFeatures = @($image.resolved_features | Sort-Object)
+    if (($actualFeatures -join "`n") -ne ($expectedFeatures -join "`n")) {
+        throw "$serviceName resolved production features drifted"
+    }
+    $sbomPath = Assert-Artifact `
+        -Artifact $image.sbom `
+        -Root $root `
+        -Context "$serviceName SBOM" `
+        -RequireFormat
+    $sbom = Get-Content -Raw -LiteralPath $sbomPath | ConvertFrom-Json
+    if ($sbom.bomFormat -ne "CycloneDX" -or $sbom.specVersion -ne "1.6") {
+        throw "$serviceName SBOM must be CycloneDX 1.6 JSON"
+    }
+    $provenancePath = Assert-Artifact `
+        -Artifact $image.provenance `
+        -Root $root `
+        -Context "$serviceName provenance" `
+        -RequireFormat
+    [void]$provenancePaths.Add($provenancePath)
+
+    if (-not $SchemaOnly) {
+        if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+            throw "docker is required for full ReleaseState validation"
+        }
+        $actualImageId = (Invoke-Captured docker image inspect --format "{{.Id}}" $image.reference).Trim()
+        if ($actualImageId -ne $image.image_id -or $actualImageId -ne $image.image_config_digest) {
+            throw "$serviceName local image identity drifted"
+        }
+        $labels = Invoke-Captured docker image inspect --format "{{json .Config.Labels}}" $image.reference |
+            ConvertFrom-Json
+        $expectedLabels = [ordered]@{
+            "org.opencontainers.image.revision" = $state.source_commit
+            "io.rocketmq.build.rust-toolchain" = $image.rust_toolchain
+            "io.rocketmq.build.cargo-lock-sha256" = $image.cargo_lock_sha256
+            "io.rocketmq.build.production-feature-profile-sha256" = $featureProfileSha256
+            "io.rocketmq.release.config-digest" = $state.config_bundle.digest
+        }
+        foreach ($label in $expectedLabels.GetEnumerator()) {
+            $property = $labels.PSObject.Properties[$label.Key]
+            if ($null -eq $property -or [string]$property.Value -ne $label.Value) {
+                throw "$serviceName image label mismatch: $($label.Key)"
+            }
+        }
+        $binary = [string]$profile.services.$serviceName.binary
+        $hashOutput = Invoke-Captured docker run --rm --entrypoint sha256sum `
+            $image.reference "/usr/local/bin/$binary"
+        if (($hashOutput -split "\s+")[0].ToLowerInvariant() -ne $image.binary_sha256) {
+            throw "$serviceName binary digest drifted"
+        }
+    }
+}
+if ($provenancePaths.Count -ne 1) {
+    throw "all five images must share one complete provenance statement"
+}
+$provenancePath = @($provenancePaths)[0]
+$provenance = Get-Content -Raw -LiteralPath $provenancePath | ConvertFrom-Json
+if (
+    $provenance.schema_version -ne 1 -or
+    $provenance.source_commit -ne $state.source_commit -or
+    $provenance.config_digest -ne $state.config_bundle.digest -or
+    -not $provenance.local_only -or
+    $provenance.remote_push_performed -or
+    @($provenance.images).Count -ne 5
+) {
+    throw "combined image provenance is incomplete or permits remote publication"
+}
+
+$policySteps = @($policy.apply_order | ForEach-Object { [string]$_.step })
+$expectedSteps = @(
+    "validate_complete_state",
+    "snapshot_before",
+    "import_local_images",
+    "apply_complete_state",
+    "wait_readiness",
+    "snapshot_after",
+    "publish_active_state"
+)
+if (($policySteps -join "`n") -ne ($expectedSteps -join "`n")) {
+    throw "release-state transition apply order drifted"
+}
+$expectedCompensation = @($expectedSteps)
+[array]::Reverse($expectedCompensation)
+if ((@($policy.compensation_order) -join "`n") -ne ($expectedCompensation -join "`n")) {
+    throw "release-state transition compensation order must reverse apply order"
+}
+if (-not $policy.local_images_only -or $policy.remote_push_enabled -or -not $policy.forbid_image_only_transition) {
+    throw "release-state transition policy must remain local-only and reject image-only transitions"
+}
+
+if ($ValidateOnly) {
+    $mode = if ($SchemaOnly) { "schema" } else { "complete" }
+    Write-Host "RELEASE_STATE_VALIDATION_OK mode=$mode release_id=$($state.release_id)"
+    exit 0
+}
+
+if ($state.cluster_import.kind -notin @("kind", "k3d")) {
+    throw "applying a ReleaseState requires cluster_import.kind kind or k3d"
+}
+if ($secretReference.provider -ne "kubernetes") {
+    throw "the Helm reconciler currently requires a Kubernetes Secret reference"
+}
+if ($secretReference.namespace -ne $Namespace) {
+    throw "the Secret reference namespace must match the Helm release namespace"
+}
+foreach ($commandName in @("helm", "kubectl", $state.cluster_import.kind)) {
+    if (-not (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+        throw "required reconcile command is unavailable: $commandName"
+    }
+}
+
+$helm = (Get-Command helm).Source
+$kubectl = (Get-Command kubectl).Source
+$chartPath = Join-Path $root "distribution/helm/rocketmq-rust"
+$valuesPath = Resolve-RepositoryPath `
+    -Root $root `
+    -RelativePath ([string]$state.config_bundle.helm_values) `
+    -Context "ReleaseState.config_bundle.helm_values"
+$snapshotRoot = Join-Path $root ".rocketmq/snapshots/$($state.release_id)"
+$activeRoot = Join-Path $root ".rocketmq/active"
+New-Item -ItemType Directory -Force -Path $snapshotRoot, $activeRoot | Out-Null
+$activeStatePath = Join-Path $activeRoot "release-state.json"
+$previousActiveStatePath = Join-Path $snapshotRoot "previous-active-release-state.json"
+if (Test-Path -LiteralPath $activeStatePath) {
+    Copy-Item -LiteralPath $activeStatePath -Destination $previousActiveStatePath -Force
+}
+
+$completedSteps = [System.Collections.Generic.List[string]]::new()
+$previousHelmStatus = Get-OptionalHelmStatus `
+    -Helm $helm `
+    -Name $ReleaseName `
+    -TargetNamespace $Namespace
+$previousRevision = if ($null -eq $previousHelmStatus) {
+    0
+}
+else {
+    [int]$previousHelmStatus.version
+}
+$helmRestored = $false
+
+try {
+    $completedSteps.Add("validate_complete_state")
+
+    $before = New-ClusterSnapshot `
+        -Helm $helm `
+        -Kubectl $kubectl `
+        -Name $ReleaseName `
+        -TargetNamespace $Namespace `
+        -Phase "before" `
+        -ReleaseState $state
+    Write-Json -Value $before -Path (Join-Path $snapshotRoot "before.json")
+    $completedSteps.Add("snapshot_before")
+
+    $imageReferences = @($services | ForEach-Object { [string]$state.images.$_.reference })
+    if ($state.cluster_import.kind -eq "kind") {
+        Invoke-Checked kind load docker-image @imageReferences --name $state.cluster_import.name
+    }
+    else {
+        Invoke-Checked k3d image import @imageReferences --cluster $state.cluster_import.name
+    }
+    $completedSteps.Add("import_local_images")
+
+    $helmArguments = [System.Collections.Generic.List[string]]::new()
+    foreach ($argument in @(
+        "upgrade",
+        "--install",
+        $ReleaseName,
+        $chartPath,
+        "--namespace",
+        $Namespace,
+        "--create-namespace",
+        "--values",
+        $valuesPath,
+        "--set-string",
+        "releaseIdentity.commit=$($state.identity.commit)",
+        "--set-string",
+        "releaseIdentity.nonce=$($state.identity.nonce)",
+        "--set-string",
+        "releaseIdentity.configDigest=$($state.identity.config_digest)",
+        "--set-string",
+        "releaseIdentity.secretVersion=$($state.identity.secret_version)",
+        "--set",
+        "releaseIdentity.storageGeneration=$($state.storage_generation)",
+        "--set-string",
+        "global.secretRefs.existingSecret=$($secretReference.name)"
+    )) {
+        $helmArguments.Add([string]$argument)
+    }
+    foreach ($serviceName in $services) {
+        $reference = [string]$state.images.$serviceName.reference
+        $separator = $reference.LastIndexOf(":")
+        $repository = $reference.Substring(0, $separator)
+        $tag = $reference.Substring($separator + 1)
+        foreach ($argument in @(
+            "--set-string",
+            "services.$serviceName.image.repository=$repository",
+            "--set-string",
+            "services.$serviceName.image.tag=$tag",
+            "--set-string",
+            "services.$serviceName.image.digest=",
+            "--set-string",
+            "services.$serviceName.image.pullPolicy=Never"
+        )) {
+            $helmArguments.Add([string]$argument)
+        }
+    }
+    Invoke-Checked $helm @helmArguments
+    $completedSteps.Add("apply_complete_state")
+
+    foreach ($workload in @($policy.readiness.workloads)) {
+        Invoke-Checked $kubectl rollout status `
+            $workload `
+            --namespace $Namespace `
+            "--timeout=$($policy.readiness.timeout)"
+    }
+    $completedSteps.Add("wait_readiness")
+
+    $after = New-ClusterSnapshot `
+        -Helm $helm `
+        -Kubectl $kubectl `
+        -Name $ReleaseName `
+        -TargetNamespace $Namespace `
+        -Phase "after" `
+        -ReleaseState $state
+    Write-Json -Value $after -Path (Join-Path $snapshotRoot "after.json")
+    $completedSteps.Add("snapshot_after")
+
+    $candidateActiveStatePath = "$activeStatePath.candidate"
+    Copy-Item -LiteralPath $resolvedStatePath -Destination $candidateActiveStatePath -Force
+    Move-Item -LiteralPath $candidateActiveStatePath -Destination $activeStatePath -Force
+    $completedSteps.Add("publish_active_state")
+}
+catch {
+    $failure = $_
+    $reverseSteps = @($completedSteps)
+    [array]::Reverse($reverseSteps)
+    foreach ($step in $reverseSteps) {
+        switch ($step) {
+            "publish_active_state" {
+                if (Test-Path -LiteralPath $previousActiveStatePath) {
+                    Copy-Item -LiteralPath $previousActiveStatePath -Destination $activeStatePath -Force
+                }
+            }
+            { $_ -in @("wait_readiness", "apply_complete_state") } {
+                if (-not $helmRestored) {
+                    if ($previousRevision -gt 0) {
+                        Invoke-Checked $helm rollback `
+                            $ReleaseName `
+                            $previousRevision `
+                            --namespace $Namespace `
+                            "--timeout=$($policy.readiness.timeout)" `
+                            --wait
+                    }
+                    else {
+                        Invoke-Checked $helm uninstall $ReleaseName --namespace $Namespace
+                    }
+                    $helmRestored = $true
+                }
+            }
+            "import_local_images" {
+                Write-Warning "retaining imported local images during compensation"
+            }
+            "snapshot_after" {
+                Write-Warning "retaining after snapshot for failure diagnosis"
+            }
+            "snapshot_before" {
+                Write-Warning "retaining before snapshot for failure diagnosis"
+            }
+        }
+    }
+    throw $failure
+}
+
+Write-Host "RELEASE_STATE_APPLY_OK release_id=$($state.release_id) snapshot_dir=$snapshotRoot"

--- a/scripts/tests/test_p3_production_release_state.py
+++ b/scripts/tests/test_p3_production_release_state.py
@@ -1,0 +1,379 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+import subprocess
+import tomllib
+import unittest
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_PATH = ROOT / "distribution" / "config" / "production-feature-profile.json"
+STATE_SCHEMA_PATH = ROOT / "distribution" / "config" / "release-state.schema.json"
+PROVENANCE_SCHEMA_PATH = ROOT / "distribution" / "config" / "image-provenance.schema.json"
+SBOM_SCHEMA_PATH = ROOT / "distribution" / "config" / "image-sbom.schema.json"
+TRANSITION_POLICY_PATH = ROOT / "distribution" / "kubernetes" / "release-state-transition-policy.json"
+SERVICES = ("broker", "namesrv", "controller", "proxy", "mcp")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def feature_closure(features: dict[str, list[str]], roots: list[str]) -> list[str]:
+    resolved: set[str] = set()
+    pending = list(roots)
+    while pending:
+        feature = pending.pop()
+        if feature in resolved:
+            continue
+        if feature not in features:
+            raise AssertionError(f"missing feature {feature}")
+        resolved.add(feature)
+        for member in features[feature]:
+            candidate = member.split("/", 1)[0]
+            if candidate in features:
+                pending.append(candidate)
+    return sorted(resolved)
+
+
+class ProductionReleaseStateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.profile = json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+        cls.state_schema = json.loads(STATE_SCHEMA_PATH.read_text(encoding="utf-8"))
+        cls.provenance_schema = json.loads(PROVENANCE_SCHEMA_PATH.read_text(encoding="utf-8"))
+        cls.sbom_schema = json.loads(SBOM_SCHEMA_PATH.read_text(encoding="utf-8"))
+        cls.transition_policy = json.loads(TRANSITION_POLICY_PATH.read_text(encoding="utf-8"))
+        cls.builder = (ROOT / "scripts" / "build-production-images.ps1").read_text(encoding="utf-8")
+        cls.reconciler = (ROOT / "scripts" / "set-architecture-release-state.ps1").read_text(encoding="utf-8")
+        cls.dockerfile = (ROOT / "docker" / "Dockerfile.base").read_text(encoding="utf-8")
+
+    def test_production_features_are_explicit_and_resolve_exactly(self) -> None:
+        self.assertEqual("production", self.profile["profile"])
+        self.assertTrue(self.profile["build_mode"]["locked"])
+        self.assertTrue(self.profile["build_mode"]["release"])
+        self.assertFalse(self.profile["build_mode"]["default_features"])
+        self.assertTrue(self.profile["build_mode"]["local_images_only"])
+        self.assertFalse(self.profile["build_mode"]["remote_push_enabled"])
+        self.assertEqual(set(SERVICES), set(self.profile["services"]))
+
+        for service_name, service in self.profile["services"].items():
+            with self.subTest(service=service_name):
+                manifest = tomllib.loads((ROOT / service["manifest"]).read_text(encoding="utf-8"))
+                features = manifest["features"]
+                self.assertEqual(["production"], service["features"])
+                self.assertEqual(
+                    service["resolved_features"],
+                    feature_closure(features, service["features"]),
+                )
+                command = (
+                    f"cargo build --locked --release --package {service['package']} "
+                    f"--no-default-features --features production --bin {service['binary']}"
+                )
+                self.assertIn(command, self.dockerfile)
+
+    def test_builder_is_local_only_and_binds_verifiable_metadata(self) -> None:
+        self.assertIn("docker buildx build", self.builder)
+        self.assertIn("--load", self.builder)
+        self.assertNotIn("--push", self.builder)
+        self.assertIn("production images must be built from a clean checkout", self.builder)
+        self.assertIn('imageReference = "rocketmq-rust/$serviceName`:$shortCommit"', self.builder)
+        for field in (
+            "source_commit",
+            "rust_toolchain",
+            "cargo_lock_sha256",
+            "feature_profile_sha256",
+            "resolved_features",
+            "binary_sha256",
+            "image_id",
+            "image_config_digest",
+            "config_digest",
+            "sbom",
+            "provenance",
+        ):
+            self.assertIn(field, self.builder)
+        for label in (
+            "io.rocketmq.build.rust-toolchain",
+            "io.rocketmq.build.cargo-lock-sha256",
+            "io.rocketmq.build.production-feature-profile-sha256",
+            "io.rocketmq.release.config-digest",
+        ):
+            self.assertIn(label, self.dockerfile)
+
+    def test_schemas_define_complete_release_and_local_provenance(self) -> None:
+        self.assertEqual("https://json-schema.org/draft/2020-12/schema", self.state_schema["$schema"])
+        self.assertFalse(self.state_schema["additionalProperties"])
+        self.assertEqual(
+            {
+                "schema_version",
+                "release_id",
+                "created_at",
+                "source_commit",
+                "images",
+                "config_bundle",
+                "secret_references",
+                "identity",
+                "storage_generation",
+                "cluster_import",
+            },
+            set(self.state_schema["required"]),
+        )
+        self.assertEqual(set(SERVICES), set(self.state_schema["properties"]["images"]["required"]))
+        identity = self.state_schema["properties"]["identity"]
+        self.assertEqual(
+            {"commit", "nonce", "config_digest", "secret_version", "storage_generation"},
+            set(identity["required"]),
+        )
+        secret_references = self.state_schema["properties"]["secret_references"]
+        self.assertEqual(1, secret_references["minItems"])
+        self.assertEqual(1, secret_references["maxItems"])
+        self.assertEqual(True, self.provenance_schema["properties"]["local_only"]["const"])
+        self.assertEqual(False, self.provenance_schema["properties"]["remote_push_performed"]["const"])
+        self.assertEqual("CycloneDX", self.sbom_schema["properties"]["bomFormat"]["const"])
+        self.assertEqual("1.6", self.sbom_schema["properties"]["specVersion"]["const"])
+
+    def test_transition_policy_is_ordered_and_compensates_in_reverse(self) -> None:
+        apply_order = [entry["step"] for entry in self.transition_policy["apply_order"]]
+        self.assertEqual(list(reversed(apply_order)), self.transition_policy["compensation_order"])
+        self.assertTrue(self.transition_policy["local_images_only"])
+        self.assertFalse(self.transition_policy["remote_push_enabled"])
+        self.assertTrue(self.transition_policy["forbid_image_only_transition"])
+        self.assertIn("kind load docker-image", self.reconciler)
+        self.assertIn("k3d image import", self.reconciler)
+        self.assertIn("helm rollback", self.reconciler)
+        self.assertIn("previous-active-release-state.json", self.reconciler)
+        self.assertIn('"before"', self.reconciler)
+        self.assertIn('"after"', self.reconciler)
+
+    def test_helm_release_identity_binds_config_secret_and_storage(self) -> None:
+        values = (ROOT / "distribution" / "helm" / "rocketmq-rust" / "values.yaml").read_text(encoding="utf-8")
+        values_schema = (
+            ROOT / "distribution" / "helm" / "rocketmq-rust" / "values.schema.json"
+        ).read_text(encoding="utf-8")
+        helpers = (
+            ROOT / "distribution" / "helm" / "rocketmq-rust" / "templates" / "_helpers.tpl"
+        ).read_text(encoding="utf-8")
+        for field in ("configDigest", "secretVersion", "storageGeneration"):
+            self.assertIn(field, values)
+            self.assertIn(field, values_schema)
+            self.assertIn(field, helpers)
+        for annotation in (
+            "rocketmq.apache.org/release-config-digest",
+            "rocketmq.apache.org/release-secret-version",
+            "rocketmq.apache.org/storage-generation",
+        ):
+            self.assertIn(annotation, helpers)
+            self.assertEqual(
+                5,
+                (ROOT / "distribution" / "kubernetes" / "base" / "manifest.yaml")
+                .read_text(encoding="utf-8")
+                .count(annotation),
+            )
+        self.assertEqual(5, (ROOT / "distribution" / "helm" / "rocketmq-rust" / "templates" / "workloads.yaml")
+                         .read_text(encoding="utf-8")
+                         .count('include "rocketmq.releaseAnnotations"'))
+
+    def test_validate_only_accepts_complete_state_and_rejects_secret_material(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        self.assertIsNotNone(powershell, "PowerShell is required to validate the release-state reconciler")
+        fixture_root = ROOT / ".rocketmq" / f"release-state-test-{uuid.uuid4().hex}"
+        fixture_root.mkdir(parents=True)
+        try:
+            state_path = self.write_fixture(fixture_root)
+            result = self.run_validate(powershell, state_path)
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("RELEASE_STATE_VALIDATION_OK mode=schema", result.stdout)
+
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            state["secret_references"][0]["secret_value"] = "must-not-appear"
+            state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+            result = self.run_validate(powershell, state_path)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("forbidden Secret field", result.stderr)
+        finally:
+            shutil.rmtree(fixture_root)
+
+    def write_fixture(self, fixture_root: Path) -> Path:
+        source_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        config_files = []
+        for relative in self.profile["config_bundle_files"]:
+            config_files.append({"path": relative, "sha256": sha256_file(ROOT / relative)})
+        manifest = "".join(f"{entry['sha256']}  {entry['path']}\n" for entry in config_files)
+        config_digest = "sha256:" + sha256_bytes(manifest.encode())
+        cargo_lock_sha256 = sha256_file(ROOT / "Cargo.lock")
+        feature_profile_sha256 = sha256_file(PROFILE_PATH)
+        generated_at = datetime.now(UTC).isoformat()
+
+        evidence = []
+        sboms: dict[str, tuple[str, str]] = {}
+        for index, service_name in enumerate(SERVICES, start=1):
+            sbom = {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "version": 1,
+                "metadata": {
+                    "timestamp": generated_at,
+                    "component": {
+                        "type": "application",
+                        "name": self.profile["services"][service_name]["package"],
+                        "version": "test",
+                        "hashes": [{"alg": "SHA-256", "content": f"{index}" * 64}],
+                    },
+                    "properties": [
+                        {"name": "rocketmq:source-commit", "value": source_commit},
+                        {"name": "rocketmq:image-reference", "value": f"rocketmq-rust/{service_name}:abcdef1"},
+                        {"name": "rocketmq:config-digest", "value": config_digest},
+                    ],
+                },
+                "components": [{"type": "library", "name": "fixture", "version": "1"}],
+            }
+            sbom_path = fixture_root / f"{service_name}.cdx.json"
+            sbom_path.write_text(json.dumps(sbom, indent=2) + "\n", encoding="utf-8")
+            relative_sbom = sbom_path.relative_to(ROOT).as_posix()
+            sboms[service_name] = (relative_sbom, sha256_file(sbom_path))
+            evidence.append(
+                {
+                    "service": service_name,
+                    "reference": f"rocketmq-rust/{service_name}:abcdef1",
+                    "image_id": "sha256:" + f"{index}" * 64,
+                    "image_config_digest": "sha256:" + f"{index}" * 64,
+                    "binary_sha256": f"{index}" * 64,
+                    "resolved_features": self.profile["services"][service_name]["resolved_features"],
+                    "sbom_path": relative_sbom,
+                    "sbom_sha256": sha256_file(sbom_path),
+                }
+            )
+
+        provenance = {
+            "schema_version": 1,
+            "release_id": "abcdef1-local-abcdef1",
+            "generated_at": generated_at,
+            "source_commit": source_commit,
+            "rust_toolchain": "1.95.0",
+            "cargo_lock_sha256": cargo_lock_sha256,
+            "feature_profile_sha256": feature_profile_sha256,
+            "config_digest": config_digest,
+            "local_only": True,
+            "remote_push_performed": False,
+            "images": evidence,
+        }
+        provenance_path = fixture_root / "provenance.json"
+        provenance_path.write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+        relative_provenance = provenance_path.relative_to(ROOT).as_posix()
+        provenance_sha256 = sha256_file(provenance_path)
+
+        images = {}
+        for index, service_name in enumerate(SERVICES, start=1):
+            images[service_name] = {
+                "service": service_name,
+                "reference": f"rocketmq-rust/{service_name}:abcdef1",
+                "image_id": "sha256:" + f"{index}" * 64,
+                "image_config_digest": "sha256:" + f"{index}" * 64,
+                "binary_sha256": f"{index}" * 64,
+                "source_commit": source_commit,
+                "rust_toolchain": "1.95.0",
+                "cargo_lock_sha256": cargo_lock_sha256,
+                "feature_profile_sha256": feature_profile_sha256,
+                "resolved_features": self.profile["services"][service_name]["resolved_features"],
+                "config_digest": config_digest,
+                "sbom": {
+                    "path": sboms[service_name][0],
+                    "sha256": sboms[service_name][1],
+                    "format": "cyclonedx-1.6-json",
+                },
+                "provenance": {
+                    "path": relative_provenance,
+                    "sha256": provenance_sha256,
+                    "format": "rocketmq-local-provenance-v1",
+                },
+            }
+        state = {
+            "schema_version": 1,
+            "release_id": "abcdef1-local-abcdef1",
+            "created_at": generated_at,
+            "source_commit": source_commit,
+            "images": images,
+            "config_bundle": {
+                "digest": config_digest,
+                "files": config_files,
+                "helm_values": "distribution/helm/rocketmq-rust/values-production-controller-ha.yaml",
+                "config_map_template": "distribution/helm/rocketmq-rust/templates/configmaps.yaml",
+                "schema": "distribution/config/release-state.schema.json",
+            },
+            "secret_references": [
+                {
+                    "name": "rocketmq-runtime-secrets",
+                    "namespace": "rocketmq",
+                    "provider": "kubernetes",
+                    "version": "local-reference-1",
+                    "mount_path": "/var/run/secrets/rocketmq",
+                }
+            ],
+            "identity": {
+                "commit": source_commit,
+                "nonce": "local-abcdef1",
+                "config_digest": config_digest,
+                "secret_version": "local-reference-1",
+                "storage_generation": 1,
+            },
+            "storage_generation": 1,
+            "cluster_import": {"kind": "none", "name": "rocketmq"},
+        }
+        state_path = fixture_root / "release-state.json"
+        state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        return state_path
+
+    @staticmethod
+    def run_validate(powershell: str, state_path: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(ROOT / "scripts" / "set-architecture-release-state.ps1"),
+                "-StatePath",
+                str(state_path),
+                "-ValidateOnly",
+                "-SchemaOnly",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_p3_production_release_state.py
+++ b/scripts/tests/test_p3_production_release_state.py
@@ -100,9 +100,11 @@ class ProductionReleaseStateTests(unittest.TestCase):
         self.assertIn("docker buildx build", self.builder)
         self.assertIn("--load", self.builder)
         self.assertNotIn("--push", self.builder)
+        self.assertNotIn("[System.IO.Path]::GetRelativePath", self.builder)
         self.assertIn("production images must be built from a clean checkout", self.builder)
         self.assertIn('imageReference = "rocketmq-rust/$serviceName`:$shortCommit"', self.builder)
         self.assertIn("Invoke-Captured -Executable docker -Arguments @(", self.builder)
+        self.assertIn(".MakeRelativeUri(", self.builder)
         for field in (
             "source_commit",
             "rust_toolchain",

--- a/scripts/tests/test_p3_production_release_state.py
+++ b/scripts/tests/test_p3_production_release_state.py
@@ -102,6 +102,7 @@ class ProductionReleaseStateTests(unittest.TestCase):
         self.assertNotIn("--push", self.builder)
         self.assertIn("production images must be built from a clean checkout", self.builder)
         self.assertIn('imageReference = "rocketmq-rust/$serviceName`:$shortCommit"', self.builder)
+        self.assertIn("Invoke-Captured -Executable docker -Arguments @(", self.builder)
         for field in (
             "source_commit",
             "rust_toolchain",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8766

### Brief Description

Model the five local production images, their resolved feature closures, configuration bundle, secret references, release identity, and storage generation as one complete `ReleaseState`.

Add local-only image construction with pinned source and toolchain metadata, binary hashes, CycloneDX SBOMs, provenance, and explicit protection against remote pushes. Add an ordered release-state reconciler that validates the complete state, imports the same image set into Kind or K3d, applies Helm values, waits for readiness, captures before/after snapshots, and performs reverse-order compensation on failure.

Bind the complete release identity into all five Helm workloads and keep the generated Kubernetes base manifest aligned with the production values.

### How Did You Test This Change?

- `powershell -File scripts/build-production-images.ps1 -Load`: passed; built and loaded five local production images and generated matching SBOM, provenance, and `ReleaseState` artifacts without a remote push.
- `powershell -File scripts/set-architecture-release-state.ps1 -ValidateOnly`: passed with `RELEASE_STATE_VALIDATION_OK mode=complete`.
- `helm lint distribution/helm/rocketmq-rust -f distribution/helm/rocketmq-rust/values-production-controller-ha.yaml --strict`: passed.
- `helm template rocketmq distribution/helm/rocketmq-rust -f distribution/helm/rocketmq-rust/values-production-controller-ha.yaml`: passed; all five workloads contain the complete release identity.
- `python -m unittest scripts.tests.test_p3_production_release_state scripts.tests.test_m11_container_foundation`: passed, 23 tests.
- `python scripts/container_image_guard.py`: passed.
- `cargo check --locked -p <service> --no-default-features --features production --bin <binary>`: passed for Broker, NameServer, Controller, Proxy, and MCP.
- `cargo fmt --package <affected-package> -- --check`: passed for all five affected Rust packages. The workspace-wide formatter cannot complete on Windows because rustfmt encounters OS error 206; no formatter findings were reported for the affected packages.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo check -p rocketmq-mcp`, `cargo test -p rocketmq-mcp`, `cargo clippy --all-targets -p rocketmq-mcp --features streamable-http -- -D warnings`, and `cargo doc -p rocketmq-mcp --no-deps`: passed; MCP ran 86 unit tests plus integration and documentation tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local production image building with verifiable metadata, SBOMs, provenance, and release-state output.
  * Added strict validation and optional application of release states in local Kubernetes environments.
  * Added schemas for release state, image provenance, and SBOM artifacts.
  * Added production build profiles and unified production feature configuration across services.
  * Added release identity tracking for configuration, secrets, and storage generations.

* **Documentation**
  * Updated local Kubernetes validation and deployment guidance.

* **Tests**
  * Added comprehensive validation coverage for production release artifacts and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->