### PR TITLE
[ISSUE #8811]🐛Release scheduled Store leases before Broker restart

### DIFF
--- a/rocketmq-broker/src/broker_runtime/lifecycle.rs
+++ b/rocketmq-broker/src/broker_runtime/lifecycle.rs
@@ -236,9 +236,35 @@ impl BrokerRuntime {
             progress.complete("topic_config");
         }
 
+        // Broker-owned scheduled tasks can hold request-scoped Store leases while executing.
+        // Cancel and join them before waiting for exclusive Store ownership; otherwise a task
+        // admitted immediately before shutdown can retain the store until the absolute deadline
+        // and prevent a same-path Broker restart from acquiring the lock file.
+        let started = Instant::now();
+        let scheduled_report = self
+            .shutdown_scheduled_tasks_with_timeout(deadline.remaining().min(SCHEDULED_TASK_SHUTDOWN_TIMEOUT))
+            .await;
+        shutdown_report.scheduled_tasks = if scheduled_report.is_healthy() {
+            BrokerShutdownComponentReport::completed("scheduled_tasks", started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::unhealthy(
+                "scheduled_tasks",
+                started.elapsed(),
+                format!(
+                    "task_count={}, completed={}, aborted={}, panicked={}, timed_out={}",
+                    scheduled_report.task_count,
+                    scheduled_report.completed,
+                    scheduled_report.aborted,
+                    scheduled_report.panicked,
+                    scheduled_report.timed_out
+                ),
+            )
+        };
+        progress.complete("scheduled_tasks");
+
         // Shutdown uses one absolute deadline and this fixed phase order:
-        // reject/drain requests -> drain store-backed delivery -> flush/replicate the store ->
-        // stop remaining background work -> telemetry.
+        // reject/drain requests -> drain store-backed delivery and scheduled Store leases ->
+        // flush/replicate the store -> stop remaining background work -> telemetry.
         // Store durability therefore cannot be starved by a slow background component.
         self.detach_message_store_provider();
         while self
@@ -291,28 +317,6 @@ impl BrokerRuntime {
                 warn!(error = %error.detail(), "Broker shutdown hook did not complete cleanly");
             }
         }
-
-        let started = Instant::now();
-        let scheduled_report = self
-            .shutdown_scheduled_tasks_with_timeout(deadline.remaining().min(SCHEDULED_TASK_SHUTDOWN_TIMEOUT))
-            .await;
-        shutdown_report.scheduled_tasks = if scheduled_report.is_healthy() {
-            BrokerShutdownComponentReport::completed("scheduled_tasks", started.elapsed())
-        } else {
-            BrokerShutdownComponentReport::unhealthy(
-                "scheduled_tasks",
-                started.elapsed(),
-                format!(
-                    "task_count={}, completed={}, aborted={}, panicked={}, timed_out={}",
-                    scheduled_report.task_count,
-                    scheduled_report.completed,
-                    scheduled_report.aborted,
-                    scheduled_report.panicked,
-                    scheduled_report.timed_out
-                ),
-            )
-        };
-        progress.complete("scheduled_tasks");
 
         if let Some(broker_stats_manager) = self.composition.state.broker_stats_manager.as_ref() {
             broker_stats_manager.shutdown().await;

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -704,6 +704,23 @@ fn transaction_shutdown_precedes_topic_coordinator_and_message_store() {
 }
 
 #[test]
+fn scheduled_tasks_shutdown_precedes_exclusive_message_store_shutdown() {
+    let source = include_str!("../../src/broker_runtime/lifecycle.rs");
+    let scheduled_shutdown = source
+        .find("let scheduled_report = self")
+        .expect("scheduled task shutdown should exist");
+    let store_detach = source
+        .find("self.detach_message_store_provider();")
+        .expect("message store provider detach should exist");
+    let store_shutdown = source
+        .find("let message_store_outcome =")
+        .expect("message store shutdown should exist");
+
+    assert!(scheduled_shutdown < store_detach);
+    assert!(store_detach < store_shutdown);
+}
+
+#[test]
 fn broker_basic_shutdown_report_aggregates_unhealthy_and_timed_out_components() {
     let report = BrokerBasicServiceShutdownReport {
         auth: BrokerShutdownComponentReport::completed("auth", Duration::from_millis(1)),
@@ -981,6 +998,89 @@ async fn shutdown_scheduled_tasks_waits_for_running_task_drop() {
         dropped.load(Ordering::Acquire),
         "broker scheduled shutdown should wait until aborted tasks release their running future"
     );
+}
+
+#[tokio::test]
+async fn broker_shutdown_cancels_scheduled_store_lease_before_store_lock_release() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "rocketmq-rust-broker-scheduled-store-lease-{}",
+        current_millis()
+    ));
+    let broker_config = Arc::new(BrokerConfig {
+        store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+        ..BrokerConfig::default()
+    });
+    let message_store_config = Arc::new(MessageStoreConfig {
+        store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+        ..MessageStoreConfig::default()
+    });
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    assert!(runtime.initialize_metadata().await.is_ok());
+    assert!(runtime.initialize_message_store().await);
+    assert!(runtime.load_message_store_for_test().await);
+    runtime
+        .start_message_store_for_test()
+        .await
+        .expect("message store should acquire its lock file");
+
+    let store = runtime.composition.data_plane.escape_bridge_owner.store_capability();
+    let lease_started = Arc::new(AtomicBool::new(false));
+    runtime
+        .lifecycle
+        .scheduled_task_manager
+        .add_fixed_delay_task(Duration::ZERO, Duration::from_secs(60), {
+            let lease_started = Arc::clone(&lease_started);
+            move |token| {
+                let store = store.clone();
+                let lease_started = Arc::clone(&lease_started);
+                async move {
+                    let _lease = store.read_lease().expect("scheduled task should acquire a Store lease");
+                    lease_started.store(true, Ordering::Release);
+                    token.cancelled().await;
+                    Ok(())
+                }
+            }
+        })
+        .expect("scheduled Store lease task should start");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !lease_started.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("scheduled Store lease should be active");
+
+    let report = runtime
+        .shutdown_basic_service_until(ShutdownDeadline::after(Duration::from_secs(10)))
+        .await;
+
+    assert!(
+        report.scheduled_tasks.present && report.scheduled_tasks.healthy,
+        "{report:?}"
+    );
+    assert!(
+        report.message_store.present && report.message_store.healthy,
+        "{report:?}"
+    );
+    let mut restarted = BrokerRuntime::new(
+        Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        }),
+        Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        }),
+    );
+    assert!(restarted.initialize_metadata().await.is_ok());
+    assert!(restarted.initialize_message_store().await);
+    assert!(restarted.load_message_store_for_test().await);
+    restarted
+        .start_message_store_for_test()
+        .await
+        .expect("shutdown Broker should release the Store lock for a same-path restart");
+    restarted.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(temp_root);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- stop and join Broker scheduled tasks before requesting exclusive message-store lifecycle access
- preserve the shared absolute shutdown deadline and scheduled-task health reporting
- add a deterministic Store-lease regression test that verifies same-path lock reacquisition
- retain the controller-mode failover and rejoin behavior

## Validation

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-broker scheduled_tasks_shutdown_precedes_exclusive_message_store_shutdown -- --nocapture --test-threads=1`
- `cargo test -p rocketmq-broker broker_shutdown_cancels_scheduled_store_lease_before_store_lock_release -- --nocapture --test-threads=1`
- `cargo test -p rocketmq-broker three_controller_two_broker_controller_mode_failover_and_rejoin -- --nocapture --test-threads=1`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff --check`

`cargo fmt --all -- --check` could not execute on Windows because rustfmt's expanded workspace command exceeded the OS command-line length (error 206); the affected package format check passed.

Closes #8811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker shutdown sequencing to stop scheduled tasks before detaching and shutting down the message store.
  * Ensured scheduled tasks holding message-store leases are cancelled cleanly, allowing the broker to shut down and restart reliably.

* **Tests**
  * Added coverage validating shutdown ordering, lease cancellation, store release, and broker restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->