### PR TITLE
[ISSUE #8768]♻️Unify production readiness observability contracts

### DIFF
--- a/distribution/config/architecture-production-readiness-policy.json
+++ b/distribution/config/architecture-production-readiness-policy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "contract_version": "1.0.0",
   "milestone": "M11-12",
   "execution_unit": "R24",
   "minimum_soak_seconds": 21600,
@@ -14,76 +15,299 @@
     "secret_rotation",
     "acknowledged_message_recovery"
   ],
+  "release_identity_contract": {
+    "metric": "rocketmq_release_info",
+    "kind": "gauge",
+    "unit": "1",
+    "owner": "observability",
+    "allowed_labels": [
+      "service",
+      "release_commit",
+      "release_nonce"
+    ],
+    "cardinality_budget": 64,
+    "privacy": "operational",
+    "dashboard_panel": "Release Identity Registration",
+    "alert": "RocketMQReleaseIdentityConflict",
+    "runbook_anchor": "release-identity"
+  },
+  "readiness_contract": {
+    "probe_path": "/readyz",
+    "ready_status": 200,
+    "not_ready_status": 503,
+    "identity_required_when_metrics_enabled": true,
+    "services": [
+      {
+        "service": "broker",
+        "identity_service": "rocketmq-broker",
+        "requirements": [
+          "security_bootstrap",
+          "message_store_writable",
+          "request_processors_started",
+          "nameserver_registration",
+          "release_identity"
+        ],
+        "source_contracts": [
+          {
+            "path": "rocketmq-broker/src/bin/broker_bootstrap_server.rs",
+            "required_markers": [
+              "validate_broker_security",
+              "register_broker_release_identity",
+              "boot_with_lifecycle"
+            ]
+          },
+          {
+            "path": "rocketmq-broker/src/broker_bootstrap.rs",
+            "required_markers": [
+              "release_identity_registered",
+              "lifecycle.mark_ready"
+            ]
+          },
+          {
+            "path": "rocketmq-broker/src/lifecycle/components.rs",
+            "required_markers": [
+              "store_writable",
+              "processors_started",
+              "security_ready",
+              "registration_ready"
+            ]
+          }
+        ]
+      },
+      {
+        "service": "namesrv",
+        "identity_service": "rocketmq-namesrv",
+        "requirements": [
+          "security_bootstrap",
+          "route_processor_started",
+          "embedded_controller_started_when_configured",
+          "release_identity"
+        ],
+        "source_contracts": [
+          {
+            "path": "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs",
+            "required_markers": [
+              "validate_namesrv_security",
+              "register_namesrv_release_identity",
+              "boot_with_lifecycle"
+            ]
+          },
+          {
+            "path": "rocketmq-namesrv/src/bootstrap.rs",
+            "required_markers": [
+              "route_info_manager().start",
+              "controller_manager.start",
+              "RuntimeState::Running",
+              "lifecycle.mark_ready"
+            ]
+          }
+        ]
+      },
+      {
+        "service": "controller",
+        "identity_service": "rocketmq-controller",
+        "requirements": [
+          "security_bootstrap",
+          "storage_recovered",
+          "raft_listener_started",
+          "cluster_recovery",
+          "release_identity"
+        ],
+        "source_contracts": [
+          {
+            "path": "rocketmq-controller/src/bin/controller_bootstrap.rs",
+            "required_markers": [
+              "validate_controller_security",
+              "register_controller_release_identity",
+              "wait_for_cluster_recovery",
+              "release_identity_registered",
+              "lifecycle.mark_ready"
+            ]
+          }
+        ]
+      },
+      {
+        "service": "proxy",
+        "identity_service": "rocketmq-proxy",
+        "requirements": [
+          "security_bootstrap",
+          "metadata_route_ready",
+          "all_configured_listeners_bound",
+          "release_identity"
+        ],
+        "source_contracts": [
+          {
+            "path": "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs",
+            "required_markers": [
+              "validate_proxy_security",
+              "register_proxy_release_identity",
+              "serve_with_lifecycle"
+            ]
+          },
+          {
+            "path": "rocketmq-proxy/src/bootstrap.rs",
+            "required_markers": [
+              "verify_cluster_route_and_security",
+              "remaining_listeners",
+              "lifecycle.mark_ready"
+            ]
+          }
+        ]
+      },
+      {
+        "service": "mcp",
+        "identity_service": "rocketmq-mcp",
+        "requirements": [
+          "security_bootstrap",
+          "application_initialized",
+          "transport_listener_ready",
+          "release_identity"
+        ],
+        "source_contracts": [
+          {
+            "path": "rocketmq-tools/rocketmq-mcp/src/main.rs",
+            "required_markers": [
+              "validate_mcp_security",
+              "McpApp::bootstrap_typed",
+              "start_lifecycle",
+              "mark_ready()"
+            ]
+          },
+          {
+            "path": "rocketmq-tools/rocketmq-mcp/src/app.rs",
+            "required_markers": [
+              "register_mcp_release_identity",
+              "release_identity_registered"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "collector_outage_contract": {
+    "registry": "scripts/telemetry-semantic-registry.json",
+    "max_queue_items": 2048,
+    "max_queue_bytes": 8388608,
+    "max_record_bytes": 65536,
+    "enqueue": "try_enqueue",
+    "overflow": "drop_newest",
+    "data_plane_blocking": false,
+    "recovery_objective_seconds": 30,
+    "drop_signal": "rocketmq.exporter.drop",
+    "shutdown_signal": "rocketmq.exporter.shutdown",
+    "required_measurements": [
+      "accepted",
+      "drained",
+      "dropped_by_reason",
+      "queued_items",
+      "queued_bytes"
+    ]
+  },
   "objectives": [
     {
       "id": "message_delivery_ratio",
       "source": "rocketmq_messages_out_total",
+      "owner": "broker",
+      "allowed_query_labels": [],
+      "source_unit": "{message}",
       "query": "sum(rate(rocketmq_messages_out_total[5m])) / clamp_min(sum(rate(rocketmq_messages_in_total[5m])), 0.000001)",
       "operator": "gte",
       "target": 0.999,
       "unit": "ratio",
+      "dashboard_unit": "percentunit",
       "dashboard_panel": "Message Delivery Ratio",
-      "alert": "RocketMQMessageDeliveryRatioBurn"
+      "alert": "RocketMQMessageDeliveryRatioBurn",
+      "runbook_anchor": "message-availability"
     },
     {
       "id": "send_message_p99_millis",
       "source": "rocketmq_send_message_latency",
+      "owner": "broker",
+      "allowed_query_labels": [],
+      "source_unit": "ms",
       "query": "histogram_quantile(0.99, sum(rate(rocketmq_send_message_latency_bucket[5m])) by (le))",
       "operator": "lte",
       "target": 1000,
       "unit": "ms",
+      "dashboard_unit": "ms",
       "dashboard_panel": "Send Message P99 Latency",
-      "alert": "RocketMQSendMessageP99High"
+      "alert": "RocketMQSendMessageP99High",
+      "runbook_anchor": "send-latency"
     },
     {
       "id": "consumer_lag_messages",
       "source": "rocketmq_consumer_lag_messages",
+      "owner": "broker",
+      "allowed_query_labels": [],
+      "source_unit": "{message}",
       "query": "max(rocketmq_consumer_lag_messages)",
       "operator": "lte",
       "target": 10000,
       "unit": "{message}",
+      "dashboard_unit": "short",
       "dashboard_panel": "Consumer Lag",
-      "alert": "RocketMQConsumerLagHigh"
+      "alert": "RocketMQConsumerLagHigh",
+      "runbook_anchor": "consumer-lag"
     },
     {
       "id": "flush_behind_bytes",
       "source": "rocketmq_storage_flush_behind_bytes",
+      "owner": "store",
+      "allowed_query_labels": [],
+      "source_unit": "By",
       "query": "max(rocketmq_storage_flush_behind_bytes)",
       "operator": "lte",
       "target": 67108864,
       "unit": "By",
+      "dashboard_unit": "bytes",
       "dashboard_panel": "Store Flush and Dispatch Lag",
-      "alert": "RocketMQStoreFlushBehindHigh"
+      "alert": "RocketMQStoreFlushBehindHigh",
+      "runbook_anchor": "store-flush"
     },
     {
       "id": "ha_replication_lag_bytes",
       "source": "rocketmq_store_ha_replication_lag_bytes",
+      "owner": "store",
+      "allowed_query_labels": [],
+      "source_unit": "By",
       "query": "max(rocketmq_store_ha_replication_lag_bytes)",
       "operator": "lte",
       "target": 67108864,
       "unit": "By",
+      "dashboard_unit": "bytes",
       "dashboard_panel": "HA Replication Lag",
-      "alert": "RocketMQHaReplicationLagHigh"
+      "alert": "RocketMQHaReplicationLagHigh",
+      "runbook_anchor": "ha-replication"
     },
     {
       "id": "collector_outage_roundtrip_seconds",
       "source": "fault_evidence",
+      "owner": "observability",
+      "allowed_query_labels": [],
+      "source_unit": null,
       "query": null,
       "operator": "lte",
       "target": 30,
       "unit": "s",
+      "dashboard_unit": null,
       "dashboard_panel": "Collector Outage Budget",
-      "alert": null
+      "alert": null,
+      "runbook_anchor": "collector-outage-budget"
     },
     {
       "id": "drain_failed_prestop_events",
       "source": "fault_evidence",
+      "owner": "release-engineering",
+      "allowed_query_labels": [],
+      "source_unit": null,
       "query": null,
       "operator": "lte",
       "target": 0,
       "unit": "{event}",
+      "dashboard_unit": null,
       "dashboard_panel": "Drain and Rollback Health",
-      "alert": null
+      "alert": null,
+      "runbook_anchor": "drain-and-rollback-health"
     }
   ],
   "release_artifacts": {

--- a/distribution/config/grafana-architecture-production-readiness.json
+++ b/distribution/config/grafana-architecture-production-readiness.json
@@ -22,6 +22,19 @@
         "defaults": {
           "max": 1,
           "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.999
+              }
+            ]
+          },
           "unit": "percentunit"
         },
         "overrides": []
@@ -32,6 +45,7 @@
         "x": 0,
         "y": 0
       },
+      "description": "Five-minute delivered/accepted message ratio. The production objective is at least 0.999.",
       "id": 1,
       "targets": [
         {
@@ -50,6 +64,19 @@
       },
       "fieldConfig": {
         "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
@@ -60,6 +87,7 @@
         "x": 12,
         "y": 0
       },
+      "description": "Five-minute p99 send-message latency. The production objective is at most 1000 ms.",
       "id": 2,
       "targets": [
         {
@@ -78,6 +106,19 @@
       },
       "fieldConfig": {
         "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
@@ -88,6 +129,7 @@
         "x": 0,
         "y": 8
       },
+      "description": "Maximum consumer lag. The production objective is at most 10000 messages.",
       "id": 3,
       "targets": [
         {
@@ -106,6 +148,19 @@
       },
       "fieldConfig": {
         "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 67108864
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
@@ -116,6 +171,7 @@
         "x": 12,
         "y": 8
       },
+      "description": "Store flush and dispatch backlog. Flush-behind must remain at or below 64 MiB.",
       "id": 4,
       "targets": [
         {
@@ -139,6 +195,19 @@
       },
       "fieldConfig": {
         "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 67108864
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
@@ -149,6 +218,7 @@
         "x": 0,
         "y": 16
       },
+      "description": "Maximum Broker HA replication lag. The production objective is at most 64 MiB.",
       "id": 5,
       "targets": [
         {
@@ -161,15 +231,46 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Exactly one low-cardinality release identity should be active for each service instance.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 12,
         "x": 12,
         "y": 16
       },
       "id": 6,
+      "targets": [
+        {
+          "expr": "max by (service, release_commit, release_nonce) (rocketmq_release_info)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{service}} {{release_commit}} {{release_nonce}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Release Identity Registration",
+      "type": "table"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
       "options": {
-        "content": "The release evidence must include the M11-11 `collector_outage` scenario with a successful message round trip below 30 seconds. A dashboard cannot replace the signed fault artifact.",
+        "content": "The release evidence must include the `collector_outage` scenario with a successful message round trip below 30 seconds. Admission is non-blocking and bounded to 2048 records, 8 MiB total, and 64 KiB per record; drops are reported through `rocketmq.exporter.drop`. A dashboard cannot replace the signed fault artifact.",
         "mode": "markdown"
       },
       "title": "Collector Outage Budget",
@@ -178,11 +279,11 @@
     {
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 16
+        "w": 12,
+        "x": 12,
+        "y": 24
       },
-      "id": 7,
+      "id": 8,
       "options": {
         "content": "The release evidence must report zero `FailedPreStopHook` events and prove baseline image/chart restoration without deleting PVCs or WAL.",
         "mode": "markdown"
@@ -223,6 +324,6 @@
   "timezone": "utc",
   "title": "RocketMQ Architecture Production Readiness",
   "uid": "rocketmq-architecture-production-readiness",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/distribution/config/prometheus-architecture-production-readiness-alerts.yaml
+++ b/distribution/config/prometheus-architecture-production-readiness-alerts.yaml
@@ -9,6 +9,8 @@ groups:
           < 0.999
         for: 10m
         labels:
+          contract: production-readiness-v1
+          owner: broker
           severity: critical
           slo: message-availability
         annotations:
@@ -23,6 +25,8 @@ groups:
           ) > 1000
         for: 10m
         labels:
+          contract: production-readiness-v1
+          owner: broker
           severity: critical
           slo: send-latency
         annotations:
@@ -33,6 +37,8 @@ groups:
         expr: max(rocketmq_consumer_lag_messages) > 10000
         for: 15m
         labels:
+          contract: production-readiness-v1
+          owner: broker
           severity: warning
           slo: consumer-lag
         annotations:
@@ -43,6 +49,8 @@ groups:
         expr: max(rocketmq_storage_flush_behind_bytes) > 67108864
         for: 10m
         labels:
+          contract: production-readiness-v1
+          owner: store
           severity: critical
           slo: store-flush
         annotations:
@@ -53,8 +61,27 @@ groups:
         expr: max(rocketmq_store_ha_replication_lag_bytes) > 67108864
         for: 10m
         labels:
+          contract: production-readiness-v1
+          owner: store
           severity: critical
           slo: ha-replication
         annotations:
           summary: RocketMQ HA replication lag exceeds 64 MiB
           runbook_url: https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-doc/en/architecture-production-readiness-runbook.md#ha-replication
+
+      - alert: RocketMQReleaseIdentityConflict
+        expr: |
+          count by (service) (
+            count by (service, release_commit, release_nonce) (
+              rocketmq_release_info
+            )
+          ) > 1
+        for: 5m
+        labels:
+          contract: production-readiness-v1
+          owner: observability
+          severity: critical
+          slo: release-identity
+        annotations:
+          summary: More than one release identity is active for a RocketMQ service
+          runbook_url: https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-doc/en/architecture-production-readiness-runbook.md#release-identity

--- a/rocketmq-doc/en/architecture-production-readiness-runbook.md
+++ b/rocketmq-doc/en/architecture-production-readiness-runbook.md
@@ -4,6 +4,11 @@ This runbook covers the M11-12/R24 release-candidate objectives. It complements 
 dynamic Kind/K3d fault evidence; dashboards and alerts cannot replace a
 `dynamic_execution=true`, non-fixture evidence package for the exact candidate commit.
 
+The versioned source of truth is
+`distribution/config/architecture-production-readiness-policy.json`. Metric names,
+units, owners, query labels, thresholds, dashboard panels, alert routes, readiness
+dependencies, and collector-outage limits must change together with that contract.
+
 ## Release invariants
 
 - CommitLog remains the authoritative WAL. Never delete or rewrite WAL, PVCs, queue
@@ -15,67 +20,121 @@ dynamic Kind/K3d fault evidence; dashboards and alerts cannot replace a
   artifact by SHA-256.
 - Any failed objective, unresolved alert, unresolved fault, mismatched commit, or
   incomplete rollback blocks promotion.
+- Release identity uses only `service`, `release_commit`, and `release_nonce`.
+  Credentials, configuration objects, message bodies, topic names, consumer groups,
+  hostnames, and request identifiers are not release-identity labels.
+- `/readyz` is the canonical service-readiness endpoint. It returns success only
+  after the service-specific security, storage or control-plane dependencies and
+  release identity have completed.
+
+## Release identity
+
+Alert: `RocketMQReleaseIdentityConflict`
+
+1. **Diagnose:** Compare `rocketmq_release_info` by `service`,
+   `release_commit`, and `release_nonce` with the active `ReleaseState`. Confirm
+   that the conflict is not a stale Prometheus target.
+2. **Contain:** Stop promotion and prevent another rollout until every workload
+   references one commit, nonce, config digest, Secret version, and storage
+   generation.
+3. **Recover:** Remove only the stale workload or scrape target, wait for its
+   series to age out, and verify all five `/readyz` endpoints against the intended
+   release identity.
+4. **Escalate:** Page the release-engineering and owning service teams when more
+   than one identity remains active for five minutes or the running identity does
+   not match the complete `ReleaseState`.
+
+## Service readiness
+
+Readiness is service-specific but governed by one policy:
+
+- Broker requires validated security, a writable MessageStore, started request
+  processors and listeners, NameServer registration, and release identity.
+- NameServer requires validated security, route processing, the optional embedded
+  Controller when configured, and release identity.
+- Controller requires validated security, recovered storage and Raft state,
+  cluster recovery, and release identity.
+- Proxy requires validated security, a healthy metadata route in cluster mode,
+  every configured listener, and release identity.
+- MCP requires validated security, initialized application state, the selected
+  transport listener, and release identity.
+
+A bound socket alone is never readiness. When `/readyz` returns 503, stop the
+rollout, inspect the failed dependency, restore that dependency, and wait for a
+fresh 200 response. Escalate to the owning service team if the dependency is
+healthy but readiness remains unpublished.
 
 ## Message availability
 
 Alert: `RocketMQMessageDeliveryRatioBurn`
 
-1. Confirm the alert is not caused by an idle input stream. The online objective
-   compares delivery and ingress rates; M11-11 separately requires explicit
-   acknowledged send/query probes.
-2. Check Broker readiness, NameServer route visibility, Controller quorum, Proxy
-   readiness, and the latest acknowledged-message recovery artifact.
-3. Stop promotion if the delivery ratio is below `0.999`.
-4. Roll back all five workloads to their recorded baseline digests. Preserve the
-   candidate evidence and verify the acknowledged message, queue offset, CommitLog
-   offset, and PVC UID set again.
+1. **Diagnose:** Confirm the alert is not caused by an idle input stream, then
+   check Broker readiness, NameServer route visibility, Controller quorum, Proxy
+   readiness, and the acknowledged send/query probe.
+2. **Contain:** Stop promotion when the delivery ratio is below `0.999`; stop new
+   writes if the configured acknowledgement contract cannot be preserved.
+3. **Recover:** Roll back all five workloads to their recorded baseline digests
+   and verify the acknowledged message, queue offset, CommitLog offset, and PVC
+   UID set again.
+4. **Escalate:** Page Broker, storage, and control-plane owners if the baseline
+   still misses the objective or the acknowledged message cannot be recovered.
 
 ## Send latency
 
 Alert: `RocketMQSendMessageP99High`
 
-1. Compare the functional-probe p99 with
+1. **Diagnose:** Compare the functional-probe p99 with
    `rocketmq_send_message_latency`; the release objective is at most `1000 ms`.
-2. Inspect flush/dispatch lag, HA replication lag, disk pressure, CPU throttling,
-   and collector outage timing before attributing the regression.
-3. Do not raise the threshold or shorten the soak window to make a candidate pass.
-4. Roll back the candidate images when the objective remains exceeded for ten
-   minutes, then repeat the same probe against the baseline.
+   Inspect flush/dispatch lag, HA replication lag, disk pressure, CPU throttling,
+   and collector-outage timing before attributing the regression.
+2. **Contain:** Stop promotion; do not raise the threshold or shorten the soak
+   window to make a candidate pass.
+3. **Recover:** Roll back the candidate images when the objective remains exceeded
+   for ten minutes, then repeat the same probe against the baseline.
+4. **Escalate:** Page Broker and storage owners when the baseline remains above
+   the objective or durable acknowledgements are delayed.
 
 ## Consumer lag
 
 Alert: `RocketMQConsumerLagHigh`
 
-1. Identify the affected topic and consumer group without exporting message bodies.
-2. Check `rocketmq_consumer_lag_messages`, inflight work, route freshness, consumer
-   connectivity, and dispatch-behind bytes.
-3. Promotion is blocked when the six-hour maximum exceeds `10000` messages.
-4. If the lag began with the candidate, restore baseline images and confirm that the
-   lag is decreasing before closing the incident.
+1. **Diagnose:** Identify the affected topic and consumer group without exporting
+   message bodies. Check `rocketmq_consumer_lag_messages`, in-flight work, route
+   freshness, consumer connectivity, and dispatch-behind bytes.
+2. **Contain:** Block promotion when the six-hour maximum exceeds `10000`
+   messages and avoid destructive offset changes.
+3. **Recover:** If the lag began with the candidate, restore baseline images and
+   confirm that the lag is decreasing before closing the incident.
+4. **Escalate:** Page Broker and consumer owners if lag does not decrease after
+   baseline recovery or route and storage health disagree.
 
 ## Store flush
 
 Alert: `RocketMQStoreFlushBehindHigh`
 
-1. Check `rocketmq_storage_flush_behind_bytes`,
+1. **Diagnose:** Check `rocketmq_storage_flush_behind_bytes`,
    `rocketmq_storage_dispatch_behind_bytes`, disk pressure, flush latency, and
    storage errors.
-2. Promotion is blocked when flush-behind exceeds `67108864` bytes.
-3. Keep the Broker available for reads when safe, but do not acknowledge new writes
-   if the configured durability contract cannot be met.
-4. Roll back executable images and chart revision only. Do not delete CommitLog,
+2. **Contain:** Block promotion when flush-behind exceeds `67108864` bytes. Keep
+   the Broker available for reads when safe, but do not acknowledge new writes if
+   the configured durability contract cannot be met.
+3. **Recover:** Roll back executable images and chart revision only. Do not delete CommitLog,
    ConsumeQueue, Index, RocksDB state, or PVCs.
+4. **Escalate:** Page the storage owner for persistent backlog, disk errors, or
+   any mismatch between reported and durable offsets.
 
 ## HA replication
 
 Alert: `RocketMQHaReplicationLagHigh`
 
-1. Check `rocketmq_store_ha_replication_lag_bytes`, replica connectivity,
-   Controller quorum, confirm offset, and disk/flush health.
-2. Promotion is blocked when replication lag exceeds `67108864` bytes.
-3. Do not force a role change that can lose acknowledged data.
-4. Restore baseline images and verify the same message ID and offsets after quorum
-   recovery.
+1. **Diagnose:** Check `rocketmq_store_ha_replication_lag_bytes`, replica
+   connectivity, Controller quorum, confirm offset, and disk/flush health.
+2. **Contain:** Block promotion when replication lag exceeds `67108864` bytes. Do
+   not force a role change that can lose acknowledged data.
+3. **Recover:** Restore baseline images and verify the same message ID and offsets
+   after quorum recovery.
+4. **Escalate:** Page storage and Controller owners if quorum cannot recover or
+   replica and leader offsets remain inconsistent.
 
 ## Collector outage budget
 
@@ -83,9 +142,22 @@ The M11-11 `collector_outage` fault scenario must demonstrate a successful
 send/query round trip in under 30 seconds while the collector is unavailable. The
 telemetry queue remains bounded and the data plane must not wait for export.
 
-If the budget is exceeded, restore the collector, preserve exporter logs and queue
-measurements, stop promotion, and fix the owning telemetry path. Never disable the
-bounded queue or privacy/cardinality guard as a workaround.
+The production boundary admits at most 2048 records, 8 MiB in total, and 64 KiB
+per record. Admission uses `try_enqueue`, rejects the newest record when full, and
+reports drops through `rocketmq.exporter.drop`; shutdown reports final queue and
+drop totals through `rocketmq.exporter.shutdown`.
+
+1. **Diagnose:** Inspect accepted, drained, dropped-by-reason, queued-item, and
+   queued-byte measurements together with the send/query probe.
+2. **Contain:** Stop promotion if the 30-second budget is exceeded; do not enlarge
+   the queue until resource usage and outage duration are understood.
+3. **Recover:** Restore the collector, allow the bounded queue to drain, and repeat
+   the same functional probe.
+4. **Escalate:** Page the observability owner if the data plane blocks, queue
+   limits are exceeded, drops are not reported, or recovery remains above 30
+   seconds.
+
+Never disable the bounded queue or privacy/cardinality guard as a workaround.
 
 ## Drain and rollback health
 
@@ -113,6 +185,7 @@ python scripts/architecture_slo_guard.py `
   --evidence scripts/tests/fixtures/m11-slo/pass `
   --allow-fixture
 python -m unittest scripts.tests.test_architecture_slo_guard -v
+cargo test -p rocketmq-observability --test production_readiness_contract
 ```
 
 For production evidence, omit `--allow-fixture`. The guard then requires the

--- a/rocketmq-observability/tests/production_readiness_contract.rs
+++ b/rocketmq-observability/tests/production_readiness_contract.rs
@@ -1,0 +1,449 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use rocketmq_observability::metrics::catalog;
+use rocketmq_observability::semantic;
+use rocketmq_observability::TelemetryDropReason;
+use rocketmq_observability::TelemetryEnqueueOutcome;
+use rocketmq_observability::TelemetryOutageQueue;
+use rocketmq_observability::TelemetryQueueLimits;
+use rocketmq_observability::DEFAULT_MAX_QUEUE_BYTES;
+use rocketmq_observability::DEFAULT_MAX_QUEUE_ITEMS;
+use rocketmq_observability::DEFAULT_MAX_RECORD_BYTES;
+use serde_json::Value;
+
+const POLICY_PATH: &str = "distribution/config/architecture-production-readiness-policy.json";
+const REGISTRY_PATH: &str = "scripts/telemetry-semantic-registry.json";
+const DASHBOARD_PATH: &str = "distribution/config/grafana-architecture-production-readiness.json";
+const ALERTS_PATH: &str = "distribution/config/prometheus-architecture-production-readiness-alerts.yaml";
+const RUNBOOK_PATH: &str = "rocketmq-doc/en/architecture-production-readiness-runbook.md";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("observability crate must remain below the repository root")
+        .to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    fs::read_to_string(repository_root().join(relative))
+        .unwrap_or_else(|error| panic!("failed to read {relative}: {error}"))
+}
+
+fn json(relative: &str) -> Value {
+    serde_json::from_str(&read(relative)).unwrap_or_else(|error| panic!("failed to parse {relative}: {error}"))
+}
+
+fn alerts() -> Value {
+    let yaml: serde_yaml::Value =
+        serde_yaml::from_str(&read(ALERTS_PATH)).expect("production readiness alerts must be valid YAML");
+    serde_json::to_value(yaml).expect("string-keyed alert YAML must convert to JSON")
+}
+
+fn registry_signals(registry: &Value) -> BTreeMap<&str, &Value> {
+    registry["signals"]
+        .as_array()
+        .expect("registry signals")
+        .iter()
+        .map(|signal| (signal["id"].as_str().expect("registry signal id"), signal))
+        .collect()
+}
+
+fn dashboard_panels(dashboard: &Value) -> BTreeMap<&str, &Value> {
+    dashboard["panels"]
+        .as_array()
+        .expect("dashboard panels")
+        .iter()
+        .map(|panel| (panel["title"].as_str().expect("dashboard panel title"), panel))
+        .collect()
+}
+
+fn alert_rules(alerts: &Value) -> BTreeMap<&str, &Value> {
+    alerts["groups"]
+        .as_array()
+        .expect("alert groups")
+        .iter()
+        .flat_map(|group| group["rules"].as_array().expect("alert rules"))
+        .map(|rule| (rule["alert"].as_str().expect("alert name"), rule))
+        .collect()
+}
+
+fn compact_promql(query: &str) -> String {
+    query.chars().filter(|character| !character.is_whitespace()).collect()
+}
+
+fn metric_names(query: &str) -> BTreeSet<String> {
+    query
+        .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+        .filter(|token| token.starts_with("rocketmq_"))
+        .map(|token| {
+            token
+                .strip_suffix("_bucket")
+                .or_else(|| token.strip_suffix("_count"))
+                .or_else(|| token.strip_suffix("_sum"))
+                .unwrap_or(token)
+                .to_string()
+        })
+        .collect()
+}
+
+fn markdown_anchors(runbook: &str) -> BTreeSet<String> {
+    runbook
+        .lines()
+        .filter_map(|line| line.strip_prefix("## "))
+        .map(|heading| {
+            let mut anchor = String::new();
+            let mut previous_hyphen = false;
+            for character in heading.chars().flat_map(char::to_lowercase) {
+                if character.is_ascii_alphanumeric() {
+                    anchor.push(character);
+                    previous_hyphen = false;
+                } else if !previous_hyphen {
+                    anchor.push('-');
+                    previous_hyphen = true;
+                }
+            }
+            anchor.trim_matches('-').to_string()
+        })
+        .collect()
+}
+
+fn runbook_alert_section<'a>(runbook: &'a str, alert: &str) -> &'a str {
+    let start = runbook
+        .find(&format!("Alert: `{alert}`"))
+        .unwrap_or_else(|| panic!("runbook route missing for {alert}"));
+    let remainder = &runbook[start..];
+    let end = remainder.find("\n## ").unwrap_or(remainder.len());
+    &remainder[..end]
+}
+
+#[test]
+fn objectives_dashboard_alerts_and_runbook_share_one_contract() {
+    let policy = json(POLICY_PATH);
+    let registry = json(REGISTRY_PATH);
+    let dashboard = json(DASHBOARD_PATH);
+    let alerts = alerts();
+    let runbook = read(RUNBOOK_PATH);
+    let signals = registry_signals(&registry);
+    let panels = dashboard_panels(&dashboard);
+    let rules = alert_rules(&alerts);
+    let anchors = markdown_anchors(&runbook);
+
+    assert_eq!(policy["contract_version"], "1.0.0");
+    for objective in policy["objectives"].as_array().expect("readiness objectives") {
+        let id = objective["id"].as_str().expect("objective id");
+        let source = objective["source"].as_str().expect("objective source");
+        let owner = objective["owner"].as_str().expect("objective owner");
+        assert_eq!(
+            objective["allowed_query_labels"].as_array().map(Vec::len),
+            Some(0),
+            "{id}: production objective queries must aggregate high-cardinality labels"
+        );
+
+        let panel_title = objective["dashboard_panel"].as_str().expect("dashboard panel");
+        let panel = panels
+            .get(panel_title)
+            .unwrap_or_else(|| panic!("{id}: dashboard panel missing"));
+        if let Some(unit) = objective["dashboard_unit"].as_str() {
+            assert_eq!(
+                panel["fieldConfig"]["defaults"]["unit"], unit,
+                "{id}: dashboard unit drift"
+            );
+            let threshold_values = panel["fieldConfig"]["defaults"]["thresholds"]["steps"]
+                .as_array()
+                .expect("live panel thresholds")
+                .iter()
+                .map(|step| &step["value"])
+                .collect::<Vec<_>>();
+            assert!(
+                threshold_values.contains(&&objective["target"]),
+                "{id}: dashboard threshold drift"
+            );
+        }
+
+        let Some(query) = objective["query"].as_str() else {
+            assert_eq!(source, "fault_evidence");
+            assert!(anchors.contains(objective["runbook_anchor"].as_str().expect("runbook anchor")));
+            continue;
+        };
+        let query_metrics = metric_names(query);
+        assert!(query_metrics.contains(source), "{id}: source is absent from its query");
+        for metric in &query_metrics {
+            assert!(
+                signals.contains_key(metric.as_str()),
+                "{id}: unregistered metric {metric}"
+            );
+        }
+        let source_signal = signals.get(source).expect("objective source signal");
+        assert_eq!(
+            source_signal["unit"], objective["source_unit"],
+            "{id}: source metric unit drift"
+        );
+        assert_eq!(source_signal["owner"], owner, "{id}: metric owner drift");
+
+        let panel_query = panel["targets"]
+            .as_array()
+            .expect("panel targets")
+            .iter()
+            .filter_map(|target| target["expr"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            query_metrics.is_subset(&metric_names(&panel_query)),
+            "{id}: dashboard query does not cover the policy metrics"
+        );
+
+        let alert = objective["alert"].as_str().expect("live objective alert");
+        let rule = rules.get(alert).unwrap_or_else(|| panic!("{id}: alert rule missing"));
+        let alert_query = compact_promql(rule["expr"].as_str().expect("alert expression"));
+        assert!(
+            alert_query.contains(&compact_promql(query)),
+            "{id}: alert expression drifted from policy query"
+        );
+        let comparison = match objective["operator"].as_str().expect("comparison operator") {
+            "gte" => "<",
+            "lte" => ">",
+            operator => panic!("{id}: unsupported operator {operator}"),
+        };
+        let target = objective["target"].to_string();
+        assert!(
+            alert_query.contains(&format!("{comparison}{target}")),
+            "{id}: alert threshold drift"
+        );
+        assert_eq!(rule["labels"]["contract"], "production-readiness-v1");
+        assert_eq!(rule["labels"]["owner"], owner, "{id}: alert owner drift");
+
+        let anchor = objective["runbook_anchor"].as_str().expect("runbook anchor");
+        assert!(anchors.contains(anchor), "{id}: runbook anchor missing");
+        assert!(
+            rule["annotations"]["runbook_url"]
+                .as_str()
+                .expect("runbook URL")
+                .ends_with(&format!("#{anchor}")),
+            "{id}: alert runbook route drift"
+        );
+        let section = runbook_alert_section(&runbook, alert);
+        for action in ["Diagnose", "Contain", "Recover", "Escalate"] {
+            assert!(section.contains(action), "{id}: runbook action missing: {action}");
+        }
+    }
+}
+
+#[test]
+fn release_identity_is_low_cardinality_and_consistent() {
+    let policy = json(POLICY_PATH);
+    let registry = json(REGISTRY_PATH);
+    let dashboard = json(DASHBOARD_PATH);
+    let alerts = alerts();
+    let runbook = read(RUNBOOK_PATH);
+    let contract = &policy["release_identity_contract"];
+    let metric = contract["metric"].as_str().expect("release identity metric");
+    let signals = registry_signals(&registry);
+    let signal = signals.get(metric).copied().expect("release identity registry signal");
+    let allowed_labels = contract["allowed_labels"]
+        .as_array()
+        .expect("release identity labels")
+        .iter()
+        .map(|label| label.as_str().expect("release identity label"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(metric, semantic::metrics::RELEASE_INFO);
+    assert_eq!(allowed_labels, ["service", "release_commit", "release_nonce"]);
+    assert_eq!(signal["kind"], contract["kind"]);
+    assert_eq!(signal["unit"], contract["unit"]);
+    assert_eq!(signal["owner"], contract["owner"]);
+    assert_eq!(signal["family"], "release-identity");
+    assert_eq!(signal["attributes"], contract["allowed_labels"]);
+    assert_eq!(signal["cardinality_budget"], contract["cardinality_budget"]);
+    assert_eq!(signal["privacy"], contract["privacy"]);
+    for label in &allowed_labels {
+        assert!(
+            !["password", "credential", "secret", "token", "message_body"].contains(label),
+            "sensitive release identity label: {label}"
+        );
+    }
+
+    let descriptor = catalog::rust_metrics()
+        .iter()
+        .find(|descriptor| descriptor.name == metric)
+        .expect("release identity catalog descriptor");
+    assert_eq!(descriptor.unit, contract["unit"].as_str().expect("identity unit"));
+    assert_eq!(descriptor.labels, allowed_labels);
+
+    let panels = dashboard_panels(&dashboard);
+    let panel = panels
+        .get(contract["dashboard_panel"].as_str().expect("identity panel"))
+        .copied()
+        .expect("release identity dashboard panel");
+    let panel_query = panel["targets"][0]["expr"].as_str().expect("identity panel query");
+    assert!(metric_names(panel_query).contains(metric));
+    assert!(compact_promql(panel_query).contains("by(service,release_commit,release_nonce)"));
+
+    let alert = contract["alert"].as_str().expect("identity alert");
+    let rules = alert_rules(&alerts);
+    let rule = rules.get(alert).copied().expect("release identity alert rule");
+    assert!(metric_names(rule["expr"].as_str().expect("identity alert query")).contains(metric));
+    assert_eq!(rule["labels"]["owner"], contract["owner"]);
+    let section = runbook_alert_section(&runbook, alert);
+    for action in ["Diagnose", "Contain", "Recover", "Escalate"] {
+        assert!(
+            section.contains(action),
+            "release identity runbook action missing: {action}"
+        );
+    }
+}
+
+#[test]
+fn five_services_publish_readiness_from_complete_evidence() {
+    let policy = json(POLICY_PATH);
+    let contract = &policy["readiness_contract"];
+    assert_eq!(contract["probe_path"], "/readyz");
+    assert_eq!(contract["ready_status"], 200);
+    assert_eq!(contract["not_ready_status"], 503);
+    assert_eq!(contract["identity_required_when_metrics_enabled"], true);
+
+    let services = contract["services"].as_array().expect("readiness services");
+    let service_names = services
+        .iter()
+        .map(|service| service["service"].as_str().expect("service name"))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        service_names,
+        BTreeSet::from(["broker", "controller", "mcp", "namesrv", "proxy"])
+    );
+
+    for service in services {
+        let name = service["service"].as_str().expect("readiness service");
+        let requirements = service["requirements"]
+            .as_array()
+            .expect("readiness requirements")
+            .iter()
+            .map(|requirement| requirement.as_str().expect("readiness requirement"))
+            .collect::<BTreeSet<_>>();
+        assert!(
+            requirements.contains("security_bootstrap"),
+            "{name}: security readiness missing"
+        );
+        assert!(
+            requirements.contains("release_identity"),
+            "{name}: release identity readiness missing"
+        );
+        assert_eq!(
+            service["identity_service"],
+            format!("rocketmq-{name}"),
+            "{name}: release identity service drift"
+        );
+
+        for source_contract in service["source_contracts"].as_array().expect("source contracts") {
+            let relative = source_contract["path"].as_str().expect("source contract path");
+            assert!(
+                !Path::new(relative).is_absolute(),
+                "{name}: source path must be repository-relative"
+            );
+            let source = read(relative);
+            for marker in source_contract["required_markers"].as_array().expect("source markers") {
+                let marker = marker.as_str().expect("source marker");
+                assert!(
+                    source.contains(marker),
+                    "{name}: source marker missing from {relative}: {marker}"
+                );
+            }
+        }
+    }
+
+    let lifecycle = read("rocketmq-runtime/src/service_lifecycle.rs");
+    for marker in [
+        r#""/readyz""#,
+        "probe_response(200",
+        "probe_response(503",
+        "pub fn mark_ready",
+    ] {
+        assert!(
+            lifecycle.contains(marker),
+            "service lifecycle readiness marker missing: {marker}"
+        );
+    }
+}
+
+#[test]
+fn collector_outage_is_bounded_measurable_and_non_blocking() {
+    let policy = json(POLICY_PATH);
+    let registry = json(REGISTRY_PATH);
+    let contract = &policy["collector_outage_contract"];
+    let outage = &registry["outage_policy"];
+
+    assert_eq!(
+        contract["max_queue_items"].as_u64(),
+        Some(DEFAULT_MAX_QUEUE_ITEMS as u64)
+    );
+    assert_eq!(
+        contract["max_queue_bytes"].as_u64(),
+        Some(DEFAULT_MAX_QUEUE_BYTES as u64)
+    );
+    assert_eq!(
+        contract["max_record_bytes"].as_u64(),
+        Some(DEFAULT_MAX_RECORD_BYTES as u64)
+    );
+    for field in [
+        "max_queue_items",
+        "max_queue_bytes",
+        "max_record_bytes",
+        "enqueue",
+        "overflow",
+        "data_plane_blocking",
+        "drop_signal",
+        "shutdown_signal",
+    ] {
+        assert_eq!(contract[field], outage[field], "collector outage field drift: {field}");
+    }
+    assert_eq!(contract["recovery_objective_seconds"], 30);
+    assert_eq!(contract["data_plane_blocking"], false);
+    let measurements = outage["measurements"]
+        .as_array()
+        .expect("outage measurements")
+        .iter()
+        .map(|measurement| measurement.as_str().expect("outage measurement"))
+        .collect::<BTreeSet<_>>();
+    for required in contract["required_measurements"]
+        .as_array()
+        .expect("required outage measurements")
+    {
+        let required = required.as_str().expect("required outage measurement");
+        assert!(
+            measurements.contains(required),
+            "missing collector outage measurement: {required}"
+        );
+    }
+    let signals = registry_signals(&registry);
+    assert!(signals.contains_key(contract["drop_signal"].as_str().expect("drop signal")));
+    assert!(signals.contains_key(contract["shutdown_signal"].as_str().expect("shutdown signal")));
+
+    let queue = TelemetryOutageQueue::new(TelemetryQueueLimits::new(1, 8, 8).expect("bounded test limits"));
+    assert_eq!(queue.try_enqueue("first", 4), TelemetryEnqueueOutcome::Accepted);
+    assert_eq!(
+        queue.try_enqueue("second", 4),
+        TelemetryEnqueueOutcome::Dropped(TelemetryDropReason::ItemLimit)
+    );
+    let snapshot = queue.snapshot();
+    assert_eq!(snapshot.queued_items, 1);
+    assert_eq!(snapshot.queued_bytes, 4);
+    assert_eq!(snapshot.accepted_items, 1);
+    assert_eq!(snapshot.dropped_items, 1);
+}

--- a/scripts/generate_telemetry_semantic_registry.py
+++ b/scripts/generate_telemetry_semantic_registry.py
@@ -53,6 +53,14 @@ SPAN_ATTRIBUTES = {
         "messaging.destination.name",
         "messaging.message.body.size",
     ],
+    "STORE_FLUSH": [
+        "component",
+        "result",
+    ],
+    "STORE_DISPATCH": [
+        "component",
+        "result",
+    ],
     "PRODUCER_SEND": [
         "messaging.system",
         "messaging.operation.name",
@@ -93,6 +101,8 @@ EVENT_CONTRACTS = {
 def metric_family(metric_id: str) -> str:
     if "metrics_label_dropped" in metric_id:
         return "exporter"
+    if metric_id == "rocketmq_release_info":
+        return "release-identity"
     if any(token in metric_id for token in ("watermark", "lag", "behind", "inflight", "ready", "queueing")):
         return "watermark-lag"
     if any(token in metric_id for token in ("connection", "bytes", "throughput", "size", "disk_usage")):
@@ -105,12 +115,20 @@ def metric_family(metric_id: str) -> str:
 def attribute_contract(attribute_id: str) -> dict[str, Any]:
     high = attribute_id in HIGH_CARDINALITY_ATTRIBUTES
     privacy = "sensitive" if high else "public" if attribute_id in PUBLIC_ATTRIBUTES else "operational"
+    release_limits = {
+        "release_commit": (64, 40),
+        "release_nonce": (64, 63),
+    }
+    max_distinct, max_value_bytes = release_limits.get(
+        attribute_id,
+        (1_000 if high else 10_000, 512 if high else 256),
+    )
     return {
         "id": attribute_id,
         "cardinality": "high" if high else "bounded",
         "privacy": privacy,
-        "max_distinct": 1_000 if high else 10_000,
-        "max_value_bytes": 512 if high else 256,
+        "max_distinct": max_distinct,
+        "max_value_bytes": max_value_bytes,
         "default_enabled": not high,
         "redaction": "hash" if high else "none",
     }
@@ -158,7 +176,11 @@ def build_registry() -> dict[str, Any]:
                 "family": metric_family(metric["id"]),
                 "stability": "stable",
                 "attributes": metric["attributes"],
-                "cardinality_budget": 10_000 if metric["attributes"] else 1,
+                "cardinality_budget": (
+                    64
+                    if metric["id"] == "rocketmq_release_info"
+                    else 10_000 if metric["attributes"] else 1
+                ),
                 "privacy": signal_privacy(metric["attributes"]),
                 "sampling": {"strategy": "aggregate"},
                 "deprecation": deprecation(),
@@ -168,6 +190,8 @@ def build_registry() -> dict[str, Any]:
     span_owners = {
         "BROKER_RECEIVE_SEND": "broker",
         "STORE_APPEND": "store",
+        "STORE_FLUSH": "store",
+        "STORE_DISPATCH": "store",
         "PRODUCER_SEND": "client",
         "CONSUMER_PROCESS": "client",
     }
@@ -179,7 +203,7 @@ def build_registry() -> dict[str, Any]:
                 "source_symbol": symbol,
                 "signal_type": "span",
                 "owner": span_owners[symbol],
-                "family": "recovery-cache" if symbol == "STORE_APPEND" else "request",
+                "family": "recovery-cache" if symbol.startswith("STORE_") else "request",
                 "stability": "stable",
                 "attributes": attributes,
                 "cardinality_budget": 1_000,
@@ -238,7 +262,7 @@ def build_registry() -> dict[str, Any]:
     )
     return {
         "schema_version": 1,
-        "registry_version": "1.0.0",
+        "registry_version": "1.1.0",
         "milestone": "M11-01",
         "description": "Canonical telemetry semantics and collector-outage behavior for RocketMQ Rust.",
         "required_families": sorted(guard.REQUIRED_FAMILIES),

--- a/scripts/telemetry-semantic-guard-violations.json
+++ b/scripts/telemetry-semantic-guard-violations.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "registry_version": "1.0.0",
+  "registry_version": "1.1.0",
   "fixtures": [
     {
       "id": "unknown-signal",
@@ -42,7 +42,7 @@
       "operation": "delete",
       "path": [
         "signals",
-        129,
+        132,
         "sampling",
         "max_per_second"
       ],
@@ -53,7 +53,7 @@
       "operation": "set",
       "path": [
         "signals",
-        129,
+        132,
         "deprecation"
       ],
       "value": {

--- a/scripts/telemetry-semantic-registry.json
+++ b/scripts/telemetry-semantic-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "registry_version": "1.0.0",
+  "registry_version": "1.1.0",
   "milestone": "M11-01",
   "description": "Canonical telemetry semantics and collector-outage behavior for RocketMQ Rust.",
   "required_families": [
@@ -8,6 +8,7 @@
     "connection-bytes",
     "exporter",
     "recovery-cache",
+    "release-identity",
     "request",
     "task",
     "watermark-lag"
@@ -424,6 +425,24 @@
       "privacy": "operational",
       "max_distinct": 10000,
       "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "release_commit",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 64,
+      "max_value_bytes": 40,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "release_nonce",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 64,
+      "max_value_bytes": 63,
       "default_enabled": true,
       "redaction": "none"
     },
@@ -3297,8 +3316,8 @@
       }
     },
     {
-      "id": "rocketmq_remoting_requests_total",
-      "source_symbol": "REMOTING_REQUESTS_TOTAL",
+      "id": "rocketmq_transport_requests_total",
+      "source_symbol": "TRANSPORT_REQUESTS_TOTAL",
       "signal_type": "metric",
       "kind": "counter",
       "unit": "{request}",
@@ -3320,8 +3339,8 @@
       }
     },
     {
-      "id": "rocketmq_remoting_request_latency",
-      "source_symbol": "REMOTING_REQUEST_LATENCY",
+      "id": "rocketmq_transport_request_latency",
+      "source_symbol": "TRANSPORT_REQUEST_LATENCY",
       "signal_type": "metric",
       "kind": "histogram",
       "unit": "ms",
@@ -3343,8 +3362,8 @@
       }
     },
     {
-      "id": "rocketmq_remoting_network_bytes",
-      "source_symbol": "REMOTING_NETWORK_BYTES",
+      "id": "rocketmq_transport_network_bytes",
+      "source_symbol": "TRANSPORT_NETWORK_BYTES",
       "signal_type": "metric",
       "kind": "counter",
       "unit": "By",
@@ -3895,6 +3914,33 @@
       }
     },
     {
+      "id": "rocketmq_release_info",
+      "source_symbol": "RELEASE_INFO",
+      "signal_type": "metric",
+      "kind": "gauge",
+      "unit": "1",
+      "owner": "observability",
+      "catalog": "rust",
+      "family": "release-identity",
+      "stability": "stable",
+      "attributes": [
+        "service",
+        "release_commit",
+        "release_nonce"
+      ],
+      "cardinality_budget": 64,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
       "id": "RocketMQ BROKER RECEIVE_SEND",
       "source_symbol": "BROKER_RECEIVE_SEND",
       "signal_type": "span",
@@ -3934,6 +3980,56 @@
         "messaging.operation.name",
         "messaging.destination.name",
         "messaging.message.body.size"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ STORE FLUSH",
+      "source_symbol": "STORE_FLUSH",
+      "signal_type": "span",
+      "owner": "store",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "component",
+        "result"
+      ],
+      "cardinality_budget": 1000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "ratio",
+        "default_ratio": 0.01,
+        "max_events_per_operation": 0
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "RocketMQ STORE DISPATCH",
+      "source_symbol": "STORE_DISPATCH",
+      "signal_type": "span",
+      "owner": "store",
+      "family": "recovery-cache",
+      "stability": "stable",
+      "attributes": [
+        "component",
+        "result"
       ],
       "cardinality_budget": 1000,
       "privacy": "operational",

--- a/scripts/telemetry_semantic_guard.py
+++ b/scripts/telemetry_semantic_guard.py
@@ -39,6 +39,7 @@ REQUIRED_FAMILIES = {
     "connection-bytes",
     "task",
     "recovery-cache",
+    "release-identity",
     "auth-mcp",
     "exporter",
 }

--- a/scripts/tests/fixtures/m11-slo/pass/run.json
+++ b/scripts/tests/fixtures/m11-slo/pass/run.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "milestone": "M11-12",
   "execution_unit": "R24",
-  "policy_sha256": "0a56c4d1d1e4907a251673e4fe589313602e953dca740e765435c330a1304b1e",
+  "policy_sha256": "e12df9458d1a6c739abcb60ffbd8cf8e0c473841bdc382308a8441e966447bd9",
   "candidate_commit": "0123456789abcdef0123456789abcdef01234567",
   "candidate_images": {
     "broker": "registry.example.invalid/rocketmq/broker@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
@@ -94,11 +94,11 @@
   "unresolved_alerts": [],
   "unresolved_faults": [],
   "release_artifacts": {
-    "distribution/config/grafana-architecture-production-readiness.json": "aedc9e704a145da81015c66be3530aa6f01d7831a733e02a6cc6edfa81b24287",
-    "distribution/config/prometheus-architecture-production-readiness-alerts.yaml": "53e35ad621710dd8c2cbac5eff6012a631ec7215e019d4e533ae35efb0cd1a1f",
-    "rocketmq-doc/en/architecture-production-readiness-runbook.md": "a3252fcc7243e92fa02ae9205f5450958cd9387db8ee73d315c0cd2606314eb1",
+    "distribution/config/grafana-architecture-production-readiness.json": "b586879abcf204d2cbf06c049fe21e0bfef10d1dadb67488a6c5ee91eab8ac70",
+    "distribution/config/prometheus-architecture-production-readiness-alerts.yaml": "44bfcbb119343fd848fe7c32ffaeab235eee960c2ec3ad2130b31493893f4646",
+    "rocketmq-doc/en/architecture-production-readiness-runbook.md": "857a461791a5f6b7ba3301278b2fd103fd7b96161f4ee72525f5c865f62afa00",
     "distribution/kubernetes/fault-matrix-policy.json": "771b3abf35213a4b6fbb3626d7822e11e6a17d9609ae7587d309bcaf2a5cdd37",
-    "scripts/telemetry-semantic-registry.json": "5211cf7882663b4220236facaa14a68c507fef60a5b1081de1be1867cd5ce277"
+    "scripts/telemetry-semantic-registry.json": "32f7824018e2f7a5a73176a177198bef08e252eb6c23fdc43dd6e73b5ae294a5"
   },
   "artifacts": [
     {

--- a/scripts/tests/test_telemetry_semantic_guard.py
+++ b/scripts/tests/test_telemetry_semantic_guard.py
@@ -40,10 +40,10 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
 
     def test_live_registry_matches_every_rust_signal(self) -> None:
         self.assertEqual([], guard.validate_registry(self.registry, self.inventory))
-        self.assertEqual(125, len(self.inventory["metrics"]))
-        self.assertEqual(4, len(self.inventory["spans"]))
+        self.assertEqual(126, len(self.inventory["metrics"]))
+        self.assertEqual(6, len(self.inventory["spans"]))
         self.assertEqual(7, len(self.inventory["events"]))
-        self.assertEqual(136, len(self.registry["signals"]))
+        self.assertEqual(139, len(self.registry["signals"]))
 
     def test_log_filter_metrics_have_stable_registry_contracts(self) -> None:
         symbols = {
@@ -84,7 +84,7 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn("metrics=125 spans=4 logs=7 attributes=68", result.stdout)
+        self.assertIn("metrics=126 spans=6 logs=7 attributes=70", result.stdout)
 
     def test_committed_violation_fixtures_are_rejected(self) -> None:
         fixture_ids = {fixture["id"] for fixture in self.fixtures}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8768

### Brief Description

- Define one versioned production-readiness contract for objective metrics, units, owners, thresholds, release identity, five-service readiness, and bounded collector-outage behavior.
- Align the Grafana dashboard, Prometheus alerts, and operational runbook with that contract, including low-cardinality release identity conflict detection and explicit diagnose/contain/recover/escalate guidance.
- Extend the generated telemetry registry with current release identity and Store span semantics, and add a cross-artifact Rust regression test that detects drift across the policy, metric catalog, dashboard, alerts, runbook, service source contracts, and exporter queue limits.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-observability -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-observability --test production_readiness_contract --all-features`
- `cargo test -p rocketmq-observability --all-features release_identity`
- `cargo test -p rocketmq-observability --all-features queue_is_count_and_byte_bounded_and_drops_are_measurable`
- Focused Broker, Controller, NameServer, Proxy, and MCP readiness/release-identity tests
- Six local `rocketmq-observability` feature-set checks covering observability, OTLP metrics/traces/logs, and Prometheus combinations
- `python scripts/telemetry_semantic_guard.py`
- `python scripts/architecture_slo_guard.py --policy-only`
- `python scripts/architecture_slo_guard.py --evidence scripts/tests/fixtures/m11-slo/pass --allow-fixture`
- `python -m unittest scripts.tests.test_architecture_slo_guard scripts.tests.test_telemetry_semantic_guard`
- Local Helm lint and render for the default and production Controller HA values

The aggregate Windows `cargo fmt --all -- --check` command still hits OS error 206 because the workspace rustfmt command line is too long; the affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release identity monitoring, conflict detection, and dashboard visibility.
  * Expanded service readiness checks through the `/readyz` endpoint for core components.
  * Added store flush and dispatch telemetry signals.
  * Defined bounded collector outage handling with queue, drop, and recovery measurements.

* **Documentation**
  * Updated the production-readiness runbook with alert-driven troubleshooting, recovery procedures, and verification guidance.

* **Tests**
  * Added contract validation covering policies, dashboards, alerts, readiness, release identity, and telemetry outage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->