### PR TITLE
[ISSUE #8796]🐛Measure performance revisions together

### DIFF
--- a/.github/workflows/architecture-performance-evidence.yml
+++ b/.github/workflows/architecture-performance-evidence.yml
@@ -2,6 +2,17 @@ name: Architecture performance evidence
 
 on:
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: Approved pre-refactor baseline commit
+        required: true
+        default: 7c952cdcd1ce625604de9c54975a201d7b1b755b
+        type: string
+      candidate_ref:
+        description: Candidate commit or ref
+        required: true
+        default: main
+        type: string
   schedule:
     - cron: "29 20 * * 0"
 
@@ -42,60 +53,106 @@ jobs:
     runs-on: [self-hosted, linux, x64, rocketmq-benchmark]
     timeout-minutes: 480
     env:
+      BASELINE_REF: ${{ inputs.baseline_ref || vars.ARCHITECTURE_PERFORMANCE_BASELINE_REF || '7c952cdcd1ce625604de9c54975a201d7b1b755b' }}
+      CANDIDATE_REF: ${{ inputs.candidate_ref || github.sha }}
       BENCHMARK_HARDWARE_ID: ${{ vars.ARCHITECTURE_BENCHMARK_HARDWARE_ID }}
       BENCHMARK_FILESYSTEM: ${{ vars.ARCHITECTURE_BENCHMARK_FILESYSTEM }}
       BENCHMARK_FEATURES: ${{ vars.ARCHITECTURE_BENCHMARK_FEATURES }}
       BENCHMARK_METHOD: ${{ vars.ARCHITECTURE_BENCHMARK_METHOD }}
-      APPROVED_BASELINE_REPORT: ${{ vars.ARCHITECTURE_PERFORMANCE_BASELINE_REPORT }}
+      RUSTUP_TOOLCHAIN: 1.95.0
 
     steps:
-      - name: Checkout
+      - name: Checkout approved baseline
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ env.BASELINE_REF }}
+          path: baseline
 
-      - name: Use repository Rust 1.95 toolchain
+      - name: Checkout candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ env.CANDIDATE_REF }}
+          path: candidate
+
+      - name: Bind immutable baseline and candidate commits
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$BASELINE_REF" =~ ^[0-9a-f]{40}$ ]]
+          BASELINE_COMMIT=$(git -C baseline rev-parse HEAD)
+          CANDIDATE_COMMIT=$(git -C candidate rev-parse HEAD)
+          [[ "$BASELINE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$CANDIDATE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$BASELINE_COMMIT" = "$BASELINE_REF"
+          test "$BASELINE_COMMIT" != "$CANDIDATE_COMMIT"
+          test -z "$(git -C baseline status --porcelain)"
+          test -z "$(git -C candidate status --porcelain)"
+          {
+            echo "BASELINE_COMMIT=$BASELINE_COMMIT"
+            echo "CANDIDATE_COMMIT=$CANDIDATE_COMMIT"
+          } >> "$GITHUB_ENV"
+          mkdir -p target/architecture-refactor/M10
+          printf '%s\n' \
+            "baseline=$BASELINE_COMMIT" \
+            "candidate=$CANDIDATE_COMMIT" \
+            "toolchain=$RUSTUP_TOOLCHAIN" \
+            > target/architecture-refactor/M10/revisions.txt
+
+      - name: Use approved Rust toolchain
         run: rustup show active-toolchain
 
-      - name: Materialize the reviewed runner manifest
+      - name: Materialize identical reviewed runner manifests
         run: |
           set -euo pipefail
           test -n "$BENCHMARK_HARDWARE_ID"
           test -n "$BENCHMARK_FILESYSTEM"
           test -n "$BENCHMARK_FEATURES"
           test -n "$BENCHMARK_METHOD"
-          python scripts/architecture_performance_sidecar.py \
-            --generate-manifest target/architecture-refactor/M10/runner-manifest.json
+          python baseline/scripts/architecture_performance_sidecar.py \
+            --generate-manifest baseline/target/architecture-refactor/M10/runner-manifest.json
+          python candidate/scripts/architecture_performance_sidecar.py \
+            --generate-manifest candidate/target/architecture-refactor/M10/runner-manifest.json
           python - <<'PY'
           import json
           import os
           from pathlib import Path
 
-          path = Path("target/architecture-refactor/M10/runner-manifest.json")
-          manifest = json.loads(path.read_text(encoding="utf-8"))
-          manifest["environment"].update(
-              hardware_id=os.environ["BENCHMARK_HARDWARE_ID"],
-              filesystem=os.environ["BENCHMARK_FILESYSTEM"],
-              features=sorted(filter(None, os.environ["BENCHMARK_FEATURES"].split(","))),
-              measurement_method=os.environ["BENCHMARK_METHOD"],
-          )
-          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          for checkout in ("baseline", "candidate"):
+              path = Path(checkout) / "target/architecture-refactor/M10/runner-manifest.json"
+              manifest = json.loads(path.read_text(encoding="utf-8"))
+              manifest["environment"].update(
+                  hardware_id=os.environ["BENCHMARK_HARDWARE_ID"],
+                  filesystem=os.environ["BENCHMARK_FILESYSTEM"],
+                  features=sorted(filter(None, os.environ["BENCHMARK_FEATURES"].split(","))),
+                  measurement_method=os.environ["BENCHMARK_METHOD"],
+              )
+              path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
           PY
 
-      - name: Collect correctness and measurement evidence
-        run: >-
-          python scripts/architecture_performance_sidecar.py
-          --manifest target/architecture-refactor/M10/runner-manifest.json
-          --output-dir target/architecture-refactor/M10/performance
-          --run-id ${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Collect baseline correctness and measurement evidence
+        run: |
+          python baseline/scripts/architecture_performance_sidecar.py \
+            --manifest baseline/target/architecture-refactor/M10/runner-manifest.json \
+            --output-dir baseline/target/architecture-refactor/M10/performance \
+            --run-id ${{ github.run_id }}-${{ github.run_attempt }}-baseline
 
-      - name: Compare with the approved baseline when configured
-        if: env.APPROVED_BASELINE_REPORT != ''
+      - name: Collect candidate correctness and measurement evidence
+        run: |
+          python candidate/scripts/architecture_performance_sidecar.py \
+            --manifest candidate/target/architecture-refactor/M10/runner-manifest.json \
+            --output-dir candidate/target/architecture-refactor/M10/performance \
+            --run-id ${{ github.run_id }}-${{ github.run_attempt }}-candidate
+
+      - name: Compare approved baseline with candidate
         run: |
           set -euo pipefail
-          CANDIDATE=$(find target/architecture-refactor/M10/performance -name report.json -print -quit)
-          test -n "$CANDIDATE"
-          python scripts/architecture_performance_guard.py \
-            --baseline "$APPROVED_BASELINE_REPORT" \
-            --candidate "$CANDIDATE" \
+          BASELINE_REPORT=$(find baseline/target/architecture-refactor/M10/performance -name measurement-report.json -print -quit)
+          CANDIDATE_REPORT=$(find candidate/target/architecture-refactor/M10/performance -name measurement-report.json -print -quit)
+          test -n "$BASELINE_REPORT"
+          test -n "$CANDIDATE_REPORT"
+          python candidate/scripts/architecture_performance_guard.py \
+            --baseline "$BASELINE_REPORT" \
+            --candidate "$CANDIDATE_REPORT" \
             --output target/architecture-refactor/M10/comparison.json
 
       - name: Upload immutable performance evidence
@@ -103,6 +160,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: architecture-performance-${{ github.sha }}
-          path: target/architecture-refactor/M10
+          path: |
+            baseline/target/architecture-refactor/M10
+            candidate/target/architecture-refactor/M10
+            target/architecture-refactor/M10
           if-no-files-found: error
           retention-days: 90

--- a/scripts/architecture_performance_guard.py
+++ b/scripts/architecture_performance_guard.py
@@ -33,6 +33,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PROFILES = ROOT / "scripts" / "architecture-performance-profiles.json"
 DEFAULT_EXCEPTIONS = ROOT / "scripts" / "architecture-performance-exceptions.json"
+DEFAULT_WORKFLOW = ROOT / ".github" / "workflows" / "architecture-performance-evidence.yml"
+APPROVED_BASELINE_COMMIT = "7c952cdcd1ce625604de9c54975a201d7b1b755b"
 REQUIRED_PROFILE_IDS = {
     "local-append",
     "sync-flush",
@@ -58,6 +60,53 @@ REQUIRED_SIDECAR_PROTOCOL = {
 }
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def validate_workflow_contract(workflow: str) -> list[str]:
+    findings: list[str] = []
+    required_fragments = {
+        "approved baseline input": "baseline_ref:",
+        "candidate input": "candidate_ref:",
+        "immutable approved baseline": f"default: {APPROVED_BASELINE_COMMIT}",
+        "baseline checkout": "ref: ${{ env.BASELINE_REF }}\n          path: baseline",
+        "candidate checkout": "ref: ${{ env.CANDIDATE_REF }}\n          path: candidate",
+        "baseline commit binding": "BASELINE_COMMIT=$(git -C baseline rev-parse HEAD)",
+        "candidate commit binding": "CANDIDATE_COMMIT=$(git -C candidate rev-parse HEAD)",
+        "different commit assertion": 'test "$BASELINE_COMMIT" != "$CANDIDATE_COMMIT"',
+        "fixed Rust toolchain": "RUSTUP_TOOLCHAIN: 1.95.0",
+        "baseline measurement": "python baseline/scripts/architecture_performance_sidecar.py",
+        "candidate measurement": "python candidate/scripts/architecture_performance_sidecar.py",
+        "baseline report discovery": (
+            "find baseline/target/architecture-refactor/M10/performance "
+            "-name measurement-report.json"
+        ),
+        "candidate report discovery": (
+            "find candidate/target/architecture-refactor/M10/performance "
+            "-name measurement-report.json"
+        ),
+        "mandatory comparison": "python candidate/scripts/architecture_performance_guard.py",
+        "baseline evidence upload": "baseline/target/architecture-refactor/M10",
+        "candidate evidence upload": "candidate/target/architecture-refactor/M10",
+    }
+    for contract, fragment in required_fragments.items():
+        if fragment not in workflow:
+            findings.append(f"performance workflow is missing {contract}")
+    if "APPROVED_BASELINE_REPORT" in workflow:
+        findings.append("performance workflow must not depend on an external baseline report path")
+    comparison_marker = "- name: Compare approved baseline with candidate"
+    comparison_start = workflow.find(comparison_marker)
+    if comparison_start < 0:
+        findings.append("performance workflow is missing the mandatory comparison step")
+    else:
+        next_step = workflow.find("\n      - name:", comparison_start + len(comparison_marker))
+        comparison_step = workflow[comparison_start : next_step if next_step >= 0 else None]
+        if "\n        if:" in comparison_step:
+            findings.append("performance baseline/candidate comparison must not be conditional")
+        if '--baseline "$BASELINE_REPORT"' not in comparison_step:
+            findings.append("performance comparison does not consume the measured baseline")
+        if '--candidate "$CANDIDATE_REPORT"' not in comparison_step:
+            findings.append("performance comparison does not consume the measured candidate")
+    return findings
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -731,6 +780,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.validate_profiles:
         findings = validate_profile_policy(policy)
+        try:
+            workflow = DEFAULT_WORKFLOW.read_text(encoding="utf-8")
+        except OSError as error:
+            findings.append(f"cannot read performance workflow: {error}")
+        else:
+            findings.extend(validate_workflow_contract(workflow))
         exceptions = active_exception_map(exception_document, datetime.now(timezone.utc), findings)
         if not findings:
             validate_exception_contracts(policy, exceptions, findings)

--- a/scripts/tests/test_architecture_performance_guard.py
+++ b/scripts/tests/test_architecture_performance_guard.py
@@ -112,6 +112,8 @@ class ArchitecturePerformanceGuardTest(unittest.TestCase):
 
     def test_live_profile_inventory_and_cli_validation_pass(self) -> None:
         self.assertEqual([], guard.validate_profile_policy(self.policy))
+        workflow = guard.DEFAULT_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual([], guard.validate_workflow_contract(workflow))
         self.assertEqual(guard.REQUIRED_PROFILE_IDS, {profile["id"] for profile in self.policy["profiles"]})
         self.assertEqual(11, sum(len(profile["variants"]) for profile in self.policy["profiles"]))
 
@@ -126,6 +128,33 @@ class ArchitecturePerformanceGuardTest(unittest.TestCase):
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         self.assertIn("profiles=8 variants=11 metric_contracts=50", result.stdout)
+
+    def test_workflow_contract_rejects_candidate_only_or_optional_comparison(self) -> None:
+        workflow = guard.DEFAULT_WORKFLOW.read_text(encoding="utf-8")
+
+        candidate_only = workflow.replace(
+            "ref: ${{ env.BASELINE_REF }}\n          path: baseline",
+            "ref: ${{ env.CANDIDATE_REF }}\n          path: candidate",
+            1,
+        )
+        findings = guard.validate_workflow_contract(candidate_only)
+        self.assertTrue(any("baseline checkout" in finding for finding in findings))
+
+        optional = workflow.replace(
+            "- name: Compare approved baseline with candidate\n        run:",
+            "- name: Compare approved baseline with candidate\n        if: env.BASELINE_REPORT != ''\n        run:",
+            1,
+        )
+        findings = guard.validate_workflow_contract(optional)
+        self.assertTrue(any("must not be conditional" in finding for finding in findings))
+
+        external_path = workflow.replace(
+            "RUSTUP_TOOLCHAIN: 1.95.0",
+            "APPROVED_BASELINE_REPORT: ${{ vars.ARCHITECTURE_PERFORMANCE_BASELINE_REPORT }}",
+            1,
+        )
+        findings = guard.validate_workflow_contract(external_path)
+        self.assertTrue(any("external baseline report path" in finding for finding in findings))
 
     def test_collection_contract_preserves_target_hardware_requirement(self) -> None:
         invalid = copy.deepcopy(self.policy)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8796

### Brief Description

Measure the approved pre-refactor baseline and the candidate sequentially on the same benchmark runner instead of accepting an optional external baseline path. Both revisions are resolved to full Git commits, use the same Rust toolchain and reviewed environment metadata, and must produce complete sidecar evidence before the comparison can run.

The performance profile guard now validates this workflow contract. Mutation tests reject candidate-only checkout, conditional comparison, and regression to an external baseline report path.

### How Did You Test This Change?

- `python -m unittest discover -s scripts/tests -p "test_architecture_performance*.py"`
- `python scripts/architecture_performance_guard.py --validate-profiles`
- `python scripts/architecture_documentation_guard.py --check`
- `python scripts/architecture_release_guard.py`
- `.\scripts\check-agents-routing.ps1`
- `python scripts/architecture_performance_sidecar.py --help`
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable manual performance comparisons using selectable baseline and candidate revisions.
  - Performance evidence now includes separate baseline and candidate results with generated comparison output.
  - Added validation to ensure the performance workflow includes required checkout, measurement, comparison, and evidence steps.

- **Bug Fixes**
  - Prevented comparisons from relying on missing, optional, or external baseline reports.

- **Tests**
  - Expanded coverage for workflow configuration validation and invalid comparison setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->