### PR TITLE
[ISSUE #8792]🐛Publish signed service image digests

### DIFF
--- a/.github/workflows/container-foundation-ci.yml
+++ b/.github/workflows/container-foundation-ci.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/service-image-contract.ps1"
       - "scripts/tests/test_m11_container_foundation.py"
       - ".github/workflows/container-foundation-ci.yml"
+      - ".github/workflows/service-image-publish.yml"
   push:
     branches:
       - main
@@ -21,6 +22,7 @@ on:
       - "scripts/service-image-contract.ps1"
       - "scripts/tests/test_m11_container_foundation.py"
       - ".github/workflows/container-foundation-ci.yml"
+      - ".github/workflows/service-image-publish.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/service-image-publish.yml
+++ b/.github/workflows/service-image-publish.yml
@@ -1,0 +1,152 @@
+name: Publish signed service images
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Repository commit, tag, or branch to publish
+        required: true
+        default: main
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: service-image-publish-${{ github.event_name }}-${{ inputs.source_ref || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish five immutable service images
+    if: github.repository == 'mxsm/rocketmq-rust'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      REPOSITORY_PREFIX: ghcr.io/mxsm/rocketmq-rust
+      CERTIFICATE_IDENTITY_REGEXP: ^https://github\.com/mxsm/rocketmq-rust/\.github/workflows/service-image-publish\.yml@refs/(heads/main|tags/[A-Za-z0-9._-]+)$
+      CERTIFICATE_OIDC_ISSUER: https://token.actions.githubusercontent.com
+    steps:
+      - name: Check out the explicit source ref
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Resolve immutable source identity
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_commit="$(git rev-parse HEAD)"
+          source_version="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          manifest = tomllib.loads(Path("Cargo.toml").read_text(encoding="utf-8"))
+          print(manifest["workspace"]["package"]["version"])
+          PY
+          )"
+          immutable_tag="${source_version}-${source_commit:0:12}"
+          [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$immutable_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{12}$ ]]
+          if [[ "$GITHUB_EVENT_NAME" == "release" && "$GITHUB_REF_NAME" != "v${source_version}" ]]; then
+            echo "release tag must equal workspace version: expected v${source_version}, got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          {
+            echo "commit=$source_commit"
+            echo "version=$source_version"
+            echo "tag=$immutable_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GHCR
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Build, publish, sign, and verify five service images
+        shell: bash
+        env:
+          SOURCE_COMMIT: ${{ steps.source.outputs.commit }}
+          SOURCE_VERSION: ${{ steps.source.outputs.version }}
+          IMMUTABLE_TAG: ${{ steps.source.outputs.tag }}
+        run: |
+          set -euo pipefail
+          output="target/service-image-publication"
+          mkdir -p "$output/signatures" "$output/manifests"
+          image_map="$output/image-map.json"
+          printf '{}\n' > "$image_map"
+
+          for service in broker namesrv controller proxy mcp; do
+            repository="${REPOSITORY_PREFIX}/${service}"
+            tagged_ref="${repository}:${IMMUTABLE_TAG}"
+            metadata="$output/manifests/${service}.json"
+            docker buildx build \
+              --file docker/Dockerfile.base \
+              --platform linux/amd64 \
+              --target "$service" \
+              --tag "$tagged_ref" \
+              --build-arg "SOURCE_REVISION=$SOURCE_COMMIT" \
+              --build-arg "SOURCE_VERSION=$SOURCE_VERSION" \
+              --metadata-file "$metadata" \
+              --push \
+              .
+
+            digest="$(jq -r '."containerimage.digest"' "$metadata")"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            digest_ref="${repository}@${digest}"
+            cosign sign --yes "$digest_ref"
+            cosign verify \
+              --certificate-identity-regexp "$CERTIFICATE_IDENTITY_REGEXP" \
+              --certificate-oidc-issuer "$CERTIFICATE_OIDC_ISSUER" \
+              --output json \
+              "$digest_ref" > "$output/signatures/${service}.json"
+            jq --arg service "$service" --arg reference "$digest_ref" \
+              '. + {($service): $reference}' "$image_map" > "$image_map.tmp"
+            mv "$image_map.tmp" "$image_map"
+          done
+
+          jq --sort-keys . "$image_map" > "$image_map.sorted"
+          mv "$image_map.sorted" "$image_map"
+          jq -n \
+            --arg source_commit "$SOURCE_COMMIT" \
+            --arg source_version "$SOURCE_VERSION" \
+            --arg immutable_tag "$IMMUTABLE_TAG" \
+            --arg workflow_run "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --slurpfile images "$image_map" \
+            '{
+              schema_version: 1,
+              source_commit: $source_commit,
+              source_version: $source_version,
+              immutable_tag: $immutable_tag,
+              workflow_run: $workflow_run,
+              images: $images[0],
+              signature: {
+                format: "sigstore-keyless",
+                oidc_issuer: "https://token.actions.githubusercontent.com"
+              }
+            }' > "$output/publication.json"
+          sha256sum "$image_map" "$output/publication.json" > "$output/SHA256SUMS"
+
+      - name: Upload commit-bound image map
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: architecture-service-images-${{ steps.source.outputs.commit }}
+          path: target/service-image-publication
+          if-no-files-found: error
+          retention-days: 90

--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -178,5 +178,11 @@
       "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     }
   },
+  "publication": {
+    "workflow": ".github/workflows/service-image-publish.yml",
+    "artifact_prefix": "architecture-service-images",
+    "platform": "linux/amd64",
+    "automatic_release": true
+  },
   "compatibility_exceptions": []
 }

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -88,6 +88,7 @@ def audit_foundation(
     signal_sources: dict[str, str] | None = None,
     dockerignore: str = "",
     smoke_configs: dict[str, str] | None = None,
+    publication_workflow: str = "",
 ) -> list[str]:
     findings: list[str] = []
     if policy.get("schema_version") != 1:
@@ -230,6 +231,14 @@ def audit_foundation(
         findings.append("service smoke config directory drifted")
     if policy.get("service_contract_script") != "scripts/service-image-contract.ps1":
         findings.append("service image contract script path drifted")
+    expected_publication = {
+        "workflow": ".github/workflows/service-image-publish.yml",
+        "artifact_prefix": "architecture-service-images",
+        "platform": "linux/amd64",
+        "automatic_release": True,
+    }
+    if policy.get("publication") != expected_publication:
+        findings.append("service image publication contract drifted")
     if policy.get("build", {}).get("service_builder_target") != "service-builder":
         findings.append("service builder target drifted")
     if policy.get("build", {}).get("service_runtime_target") != "service-runtime":
@@ -459,6 +468,37 @@ def audit_foundation(
         findings.append("service image CRITICAL vulnerability gate must not ignore unfixed findings")
     if "$_.FixedVersion" in service_script:
         findings.append("service vulnerability summary must tolerate a missing FixedVersion property")
+
+    publication_fragments = [
+        "workflow_dispatch:",
+        "release:",
+        "types: [published]",
+        "contents: read",
+        "packages: write",
+        "id-token: write",
+        "github.repository == 'mxsm/rocketmq-rust'",
+        "source_ref:",
+        "docker login ghcr.io",
+        "docker buildx build",
+        "--platform linux/amd64",
+        '--target "$service"',
+        '--tag "$tagged_ref"',
+        "--push",
+        "cosign sign --yes",
+        "cosign verify",
+        "containerimage.digest",
+        "image-map.json",
+        "publication.json",
+        "architecture-service-images-${{ steps.source.outputs.commit }}",
+    ]
+    for fragment in publication_fragments:
+        if fragment not in publication_workflow:
+            findings.append(f"service image publication workflow missing: {fragment}")
+    if "pull_request:" in publication_workflow:
+        findings.append("service image publication workflow must never run for pull requests")
+    for mutable_tag in (":latest", ":main", ":master"):
+        if mutable_tag in publication_workflow:
+            findings.append(f"service image publication workflow contains mutable tag: {mutable_tag}")
     return findings
 
 
@@ -477,6 +517,7 @@ def main() -> int:
         workflow = (ROOT / policy["workflow"]["path"]).read_text(encoding="utf-8")
         supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
         service_script = (ROOT / policy["service_contract_script"]).read_text(encoding="utf-8")
+        publication_workflow = (ROOT / policy["publication"]["workflow"]).read_text(encoding="utf-8")
         signal_sources = {
             name: (ROOT / path).read_text(encoding="utf-8") for name, path in policy["signal_sources"].items()
         }
@@ -495,6 +536,7 @@ def main() -> int:
             signal_sources,
             dockerignore,
             smoke_configs,
+            publication_workflow,
         )
     except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
         print(f"CONTAINER_IMAGE_GUARD_FAILED {error}", file=sys.stderr)

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -50,6 +50,7 @@ class ContainerFoundationTests(unittest.TestCase):
         cls.workflow = (ROOT / cls.policy["workflow"]["path"]).read_text(encoding="utf-8")
         cls.supply_script = (ROOT / "scripts" / "container-supply-chain.ps1").read_text(encoding="utf-8")
         cls.service_script = (ROOT / cls.policy["service_contract_script"]).read_text(encoding="utf-8")
+        cls.publication_workflow = (ROOT / cls.policy["publication"]["workflow"]).read_text(encoding="utf-8")
         cls.dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
         cls.smoke_configs = {
             path.name: path.read_text(encoding="utf-8")
@@ -73,6 +74,7 @@ class ContainerFoundationTests(unittest.TestCase):
         dockerfiles=None,
         dockerignore=None,
         smoke_configs=None,
+        publication_workflow=None,
     ):
         return GUARD.audit_foundation(
             policy or self.policy,
@@ -84,6 +86,7 @@ class ContainerFoundationTests(unittest.TestCase):
             signal_sources if signal_sources is not None else self.signal_sources,
             dockerignore if dockerignore is not None else self.dockerignore,
             smoke_configs if smoke_configs is not None else self.smoke_configs,
+            publication_workflow if publication_workflow is not None else self.publication_workflow,
         )
 
     def test_repository_foundation_contract_passes(self) -> None:
@@ -128,6 +131,36 @@ class ContainerFoundationTests(unittest.TestCase):
         workflow = self.workflow.replace("if: always()", "if: success()", 1)
         findings = self.audit(workflow=workflow)
         self.assertTrue(any("if: always()" in finding for finding in findings))
+
+    def test_publication_requires_immutable_signed_digest_outputs(self) -> None:
+        pull_request_publish = self.publication_workflow.replace(
+            "  workflow_dispatch:",
+            "  pull_request:\n  workflow_dispatch:",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "must never run for pull requests" in finding
+                for finding in self.audit(publication_workflow=pull_request_publish)
+            )
+        )
+
+        unsigned = self.publication_workflow.replace("cosign sign --yes", "cosign skipped", 1)
+        self.assertTrue(
+            any(
+                "cosign sign --yes" in finding
+                for finding in self.audit(publication_workflow=unsigned)
+            )
+        )
+
+        mutable = self.publication_workflow.replace(
+            'tagged_ref="${repository}:${IMMUTABLE_TAG}"',
+            'tagged_ref="${repository}:latest"',
+            1,
+        )
+        self.assertTrue(
+            any("mutable tag: :latest" in finding for finding in self.audit(publication_workflow=mutable))
+        )
 
     def test_unregistered_dockerfile_or_restored_legacy_exception_is_rejected(self) -> None:
         dockerfiles = set(self.dockerfiles)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8792

### Brief Description

Add a least-privilege manual/release publisher for the five production service images. The workflow checks out an explicit source ref, publishes only immutable version-plus-commit tags to GHCR, resolves each registry digest, keyless-signs and verifies every digest, and uploads commit-bound image-map and provenance artifacts. Extend the container policy guard and mutation tests so pull-request publication, mutable tags, or unsigned outputs fail closed.

### How Did You Test This Change?

- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation`
- `python -m py_compile scripts/container_image_guard.py scripts/tests/test_m11_container_foundation.py`
- `actionlint .github/workflows/service-image-publish.yml .github/workflows/container-foundation-ci.yml`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`
