### PR TITLE
[ISSUE #8851]♻️Retain only active task-group state and honor earliest shutdown deadlines

### DIFF
--- a/rocketmq-runtime/benches/task_group_lifecycle_bench.rs
+++ b/rocketmq-runtime/benches/task_group_lifecycle_bench.rs
@@ -60,6 +60,32 @@ fn run_spawn_shutdown(task_count: usize) -> ShutdownReport {
     report
 }
 
+fn run_child_churn(operation_count: usize) -> ShutdownReport {
+    let owner = RuntimeOwner::new(runtime_config()).expect("runtime owner should start");
+    let context = owner.root_context().child("bench.child-registry-root");
+
+    let report = owner.block_on(async move {
+        let service = context.child(format!("bench.child-registry.{operation_count}"));
+        for operation_index in 0..operation_count {
+            drop(service.child(format!("component-{operation_index}")));
+            drop(
+                service
+                    .task_group()
+                    .try_child_lease(format!("operation-{operation_index}"))
+                    .expect("child lease should be accepted while the group is open"),
+            );
+        }
+
+        assert_eq!(service.task_group().child_count(), 0);
+        assert_eq!(service.task_group().child_stats().registry_slots, 0);
+        context.task_group().shutdown(Duration::from_secs(5)).await
+    });
+
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{}", report.to_json());
+    report
+}
+
 fn write_shutdown_report_artifact() {
     let task_count = 10_000;
     let report = run_spawn_shutdown(task_count);
@@ -106,6 +132,21 @@ fn bench_task_group_lifecycle(criterion: &mut Criterion) {
         );
     }
     group.finish();
+
+    let mut child_churn = criterion.benchmark_group("task_group_active_child_registry");
+    for operation_count in [1_024usize, 10_000] {
+        child_churn.bench_with_input(
+            BenchmarkId::new("register_drop_shutdown", operation_count),
+            &operation_count,
+            |bencher, operation_count| {
+                bencher.iter(|| {
+                    let report = run_child_churn(black_box(*operation_count));
+                    black_box(report.is_healthy());
+                });
+            },
+        );
+    }
+    child_churn.finish();
 }
 
 criterion_group! {

--- a/rocketmq-runtime/src/diagnostics.rs
+++ b/rocketmq-runtime/src/diagnostics.rs
@@ -54,6 +54,10 @@ pub struct RuntimeDiagnosticsSnapshot {
     pub task_count: usize,
     /// The number of child entries.
     pub child_count: usize,
+    /// The number of active task entries.
+    pub active_tasks: usize,
+    /// The number of active child registry slots.
+    pub registry_slots: usize,
     /// The blocking lanes value.
     pub blocking_lanes: Vec<BlockingExecutorSnapshot>,
 }
@@ -271,6 +275,8 @@ impl RuntimeDiagnostics {
             lifecycle_state: root.lifecycle_state(),
             task_count: root.task_count(),
             child_count: root.child_count(),
+            active_tasks: root.task_count(),
+            registry_slots: root.child_count(),
             blocking_lanes,
         }
     }

--- a/rocketmq-runtime/src/schedule.rs
+++ b/rocketmq-runtime/src/schedule.rs
@@ -891,16 +891,13 @@ mod tests {
 
         manager.cancel_task(task_id);
         manager.shutdown_all(Duration::from_secs(1)).await;
+        let child_report = manager
+            .last_task_group_shutdown_report()
+            .expect("scheduled task manager shutdown report should exist");
+        assert_eq!(child_report.name, "rocketmq.simple-scheduled-task-manager");
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
-        assert!(
-            report
-                .children
-                .iter()
-                .any(|child| child.name == "rocketmq.simple-scheduled-task-manager"),
-            "{}",
-            report.to_json()
-        );
+        assert!(report.children.is_empty(), "{}", report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-runtime/src/schedule/executor.rs
+++ b/rocketmq-runtime/src/schedule/executor.rs
@@ -638,17 +638,15 @@ mod tests {
             .await
             .expect("parented executor task should start");
         executor.shutdown_all(Duration::from_secs(1)).await;
+        let child_report = executor
+            .last_task_group_shutdown_report()
+            .await
+            .expect("executor shutdown report should exist");
+        assert_eq!(child_report.name, "rocketmq.task-executor");
 
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
-        assert!(
-            report
-                .children
-                .iter()
-                .any(|child| child.name == "rocketmq.task-executor"),
-            "{}",
-            report.to_json()
-        );
+        assert!(report.children.is_empty(), "{}", report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-runtime/src/schedule/scheduler.rs
+++ b/rocketmq-runtime/src/schedule/scheduler.rs
@@ -724,17 +724,15 @@ mod tests {
 
         scheduler.start().await.expect("parented scheduler should start");
         scheduler.stop().await.expect("parented scheduler should stop");
+        let child_report = scheduler
+            .last_scheduler_shutdown_report()
+            .await
+            .expect("scheduler shutdown report should exist");
+        assert_eq!(child_report.name, "rocketmq.task-scheduler");
 
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
-        assert!(
-            report
-                .children
-                .iter()
-                .any(|child| child.name == "rocketmq.task-scheduler"),
-            "{}",
-            report.to_json()
-        );
+        assert!(report.children.is_empty(), "{}", report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-runtime/src/service_lifecycle.rs
+++ b/rocketmq-runtime/src/service_lifecycle.rs
@@ -773,6 +773,7 @@ mod tests {
                 active: 0,
                 created: 1,
                 pruned: 1,
+                registry_slots: 0,
             }
         );
 

--- a/rocketmq-runtime/src/shutdown_deadline.rs
+++ b/rocketmq-runtime/src/shutdown_deadline.rs
@@ -48,4 +48,12 @@ impl ShutdownDeadline {
     pub fn is_expired(self) -> bool {
         self.remaining().is_zero()
     }
+
+    pub(crate) fn earliest(self, other: Self) -> Self {
+        if self.at <= other.at {
+            self
+        } else {
+            other
+        }
+    }
 }

--- a/rocketmq-runtime/src/task/service_task.rs
+++ b/rocketmq-runtime/src/task/service_task.rs
@@ -861,17 +861,15 @@ mod tests {
 
         service_thread.start().await.unwrap();
         service_thread.shutdown().await.unwrap();
+        let child_report = service_thread
+            .last_task_group_shutdown_report()
+            .await
+            .expect("service manager shutdown report should exist");
+        assert_eq!(child_report.name, "rocketmq.service-manager");
 
         let report = service_context.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
-        assert!(
-            report
-                .children
-                .iter()
-                .any(|child| child.name == "rocketmq.service-manager"),
-            "{}",
-            report.to_json()
-        );
+        assert!(report.children.is_empty(), "{}", report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -19,11 +19,9 @@ use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::sync::Weak;
 use std::time::Duration;
 use std::time::Instant;
 
-use dashmap::DashMap;
 use futures::future::join_all;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
@@ -41,6 +39,11 @@ use crate::shutdown_deadline::ShutdownDeadline;
 use crate::shutdown_report::ShutdownAnnotation;
 use crate::shutdown_report::ShutdownReport;
 use crate::shutdown_report::TaskSnapshot;
+
+mod registry;
+
+use registry::ActiveTaskRegistry;
+use registry::ChildRegistrationKind;
 
 const STATE_OPEN: u8 = 0;
 const STATE_CLOSING: u8 = 1;
@@ -170,6 +173,8 @@ pub struct TaskGroupChildStats {
     pub created: usize,
     /// The pruned value.
     pub pruned: usize,
+    /// The number of active child registry slots.
+    pub registry_slots: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -195,13 +200,10 @@ struct TaskGroupInner {
     runtime: RuntimeHandle,
     cancellation_token: CancellationToken,
     tracker: TaskTracker,
-    tasks: DashMap<TaskId, TaskMeta>,
-    children: Mutex<Vec<TaskGroup>>,
-    dynamic_children: Mutex<Vec<Weak<TaskGroupInner>>>,
+    registry: Arc<ActiveTaskRegistry>,
+    parent_registry: Option<std::sync::Weak<ActiveTaskRegistry>>,
     next_group_id: Arc<AtomicU64>,
     next_task_id: AtomicU64,
-    dynamic_children_created: AtomicUsize,
-    dynamic_children_pruned: AtomicUsize,
     completed: AtomicUsize,
     cancelled: AtomicUsize,
     aborted: AtomicUsize,
@@ -301,6 +303,7 @@ impl TaskGroup {
                 runtime,
                 CancellationToken::new(),
                 next_group_id,
+                None,
             )),
         }
     }
@@ -337,21 +340,22 @@ impl TaskGroup {
 
     /// Returns the task count.
     pub fn task_count(&self) -> usize {
-        self.inner.tasks.len()
+        self.inner.registry.tasks.len()
     }
 
     /// Returns the child count.
     pub fn child_count(&self) -> usize {
-        self.inner.children.lock().len() + self.live_dynamic_children().len()
+        self.inner.registry.child_count()
     }
 
     /// Returns the child stats.
     pub fn child_stats(&self) -> TaskGroupChildStats {
-        let active = self.live_dynamic_children().len();
+        let stats = self.inner.registry.child_stats();
         TaskGroupChildStats {
-            active,
-            created: self.inner.dynamic_children_created.load(Ordering::Relaxed),
-            pruned: self.inner.dynamic_children_pruned.load(Ordering::Relaxed),
+            active: stats.active_operations,
+            created: stats.operations_created,
+            pruned: stats.operations_released,
+            registry_slots: stats.registry_slots,
         }
     }
 
@@ -367,21 +371,19 @@ impl TaskGroup {
         aggregate: &mut TaskGroupDiagnosticsAccumulator,
     ) {
         aggregate.group_count = aggregate.group_count.saturating_add(1);
-        for task in self.inner.tasks.iter() {
+        for task in self.inner.registry.tasks.iter() {
             let elapsed = task.started_at.elapsed();
             aggregate.record_task(task.kind, elapsed, elapsed >= long_running_threshold);
         }
 
-        let mut children = self.inner.children.lock().clone();
-        children.extend(self.live_dynamic_children());
-        for child in children {
+        for child in self.inner.registry.children_snapshot() {
             child.accumulate_diagnostics(long_running_threshold, aggregate);
         }
     }
 
     /// Returns the contains task.
     pub fn contains_task(&self, task_id: TaskId) -> bool {
-        self.inner.tasks.contains_key(&task_id)
+        self.inner.registry.tasks.contains_key(&task_id)
     }
 
     /// Returns the child.
@@ -403,7 +405,11 @@ impl TaskGroup {
         }
 
         let child = self.open_child(name);
-        self.inner.children.lock().push(child.clone());
+        self.inner.registry.register_child(
+            child.id(),
+            Arc::downgrade(&child.inner),
+            ChildRegistrationKind::Component,
+        );
         Ok(child)
     }
 
@@ -419,8 +425,11 @@ impl TaskGroup {
         }
 
         let child = self.open_child(name);
-        self.inner.dynamic_children.lock().push(Arc::downgrade(&child.inner));
-        self.inner.dynamic_children_created.fetch_add(1, Ordering::Relaxed);
+        self.inner.registry.register_child(
+            child.id(),
+            Arc::downgrade(&child.inner),
+            ChildRegistrationKind::Operation,
+        );
         Ok(TaskGroupChildLease { group: child })
     }
 
@@ -434,6 +443,7 @@ impl TaskGroup {
                 self.inner.runtime.clone(),
                 self.inner.cancellation_token.child_token(),
                 self.inner.next_group_id.clone(),
+                Some(Arc::downgrade(&self.inner.registry)),
             )),
         }
     }
@@ -444,23 +454,6 @@ impl TaskGroup {
         child.inner.cancellation_token.cancel();
         child.inner.lifecycle.store(STATE_SHUTDOWN_COMPLETED, Ordering::Release);
         child
-    }
-
-    fn live_dynamic_children(&self) -> Vec<TaskGroup> {
-        let mut registry = self.inner.dynamic_children.lock();
-        let before = registry.len();
-        let mut live = Vec::with_capacity(before);
-        registry.retain(|entry| {
-            let Some(inner) = entry.upgrade() else {
-                return false;
-            };
-            live.push(TaskGroup { inner });
-            true
-        });
-        self.inner
-            .dynamic_children_pruned
-            .fetch_add(before - registry.len(), Ordering::Relaxed);
-        live
     }
 
     /// Spawns the supplied task.
@@ -533,7 +526,13 @@ impl TaskGroup {
 
     /// Returns the wait task.
     pub async fn wait_task(&self, task_id: TaskId, timeout: Duration) -> bool {
-        let Some(completion) = self.inner.tasks.get(&task_id).map(|meta| meta.completion.clone()) else {
+        let Some(completion) = self
+            .inner
+            .registry
+            .tasks
+            .get(&task_id)
+            .map(|meta| meta.completion.clone())
+        else {
             return true;
         };
 
@@ -622,7 +621,7 @@ impl TaskGroup {
 
         let task_id = TaskId(self.inner.next_task_id.fetch_add(1, Ordering::Relaxed));
         let completion = Arc::new(TaskCompletion::new());
-        self.inner.tasks.insert(
+        self.inner.registry.tasks.insert(
             task_id,
             TaskMeta {
                 id: task_id,
@@ -673,7 +672,7 @@ impl TaskGroup {
         };
         let abort_handle = join_handle.abort_handle();
 
-        if let Some(mut meta) = self.inner.tasks.get_mut(&task_id) {
+        if let Some(mut meta) = self.inner.registry.tasks.get_mut(&task_id) {
             meta.abort_handle = Some(abort_handle);
             meta.state = TaskState::Running;
         }
@@ -682,7 +681,7 @@ impl TaskGroup {
     }
 
     fn abort_task_inner(&self, task_id: TaskId) -> Option<Arc<TaskCompletion>> {
-        let (_, meta) = self.inner.tasks.remove(&task_id)?;
+        let (_, meta) = self.inner.registry.tasks.remove(&task_id)?;
         if let Some(abort_handle) = meta.abort_handle {
             abort_handle.abort();
         }
@@ -698,9 +697,7 @@ impl TaskGroup {
             self.inner.tracker.close();
             self.inner.cancellation_token.cancel();
             self.inner.lifecycle.store(STATE_CLOSED, Ordering::Release);
-            let mut children = self.inner.children.lock().clone();
-            children.extend(self.live_dynamic_children());
-            children
+            self.inner.registry.children_snapshot()
         };
         self.abort_detached_abort_on_shutdown_tasks();
 
@@ -770,9 +767,7 @@ impl TaskGroup {
             self.inner.tracker.close();
             self.inner.cancellation_token.cancel();
             self.inner.lifecycle.store(STATE_CLOSED, Ordering::Release);
-            let mut children = self.inner.children.lock().clone();
-            children.extend(self.live_dynamic_children());
-            children
+            self.inner.registry.children_snapshot()
         };
 
         let mut child_reports = Vec::with_capacity(children.len());
@@ -814,7 +809,7 @@ impl TaskGroup {
     }
 
     fn abort_tracked_tasks(&self) {
-        for mut entry in self.inner.tasks.iter_mut() {
+        for mut entry in self.inner.registry.tasks.iter_mut() {
             if entry.detached {
                 continue;
             }
@@ -826,7 +821,7 @@ impl TaskGroup {
     }
 
     fn abort_detached_abort_on_shutdown_tasks(&self) {
-        for mut entry in self.inner.tasks.iter_mut() {
+        for mut entry in self.inner.registry.tasks.iter_mut() {
             if entry.detached_policy != Some(DetachedTaskPolicy::AbortOnShutdown) {
                 continue;
             }
@@ -840,13 +835,14 @@ impl TaskGroup {
     fn remove_aborted_tasks(&self) -> usize {
         let aborted_ids = self
             .inner
+            .registry
             .tasks
             .iter()
             .filter_map(|entry| (entry.state == TaskState::Aborted).then_some(*entry.key()))
             .collect::<Vec<_>>();
 
         for task_id in &aborted_ids {
-            self.inner.tasks.remove(task_id);
+            self.inner.registry.tasks.remove(task_id);
         }
 
         aborted_ids.len()
@@ -854,6 +850,7 @@ impl TaskGroup {
 
     fn remaining_snapshots(&self, state: TaskState) -> Vec<TaskSnapshot> {
         self.inner
+            .registry
             .tasks
             .iter()
             .map(|entry| entry.value().snapshot(state))
@@ -869,6 +866,7 @@ impl TaskGroupInner {
         runtime: RuntimeHandle,
         cancellation_token: CancellationToken,
         next_group_id: Arc<AtomicU64>,
+        parent_registry: Option<std::sync::Weak<ActiveTaskRegistry>>,
     ) -> Self {
         Self {
             id,
@@ -877,13 +875,10 @@ impl TaskGroupInner {
             runtime,
             cancellation_token,
             tracker: TaskTracker::new(),
-            tasks: DashMap::new(),
-            children: Mutex::new(Vec::new()),
-            dynamic_children: Mutex::new(Vec::new()),
+            registry: Arc::new(ActiveTaskRegistry::new()),
+            parent_registry,
             next_group_id,
             next_task_id: AtomicU64::new(1),
-            dynamic_children_created: AtomicUsize::new(0),
-            dynamic_children_pruned: AtomicUsize::new(0),
             completed: AtomicUsize::new(0),
             cancelled: AtomicUsize::new(0),
             aborted: AtomicUsize::new(0),
@@ -912,7 +907,7 @@ impl TaskGroupInner {
     }
 
     fn finish_task(&self, task_id: TaskId, result: TaskResult) {
-        let Some((_, meta)) = self.tasks.remove(&task_id) else {
+        let Some((_, meta)) = self.registry.tasks.remove(&task_id) else {
             return;
         };
 
@@ -933,6 +928,14 @@ impl TaskGroupInner {
                 self.mark_poisoned_if_open();
             }
             TaskResult::Aborted => {}
+        }
+    }
+}
+
+impl Drop for TaskGroupInner {
+    fn drop(&mut self) {
+        if let Some(parent_registry) = self.parent_registry.as_ref().and_then(std::sync::Weak::upgrade) {
+            parent_registry.unregister_child(self.id);
         }
     }
 }

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -41,9 +41,11 @@ use crate::shutdown_report::ShutdownReport;
 use crate::shutdown_report::TaskSnapshot;
 
 mod registry;
+mod shutdown;
 
 use registry::ActiveTaskRegistry;
 use registry::ChildRegistrationKind;
+use shutdown::ShutdownCoordinator;
 
 const STATE_OPEN: u8 = 0;
 const STATE_CLOSING: u8 = 1;
@@ -210,8 +212,7 @@ struct TaskGroupInner {
     panicked: AtomicUsize,
     lifecycle: AtomicU8,
     spawn_gate: Mutex<()>,
-    shutdown_deadline: Mutex<Option<ShutdownDeadline>>,
-    shutdown_report: tokio::sync::OnceCell<ShutdownReport>,
+    shutdown: ShutdownCoordinator,
 }
 
 #[derive(Debug, Clone)]
@@ -330,7 +331,7 @@ impl TaskGroup {
 
     /// Returns the earliest absolute deadline installed by a shutdown owner.
     pub fn shutdown_deadline(&self) -> Option<ShutdownDeadline> {
-        *self.inner.shutdown_deadline.lock()
+        self.inner.shutdown.deadline()
     }
 
     /// Returns the lifecycle state.
@@ -554,20 +555,12 @@ impl TaskGroup {
 
     /// Shuts down until.
     pub fn shutdown_until(&self, deadline: ShutdownDeadline) -> BoxFuture<'_, ShutdownReport> {
-        let deadline = {
-            let mut installed = self.inner.shutdown_deadline.lock();
-            match *installed {
-                Some(existing) if existing.instant() <= deadline.instant() => existing,
-                Some(_) | None => {
-                    *installed = Some(deadline);
-                    deadline
-                }
-            }
-        };
+        self.tighten_shutdown_deadline(deadline);
         async move {
             self.inner
-                .shutdown_report
-                .get_or_init(|| async { self.shutdown_inner(deadline).await })
+                .shutdown
+                .report
+                .get_or_init(|| async { self.shutdown_inner().await })
                 .await
                 .clone()
         }
@@ -576,13 +569,20 @@ impl TaskGroup {
 
     /// Shuts down now.
     pub fn shutdown_now(&self) -> ShutdownReport {
-        if let Some(report) = self.inner.shutdown_report.get() {
+        if let Some(report) = self.inner.shutdown.report.get() {
             return report.clone();
         }
 
         let report = self.shutdown_now_inner();
-        let _ = self.inner.shutdown_report.set(report.clone());
+        let _ = self.inner.shutdown.report.set(report.clone());
         report
+    }
+
+    fn tighten_shutdown_deadline(&self, deadline: ShutdownDeadline) {
+        let installed = self.inner.shutdown.tighten(deadline);
+        for child in self.inner.registry.children_snapshot() {
+            child.tighten_shutdown_deadline(installed);
+        }
     }
 
     fn spawn_inner<F>(
@@ -689,8 +689,13 @@ impl TaskGroup {
         Some(meta.completion)
     }
 
-    async fn shutdown_inner(&self, deadline: ShutdownDeadline) -> ShutdownReport {
+    async fn shutdown_inner(&self) -> ShutdownReport {
         let started_at = Instant::now();
+        let deadline = self
+            .inner
+            .shutdown
+            .deadline()
+            .unwrap_or_else(|| ShutdownDeadline::after(Duration::ZERO));
         let children = {
             let _spawn_guard = self.inner.spawn_gate.lock();
             self.inner.lifecycle.store(STATE_CLOSING, Ordering::Release);
@@ -710,14 +715,9 @@ impl TaskGroup {
             .await
         };
         let tracked_shutdown = async {
-            let remaining = deadline.remaining();
-            if tokio::time::timeout(remaining, self.inner.tracker.wait())
-                .await
-                .is_err()
-            {
+            if self.inner.shutdown.run_until(self.inner.tracker.wait()).await.is_err() {
                 self.abort_tracked_tasks();
-                let drain_timeout = deadline.remaining().min(Duration::from_secs(1));
-                let _ = tokio::time::timeout(drain_timeout, self.inner.tracker.wait()).await;
+                let _ = self.inner.shutdown.run_until(self.inner.tracker.wait()).await;
                 true
             } else {
                 false
@@ -885,8 +885,7 @@ impl TaskGroupInner {
             panicked: AtomicUsize::new(0),
             lifecycle: AtomicU8::new(STATE_OPEN),
             spawn_gate: Mutex::new(()),
-            shutdown_deadline: Mutex::new(None),
-            shutdown_report: tokio::sync::OnceCell::new(),
+            shutdown: ShutdownCoordinator::new(),
         }
     }
 

--- a/rocketmq-runtime/src/task_group/registry.rs
+++ b/rocketmq-runtime/src/task_group/registry.rs
@@ -1,0 +1,110 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Weak;
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::TaskGroup;
+use super::TaskGroupId;
+use super::TaskGroupInner;
+use super::TaskId;
+use super::TaskMeta;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ChildRegistrationKind {
+    Component,
+    Operation,
+}
+
+#[derive(Debug)]
+struct ChildRegistration {
+    inner: Weak<TaskGroupInner>,
+    kind: ChildRegistrationKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ActiveChildStats {
+    pub(super) active_operations: usize,
+    pub(super) operations_created: usize,
+    pub(super) operations_released: usize,
+    pub(super) registry_slots: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct ActiveTaskRegistry {
+    pub(super) tasks: DashMap<TaskId, TaskMeta>,
+    children: Mutex<HashMap<TaskGroupId, ChildRegistration>>,
+    operations_created: AtomicUsize,
+    operations_released: AtomicUsize,
+}
+
+impl ActiveTaskRegistry {
+    pub(super) fn new() -> Self {
+        Self {
+            tasks: DashMap::new(),
+            children: Mutex::new(HashMap::new()),
+            operations_created: AtomicUsize::new(0),
+            operations_released: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn register_child(&self, id: TaskGroupId, child: Weak<TaskGroupInner>, kind: ChildRegistrationKind) {
+        let previous = self
+            .children
+            .lock()
+            .insert(id, ChildRegistration { inner: child, kind });
+        debug_assert!(previous.is_none(), "task-group ids must be unique");
+        if kind == ChildRegistrationKind::Operation {
+            self.operations_created.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn unregister_child(&self, id: TaskGroupId) {
+        let removed = self.children.lock().remove(&id);
+        if removed.is_some_and(|entry| entry.kind == ChildRegistrationKind::Operation) {
+            self.operations_released.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn child_count(&self) -> usize {
+        self.children.lock().len()
+    }
+
+    pub(super) fn child_stats(&self) -> ActiveChildStats {
+        let children = self.children.lock();
+        ActiveChildStats {
+            active_operations: children
+                .values()
+                .filter(|entry| entry.kind == ChildRegistrationKind::Operation)
+                .count(),
+            operations_created: self.operations_created.load(Ordering::Relaxed),
+            operations_released: self.operations_released.load(Ordering::Relaxed),
+            registry_slots: children.len(),
+        }
+    }
+
+    pub(super) fn children_snapshot(&self) -> Vec<TaskGroup> {
+        self.children
+            .lock()
+            .values()
+            .filter_map(|entry| entry.inner.upgrade())
+            .map(|inner| TaskGroup { inner })
+            .collect()
+    }
+}

--- a/rocketmq-runtime/src/task_group/registry.rs
+++ b/rocketmq-runtime/src/task_group/registry.rs
@@ -100,11 +100,22 @@ impl ActiveTaskRegistry {
     }
 
     pub(super) fn children_snapshot(&self) -> Vec<TaskGroup> {
-        self.children
-            .lock()
-            .values()
-            .filter_map(|entry| entry.inner.upgrade())
-            .map(|inner| TaskGroup { inner })
-            .collect()
+        let mut children = self.children.lock();
+        let mut stale_operations = 0usize;
+        let mut snapshot = Vec::with_capacity(children.len());
+        children.retain(|_, entry| {
+            let Some(inner) = entry.inner.upgrade() else {
+                stale_operations += usize::from(entry.kind == ChildRegistrationKind::Operation);
+                return false;
+            };
+            snapshot.push(TaskGroup { inner });
+            true
+        });
+        drop(children);
+
+        if stale_operations > 0 {
+            self.operations_released.fetch_add(stale_operations, Ordering::Relaxed);
+        }
+        snapshot
     }
 }

--- a/rocketmq-runtime/src/task_group/shutdown.rs
+++ b/rocketmq-runtime/src/task_group/shutdown.rs
@@ -1,0 +1,84 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::sync::OnceCell;
+
+use crate::shutdown_deadline::ShutdownDeadline;
+use crate::shutdown_report::ShutdownReport;
+
+#[derive(Debug)]
+pub(super) struct ShutdownTimeout;
+
+#[derive(Debug)]
+pub(super) struct ShutdownCoordinator {
+    deadline: Mutex<Option<ShutdownDeadline>>,
+    changed: Notify,
+    pub(super) report: OnceCell<ShutdownReport>,
+}
+
+impl ShutdownCoordinator {
+    pub(super) fn new() -> Self {
+        Self {
+            deadline: Mutex::new(None),
+            changed: Notify::new(),
+            report: OnceCell::new(),
+        }
+    }
+
+    pub(super) fn deadline(&self) -> Option<ShutdownDeadline> {
+        *self.deadline.lock()
+    }
+
+    pub(super) fn tighten(&self, deadline: ShutdownDeadline) -> ShutdownDeadline {
+        let (installed, changed) = {
+            let mut current = self.deadline.lock();
+            let installed = current.map_or(deadline, |existing| existing.earliest(deadline));
+            let changed = current.is_none_or(|existing| installed.instant() < existing.instant());
+            *current = Some(installed);
+            (installed, changed)
+        };
+
+        if changed {
+            self.changed.notify_waiters();
+        }
+        installed
+    }
+
+    pub(super) async fn run_until<F>(&self, future: F) -> Result<F::Output, ShutdownTimeout>
+    where
+        F: Future,
+    {
+        tokio::pin!(future);
+        loop {
+            let changed = self.changed.notified();
+            let Some(deadline) = self.deadline() else {
+                return Ok(future.await);
+            };
+            let deadline_elapsed = tokio::time::sleep(deadline.remaining());
+            tokio::pin!(changed);
+            tokio::pin!(deadline_elapsed);
+
+            tokio::select! {
+                biased;
+                output = &mut future => return Ok(output),
+                () = &mut changed => {}
+                () = &mut deadline_elapsed => return Err(ShutdownTimeout),
+            }
+        }
+    }
+}

--- a/rocketmq-runtime/tests/task_group_concurrency_model.rs
+++ b/rocketmq-runtime/tests/task_group_concurrency_model.rs
@@ -206,14 +206,17 @@ async fn duplicate_child_names_keep_distinct_identity(group: TaskGroup) {
                 .try_child("duplicate-model-child")
                 .expect("duplicate child name should still create a distinct child");
             assert_eq!(child.parent_id(), Some(group.id()));
-            child.id()
+            child
         }));
     }
 
     let mut child_ids = HashSet::with_capacity(CHILDREN);
+    let mut children = Vec::with_capacity(CHILDREN);
     for creator in creators {
-        let child_id = creator.await.expect("child creator should not panic");
+        let child = creator.await.expect("child creator should not panic");
+        let child_id = child.id();
         assert!(child_ids.insert(child_id), "duplicate TaskGroupId: {child_id:?}");
+        children.push(child);
     }
     assert_eq!(child_ids.len(), CHILDREN);
 
@@ -224,6 +227,7 @@ async fn duplicate_child_names_keep_distinct_identity(group: TaskGroup) {
         .children
         .iter()
         .all(|child| child.name == "duplicate-model-child"));
+    drop(children);
 }
 
 async fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> Result<(), tokio::time::error::Elapsed> {

--- a/rocketmq-runtime/tests/task_group_concurrency_model.rs
+++ b/rocketmq-runtime/tests/task_group_concurrency_model.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskGroupLifecycleState;
 use tokio::sync::Barrier;
@@ -43,6 +44,33 @@ async fn dynamic_child_churn_prunes_inactive_groups_without_retaining_history() 
     let report = group.shutdown(Duration::from_secs(1)).await;
     assert!(report.is_healthy(), "{}", report.to_json());
     assert!(report.children.is_empty(), "{}", report.to_json());
+}
+
+#[tokio::test(start_paused = true)]
+async fn earliest_shutdown_deadline_wakes_existing_waiter() {
+    let context = RuntimeContext::from_current("task-group-earliest-deadline");
+    let group = context.root_group().child("deadline-owner");
+    group
+        .spawn_service("deadline-blocked-task", std::future::pending())
+        .expect("tracked task should spawn");
+
+    let shutdown_group = group.clone();
+    let late = ShutdownDeadline::after(Duration::from_secs(30));
+    let waiter = tokio::spawn(async move { shutdown_group.shutdown_until(late).await });
+    tokio::task::yield_now().await;
+
+    let early = ShutdownDeadline::after(Duration::from_millis(50));
+    drop(group.shutdown_until(early));
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(50)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        waiter.is_finished(),
+        "tightening the deadline must wake a shutdown waiter that already observed a later deadline"
+    );
+    let report = waiter.await.expect("shutdown waiter should not panic");
+    assert!(report.timed_out > 0, "{}", report.to_json());
 }
 
 async fn run_task_group_concurrency_model(group: TaskGroup) {

--- a/rocketmq-runtime/tests/task_group_history_reproducer.rs
+++ b/rocketmq-runtime/tests/task_group_history_reproducer.rs
@@ -14,15 +14,46 @@
 
 use rocketmq_runtime::RuntimeContext;
 
-const OPERATIONS: usize = 100_000;
+const PR_OPERATIONS: usize = 1_024;
 
 #[tokio::test]
-#[ignore = "red reproducer: active-only registration is implemented by issue #8849 follow-up"]
 async fn transient_static_children_do_not_retain_history_without_scrape() {
     let context = RuntimeContext::from_current("task-group-static-history-reproducer");
     let parent = context.root_group().child("component");
 
-    for index in 0..OPERATIONS {
+    exercise_static_child_churn(&parent, PR_OPERATIONS);
+}
+
+#[tokio::test]
+async fn transient_child_leases_do_not_require_a_diagnostics_scrape_for_cleanup() {
+    let context = RuntimeContext::from_current("task-group-lease-history-reproducer");
+    let parent = context.root_group().child("component");
+
+    exercise_child_lease_churn(&parent, PR_OPERATIONS);
+}
+
+#[tokio::test]
+#[ignore = "100k churn profile is reserved for explicit lifecycle validation"]
+async fn churn_100k() {
+    let context = RuntimeContext::from_current("task-group-100k-history-reproducer");
+    let parent = context.root_group().child("component");
+
+    exercise_static_child_churn(&parent, 100_000);
+    exercise_child_lease_churn(&parent, 100_000);
+}
+
+#[tokio::test]
+#[ignore = "1m churn profile is reserved for explicit lifecycle validation"]
+async fn churn_1m() {
+    let context = RuntimeContext::from_current("task-group-1m-history-reproducer");
+    let parent = context.root_group().child("component");
+
+    exercise_static_child_churn(&parent, 1_000_000);
+    exercise_child_lease_churn(&parent, 1_000_000);
+}
+
+fn exercise_static_child_churn(parent: &rocketmq_runtime::TaskGroup, operations: usize) {
+    for index in 0..operations {
         drop(parent.child(format!("operation-{index}")));
     }
 
@@ -33,13 +64,9 @@ async fn transient_static_children_do_not_retain_history_without_scrape() {
     );
 }
 
-#[tokio::test]
-#[ignore = "red reproducer: lease drop must unregister without diagnostics-driven pruning"]
-async fn transient_child_leases_do_not_require_a_diagnostics_scrape_for_cleanup() {
-    let context = RuntimeContext::from_current("task-group-lease-history-reproducer");
-    let parent = context.root_group().child("component");
-
-    for index in 0..OPERATIONS {
+fn exercise_child_lease_churn(parent: &rocketmq_runtime::TaskGroup, operations: usize) {
+    let before = parent.child_stats();
+    for index in 0..operations {
         drop(
             parent
                 .try_child_lease(format!("operation-{index}"))
@@ -49,8 +76,11 @@ async fn transient_child_leases_do_not_require_a_diagnostics_scrape_for_cleanup(
 
     let stats = parent.child_stats();
     assert_eq!(stats.active, 0);
+    assert_eq!(stats.registry_slots, 0);
+    assert_eq!(stats.created - before.created, operations);
     assert_eq!(
-        stats.pruned, 0,
-        "lease drop must unregister immediately instead of leaving cleanup to child_stats"
+        stats.pruned - before.pruned,
+        operations,
+        "lease drop must unregister immediately"
     );
 }

--- a/rocketmq-runtime/tests/task_group_shutdown_loom.rs
+++ b/rocketmq-runtime/tests/task_group_shutdown_loom.rs
@@ -36,6 +36,29 @@ struct TaskGroupModel {
     released_child_leases: usize,
 }
 
+#[derive(Debug)]
+struct RemovalModel {
+    registered: bool,
+    removals: usize,
+}
+
+impl RemovalModel {
+    fn remove_once(&mut self) -> bool {
+        if !self.registered {
+            return false;
+        }
+        self.registered = false;
+        self.removals += 1;
+        true
+    }
+}
+
+#[derive(Debug)]
+struct ChildRegistryModel {
+    registered: bool,
+    joinable: bool,
+}
+
 impl TaskGroupModel {
     fn new() -> Self {
         Self {
@@ -172,5 +195,68 @@ fn ha_reconnect_child_lease_racing_with_shutdown_is_tracked_or_rejected() {
         assert_eq!(group.lifecycle, Lifecycle::Closed);
         assert_eq!(group.accepted_child_leases, accepted);
         assert_eq!(group.released_child_leases, accepted);
+    });
+}
+
+#[test]
+fn completion_racing_with_abort_removes_the_task_once() {
+    loom::model(|| {
+        let removal = Arc::new(Mutex::new(RemovalModel {
+            registered: true,
+            removals: 0,
+        }));
+
+        let completed_removal = Arc::clone(&removal);
+        let completion = thread::spawn(move || {
+            thread::yield_now();
+            completed_removal.lock().expect("completion removal lock").remove_once()
+        });
+
+        let aborted_removal = Arc::clone(&removal);
+        let abort = thread::spawn(move || {
+            thread::yield_now();
+            aborted_removal.lock().expect("abort removal lock").remove_once()
+        });
+
+        let completed = completion.join().expect("completion thread");
+        let aborted = abort.join().expect("abort thread");
+        let removal = removal.lock().expect("final removal lock");
+        assert_ne!(completed, aborted, "exactly one racing path must remove the task");
+        assert!(!removal.registered);
+        assert_eq!(removal.removals, 1);
+    });
+}
+
+#[test]
+fn child_drop_racing_with_parent_snapshot_is_joinable_or_unregistered() {
+    loom::model(|| {
+        let registry = Arc::new(Mutex::new(ChildRegistryModel {
+            registered: true,
+            joinable: true,
+        }));
+
+        let drop_registry = Arc::clone(&registry);
+        let dropper = thread::spawn(move || {
+            drop_registry.lock().expect("last owner drop lock").joinable = false;
+            thread::yield_now();
+            drop_registry.lock().expect("child unregister lock").registered = false;
+        });
+
+        let snapshot_registry = Arc::clone(&registry);
+        let snapshot = thread::spawn(move || {
+            thread::yield_now();
+            let mut registry = snapshot_registry.lock().expect("snapshot lock");
+            if !registry.joinable {
+                registry.registered = false;
+            }
+            assert!(
+                registry.joinable || !registry.registered,
+                "a registered child snapshot must retain a joinable strong owner"
+            );
+        });
+
+        dropper.join().expect("child drop thread");
+        snapshot.join().expect("parent snapshot thread");
+        assert!(!registry.lock().expect("final child registry lock").registered);
     });
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8851

### Brief Description

- Replace historical static and dynamic child vectors with a keyed active registry that holds weak child registrations and unregisters by `TaskGroupId`.
- Move task and child lifecycle storage into a focused registry module and expose active task and registry-slot diagnostics.
- Coordinate shutdown through the earliest installed absolute deadline and wake waiters when a later owner tightens it.
- Preserve component-local shutdown evidence while parent reports contain only children that are active when parent shutdown begins.
- Turn the historical-retention reproducer into default regression coverage, retain 100k and 1m explicit churn profiles, and extend Loom and Criterion coverage for lifecycle races.

### How Did You Test This Change?

- `cargo test -p rocketmq-runtime` passed, including 120 unit tests, integration tests, compile-fail tests, Loom models, and doctests.
- The 100k and 1m ignored churn profiles passed with active registry slots returning to zero.
- `cargo bench -p rocketmq-runtime --bench task_group_lifecycle_bench` passed; the 10k register/drop/shutdown case completed at about 26.6 ms.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `cargo fmt --all -- --check` could not start on Windows because of OS error 206; the equivalent per-package check passed for all 28 root workspace packages.
- `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` passed.
- The PR static architecture runner retained the same eight pre-existing baseline failures and introduced no new failing module; the critical architecture freeze guard passed.
- Standalone consumer validation passed for RocketMQ Example, both Dashboard Rust backends, RocketMQ MCP, and the complete RocketMQ SRE workspace matrix.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime diagnostics now report active task counts and registry-slot usage.
  - Shutdown coordination now honors the earliest requested deadline and provides clearer timeout handling.

- **Bug Fixes**
  - Task groups and managed services now clean up child registrations reliably after shutdown or failed startup.
  - Shutdown reports are recorded consistently for schedulers, executors, and service managers.
  - Improved handling of concurrent task completion, cancellation, and child removal.

- **Tests**
  - Expanded coverage for shutdown races, deadline updates, cleanup, and lifecycle churn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->