### PR TITLE
[ISSUE #8788]🐛Restore dependency-aware service image smoke

### DIFF
--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -4,6 +4,13 @@
   "foundation_dockerfile": "docker/Dockerfile.base",
   "service_contract_script": "scripts/service-image-contract.ps1",
   "smoke_config_directory": "docker/smoke-config",
+  "smoke_network": {
+    "network_prefix": "rocketmq-service-smoke",
+    "namesrv_alias": "rocketmq-namesrv",
+    "namesrv_port": 9876,
+    "dependency_chain": ["namesrv", "broker"],
+    "dependent_services": ["proxy", "mcp"]
+  },
   "base_images": {
     "builder": {
       "reference": "docker.io/library/rust:slim-bookworm@sha256:99e09cb2284e2ddbb73a995deee3e91783fd04d177602ccf6eab326d778ee777",

--- a/docker/smoke-config/broker.toml
+++ b/docker/smoke-config/broker.toml
@@ -5,7 +5,7 @@
 listenPort = 10911
 brokerIp1 = "127.0.0.1"
 storePathRootDir = "/var/lib/rocketmq/broker"
-namesrvAddr = "127.0.0.1:9876"
+namesrvAddr = "rocketmq-namesrv:9876"
 autoCreateTopicEnable = false
 
 [broker.brokerIdentity]

--- a/docker/smoke-config/mcp.toml
+++ b/docker/smoke-config/mcp.toml
@@ -36,7 +36,7 @@ protected_resource_metadata_path = "/.well-known/oauth-protected-resource"
 
 [[clusters]]
 name = "container-smoke"
-namesrv_addr = "127.0.0.1:9876"
+namesrv_addr = "rocketmq-namesrv:9876"
 default = true
 
 [security]

--- a/docker/smoke-config/proxy.toml
+++ b/docker/smoke-config/proxy.toml
@@ -11,4 +11,4 @@ enabled = false
 listenAddr = "0.0.0.0:8080"
 
 [cluster]
-namesrvAddr = "127.0.0.1:9876"
+namesrvAddr = "rocketmq-namesrv:9876"

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -121,6 +121,28 @@ def audit_foundation(
         expected_peer = [{"id": 1, "addr": "127.0.0.1:60110"}]
         if parsed_smoke_configs["controller.toml"].get("raftPeers") != expected_peer:
             findings.append("controller smoke config must retain its single-node Raft peer")
+    expected_smoke_network = {
+        "network_prefix": "rocketmq-service-smoke",
+        "namesrv_alias": "rocketmq-namesrv",
+        "namesrv_port": 9876,
+        "dependency_chain": ["namesrv", "broker"],
+        "dependent_services": ["proxy", "mcp"],
+    }
+    if policy.get("smoke_network") != expected_smoke_network:
+        findings.append("service smoke network contract drifted")
+    expected_namesrv_address = (
+        f"{expected_smoke_network['namesrv_alias']}:{expected_smoke_network['namesrv_port']}"
+    )
+    dependent_addresses = {
+        "broker.toml": lambda config: config.get("broker", {}).get("namesrvAddr"),
+        "proxy.toml": lambda config: config.get("cluster", {}).get("namesrvAddr"),
+        "mcp.toml": lambda config: (config.get("clusters") or [{}])[0].get("namesrv_addr"),
+    }
+    for name, address in dependent_addresses.items():
+        if name not in parsed_smoke_configs:
+            findings.append(f"{name} smoke config is missing")
+        elif address(parsed_smoke_configs[name]) != expected_namesrv_address:
+            findings.append(f"{name} must use the isolated smoke NameServer alias")
 
     builder_ref = policy["base_images"]["builder"]["reference"]
     runtime_ref = policy["base_images"]["runtime"]["reference"]
@@ -405,8 +427,17 @@ def audit_foundation(
         "--target $service.target",
         "--read-only",
         "must fail closed when its required config mount is absent",
-        "docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds)",
+        "docker stop --signal SIGTERM --timeout $GracePeriodSeconds",
         "{{.State.ExitCode}}",
+        "docker network create $smokeNetwork",
+        "docker network rm $smokeNetwork",
+        '"--network",',
+        "-NetworkName $smokeNetwork",
+        '"--network-alias",',
+        "-NetworkAlias $networkAlias",
+        "--volumes",
+        "$policy.smoke_network.namesrv_alias",
+        "$policy.smoke_network.dependency_chain",
         "$service.data_path",
         "find /usr/local/bin",
         "cyclonedx-json",

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -52,6 +52,78 @@ function Invoke-Captured {
     return $output
 }
 
+function Start-ServiceSmokeContainer {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ImageRef,
+        [Parameter(Mandatory = $true)]
+        [string]$NetworkName,
+        [Parameter(Mandatory = $true)]
+        [string]$ConfigPath,
+        [Parameter(Mandatory = $true)]
+        [string]$WritableDataPath,
+        [Parameter(Mandatory = $true)]
+        [string]$TmpfsOptions,
+        [string]$NetworkAlias = ""
+    )
+
+    $dockerArguments = @(
+        "run",
+        "--detach",
+        "--interactive",
+        "--network",
+        $NetworkName
+    )
+    if (-not [string]::IsNullOrWhiteSpace($NetworkAlias)) {
+        $dockerArguments += @("--network-alias", $NetworkAlias)
+    }
+    $dockerArguments += @(
+        "--read-only",
+        "--mount",
+        "type=volume,destination=$WritableDataPath",
+        "--mount",
+        "type=bind,source=$ConfigPath,target=/etc/rocketmq,readonly",
+        "--tmpfs",
+        $TmpfsOptions,
+        $ImageRef
+    )
+    return (Invoke-Captured docker @dockerArguments).Trim()
+}
+
+function Assert-ServiceSmokeRunning {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ServiceName,
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerId
+    )
+
+    Start-Sleep -Seconds 5
+    $running = (Invoke-Captured docker inspect --format "{{.State.Running}}" $ContainerId).Trim()
+    if ($running -ne "true") {
+        $logs = Invoke-Captured docker logs $ContainerId
+        throw "$ServiceName exited before SIGTERM smoke: $logs"
+    }
+}
+
+function Stop-ServiceSmokeContainer {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ServiceName,
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerId,
+        [Parameter(Mandatory = $true)]
+        [int]$GracePeriodSeconds
+    )
+
+    Invoke-Checked docker stop --signal SIGTERM --timeout $GracePeriodSeconds $ContainerId
+    $exitCode = [int](Invoke-Captured docker inspect --format "{{.State.ExitCode}}" $ContainerId).Trim()
+    if ($exitCode -ne 0) {
+        $logs = Invoke-Captured docker logs $ContainerId
+        throw "$ServiceName SIGTERM exit code was $exitCode`: $logs"
+    }
+}
+
 function Format-CriticalVulnerabilitySummary {
     param(
         [object[]]$Vulnerabilities
@@ -104,6 +176,10 @@ $oldPassword = $env:COSIGN_PASSWORD
 $randomBytes = New-Object byte[] 32
 $random = [System.Security.Cryptography.RandomNumberGenerator]::Create()
 $evidence = [System.Collections.Generic.List[object]]::new()
+$smokeContainerIds = [System.Collections.Generic.List[string]]::new()
+$dependencyContainerIds = @{}
+$smokeNetwork = ""
+$smokeNetworkCreated = $false
 
 try {
     $random.GetBytes($randomBytes)
@@ -176,28 +252,6 @@ try {
         ) -join "; "
         Invoke-Checked docker run --rm --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --tmpfs $tmpfsOptions --entrypoint /bin/sh $imageRef -c $permissionSmoke
 
-        $containerId = ""
-        try {
-            $containerId = (Invoke-Captured docker run --detach --interactive --network none --read-only --mount "type=volume,destination=$($policy.runtime.writable_data_path)" --mount "type=bind,source=$smokeConfigPath,target=/etc/rocketmq,readonly" --tmpfs $tmpfsOptions $imageRef).Trim()
-            Start-Sleep -Seconds 5
-            $running = (Invoke-Captured docker inspect --format "{{.State.Running}}" $containerId).Trim()
-            if ($running -ne "true") {
-                $logs = Invoke-Captured docker logs $containerId
-                throw "$serviceName exited before SIGTERM smoke: $logs"
-            }
-            Invoke-Checked docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds) $containerId
-            $exitCode = [int](Invoke-Captured docker inspect --format "{{.State.ExitCode}}" $containerId).Trim()
-            if ($exitCode -ne 0) {
-                $logs = Invoke-Captured docker logs $containerId
-                throw "$serviceName SIGTERM exit code was $exitCode`: $logs"
-            }
-        }
-        finally {
-            if ($containerId) {
-                & docker rm --force $containerId *> $null
-            }
-        }
-
         $sbomPath = Join-Path $outputPath "$serviceName.cdx.json"
         $trivyPath = Join-Path $outputPath "$serviceName.trivy.json"
         $bundlePath = Join-Path $outputPath "$serviceName.sbom.sigstore.json"
@@ -247,8 +301,65 @@ try {
             signature_bundle_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $bundlePath).Hash.ToLowerInvariant()
         })
     }
+
+    $smokeNetwork = "$($policy.smoke_network.network_prefix)-$PID-$($sourceCommit.Substring(0, 8))"
+    Invoke-Checked docker network create $smokeNetwork
+    $smokeNetworkCreated = $true
+
+    $namesrvAlias = $policy.smoke_network.namesrv_alias
+    foreach ($dependencyServiceName in @($policy.smoke_network.dependency_chain)) {
+        $networkAlias = if ($dependencyServiceName -eq "namesrv") {
+            $namesrvAlias
+        }
+        else {
+            ""
+        }
+        $containerId = Start-ServiceSmokeContainer `
+            -ImageRef "rocketmq-rust/$($dependencyServiceName):verification" `
+            -NetworkName $smokeNetwork `
+            -NetworkAlias $networkAlias `
+            -ConfigPath $smokeConfigPath `
+            -WritableDataPath $policy.runtime.writable_data_path `
+            -TmpfsOptions $tmpfsOptions
+        $smokeContainerIds.Add($containerId)
+        $dependencyContainerIds[$dependencyServiceName] = $containerId
+        Assert-ServiceSmokeRunning -ServiceName $dependencyServiceName -ContainerId $containerId
+    }
+
+    foreach ($serviceProperty in $policy.services.PSObject.Properties) {
+        $serviceName = $serviceProperty.Name
+        if (@($policy.smoke_network.dependency_chain) -contains $serviceName) {
+            continue
+        }
+        $containerId = Start-ServiceSmokeContainer `
+            -ImageRef "rocketmq-rust/$($serviceName):verification" `
+            -NetworkName $smokeNetwork `
+            -ConfigPath $smokeConfigPath `
+            -WritableDataPath $policy.runtime.writable_data_path `
+            -TmpfsOptions $tmpfsOptions
+        $smokeContainerIds.Add($containerId)
+        Assert-ServiceSmokeRunning -ServiceName $serviceName -ContainerId $containerId
+        Stop-ServiceSmokeContainer `
+            -ServiceName $serviceName `
+            -ContainerId $containerId `
+            -GracePeriodSeconds $policy.runtime.stop_grace_period_seconds
+    }
+    [array]$dependencyShutdownOrder = @($policy.smoke_network.dependency_chain)
+    [array]::Reverse($dependencyShutdownOrder)
+    foreach ($dependencyServiceName in $dependencyShutdownOrder) {
+        Stop-ServiceSmokeContainer `
+            -ServiceName $dependencyServiceName `
+            -ContainerId $dependencyContainerIds[$dependencyServiceName] `
+            -GracePeriodSeconds $policy.runtime.stop_grace_period_seconds
+    }
 }
 finally {
+    foreach ($containerId in @($smokeContainerIds)) {
+        & docker rm --force --volumes $containerId *> $null
+    }
+    if ($smokeNetworkCreated) {
+        & docker network rm $smokeNetwork *> $null
+    }
     $random.Dispose()
     $env:COSIGN_PASSWORD = $oldPassword
     if (Test-Path -LiteralPath $privateKey) {

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -171,6 +171,27 @@ class ContainerFoundationTests(unittest.TestCase):
         findings = self.audit(smoke_configs=missing_peer)
         self.assertTrue(any("single-node Raft peer" in finding for finding in findings))
 
+    def test_smoke_dependencies_must_use_the_isolated_namesrv_alias(self) -> None:
+        for config_name in ("broker.toml", "proxy.toml", "mcp.toml"):
+            with self.subTest(config=config_name):
+                loopback = dict(self.smoke_configs)
+                loopback[config_name] = loopback[config_name].replace(
+                    'rocketmq-namesrv:9876',
+                    '127.0.0.1:9876',
+                    1,
+                )
+                findings = self.audit(smoke_configs=loopback)
+                self.assertTrue(
+                    any(
+                        config_name in finding and "NameServer alias" in finding
+                        for finding in findings
+                    )
+                )
+
+        policy = copy.deepcopy(self.policy)
+        policy["smoke_network"]["dependency_chain"].remove("broker")
+        self.assertTrue(any("smoke network contract" in finding for finding in self.audit(policy=policy)))
+
     def test_missing_read_only_or_signature_verification_is_rejected(self) -> None:
         no_read_only = self.supply_script.replace("--read-only", "--read-write", 1)
         self.assertTrue(any("--read-only" in finding for finding in self.audit(supply_script=no_read_only)))
@@ -280,10 +301,20 @@ class ContainerFoundationTests(unittest.TestCase):
         findings = self.audit(signal_sources=signal_sources)
         self.assertTrue(any("mcp_stdio entrypoint" in finding for finding in findings))
 
-        stop_contract = "docker stop --signal SIGTERM --timeout $($policy.runtime.stop_grace_period_seconds)"
+        stop_contract = "docker stop --signal SIGTERM --timeout $GracePeriodSeconds"
         weakened = self.service_script.replace(stop_contract, "docker kill", 1)
         self.assertTrue(
             any("docker stop --signal SIGTERM" in finding for finding in self.audit(service_script=weakened))
+        )
+
+        isolated = self.service_script.replace("-NetworkName $smokeNetwork", "-NetworkName none")
+        self.assertTrue(
+            any("-NetworkName $smokeNetwork" in finding for finding in self.audit(service_script=isolated))
+        )
+
+        no_alias = self.service_script.replace("-NetworkAlias $networkAlias", "-NetworkAlias removed")
+        self.assertTrue(
+            any("-NetworkAlias $networkAlias" in finding for finding in self.audit(service_script=no_alias))
         )
 
     def test_native_dash_c_arguments_are_preserved_by_real_script_helpers(self) -> None:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8788

### Brief Description

Restore the five-service container lifecycle contract by running smoke containers on an isolated Docker bridge instead of disconnecting services from their required dependencies.

- Encode the NameServer and Broker dependency chain in the container policy.
- Keep NameServer and Broker alive while Proxy and MCP readiness checks run.
- Resolve NameServer through a dedicated network alias in Broker, Proxy, and MCP smoke configurations.
- Shut down dependencies in reverse order and remove smoke containers, anonymous volumes, and the isolated network.
- Extend the architecture guard and mutation tests to reject loopback, disconnected-network, alias, and dependency-order regressions.

### How Did You Test This Change?

- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation`
- PowerShell parser validation for `scripts/service-image-contract.ps1`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`
- Real Docker lifecycle validation against all five service images: isolated NameServer and Broker dependency chain, service liveness, SIGTERM, zero exit codes, and resource cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added isolated container smoke testing with dedicated networking, service aliases, and dependency-aware startup and shutdown.
  * Improved verification of service readiness, graceful termination, logs, and cleanup.

* **Bug Fixes**
  * Updated containerized services to connect to the correct NameServer hostname instead of localhost.

* **Tests**
  * Added coverage ensuring smoke-test dependencies use the isolated NameServer configuration and required network behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->