### PR TITLE
[ISSUE #8798]🐛Bind performance to the phase baseline

### DIFF
--- a/.github/workflows/architecture-performance-evidence.yml
+++ b/.github/workflows/architecture-performance-evidence.yml
@@ -6,7 +6,7 @@ on:
       baseline_ref:
         description: Approved pre-refactor baseline commit
         required: true
-        default: 7c952cdcd1ce625604de9c54975a201d7b1b755b
+        default: a4c71a710086e8ca5079dc1db7a585a283cfcfca
         type: string
       candidate_ref:
         description: Candidate commit or ref
@@ -53,7 +53,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, rocketmq-benchmark]
     timeout-minutes: 480
     env:
-      BASELINE_REF: ${{ inputs.baseline_ref || vars.ARCHITECTURE_PERFORMANCE_BASELINE_REF || '7c952cdcd1ce625604de9c54975a201d7b1b755b' }}
+      BASELINE_REF: ${{ inputs.baseline_ref || vars.ARCHITECTURE_PERFORMANCE_BASELINE_REF || 'a4c71a710086e8ca5079dc1db7a585a283cfcfca' }}
       CANDIDATE_REF: ${{ inputs.candidate_ref || github.sha }}
       BENCHMARK_HARDWARE_ID: ${{ vars.ARCHITECTURE_BENCHMARK_HARDWARE_ID }}
       BENCHMARK_FILESYSTEM: ${{ vars.ARCHITECTURE_BENCHMARK_FILESYSTEM }}

--- a/scripts/architecture_performance_guard.py
+++ b/scripts/architecture_performance_guard.py
@@ -34,7 +34,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PROFILES = ROOT / "scripts" / "architecture-performance-profiles.json"
 DEFAULT_EXCEPTIONS = ROOT / "scripts" / "architecture-performance-exceptions.json"
 DEFAULT_WORKFLOW = ROOT / ".github" / "workflows" / "architecture-performance-evidence.yml"
-APPROVED_BASELINE_COMMIT = "7c952cdcd1ce625604de9c54975a201d7b1b755b"
+APPROVED_BASELINE_COMMIT = "a4c71a710086e8ca5079dc1db7a585a283cfcfca"
 REQUIRED_PROFILE_IDS = {
     "local-append",
     "sync-flush",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8798

### Brief Description

Bind architecture performance evidence to `a4c71a710086e8ca5079dc1db7a585a283cfcfca`, the last commit before the current P0-P3 phase implementation began. This replaces the earlier collector-completion commit, which would have mixed 35 already-landed changes into the measured scope.

The workflow dispatch default, scheduled-run fallback, and fail-closed workflow contract now agree on the exact phase baseline commit.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_architecture_performance_guard`
- `python scripts/architecture_performance_guard.py --validate-profiles`
- `.\scripts\check-agents-routing.ps1`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/architecture-performance-evidence.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the approved baseline used for architecture performance measurements and validation.
  * Ensured automated performance checks compare results against the latest approved reference point.
  * No changes were made to workflow behavior, processing steps, or generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->