### PR TITLE
[ISSUE #8794]🐛Make dynamic architecture evidence executable

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - rocketmq-architecture-evidence
+    - rocketmq-benchmark

--- a/.github/workflows/architecture-slo-evidence.yml
+++ b/.github/workflows/architecture-slo-evidence.yml
@@ -3,6 +3,7 @@ name: Architecture production-readiness SLO evidence
 on:
   pull_request:
     paths:
+      - ".github/actionlint.yaml"
       - ".github/workflows/architecture-slo-evidence.yml"
       - "distribution/config/architecture-production-readiness-policy.json"
       - "distribution/config/grafana-architecture-production-readiness.json"
@@ -12,13 +13,17 @@ on:
       - "scripts/architecture_slo_guard.py"
       - "scripts/fault_matrix_guard.py"
       - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/new-m11-evidence-secrets.ps1"
+      - "scripts/run-architecture-slo-cluster.ps1"
       - "scripts/run-architecture-slo-evidence.ps1"
       - "scripts/telemetry-semantic-registry.json"
       - "scripts/tests/test_architecture_slo_guard.py"
+      - "scripts/tests/test_m11_dynamic_evidence.py"
       - "scripts/tests/fixtures/m11-slo/**"
   push:
     branches: [main]
     paths:
+      - ".github/actionlint.yaml"
       - ".github/workflows/architecture-slo-evidence.yml"
       - "distribution/config/architecture-production-readiness-policy.json"
       - "distribution/config/grafana-architecture-production-readiness.json"
@@ -28,9 +33,12 @@ on:
       - "scripts/architecture_slo_guard.py"
       - "scripts/fault_matrix_guard.py"
       - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/new-m11-evidence-secrets.ps1"
+      - "scripts/run-architecture-slo-cluster.ps1"
       - "scripts/run-architecture-slo-evidence.ps1"
       - "scripts/telemetry-semantic-registry.json"
       - "scripts/tests/test_architecture_slo_guard.py"
+      - "scripts/tests/test_m11_dynamic_evidence.py"
       - "scripts/tests/fixtures/m11-slo/**"
   workflow_dispatch:
     inputs:
@@ -50,16 +58,19 @@ on:
       collector_image:
         description: OpenTelemetry Collector image@sha256 reference
         required: true
+        default: docker.io/otel/opentelemetry-collector-contrib@sha256:9c247564e65ca19f97d891cca19a1a8d291ce631b890885b44e3503c5fdb3895
         type: string
-      prometheus_url:
-        description: Prometheus API that observes the candidate cluster
+      prometheus_image:
+        description: Prometheus image@sha256 reference for the private evidence cluster
         required: true
+        default: docker.io/prom/prometheus@sha256:63805ebb8d2b3920190daf1cb14a60871b16fd38bed42b857a3182bc621f4996
         type: string
   schedule:
     - cron: "47 21 * * 6"
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   static-contract:
@@ -85,17 +96,16 @@ jobs:
 
   dynamic-candidate:
     name: Dynamic fault and six-hour SLO evidence
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
     needs: static-contract
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rocketmq-architecture-evidence]
     timeout-minutes: 540
     env:
-      PROMETHEUS_BEARER_TOKEN: ${{ secrets.M11_PROMETHEUS_BEARER_TOKEN }}
-      EVIDENCE_BACKEND: ${{ github.event_name == 'workflow_dispatch' && inputs.backend || vars.ARCHITECTURE_FAULT_BACKEND }}
+      EVIDENCE_BACKEND: ${{ github.event_name == 'workflow_dispatch' && inputs.backend || vars.ARCHITECTURE_FAULT_BACKEND || 'kind' }}
       BASELINE_IMAGES: ${{ github.event_name == 'workflow_dispatch' && inputs.baseline_images_json || vars.ARCHITECTURE_BASELINE_IMAGES_JSON }}
       CANDIDATE_IMAGES: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate_images_json || vars.ARCHITECTURE_CANDIDATE_IMAGES_JSON }}
-      COLLECTOR_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.collector_image || vars.ARCHITECTURE_COLLECTOR_IMAGE }}
-      PROMETHEUS_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.prometheus_url || vars.ARCHITECTURE_PROMETHEUS_URL }}
+      COLLECTOR_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.collector_image || vars.ARCHITECTURE_COLLECTOR_IMAGE || 'docker.io/otel/opentelemetry-collector-contrib@sha256:9c247564e65ca19f97d891cca19a1a8d291ce631b890885b44e3503c5fdb3895' }}
+      PROMETHEUS_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.prometheus_image || vars.ARCHITECTURE_PROMETHEUS_IMAGE || 'docker.io/prom/prometheus@sha256:63805ebb8d2b3920190daf1cb14a60871b16fd38bed42b857a3182bc621f4996' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -125,26 +135,31 @@ jobs:
           tar -xzf /tmp/helm.tgz -C /tmp
           sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
-      - name: Materialize dynamic inputs
+      - name: Authenticate immutable service image pulls
         shell: bash
         env:
-          RUNTIME_SECRET_B64: ${{ secrets.M11_RUNTIME_SECRET_MANIFEST_B64 }}
-          ROTATED_RUNTIME_SECRET_B64: ${{ secrets.M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64 }}
-          BASELINE_DRIVER_SECRET_B64: ${{ secrets.M11_BASELINE_DRIVER_SECRET_MANIFEST_B64 }}
-          ROTATED_DRIVER_SECRET_B64: ${{ secrets.M11_ROTATED_DRIVER_SECRET_MANIFEST_B64 }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          test -n "$RUNTIME_SECRET_B64"
-          test -n "$ROTATED_RUNTIME_SECRET_B64"
-          test -n "$BASELINE_DRIVER_SECRET_B64"
-          test -n "$ROTATED_DRIVER_SECRET_B64"
-          mkdir -p target/slo-inputs
-          printf '%s' "$BASELINE_IMAGES" > target/slo-inputs/baseline-images.json
-          printf '%s' "$CANDIDATE_IMAGES" > target/slo-inputs/candidate-images.json
-          printf '%s' "$RUNTIME_SECRET_B64" | base64 --decode > target/slo-inputs/runtime-secret.yaml
-          printf '%s' "$ROTATED_RUNTIME_SECRET_B64" | base64 --decode > target/slo-inputs/rotated-runtime-secret.yaml
-          printf '%s' "$BASELINE_DRIVER_SECRET_B64" | base64 --decode > target/slo-inputs/baseline-driver-secret.yaml
-          printf '%s' "$ROTATED_DRIVER_SECRET_B64" | base64 --decode > target/slo-inputs/rotated-driver-secret.yaml
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Materialize dynamic inputs
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path target/slo-inputs | Out-Null
+          [IO.File]::WriteAllText(
+            (Join-Path $PWD target/slo-inputs/baseline-images.json),
+            $env:BASELINE_IMAGES,
+            [Text.UTF8Encoding]::new($false)
+          )
+          [IO.File]::WriteAllText(
+            (Join-Path $PWD target/slo-inputs/candidate-images.json),
+            $env:CANDIDATE_IMAGES,
+            [Text.UTF8Encoding]::new($false)
+          )
+          ./scripts/new-m11-evidence-secrets.ps1 `
+            -Mode Generate `
+            -OutputDirectory target/slo-inputs
 
       - name: Execute the dynamic fault matrix and keep the cluster
         shell: pwsh
@@ -181,12 +196,13 @@ jobs:
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
           if (-not $fault) { throw 'dynamic fault evidence directory is missing' }
-          ./scripts/run-architecture-slo-evidence.ps1 `
+          ./scripts/run-architecture-slo-cluster.ps1 `
             -Mode Run `
             -CandidateCommit '${{ github.sha }}' `
             -CandidateImageMap target/slo-inputs/candidate-images.json `
             -FaultEvidence $fault.FullName `
-            -PrometheusUrl '${{ env.PROMETHEUS_URL }}'
+            -PrometheusImage '${{ env.PROMETHEUS_IMAGE }}' `
+            -Backend '${{ env.EVIDENCE_BACKEND }}'
 
       - name: Delete the retained cluster
         if: always()
@@ -198,6 +214,19 @@ jobs:
             k3d cluster delete rocketmq-architecture-refactor || true
           fi
 
+      - name: Remove run-scoped credentials and registry session
+        if: always()
+        shell: pwsh
+        run: |
+          $inputDirectory = Join-Path $PWD 'target/slo-inputs'
+          if (Test-Path -LiteralPath $inputDirectory) {
+            Remove-Item -LiteralPath $inputDirectory -Recurse -Force
+          }
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker logout ghcr.io 2>&1 | Out-Null
+          }
+          $global:LASTEXITCODE = 0
+
       - name: Upload immutable release evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -206,5 +235,6 @@ jobs:
           path: |
             target/architecture-refactor/M11/fault-matrix
             target/architecture-refactor/M11/slo
+            target/architecture-refactor/M11/slo-support
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/kubernetes-fault-matrix.yml
+++ b/.github/workflows/kubernetes-fault-matrix.yml
@@ -3,6 +3,7 @@ name: Kubernetes architecture fault matrix
 on:
   pull_request:
     paths:
+      - ".github/actionlint.yaml"
       - ".github/workflows/kubernetes-fault-matrix.yml"
       - "distribution/helm/**"
       - "distribution/kubernetes/**"
@@ -10,11 +11,14 @@ on:
       - "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/**"
       - "scripts/fault_matrix_guard.py"
       - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/new-m11-evidence-secrets.ps1"
       - "scripts/tests/test_m11_fault_matrix.py"
+      - "scripts/tests/test_m11_dynamic_evidence.py"
       - "scripts/tests/fixtures/m11-fault-matrix/**"
   push:
     branches: [main]
     paths:
+      - ".github/actionlint.yaml"
       - ".github/workflows/kubernetes-fault-matrix.yml"
       - "distribution/helm/**"
       - "distribution/kubernetes/**"
@@ -22,7 +26,9 @@ on:
       - "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/**"
       - "scripts/fault_matrix_guard.py"
       - "scripts/kind-architecture-refactor-e2e.ps1"
+      - "scripts/new-m11-evidence-secrets.ps1"
       - "scripts/tests/test_m11_fault_matrix.py"
+      - "scripts/tests/test_m11_dynamic_evidence.py"
       - "scripts/tests/fixtures/m11-fault-matrix/**"
   workflow_dispatch:
     inputs:
@@ -42,12 +48,14 @@ on:
       collector_image:
         description: OpenTelemetry Collector image@sha256 reference
         required: true
+        default: docker.io/otel/opentelemetry-collector-contrib@sha256:9c247564e65ca19f97d891cca19a1a8d291ce631b890885b44e3503c5fdb3895
         type: string
   schedule:
     - cron: "11 21 * * 6"
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   static-contract:
@@ -73,15 +81,15 @@ jobs:
 
   dynamic-fault-matrix:
     name: Dynamic fault matrix
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
     needs: static-contract
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      EVIDENCE_BACKEND: ${{ github.event_name == 'workflow_dispatch' && inputs.backend || vars.ARCHITECTURE_FAULT_BACKEND }}
+      EVIDENCE_BACKEND: ${{ github.event_name == 'workflow_dispatch' && inputs.backend || vars.ARCHITECTURE_FAULT_BACKEND || 'kind' }}
       BASELINE_IMAGES: ${{ github.event_name == 'workflow_dispatch' && inputs.baseline_images_json || vars.ARCHITECTURE_BASELINE_IMAGES_JSON }}
       CANDIDATE_IMAGES: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate_images_json || vars.ARCHITECTURE_CANDIDATE_IMAGES_JSON }}
-      COLLECTOR_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.collector_image || vars.ARCHITECTURE_COLLECTOR_IMAGE }}
+      COLLECTOR_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.collector_image || vars.ARCHITECTURE_COLLECTOR_IMAGE || 'docker.io/otel/opentelemetry-collector-contrib@sha256:9c247564e65ca19f97d891cca19a1a8d291ce631b890885b44e3503c5fdb3895' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -111,26 +119,31 @@ jobs:
           tar -xzf /tmp/helm.tgz -C /tmp
           sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
-      - name: Materialize explicit dynamic inputs
+      - name: Authenticate immutable service image pulls
         shell: bash
         env:
-          RUNTIME_SECRET_B64: ${{ secrets.M11_RUNTIME_SECRET_MANIFEST_B64 }}
-          ROTATED_RUNTIME_SECRET_B64: ${{ secrets.M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64 }}
-          BASELINE_DRIVER_SECRET_B64: ${{ secrets.M11_BASELINE_DRIVER_SECRET_MANIFEST_B64 }}
-          ROTATED_DRIVER_SECRET_B64: ${{ secrets.M11_ROTATED_DRIVER_SECRET_MANIFEST_B64 }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          test -n "$RUNTIME_SECRET_B64"
-          test -n "$ROTATED_RUNTIME_SECRET_B64"
-          test -n "$BASELINE_DRIVER_SECRET_B64"
-          test -n "$ROTATED_DRIVER_SECRET_B64"
-          mkdir -p target/fault-inputs
-          printf '%s' "$BASELINE_IMAGES" > target/fault-inputs/baseline-images.json
-          printf '%s' "$CANDIDATE_IMAGES" > target/fault-inputs/candidate-images.json
-          printf '%s' "$RUNTIME_SECRET_B64" | base64 --decode > target/fault-inputs/runtime-secret.yaml
-          printf '%s' "$ROTATED_RUNTIME_SECRET_B64" | base64 --decode > target/fault-inputs/rotated-runtime-secret.yaml
-          printf '%s' "$BASELINE_DRIVER_SECRET_B64" | base64 --decode > target/fault-inputs/baseline-driver-secret.yaml
-          printf '%s' "$ROTATED_DRIVER_SECRET_B64" | base64 --decode > target/fault-inputs/rotated-driver-secret.yaml
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Materialize explicit dynamic inputs
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path target/fault-inputs | Out-Null
+          [IO.File]::WriteAllText(
+            (Join-Path $PWD target/fault-inputs/baseline-images.json),
+            $env:BASELINE_IMAGES,
+            [Text.UTF8Encoding]::new($false)
+          )
+          [IO.File]::WriteAllText(
+            (Join-Path $PWD target/fault-inputs/candidate-images.json),
+            $env:CANDIDATE_IMAGES,
+            [Text.UTF8Encoding]::new($false)
+          )
+          ./scripts/new-m11-evidence-secrets.ps1 `
+            -Mode Generate `
+            -OutputDirectory target/fault-inputs
 
       - name: Execute real fault matrix
         shell: pwsh
@@ -145,6 +158,19 @@ jobs:
           -BaselineDriverSecretManifest target/fault-inputs/baseline-driver-secret.yaml
           -RotatedDriverSecretManifest target/fault-inputs/rotated-driver-secret.yaml
           -CollectorImage '${{ env.COLLECTOR_IMAGE }}'
+
+      - name: Remove run-scoped credentials and registry session
+        if: always()
+        shell: pwsh
+        run: |
+          $inputDirectory = Join-Path $PWD 'target/fault-inputs'
+          if (Test-Path -LiteralPath $inputDirectory) {
+            Remove-Item -LiteralPath $inputDirectory -Recurse -Force
+          }
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker logout ghcr.io 2>&1 | Out-Null
+          }
+          $global:LASTEXITCODE = 0
 
       - name: Upload immutable fault evidence
         if: always()

--- a/distribution/kubernetes/README.md
+++ b/distribution/kubernetes/README.md
@@ -83,11 +83,13 @@ candidate; operators must not deploy the fixture values directly.
 The static policy check validates only the fault contract and committed fixture
 shape. Release evidence requires the `Kubernetes architecture fault matrix`
 workflow to run from `workflow_dispatch` or its weekly schedule with
-digest-pinned baseline, candidate, and collector images plus the required
-runtime and driver Secrets. The dynamic job executes the Kind or K3d fault
-driver, preserves the per-scenario reports, and uploads an artifact whose name
-contains the tested commit SHA. A skipped dynamic job or a fixture-only report
-is not release evidence.
+digest-pinned baseline, candidate, and collector images. The isolated evidence
+job generates run-scoped synthetic runtime and driver credentials, authenticates
+and preloads every image digest, executes the Kind or K3d fault driver, preserves
+the per-scenario reports, and uploads an artifact whose name contains the tested
+commit SHA. Generated evidence credentials are never production credentials and
+are never uploaded. A skipped dynamic job or a fixture-only report is not release
+evidence.
 
 To update `base/manifest.yaml`, render the production profile as UTF-8 and
 replace the file only after the local lint and schema checks pass. The committed

--- a/rocketmq-doc/en/architecture-production-readiness-runbook.md
+++ b/rocketmq-doc/en/architecture-production-readiness-runbook.md
@@ -175,6 +175,22 @@ acknowledged-message query succeeds. Preserve both failed and successful evidenc
 directories. A failed run must not contain a production `run.json` that can be
 mistaken for a pass.
 
+## Evidence execution boundary
+
+The six-hour sampler runs only on the dedicated
+`self-hosted,linux,x64,rocketmq-architecture-evidence` runner. Pull requests execute
+the static contract job only. The dynamic workflow generates cryptographically
+random, run-scoped test credentials, authenticates and preloads immutable image
+digests, and never uploads those credential manifests.
+
+The retained fault cluster is promoted to the candidate digests before the soak.
+`run-architecture-slo-cluster.ps1` then deploys a digest-pinned private Prometheus
+that scrapes all five metrics Services and a bounded message send/consume probe.
+Prometheus is reached only through a loopback `kubectl port-forward`. The wrapper
+keeps the port-forward owned for the full sampler lifetime and terminates it during
+cleanup. Production credentials and an externally reachable metrics endpoint are
+not inputs to this isolated evidence environment.
+
 ## Evidence verification
 
 From the repository root, validate policy and fixtures:
@@ -185,6 +201,7 @@ python scripts/architecture_slo_guard.py `
   --evidence scripts/tests/fixtures/m11-slo/pass `
   --allow-fixture
 python -m unittest scripts.tests.test_architecture_slo_guard -v
+python -m unittest scripts.tests.test_m11_dynamic_evidence -v
 cargo test -p rocketmq-observability --test production_readiness_contract
 ```
 

--- a/scripts/architecture_slo_guard.py
+++ b/scripts/architecture_slo_guard.py
@@ -331,6 +331,8 @@ def validate_release_assets(
         guard.require(marker in runbook, f"runbook marker missing: {marker}")
 
     runner = guard.read("scripts/run-architecture-slo-evidence.ps1")
+    cluster_runner = guard.read("scripts/run-architecture-slo-cluster.ps1")
+    secret_generator = guard.read("scripts/new-m11-evidence-secrets.ps1")
     workflow = guard.read(".github/workflows/architecture-slo-evidence.yml")
     tests = guard.read("scripts/tests/test_architecture_slo_guard.py")
     for marker in (
@@ -348,12 +350,51 @@ def validate_release_assets(
         "SLO workflow must require explicit dispatch",
     )
     guard.require(
-        "run-architecture-slo-evidence.ps1" in workflow,
-        "SLO workflow must execute the real runner",
+        "run-architecture-slo-cluster.ps1" in workflow,
+        "SLO workflow must execute the cluster-connected runner",
     )
     guard.require(
-        "permissions:\n  contents: read" in workflow,
-        "SLO workflow must retain contents:read only",
+        "permissions:\n  contents: read\n  packages: read" in workflow,
+        "SLO workflow must retain least-privilege contents/package reads",
+    )
+    guard.require(
+        "runs-on: [self-hosted, linux, x64, rocketmq-architecture-evidence]" in workflow,
+        "six-hour SLO must run on the dedicated self-hosted evidence runner",
+    )
+    guard.require(
+        "if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && "
+        "github.ref == 'refs/heads/main'" in workflow,
+        "untrusted refs must never reach the dynamic evidence runner",
+    )
+    guard.require("docker login ghcr.io" in workflow, "SLO workflow must authenticate immutable GHCR pulls")
+    guard.require(
+        "new-m11-evidence-secrets.ps1" in workflow,
+        "SLO workflow must generate isolated run-scoped evidence credentials",
+    )
+    guard.require(
+        "M11_RUNTIME_SECRET_MANIFEST_B64" not in workflow
+        and "M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64" not in workflow,
+        "SLO workflow must not depend on repository-stored test secret manifests",
+    )
+    guard.require(
+        "Remove-Item -LiteralPath $inputDirectory -Recurse -Force" in workflow
+        and "docker logout ghcr.io" in workflow,
+        "SLO workflow must remove run-scoped credentials and registry sessions",
+    )
+    for marker in (
+        "PrometheusImage must be pinned by digest",
+        "rocketmq-slo-prometheus",
+        "rocketmq-slo-message-probe",
+        "while true; do",
+        "message sendMessage",
+        "message consumeMessage",
+        "run-architecture-slo-evidence.ps1",
+        "Stop-Process",
+    ):
+        guard.require(marker in cluster_runner, f"SLO cluster runner contract marker missing: {marker}")
+    guard.require(
+        "[Security.Cryptography.RandomNumberGenerator]::Create" in secret_generator,
+        "SLO evidence credentials must use a cryptographic run-scoped generator",
     )
     guard.require(
         "test_architecture_slo_guard" in workflow and "deliberate" in tests,

--- a/scripts/fault_matrix_guard.py
+++ b/scripts/fault_matrix_guard.py
@@ -191,6 +191,7 @@ def validate_policy(guard: Guard, policy: dict[str, Any]) -> None:
 
 def validate_sources(guard: Guard) -> None:
     runner = guard.read("scripts/kind-architecture-refactor-e2e.ps1")
+    secret_generator = guard.read("scripts/new-m11-evidence-secrets.ps1")
     workflow = guard.read(".github/workflows/kubernetes-fault-matrix.yml")
     dockerfile = guard.read("docker/Dockerfile.base")
     tests = guard.read("scripts/tests/test_m11_fault_matrix.py")
@@ -220,6 +221,9 @@ def validate_sources(guard: Guard) -> None:
         "stateless_pod_rescheduled = $null -ne $replacementProxyPod",
         "Get-ControllerLeaderOrdinal",
         "leader_changed = $leaderAfterOrdinal -ne $leaderBeforeOrdinal",
+        "Invoke-Native docker @('pull', $image)",
+        "Invoke-Native kind (@('load', 'docker-image') + $clusterImages",
+        "Invoke-Native k3d (@('image', 'import') + $clusterImages",
     ):
         guard.require(marker in runner, f"fault runner contract marker missing: {marker}")
     guard.require("Mode -eq \"Validate\"" in runner, "runner must provide a non-dynamic Validate mode")
@@ -230,7 +234,32 @@ def validate_sources(guard: Guard) -> None:
     guard.require("fault_matrix_guard.py" in workflow, "fault workflow must execute evidence guard")
     guard.require("kind-architecture-refactor-e2e.ps1" in workflow, "fault workflow must execute the real runner")
     guard.require("workflow_dispatch:" in workflow, "fault workflow must support explicit dynamic dispatch")
-    guard.require("permissions:\n  contents: read" in workflow, "fault workflow must retain contents:read only")
+    guard.require(
+        "permissions:\n  contents: read\n  packages: read" in workflow,
+        "fault workflow must retain least-privilege contents/package reads",
+    )
+    guard.require("docker login ghcr.io" in workflow, "fault workflow must authenticate immutable GHCR pulls")
+    guard.require(
+        "new-m11-evidence-secrets.ps1" in workflow,
+        "fault workflow must generate isolated run-scoped evidence credentials",
+    )
+    guard.require(
+        "M11_RUNTIME_SECRET_MANIFEST_B64" not in workflow
+        and "M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64" not in workflow,
+        "fault workflow must not depend on repository-stored test secret manifests",
+    )
+    guard.require(
+        "Remove-Item -LiteralPath $inputDirectory -Recurse -Force" in workflow
+        and "docker logout ghcr.io" in workflow,
+        "fault workflow must remove run-scoped credentials and registry sessions",
+    )
+    for marker in (
+        "[Security.Cryptography.RandomNumberGenerator]::Create",
+        "M11_EPHEMERAL_SECRET_MANIFESTS_OK",
+        "rocketmq-fault-driver-baseline",
+        "rocketmq-fault-driver-rotated",
+    ):
+        guard.require(marker in secret_generator, f"evidence secret generator marker missing: {marker}")
     guard.require("test_m11_fault_matrix" in workflow and "deliberate" in tests, "deliberate-violation tests missing")
     guard.require("dynamic" in readme.lower() and "fault" in readme.lower(), "Kubernetes README must document dynamic fault evidence")
 

--- a/scripts/kind-architecture-refactor-e2e.ps1
+++ b/scripts/kind-architecture-refactor-e2e.ps1
@@ -407,6 +407,20 @@ nodes:
         $StorageClass = 'local-path'
     }
 
+    $clusterImages = @(
+        @('broker', 'namesrv', 'controller', 'proxy', 'mcp') | ForEach-Object { $BaselineImages[$_] }
+        @('broker', 'namesrv', 'controller', 'proxy', 'mcp') | ForEach-Object { $CandidateImages[$_] }
+        $CollectorImage
+    ) | Sort-Object -Unique
+    foreach ($image in $clusterImages) {
+        Invoke-Native docker @('pull', $image) | Out-Null
+    }
+    if ($Backend -eq 'kind') {
+        Invoke-Native kind (@('load', 'docker-image') + $clusterImages + @('--name', $ClusterName)) | Out-Null
+    } else {
+        Invoke-Native k3d (@('image', 'import') + $clusterImages + @('--cluster', $ClusterName)) | Out-Null
+    }
+
     $nodes = ((Invoke-Native kubectl @('get', 'nodes', '-o', 'json')).Output | ConvertFrom-Json).items
     Assert-True ($nodes.Count -eq 4) 'fault cluster must contain exactly four nodes'
     $workers = @($nodes | Where-Object { -not $_.metadata.labels.'node-role.kubernetes.io/control-plane' })

--- a/scripts/new-m11-evidence-secrets.ps1
+++ b/scripts/new-m11-evidence-secrets.ps1
@@ -1,0 +1,263 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Generate")]
+    [string]$Mode = "Validate",
+
+    [string]$OutputDirectory = "target/m11-evidence-inputs",
+    [string]$Namespace = "rocketmq-system"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ExpectedFiles = @(
+    "runtime-secret.yaml",
+    "rotated-runtime-secret.yaml",
+    "baseline-driver-secret.yaml",
+    "rotated-driver-secret.yaml"
+)
+
+function ConvertTo-Base64 {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+
+    [Convert]::ToBase64String([Text.UTF8Encoding]::new($false).GetBytes($Value))
+}
+
+function New-RandomHex {
+    param([ValidateRange(8, 128)][int]$ByteCount)
+
+    $bytes = [byte[]]::new($ByteCount)
+    $generator = [Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $generator.GetBytes($bytes)
+    } finally {
+        $generator.Dispose()
+    }
+    ([BitConverter]::ToString($bytes)).Replace("-", "").ToLowerInvariant()
+}
+
+function ConvertTo-DerLength {
+    param([ValidateRange(0, [int]::MaxValue)][int]$Length)
+
+    if ($Length -lt 128) {
+        return ,([byte[]]@([byte]$Length))
+    }
+    $octets = [System.Collections.Generic.List[byte]]::new()
+    $remaining = $Length
+    while ($remaining -gt 0) {
+        $octets.Insert(0, [byte]($remaining -band 0xff))
+        $remaining = $remaining -shr 8
+    }
+    $encoded = [System.Collections.Generic.List[byte]]::new()
+    $encoded.Add([byte](0x80 -bor $octets.Count))
+    $encoded.AddRange($octets)
+    return ,$encoded.ToArray()
+}
+
+function ConvertTo-DerInteger {
+    param([Parameter(Mandatory)][byte[]]$Value)
+
+    $offset = 0
+    while ($offset -lt $Value.Length - 1 -and $Value[$offset] -eq 0) {
+        $offset++
+    }
+    [byte[]]$content = $Value[$offset..($Value.Length - 1)]
+    if (($content[0] -band 0x80) -ne 0) {
+        [byte[]]$content = @([byte]0) + $content
+    }
+    $encoded = [System.Collections.Generic.List[byte]]::new()
+    $encoded.Add([byte]0x02)
+    $encoded.AddRange([byte[]](ConvertTo-DerLength $content.Length))
+    $encoded.AddRange($content)
+    return ,$encoded.ToArray()
+}
+
+function ConvertTo-Pkcs1PrivateKey {
+    param([Parameter(Mandatory)][Security.Cryptography.RSAParameters]$Parameters)
+
+    $content = [System.Collections.Generic.List[byte]]::new()
+    foreach ($value in @(
+            [byte[]]@(0),
+            $Parameters.Modulus,
+            $Parameters.Exponent,
+            $Parameters.D,
+            $Parameters.P,
+            $Parameters.Q,
+            $Parameters.DP,
+            $Parameters.DQ,
+            $Parameters.InverseQ
+        )) {
+        $content.AddRange([byte[]](ConvertTo-DerInteger $value))
+    }
+    $encoded = [System.Collections.Generic.List[byte]]::new()
+    $encoded.Add([byte]0x30)
+    $encoded.AddRange([byte[]](ConvertTo-DerLength $content.Count))
+    $encoded.AddRange($content)
+    return ,$encoded.ToArray()
+}
+
+function ConvertTo-Pem {
+    param(
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][byte[]]$Der
+    )
+
+    $payload = [Convert]::ToBase64String(
+        $Der,
+        [Base64FormattingOptions]::InsertLineBreaks
+    ).Replace("`r`n", "`n")
+    "-----BEGIN $Label-----`n$payload`n-----END $Label-----`n"
+}
+
+function New-TlsIdentity {
+    param([Parameter(Mandatory)][string]$CommonName)
+
+    $rsa = [Security.Cryptography.RSA]::Create(2048)
+    $certificate = $null
+    try {
+        $request = [Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            "CN=$CommonName",
+            $rsa,
+            [Security.Cryptography.HashAlgorithmName]::SHA256,
+            [Security.Cryptography.RSASignaturePadding]::Pkcs1
+        )
+        $certificate = $request.CreateSelfSigned(
+            [DateTimeOffset]::UtcNow.AddMinutes(-5),
+            [DateTimeOffset]::UtcNow.AddDays(2)
+        )
+        @{
+            Certificate = ConvertTo-Pem "CERTIFICATE" $certificate.RawData
+            PrivateKey = ConvertTo-Pem "RSA PRIVATE KEY" (ConvertTo-Pkcs1PrivateKey $rsa.ExportParameters($true))
+        }
+    } finally {
+        if ($null -ne $certificate) {
+            $certificate.Dispose()
+        }
+        $rsa.Dispose()
+    }
+}
+
+function Write-SecretManifest {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][hashtable]$Data
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in @(
+            "apiVersion: v1",
+            "kind: Secret",
+            "metadata:",
+            "  name: $Name",
+            "  namespace: $Namespace",
+            "type: Opaque",
+            "data:"
+        )) {
+        $lines.Add($line)
+    }
+    foreach ($key in ($Data.Keys | Sort-Object)) {
+        $lines.Add("  ${key}: $(ConvertTo-Base64 ([string]$Data[$key]))")
+    }
+    [IO.File]::WriteAllText(
+        $Path,
+        (($lines -join "`n") + "`n"),
+        [Text.UTF8Encoding]::new($false)
+    )
+}
+
+function New-RuntimeSecretData {
+    param(
+        [Parameter(Mandatory)][string]$AccessKey,
+        [Parameter(Mandatory)][string]$SecretKey,
+        [Parameter(Mandatory)][string]$Nonce,
+        [Parameter(Mandatory)][hashtable]$TlsIdentity
+    )
+
+    $acl = @"
+globalWhiteRemoteAddresses: []
+accounts:
+  - accessKey: '$AccessKey'
+    secretKey: '$SecretKey'
+    admin: true
+    defaultTopicPerm: PUB|SUB
+    defaultGroupPerm: PUB|SUB
+"@
+    @{
+        "admin.identity" = "m11-evidence-admin-$Nonce"
+        "broker-acl.yml" = $acl
+        "ca.crt" = "m11-evidence-trust-anchor-$Nonce"
+        "proxy-acl.yml" = $acl
+        "request-policy.json" = '{"profile":"m11-ephemeral-evidence"}'
+        "tls.crt" = $TlsIdentity.Certificate
+        "tls.key" = $TlsIdentity.PrivateKey
+    }
+}
+
+if ($Mode -eq "Validate") {
+    Write-Output "M11_EVIDENCE_SECRET_GENERATOR_OK files=$($ExpectedFiles.Count)"
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    throw "OutputDirectory is required in Generate mode"
+}
+if ([string]::IsNullOrWhiteSpace($Namespace)) {
+    throw "Namespace is required in Generate mode"
+}
+
+$resolvedOutput = [IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Force -Path $resolvedOutput | Out-Null
+
+$nonce = New-RandomHex 12
+$baselineAccessKey = "M11B$(New-RandomHex 10)"
+$baselineSecretKey = New-RandomHex 32
+$rotatedAccessKey = "M11R$(New-RandomHex 10)"
+$rotatedSecretKey = New-RandomHex 32
+$tlsIdentity = New-TlsIdentity "rocketmq-mcp.$Namespace.svc.cluster.local"
+
+Write-SecretManifest `
+    -Path (Join-Path $resolvedOutput "runtime-secret.yaml") `
+    -Name "rocketmq-runtime-secrets" `
+    -Data (New-RuntimeSecretData $baselineAccessKey $baselineSecretKey $nonce $tlsIdentity)
+Write-SecretManifest `
+    -Path (Join-Path $resolvedOutput "rotated-runtime-secret.yaml") `
+    -Name "rocketmq-runtime-secrets" `
+    -Data (New-RuntimeSecretData $rotatedAccessKey $rotatedSecretKey $nonce $tlsIdentity)
+Write-SecretManifest `
+    -Path (Join-Path $resolvedOutput "baseline-driver-secret.yaml") `
+    -Name "rocketmq-fault-driver-baseline" `
+    -Data @{
+        ROCKETMQ_ACL_ACCESS_KEY = $baselineAccessKey
+        ROCKETMQ_ACL_SECRET_KEY = $baselineSecretKey
+    }
+Write-SecretManifest `
+    -Path (Join-Path $resolvedOutput "rotated-driver-secret.yaml") `
+    -Name "rocketmq-fault-driver-rotated" `
+    -Data @{
+        ROCKETMQ_ACL_ACCESS_KEY = $rotatedAccessKey
+        ROCKETMQ_ACL_SECRET_KEY = $rotatedSecretKey
+    }
+
+foreach ($file in $ExpectedFiles) {
+    $path = Join-Path $resolvedOutput $file
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf) -or (Get-Item -LiteralPath $path).Length -eq 0) {
+        throw "failed to create evidence input manifest: $file"
+    }
+}
+
+Write-Output "M11_EPHEMERAL_SECRET_MANIFESTS_OK files=$($ExpectedFiles.Count)"

--- a/scripts/run-architecture-slo-cluster.ps1
+++ b/scripts/run-architecture-slo-cluster.ps1
@@ -1,0 +1,305 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Run")]
+    [string]$Mode = "Validate",
+
+    [string]$CandidateCommit,
+    [string]$CandidateImageMap,
+    [string]$FaultEvidence,
+    [string]$PrometheusImage,
+    [int]$SoakSeconds = 21600,
+    [ValidateSet("kind", "k3d")]
+    [string]$Backend = "kind",
+    [string]$ClusterName = "rocketmq-architecture-refactor",
+    [string]$Namespace = "rocketmq-system",
+    [string]$SupportRoot = "target/architecture-refactor/M11/slo-support"
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+Set-StrictMode -Version Latest
+
+$Root = Split-Path -Parent $PSScriptRoot
+$EvidenceRunner = Join-Path $PSScriptRoot "run-architecture-slo-evidence.ps1"
+
+function Assert-True {
+    param([Parameter(Mandatory)][bool]$Condition, [Parameter(Mandatory)][string]$Message)
+
+    if (-not $Condition) {
+        throw "SLO cluster assertion failed: $Message"
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    $output = & $Command @Arguments 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command $($Arguments -join ' ') failed with exit code ${LASTEXITCODE}:`n$output"
+    }
+    $output.TrimEnd()
+}
+
+function Resolve-RepositoryPath {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if ([IO.Path]::IsPathRooted($Path)) {
+        return [IO.Path]::GetFullPath($Path)
+    }
+    [IO.Path]::GetFullPath((Join-Path $Root $Path))
+}
+
+function Get-FreeTcpPort {
+    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        ([Net.IPEndPoint]$listener.LocalEndpoint).Port
+    } finally {
+        $listener.Stop()
+    }
+}
+
+if ($Mode -eq "Validate") {
+    & $EvidenceRunner -Mode Validate
+    Write-Output "M11_SLO_CLUSTER_WRAPPER_OK self_hosted_required=true"
+    exit 0
+}
+
+foreach ($command in @("docker", "kubectl", "python", $Backend)) {
+    Assert-True ($null -ne (Get-Command $command -ErrorAction SilentlyContinue)) "required command is unavailable: $command"
+}
+Assert-True ($PrometheusImage -match '^[^@\s]+@sha256:[0-9a-f]{64}$') "PrometheusImage must be pinned by digest"
+Assert-True (-not [string]::IsNullOrWhiteSpace($FaultEvidence)) "FaultEvidence is required"
+
+$faultDirectory = Resolve-RepositoryPath $FaultEvidence
+$faultRunPath = Join-Path $faultDirectory "run.json"
+Assert-True (Test-Path -LiteralPath $faultRunPath -PathType Leaf) "fault run.json is missing"
+$faultRun = Get-Content -Raw -LiteralPath $faultRunPath | ConvertFrom-Json
+Assert-True ($faultRun.dynamic_execution -eq $true -and $faultRun.fixture -eq $false) "fault evidence must be dynamic"
+$faultDriverImage = "rocketmq-rust/fault-driver:$($faultRun.run_id)"
+
+$supportDirectory = Resolve-RepositoryPath $SupportRoot
+New-Item -ItemType Directory -Force -Path $supportDirectory | Out-Null
+$manifestPath = Join-Path $supportDirectory "runtime.yaml"
+$stdoutPath = Join-Path $supportDirectory "prometheus-port-forward.stdout.log"
+$stderrPath = Join-Path $supportDirectory "prometheus-port-forward.stderr.log"
+
+$prometheusTargets = @(
+    "rocketmq-broker-metrics.$Namespace.svc.cluster.local:5557",
+    "rocketmq-namesrv-metrics.$Namespace.svc.cluster.local:5557",
+    "rocketmq-controller-metrics.$Namespace.svc.cluster.local:5557",
+    "rocketmq-proxy-metrics.$Namespace.svc.cluster.local:5557",
+    "rocketmq-mcp-metrics.$Namespace.svc.cluster.local:5557"
+)
+$targetYaml = ($prometheusTargets | ForEach-Object { "          - '$_'" }) -join "`n"
+$manifest = @"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rocketmq-slo-prometheus
+  namespace: observability
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: rocketmq-architecture-slo
+        metrics_path: /metrics
+        static_configs:
+          - targets:
+$targetYaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rocketmq-slo-prometheus
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/component: architecture-slo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/component: architecture-slo
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: prometheus
+          image: $PrometheusImage
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=8h
+            - --web.listen-address=0.0.0.0:9090
+          ports:
+            - { name: http, containerPort: 9090 }
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits: { cpu: 1000m, memory: 1Gi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: config, mountPath: /etc/prometheus, readOnly: true }
+            - { name: data, mountPath: /prometheus }
+      volumes:
+        - name: config
+          configMap: { name: rocketmq-slo-prometheus }
+        - name: data
+          emptyDir: { sizeLimit: 4Gi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rocketmq-slo-prometheus
+  namespace: observability
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: architecture-slo
+  ports:
+    - { name: http, port: 9090, targetPort: http }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rocketmq-slo-message-probe
+  namespace: $Namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rocketmq-slo-message-probe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rocketmq-slo-message-probe
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: probe
+          image: $faultDriverImage
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              sequence=0
+              while true; do
+                key="slo-$($faultRun.run_id)-`$sequence"
+                rocketmq-admin-cli message sendMessage \
+                  -t ArchitectureRefactorFaultMatrix \
+                  -p "six-hour-slo-probe-`$sequence" \
+                  -k "`$key" >/tmp/send.out 2>/tmp/send.err || true
+                rocketmq-admin-cli message consumeMessage \
+                  -t ArchitectureRefactorFaultMatrix \
+                  -g ArchitectureSloConsumer \
+                  -c 16 >/tmp/consume.out 2>/tmp/consume.err || true
+                sequence=`$((sequence + 1))
+                sleep 5
+              done
+          env:
+            - name: NAMESRV_ADDR
+              value: rocketmq-namesrv-0.rocketmq-namesrv-headless.$Namespace.svc.cluster.local:9876
+          envFrom:
+            - secretRef: { name: rocketmq-fault-driver-baseline }
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp, mountPath: /tmp }
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 32Mi }
+"@
+[IO.File]::WriteAllText($manifestPath, $manifest, [Text.UTF8Encoding]::new($false))
+
+$portForward = $null
+try {
+    Invoke-Native docker @("pull", $PrometheusImage) | Out-Null
+    if ($Backend -eq "kind") {
+        Invoke-Native kind @("load", "docker-image", $PrometheusImage, "--name", $ClusterName) | Out-Null
+    } else {
+        Invoke-Native k3d @("image", "import", $PrometheusImage, "--cluster", $ClusterName) | Out-Null
+    }
+    Invoke-Native kubectl @("apply", "-f", $manifestPath) | Out-Null
+    Invoke-Native kubectl @("-n", "observability", "rollout", "status", "deployment/rocketmq-slo-prometheus", "--timeout=180s") | Out-Null
+    Invoke-Native kubectl @("-n", $Namespace, "rollout", "status", "deployment/rocketmq-slo-message-probe", "--timeout=180s") | Out-Null
+
+    $localPort = Get-FreeTcpPort
+    $portForward = Start-Process `
+        -FilePath "kubectl" `
+        -ArgumentList @(
+            "-n", "observability", "port-forward", "service/rocketmq-slo-prometheus",
+            "${localPort}:9090", "--address=127.0.0.1"
+        ) `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -PassThru
+    $prometheusUrl = "http://127.0.0.1:$localPort"
+    $ready = $false
+    for ($attempt = 0; $attempt -lt 60 -and -not $ready; $attempt++) {
+        if ($portForward.HasExited) {
+            throw "Prometheus port-forward exited before readiness"
+        }
+        try {
+            $response = Invoke-RestMethod -Method Get -Uri "$prometheusUrl/-/ready" -TimeoutSec 5
+            $ready = ([string]$response).Trim() -eq "Prometheus Server is Ready."
+        } catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+    Assert-True $ready "in-cluster Prometheus did not become ready"
+
+    & $EvidenceRunner `
+        -Mode Run `
+        -CandidateCommit $CandidateCommit `
+        -CandidateImageMap $CandidateImageMap `
+        -FaultEvidence $faultDirectory `
+        -PrometheusUrl $prometheusUrl `
+        -SoakSeconds $SoakSeconds
+} finally {
+    if ($null -ne $portForward -and -not $portForward.HasExited) {
+        Stop-Process -Id $portForward.Id -Force -ErrorAction SilentlyContinue
+        $portForward.WaitForExit()
+    }
+}

--- a/scripts/tests/fixtures/m11-slo/pass/run.json
+++ b/scripts/tests/fixtures/m11-slo/pass/run.json
@@ -96,7 +96,7 @@
   "release_artifacts": {
     "distribution/config/grafana-architecture-production-readiness.json": "b586879abcf204d2cbf06c049fe21e0bfef10d1dadb67488a6c5ee91eab8ac70",
     "distribution/config/prometheus-architecture-production-readiness-alerts.yaml": "44bfcbb119343fd848fe7c32ffaeab235eee960c2ec3ad2130b31493893f4646",
-    "rocketmq-doc/en/architecture-production-readiness-runbook.md": "857a461791a5f6b7ba3301278b2fd103fd7b96161f4ee72525f5c865f62afa00",
+    "rocketmq-doc/en/architecture-production-readiness-runbook.md": "c19a9ee5ea258523bf3678f9f5167c8161197a72f75e094fd0bef0556e8a678d",
     "distribution/kubernetes/fault-matrix-policy.json": "771b3abf35213a4b6fbb3626d7822e11e6a17d9609ae7587d309bcaf2a5cdd37",
     "scripts/telemetry-semantic-registry.json": "32f7824018e2f7a5a73176a177198bef08e252eb6c23fdc43dd6e73b5ae294a5"
   },

--- a/scripts/tests/test_architecture_slo_guard.py
+++ b/scripts/tests/test_architecture_slo_guard.py
@@ -41,6 +41,8 @@ class ArchitectureSloGuardTests(unittest.TestCase):
             "distribution/kubernetes/fault-matrix-policy.json",
             "rocketmq-doc/en/architecture-production-readiness-runbook.md",
             "scripts/telemetry-semantic-registry.json",
+            "scripts/new-m11-evidence-secrets.ps1",
+            "scripts/run-architecture-slo-cluster.ps1",
             "scripts/run-architecture-slo-evidence.ps1",
             "scripts/architecture_slo_guard.py",
             "scripts/tests/test_architecture_slo_guard.py",
@@ -189,6 +191,27 @@ class ArchitectureSloGuardTests(unittest.TestCase):
             "--evidence", str(FIXTURE), "--allow-fixture", expect_success=False
         )
         self.assertIn("release artifact hash mismatch", result.stderr)
+
+    def test_hosted_six_hour_runner_regression_is_rejected(self) -> None:
+        workflow = self.root / ".github" / "workflows" / "architecture-slo-evidence.yml"
+        source = workflow.read_text(encoding="utf-8")
+        workflow.write_text(
+            source.replace(
+                "runs-on: [self-hosted, linux, x64, rocketmq-architecture-evidence]",
+                "runs-on: ubuntu-latest",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        result = self.run_guard("--policy-only", expect_success=False)
+        self.assertIn("dedicated self-hosted evidence runner", result.stderr)
+
+    def test_sustained_probe_regression_is_rejected(self) -> None:
+        wrapper = self.root / "scripts" / "run-architecture-slo-cluster.ps1"
+        source = wrapper.read_text(encoding="utf-8")
+        wrapper.write_text(source.replace("while true; do", "run-once", 1), encoding="utf-8")
+        result = self.run_guard("--policy-only", expect_success=False)
+        self.assertIn("while true; do", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_m11_dynamic_evidence.py
+++ b/scripts/tests/test_m11_dynamic_evidence.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import base64
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_secret_data(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    in_data = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line == "data:":
+            in_data = True
+            continue
+        if in_data:
+            match = re.fullmatch(r"  ([A-Za-z0-9_.-]+): ([A-Za-z0-9+/=]+)", line)
+            if not match:
+                raise AssertionError(f"invalid generated Secret data line: {line}")
+            data[match.group(1)] = base64.b64decode(match.group(2), validate=True).decode("utf-8")
+    return data
+
+
+class DynamicEvidenceInputTests(unittest.TestCase):
+    def test_generator_creates_distinct_run_scoped_acl_material_without_logging_it(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            powershell = shutil.which("pwsh") or shutil.which("powershell")
+            self.assertIsNotNone(powershell, "PowerShell is required for the evidence generator test")
+            completed = subprocess.run(
+                [
+                    str(powershell),
+                    "-NoProfile",
+                    "-File",
+                    str(ROOT / "scripts" / "new-m11-evidence-secrets.ps1"),
+                    "-Mode",
+                    "Generate",
+                    "-OutputDirectory",
+                    directory,
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual("M11_EPHEMERAL_SECRET_MANIFESTS_OK files=4", completed.stdout.strip())
+
+            output = Path(directory)
+            runtime = parse_secret_data(output / "runtime-secret.yaml")
+            rotated_runtime = parse_secret_data(output / "rotated-runtime-secret.yaml")
+            baseline_driver = parse_secret_data(output / "baseline-driver-secret.yaml")
+            rotated_driver = parse_secret_data(output / "rotated-driver-secret.yaml")
+
+            self.assertEqual(
+                {
+                    "admin.identity",
+                    "broker-acl.yml",
+                    "ca.crt",
+                    "proxy-acl.yml",
+                    "request-policy.json",
+                    "tls.crt",
+                    "tls.key",
+                },
+                set(runtime),
+            )
+            self.assertEqual(set(runtime), set(rotated_runtime))
+            self.assertNotEqual(runtime["broker-acl.yml"], rotated_runtime["broker-acl.yml"])
+            self.assertTrue(runtime["tls.crt"].startswith("-----BEGIN CERTIFICATE-----"))
+            self.assertTrue(runtime["tls.key"].startswith("-----BEGIN RSA PRIVATE KEY-----"))
+            self.assertEqual(runtime["tls.crt"], rotated_runtime["tls.crt"])
+            self.assertEqual(runtime["tls.key"], rotated_runtime["tls.key"])
+            self.assertIn(baseline_driver["ROCKETMQ_ACL_ACCESS_KEY"], runtime["broker-acl.yml"])
+            self.assertIn(baseline_driver["ROCKETMQ_ACL_SECRET_KEY"], runtime["broker-acl.yml"])
+            self.assertIn(rotated_driver["ROCKETMQ_ACL_ACCESS_KEY"], rotated_runtime["broker-acl.yml"])
+            self.assertIn(rotated_driver["ROCKETMQ_ACL_SECRET_KEY"], rotated_runtime["broker-acl.yml"])
+            for value in (*baseline_driver.values(), *rotated_driver.values()):
+                self.assertNotIn(value, completed.stdout)
+
+    def test_workflows_keep_untrusted_events_off_the_long_runner(self) -> None:
+        slo = (ROOT / ".github" / "workflows" / "architecture-slo-evidence.yml").read_text(encoding="utf-8")
+        fault = (ROOT / ".github" / "workflows" / "kubernetes-fault-matrix.yml").read_text(encoding="utf-8")
+
+        self.assertIn("runs-on: [self-hosted, linux, x64, rocketmq-architecture-evidence]", slo)
+        self.assertIn("github.ref == 'refs/heads/main'", slo)
+        self.assertIn("packages: read", slo)
+        self.assertIn("packages: read", fault)
+        self.assertNotIn("M11_RUNTIME_SECRET_MANIFEST_B64", slo + fault)
+        self.assertNotIn("M11_ROTATED_RUNTIME_SECRET_MANIFEST_B64", slo + fault)
+        self.assertIn("new-m11-evidence-secrets.ps1", slo)
+        self.assertIn("new-m11-evidence-secrets.ps1", fault)
+        self.assertIn("run-architecture-slo-cluster.ps1", slo)
+
+    def test_cluster_wrapper_has_digest_prometheus_and_sustained_probe(self) -> None:
+        wrapper = (ROOT / "scripts" / "run-architecture-slo-cluster.ps1").read_text(encoding="utf-8")
+        self.assertIn("PrometheusImage must be pinned by digest", wrapper)
+        self.assertIn("rocketmq-slo-message-probe", wrapper)
+        self.assertIn("while true; do", wrapper)
+        self.assertIn("message sendMessage", wrapper)
+        self.assertIn("message consumeMessage", wrapper)
+        self.assertIn("Stop-Process", wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_m11_fault_matrix.py
+++ b/scripts/tests/test_m11_fault_matrix.py
@@ -43,6 +43,10 @@ class FaultMatrixGuardTests(unittest.TestCase):
             self.root / "scripts" / "kind-architecture-refactor-e2e.ps1",
         )
         shutil.copy2(
+            REPO_ROOT / "scripts" / "new-m11-evidence-secrets.ps1",
+            self.root / "scripts" / "new-m11-evidence-secrets.ps1",
+        )
+        shutil.copy2(
             REPO_ROOT / "scripts" / "tests" / "test_m11_fault_matrix.py",
             self.root / "scripts" / "tests" / "test_m11_fault_matrix.py",
         )
@@ -144,6 +148,22 @@ class FaultMatrixGuardTests(unittest.TestCase):
         runner.write_text(source.replace("commitlog_offset_preserved", "offset_not_checked"), encoding="utf-8")
         result = self.run_guard("--policy-only", expect_success=False)
         self.assertIn("commitlog_offset_preserved", result.stderr)
+
+    def test_dynamic_input_and_registry_regressions_are_rejected(self) -> None:
+        workflow = self.root / ".github" / "workflows" / "kubernetes-fault-matrix.yml"
+        source = workflow.read_text(encoding="utf-8")
+        workflow.write_text(source.replace("  packages: read\n", "", 1), encoding="utf-8")
+        result = self.run_guard("--policy-only", expect_success=False)
+        self.assertIn("contents/package reads", result.stderr)
+
+        runner = self.root / "scripts" / "kind-architecture-refactor-e2e.ps1"
+        runner_source = runner.read_text(encoding="utf-8")
+        runner.write_text(
+            runner_source.replace("Invoke-Native docker @('pull', $image)", "docker pull skipped", 1),
+            encoding="utf-8",
+        )
+        result = self.run_guard("--policy-only", expect_success=False)
+        self.assertIn("docker @('pull', $image)", result.stderr)
 
     def test_deliberate_fault_causality_regressions_are_rejected(self) -> None:
         runner = self.root / "scripts" / "kind-architecture-refactor-e2e.ps1"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8794

### Brief Description

Make the dynamic fault and six-hour SLO evidence path executable end to end. Route long evidence only from `main` to a dedicated self-hosted Linux runner, authenticate and preload immutable image digests, generate cryptographically random run-scoped test credentials without uploading them, and clean credentials plus registry sessions on every outcome. Add a digest-pinned in-cluster Prometheus and sustained send/consume probe owned by the SLO wrapper, with fail-closed guards for runner isolation, workload continuity, image loading, credential generation, and cleanup.

### How Did You Test This Change?

- `python scripts/fault_matrix_guard.py --policy-only`
- `python scripts/fault_matrix_guard.py --evidence scripts/tests/fixtures/m11-fault-matrix/pass --allow-fixture`
- `python scripts/architecture_slo_guard.py --policy-only`
- `python scripts/architecture_slo_guard.py --evidence scripts/tests/fixtures/m11-slo/pass --allow-fixture`
- `python -m unittest scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_fault_matrix scripts.tests.test_architecture_slo_guard scripts.tests.test_m11_dynamic_evidence` (39 tests)
- PowerShell parser and Validate modes for the secret generator, fault runner, and SLO cluster wrapper
- `actionlint .github/workflows/kubernetes-fault-matrix.yml .github/workflows/architecture-slo-evidence.yml .github/workflows/architecture-performance-evidence.yml`
- Generated certificate and RSA private-key validation with OpenSSL
- `python scripts/kubernetes_assets_guard.py`
- `python scripts/architecture_documentation_guard.py --check`
- `.\scripts\check-agents-routing.ps1`
- `python -m py_compile ...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated architecture SLO cluster evidence collection with digest-pinned Prometheus support.
  * Added run-scoped synthetic credentials for dynamic evidence and fault testing.
  * Improved image preloading for Kind and K3d test clusters.
  * Added registry authentication and cleanup for evidence workflows.

* **Bug Fixes**
  * Strengthened validation to reject insecure runner, credential, permission, and cleanup configurations.

* **Documentation**
  * Clarified evidence execution boundaries, image requirements, credential handling, and verification steps.

* **Tests**
  * Added coverage for credential generation, workflow safety, sustained probes, and regression detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->