### PR TITLE
[ISSUE #8810]🐛Eliminate Proxy Cluster execution head-of-line blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4953,6 +4953,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "cheetah-string",
+ "criterion",
  "rocketmq-client-rust",
  "rocketmq-error",
  "rocketmq-model",

--- a/rocketmq-doc/en/architecture-debt-register.md
+++ b/rocketmq-doc/en/architecture-debt-register.md
@@ -14,6 +14,7 @@ Release boundary: `2.0.0`.
 | `ARC-PANIC-001` | `panic` | `architecture-maintainers` | `active` | 938 | production panic-surface inventory reaches zero | `scripts/rust-hygiene-baseline.json`<br>`scripts/rust_hygiene_guard.py` |
 | `ARC-RUNTIME-001` | `runtime_adapter` | `runtime-maintainers` | `active` | 28 | runtime audit reports zero current-runtime-adapter and task-group-root identities | `scripts/runtime-audit-baseline.json`<br>`scripts/runtime-audit.ps1` |
 | `ARC-RUNTIME-002` | `runtime_adapter` | `runtime-maintainers` | `resolved` | 0 | the ClientRuntime::new API remains absent | `rocketmq-client/src/runtime.rs` |
+| `ARC-RUNTIME-003` | `runtime_adapter` | `proxy` | `resolved` | 0 | fixed Cluster lane count and hash-routing helpers remain absent | `rocketmq-proxy-cluster/src/cluster_admission.rs`<br>`rocketmq-proxy-cluster/src/cluster_behavior_tests.rs`<br>`scripts/tests/test_m08_proxy_core_contract.py` |
 | `ARC-TRAIT-001` | `trait` | `architecture-maintainers` | `active` | 660 | all migrate-on-touch trait identities are resolved or accepted as final design | `scripts/trait-policy-baseline.json`<br>`scripts/trait_policy_guard.py` |
 
 Removed internal crates, facade re-exports, old module paths, and historical migration

--- a/rocketmq-doc/en/architecture-public-api-compatibility.md
+++ b/rocketmq-doc/en/architecture-public-api-compatibility.md
@@ -10,10 +10,15 @@ paths removed by the architecture migration.
 - Feature profile: default
 - Snapshot comparison: `differences=0`
 - Accepted source-level cleanup relative to the previous compatibility surface:
-  - additive: 0
+  - additive: 1 (`ClusterExecutionDiagnostics` and its client snapshot
+    accessor)
   - deprecated: 0
-  - breaking: 1 (`ClientRuntime::new` removed; callers use fallible
-    `ClientRuntime::try_new`)
+  - breaking: 2
+    - `ClientRuntime::new` removed; callers use fallible
+      `ClientRuntime::try_new`
+    - `ClusterConfig` gained mandatory bounded-execution fields for Rust
+      struct literals; Serde configuration remains backward-readable through
+      defaults
 
 The package count is derived from `cargo metadata`; the guard rejects a
 baseline that is missing a current library target or retains a removed one.
@@ -22,6 +27,8 @@ The repository owner explicitly approved removal of obsolete internal crates,
 facades, module paths, and source-level contracts on 2026-07-29. That decision
 is the compatibility classification authority for this change; it does not
 waive protocol, wire, persisted-layout, or implemented-behavior compatibility.
+The same authority explicitly approved the `ClusterConfig` source-shape change:
+the obsolete fixed-lane execution contract is not retained.
 
 ## Compatibility matrix
 

--- a/rocketmq-doc/en/module-interface-deepening-acceptance.md
+++ b/rocketmq-doc/en/module-interface-deepening-acceptance.md
@@ -278,3 +278,30 @@ public `RuntimeHandle`, and detached task spawning.
   registration behavior have focused tests.
 - Phase 3 owns long-running soak, failure-matrix, and production evidence work;
   those are intentionally not Phase 2 merge prerequisites.
+
+## Proxy Cluster execution ownership
+
+The [Proxy Cluster keyed execution ADR](proxy-cluster-keyed-execution-adr.md)
+is accepted. The fixed sixteen-lane hash worker has been removed. Exact
+structural ordering keys now select dynamically owned lanes, so the same key is
+FIFO without serializing unrelated keys through hash collisions.
+
+| Command family | Class | Ordering owner |
+|---|---|---|
+| Readiness | Control | Singleton readiness key with reserved queue and I/O capacity |
+| Route and topic metadata | Data | Topic or topic/group key |
+| Send, recall, end transaction | Data | Effective producer-group key and exclusive mutable producer |
+| Pull, receive, ack, invisible time, consumer offset | Data | Consumer group/topic key |
+| Queue offset query | Data | Exact queue target |
+| Lock and unlock | Data | Consumer group/client key |
+
+Count, retained bytes, maximum queue age, request deadline, global inflight
+work, and control reserve are validated configuration. Caller drop, timeout,
+cancellation, and shutdown all cancel the owned command future and release its
+permits. Runtime diagnostics expose retained age and other aggregates only; no
+topic, group, request ID, payload, or credential becomes a metric label.
+
+The `cluster_executor` Criterion target measures same-key FIFO admission and
+high-cardinality exact-key admission/retirement as an algorithm regression
+signal. It is explicitly separate from the target-hardware mixed workload
+profile and does not claim production throughput.

--- a/rocketmq-doc/en/proxy-cluster-keyed-execution-adr.md
+++ b/rocketmq-doc/en/proxy-cluster-keyed-execution-adr.md
@@ -1,0 +1,91 @@
+# Proxy Cluster Keyed Execution ADR
+
+- Status: Accepted
+- Date: 2026-07-29
+- Owner: Proxy Cluster
+- Decision scope: command admission, ordering, remote I/O ownership, cancellation, and shutdown
+
+## Context
+
+The original Cluster adapter executed every remote operation on one worker.
+An intermediate implementation replaced that worker with sixteen fixed hash
+lanes. It reduced common head-of-line blocking, but unrelated keys could still
+collide, data traffic could consume the complete admission budget, and the
+fixed lane count was also the implicit and unconfigurable I/O limit.
+
+The adapter must preserve RocketMQ request and response mapping, timeout and
+retry semantics, consumer ordering, and exclusive mutable producer access.
+Production tasks must remain descendants of the injected service context.
+
+## Decision
+
+The Cluster adapter uses exact structural ordering keys rather than hash
+shards. The registry creates one managed lane for each active key and retires
+it after a configured idle interval. Registry insertion, enqueue, and
+retirement are atomic under a short synchronous metadata lock; no lock guard is
+held across remote I/O.
+
+Each keyed lane owns its cache and producer state. Commands with the same key
+execute FIFO on that owner. Distinct keys use separate tasks and can enter
+remote I/O concurrently up to the configured global limit. Producer commands
+use the effective producer group as their key, so one lane exclusively owns
+each mutable producer instance.
+
+Admission is fail-fast and retains count and byte permits from enqueue through
+execution. Request deadline and maximum queue age are checked before I/O.
+The root budget and I/O semaphore both reserve capacity for readiness traffic,
+so data saturation cannot starve the control path.
+
+Every lane is spawned through the injected `ChildServiceContext`. Caller drop,
+deadline expiry, and service shutdown cancel the owned command future. Permit
+types release count, bytes, and inflight capacity on normal return,
+cancellation, timeout, or panic. Shutdown closes admission first, cancels
+active work, drains queued replies with typed errors, shuts producers before
+clients, waits for lane tasks under the shared deadline, and finally shuts down
+the Client runtime.
+
+## Fencing model
+
+The registry assigns a monotonic generation to every key-lane incarnation.
+Retirement removes a lane only when both the key and generation still match
+and its queue is empty. A late retirement cannot remove a replacement lane.
+
+Remote result commit is fused to the single keyed owner: there is never more
+than one active command future for the same key. Cancellation drops that future
+before any later state mutation can run. Consequently no detached result can
+commit after a replacement generation starts.
+
+## Diagnostics
+
+`RocketmqClusterClient::execution_diagnostics` exposes only low-cardinality
+aggregates: active keys and lane tasks, retained items and bytes, oldest queued
+age, current and maximum inflight work, admission/rejection/timeout/
+cancellation/shutdown counters, and closed state. Ordering keys, topics,
+groups, request IDs, message bodies, and credentials are never exported as
+labels.
+
+## Rejected alternatives
+
+- A larger fixed hash-shard array still serializes unrelated colliding keys.
+- One shared async mutex around `ClusterWorkerState` recreates global
+  head-of-line blocking and would hold a guard across remote I/O.
+- Detached per-command tasks lose producer ownership and bounded shutdown.
+- Increasing channel capacity hides overload rather than controlling it.
+
+## Compatibility
+
+The internal fixed-lane implementation is deleted. Source compatibility for
+that private implementation is not retained. RocketMQ wire fields, response
+codes, persisted formats, retry behavior, and implemented request semantics
+remain unchanged.
+
+## Evidence
+
+- `rocketmq-proxy-cluster/src/cluster_admission.rs`
+- `rocketmq-proxy-cluster/src/cluster_execution.rs`
+- `rocketmq-proxy-cluster/src/cluster_behavior_tests.rs`
+- `scripts/runtime-audit.ps1`
+- `cargo test -p rocketmq-proxy-cluster`
+- `cargo clippy -p rocketmq-proxy-cluster --all-targets --all-features -- -D warnings`
+- `cargo bench -p rocketmq-proxy-cluster --features bench-support --bench cluster_executor -- --noplot`
+- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`

--- a/rocketmq-proxy-cluster/Cargo.toml
+++ b/rocketmq-proxy-cluster/Cargo.toml
@@ -27,6 +27,7 @@ rust-version.workspace = true
 
 [features]
 default = []
+bench-support = []
 observability = ["rocketmq-client-rust/observability-metrics"]
 observability-traces = ["rocketmq-client-rust/observability"]
 
@@ -46,3 +47,12 @@ serde = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+tokio = { workspace = true, features = ["test-util"] }
+
+[[bench]]
+name = "cluster_executor"
+harness = false
+required-features = ["bench-support"]

--- a/rocketmq-proxy-cluster/benches/cluster_executor.rs
+++ b/rocketmq-proxy-cluster/benches/cluster_executor.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rocketmq_proxy_cluster::bench_support::run_cluster_admission_probe;
+use rocketmq_proxy_cluster::bench_support::ClusterAdmissionPattern;
+
+fn bench_cluster_executor(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("proxy_cluster_keyed_admission");
+    for command_count in [256usize, 1_024] {
+        for pattern in [ClusterAdmissionPattern::SameKey, ClusterAdmissionPattern::DistinctKeys] {
+            group.bench_with_input(
+                BenchmarkId::new(format!("{pattern:?}"), command_count),
+                &(pattern, command_count),
+                |bencher, &(pattern, command_count)| {
+                    bencher.iter(|| {
+                        let probe = run_cluster_admission_probe(black_box(command_count), pattern)
+                            .expect("proxy cluster admission benchmark should complete");
+                        assert_eq!(probe.drained_count, probe.command_count);
+                        assert_eq!(probe.diagnostics.active_keys, 0);
+                        assert_eq!(probe.diagnostics.queued_and_active, 0);
+                        black_box(probe);
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1));
+    targets = bench_cluster_executor
+}
+criterion_main!(benches);

--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -117,11 +117,17 @@ use rocketmq_runtime::ChildServiceContext;
 use rocketmq_security_api::OutboundSigner;
 
 use crate::config::ClusterConfig;
+use crate::config::ClusterExecutionDiagnostics;
 use crate::message::message_ext_to_core;
 use crate::message::message_from_core;
 
 #[path = "cluster_admission.rs"]
 mod cluster_admission;
+
+#[cfg(feature = "bench-support")]
+#[doc(hidden)]
+#[path = "cluster_bench_support.rs"]
+pub mod bench_support;
 
 #[async_trait]
 pub trait ClusterClient: Send + Sync {
@@ -795,6 +801,11 @@ impl RocketmqClusterClient {
         })
     }
 
+    /// Returns a low-cardinality snapshot of bounded command execution.
+    pub fn execution_diagnostics(&self) -> ClusterExecutionDiagnostics {
+        self.executor.lanes.snapshot()
+    }
+
     pub(crate) async fn lock_batch_mq(&self, request: LockBatchRequestBody) -> ProxyResult<LockBatchResponseBody> {
         self.executor.lock_batch_mq(request).await
     }
@@ -957,21 +968,9 @@ impl ClusterClient for RocketmqClusterClient {
 mod cluster_execution;
 
 #[cfg(test)]
-use cluster_admission::cluster_lane;
-#[cfg(test)]
-use cluster_admission::cluster_lane_domain_id;
-#[cfg(test)]
 use cluster_admission::ClusterExecutionLanes;
 #[cfg(test)]
 use cluster_admission::ClusterExecutionPolicy;
-#[cfg(test)]
-use cluster_admission::QueuedClusterCommand;
-#[cfg(test)]
-use cluster_admission::CLUSTER_COMMAND_BYTE_CAPACITY;
-#[cfg(test)]
-use cluster_admission::CLUSTER_COMMAND_CAPACITY;
-#[cfg(test)]
-use cluster_admission::CLUSTER_EXECUTION_LANE_COUNT;
 #[cfg(test)]
 use cluster_execution::run_cluster_lane;
 use cluster_execution::ClusterCommand;
@@ -2755,6 +2754,7 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::mem::size_of;
+    use std::sync::Arc;
     use std::time::Duration;
     use std::time::Instant;
 
@@ -2774,10 +2774,6 @@ mod tests {
     use rocketmq_proxy_core::SendMessageEntry;
     use rocketmq_proxy_core::SendMessageRequest;
     use rocketmq_proxy_core::UpdateOffsetRequest;
-    use rocketmq_runtime::BudgetLimit;
-    use rocketmq_runtime::BudgetedQueue;
-    use rocketmq_runtime::FullPolicy;
-    use rocketmq_runtime::ResourceBudgetTree;
     use tokio::sync::oneshot;
     use tokio_util::sync::CancellationToken;
 
@@ -2797,12 +2793,8 @@ mod tests {
     use super::ClusterExecutionPolicy;
     use super::ClusterTaskExecutor;
     use super::ClusterWorkerState;
-    use super::QueuedClusterCommand;
     use super::RocketmqClusterClient;
     use super::TelemetryHandle;
-    use super::CLUSTER_COMMAND_BYTE_CAPACITY;
-    use super::CLUSTER_COMMAND_CAPACITY;
-    use super::CLUSTER_EXECUTION_LANE_COUNT;
     use crate::config::ClusterConfig;
     use rocketmq_client_rust::proxy_adapter_compat::MessageQueue;
     use rocketmq_proxy_core::ProxyError;
@@ -2962,19 +2954,41 @@ mod tests {
 
     #[test]
     fn cluster_command_admission_rejects_count_and_byte_saturation() {
+        let config = ClusterConfig::default();
         let count_lanes = ClusterExecutionLanes::new(ClusterExecutionPolicy {
-            capacity_count: 1,
+            capacity_count: 2,
             capacity_bytes: 4 * 1024,
-            default_queue_deadline: Duration::from_secs(1),
+            max_queue_age: Duration::from_secs(1),
+            io_max_inflight: 2,
+            control_reserve: 1,
+            lane_idle_timeout: Duration::from_secs(1),
         })
         .expect("count budget");
         let (first_reply, _first_receiver) = oneshot::channel();
         count_lanes
-            .enqueue(ClusterCommand::ReadinessCheck { reply: first_reply })
+            .enqueue(
+                ClusterCommand::QueryRoute {
+                    topic: ResourceIdentity::new("", "TopicA"),
+                    reply: first_reply,
+                },
+                CancellationToken::new(),
+                &config,
+            )
             .expect("first command is admitted");
+        assert!(
+            count_lanes.snapshot().oldest_queued_age_ms.is_some(),
+            "diagnostics expose the oldest retained command age"
+        );
         let (second_reply, _second_receiver) = oneshot::channel();
         let count_error = count_lanes
-            .enqueue(ClusterCommand::ReadinessCheck { reply: second_reply })
+            .enqueue(
+                ClusterCommand::QueryRoute {
+                    topic: ResourceIdentity::new("", "TopicA"),
+                    reply: second_reply,
+                },
+                CancellationToken::new(),
+                &config,
+            )
             .expect_err("second command exceeds the global count budget");
         assert!(matches!(
             count_error,
@@ -2987,25 +3001,32 @@ mod tests {
         let byte_lanes = ClusterExecutionLanes::new(ClusterExecutionPolicy {
             capacity_count: 2,
             capacity_bytes: size_of::<ClusterCommand>() + 8,
-            default_queue_deadline: Duration::from_secs(1),
+            max_queue_age: Duration::from_secs(1),
+            io_max_inflight: 2,
+            control_reserve: 1,
+            lane_idle_timeout: Duration::from_secs(1),
         })
         .expect("byte budget");
         let (reply, _receiver) = oneshot::channel();
         let byte_error = byte_lanes
-            .enqueue(ClusterCommand::SendMessage {
-                request: SendMessageRequest {
-                    messages: vec![SendMessageEntry {
-                        topic: ResourceIdentity::new("", "TopicA"),
-                        client_message_id: "message-a".to_owned(),
-                        message: ProxyMessage::new("TopicA", vec![7_u8; 32]),
-                        queue_id: None,
-                    }],
-                    timeout: None,
+            .enqueue(
+                ClusterCommand::SendMessage {
+                    request: SendMessageRequest {
+                        messages: vec![SendMessageEntry {
+                            topic: ResourceIdentity::new("", "TopicA"),
+                            client_message_id: "message-a".to_owned(),
+                            message: ProxyMessage::new("TopicA", vec![7_u8; 32]),
+                            queue_id: None,
+                        }],
+                        timeout: None,
+                    },
+                    client_id: Some("client-a".to_owned()),
+                    request_id: "request-a".to_owned(),
+                    reply,
                 },
-                client_id: Some("client-a".to_owned()),
-                request_id: "request-a".to_owned(),
-                reply,
-            })
+                CancellationToken::new(),
+                &config,
+            )
             .expect_err("retained payload exceeds the global byte budget");
         assert!(matches!(
             byte_error,
@@ -3014,6 +3035,41 @@ mod tests {
             }
         ));
         assert_eq!(byte_lanes.root_budget.snapshot().current_bytes, 0);
+    }
+
+    #[test]
+    fn cluster_execution_config_rejects_invalid_capacity_reserve_and_timeouts() {
+        let cases = [
+            ClusterConfig {
+                command_queue_capacity: 1,
+                control_reserve: 1,
+                ..Default::default()
+            },
+            ClusterConfig {
+                io_max_inflight: 1,
+                control_reserve: 1,
+                ..Default::default()
+            },
+            ClusterConfig {
+                control_reserve: 0,
+                ..Default::default()
+            },
+            ClusterConfig {
+                command_queue_max_age_ms: 0,
+                ..Default::default()
+            },
+            ClusterConfig {
+                execution_lane_idle_timeout_ms: 0,
+                ..Default::default()
+            },
+        ];
+
+        for config in cases {
+            let result = ClusterExecutionLanes::new(ClusterExecutionPolicy::from_config(&config));
+            assert!(result.is_err(), "invalid execution config must fail closed");
+            let error = result.err().expect("invalid config returns an error");
+            assert!(matches!(error, ProxyError::Transport { .. }));
+        }
     }
 
     #[test]
@@ -3063,41 +3119,53 @@ mod tests {
             reply: offset_reply,
         };
 
-        assert_eq!(pull.lane(), ack.lane());
-        assert_eq!(pull.lane(), update_offset.lane());
+        let config = ClusterConfig::default();
+        assert_eq!(pull.ordering_key(&config), ack.ordering_key(&config));
+        assert_eq!(pull.ordering_key(&config), update_offset.ordering_key(&config));
     }
 
     #[tokio::test]
     async fn expired_queued_command_is_rejected_before_client_io() {
         let service = super::test_service_context("proxy-cluster-expiry");
-        let budget = ResourceBudgetTree::new(
-            "proxy-cluster-expiry",
-            BudgetLimit::new(1, 4 * 1024, FullPolicy::Reject),
-        )
-        .expect("expiry budget");
-        let queue = BudgetedQueue::new(budget.root());
+        let config = ClusterConfig::default();
+        let lanes = Arc::new(
+            ClusterExecutionLanes::new(ClusterExecutionPolicy {
+                capacity_count: 2,
+                capacity_bytes: 4 * 1024,
+                max_queue_age: Duration::from_millis(1),
+                io_max_inflight: 2,
+                control_reserve: 1,
+                lane_idle_timeout: Duration::from_secs(1),
+            })
+            .expect("expiry lanes"),
+        );
         let (reply, receiver) = oneshot::channel();
-        let command = ClusterCommand::ReadinessCheck { reply };
-        queue
-            .try_push_data(
-                QueuedClusterCommand {
-                    command,
-                    enqueued_at: Instant::now()
-                        .checked_sub(Duration::from_millis(10))
-                        .expect("test instant supports subtraction"),
-                    deadline: Duration::from_millis(1),
-                },
-                size_of::<ClusterCommand>(),
+        let registration = lanes
+            .enqueue(
+                ClusterCommand::ReadinessCheck { reply },
+                CancellationToken::new(),
+                &config,
             )
+            .expect("expired command admission")
+            .expect("first key creates a lane");
+        let mut queued = registration.queue.try_pop().expect("admitted command");
+        queued.enqueued_at = Instant::now()
+            .checked_sub(Duration::from_millis(10))
+            .expect("test instant supports subtraction");
+        queued.queue_deadline = Duration::from_millis(1);
+        registration
+            .queue
+            .try_push_control(queued, size_of::<ClusterCommand>())
             .expect("expired command enters the queue");
-        queue.close();
+        registration.queue.close();
 
         run_cluster_lane(
-            ClusterConfig::default(),
+            config,
             ClusterWorkerState::new(),
-            queue,
+            registration,
             CancellationToken::new(),
             service,
+            lanes,
         )
         .await;
         let error = receiver
@@ -3120,15 +3188,20 @@ mod tests {
         let service = runtime.service_context("proxy-cluster-test.queue");
         let executor = ClusterTaskExecutor::new(ClusterConfig::default(), None, &service, TelemetryHandle::noop())
             .expect("managed executor builds");
+        let config = ClusterConfig::default();
         assert_eq!(
             executor.lanes.root_budget.limit().capacity.count,
-            CLUSTER_COMMAND_CAPACITY
+            config.command_queue_capacity
         );
         assert_eq!(
             executor.lanes.root_budget.limit().capacity.bytes,
-            CLUSTER_COMMAND_BYTE_CAPACITY
+            config.command_queue_max_bytes
         );
-        assert_eq!(executor.lanes.snapshots().len(), CLUSTER_EXECUTION_LANE_COUNT);
+        assert_eq!(
+            executor.lanes.root_budget.limit().control_reserve.count,
+            config.control_reserve
+        );
+        assert_eq!(executor.lanes.snapshot().active_keys, 0);
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
     }

--- a/rocketmq-proxy-cluster/src/cluster_admission.rs
+++ b/rocketmq-proxy-cluster/src/cluster_admission.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::hash::DefaultHasher;
-use std::hash::Hash;
-use std::hash::Hasher;
+use std::collections::HashMap;
 use std::mem::size_of;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -25,80 +29,193 @@ use rocketmq_proxy_core::MessageQueueTarget;
 use rocketmq_proxy_core::ProxyError;
 use rocketmq_proxy_core::ProxyResult;
 use rocketmq_proxy_core::ResourceIdentity;
+use rocketmq_runtime::BudgetCapacity;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::BudgetedQueue;
 use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::QueuePushErrorKind;
-#[cfg(test)]
-use rocketmq_runtime::QueueSnapshot;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ResourceBudgetTree;
+use tokio::sync::Notify;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 
+use super::build_proxy_producer_group;
 use super::ClusterCommand;
+use crate::config::ClusterConfig;
+use crate::config::ClusterExecutionDiagnostics;
 
-pub(super) const CLUSTER_COMMAND_CAPACITY: usize = 1024;
-pub(super) const CLUSTER_COMMAND_BYTE_CAPACITY: usize = 64 * 1024 * 1024;
-pub(super) const CLUSTER_EXECUTION_LANE_COUNT: usize = 16;
-const CLUSTER_LANES_PER_CLASS: usize = 4;
-const CLUSTER_DEFAULT_QUEUE_DEADLINE: Duration = Duration::from_secs(30);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ClusterCommandClass {
+    Control,
+    Data,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct ClusterOrderingKey {
+    domain: &'static str,
+    components: Arc<[String]>,
+}
+
+impl ClusterOrderingKey {
+    fn new(domain: &'static str, components: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            domain,
+            components: components.into_iter().collect(),
+        }
+    }
+
+    fn singleton(domain: &'static str) -> Self {
+        Self::new(domain, [])
+    }
+}
+
+#[derive(Clone)]
+struct RegisteredLane {
+    generation: u64,
+    queue: BudgetedQueue<QueuedClusterCommand>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ClusterLaneRegistration {
+    pub(super) key: ClusterOrderingKey,
+    pub(super) generation: u64,
+    pub(super) queue: BudgetedQueue<QueuedClusterCommand>,
+}
+
+#[derive(Default)]
+struct ClusterExecutionCounters {
+    current_inflight: AtomicUsize,
+    max_inflight: AtomicUsize,
+    admitted: AtomicU64,
+    rejected: AtomicU64,
+    timed_out: AtomicU64,
+    cancelled: AtomicU64,
+    shutdown_rejected: AtomicU64,
+}
 
 pub(super) struct ClusterExecutionLanes {
-    pub(super) queues: Box<[BudgetedQueue<QueuedClusterCommand>]>,
+    registry: Mutex<HashMap<ClusterOrderingKey, RegisteredLane>>,
     pub(super) root_budget: ResourceBudget,
-    default_queue_deadline: Duration,
+    policy: ClusterExecutionPolicy,
+    next_generation: AtomicU64,
+    closed: AtomicBool,
+    total_inflight: Arc<Semaphore>,
+    data_inflight: Arc<Semaphore>,
+    counters: Arc<ClusterExecutionCounters>,
+    active_lane_tasks: AtomicUsize,
+    lane_tasks_idle: Notify,
 }
 
 impl ClusterExecutionLanes {
     pub(super) fn new(policy: ClusterExecutionPolicy) -> ProxyResult<Self> {
-        let tree = ResourceBudgetTree::new(
-            "proxy-cluster-commands",
-            BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject),
-        )
-        .map_err(|error| ProxyError::Transport {
+        policy.validate()?;
+        let control_bytes = policy.control_reserve_bytes();
+        let limit = BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject)
+            .with_control_reserve(BudgetCapacity::new(policy.control_reserve, control_bytes));
+        let tree = ResourceBudgetTree::new("proxy-cluster-commands", limit).map_err(|error| ProxyError::Transport {
             message: format!("invalid proxy cluster command budget: {error}"),
         })?;
         let root_budget = tree.root();
-        let queues = (0..CLUSTER_EXECUTION_LANE_COUNT)
-            .map(|lane| {
-                root_budget
-                    .child(
-                        format!("lane-{lane}"),
-                        BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject),
-                    )
-                    .map(BudgetedQueue::new)
-                    .map_err(|error| ProxyError::Transport {
-                        message: format!("invalid proxy cluster command lane budget: {error}"),
-                    })
-            })
-            .collect::<ProxyResult<Vec<_>>>()?
-            .into_boxed_slice();
         Ok(Self {
-            queues,
+            registry: Mutex::new(HashMap::new()),
             root_budget,
-            default_queue_deadline: policy.default_queue_deadline,
+            policy,
+            next_generation: AtomicU64::new(1),
+            closed: AtomicBool::new(false),
+            total_inflight: Arc::new(Semaphore::new(policy.io_max_inflight)),
+            data_inflight: Arc::new(Semaphore::new(policy.io_max_inflight - policy.control_reserve)),
+            counters: Arc::new(ClusterExecutionCounters::default()),
+            active_lane_tasks: AtomicUsize::new(0),
+            lane_tasks_idle: Notify::new(),
         })
     }
 
-    pub(super) fn enqueue(&self, command: ClusterCommand) -> ProxyResult<()> {
-        let lane = command.lane();
+    pub(super) fn enqueue(
+        &self,
+        command: ClusterCommand,
+        cancellation: CancellationToken,
+        config: &ClusterConfig,
+    ) -> ProxyResult<Option<ClusterLaneRegistration>> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(cluster_execution_unavailable());
+        }
+        let key = command.ordering_key(config);
+        let class = command.class();
         let retained_bytes = command.retained_bytes();
-        let deadline = command
+        let queue_deadline = command
             .queue_deadline()
-            .unwrap_or(self.default_queue_deadline)
+            .unwrap_or(self.policy.max_queue_age)
+            .min(self.policy.max_queue_age)
             .max(Duration::from_millis(1));
         let queued = QueuedClusterCommand {
             command,
             enqueued_at: Instant::now(),
-            deadline,
+            queue_deadline,
+            cancellation,
+            class,
         };
-        match self.queues[lane].try_push_data(queued, retained_bytes) {
-            Ok(_) => Ok(()),
+
+        let mut registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.closed.load(Ordering::Acquire) {
+            return Err(cluster_execution_unavailable());
+        }
+        let (registered, created) = match registry.get(&key) {
+            Some(registered) => (registered.clone(), false),
+            None => {
+                let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+                let queue = self
+                    .root_budget
+                    .child(
+                        format!("key-{generation}"),
+                        BudgetLimit::new(
+                            self.policy.capacity_count,
+                            self.policy.capacity_bytes,
+                            FullPolicy::Reject,
+                        )
+                        .with_control_reserve(BudgetCapacity::new(
+                            self.policy.control_reserve,
+                            self.policy.control_reserve_bytes(),
+                        )),
+                    )
+                    .map(BudgetedQueue::new)
+                    .map_err(|error| ProxyError::Transport {
+                        message: format!("invalid proxy cluster keyed lane budget: {error}"),
+                    })?;
+                let registered = RegisteredLane { generation, queue };
+                registry.insert(key.clone(), registered.clone());
+                (registered, true)
+            }
+        };
+
+        let push_result = match class {
+            ClusterCommandClass::Control => registered.queue.try_push_control(queued, retained_bytes),
+            ClusterCommandClass::Data => registered.queue.try_push_data(queued, retained_bytes),
+        };
+        match push_result {
+            Ok(_) => {
+                self.counters.admitted.fetch_add(1, Ordering::Relaxed);
+                if created {
+                    Ok(Some(ClusterLaneRegistration {
+                        key,
+                        generation: registered.generation,
+                        queue: registered.queue,
+                    }))
+                } else {
+                    Ok(None)
+                }
+            }
             Err(error) => {
                 let kind = error.kind().clone();
-                let snapshot = self.queues[lane].snapshot();
+                if created {
+                    registry.remove(&key);
+                    registered.queue.close();
+                }
+                self.counters.rejected.fetch_add(1, Ordering::Relaxed);
+                let snapshot = registered.queue.snapshot();
                 let root_snapshot = self.root_budget.snapshot();
                 tracing::warn!(
-                    lane,
                     depth = snapshot.depth,
                     retained_bytes = snapshot.retained_bytes,
                     oldest_age_ms = snapshot.oldest_age.map(|age| age.as_millis() as u64),
@@ -119,96 +236,326 @@ impl ClusterExecutionLanes {
         }
     }
 
-    pub(super) fn queue_clones(&self) -> Vec<BudgetedQueue<QueuedClusterCommand>> {
-        self.queues.to_vec()
+    pub(super) fn retire(&self, registration: &ClusterLaneRegistration) -> bool {
+        let mut registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let should_remove = registry.get(&registration.key).is_some_and(|registered| {
+            registered.generation == registration.generation
+                && registered.queue.is_same_queue(&registration.queue)
+                && registered.queue.is_empty()
+        });
+        if should_remove {
+            registry.remove(&registration.key);
+            registration.queue.close();
+        }
+        should_remove
     }
 
-    #[cfg(test)]
-    pub(super) fn snapshots(&self) -> Vec<QueueSnapshot> {
-        self.queues.iter().map(BudgetedQueue::snapshot).collect()
+    pub(super) fn reject_failed_lane(&self, registration: &ClusterLaneRegistration, message: &str) {
+        let mut registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if registry
+            .get(&registration.key)
+            .is_some_and(|registered| registered.generation == registration.generation)
+        {
+            registry.remove(&registration.key);
+        }
+        registration.queue.close();
+        while let Some(queued) = registration.queue.try_pop() {
+            queued.command.reject(ProxyError::Transport {
+                message: message.to_owned(),
+            });
+        }
+    }
+
+    pub(super) fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        for registered in registry.values() {
+            registered.queue.close();
+        }
+    }
+
+    pub(super) fn snapshot(&self) -> ClusterExecutionDiagnostics {
+        let budget = self.root_budget.snapshot();
+        let registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let active_keys = registry.len();
+        let oldest_queued_age_ms = registry
+            .values()
+            .filter_map(|registered| registered.queue.snapshot().oldest_age)
+            .map(|age| age.as_millis().min(u128::from(u64::MAX)) as u64)
+            .max();
+        ClusterExecutionDiagnostics {
+            active_keys,
+            active_lane_tasks: self.active_lane_tasks.load(Ordering::Acquire),
+            queued_and_active: budget.current_count,
+            retained_bytes: budget.current_bytes,
+            oldest_queued_age_ms,
+            current_inflight: self.counters.current_inflight.load(Ordering::Relaxed),
+            max_inflight: self.counters.max_inflight.load(Ordering::Relaxed),
+            admitted: self.counters.admitted.load(Ordering::Relaxed),
+            rejected: self.counters.rejected.load(Ordering::Relaxed),
+            timed_out: self.counters.timed_out.load(Ordering::Relaxed),
+            cancelled: self.counters.cancelled.load(Ordering::Relaxed),
+            shutdown_rejected: self.counters.shutdown_rejected.load(Ordering::Relaxed),
+            closed: self.closed.load(Ordering::Acquire),
+        }
+    }
+
+    pub(super) async fn acquire_inflight(&self, class: ClusterCommandClass) -> ClusterInflightPermit {
+        let data = match class {
+            ClusterCommandClass::Control => None,
+            ClusterCommandClass::Data => Some(
+                self.data_inflight
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("proxy cluster data semaphore remains open"),
+            ),
+        };
+        let total = self
+            .total_inflight
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("proxy cluster total semaphore remains open");
+        let current = self.counters.current_inflight.fetch_add(1, Ordering::AcqRel) + 1;
+        self.counters.max_inflight.fetch_max(current, Ordering::Relaxed);
+        ClusterInflightPermit {
+            _data: data,
+            _total: total,
+            counters: self.counters.clone(),
+        }
+    }
+
+    pub(super) fn record_timeout(&self) {
+        self.counters.timed_out.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn record_cancelled(&self) {
+        self.counters.cancelled.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn record_shutdown_rejected(&self) {
+        self.counters.shutdown_rejected.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn lane_task_started(&self) {
+        self.active_lane_tasks.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(super) fn lane_task_finished(&self) {
+        if self.active_lane_tasks.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.lane_tasks_idle.notify_waiters();
+        }
+    }
+
+    pub(super) async fn wait_for_lane_tasks(&self, deadline: rocketmq_runtime::ShutdownDeadline) -> bool {
+        loop {
+            let idle = self.lane_tasks_idle.notified();
+            if self.active_lane_tasks.load(Ordering::Acquire) == 0 {
+                return true;
+            }
+            if tokio::time::timeout(deadline.remaining(), idle).await.is_err() {
+                return self.active_lane_tasks.load(Ordering::Acquire) == 0;
+            }
+        }
+    }
+
+    pub(super) const fn idle_timeout(&self) -> Duration {
+        self.policy.lane_idle_timeout
     }
 }
 
 impl Drop for ClusterExecutionLanes {
     fn drop(&mut self) {
-        for queue in &self.queues {
-            queue.close();
-        }
+        self.close();
     }
 }
 
-#[derive(Clone, Copy)]
+pub(super) struct ClusterInflightPermit {
+    _data: Option<OwnedSemaphorePermit>,
+    _total: OwnedSemaphorePermit,
+    counters: Arc<ClusterExecutionCounters>,
+}
+
+impl Drop for ClusterInflightPermit {
+    fn drop(&mut self) {
+        self.counters.current_inflight.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub(super) struct ClusterExecutionPolicy {
     pub(super) capacity_count: usize,
     pub(super) capacity_bytes: usize,
-    pub(super) default_queue_deadline: Duration,
+    pub(super) max_queue_age: Duration,
+    pub(super) io_max_inflight: usize,
+    pub(super) control_reserve: usize,
+    pub(super) lane_idle_timeout: Duration,
 }
 
 impl Default for ClusterExecutionPolicy {
     fn default() -> Self {
+        Self::from_config(&ClusterConfig::default())
+    }
+}
+
+impl ClusterExecutionPolicy {
+    pub(super) fn from_config(config: &ClusterConfig) -> Self {
         Self {
-            capacity_count: CLUSTER_COMMAND_CAPACITY,
-            capacity_bytes: CLUSTER_COMMAND_BYTE_CAPACITY,
-            default_queue_deadline: CLUSTER_DEFAULT_QUEUE_DEADLINE,
+            capacity_count: config.command_queue_capacity,
+            capacity_bytes: config.command_queue_max_bytes,
+            max_queue_age: config.command_queue_max_age(),
+            io_max_inflight: config.io_max_inflight,
+            control_reserve: config.control_reserve,
+            lane_idle_timeout: config.execution_lane_idle_timeout(),
         }
+    }
+
+    fn validate(self) -> ProxyResult<()> {
+        if self.capacity_count <= self.control_reserve {
+            return Err(invalid_execution_policy(
+                "command_queue_capacity must be greater than control_reserve",
+            ));
+        }
+        if self.io_max_inflight <= self.control_reserve {
+            return Err(invalid_execution_policy(
+                "io_max_inflight must be greater than control_reserve",
+            ));
+        }
+        if self.control_reserve == 0 {
+            return Err(invalid_execution_policy("control_reserve must be greater than zero"));
+        }
+        if self.max_queue_age.is_zero() {
+            return Err(invalid_execution_policy(
+                "command_queue_max_age_ms must be greater than zero",
+            ));
+        }
+        if self.lane_idle_timeout.is_zero() {
+            return Err(invalid_execution_policy(
+                "execution_lane_idle_timeout_ms must be greater than zero",
+            ));
+        }
+        let control_bytes = self.control_reserve_bytes();
+        if control_bytes >= self.capacity_bytes {
+            return Err(invalid_execution_policy(
+                "command_queue_max_bytes must leave capacity for data commands",
+            ));
+        }
+        Ok(())
+    }
+
+    fn control_reserve_bytes(self) -> usize {
+        let proportional = self
+            .capacity_bytes
+            .saturating_mul(self.control_reserve)
+            .checked_div(self.capacity_count)
+            .unwrap_or(0);
+        proportional.max(size_of::<ClusterCommand>())
     }
 }
 
 pub(super) struct QueuedClusterCommand {
     pub(super) command: ClusterCommand,
     pub(super) enqueued_at: Instant,
-    pub(super) deadline: Duration,
+    pub(super) queue_deadline: Duration,
+    pub(super) cancellation: CancellationToken,
+    pub(super) class: ClusterCommandClass,
 }
 
 impl ClusterCommand {
-    pub(super) fn lane(&self) -> usize {
+    pub(super) fn class(&self) -> ClusterCommandClass {
         match self {
-            Self::ReadinessCheck { .. } => cluster_lane(0, &"readiness"),
-            Self::QueryRoute { topic, .. } | Self::QueryTopicMessageType { topic, .. } => cluster_lane(0, topic),
-            Self::QueryAssignment { topic, group, .. } | Self::QuerySubscriptionGroup { topic, group, .. } => {
-                cluster_lane(0, &(topic, group))
+            Self::ReadinessCheck { .. } => ClusterCommandClass::Control,
+            _ => ClusterCommandClass::Data,
+        }
+    }
+
+    pub(super) fn ordering_key(&self, config: &ClusterConfig) -> ClusterOrderingKey {
+        match self {
+            Self::ReadinessCheck { .. } => ClusterOrderingKey::singleton("readiness"),
+            Self::QueryRoute { topic, .. } | Self::QueryTopicMessageType { topic, .. } => {
+                resource_ordering_key("topic", [topic])
             }
-            Self::QueryUser { username, .. } => cluster_lane(0, username),
-            Self::QueryAcl { subject, .. } => cluster_lane(0, subject),
+            Self::QueryAssignment { topic, group, .. } | Self::QuerySubscriptionGroup { topic, group, .. } => {
+                resource_ordering_key("topic-group", [topic, group])
+            }
+            Self::QueryUser { username, .. } => ClusterOrderingKey::new("user", [username.clone()]),
+            Self::QueryAcl { subject, .. } => ClusterOrderingKey::new("acl", [subject.clone()]),
             Self::SendMessage {
                 client_id, request_id, ..
-            }
-            | Self::RecallMessage {
+            } => ClusterOrderingKey::new(
+                "producer",
+                [build_proxy_producer_group(
+                    config,
+                    client_id.as_deref(),
+                    request_id.as_str(),
+                )],
+            ),
+            Self::RecallMessage {
                 client_id, request_id, ..
-            } => cluster_lane(1, &client_id.as_deref().unwrap_or(request_id.as_str())),
+            } => ClusterOrderingKey::new(
+                "producer",
+                [build_proxy_producer_group(
+                    config,
+                    client_id.as_deref(),
+                    request_id.as_str(),
+                )],
+            ),
             Self::EndTransaction {
                 request,
                 client_id,
                 request_id,
                 ..
-            } => cluster_lane(
-                1,
-                &client_id
-                    .as_deref()
-                    .or(request.producer_group.as_deref())
-                    .unwrap_or(request_id.as_str()),
+            } => ClusterOrderingKey::new(
+                "producer",
+                [request
+                    .producer_group
+                    .clone()
+                    .unwrap_or_else(|| build_proxy_producer_group(config, client_id.as_deref(), request_id.as_str()))],
             ),
-            Self::ReceiveMessage { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
-            Self::PullMessage { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
-            Self::AckMessage { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
-            Self::ForwardMessageToDeadLetterQueue { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
-            Self::ChangeInvisibleDuration { request, .. } => cluster_lane(2, &(&request.group, &request.topic)),
-            Self::UpdateOffset { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
-            Self::GetOffset { request, .. } => cluster_lane(2, &(&request.group, &request.target.topic)),
-            Self::QueryOffset { request, .. } => cluster_lane(2, &request.target.topic),
-            Self::LockBatchMq { request, .. } => cluster_lane(
-                3,
-                &(
-                    request.consumer_group.as_deref().unwrap_or_default(),
-                    request.client_id.as_deref().unwrap_or_default(),
-                ),
+            Self::ReceiveMessage { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+            }
+            Self::PullMessage { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+            }
+            Self::AckMessage { request, .. } => resource_ordering_key("consumer", [&request.group, &request.topic]),
+            Self::ForwardMessageToDeadLetterQueue { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.topic])
+            }
+            Self::ChangeInvisibleDuration { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.topic])
+            }
+            Self::UpdateOffset { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+            }
+            Self::GetOffset { request, .. } => {
+                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+            }
+            Self::QueryOffset { request, .. } => target_ordering_key("queue-offset", None, &request.target),
+            Self::LockBatchMq { request, .. } => ClusterOrderingKey::new(
+                "consumer-lock",
+                [
+                    request
+                        .consumer_group
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_default(),
+                    request.client_id.as_ref().map(ToString::to_string).unwrap_or_default(),
+                ],
             ),
-            Self::UnlockBatchMq { request, .. } => cluster_lane(
-                3,
-                &(
-                    request.consumer_group.as_deref().unwrap_or_default(),
-                    request.client_id.as_deref().unwrap_or_default(),
-                ),
+            Self::UnlockBatchMq { request, .. } => ClusterOrderingKey::new(
+                "consumer-lock",
+                [
+                    request
+                        .consumer_group
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_default(),
+                    request.client_id.as_ref().map(ToString::to_string).unwrap_or_default(),
+                ],
             ),
         }
     }
@@ -465,16 +812,44 @@ impl ClusterCommand {
     }
 }
 
-pub(super) fn cluster_lane(class: usize, key: &impl Hash) -> usize {
-    let mut hasher = DefaultHasher::new();
-    key.hash(&mut hasher);
-    class * CLUSTER_LANES_PER_CLASS + (hasher.finish() as usize % CLUSTER_LANES_PER_CLASS)
+fn resource_ordering_key<'a>(
+    domain: &'static str,
+    identities: impl IntoIterator<Item = &'a ResourceIdentity>,
+) -> ClusterOrderingKey {
+    let components = identities
+        .into_iter()
+        .flat_map(|identity| [identity.namespace().to_owned(), identity.name().to_owned()]);
+    ClusterOrderingKey::new(domain, components)
 }
 
-pub(super) fn cluster_lane_domain_id(base_domain_id: u64, lane: usize) -> u64 {
-    base_domain_id
-        .wrapping_mul(CLUSTER_EXECUTION_LANE_COUNT as u64)
-        .wrapping_add(lane as u64 + 1)
+fn target_ordering_key(
+    domain: &'static str,
+    group: Option<&ResourceIdentity>,
+    target: &MessageQueueTarget,
+) -> ClusterOrderingKey {
+    let mut components = Vec::with_capacity(8);
+    if let Some(group) = group {
+        components.push(group.namespace().to_owned());
+        components.push(group.name().to_owned());
+    }
+    components.push(target.topic.namespace().to_owned());
+    components.push(target.topic.name().to_owned());
+    components.push(target.queue_id.to_string());
+    components.push(target.broker_name.clone().unwrap_or_default());
+    components.push(target.broker_addr.clone().unwrap_or_default());
+    ClusterOrderingKey::new(domain, components)
+}
+
+fn invalid_execution_policy(message: &str) -> ProxyError {
+    ProxyError::Transport {
+        message: format!("invalid proxy cluster execution policy: {message}"),
+    }
+}
+
+fn cluster_execution_unavailable() -> ProxyError {
+    ProxyError::Transport {
+        message: "proxy cluster command execution is unavailable".to_owned(),
+    }
 }
 
 fn resource_identity_bytes(identity: &ResourceIdentity) -> usize {

--- a/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
+++ b/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
@@ -59,9 +59,12 @@ struct ScriptedClientIo {
     pops: Mutex<VecDeque<Result<PopResult, RocketMQError>>>,
     acks: Mutex<VecDeque<Result<AckResult, RocketMQError>>>,
     broker_lookup_misses: AtomicUsize,
+    route_panics: AtomicUsize,
     route_calls: AtomicUsize,
     refresh_calls: AtomicUsize,
     ack_calls: AtomicUsize,
+    pull_calls: AtomicUsize,
+    readiness_calls: AtomicUsize,
     start_entered: Mutex<Option<oneshot::Sender<()>>>,
     start_block: Option<Arc<Notify>>,
     pull_entered: Mutex<Option<oneshot::Sender<()>>>,
@@ -78,9 +81,12 @@ impl ScriptedClientIo {
             pops: Mutex::new(VecDeque::new()),
             acks: Mutex::new(VecDeque::new()),
             broker_lookup_misses: AtomicUsize::new(0),
+            route_panics: AtomicUsize::new(0),
             route_calls: AtomicUsize::new(0),
             refresh_calls: AtomicUsize::new(0),
             ack_calls: AtomicUsize::new(0),
+            pull_calls: AtomicUsize::new(0),
+            readiness_calls: AtomicUsize::new(0),
             start_entered: Mutex::new(None),
             start_block: None,
             pull_entered: Mutex::new(None),
@@ -147,6 +153,10 @@ impl ScriptedClientIo {
         self.broker_lookup_misses.store(count, Ordering::Release);
     }
 
+    fn panic_route_times(&self, count: usize) {
+        self.route_panics.store(count, Ordering::Release);
+    }
+
     fn scripted<T>(queue: &Mutex<VecDeque<Result<T, RocketMQError>>>, operation: &str) -> Result<T, RocketMQError> {
         queue
             .lock()
@@ -188,6 +198,15 @@ impl ClusterClientIo for ScriptedClientIo {
     async fn topic_route(&self, _topic: &str, _timeout_millis: u64) -> Result<Option<TopicRouteData>, RocketMQError> {
         self.record("client.route");
         self.route_calls.fetch_add(1, Ordering::AcqRel);
+        if self
+            .route_panics
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            panic!("scripted route panic");
+        }
         Self::scripted(&self.routes, "topic_route")
     }
 
@@ -303,6 +322,7 @@ impl ClusterClientIo for ScriptedClientIo {
         _timeout_millis: u64,
     ) -> Result<PullOutcome<MessageExt>, RocketMQError> {
         self.record("client.pull");
+        self.pull_calls.fetch_add(1, Ordering::AcqRel);
         if let Some(sender) = self
             .pull_entered
             .lock()
@@ -396,6 +416,7 @@ impl ClusterClientIo for ScriptedClientIo {
     }
 
     async fn broker_cluster_info(&self, _timeout_millis: u64) -> Result<ClusterInfo, RocketMQError> {
+        self.readiness_calls.fetch_add(1, Ordering::AcqRel);
         Err(unexpected_client_call("broker_cluster_info"))
     }
 
@@ -634,6 +655,31 @@ fn target() -> MessageQueueTarget {
     }
 }
 
+fn pull_request(group: &str) -> PullMessageRequest {
+    PullMessageRequest {
+        group: ResourceIdentity::new("", group),
+        target: target(),
+        offset: 5,
+        batch_size: 16,
+        filter_expression: filter_expression(),
+        long_polling_timeout: Duration::from_secs(1),
+    }
+}
+
+async fn wait_until(mut condition: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_millis(250), async {
+        while !condition() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deterministic execution condition was not reached");
+}
+
+fn shutdown_report_panics(report: &rocketmq_runtime::ShutdownReport) -> usize {
+    report.panicked + report.children.iter().map(shutdown_report_panics).sum::<usize>()
+}
+
 #[tokio::test]
 async fn unrelated_route_progresses_while_pull_is_blocked() {
     let events = Arc::new(Mutex::new(Vec::new()));
@@ -697,6 +743,239 @@ async fn unrelated_route_progresses_while_pull_is_blocked() {
 }
 
 #[tokio::test]
+async fn same_consumer_key_is_fifo_without_serializing_distinct_keys() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, first_pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        11,
+        1,
+        21,
+        None::<Vec<MessageExt>>,
+    ));
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        22,
+        1,
+        32,
+        None::<Vec<MessageExt>>,
+    ));
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let first = executor.pull_message(pull_request("GroupA"), Some(Duration::from_secs(2)));
+        let probe = async {
+            first_pull_entered.await.expect("first pull entered remote I/O");
+            let second = executor.pull_message(pull_request("GroupA"), Some(Duration::from_secs(2)));
+            let observe = async {
+                wait_until(|| executor.lanes.snapshot().queued_and_active == 2).await;
+                assert_eq!(
+                    client.pull_calls.load(Ordering::Acquire),
+                    1,
+                    "the second same-key command must remain queued"
+                );
+                client.pull_block.as_ref().expect("blocking pull control").notify_one();
+                wait_until(|| client.pull_calls.load(Ordering::Acquire) == 2).await;
+                client.pull_block.as_ref().expect("blocking pull control").notify_one();
+            };
+            let (second, ()) = tokio::join!(second, observe);
+            second
+        };
+        let (first, second) = tokio::join!(first, probe);
+        assert_eq!(first.expect("first pull").next_offset, 11);
+        assert_eq!(second.expect("second pull").next_offset, 22);
+        cancellation.cancel();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn distinct_consumer_keys_reach_remote_io_concurrently() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, first_pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        11,
+        1,
+        21,
+        None::<Vec<MessageExt>>,
+    ));
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        22,
+        1,
+        32,
+        None::<Vec<MessageExt>>,
+    ));
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let first = executor.pull_message(pull_request("GroupA"), Some(Duration::from_secs(2)));
+        let probe = async {
+            first_pull_entered.await.expect("first pull entered remote I/O");
+            let second = executor.pull_message(pull_request("GroupB"), Some(Duration::from_secs(2)));
+            let observe = async {
+                wait_until(|| client.pull_calls.load(Ordering::Acquire) == 2).await;
+                assert_eq!(executor.lanes.snapshot().current_inflight, 2);
+                client
+                    .pull_block
+                    .as_ref()
+                    .expect("blocking pull control")
+                    .notify_waiters();
+            };
+            let (second, ()) = tokio::join!(second, observe);
+            second
+        };
+        let (first, second) = tokio::join!(first, probe);
+        assert!(first.is_ok(), "first distinct-key pull");
+        assert!(second.is_ok(), "second distinct-key pull");
+        assert_eq!(executor.lanes.snapshot().max_inflight, 2);
+        cancellation.cancel();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, first_pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        11,
+        1,
+        21,
+        None::<Vec<MessageExt>>,
+    ));
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+    let state = ClusterWorkerState::with_test_runtime(client.clone(), factory);
+    let policy = ClusterExecutionPolicy {
+        capacity_count: 3,
+        capacity_bytes: 16 * 1024,
+        max_queue_age: Duration::from_secs(2),
+        io_max_inflight: 2,
+        control_reserve: 1,
+        lane_idle_timeout: Duration::from_secs(1),
+    };
+
+    run_scripted_worker_with_policy(
+        ClusterConfig::default(),
+        state,
+        policy,
+        |executor, cancellation| async move {
+            let first = executor.pull_message(pull_request("GroupA"), Some(Duration::from_secs(2)));
+            let probe = async {
+                first_pull_entered.await.expect("first pull entered remote I/O");
+                let second = executor.pull_message(pull_request("GroupB"), Some(Duration::from_secs(2)));
+                let checks = async {
+                    wait_until(|| {
+                        let snapshot = executor.lanes.snapshot();
+                        snapshot.queued_and_active == 2 && snapshot.current_inflight == 1
+                    })
+                    .await;
+                    let data_error = executor
+                        .query_route(ResourceIdentity::new("", "DataOverflow"))
+                        .await
+                        .expect_err("data capacity is saturated");
+                    assert!(matches!(data_error, ProxyError::TooManyRequests { .. }));
+
+                    let readiness_error = executor
+                        .readiness_check()
+                        .await
+                        .expect_err("scripted readiness returns a remote error");
+                    assert!(
+                        !matches!(readiness_error, ProxyError::TooManyRequests { .. }),
+                        "control reserve must admit readiness"
+                    );
+                    assert_eq!(client.readiness_calls.load(Ordering::Acquire), 1);
+                    cancellation.cancel();
+                };
+                let (second, ()) = tokio::join!(second, checks);
+                second
+            };
+            let (first, second) = tokio::join!(first, probe);
+            assert!(first.is_err(), "shutdown cancels the active data command");
+            assert!(second.is_err(), "shutdown cancels the queued data command");
+            wait_until(|| {
+                let snapshot = executor.lanes.snapshot();
+                snapshot.current_inflight == 0 && snapshot.queued_and_active == 0 && snapshot.active_keys == 0
+            })
+            .await;
+            assert_eq!(executor.lanes.snapshot().oldest_queued_age_ms, None);
+        },
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn idle_key_lane_is_reclaimed_without_leaking_budget_or_tasks() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let client = Arc::new(ScriptedClientIo::new(events.clone()));
+    client.push_route(TopicRouteData::default());
+    client.push_route(TopicRouteData::default());
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+    let state = ClusterWorkerState::with_test_runtime(client, factory);
+    let policy = ClusterExecutionPolicy {
+        capacity_count: 4,
+        capacity_bytes: 16 * 1024,
+        max_queue_age: Duration::from_secs(1),
+        io_max_inflight: 2,
+        control_reserve: 1,
+        lane_idle_timeout: Duration::from_millis(10),
+    };
+
+    run_scripted_worker_with_policy(
+        ClusterConfig::default(),
+        state,
+        policy,
+        |executor, cancellation| async move {
+            executor
+                .query_route(ResourceIdentity::new("", "TopicA"))
+                .await
+                .expect("route command");
+            assert_eq!(executor.lanes.snapshot().active_keys, 1);
+            tokio::time::advance(Duration::from_millis(10)).await;
+            wait_until(|| {
+                let snapshot = executor.lanes.snapshot();
+                snapshot.active_keys == 0
+                    && snapshot.active_lane_tasks == 0
+                    && snapshot.current_inflight == 0
+                    && snapshot.queued_and_active == 0
+            })
+            .await;
+            executor
+                .query_route(ResourceIdentity::new("", "TopicA"))
+                .await
+                .expect("retired exact key is recreated with a new generation");
+            assert_eq!(executor.lanes.snapshot().active_keys, 1);
+            tokio::time::advance(Duration::from_millis(10)).await;
+            wait_until(|| executor.lanes.snapshot().active_lane_tasks == 0).await;
+            tokio::time::resume();
+            cancellation.cancel();
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn active_command_holds_its_global_admission_permit() {
     let events = Arc::new(Mutex::new(Vec::new()));
     let (client, pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
@@ -715,9 +994,12 @@ async fn active_command_holds_its_global_admission_permit() {
     });
     let state = ClusterWorkerState::with_test_runtime(client.clone(), factory);
     let policy = ClusterExecutionPolicy {
-        capacity_count: 1,
+        capacity_count: 2,
         capacity_bytes: 4 * 1024,
-        default_queue_deadline: Duration::from_secs(1),
+        max_queue_age: Duration::from_secs(1),
+        io_max_inflight: 2,
+        control_reserve: 1,
+        lane_idle_timeout: Duration::from_secs(1),
     };
 
     run_scripted_worker_with_policy(
@@ -766,6 +1048,100 @@ async fn active_command_holds_its_global_admission_permit() {
         },
     )
     .await;
+}
+
+#[tokio::test]
+async fn request_timeout_cancels_remote_io_and_releases_all_permits() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let (client, pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        7,
+        1,
+        11,
+        None::<Vec<MessageExt>>,
+    ));
+    let client = Arc::new(client);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client, factory, |executor, cancellation| async move {
+        let request = executor.pull_message(pull_request("TimedOutGroup"), Some(Duration::from_millis(10)));
+        let observe = async {
+            pull_entered.await.expect("pull entered remote I/O");
+        };
+        let (result, ()) = tokio::join!(request, observe);
+        assert!(matches!(
+            result,
+            Err(ProxyError::RocketMQ(RocketMQError::Timeout {
+                operation: "proxy cluster command",
+                timeout_ms: 10,
+            }))
+        ));
+        wait_until(|| {
+            let snapshot = executor.lanes.snapshot();
+            snapshot.current_inflight == 0
+                && snapshot.queued_and_active == 0
+                && snapshot.cancelled == 1
+                && snapshot.timed_out == 1
+        })
+        .await;
+        cancellation.cancel();
+        wait_until(|| executor.lanes.snapshot().active_lane_tasks == 0).await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn panicked_lane_is_reclaimed_and_closes_without_leaks() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let client = Arc::new(ScriptedClientIo::new(events.clone()));
+    client.panic_route_times(1);
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+    let state = ClusterWorkerState::with_test_runtime(client, factory);
+    let service = test_service_context("proxy-cluster-panicked-lane");
+    let executor_result = ClusterTaskExecutor::new_with_test_state(
+        ClusterConfig::default(),
+        state,
+        &service,
+        ClusterExecutionPolicy::default(),
+    );
+    assert!(executor_result.is_ok(), "scripted cluster execution starts");
+    let Some((executor, cancellation)) = executor_result.ok() else {
+        std::process::abort();
+    };
+
+    let first = executor
+        .query_route(ResourceIdentity::new("", "RecoveredTopic"))
+        .await
+        .expect_err("first keyed lane panics");
+    assert!(matches!(first, ProxyError::Transport { .. }));
+    wait_until(|| {
+        let snapshot = executor.lanes.snapshot();
+        snapshot.active_keys == 0
+            && snapshot.active_lane_tasks == 0
+            && snapshot.current_inflight == 0
+            && snapshot.queued_and_active == 0
+    })
+    .await;
+
+    let closed = executor
+        .query_route(ResourceIdentity::new("", "RecoveredTopic"))
+        .await
+        .expect_err("a lane panic cancels the owning execution task group");
+    assert!(matches!(closed, ProxyError::Transport { .. }));
+    cancellation.cancel();
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert_eq!(report.detached_still_running, 0, "{}", report.to_json());
+    assert_eq!(shutdown_report_panics(&report), 1, "{}", report.to_json());
 }
 
 #[tokio::test]
@@ -978,7 +1354,7 @@ async fn worker_passes_the_outbound_signer_hook_to_the_client_transport_factory(
         producer_factory,
     );
     let topic = ResourceIdentity::new("", "TopicA");
-    let expected_domain_id = cluster_lane_domain_id(domain_id, cluster_lane(0, &topic));
+    let expected_domain_id = domain_id;
 
     run_scripted_worker(ClusterConfig::default(), state, |executor, cancellation| async move {
         let route_result = executor.query_route(topic).await;

--- a/rocketmq-proxy-cluster/src/cluster_bench_support.rs
+++ b/rocketmq-proxy-cluster/src/cluster_bench_support.rs
@@ -1,0 +1,110 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rocketmq_proxy_core::ProxyError;
+use rocketmq_proxy_core::ProxyResult;
+use rocketmq_proxy_core::ResourceIdentity;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use super::cluster_admission::ClusterExecutionLanes;
+use super::cluster_admission::ClusterExecutionPolicy;
+use super::ClusterCommand;
+use crate::config::ClusterConfig;
+use crate::config::ClusterExecutionDiagnostics;
+
+/// Key distribution used by the admission and retirement microbenchmark.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClusterAdmissionPattern {
+    SameKey,
+    DistinctKeys,
+}
+
+/// Result of one synchronous keyed-admission probe.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClusterAdmissionProbe {
+    pub command_count: usize,
+    pub lane_count: usize,
+    pub drained_count: usize,
+    pub diagnostics: ClusterExecutionDiagnostics,
+}
+
+/// Exercises the real count/byte admission, exact-key registry, and lane retirement
+/// implementation without network I/O.
+pub fn run_cluster_admission_probe(
+    command_count: usize,
+    pattern: ClusterAdmissionPattern,
+) -> ProxyResult<ClusterAdmissionProbe> {
+    if command_count == 0 {
+        return Err(ProxyError::Transport {
+            message: "cluster admission benchmark requires at least one command".to_owned(),
+        });
+    }
+
+    let control_reserve = 2;
+    let policy = ClusterExecutionPolicy {
+        capacity_count: command_count.saturating_add(control_reserve).saturating_add(1),
+        capacity_bytes: command_count.saturating_mul(1_024).max(1 << 20),
+        max_queue_age: Duration::from_secs(30),
+        io_max_inflight: 16,
+        control_reserve,
+        lane_idle_timeout: Duration::from_secs(30),
+    };
+    let lanes = ClusterExecutionLanes::new(policy)?;
+    let config = ClusterConfig::default();
+    let mut registrations = Vec::with_capacity(match pattern {
+        ClusterAdmissionPattern::SameKey => 1,
+        ClusterAdmissionPattern::DistinctKeys => command_count,
+    });
+
+    for index in 0..command_count {
+        let topic = match pattern {
+            ClusterAdmissionPattern::SameKey => "TopicA".to_owned(),
+            ClusterAdmissionPattern::DistinctKeys => format!("Topic{index}"),
+        };
+        let (reply, _receiver) = oneshot::channel();
+        if let Some(registration) = lanes.enqueue(
+            ClusterCommand::QueryRoute {
+                topic: ResourceIdentity::new("", topic),
+                reply,
+            },
+            CancellationToken::new(),
+            &config,
+        )? {
+            registrations.push(registration);
+        }
+    }
+
+    let lane_count = registrations.len();
+    let mut drained_count = 0;
+    for registration in &registrations {
+        while registration.queue.try_pop().is_some() {
+            drained_count += 1;
+        }
+        if !lanes.retire(registration) {
+            return Err(ProxyError::Transport {
+                message: "cluster admission benchmark failed to retire an empty lane".to_owned(),
+            });
+        }
+    }
+    let diagnostics = lanes.snapshot();
+    Ok(ClusterAdmissionProbe {
+        command_count,
+        lane_count,
+        drained_count,
+        diagnostics,
+    })
+}

--- a/rocketmq-proxy-cluster/src/cluster_execution.rs
+++ b/rocketmq-proxy-cluster/src/cluster_execution.rs
@@ -55,18 +55,15 @@ use rocketmq_proxy_core::SendMessageResultEntry;
 use rocketmq_proxy_core::SubscriptionGroupMetadata;
 use rocketmq_proxy_core::UpdateOffsetPlan;
 use rocketmq_proxy_core::UpdateOffsetRequest;
-use rocketmq_runtime::BudgetedQueue;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_security_api::OutboundSigner;
-use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 
-use super::cluster_admission::cluster_lane_domain_id;
 use super::cluster_admission::ClusterExecutionLanes;
 use super::cluster_admission::ClusterExecutionPolicy;
-use super::cluster_admission::QueuedClusterCommand;
-use super::cluster_admission::CLUSTER_EXECUTION_LANE_COUNT;
+use super::cluster_admission::ClusterLaneRegistration;
 use super::handle_cluster_command;
 use super::ClusterClientFactory;
 use super::ClusterProducerFactory;
@@ -78,6 +75,19 @@ use crate::config::ClusterConfig;
 #[derive(Clone)]
 pub(super) struct ClusterTaskExecutor {
     pub(super) lanes: Arc<ClusterExecutionLanes>,
+    runtime: Arc<ClusterExecutionRuntime>,
+    cancellation: CancellationToken,
+}
+
+struct ClusterExecutionRuntime {
+    config: ClusterConfig,
+    worker_context: ChildServiceContext,
+    shutdown_context: ChildServiceContext,
+    client_runtime: Arc<ClientRuntime>,
+    base_domain_id: u64,
+    rpc_hook: Option<Arc<ClientRpcHook>>,
+    client_factory: Arc<dyn ClusterClientFactory>,
+    producer_factory: Arc<dyn ClusterProducerFactory>,
 }
 
 pub(super) enum ClusterCommand {
@@ -204,6 +214,7 @@ impl ClusterTaskExecutor {
             telemetry_handle,
         )?;
         let base_domain_id = worker_context.task_group().id().as_u64();
+        let policy = ClusterExecutionPolicy::from_config(&config);
         Self::spawn_execution(
             config,
             rpc_hook,
@@ -213,7 +224,7 @@ impl ClusterTaskExecutor {
             base_domain_id,
             Arc::new(DefaultClusterClientFactory),
             Arc::new(DefaultClusterProducerFactory),
-            ClusterExecutionPolicy::default(),
+            policy,
         )
         .map(|(executor, _)| executor)
     }
@@ -264,62 +275,37 @@ impl ClusterTaskExecutor {
     ) -> ProxyResult<(Self, tokio_util::sync::CancellationToken)> {
         let lanes = Arc::new(ClusterExecutionLanes::new(policy)?);
         let cancellation = worker_context.task_group().cancellation_token();
-        let queue_clones = lanes.queue_clones();
-        let (completed_sender, completed_receiver) = mpsc::channel(CLUSTER_EXECUTION_LANE_COUNT);
-
-        for (lane, queue) in queue_clones.iter().cloned().enumerate() {
-            let lane_context = worker_context.child(format!("command-lane-{lane}"));
-            let lane_cancellation = lane_context.task_group().cancellation_token();
-            let lane_shutdown_context = service_context.clone();
-            let lane_config = config.clone();
-            let lane_state = ClusterWorkerState::with_factories(
-                client_runtime.clone(),
-                cluster_lane_domain_id(base_domain_id, lane),
-                rpc_hook.clone(),
-                client_factory.clone(),
-                producer_factory.clone(),
-            );
-            let completed_sender = completed_sender.clone();
-            if let Err(error) = lane_context.spawn_service(format!("proxy.cluster.lane-{lane}"), async move {
-                run_cluster_lane(lane_config, lane_state, queue, lane_cancellation, lane_shutdown_context).await;
-                let _ = completed_sender.try_send(());
-            }) {
-                worker_context.task_group().cancel();
-                for queue in &queue_clones {
-                    queue.close();
-                }
-                return Err(ProxyError::Transport {
-                    message: format!("failed to spawn proxy cluster execution lane {lane}: {error}"),
-                });
-            }
-        }
-        drop(completed_sender);
-
+        let runtime = Arc::new(ClusterExecutionRuntime {
+            config: config.clone(),
+            worker_context: worker_context.clone(),
+            shutdown_context: service_context.clone(),
+            client_runtime: client_runtime.clone(),
+            base_domain_id,
+            rpc_hook,
+            client_factory,
+            producer_factory,
+        });
         let owner_runtime = client_runtime;
-        let owner_queues = queue_clones;
+        let owner_lanes = lanes.clone();
         let owner_cancellation = cancellation.clone();
-        let owner_config = config;
         let owner_shutdown_context = service_context.clone();
         if let Err(error) = worker_context.spawn_service("proxy.cluster.execution-owner", async move {
-            run_cluster_execution_owner(
-                owner_config,
-                owner_runtime,
-                owner_queues,
-                completed_receiver,
-                owner_cancellation,
-                owner_shutdown_context,
-            )
-            .await;
+            run_cluster_execution_owner(owner_runtime, owner_lanes, owner_cancellation, owner_shutdown_context).await;
         }) {
             worker_context.task_group().cancel();
-            for queue in &lanes.queues {
-                queue.close();
-            }
+            lanes.close();
             return Err(ProxyError::Transport {
                 message: format!("failed to spawn proxy cluster execution owner: {error}"),
             });
         }
-        Ok((Self { lanes }, cancellation))
+        Ok((
+            Self {
+                lanes,
+                runtime,
+                cancellation: cancellation.clone(),
+            },
+            cancellation,
+        ))
     }
 
     pub(super) async fn readiness_check(&self) -> ProxyResult<()> {
@@ -537,21 +523,125 @@ impl ClusterTaskExecutor {
         T: Send + 'static,
     {
         let (reply, receiver) = oneshot::channel();
-        self.lanes.enqueue(command(reply))?;
-        receiver.await.map_err(|_| ProxyError::Transport {
-            message: "proxy cluster worker dropped response".to_owned(),
-        })?
+        let command = command(reply);
+        let request_deadline = command.queue_deadline();
+        let command_cancellation = CancellationToken::new();
+        let _drop_guard = CommandCancellationGuard(command_cancellation.clone());
+        if let Some(registration) = self
+            .lanes
+            .enqueue(command, command_cancellation.clone(), &self.runtime.config)?
+        {
+            self.spawn_lane(registration)?;
+        }
+
+        let receive = async {
+            receiver.await.map_err(|_| ProxyError::Transport {
+                message: "proxy cluster keyed executor dropped response".to_owned(),
+            })?
+        };
+        tokio::pin!(receive);
+        match request_deadline {
+            Some(deadline) => {
+                tokio::select! {
+                    biased;
+                    result = &mut receive => result,
+                    () = self.cancellation.cancelled() => {
+                        self.lanes.record_shutdown_rejected();
+                        Err(cluster_shutdown_error())
+                    },
+                    () = tokio::time::sleep(deadline.max(Duration::from_millis(1))) => {
+                        self.lanes.record_timeout();
+                        Err(cluster_command_timeout(deadline))
+                    },
+                }
+            }
+            None => {
+                tokio::select! {
+                    biased;
+                    result = &mut receive => result,
+                    () = self.cancellation.cancelled() => {
+                        self.lanes.record_shutdown_rejected();
+                        Err(cluster_shutdown_error())
+                    },
+                }
+            }
+        }
+    }
+
+    fn spawn_lane(&self, registration: ClusterLaneRegistration) -> ProxyResult<()> {
+        let lanes = self.lanes.clone();
+        let runtime = self.runtime.clone();
+        let cancellation = self.cancellation.clone();
+        let task_registration = registration.clone();
+        lanes.lane_task_started();
+        let task_lanes = lanes.clone();
+        let worker_context = runtime.worker_context.clone();
+        let lane_task = LaneTaskGuard {
+            lanes: task_lanes.clone(),
+            registration: task_registration.clone(),
+        };
+        let spawn_result = worker_context.spawn_service("proxy.cluster.keyed-lane", async move {
+            let _lane_task = lane_task;
+            let state = ClusterWorkerState::with_factories(
+                runtime.client_runtime.clone(),
+                runtime.base_domain_id,
+                runtime.rpc_hook.clone(),
+                runtime.client_factory.clone(),
+                runtime.producer_factory.clone(),
+            );
+            run_cluster_lane(
+                runtime.config.clone(),
+                state,
+                task_registration,
+                cancellation,
+                runtime.shutdown_context.clone(),
+                task_lanes.clone(),
+            )
+            .await;
+        });
+        if let Err(error) = spawn_result {
+            let message = format!("failed to spawn proxy cluster keyed lane: {error}");
+            return Err(ProxyError::Transport { message });
+        }
+        Ok(())
+    }
+}
+
+struct LaneTaskGuard {
+    lanes: Arc<ClusterExecutionLanes>,
+    registration: ClusterLaneRegistration,
+}
+
+impl Drop for LaneTaskGuard {
+    fn drop(&mut self) {
+        self.lanes.reject_failed_lane(
+            &self.registration,
+            "proxy cluster keyed lane terminated before completing the command",
+        );
+        self.lanes.lane_task_finished();
+    }
+}
+
+struct CommandCancellationGuard(CancellationToken);
+
+impl Drop for CommandCancellationGuard {
+    fn drop(&mut self) {
+        self.0.cancel();
     }
 }
 
 pub(super) async fn run_cluster_lane(
     config: ClusterConfig,
     mut state: ClusterWorkerState,
-    queue: BudgetedQueue<QueuedClusterCommand>,
-    cancellation: tokio_util::sync::CancellationToken,
+    registration: ClusterLaneRegistration,
+    cancellation: CancellationToken,
     shutdown_context: ChildServiceContext,
+    lanes: Arc<ClusterExecutionLanes>,
 ) {
+    let queue = &registration.queue;
     loop {
+        let idle = tokio::time::sleep(lanes.idle_timeout());
+        tokio::pin!(idle);
         let queued = tokio::select! {
             biased;
             () = cancellation.cancelled() => {
@@ -561,31 +651,91 @@ pub(super) async fn run_cluster_lane(
             command = queue.recv_budgeted() => match command {
                 Some(command) => command,
                 None => break,
-            }
+            },
+            () = &mut idle => {
+                shutdown_cluster_state(&config, &mut state, &shutdown_context).await;
+                if lanes.retire(&registration) {
+                    return;
+                }
+                continue;
+            },
         };
         let (queued, active_permit, _) = queued.into_parts();
         let waited = queued.enqueued_at.elapsed();
-        if waited >= queued.deadline {
-            queued.command.reject(cluster_queue_timeout(queued.deadline));
+        if waited >= queued.queue_deadline {
+            lanes.record_timeout();
+            queued.command.reject(cluster_queue_timeout(queued.queue_deadline));
             drop(active_permit);
             continue;
         }
-        let mut command = queued.command;
-        command.apply_queue_wait(waited);
-        tokio::select! {
-            biased;
-            () = cancellation.cancelled() => break,
-            () = handle_cluster_command(&config, &mut state, command) => {}
+        if queued.cancellation.is_cancelled() {
+            lanes.record_cancelled();
+            drop(active_permit);
+            continue;
         }
+
+        let remaining_queue_time = queued.queue_deadline.saturating_sub(waited);
+        let acquire_inflight = lanes.acquire_inflight(queued.class);
+        tokio::pin!(acquire_inflight);
+        let inflight_permit = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                lanes.record_shutdown_rejected();
+                queued.command.reject(cluster_shutdown_error());
+                drop(active_permit);
+                break;
+            },
+            () = queued.cancellation.cancelled() => {
+                lanes.record_cancelled();
+                drop(active_permit);
+                continue;
+            },
+            () = tokio::time::sleep(remaining_queue_time) => {
+                lanes.record_timeout();
+                queued.command.reject(cluster_queue_timeout(queued.queue_deadline));
+                drop(active_permit);
+                continue;
+            },
+            permit = &mut acquire_inflight => permit,
+        };
+
+        let mut command = queued.command;
+        command.apply_queue_wait(queued.enqueued_at.elapsed());
+        let shutdown_during_command = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                lanes.record_shutdown_rejected();
+                true
+            },
+            () = queued.cancellation.cancelled() => {
+                lanes.record_cancelled();
+                false
+            },
+            () = handle_cluster_command(&config, &mut state, command) => false,
+        };
+        drop(inflight_permit);
         drop(active_permit);
+        if shutdown_during_command {
+            break;
+        }
     }
     while let Some(queued) = queue.try_pop() {
+        lanes.record_shutdown_rejected();
         queued.command.reject(ProxyError::Transport {
             message: "proxy cluster command execution stopped during shutdown".to_owned(),
         });
     }
-    let shutdown_deadline = cluster_shutdown_deadline(&shutdown_context, config.shutdown_timeout());
-    for (producer_group, producer) in &mut state.send_producers {
+    shutdown_cluster_state(&config, &mut state, &shutdown_context).await;
+    lanes.retire(&registration);
+}
+
+async fn shutdown_cluster_state(
+    config: &ClusterConfig,
+    state: &mut ClusterWorkerState,
+    shutdown_context: &ChildServiceContext,
+) {
+    let shutdown_deadline = cluster_shutdown_deadline(shutdown_context, config.shutdown_timeout());
+    for (producer_group, mut producer) in state.send_producers.drain() {
         if tokio::time::timeout(shutdown_deadline.remaining(), producer.shutdown())
             .await
             .is_err()
@@ -607,30 +757,25 @@ pub(super) async fn run_cluster_lane(
 }
 
 async fn run_cluster_execution_owner(
-    config: ClusterConfig,
     client_runtime: Arc<ClientRuntime>,
-    queues: Vec<BudgetedQueue<QueuedClusterCommand>>,
-    mut completed_receiver: mpsc::Receiver<()>,
-    cancellation: tokio_util::sync::CancellationToken,
+    lanes: Arc<ClusterExecutionLanes>,
+    cancellation: CancellationToken,
     shutdown_context: ChildServiceContext,
 ) {
     cancellation.cancelled().await;
-    for queue in &queues {
-        queue.close();
-    }
-    let shutdown_deadline = cluster_shutdown_deadline(&shutdown_context, config.shutdown_timeout());
-    for lane in 0..CLUSTER_EXECUTION_LANE_COUNT {
-        match tokio::time::timeout(shutdown_deadline.remaining(), completed_receiver.recv()).await {
-            Ok(Some(())) => {}
-            Ok(None) => break,
-            Err(_) => {
-                tracing::warn!(
-                    lane,
-                    "proxy cluster execution lane shutdown exceeded the shared deadline"
-                );
-                break;
-            }
-        }
+    lanes.close();
+    let shutdown_deadline = shutdown_context
+        .task_group()
+        .shutdown_deadline()
+        .unwrap_or_else(|| ShutdownDeadline::after(Duration::from_secs(5)));
+    if !lanes.wait_for_lane_tasks(shutdown_deadline).await {
+        let snapshot = lanes.snapshot();
+        tracing::warn!(
+            active_lane_tasks = snapshot.active_lane_tasks,
+            active_keys = snapshot.active_keys,
+            current_inflight = snapshot.current_inflight,
+            "proxy cluster keyed lanes exceeded the shared shutdown deadline"
+        );
     }
     let _ = client_runtime.shutdown_until(shutdown_deadline).await;
 }
@@ -643,10 +788,62 @@ fn cluster_queue_timeout(deadline: Duration) -> ProxyError {
     .into()
 }
 
+fn cluster_command_timeout(deadline: Duration) -> ProxyError {
+    RocketMQError::Timeout {
+        operation: "proxy cluster command",
+        timeout_ms: deadline.as_millis().clamp(1, u128::from(u64::MAX)) as u64,
+    }
+    .into()
+}
+
+fn cluster_shutdown_error() -> ProxyError {
+    ProxyError::Transport {
+        message: "proxy cluster command execution stopped during shutdown".to_owned(),
+    }
+}
+
 fn cluster_shutdown_deadline(context: &ChildServiceContext, configured_timeout: Duration) -> ShutdownDeadline {
     let configured = ShutdownDeadline::after(configured_timeout);
     match context.task_group().shutdown_deadline() {
         Some(parent) if parent.instant() <= configured.instant() => parent,
         Some(_) | None => configured,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dropping_an_unpolled_lane_future_releases_registration_and_task_count() {
+        let lanes =
+            Arc::new(ClusterExecutionLanes::new(ClusterExecutionPolicy::default()).expect("valid execution policy"));
+        let config = ClusterConfig::default();
+        let (reply, mut receiver) = oneshot::channel();
+        let registration = lanes
+            .enqueue(
+                ClusterCommand::ReadinessCheck { reply },
+                CancellationToken::new(),
+                &config,
+            )
+            .expect("command admission")
+            .expect("first key creates a lane");
+
+        lanes.lane_task_started();
+        let guard = LaneTaskGuard {
+            lanes: lanes.clone(),
+            registration,
+        };
+        let unpolled = async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        };
+        drop(unpolled);
+
+        let diagnostics = lanes.snapshot();
+        assert_eq!(diagnostics.active_lane_tasks, 0);
+        assert_eq!(diagnostics.active_keys, 0);
+        assert_eq!(diagnostics.queued_and_active, 0);
+        assert!(receiver.try_recv().expect("queued command is rejected").is_err());
     }
 }

--- a/rocketmq-proxy-cluster/src/config.rs
+++ b/rocketmq-proxy-cluster/src/config.rs
@@ -17,6 +17,25 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Low-cardinality runtime state for the bounded Cluster command executor.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClusterExecutionDiagnostics {
+    pub active_keys: usize,
+    pub active_lane_tasks: usize,
+    pub queued_and_active: usize,
+    pub retained_bytes: usize,
+    pub oldest_queued_age_ms: Option<u64>,
+    pub current_inflight: usize,
+    pub max_inflight: usize,
+    pub admitted: u64,
+    pub rejected: u64,
+    pub timed_out: u64,
+    pub cancelled: u64,
+    pub shutdown_rejected: u64,
+    pub closed: bool,
+}
+
 /// Configuration owned by the Client-backed cluster adapter.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
@@ -31,6 +50,12 @@ pub struct ClusterConfig {
     pub route_cache_ttl_ms: u64,
     pub metadata_cache_ttl_ms: u64,
     pub shutdown_timeout_ms: u64,
+    pub command_queue_capacity: usize,
+    pub command_queue_max_bytes: usize,
+    pub command_queue_max_age_ms: u64,
+    pub io_max_inflight: usize,
+    pub control_reserve: usize,
+    pub execution_lane_idle_timeout_ms: u64,
 }
 
 impl Default for ClusterConfig {
@@ -46,6 +71,12 @@ impl Default for ClusterConfig {
             route_cache_ttl_ms: 5_000,
             metadata_cache_ttl_ms: 5_000,
             shutdown_timeout_ms: 5_000,
+            command_queue_capacity: 1_024,
+            command_queue_max_bytes: 64 * 1024 * 1024,
+            command_queue_max_age_ms: 30_000,
+            io_max_inflight: 16,
+            control_reserve: 2,
+            execution_lane_idle_timeout_ms: 30_000,
         }
     }
 }
@@ -61,5 +92,13 @@ impl ClusterConfig {
 
     pub fn shutdown_timeout(&self) -> Duration {
         Duration::from_millis(self.shutdown_timeout_ms)
+    }
+
+    pub fn command_queue_max_age(&self) -> Duration {
+        Duration::from_millis(self.command_queue_max_age_ms)
+    }
+
+    pub fn execution_lane_idle_timeout(&self) -> Duration {
+        Duration::from_millis(self.execution_lane_idle_timeout_ms)
     }
 }

--- a/rocketmq-proxy-cluster/src/lib.rs
+++ b/rocketmq-proxy-cluster/src/lib.rs
@@ -24,9 +24,13 @@ mod message;
 pub mod remoting;
 pub mod service;
 
+#[cfg(feature = "bench-support")]
+#[doc(hidden)]
+pub use cluster::bench_support;
 pub use cluster::ClusterClient;
 pub use cluster::RocketmqClusterClient;
 pub use config::ClusterConfig;
+pub use config::ClusterExecutionDiagnostics;
 pub use remoting::ClusterRemotingBackend;
 pub use service::ClusterAssignmentService;
 pub use service::ClusterConsumerService;

--- a/scripts/architecture-debt-registry.json
+++ b/scripts/architecture-debt-registry.json
@@ -145,6 +145,40 @@
           ]
         }
       ]
+    },
+    {
+      "id": "ARC-RUNTIME-003",
+      "class": "runtime_adapter",
+      "owner": "proxy",
+      "status": "resolved",
+      "reason": "fixed hash-sharded Cluster workers were replaced by exact keyed lanes with bounded admission and owned shutdown",
+      "adr": "rocketmq-doc/en/proxy-cluster-keyed-execution-adr.md",
+      "removal_condition": "fixed Cluster lane count and hash-routing helpers remain absent",
+      "target_release": "2.0.0",
+      "evidence": [
+        "rocketmq-proxy-cluster/src/cluster_admission.rs",
+        "rocketmq-proxy-cluster/src/cluster_behavior_tests.rs",
+        "scripts/tests/test_m08_proxy_core_contract.py"
+      ],
+      "scope_count": 0,
+      "source_checks": [
+        {
+          "pattern": "CLUSTER_EXECUTION_LANE_COUNT",
+          "max_count": 0,
+          "paths": [
+            "rocketmq-proxy-cluster/src/cluster_admission.rs",
+            "rocketmq-proxy-cluster/src/cluster_execution.rs"
+          ]
+        },
+        {
+          "pattern": "fn cluster_lane(",
+          "max_count": 0,
+          "paths": [
+            "rocketmq-proxy-cluster/src/cluster_admission.rs",
+            "rocketmq-proxy-cluster/src/cluster_execution.rs"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/scripts/public-api-snapshot-baseline.json
+++ b/scripts/public-api-snapshot-baseline.json
@@ -110,14 +110,14 @@
       "crate_version": "1.0.0",
       "public_path_count": 24,
       "public_path_sha256": "3c461c0143acb1fe6316118715e11a4fb31620b6b6f1bd7fdf6e3170eedd6e9a",
-      "rustdoc_json_sha256": "9f7d54c18335ddc4722616bf0d84cda5c7199b92df42a17d9ea8e129d14cc082",
+      "rustdoc_json_sha256": "bd0829ac8ee9a9a7ac8d95eef9ccee5b3f1ac802da95bf9ad60652ccf2e1439d",
       "target": "rocketmq_proxy"
     },
     "rocketmq-proxy-cluster": {
       "crate_version": "1.0.0",
-      "public_path_count": 16,
-      "public_path_sha256": "a54347aa28148322afe3d20aaf05915c76060a2c32efb7809271c063296e32b2",
-      "rustdoc_json_sha256": "bd8784a47d47c5270cef5e01e4d73e373a42bfb99ae2aebabaccba354af5e4ea",
+      "public_path_count": 17,
+      "public_path_sha256": "9c935df58f31dc54ca22ec4c844ac4b76c2750b39725779c8bfce92d99fe4a2b",
+      "rustdoc_json_sha256": "10b2bc560886eb69787c6184d398c23cf8254eafddf76c1d3d5f5e7194b0cc88",
       "target": "rocketmq_proxy_cluster"
     },
     "rocketmq-proxy-core": {
@@ -199,7 +199,7 @@
     }
   },
   "schema_version": 1,
-  "source_commit": "875aefe8c5476e1c6148c566d8e37b0df16b1b39",
+  "source_commit": "96e7a95b428ba53b8876a3f9487e065856c6cbb5",
   "toolchain": {
     "cargo": "cargo 1.98.0-nightly (a335d47ff 2026-06-26)",
     "rustc": "rustc 1.98.0-nightly (c397dae80 2026-07-02)",

--- a/scripts/runtime-audit.ps1
+++ b/scripts/runtime-audit.ps1
@@ -1727,6 +1727,14 @@ function Get-SchedulerDisposition {
         }
     }
 
+    if ($path -eq "rocketmq-proxy-cluster/src/cluster_execution.rs") {
+        return [pscustomobject]@{
+            Disposition = "proxy-cluster-owned-execution-timer"
+            ActionRequired = $false
+            Reason = "Allowed request deadline, inflight admission timeout, and keyed-lane idle retirement inside tasks owned by the injected Proxy Cluster TaskGroup."
+        }
+    }
+
     if ($path -match "^rocketmq-controller/src/") {
         return [pscustomobject]@{
             Disposition = "controller-retry-backoff"

--- a/scripts/tests/test_m08_proxy_core_contract.py
+++ b/scripts/tests/test_m08_proxy_core_contract.py
@@ -36,6 +36,49 @@ class ProxyCoreContractTests(unittest.TestCase):
         result = run_dependency_guard("target")
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
 
+    def test_cluster_execution_uses_exact_managed_keys_and_reserved_control_capacity(self) -> None:
+        admission = (
+            ROOT / "rocketmq-proxy-cluster/src/cluster_admission.rs"
+        ).read_text(encoding="utf-8")
+        execution = (
+            ROOT / "rocketmq-proxy-cluster/src/cluster_execution.rs"
+        ).read_text(encoding="utf-8")
+        config = (ROOT / "rocketmq-proxy-cluster/src/config.rs").read_text(
+            encoding="utf-8"
+        )
+
+        for token in (
+            "HashMap<ClusterOrderingKey, RegisteredLane>",
+            "with_control_reserve",
+            "data_inflight",
+            "wait_for_lane_tasks",
+            "generation",
+        ):
+            self.assertIn(token, admission)
+        for token in (
+            'spawn_service("proxy.cluster.keyed-lane"',
+            "CommandCancellationGuard",
+            "LaneTaskGuard",
+            "cluster_shutdown_error",
+        ):
+            self.assertIn(token, execution)
+        for field in (
+            "command_queue_capacity",
+            "command_queue_max_bytes",
+            "command_queue_max_age_ms",
+            "io_max_inflight",
+            "control_reserve",
+            "execution_lane_idle_timeout_ms",
+        ):
+            self.assertIn(field, config)
+
+        combined = admission + execution
+        self.assertNotIn("CLUSTER_EXECUTION_LANE_COUNT", combined)
+        self.assertNotIn("fn cluster_lane(", combined)
+        self.assertTrue(
+            (ROOT / "rocketmq-doc/en/proxy-cluster-keyed-execution-adr.md").is_file()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_m09_public_api_compatibility.py
+++ b/scripts/tests/test_m09_public_api_compatibility.py
@@ -171,10 +171,11 @@ class PublicApiCompatibilityTests(unittest.TestCase):
         self.assertIn("feature=24/24", evidence)
         self.assertIn("wire=6/6", evidence)
         self.assertIn("storage=10/10", evidence)
-        self.assertIn("additive: 0", evidence)
+        self.assertIn("additive: 1", evidence)
         self.assertIn("deprecated: 0", evidence)
-        self.assertIn("breaking: 1", evidence)
+        self.assertIn("breaking: 2", evidence)
         self.assertIn("ClientRuntime::new", evidence)
+        self.assertIn("ClusterConfig", evidence)
         self.assertIn("repository owner explicitly approved", evidence)
 
 

--- a/scripts/trait-policy-baseline.json
+++ b/scripts/trait-policy-baseline.json
@@ -62,7 +62,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 126,
+      "line": 132,
       "item": "trait ClusterClient",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -70,7 +70,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 217,
+      "line": 223,
       "item": "trait ClusterClientIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -78,7 +78,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 426,
+      "line": 432,
       "item": "impl ClusterClientIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -86,7 +86,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 660,
+      "line": 666,
       "item": "trait ClusterProducerIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -94,7 +94,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 692,
+      "line": 698,
       "item": "impl ClusterProducerIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -102,7 +102,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 807,
+      "line": 818,
       "item": "impl ClusterClient",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -110,7 +110,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster_behavior_tests.rs",
-      "line": 163,
+      "line": 173,
       "item": "impl ClusterClientIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -118,7 +118,7 @@
     {
       "kind": "async_trait",
       "path": "rocketmq-proxy-cluster/src/cluster_behavior_tests.rs",
-      "line": 478,
+      "line": 499,
       "item": "impl ClusterProducerIo",
       "owner": "proxy-cluster",
       "decision": "migrate-on-touch"
@@ -3662,7 +3662,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 133,
+      "line": 139,
       "item": "trait ClusterClient::readiness_check",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3670,7 +3670,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 137,
+      "line": 143,
       "item": "trait ClusterClient::query_route",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3678,7 +3678,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 139,
+      "line": 145,
       "item": "trait ClusterClient::query_assignment",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3686,7 +3686,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 146,
+      "line": 152,
       "item": "trait ClusterClient::query_topic_message_type",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3694,7 +3694,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 148,
+      "line": 154,
       "item": "trait ClusterClient::query_subscription_group",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3702,7 +3702,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 154,
+      "line": 160,
       "item": "trait ClusterClient::query_user",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3710,7 +3710,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 158,
+      "line": 164,
       "item": "trait ClusterClient::query_acl",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3718,7 +3718,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 162,
+      "line": 168,
       "item": "trait ClusterClient::send_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3726,7 +3726,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 168,
+      "line": 174,
       "item": "trait ClusterClient::recall_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3734,7 +3734,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 174,
+      "line": 180,
       "item": "trait ClusterClient::receive_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3742,7 +3742,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 180,
+      "line": 186,
       "item": "trait ClusterClient::pull_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3750,7 +3750,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 182,
+      "line": 188,
       "item": "trait ClusterClient::ack_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3758,7 +3758,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 188,
+      "line": 194,
       "item": "trait ClusterClient::forward_message_to_dead_letter_queue",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3766,7 +3766,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 194,
+      "line": 200,
       "item": "trait ClusterClient::change_invisible_duration",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3774,7 +3774,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 200,
+      "line": 206,
       "item": "trait ClusterClient::update_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3782,7 +3782,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 206,
+      "line": 212,
       "item": "trait ClusterClient::get_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3790,7 +3790,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 208,
+      "line": 214,
       "item": "trait ClusterClient::query_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3798,7 +3798,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 210,
+      "line": 216,
       "item": "trait ClusterClient::end_transaction",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3806,7 +3806,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 219,
+      "line": 225,
       "item": "trait ClusterClientIo::start",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3814,7 +3814,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 221,
+      "line": 227,
       "item": "trait ClusterClientIo::shutdown",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3822,7 +3822,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 223,
+      "line": 229,
       "item": "trait ClusterClientIo::topic_route",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3830,7 +3830,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 225,
+      "line": 231,
       "item": "trait ClusterClientIo::lock_batch_mq",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3838,7 +3838,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 232,
+      "line": 238,
       "item": "trait ClusterClientIo::unlock_batch_mq",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3846,7 +3846,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 243,
+      "line": 249,
       "item": "trait ClusterClientIo::query_assignment",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3854,7 +3854,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 254,
+      "line": 260,
       "item": "trait ClusterClientIo::pop_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3862,7 +3862,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 262,
+      "line": 268,
       "item": "trait ClusterClientIo::ack_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3870,7 +3870,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 269,
+      "line": 275,
       "item": "trait ClusterClientIo::change_invisible_time",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3878,7 +3878,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 277,
+      "line": 283,
       "item": "trait ClusterClientIo::end_transaction",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3886,7 +3886,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 285,
+      "line": 291,
       "item": "trait ClusterClientIo::find_subscribe_broker_addr",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3894,7 +3894,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 292,
+      "line": 298,
       "item": "trait ClusterClientIo::refresh_topic_route",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3902,7 +3902,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 294,
+      "line": 300,
       "item": "trait ClusterClientIo::broker_name_for_queue",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3910,7 +3910,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 296,
+      "line": 302,
       "item": "trait ClusterClientIo::pull_outcome_from_broker",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3918,7 +3918,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 304,
+      "line": 310,
       "item": "trait ClusterClientIo::consumer_send_message_back",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3926,7 +3926,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 315,
+      "line": 321,
       "item": "trait ClusterClientIo::update_consumer_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3934,7 +3934,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 322,
+      "line": 328,
       "item": "trait ClusterClientIo::query_consumer_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3942,7 +3942,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 329,
+      "line": 335,
       "item": "trait ClusterClientIo::min_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3950,7 +3950,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 336,
+      "line": 342,
       "item": "trait ClusterClientIo::max_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3958,7 +3958,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 343,
+      "line": 349,
       "item": "trait ClusterClientIo::search_offset",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3966,7 +3966,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 352,
+      "line": 358,
       "item": "trait ClusterClientIo::topic_config",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3974,7 +3974,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 359,
+      "line": 365,
       "item": "trait ClusterClientIo::subscription_group_config",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3982,7 +3982,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 366,
+      "line": 372,
       "item": "trait ClusterClientIo::broker_cluster_info",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3990,7 +3990,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 368,
+      "line": 374,
       "item": "trait ClusterClientIo::user",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -3998,7 +3998,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 375,
+      "line": 381,
       "item": "trait ClusterClientIo::acl",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4006,7 +4006,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 670,
+      "line": 676,
       "item": "trait ClusterProducerIo::start",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4014,7 +4014,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 672,
+      "line": 678,
       "item": "trait ClusterProducerIo::shutdown",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4022,7 +4022,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 674,
+      "line": 680,
       "item": "trait ClusterProducerIo::recall_message",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4030,7 +4030,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 680,
+      "line": 686,
       "item": "trait ClusterProducerIo::fetch_publish_message_queues",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4038,7 +4038,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 682,
+      "line": 688,
       "item": "trait ClusterProducerIo::send",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"
@@ -4046,7 +4046,7 @@
     {
       "kind": "native_async",
       "path": "rocketmq-proxy-cluster/src/cluster.rs",
-      "line": 684,
+      "line": 690,
       "item": "trait ClusterProducerIo::send_to_queue",
       "owner": "proxy-cluster",
       "decision": "preferred-static-dispatch"


### PR DESCRIPTION
## Summary
- replace the fixed sixteen-way hash executor with dynamically owned exact-key lanes
- enforce fail-fast count, retained-byte, queue-age, request-deadline, inflight, and control-reserve limits
- preserve same-key FIFO and exclusive producer ownership while allowing unrelated remote I/O to progress concurrently
- make caller drop, timeout, panic, and shutdown reclaim commands, permits, lane registrations, and managed tasks
- expose low-cardinality diagnostics and accept the keyed-execution ADR
- remove the obsolete fixed-lane contract and record the approved `ClusterConfig` source-shape change without changing RocketMQ wire or persisted formats

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p rocketmq-proxy-cluster --all-features` (31 passed)
- `cargo clippy -p rocketmq-proxy-cluster --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-runtime --test runtime_model` (42 passed)
- `python scripts/run_architecture_tests.py` (49/49 passed)
- `python scripts/public_api_snapshot.py --check scripts/public-api-snapshot-baseline.json` (28 packages, zero differences)
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`
- `cargo bench -p rocketmq-proxy-cluster --features bench-support --bench cluster_executor -- --noplot`
  - same key / 256: 182.15-194.37 us
  - distinct keys / 256: 437.40-464.77 us
  - same key / 1024: 703.37-728.62 us
  - distinct keys / 1024: 2.1166-2.2622 ms

The Criterion target is an algorithm regression signal, not a production-throughput claim. The target-hardware mixed workload remains a separate evidence gate. No image was published or pushed to an external registry.

Closes #8810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cluster command queue capacity, aging, in-flight limits, control reserves, and lane idle timeouts.
  * Added runtime execution diagnostics, including queue, activity, timing, admission, cancellation, and timeout metrics.
  * Improved keyed execution to preserve FIFO ordering for matching keys while allowing unrelated operations to run concurrently.
  * Added graceful cancellation, shutdown handling, and recovery from execution failures.

* **Documentation**
  * Added architecture and compatibility documentation for the new cluster execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->