### PR TITLE
[ISSUE #8800]🐛Isolate image target caches by revision

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -160,7 +160,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/workspace/target,sharing=locked <<EOF
+    --mount=type=cache,id=rocketmq-service-target-${SOURCE_REVISION},target=/workspace/target,sharing=locked <<EOF
 set -eux
 cargo build --locked --release --package rocketmq-broker --no-default-features --features production --bin rocketmq-broker-rust
 cargo build --locked --release --package rocketmq-namesrv --no-default-features --features production --bin rocketmq-namesrv-rust

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -265,6 +265,23 @@ def audit_foundation(
     ):
         if fragment not in dockerfile:
             findings.append(f"service Dockerfile missing: {fragment}")
+    service_builder_match = re.search(
+        r"(?ms)^FROM builder-base AS service-builder\s*(.*?)(?=^FROM |\Z)",
+        dockerfile,
+    )
+    if service_builder_match is not None:
+        service_builder = service_builder_match.group(1)
+        revision_scoped_target_cache = (
+            "--mount=type=cache,id=rocketmq-service-target-${SOURCE_REVISION},"
+            "target=/workspace/target,sharing=locked"
+        )
+        if service_builder.count(revision_scoped_target_cache) != 1:
+            findings.append("service builder target cache must be isolated by the full source revision")
+        if re.search(
+            r"--mount=type=cache,(?![^\n]*\bid=)[^\n]*\btarget=/workspace/target(?:,|\\|\s)",
+            service_builder,
+        ):
+            findings.append("service builder must not share an unscoped Cargo target cache across revisions")
     if "ROCKETMQ_COMPONENT" in dockerfile:
         findings.append("service images must not use component-selector dispatch")
     for service_name, contract in EXPECTED_SERVICES.items():

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -113,6 +113,17 @@ class ContainerFoundationTests(unittest.TestCase):
         root = self.dockerfile.replace("USER 10001:10001", "USER 0:0")
         self.assertTrue(any("USER 10001:10001" in finding for finding in self.audit(dockerfile=root)))
 
+    def test_cross_revision_service_target_cache_is_rejected(self) -> None:
+        revision_scoped = (
+            "--mount=type=cache,id=rocketmq-service-target-${SOURCE_REVISION},"
+            "target=/workspace/target,sharing=locked"
+        )
+        shared = "--mount=type=cache,target=/workspace/target,sharing=locked"
+        dockerfile = self.dockerfile.replace(revision_scoped, shared, 1)
+        findings = self.audit(dockerfile=dockerfile)
+        self.assertTrue(any("isolated by the full source revision" in finding for finding in findings))
+        self.assertTrue(any("unscoped Cargo target cache" in finding for finding in findings))
+
     def test_unpinned_action_or_weakened_scanner_is_rejected(self) -> None:
         checkout_sha = self.policy["workflow"]["actions"]["actions/checkout"]
         workflow = self.workflow.replace(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8800

### Brief Description

Isolate the production service Cargo target cache by the validated full `SOURCE_REVISION`. This prevents a long-lived BuildKit builder from treating artifacts produced for an earlier checkout at `/workspace` as fresh for a later revision.

The immutable Cargo registry and Git caches remain shared. The container contract now fails closed if the service builder restores an unscoped `/workspace/target` cache, with a mutation test covering the reproduced cross-revision regression.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_m11_container_foundation`
- `python scripts/container_image_guard.py`
- `python -m unittest scripts.tests.test_m11_container_foundation scripts.tests.test_m11_fault_matrix scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_service_lifecycle`
- `python scripts/fault_matrix_guard.py`
- `python scripts/kubernetes_assets_guard.py`
- `.\scripts\check-agents-routing.ps1`
- `docker buildx build --check --file docker/Dockerfile.base --build-arg SOURCE_REVISION=8e01ee9ac0bfbd14528939160cd7c2b2fb6d01e4 .`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build artifacts are now cached separately for each source revision, helping prevent stale artifacts from being reused across builds.
  * Container policy checks now enforce revision-specific caching for service build outputs.

* **Tests**
  * Added validation to detect and reject unscoped build caches, ensuring cache isolation rules remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->