### PR TITLE
[ISSUE #8802]🐛Eliminate Proxy Cluster head-of-line blocking

### DIFF
--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::proxy_adapter_compat::client_config_for_managed_domain;
 use rocketmq_client_rust::proxy_adapter_compat::current_millis;
+#[cfg(test)]
 use rocketmq_client_rust::proxy_adapter_compat::rpc_hook_from_outbound_signer;
 use rocketmq_client_rust::proxy_adapter_compat::BoundaryType;
 use rocketmq_client_rust::proxy_adapter_compat::BrokerDataExt;
@@ -45,6 +46,7 @@ use rocketmq_client_rust::AckResult;
 use rocketmq_client_rust::AckStatus;
 use rocketmq_client_rust::ClientConfig as RocketmqClientConfig;
 use rocketmq_client_rust::ClientRuntime;
+#[cfg(test)]
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::DefaultMQProducer;
 use rocketmq_client_rust::PopResult;
@@ -112,16 +114,14 @@ use rocketmq_proxy_core::TransactionSource;
 use rocketmq_proxy_core::UpdateOffsetPlan;
 use rocketmq_proxy_core::UpdateOffsetRequest;
 use rocketmq_runtime::ChildServiceContext;
-use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_security_api::OutboundSigner;
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 
 use crate::config::ClusterConfig;
 use crate::message::message_ext_to_core;
 use crate::message::message_from_core;
 
-const CLUSTER_COMMAND_CAPACITY: usize = 1024;
+#[path = "cluster_admission.rs"]
+mod cluster_admission;
 
 #[async_trait]
 pub trait ClusterClient: Send + Sync {
@@ -953,110 +953,29 @@ impl ClusterClient for RocketmqClusterClient {
     }
 }
 
-#[derive(Clone)]
-struct ClusterTaskExecutor {
-    sender: mpsc::Sender<ClusterCommand>,
-}
+#[path = "cluster_execution.rs"]
+mod cluster_execution;
 
-enum ClusterCommand {
-    ReadinessCheck {
-        reply: oneshot::Sender<ProxyResult<()>>,
-    },
-    QueryRoute {
-        topic: ResourceIdentity,
-        reply: oneshot::Sender<ProxyResult<TopicRouteData>>,
-    },
-    QueryAssignment {
-        topic: ResourceIdentity,
-        group: ResourceIdentity,
-        client_id: String,
-        reply: oneshot::Sender<ProxyResult<Option<Vec<MessageQueueAssignment>>>>,
-    },
-    QueryTopicMessageType {
-        topic: ResourceIdentity,
-        reply: oneshot::Sender<ProxyResult<ProxyTopicMessageType>>,
-    },
-    QuerySubscriptionGroup {
-        topic: ResourceIdentity,
-        group: ResourceIdentity,
-        reply: oneshot::Sender<ProxyResult<Option<SubscriptionGroupMetadata>>>,
-    },
-    QueryUser {
-        username: String,
-        reply: oneshot::Sender<ProxyResult<Option<UserInfo>>>,
-    },
-    QueryAcl {
-        subject: String,
-        reply: oneshot::Sender<ProxyResult<Option<AclInfo>>>,
-    },
-    SendMessage {
-        request: SendMessageRequest,
-        client_id: Option<String>,
-        request_id: String,
-        reply: oneshot::Sender<ProxyResult<Vec<SendMessageResultEntry>>>,
-    },
-    RecallMessage {
-        request: RecallMessageRequest,
-        client_id: Option<String>,
-        request_id: String,
-        reply: oneshot::Sender<ProxyResult<RecallMessagePlan>>,
-    },
-    ReceiveMessage {
-        request: ReceiveMessageRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<ReceiveMessagePlan>>,
-    },
-    PullMessage {
-        request: PullMessageRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<PullMessagePlan>>,
-    },
-    AckMessage {
-        request: AckMessageRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<Vec<AckMessageResultEntry>>>,
-    },
-    ForwardMessageToDeadLetterQueue {
-        request: ForwardMessageToDeadLetterQueueRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<ForwardMessageToDeadLetterQueuePlan>>,
-    },
-    ChangeInvisibleDuration {
-        request: ChangeInvisibleDurationRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<ChangeInvisibleDurationPlan>>,
-    },
-    UpdateOffset {
-        request: UpdateOffsetRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<UpdateOffsetPlan>>,
-    },
-    GetOffset {
-        request: GetOffsetRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<GetOffsetPlan>>,
-    },
-    QueryOffset {
-        request: QueryOffsetRequest,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<QueryOffsetPlan>>,
-    },
-    EndTransaction {
-        request: EndTransactionRequest,
-        client_id: Option<String>,
-        request_id: String,
-        deadline: Option<Duration>,
-        reply: oneshot::Sender<ProxyResult<EndTransactionPlan>>,
-    },
-    LockBatchMq {
-        request: LockBatchRequestBody,
-        reply: oneshot::Sender<ProxyResult<LockBatchResponseBody>>,
-    },
-    UnlockBatchMq {
-        request: UnlockBatchRequestBody,
-        reply: oneshot::Sender<ProxyResult<()>>,
-    },
-}
+#[cfg(test)]
+use cluster_admission::cluster_lane;
+#[cfg(test)]
+use cluster_admission::cluster_lane_domain_id;
+#[cfg(test)]
+use cluster_admission::ClusterExecutionLanes;
+#[cfg(test)]
+use cluster_admission::ClusterExecutionPolicy;
+#[cfg(test)]
+use cluster_admission::QueuedClusterCommand;
+#[cfg(test)]
+use cluster_admission::CLUSTER_COMMAND_BYTE_CAPACITY;
+#[cfg(test)]
+use cluster_admission::CLUSTER_COMMAND_CAPACITY;
+#[cfg(test)]
+use cluster_admission::CLUSTER_EXECUTION_LANE_COUNT;
+#[cfg(test)]
+use cluster_execution::run_cluster_lane;
+use cluster_execution::ClusterCommand;
+use cluster_execution::ClusterTaskExecutor;
 
 #[derive(Clone)]
 struct CachedValue<T> {
@@ -1078,20 +997,34 @@ impl<T> CachedValue<T> {
 }
 
 #[cfg(test)]
-fn test_client_runtime() -> Arc<ClientRuntime> {
-    static OWNER: std::sync::LazyLock<rocketmq_runtime::RuntimeOwner> = std::sync::LazyLock::new(|| {
+mod cluster_test_runtime {
+    use super::*;
+
+    static TEST_RUNTIME_OWNER: std::sync::LazyLock<rocketmq_runtime::RuntimeOwner> = std::sync::LazyLock::new(|| {
         rocketmq_runtime::RuntimeOwner::new(rocketmq_runtime::RuntimeConfig {
             thread_name: "rocketmq-proxy-cluster-test".to_string(),
             ..Default::default()
         })
         .expect("proxy cluster test runtime should start")
     });
-    ClientRuntime::new(
-        OWNER.root_context().child("client"),
-        ClientRuntimeConfig::default(),
-        TelemetryHandle::noop(),
-    )
+
+    pub(super) fn client_runtime() -> Arc<ClientRuntime> {
+        ClientRuntime::new(
+            TEST_RUNTIME_OWNER.root_context().child("client"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+        )
+    }
+
+    pub(super) fn service_context(scope: &'static str) -> ChildServiceContext {
+        TEST_RUNTIME_OWNER.root_context().child(scope)
+    }
 }
+
+#[cfg(test)]
+use cluster_test_runtime::client_runtime as test_client_runtime;
+#[cfg(test)]
+use cluster_test_runtime::service_context as test_service_context;
 
 struct ClusterWorkerState {
     client_runtime: Arc<ClientRuntime>,
@@ -1114,14 +1047,31 @@ impl ClusterWorkerState {
         Self::with_rpc_hook(test_client_runtime(), 0, None)
     }
 
+    #[cfg(test)]
     fn with_rpc_hook(client_runtime: Arc<ClientRuntime>, domain_id: u64, rpc_hook: Option<Arc<ClientRpcHook>>) -> Self {
+        Self::with_factories(
+            client_runtime,
+            domain_id,
+            rpc_hook,
+            Arc::new(DefaultClusterClientFactory),
+            Arc::new(DefaultClusterProducerFactory),
+        )
+    }
+
+    fn with_factories(
+        client_runtime: Arc<ClientRuntime>,
+        domain_id: u64,
+        rpc_hook: Option<Arc<ClientRpcHook>>,
+        client_factory: Arc<dyn ClusterClientFactory>,
+        producer_factory: Arc<dyn ClusterProducerFactory>,
+    ) -> Self {
         Self {
             client_runtime,
             domain_id,
             rpc_hook,
             client: None,
-            client_factory: Arc::new(DefaultClusterClientFactory),
-            producer_factory: Arc::new(DefaultClusterProducerFactory),
+            client_factory,
+            producer_factory,
             send_producers: HashMap::new(),
             route_cache: HashMap::new(),
             topic_message_type_cache: HashMap::new(),
@@ -1150,20 +1100,7 @@ impl ClusterWorkerState {
         client_factory: Arc<dyn ClusterClientFactory>,
         producer_factory: Arc<dyn ClusterProducerFactory>,
     ) -> Self {
-        Self {
-            client_runtime,
-            domain_id,
-            rpc_hook,
-            client: None,
-            client_factory,
-            producer_factory,
-            send_producers: HashMap::new(),
-            route_cache: HashMap::new(),
-            topic_message_type_cache: HashMap::new(),
-            subscription_group_cache: HashMap::new(),
-            user_cache: HashMap::new(),
-            acl_cache: HashMap::new(),
-        }
+        Self::with_factories(client_runtime, domain_id, rpc_hook, client_factory, producer_factory)
     }
 
     fn rpc_hook(&self) -> Option<Arc<ClientRpcHook>> {
@@ -1259,336 +1196,6 @@ impl ClusterWorkerState {
     fn cache_acl(&mut self, subject: impl Into<String>, acl: Option<AclInfo>, ttl: Duration) {
         cache_value(&mut self.acl_cache, subject.into(), acl, ttl);
     }
-}
-
-impl ClusterTaskExecutor {
-    fn new(
-        config: ClusterConfig,
-        signer: Option<Arc<dyn OutboundSigner>>,
-        service_context: &ChildServiceContext,
-        telemetry_handle: TelemetryHandle,
-    ) -> ProxyResult<Self> {
-        let rpc_hook = signer.map(rpc_hook_from_outbound_signer);
-        Self::new_with_rpc_hook(config, rpc_hook, service_context, telemetry_handle)
-    }
-
-    fn new_with_rpc_hook(
-        config: ClusterConfig,
-        rpc_hook: Option<Arc<ClientRpcHook>>,
-        service_context: &ChildServiceContext,
-        telemetry_handle: TelemetryHandle,
-    ) -> ProxyResult<Self> {
-        let (sender, receiver) = mpsc::channel(CLUSTER_COMMAND_CAPACITY);
-        let worker_context = service_context.child("command-worker");
-        let shutdown_context = service_context.clone();
-        let client_runtime = ClientRuntime::new(
-            worker_context.child("client-runtime"),
-            ClientRuntimeConfig::default(),
-            telemetry_handle,
-        );
-        let cancellation = worker_context.task_group().cancellation_token();
-        let domain_id = worker_context.task_group().id().as_u64();
-        worker_context
-            .spawn_service("proxy.cluster.worker", async move {
-                run_cluster_worker(
-                    config,
-                    client_runtime,
-                    domain_id,
-                    rpc_hook,
-                    receiver,
-                    cancellation,
-                    shutdown_context,
-                )
-                .await;
-            })
-            .map_err(|error| ProxyError::Transport {
-                message: format!("failed to spawn proxy cluster worker: {error}"),
-            })?;
-        Ok(Self { sender })
-    }
-
-    async fn readiness_check(&self) -> ProxyResult<()> {
-        self.execute(|reply| ClusterCommand::ReadinessCheck { reply }).await
-    }
-
-    async fn query_route(&self, topic: ResourceIdentity) -> ProxyResult<TopicRouteData> {
-        self.execute(|reply| ClusterCommand::QueryRoute { topic, reply }).await
-    }
-
-    async fn query_assignment(
-        &self,
-        topic: ResourceIdentity,
-        group: ResourceIdentity,
-        client_id: String,
-    ) -> ProxyResult<Option<Vec<MessageQueueAssignment>>> {
-        self.execute(|reply| ClusterCommand::QueryAssignment {
-            topic,
-            group,
-            client_id,
-            reply,
-        })
-        .await
-    }
-
-    async fn query_topic_message_type(&self, topic: ResourceIdentity) -> ProxyResult<ProxyTopicMessageType> {
-        self.execute(|reply| ClusterCommand::QueryTopicMessageType { topic, reply })
-            .await
-    }
-
-    async fn query_subscription_group(
-        &self,
-        topic: ResourceIdentity,
-        group: ResourceIdentity,
-    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
-        self.execute(|reply| ClusterCommand::QuerySubscriptionGroup { topic, group, reply })
-            .await
-    }
-
-    async fn query_user(&self, username: String) -> ProxyResult<Option<UserInfo>> {
-        self.execute(|reply| ClusterCommand::QueryUser { username, reply })
-            .await
-    }
-
-    async fn query_acl(&self, subject: String) -> ProxyResult<Option<AclInfo>> {
-        self.execute(|reply| ClusterCommand::QueryAcl { subject, reply }).await
-    }
-
-    async fn send_message(
-        &self,
-        request: SendMessageRequest,
-        client_id: Option<String>,
-        request_id: String,
-    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
-        self.execute(|reply| ClusterCommand::SendMessage {
-            request,
-            client_id,
-            request_id,
-            reply,
-        })
-        .await
-    }
-
-    async fn recall_message(
-        &self,
-        request: RecallMessageRequest,
-        client_id: Option<String>,
-        request_id: String,
-    ) -> ProxyResult<RecallMessagePlan> {
-        self.execute(|reply| ClusterCommand::RecallMessage {
-            request,
-            client_id,
-            request_id,
-            reply,
-        })
-        .await
-    }
-
-    async fn receive_message(
-        &self,
-        request: ReceiveMessageRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<ReceiveMessagePlan> {
-        self.execute(|reply| ClusterCommand::ReceiveMessage {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn pull_message(
-        &self,
-        request: PullMessageRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<PullMessagePlan> {
-        self.execute(|reply| ClusterCommand::PullMessage {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn ack_message(
-        &self,
-        request: AckMessageRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<Vec<AckMessageResultEntry>> {
-        self.execute(|reply| ClusterCommand::AckMessage {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn forward_message_to_dead_letter_queue(
-        &self,
-        request: ForwardMessageToDeadLetterQueueRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
-        self.execute(|reply| ClusterCommand::ForwardMessageToDeadLetterQueue {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn change_invisible_duration(
-        &self,
-        request: ChangeInvisibleDurationRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<ChangeInvisibleDurationPlan> {
-        self.execute(|reply| ClusterCommand::ChangeInvisibleDuration {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn update_offset(
-        &self,
-        request: UpdateOffsetRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<UpdateOffsetPlan> {
-        self.execute(|reply| ClusterCommand::UpdateOffset {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn get_offset(&self, request: GetOffsetRequest, deadline: Option<Duration>) -> ProxyResult<GetOffsetPlan> {
-        self.execute(|reply| ClusterCommand::GetOffset {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn query_offset(
-        &self,
-        request: QueryOffsetRequest,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<QueryOffsetPlan> {
-        self.execute(|reply| ClusterCommand::QueryOffset {
-            request,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn end_transaction(
-        &self,
-        request: EndTransactionRequest,
-        client_id: Option<String>,
-        request_id: String,
-        deadline: Option<Duration>,
-    ) -> ProxyResult<EndTransactionPlan> {
-        self.execute(|reply| ClusterCommand::EndTransaction {
-            request,
-            client_id,
-            request_id,
-            deadline,
-            reply,
-        })
-        .await
-    }
-
-    async fn lock_batch_mq(&self, request: LockBatchRequestBody) -> ProxyResult<LockBatchResponseBody> {
-        self.execute(|reply| ClusterCommand::LockBatchMq { request, reply })
-            .await
-    }
-
-    async fn unlock_batch_mq(&self, request: UnlockBatchRequestBody) -> ProxyResult<()> {
-        self.execute(|reply| ClusterCommand::UnlockBatchMq { request, reply })
-            .await
-    }
-
-    async fn execute<T>(
-        &self,
-        command: impl FnOnce(oneshot::Sender<ProxyResult<T>>) -> ClusterCommand,
-    ) -> ProxyResult<T>
-    where
-        T: Send + 'static,
-    {
-        let (reply, receiver) = oneshot::channel();
-        self.sender
-            .send(command(reply))
-            .await
-            .map_err(|_| ProxyError::Transport {
-                message: "proxy cluster worker task is unavailable".to_owned(),
-            })?;
-        receiver.await.map_err(|_| ProxyError::Transport {
-            message: "proxy cluster worker dropped response".to_owned(),
-        })?
-    }
-}
-
-async fn run_cluster_worker(
-    config: ClusterConfig,
-    client_runtime: Arc<ClientRuntime>,
-    domain_id: u64,
-    rpc_hook: Option<Arc<ClientRpcHook>>,
-    receiver: mpsc::Receiver<ClusterCommand>,
-    cancellation: tokio_util::sync::CancellationToken,
-    shutdown_context: ChildServiceContext,
-) {
-    let state = ClusterWorkerState::with_rpc_hook(client_runtime, domain_id, rpc_hook);
-    run_cluster_worker_with_state(config, state, receiver, cancellation, Some(shutdown_context)).await;
-}
-
-async fn run_cluster_worker_with_state(
-    config: ClusterConfig,
-    mut state: ClusterWorkerState,
-    mut receiver: mpsc::Receiver<ClusterCommand>,
-    cancellation: tokio_util::sync::CancellationToken,
-    shutdown_context: Option<ChildServiceContext>,
-) {
-    loop {
-        tokio::select! {
-            biased;
-            () = cancellation.cancelled() => break,
-            command = receiver.recv() => match command {
-                Some(command) => {
-                    tokio::select! {
-                        biased;
-                        () = cancellation.cancelled() => break,
-                        () = handle_cluster_command(&config, &mut state, command) => {}
-                    }
-                }
-                None => break,
-            },
-        }
-    }
-    let shutdown_deadline = shutdown_context
-        .and_then(|context| context.task_group().shutdown_deadline())
-        .unwrap_or_else(|| ShutdownDeadline::after(config.shutdown_timeout()));
-    for (producer_group, producer) in &mut state.send_producers {
-        if tokio::time::timeout(shutdown_deadline.remaining(), producer.shutdown())
-            .await
-            .is_err()
-        {
-            tracing::warn!(
-                producer_group,
-                "proxy cluster producer shutdown exceeded the shared deadline"
-            );
-        }
-    }
-    if let Some(client) = state.client.take() {
-        if tokio::time::timeout(shutdown_deadline.remaining(), client.shutdown())
-            .await
-            .is_err()
-        {
-            tracing::warn!("proxy cluster Client shutdown exceeded the shared deadline");
-        }
-    }
-    let _ = state.client_runtime.shutdown_until(shutdown_deadline).await;
 }
 
 fn cluster_client_config(config: &ClusterConfig) -> RocketmqClientConfig {
@@ -3146,32 +2753,55 @@ fn convert_subscription_group(group_config: SubscriptionGroupConfig) -> Subscrip
 mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
+    use std::mem::size_of;
     use std::time::Duration;
     use std::time::Instant;
 
     use cheetah_string::CheetahString;
     use rocketmq_client_rust::proxy_adapter_compat::TopicMessageType;
+    use rocketmq_error::RocketMQError;
     use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
     use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
     use rocketmq_protocol::protocol::route::route_data_view::QueueData;
     use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
     use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+    use rocketmq_proxy_core::AckMessageRequest;
+    use rocketmq_proxy_core::MessageQueueTarget;
+    use rocketmq_proxy_core::ProxyMessage;
+    use rocketmq_proxy_core::PullMessageRequest;
+    use rocketmq_proxy_core::ResourceIdentity;
+    use rocketmq_proxy_core::SendMessageEntry;
+    use rocketmq_proxy_core::SendMessageRequest;
+    use rocketmq_proxy_core::UpdateOffsetRequest;
+    use rocketmq_runtime::BudgetLimit;
+    use rocketmq_runtime::BudgetedQueue;
+    use rocketmq_runtime::FullPolicy;
+    use rocketmq_runtime::ResourceBudgetTree;
+    use tokio::sync::oneshot;
+    use tokio_util::sync::CancellationToken;
 
     use super::build_send_producer;
     use super::cluster_client_config;
     use super::cluster_info_has_registered_broker;
     use super::convert_subscription_group;
     use super::convert_topic_message_type;
+    use super::run_cluster_lane;
     use super::select_auth_metadata_broker_addr;
     use super::select_master_broker_addr;
     use super::single_broker_and_topic;
     use super::test_client_runtime;
     use super::CachedValue;
+    use super::ClusterCommand;
+    use super::ClusterExecutionLanes;
+    use super::ClusterExecutionPolicy;
     use super::ClusterTaskExecutor;
     use super::ClusterWorkerState;
+    use super::QueuedClusterCommand;
     use super::RocketmqClusterClient;
     use super::TelemetryHandle;
+    use super::CLUSTER_COMMAND_BYTE_CAPACITY;
     use super::CLUSTER_COMMAND_CAPACITY;
+    use super::CLUSTER_EXECUTION_LANE_COUNT;
     use crate::config::ClusterConfig;
     use rocketmq_client_rust::proxy_adapter_compat::MessageQueue;
     use rocketmq_proxy_core::ProxyError;
@@ -3329,6 +2959,159 @@ mod tests {
         assert!(matches!(error, ProxyError::InvalidMetadata { message } if message.contains("single topic")));
     }
 
+    #[test]
+    fn cluster_command_admission_rejects_count_and_byte_saturation() {
+        let count_lanes = ClusterExecutionLanes::new(ClusterExecutionPolicy {
+            capacity_count: 1,
+            capacity_bytes: 4 * 1024,
+            default_queue_deadline: Duration::from_secs(1),
+        })
+        .expect("count budget");
+        let (first_reply, _first_receiver) = oneshot::channel();
+        count_lanes
+            .enqueue(ClusterCommand::ReadinessCheck { reply: first_reply })
+            .expect("first command is admitted");
+        let (second_reply, _second_receiver) = oneshot::channel();
+        let count_error = count_lanes
+            .enqueue(ClusterCommand::ReadinessCheck { reply: second_reply })
+            .expect_err("second command exceeds the global count budget");
+        assert!(matches!(
+            count_error,
+            ProxyError::TooManyRequests {
+                resource: "proxy-cluster-command-queue"
+            }
+        ));
+        assert_eq!(count_lanes.root_budget.snapshot().current_count, 1);
+
+        let byte_lanes = ClusterExecutionLanes::new(ClusterExecutionPolicy {
+            capacity_count: 2,
+            capacity_bytes: size_of::<ClusterCommand>() + 8,
+            default_queue_deadline: Duration::from_secs(1),
+        })
+        .expect("byte budget");
+        let (reply, _receiver) = oneshot::channel();
+        let byte_error = byte_lanes
+            .enqueue(ClusterCommand::SendMessage {
+                request: SendMessageRequest {
+                    messages: vec![SendMessageEntry {
+                        topic: ResourceIdentity::new("", "TopicA"),
+                        client_message_id: "message-a".to_owned(),
+                        message: ProxyMessage::new("TopicA", vec![7_u8; 32]),
+                        queue_id: None,
+                    }],
+                    timeout: None,
+                },
+                client_id: Some("client-a".to_owned()),
+                request_id: "request-a".to_owned(),
+                reply,
+            })
+            .expect_err("retained payload exceeds the global byte budget");
+        assert!(matches!(
+            byte_error,
+            ProxyError::TooManyRequests {
+                resource: "proxy-cluster-command-queue"
+            }
+        ));
+        assert_eq!(byte_lanes.root_budget.snapshot().current_bytes, 0);
+    }
+
+    #[test]
+    fn related_consumer_commands_share_a_fifo_lane() {
+        let group = ResourceIdentity::new("tenant-a", "GroupA");
+        let topic = ResourceIdentity::new("tenant-a", "TopicA");
+        let target = MessageQueueTarget {
+            topic: topic.clone(),
+            queue_id: 0,
+            broker_name: Some("broker-a".to_owned()),
+            broker_addr: Some("127.0.0.1:10911".to_owned()),
+        };
+        let (pull_reply, _pull_receiver) = oneshot::channel();
+        let pull = ClusterCommand::PullMessage {
+            request: PullMessageRequest {
+                group: group.clone(),
+                target: target.clone(),
+                offset: 0,
+                batch_size: 1,
+                filter_expression: rocketmq_proxy_core::ConsumerFilterExpression {
+                    expression_type: "TAG".to_owned(),
+                    expression: "*".to_owned(),
+                },
+                long_polling_timeout: Duration::from_secs(1),
+            },
+            deadline: Some(Duration::from_secs(2)),
+            reply: pull_reply,
+        };
+        let (ack_reply, _ack_receiver) = oneshot::channel();
+        let ack = ClusterCommand::AckMessage {
+            request: AckMessageRequest {
+                group: group.clone(),
+                topic,
+                entries: Vec::new(),
+            },
+            deadline: Some(Duration::from_secs(2)),
+            reply: ack_reply,
+        };
+        let (offset_reply, _offset_receiver) = oneshot::channel();
+        let update_offset = ClusterCommand::UpdateOffset {
+            request: UpdateOffsetRequest {
+                group,
+                target,
+                offset: 1,
+            },
+            deadline: Some(Duration::from_secs(2)),
+            reply: offset_reply,
+        };
+
+        assert_eq!(pull.lane(), ack.lane());
+        assert_eq!(pull.lane(), update_offset.lane());
+    }
+
+    #[tokio::test]
+    async fn expired_queued_command_is_rejected_before_client_io() {
+        let service = super::test_service_context("proxy-cluster-expiry");
+        let budget = ResourceBudgetTree::new(
+            "proxy-cluster-expiry",
+            BudgetLimit::new(1, 4 * 1024, FullPolicy::Reject),
+        )
+        .expect("expiry budget");
+        let queue = BudgetedQueue::new(budget.root());
+        let (reply, receiver) = oneshot::channel();
+        let command = ClusterCommand::ReadinessCheck { reply };
+        queue
+            .try_push_data(
+                QueuedClusterCommand {
+                    command,
+                    enqueued_at: Instant::now()
+                        .checked_sub(Duration::from_millis(10))
+                        .expect("test instant supports subtraction"),
+                    deadline: Duration::from_millis(1),
+                },
+                size_of::<ClusterCommand>(),
+            )
+            .expect("expired command enters the queue");
+        queue.close();
+
+        run_cluster_lane(
+            ClusterConfig::default(),
+            ClusterWorkerState::new(),
+            queue,
+            CancellationToken::new(),
+            service,
+        )
+        .await;
+        let error = receiver
+            .await
+            .expect("expiry response")
+            .expect_err("expired command must not execute");
+        assert!(matches!(
+            error,
+            ProxyError::RocketMQ(RocketMQError::Timeout {
+                operation: "proxy cluster command queue",
+                timeout_ms: 1
+            })
+        ));
+    }
+
     #[tokio::test]
     async fn cluster_command_queue_is_bounded() {
         let runtime =
@@ -3336,7 +3119,15 @@ mod tests {
         let service = runtime.service_context("proxy-cluster-test.queue");
         let executor = ClusterTaskExecutor::new(ClusterConfig::default(), None, &service, TelemetryHandle::noop())
             .expect("managed executor builds");
-        assert_eq!(executor.sender.max_capacity(), CLUSTER_COMMAND_CAPACITY);
+        assert_eq!(
+            executor.lanes.root_budget.limit().capacity.count,
+            CLUSTER_COMMAND_CAPACITY
+        );
+        assert_eq!(
+            executor.lanes.root_budget.limit().capacity.bytes,
+            CLUSTER_COMMAND_BYTE_CAPACITY
+        );
+        assert_eq!(executor.lanes.snapshots().len(), CLUSTER_EXECUTION_LANE_COUNT);
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
     }

--- a/rocketmq-proxy-cluster/src/cluster_admission.rs
+++ b/rocketmq-proxy-cluster/src/cluster_admission.rs
@@ -1,0 +1,505 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::mem::size_of;
+use std::time::Duration;
+use std::time::Instant;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::proxy_adapter_compat::MessageQueue;
+use rocketmq_proxy_core::MessageQueueTarget;
+use rocketmq_proxy_core::ProxyError;
+use rocketmq_proxy_core::ProxyResult;
+use rocketmq_proxy_core::ResourceIdentity;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::BudgetedQueue;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::QueuePushErrorKind;
+#[cfg(test)]
+use rocketmq_runtime::QueueSnapshot;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourceBudgetTree;
+
+use super::ClusterCommand;
+
+pub(super) const CLUSTER_COMMAND_CAPACITY: usize = 1024;
+pub(super) const CLUSTER_COMMAND_BYTE_CAPACITY: usize = 64 * 1024 * 1024;
+pub(super) const CLUSTER_EXECUTION_LANE_COUNT: usize = 16;
+const CLUSTER_LANES_PER_CLASS: usize = 4;
+const CLUSTER_DEFAULT_QUEUE_DEADLINE: Duration = Duration::from_secs(30);
+
+pub(super) struct ClusterExecutionLanes {
+    pub(super) queues: Box<[BudgetedQueue<QueuedClusterCommand>]>,
+    pub(super) root_budget: ResourceBudget,
+    default_queue_deadline: Duration,
+}
+
+impl ClusterExecutionLanes {
+    pub(super) fn new(policy: ClusterExecutionPolicy) -> ProxyResult<Self> {
+        let tree = ResourceBudgetTree::new(
+            "proxy-cluster-commands",
+            BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject),
+        )
+        .map_err(|error| ProxyError::Transport {
+            message: format!("invalid proxy cluster command budget: {error}"),
+        })?;
+        let root_budget = tree.root();
+        let queues = (0..CLUSTER_EXECUTION_LANE_COUNT)
+            .map(|lane| {
+                root_budget
+                    .child(
+                        format!("lane-{lane}"),
+                        BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject),
+                    )
+                    .map(BudgetedQueue::new)
+                    .map_err(|error| ProxyError::Transport {
+                        message: format!("invalid proxy cluster command lane budget: {error}"),
+                    })
+            })
+            .collect::<ProxyResult<Vec<_>>>()?
+            .into_boxed_slice();
+        Ok(Self {
+            queues,
+            root_budget,
+            default_queue_deadline: policy.default_queue_deadline,
+        })
+    }
+
+    pub(super) fn enqueue(&self, command: ClusterCommand) -> ProxyResult<()> {
+        let lane = command.lane();
+        let retained_bytes = command.retained_bytes();
+        let deadline = command
+            .queue_deadline()
+            .unwrap_or(self.default_queue_deadline)
+            .max(Duration::from_millis(1));
+        let queued = QueuedClusterCommand {
+            command,
+            enqueued_at: Instant::now(),
+            deadline,
+        };
+        match self.queues[lane].try_push_data(queued, retained_bytes) {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                let kind = error.kind().clone();
+                let snapshot = self.queues[lane].snapshot();
+                let root_snapshot = self.root_budget.snapshot();
+                tracing::warn!(
+                    lane,
+                    depth = snapshot.depth,
+                    retained_bytes = snapshot.retained_bytes,
+                    oldest_age_ms = snapshot.oldest_age.map(|age| age.as_millis() as u64),
+                    total_depth = root_snapshot.current_count,
+                    total_retained_bytes = root_snapshot.current_bytes,
+                    ?kind,
+                    "proxy cluster command admission rejected"
+                );
+                match kind {
+                    QueuePushErrorKind::BudgetExhausted(_) => {
+                        Err(ProxyError::too_many_requests("proxy-cluster-command-queue"))
+                    }
+                    QueuePushErrorKind::Closed | QueuePushErrorKind::SlowConsumerClosed => Err(ProxyError::Transport {
+                        message: "proxy cluster command execution is unavailable".to_owned(),
+                    }),
+                }
+            }
+        }
+    }
+
+    pub(super) fn queue_clones(&self) -> Vec<BudgetedQueue<QueuedClusterCommand>> {
+        self.queues.to_vec()
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshots(&self) -> Vec<QueueSnapshot> {
+        self.queues.iter().map(BudgetedQueue::snapshot).collect()
+    }
+}
+
+impl Drop for ClusterExecutionLanes {
+    fn drop(&mut self) {
+        for queue in &self.queues {
+            queue.close();
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ClusterExecutionPolicy {
+    pub(super) capacity_count: usize,
+    pub(super) capacity_bytes: usize,
+    pub(super) default_queue_deadline: Duration,
+}
+
+impl Default for ClusterExecutionPolicy {
+    fn default() -> Self {
+        Self {
+            capacity_count: CLUSTER_COMMAND_CAPACITY,
+            capacity_bytes: CLUSTER_COMMAND_BYTE_CAPACITY,
+            default_queue_deadline: CLUSTER_DEFAULT_QUEUE_DEADLINE,
+        }
+    }
+}
+
+pub(super) struct QueuedClusterCommand {
+    pub(super) command: ClusterCommand,
+    pub(super) enqueued_at: Instant,
+    pub(super) deadline: Duration,
+}
+
+impl ClusterCommand {
+    pub(super) fn lane(&self) -> usize {
+        match self {
+            Self::ReadinessCheck { .. } => cluster_lane(0, &"readiness"),
+            Self::QueryRoute { topic, .. } | Self::QueryTopicMessageType { topic, .. } => cluster_lane(0, topic),
+            Self::QueryAssignment { topic, group, .. } | Self::QuerySubscriptionGroup { topic, group, .. } => {
+                cluster_lane(0, &(topic, group))
+            }
+            Self::QueryUser { username, .. } => cluster_lane(0, username),
+            Self::QueryAcl { subject, .. } => cluster_lane(0, subject),
+            Self::SendMessage {
+                client_id, request_id, ..
+            }
+            | Self::RecallMessage {
+                client_id, request_id, ..
+            } => cluster_lane(1, &client_id.as_deref().unwrap_or(request_id.as_str())),
+            Self::EndTransaction {
+                request,
+                client_id,
+                request_id,
+                ..
+            } => cluster_lane(
+                1,
+                &client_id
+                    .as_deref()
+                    .or(request.producer_group.as_deref())
+                    .unwrap_or(request_id.as_str()),
+            ),
+            Self::ReceiveMessage { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
+            Self::PullMessage { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
+            Self::AckMessage { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
+            Self::ForwardMessageToDeadLetterQueue { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
+            Self::ChangeInvisibleDuration { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
+            Self::UpdateOffset { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
+            Self::GetOffset { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
+            Self::QueryOffset { request, .. } => cluster_lane(2, &request.target.topic),
+            Self::LockBatchMq { request, .. } => cluster_lane(
+                3,
+                &(
+                    request.consumer_group.as_deref().unwrap_or_default(),
+                    request.client_id.as_deref().unwrap_or_default(),
+                ),
+            ),
+            Self::UnlockBatchMq { request, .. } => cluster_lane(
+                3,
+                &(
+                    request.consumer_group.as_deref().unwrap_or_default(),
+                    request.client_id.as_deref().unwrap_or_default(),
+                ),
+            ),
+        }
+    }
+
+    pub(super) fn queue_deadline(&self) -> Option<Duration> {
+        match self {
+            Self::SendMessage { request, .. } => request.timeout,
+            Self::ReceiveMessage { deadline, .. }
+            | Self::PullMessage { deadline, .. }
+            | Self::AckMessage { deadline, .. }
+            | Self::ForwardMessageToDeadLetterQueue { deadline, .. }
+            | Self::ChangeInvisibleDuration { deadline, .. }
+            | Self::UpdateOffset { deadline, .. }
+            | Self::GetOffset { deadline, .. }
+            | Self::QueryOffset { deadline, .. }
+            | Self::EndTransaction { deadline, .. } => *deadline,
+            Self::ReadinessCheck { .. }
+            | Self::QueryRoute { .. }
+            | Self::QueryAssignment { .. }
+            | Self::QueryTopicMessageType { .. }
+            | Self::QuerySubscriptionGroup { .. }
+            | Self::QueryUser { .. }
+            | Self::QueryAcl { .. }
+            | Self::RecallMessage { .. }
+            | Self::LockBatchMq { .. }
+            | Self::UnlockBatchMq { .. } => None,
+        }
+    }
+
+    pub(super) fn apply_queue_wait(&mut self, waited: Duration) {
+        match self {
+            Self::SendMessage { request, .. } => {
+                request.timeout = request.timeout.map(|deadline| deadline.saturating_sub(waited));
+            }
+            Self::ReceiveMessage { deadline, .. }
+            | Self::PullMessage { deadline, .. }
+            | Self::AckMessage { deadline, .. }
+            | Self::ForwardMessageToDeadLetterQueue { deadline, .. }
+            | Self::ChangeInvisibleDuration { deadline, .. }
+            | Self::UpdateOffset { deadline, .. }
+            | Self::GetOffset { deadline, .. }
+            | Self::QueryOffset { deadline, .. }
+            | Self::EndTransaction { deadline, .. } => {
+                *deadline = deadline.map(|value| value.saturating_sub(waited));
+            }
+            Self::ReadinessCheck { .. }
+            | Self::QueryRoute { .. }
+            | Self::QueryAssignment { .. }
+            | Self::QueryTopicMessageType { .. }
+            | Self::QuerySubscriptionGroup { .. }
+            | Self::QueryUser { .. }
+            | Self::QueryAcl { .. }
+            | Self::RecallMessage { .. }
+            | Self::LockBatchMq { .. }
+            | Self::UnlockBatchMq { .. } => {}
+        }
+    }
+
+    pub(super) fn retained_bytes(&self) -> usize {
+        let dynamic = match self {
+            Self::ReadinessCheck { .. } => 0,
+            Self::QueryRoute { topic, .. } | Self::QueryTopicMessageType { topic, .. } => {
+                resource_identity_bytes(topic)
+            }
+            Self::QueryAssignment {
+                topic,
+                group,
+                client_id,
+                ..
+            } => resource_identity_bytes(topic) + resource_identity_bytes(group) + client_id.len(),
+            Self::QuerySubscriptionGroup { topic, group, .. } => {
+                resource_identity_bytes(topic) + resource_identity_bytes(group)
+            }
+            Self::QueryUser { username, .. } => username.len(),
+            Self::QueryAcl { subject, .. } => subject.len(),
+            Self::SendMessage {
+                request,
+                client_id,
+                request_id,
+                ..
+            } => {
+                option_string_bytes(client_id.as_ref())
+                    + request_id.len()
+                    + request
+                        .messages
+                        .iter()
+                        .map(|entry| {
+                            resource_identity_bytes(&entry.topic)
+                                + entry.client_message_id.len()
+                                + entry.message.topic().len()
+                                + entry.message.body().map_or(0, <[u8]>::len)
+                                + entry
+                                    .message
+                                    .properties()
+                                    .iter()
+                                    .map(|(key, value)| key.len() + value.len())
+                                    .sum::<usize>()
+                                + entry.message.transaction_id().map_or(0, str::len)
+                        })
+                        .sum::<usize>()
+            }
+            Self::RecallMessage {
+                request,
+                client_id,
+                request_id,
+                ..
+            } => {
+                resource_identity_bytes(&request.topic)
+                    + request.recall_handle.len()
+                    + option_string_bytes(client_id.as_ref())
+                    + request_id.len()
+            }
+            Self::ReceiveMessage { request, .. } => {
+                resource_identity_bytes(&request.group)
+                    + resource_identity_bytes(&request.target.topic)
+                    + request.target.broker_name.as_deref().map_or(0, str::len)
+                    + request.target.broker_addr.as_deref().map_or(0, str::len)
+                    + request.filter_expression.expression_type.len()
+                    + request.filter_expression.expression.len()
+                    + request.attempt_id.as_deref().map_or(0, str::len)
+            }
+            Self::PullMessage { request, .. } => {
+                resource_identity_bytes(&request.group)
+                    + message_queue_target_bytes(&request.target)
+                    + request.filter_expression.expression_type.len()
+                    + request.filter_expression.expression.len()
+            }
+            Self::AckMessage { request, .. } => {
+                resource_identity_bytes(&request.group)
+                    + resource_identity_bytes(&request.topic)
+                    + request
+                        .entries
+                        .iter()
+                        .map(|entry| {
+                            entry.message_id.len()
+                                + entry.receipt_handle.len()
+                                + entry.lite_topic.as_deref().map_or(0, str::len)
+                        })
+                        .sum::<usize>()
+            }
+            Self::ForwardMessageToDeadLetterQueue { request, .. } => {
+                resource_identity_bytes(&request.group)
+                    + resource_identity_bytes(&request.topic)
+                    + request.receipt_handle.len()
+                    + request.message_id.len()
+                    + request.lite_topic.as_deref().map_or(0, str::len)
+            }
+            Self::ChangeInvisibleDuration { request, .. } => {
+                resource_identity_bytes(&request.group)
+                    + resource_identity_bytes(&request.topic)
+                    + request.receipt_handle.len()
+                    + request.message_id.len()
+                    + request.lite_topic.as_deref().map_or(0, str::len)
+            }
+            Self::UpdateOffset { request, .. } => {
+                resource_identity_bytes(&request.group) + message_queue_target_bytes(&request.target)
+            }
+            Self::GetOffset { request, .. } => {
+                resource_identity_bytes(&request.group) + message_queue_target_bytes(&request.target)
+            }
+            Self::QueryOffset { request, .. } => message_queue_target_bytes(&request.target),
+            Self::EndTransaction {
+                request,
+                client_id,
+                request_id,
+                ..
+            } => {
+                resource_identity_bytes(&request.topic)
+                    + request.message_id.len()
+                    + request.transaction_id.len()
+                    + request.trace_context.as_deref().map_or(0, str::len)
+                    + request.producer_group.as_deref().map_or(0, str::len)
+                    + request.commit_log_message_id.as_deref().map_or(0, str::len)
+                    + option_string_bytes(client_id.as_ref())
+                    + request_id.len()
+            }
+            Self::LockBatchMq { request, .. } => lock_request_bytes(
+                request.consumer_group.as_ref(),
+                request.client_id.as_ref(),
+                &request.mq_set,
+            ),
+            Self::UnlockBatchMq { request, .. } => lock_request_bytes(
+                request.consumer_group.as_ref(),
+                request.client_id.as_ref(),
+                &request.mq_set,
+            ),
+        };
+        size_of::<Self>().saturating_add(dynamic)
+    }
+
+    pub(super) fn reject(self, error: ProxyError) {
+        match self {
+            Self::ReadinessCheck { reply } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryRoute { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryAssignment { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryTopicMessageType { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QuerySubscriptionGroup { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryUser { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryAcl { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::SendMessage { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::RecallMessage { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ReceiveMessage { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::PullMessage { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::AckMessage { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ForwardMessageToDeadLetterQueue { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ChangeInvisibleDuration { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::UpdateOffset { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::GetOffset { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::QueryOffset { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::EndTransaction { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::LockBatchMq { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::UnlockBatchMq { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+        }
+    }
+}
+
+pub(super) fn cluster_lane(class: usize, key: &impl Hash) -> usize {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    class * CLUSTER_LANES_PER_CLASS + (hasher.finish() as usize % CLUSTER_LANES_PER_CLASS)
+}
+
+pub(super) fn cluster_lane_domain_id(base_domain_id: u64, lane: usize) -> u64 {
+    base_domain_id
+        .wrapping_mul(CLUSTER_EXECUTION_LANE_COUNT as u64)
+        .wrapping_add(lane as u64 + 1)
+}
+
+fn resource_identity_bytes(identity: &ResourceIdentity) -> usize {
+    identity.namespace().len() + identity.name().len()
+}
+
+fn message_queue_target_bytes(target: &MessageQueueTarget) -> usize {
+    resource_identity_bytes(&target.topic)
+        + target.broker_name.as_deref().map_or(0, str::len)
+        + target.broker_addr.as_deref().map_or(0, str::len)
+}
+
+fn option_string_bytes(value: Option<&String>) -> usize {
+    value.map_or(0, String::len)
+}
+
+fn lock_request_bytes(
+    consumer_group: Option<&CheetahString>,
+    client_id: Option<&CheetahString>,
+    queues: &std::collections::HashSet<MessageQueue>,
+) -> usize {
+    consumer_group.map_or(0, CheetahString::len)
+        + client_id.map_or(0, CheetahString::len)
+        + queues
+            .iter()
+            .map(|queue| queue.topic().len() + queue.broker_name().len())
+            .sum::<usize>()
+}

--- a/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
+++ b/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
@@ -582,12 +582,29 @@ where
     F: FnOnce(ClusterTaskExecutor, CancellationToken) -> Fut,
     Fut: Future<Output = T>,
 {
-    let (sender, receiver) = mpsc::channel(CLUSTER_COMMAND_CAPACITY);
-    let executor = ClusterTaskExecutor { sender };
-    let cancellation = CancellationToken::new();
-    let scenario = scenario(executor, cancellation.clone());
-    let worker = run_cluster_worker_with_state(config, state, receiver, cancellation, None);
-    let ((), result) = tokio::join!(worker, scenario);
+    run_scripted_worker_with_policy(config, state, ClusterExecutionPolicy::default(), scenario).await
+}
+
+async fn run_scripted_worker_with_policy<T, F, Fut>(
+    config: ClusterConfig,
+    state: ClusterWorkerState,
+    policy: ClusterExecutionPolicy,
+    scenario: F,
+) -> T
+where
+    F: FnOnce(ClusterTaskExecutor, CancellationToken) -> Fut,
+    Fut: Future<Output = T>,
+{
+    let service = test_service_context("proxy-cluster-scripted");
+    let executor_result = ClusterTaskExecutor::new_with_test_state(config, state, &service, policy);
+    assert!(executor_result.is_ok(), "scripted cluster execution starts");
+    let Some((executor, cancellation)) = executor_result.ok() else {
+        std::process::abort();
+    };
+    let result = scenario(executor, cancellation.clone()).await;
+    cancellation.cancel();
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
     result
 }
 
@@ -615,6 +632,140 @@ fn target() -> MessageQueueTarget {
         broker_name: Some("broker-a".to_owned()),
         broker_addr: Some("127.0.0.1:10911".to_owned()),
     }
+}
+
+#[tokio::test]
+async fn unrelated_route_progresses_while_pull_is_blocked() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        7,
+        1,
+        11,
+        None::<Vec<MessageExt>>,
+    ));
+    client.push_route(TopicRouteData::default());
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let pull = executor.pull_message(
+            PullMessageRequest {
+                group: ResourceIdentity::new("", "BlockedGroup"),
+                target: target(),
+                offset: 5,
+                batch_size: 16,
+                filter_expression: filter_expression(),
+                long_polling_timeout: Duration::from_secs(1),
+            },
+            Some(Duration::from_secs(2)),
+        );
+        let probe = async {
+            let pull_started = pull_entered.await;
+            assert!(pull_started.is_ok(), "pull operation was entered");
+            let route = executor.query_route(ResourceIdentity::new("", "IndependentTopic"));
+            let observe = async {
+                let progress = tokio::time::timeout(Duration::from_millis(250), async {
+                    while client.route_calls.load(Ordering::Acquire) == 0 {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await;
+                if let Some(block) = &client.pull_block {
+                    block.notify_one();
+                }
+                progress
+            };
+            let (route_result, progress) = tokio::join!(route, observe);
+            assert!(route_result.is_ok(), "unrelated route query");
+            progress
+        };
+        let (pull_result, route_progress) = tokio::join!(pull, probe);
+        assert!(pull_result.is_ok(), "blocked pull result");
+        cancellation.cancel();
+        assert!(
+            route_progress.is_ok(),
+            "an unrelated route query must not wait behind a blocked pull"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn active_command_holds_its_global_admission_permit() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        7,
+        1,
+        11,
+        None::<Vec<MessageExt>>,
+    ));
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+    let state = ClusterWorkerState::with_test_runtime(client.clone(), factory);
+    let policy = ClusterExecutionPolicy {
+        capacity_count: 1,
+        capacity_bytes: 4 * 1024,
+        default_queue_deadline: Duration::from_secs(1),
+    };
+
+    run_scripted_worker_with_policy(
+        ClusterConfig::default(),
+        state,
+        policy,
+        |executor, cancellation| async move {
+            let pull = executor.pull_message(
+                PullMessageRequest {
+                    group: ResourceIdentity::new("", "BlockedGroup"),
+                    target: target(),
+                    offset: 5,
+                    batch_size: 16,
+                    filter_expression: filter_expression(),
+                    long_polling_timeout: Duration::from_secs(1),
+                },
+                Some(Duration::from_secs(2)),
+            );
+            let probe = async {
+                let pull_started = pull_entered.await;
+                assert!(pull_started.is_ok(), "pull operation was entered");
+                let route_result = executor
+                    .query_route(ResourceIdentity::new("", "IndependentTopic"))
+                    .await;
+                assert!(
+                    route_result.is_err(),
+                    "the one-command global budget remains reserved while pull is active"
+                );
+                let Some(error) = route_result.err() else {
+                    std::process::abort();
+                };
+                if let Some(block) = &client.pull_block {
+                    block.notify_one();
+                }
+                error
+            };
+            let (pull_result, admission_error) = tokio::join!(pull, probe);
+            assert!(pull_result.is_ok(), "blocked pull result");
+            cancellation.cancel();
+            assert!(matches!(
+                admission_error,
+                ProxyError::TooManyRequests {
+                    resource: "proxy-cluster-command-queue"
+                }
+            ));
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -826,20 +977,18 @@ async fn worker_passes_the_outbound_signer_hook_to_the_client_transport_factory(
         client_factory,
         producer_factory,
     );
+    let topic = ResourceIdentity::new("", "TopicA");
+    let expected_domain_id = cluster_lane_domain_id(domain_id, cluster_lane(0, &topic));
 
     run_scripted_worker(ClusterConfig::default(), state, |executor, cancellation| async move {
-        executor
-            .query_route(ResourceIdentity::new("", "TopicA"))
-            .await
-            .expect("signed Client route command");
+        let route_result = executor.query_route(topic).await;
+        assert!(route_result.is_ok(), "signed Client route command");
         cancellation.cancel();
     })
     .await;
 
-    assert_eq!(
-        *observed.lock().expect("Client factory observation lock poisoned"),
-        Some((domain_id, true))
-    );
+    let observed = observed.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(*observed, Some((expected_domain_id, true)));
 }
 
 #[tokio::test]

--- a/rocketmq-proxy-cluster/src/cluster_execution.rs
+++ b/rocketmq-proxy-cluster/src/cluster_execution.rs
@@ -1,0 +1,652 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_client_rust::proxy_adapter_compat::rpc_hook_from_outbound_signer;
+use rocketmq_client_rust::proxy_adapter_compat::ClientRpcHook;
+use rocketmq_client_rust::proxy_adapter_compat::MessageQueueAssignment;
+use rocketmq_client_rust::ClientRuntime;
+use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::TelemetryHandle;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::body::acl_info::AclInfo;
+use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
+use rocketmq_protocol::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
+use rocketmq_protocol::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
+use rocketmq_protocol::protocol::body::user_info::UserInfo;
+use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_proxy_core::AckMessageRequest;
+use rocketmq_proxy_core::AckMessageResultEntry;
+use rocketmq_proxy_core::ChangeInvisibleDurationPlan;
+use rocketmq_proxy_core::ChangeInvisibleDurationRequest;
+use rocketmq_proxy_core::EndTransactionPlan;
+use rocketmq_proxy_core::EndTransactionRequest;
+use rocketmq_proxy_core::ForwardMessageToDeadLetterQueuePlan;
+use rocketmq_proxy_core::ForwardMessageToDeadLetterQueueRequest;
+use rocketmq_proxy_core::GetOffsetPlan;
+use rocketmq_proxy_core::GetOffsetRequest;
+use rocketmq_proxy_core::ProxyError;
+use rocketmq_proxy_core::ProxyResult;
+use rocketmq_proxy_core::ProxyTopicMessageType;
+use rocketmq_proxy_core::PullMessagePlan;
+use rocketmq_proxy_core::PullMessageRequest;
+use rocketmq_proxy_core::QueryOffsetPlan;
+use rocketmq_proxy_core::QueryOffsetRequest;
+use rocketmq_proxy_core::RecallMessagePlan;
+use rocketmq_proxy_core::RecallMessageRequest;
+use rocketmq_proxy_core::ReceiveMessagePlan;
+use rocketmq_proxy_core::ReceiveMessageRequest;
+use rocketmq_proxy_core::ResourceIdentity;
+use rocketmq_proxy_core::SendMessageRequest;
+use rocketmq_proxy_core::SendMessageResultEntry;
+use rocketmq_proxy_core::SubscriptionGroupMetadata;
+use rocketmq_proxy_core::UpdateOffsetPlan;
+use rocketmq_proxy_core::UpdateOffsetRequest;
+use rocketmq_runtime::BudgetedQueue;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_security_api::OutboundSigner;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use super::cluster_admission::cluster_lane_domain_id;
+use super::cluster_admission::ClusterExecutionLanes;
+use super::cluster_admission::ClusterExecutionPolicy;
+use super::cluster_admission::QueuedClusterCommand;
+use super::cluster_admission::CLUSTER_EXECUTION_LANE_COUNT;
+use super::handle_cluster_command;
+use super::ClusterClientFactory;
+use super::ClusterProducerFactory;
+use super::ClusterWorkerState;
+use super::DefaultClusterClientFactory;
+use super::DefaultClusterProducerFactory;
+use crate::config::ClusterConfig;
+
+#[derive(Clone)]
+pub(super) struct ClusterTaskExecutor {
+    pub(super) lanes: Arc<ClusterExecutionLanes>,
+}
+
+pub(super) enum ClusterCommand {
+    ReadinessCheck {
+        reply: oneshot::Sender<ProxyResult<()>>,
+    },
+    QueryRoute {
+        topic: ResourceIdentity,
+        reply: oneshot::Sender<ProxyResult<TopicRouteData>>,
+    },
+    QueryAssignment {
+        topic: ResourceIdentity,
+        group: ResourceIdentity,
+        client_id: String,
+        reply: oneshot::Sender<ProxyResult<Option<Vec<MessageQueueAssignment>>>>,
+    },
+    QueryTopicMessageType {
+        topic: ResourceIdentity,
+        reply: oneshot::Sender<ProxyResult<ProxyTopicMessageType>>,
+    },
+    QuerySubscriptionGroup {
+        topic: ResourceIdentity,
+        group: ResourceIdentity,
+        reply: oneshot::Sender<ProxyResult<Option<SubscriptionGroupMetadata>>>,
+    },
+    QueryUser {
+        username: String,
+        reply: oneshot::Sender<ProxyResult<Option<UserInfo>>>,
+    },
+    QueryAcl {
+        subject: String,
+        reply: oneshot::Sender<ProxyResult<Option<AclInfo>>>,
+    },
+    SendMessage {
+        request: SendMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+        reply: oneshot::Sender<ProxyResult<Vec<SendMessageResultEntry>>>,
+    },
+    RecallMessage {
+        request: RecallMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+        reply: oneshot::Sender<ProxyResult<RecallMessagePlan>>,
+    },
+    ReceiveMessage {
+        request: ReceiveMessageRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<ReceiveMessagePlan>>,
+    },
+    PullMessage {
+        request: PullMessageRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<PullMessagePlan>>,
+    },
+    AckMessage {
+        request: AckMessageRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<Vec<AckMessageResultEntry>>>,
+    },
+    ForwardMessageToDeadLetterQueue {
+        request: ForwardMessageToDeadLetterQueueRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<ForwardMessageToDeadLetterQueuePlan>>,
+    },
+    ChangeInvisibleDuration {
+        request: ChangeInvisibleDurationRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<ChangeInvisibleDurationPlan>>,
+    },
+    UpdateOffset {
+        request: UpdateOffsetRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<UpdateOffsetPlan>>,
+    },
+    GetOffset {
+        request: GetOffsetRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<GetOffsetPlan>>,
+    },
+    QueryOffset {
+        request: QueryOffsetRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<QueryOffsetPlan>>,
+    },
+    EndTransaction {
+        request: EndTransactionRequest,
+        client_id: Option<String>,
+        request_id: String,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<EndTransactionPlan>>,
+    },
+    LockBatchMq {
+        request: LockBatchRequestBody,
+        reply: oneshot::Sender<ProxyResult<LockBatchResponseBody>>,
+    },
+    UnlockBatchMq {
+        request: UnlockBatchRequestBody,
+        reply: oneshot::Sender<ProxyResult<()>>,
+    },
+}
+
+impl ClusterTaskExecutor {
+    pub(super) fn new(
+        config: ClusterConfig,
+        signer: Option<Arc<dyn OutboundSigner>>,
+        service_context: &ChildServiceContext,
+        telemetry_handle: TelemetryHandle,
+    ) -> ProxyResult<Self> {
+        let rpc_hook = signer.map(rpc_hook_from_outbound_signer);
+        Self::new_with_rpc_hook(config, rpc_hook, service_context, telemetry_handle)
+    }
+
+    fn new_with_rpc_hook(
+        config: ClusterConfig,
+        rpc_hook: Option<Arc<ClientRpcHook>>,
+        service_context: &ChildServiceContext,
+        telemetry_handle: TelemetryHandle,
+    ) -> ProxyResult<Self> {
+        let worker_context = service_context.child("command-worker");
+        let client_runtime = ClientRuntime::new(
+            worker_context.child("client-runtime"),
+            ClientRuntimeConfig::default(),
+            telemetry_handle,
+        );
+        let base_domain_id = worker_context.task_group().id().as_u64();
+        Self::spawn_execution(
+            config,
+            rpc_hook,
+            service_context,
+            worker_context,
+            client_runtime,
+            base_domain_id,
+            Arc::new(DefaultClusterClientFactory),
+            Arc::new(DefaultClusterProducerFactory),
+            ClusterExecutionPolicy::default(),
+        )
+        .map(|(executor, _)| executor)
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_with_test_state(
+        config: ClusterConfig,
+        state: ClusterWorkerState,
+        service_context: &ChildServiceContext,
+        policy: ClusterExecutionPolicy,
+    ) -> ProxyResult<(Self, tokio_util::sync::CancellationToken)> {
+        let ClusterWorkerState {
+            client_runtime,
+            domain_id,
+            rpc_hook,
+            client_factory,
+            producer_factory,
+            ..
+        } = state;
+        let worker_context = service_context.child("command-worker");
+        Self::spawn_execution(
+            config,
+            rpc_hook,
+            service_context,
+            worker_context,
+            client_runtime,
+            domain_id,
+            client_factory,
+            producer_factory,
+            policy,
+        )
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "execution ownership is assembled at one private boundary"
+    )]
+    fn spawn_execution(
+        config: ClusterConfig,
+        rpc_hook: Option<Arc<ClientRpcHook>>,
+        service_context: &ChildServiceContext,
+        worker_context: ChildServiceContext,
+        client_runtime: Arc<ClientRuntime>,
+        base_domain_id: u64,
+        client_factory: Arc<dyn ClusterClientFactory>,
+        producer_factory: Arc<dyn ClusterProducerFactory>,
+        policy: ClusterExecutionPolicy,
+    ) -> ProxyResult<(Self, tokio_util::sync::CancellationToken)> {
+        let lanes = Arc::new(ClusterExecutionLanes::new(policy)?);
+        let cancellation = worker_context.task_group().cancellation_token();
+        let queue_clones = lanes.queue_clones();
+        let (completed_sender, completed_receiver) = mpsc::channel(CLUSTER_EXECUTION_LANE_COUNT);
+
+        for (lane, queue) in queue_clones.iter().cloned().enumerate() {
+            let lane_context = worker_context.child(format!("command-lane-{lane}"));
+            let lane_cancellation = lane_context.task_group().cancellation_token();
+            let lane_shutdown_context = service_context.clone();
+            let lane_config = config.clone();
+            let lane_state = ClusterWorkerState::with_factories(
+                client_runtime.clone(),
+                cluster_lane_domain_id(base_domain_id, lane),
+                rpc_hook.clone(),
+                client_factory.clone(),
+                producer_factory.clone(),
+            );
+            let completed_sender = completed_sender.clone();
+            if let Err(error) = lane_context.spawn_service(format!("proxy.cluster.lane-{lane}"), async move {
+                run_cluster_lane(lane_config, lane_state, queue, lane_cancellation, lane_shutdown_context).await;
+                let _ = completed_sender.try_send(());
+            }) {
+                worker_context.task_group().cancel();
+                for queue in &queue_clones {
+                    queue.close();
+                }
+                return Err(ProxyError::Transport {
+                    message: format!("failed to spawn proxy cluster execution lane {lane}: {error}"),
+                });
+            }
+        }
+        drop(completed_sender);
+
+        let owner_runtime = client_runtime;
+        let owner_queues = queue_clones;
+        let owner_cancellation = cancellation.clone();
+        let owner_config = config;
+        let owner_shutdown_context = service_context.clone();
+        if let Err(error) = worker_context.spawn_service("proxy.cluster.execution-owner", async move {
+            run_cluster_execution_owner(
+                owner_config,
+                owner_runtime,
+                owner_queues,
+                completed_receiver,
+                owner_cancellation,
+                owner_shutdown_context,
+            )
+            .await;
+        }) {
+            worker_context.task_group().cancel();
+            for queue in &lanes.queues {
+                queue.close();
+            }
+            return Err(ProxyError::Transport {
+                message: format!("failed to spawn proxy cluster execution owner: {error}"),
+            });
+        }
+        Ok((Self { lanes }, cancellation))
+    }
+
+    pub(super) async fn readiness_check(&self) -> ProxyResult<()> {
+        self.execute(|reply| ClusterCommand::ReadinessCheck { reply }).await
+    }
+
+    pub(super) async fn query_route(&self, topic: ResourceIdentity) -> ProxyResult<TopicRouteData> {
+        self.execute(|reply| ClusterCommand::QueryRoute { topic, reply }).await
+    }
+
+    pub(super) async fn query_assignment(
+        &self,
+        topic: ResourceIdentity,
+        group: ResourceIdentity,
+        client_id: String,
+    ) -> ProxyResult<Option<Vec<MessageQueueAssignment>>> {
+        self.execute(|reply| ClusterCommand::QueryAssignment {
+            topic,
+            group,
+            client_id,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn query_topic_message_type(&self, topic: ResourceIdentity) -> ProxyResult<ProxyTopicMessageType> {
+        self.execute(|reply| ClusterCommand::QueryTopicMessageType { topic, reply })
+            .await
+    }
+
+    pub(super) async fn query_subscription_group(
+        &self,
+        topic: ResourceIdentity,
+        group: ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
+        self.execute(|reply| ClusterCommand::QuerySubscriptionGroup { topic, group, reply })
+            .await
+    }
+
+    pub(super) async fn query_user(&self, username: String) -> ProxyResult<Option<UserInfo>> {
+        self.execute(|reply| ClusterCommand::QueryUser { username, reply })
+            .await
+    }
+
+    pub(super) async fn query_acl(&self, subject: String) -> ProxyResult<Option<AclInfo>> {
+        self.execute(|reply| ClusterCommand::QueryAcl { subject, reply }).await
+    }
+
+    pub(super) async fn send_message(
+        &self,
+        request: SendMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
+        self.execute(|reply| ClusterCommand::SendMessage {
+            request,
+            client_id,
+            request_id,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn recall_message(
+        &self,
+        request: RecallMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+    ) -> ProxyResult<RecallMessagePlan> {
+        self.execute(|reply| ClusterCommand::RecallMessage {
+            request,
+            client_id,
+            request_id,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn receive_message(
+        &self,
+        request: ReceiveMessageRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<ReceiveMessagePlan> {
+        self.execute(|reply| ClusterCommand::ReceiveMessage {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn pull_message(
+        &self,
+        request: PullMessageRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<PullMessagePlan> {
+        self.execute(|reply| ClusterCommand::PullMessage {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn ack_message(
+        &self,
+        request: AckMessageRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<Vec<AckMessageResultEntry>> {
+        self.execute(|reply| ClusterCommand::AckMessage {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn forward_message_to_dead_letter_queue(
+        &self,
+        request: ForwardMessageToDeadLetterQueueRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        self.execute(|reply| ClusterCommand::ForwardMessageToDeadLetterQueue {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn change_invisible_duration(
+        &self,
+        request: ChangeInvisibleDurationRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<ChangeInvisibleDurationPlan> {
+        self.execute(|reply| ClusterCommand::ChangeInvisibleDuration {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn update_offset(
+        &self,
+        request: UpdateOffsetRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<UpdateOffsetPlan> {
+        self.execute(|reply| ClusterCommand::UpdateOffset {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn get_offset(
+        &self,
+        request: GetOffsetRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<GetOffsetPlan> {
+        self.execute(|reply| ClusterCommand::GetOffset {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn query_offset(
+        &self,
+        request: QueryOffsetRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<QueryOffsetPlan> {
+        self.execute(|reply| ClusterCommand::QueryOffset {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn end_transaction(
+        &self,
+        request: EndTransactionRequest,
+        client_id: Option<String>,
+        request_id: String,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<EndTransactionPlan> {
+        self.execute(|reply| ClusterCommand::EndTransaction {
+            request,
+            client_id,
+            request_id,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    pub(super) async fn lock_batch_mq(&self, request: LockBatchRequestBody) -> ProxyResult<LockBatchResponseBody> {
+        self.execute(|reply| ClusterCommand::LockBatchMq { request, reply })
+            .await
+    }
+
+    pub(super) async fn unlock_batch_mq(&self, request: UnlockBatchRequestBody) -> ProxyResult<()> {
+        self.execute(|reply| ClusterCommand::UnlockBatchMq { request, reply })
+            .await
+    }
+
+    async fn execute<T>(
+        &self,
+        command: impl FnOnce(oneshot::Sender<ProxyResult<T>>) -> ClusterCommand,
+    ) -> ProxyResult<T>
+    where
+        T: Send + 'static,
+    {
+        let (reply, receiver) = oneshot::channel();
+        self.lanes.enqueue(command(reply))?;
+        receiver.await.map_err(|_| ProxyError::Transport {
+            message: "proxy cluster worker dropped response".to_owned(),
+        })?
+    }
+}
+
+pub(super) async fn run_cluster_lane(
+    config: ClusterConfig,
+    mut state: ClusterWorkerState,
+    queue: BudgetedQueue<QueuedClusterCommand>,
+    cancellation: tokio_util::sync::CancellationToken,
+    shutdown_context: ChildServiceContext,
+) {
+    loop {
+        let queued = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                queue.close();
+                break;
+            },
+            command = queue.recv_budgeted() => match command {
+                Some(command) => command,
+                None => break,
+            }
+        };
+        let (queued, active_permit, _) = queued.into_parts();
+        let waited = queued.enqueued_at.elapsed();
+        if waited >= queued.deadline {
+            queued.command.reject(cluster_queue_timeout(queued.deadline));
+            drop(active_permit);
+            continue;
+        }
+        let mut command = queued.command;
+        command.apply_queue_wait(waited);
+        tokio::select! {
+            biased;
+            () = cancellation.cancelled() => break,
+            () = handle_cluster_command(&config, &mut state, command) => {}
+        }
+        drop(active_permit);
+    }
+    while let Some(queued) = queue.try_pop() {
+        queued.command.reject(ProxyError::Transport {
+            message: "proxy cluster command execution stopped during shutdown".to_owned(),
+        });
+    }
+    let shutdown_deadline = cluster_shutdown_deadline(&shutdown_context, config.shutdown_timeout());
+    for (producer_group, producer) in &mut state.send_producers {
+        if tokio::time::timeout(shutdown_deadline.remaining(), producer.shutdown())
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                producer_group,
+                "proxy cluster producer shutdown exceeded the shared deadline"
+            );
+        }
+    }
+    if let Some(client) = state.client.take() {
+        if tokio::time::timeout(shutdown_deadline.remaining(), client.shutdown())
+            .await
+            .is_err()
+        {
+            tracing::warn!("proxy cluster Client shutdown exceeded the shared deadline");
+        }
+    }
+}
+
+async fn run_cluster_execution_owner(
+    config: ClusterConfig,
+    client_runtime: Arc<ClientRuntime>,
+    queues: Vec<BudgetedQueue<QueuedClusterCommand>>,
+    mut completed_receiver: mpsc::Receiver<()>,
+    cancellation: tokio_util::sync::CancellationToken,
+    shutdown_context: ChildServiceContext,
+) {
+    cancellation.cancelled().await;
+    for queue in &queues {
+        queue.close();
+    }
+    let shutdown_deadline = cluster_shutdown_deadline(&shutdown_context, config.shutdown_timeout());
+    for lane in 0..CLUSTER_EXECUTION_LANE_COUNT {
+        match tokio::time::timeout(shutdown_deadline.remaining(), completed_receiver.recv()).await {
+            Ok(Some(())) => {}
+            Ok(None) => break,
+            Err(_) => {
+                tracing::warn!(
+                    lane,
+                    "proxy cluster execution lane shutdown exceeded the shared deadline"
+                );
+                break;
+            }
+        }
+    }
+    let _ = client_runtime.shutdown_until(shutdown_deadline).await;
+}
+
+fn cluster_queue_timeout(deadline: Duration) -> ProxyError {
+    RocketMQError::Timeout {
+        operation: "proxy cluster command queue",
+        timeout_ms: deadline.as_millis().clamp(1, u128::from(u64::MAX)) as u64,
+    }
+    .into()
+}
+
+fn cluster_shutdown_deadline(context: &ChildServiceContext, configured_timeout: Duration) -> ShutdownDeadline {
+    let configured = ShutdownDeadline::after(configured_timeout);
+    match context.task_group().shutdown_deadline() {
+        Some(parent) if parent.instant() <= configured.instant() => parent,
+        Some(_) | None => configured,
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8802

### Brief Description

Replace the single Proxy Cluster command worker with sixteen managed execution lanes split across metadata, producer, consumer, and lock operation classes. Related ordering keys remain FIFO within a lane, while unrelated classes and keys can make progress independently.

Admission now shares a global 1,024-command and 64 MiB retained-byte budget across queued and active work. Saturation returns a typed `TooManyRequests` error, queued work expires before remote I/O, and queue wait is deducted from downstream request deadlines. Each lane owns its client state and producers under a child `ServiceContext`; shutdown cancels and awaits all lanes, stops producers before clients, and closes the shared client runtime once.

Add deterministic regression coverage for cross-operation progress, active-command admission accounting, related consumer ordering, retained-byte saturation, queue expiry, cancellation, and bounded shutdown.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy-cluster`: passed, 23 tests.
- `cargo clippy -p rocketmq-proxy-cluster --all-targets --all-features -- -D warnings`: passed.
- `cargo check -p rocketmq-proxy-cluster --no-default-features`: passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `.\scripts\check-error-hygiene.ps1`: passed.
- `python scripts/trait_policy_guard.py`: passed with no baseline drift.
- `python scripts/rust_hygiene_guard.py`: passed with no new panic surface.
- `python -m unittest scripts.tests.test_trait_policy_guard scripts.tests.test_rust_hygiene_guard`: passed, 9 tests.
- `python scripts/architecture_dependency_guard.py --policy scripts/architecture-dependency-policy.json --mode baseline`: passed.
- `python scripts/architecture_dependency_guard.py --policy scripts/architecture-dependency-policy.json --mode transition`: passed.
- `python scripts/architecture_dependency_guard.py --policy scripts/architecture-dependency-policy.json --mode target`: passed.
- `python scripts/architecture_release_guard.py`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fair, lane-based processing for cluster operations so unrelated requests can continue while another operation is waiting.
  * Added queue capacity controls based on both request count and retained data size.
  * Added request deadlines and clear rejection handling for expired or overloaded queues.
  * Improved orderly shutdown and cleanup of in-flight and queued operations.

* **Bug Fixes**
  * Prevented active operations from exceeding global admission limits.
  * Ensured consumer-related commands share appropriate processing lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->