### PR TITLE
[ISSUE #8857]♻️Make HA state exhaustive and mmap regions checked

### DIFF
--- a/rocketmq-store-local/src/mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file.rs
@@ -65,6 +65,7 @@ pub use mapped_buffer::MappedBuffer;
 pub use mapped_file_error::MappedFileError;
 pub use mapped_file_error::MappedFileResult;
 pub use memory::MappedMemory;
+pub use memory::MmapRangeError;
 pub use memory::MmapRegionSlice;
 pub use memory::NativeMappedMemory;
 pub use metrics::MappedFileMetrics;

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -1574,12 +1574,23 @@ mod tests {
             self.mmap.flush_range(offset, len)
         }
 
-        fn region(&self, offset: usize, len: usize) -> Self::Region {
-            TestMappedRegion {
+        fn region(&self, offset: usize, len: usize) -> Result<Self::Region, crate::mapped_file::MmapRangeError> {
+            let end = offset
+                .checked_add(len)
+                .ok_or(crate::mapped_file::MmapRangeError::Overflow { offset, len })?;
+            let mapping_len = self.mmap.len();
+            if end > mapping_len {
+                return Err(crate::mapped_file::MmapRangeError::OutOfBounds {
+                    offset,
+                    len,
+                    mapping_len,
+                });
+            }
+            Ok(TestMappedRegion {
                 mmap: self.mmap.clone(),
                 offset,
                 len,
-            }
+            })
         }
     }
 

--- a/rocketmq-store-local/src/mapped_file/memory.rs
+++ b/rocketmq-store-local/src/mapped_file/memory.rs
@@ -15,17 +15,34 @@
 use std::fs::File;
 use std::io;
 use std::ops::Deref;
+use std::ops::Range;
 use std::sync::Arc;
 
 use memmap2::MmapMut;
+
+/// Failure to construct a safe view over a mapped range.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum MmapRangeError {
+    /// `offset + len` cannot be represented by [`usize`].
+    #[error("mapped range offset {offset} + length {len} overflowed")]
+    Overflow { offset: usize, len: usize },
+    /// The representable range extends beyond the live mapping.
+    #[error("mapped range {offset}..+{len} exceeds mapping length {mapping_len}")]
+    OutOfBounds {
+        offset: usize,
+        len: usize,
+        mapping_len: usize,
+    },
+}
 
 /// Memory-mapping backend used by the canonical local mapped-file owner.
 ///
 /// # Safety
 ///
 /// Implementors must keep returned slices and regions backed by the same live mapping, serialize
-/// mutable access so it cannot race with reads or writes, and keep the mapping valid independently
-/// of compatible file-handle rename/reopen operations.
+/// mutable access so it cannot race with reads or writes, reject overflowing or out-of-bounds
+/// regions before construction, and keep the mapping valid independently of compatible file-handle
+/// rename/reopen operations.
 pub unsafe trait MappedMemory: Clone + Send + Sync + 'static {
     /// Owned immutable region suitable for zero-copy byte ownership.
     type Region: AsRef<[u8]> + Send + Sync + 'static;
@@ -79,7 +96,13 @@ pub unsafe trait MappedMemory: Clone + Send + Sync + 'static {
     fn flush_range(&self, offset: usize, len: usize) -> io::Result<()>;
 
     /// Creates an owned immutable view over one mapped range.
-    fn region(&self, offset: usize, len: usize) -> Self::Region;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MmapRangeError::Overflow`] when `offset + len` cannot be
+    /// represented, or [`MmapRangeError::OutOfBounds`] when it exceeds the
+    /// mapping.
+    fn region(&self, offset: usize, len: usize) -> Result<Self::Region, MmapRangeError>;
 }
 
 /// Native writable mmap backend used by the default Local mapped-file owner.
@@ -124,35 +147,89 @@ unsafe impl MappedMemory for NativeMappedMemory {
         self.mmap.flush_range(offset, len)
     }
 
-    fn region(&self, offset: usize, len: usize) -> Self::Region {
-        MmapRegionSlice::new(self.mmap.clone(), offset, len)
+    fn region(&self, offset: usize, len: usize) -> Result<Self::Region, MmapRangeError> {
+        MmapRegionSlice::try_new(self.mmap.clone(), offset, len)
     }
 }
 
 /// Immutable owner for one region of a native mapping.
 pub struct MmapRegionSlice {
     mmap: Arc<MmapMut>,
-    offset: usize,
-    len: usize,
+    range: Range<usize>,
 }
 
 impl MmapRegionSlice {
-    /// Creates a region backed by a live native mapping.
-    pub fn new(mmap: Arc<MmapMut>, offset: usize, len: usize) -> Self {
-        Self { mmap, offset, len }
+    /// Creates a checked region backed by a live native mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MmapRangeError::Overflow`] when `offset + len` cannot be
+    /// represented, or [`MmapRangeError::OutOfBounds`] when the resulting range
+    /// exceeds the mapping.
+    pub fn try_new(mmap: Arc<MmapMut>, offset: usize, len: usize) -> Result<Self, MmapRangeError> {
+        let range = checked_mmap_range(mmap.len(), offset, len)?;
+        Ok(Self { mmap, range })
     }
+}
+
+fn checked_mmap_range(mapping_len: usize, offset: usize, len: usize) -> Result<Range<usize>, MmapRangeError> {
+    let end = offset
+        .checked_add(len)
+        .ok_or(MmapRangeError::Overflow { offset, len })?;
+    if end > mapping_len {
+        return Err(MmapRangeError::OutOfBounds {
+            offset,
+            len,
+            mapping_len,
+        });
+    }
+    Ok(offset..end)
 }
 
 impl Deref for MmapRegionSlice {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &self.mmap[self.offset..self.offset + self.len]
+        &self.mmap[self.range.clone()]
     }
 }
 
 impl AsRef<[u8]> for MmapRegionSlice {
     fn as_ref(&self) -> &[u8] {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_ranges_distinguish_valid_overflow_and_out_of_bounds() {
+        assert_eq!(checked_mmap_range(8, 0, 0), Ok(0..0));
+        assert_eq!(checked_mmap_range(8, 0, 8), Ok(0..8));
+        assert_eq!(checked_mmap_range(8, 8, 0), Ok(8..8));
+        assert_eq!(
+            checked_mmap_range(8, 8, 1),
+            Err(MmapRangeError::OutOfBounds {
+                offset: 8,
+                len: 1,
+                mapping_len: 8,
+            })
+        );
+        assert_eq!(
+            checked_mmap_range(8, usize::MAX, 1),
+            Err(MmapRangeError::Overflow {
+                offset: usize::MAX,
+                len: 1,
+            })
+        );
+        assert_eq!(
+            checked_mmap_range(8, 1, usize::MAX),
+            Err(MmapRangeError::Overflow {
+                offset: 1,
+                len: usize::MAX,
+            })
+        );
     }
 }

--- a/rocketmq-store-local/tests/mmap_region_bounds.rs
+++ b/rocketmq-store-local/tests/mmap_region_bounds.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic::catch_unwind;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use memmap2::MmapMut;
+use rocketmq_store_local::mapped_file::MmapRangeError;
+use rocketmq_store_local::mapped_file::MmapRegionSlice;
+
+#[derive(Debug, Clone, Copy)]
+enum Expected {
+    Valid(usize),
+    Overflow,
+    OutOfBounds,
+}
+
+#[test]
+fn safe_region_construction_never_panics_and_classifies_invalid_ranges() {
+    let mapping_len = 8;
+    let mmap = Arc::new(MmapMut::map_anon(mapping_len).expect("create anonymous mapping"));
+    let cases = [
+        (0, 0, Expected::Valid(0)),
+        (0, mapping_len, Expected::Valid(mapping_len)),
+        (mapping_len, 0, Expected::Valid(0)),
+        (mapping_len, 1, Expected::OutOfBounds),
+        (usize::MAX, 1, Expected::Overflow),
+        (1, usize::MAX, Expected::Overflow),
+    ];
+
+    for (offset, len, expected) in cases {
+        let outcome = catch_unwind(AssertUnwindSafe({
+            let mmap = Arc::clone(&mmap);
+            move || MmapRegionSlice::try_new(mmap, offset, len)
+        }));
+        let result = outcome.unwrap_or_else(|_| panic!("safe constructor panicked for offset={offset}, len={len}"));
+
+        match expected {
+            Expected::Valid(expected_len) => {
+                let region =
+                    result.unwrap_or_else(|error| panic!("valid range offset={offset}, len={len} returned {error}"));
+                assert_eq!(region.as_ref().len(), expected_len);
+            }
+            Expected::Overflow => {
+                assert!(
+                    matches!(result, Err(MmapRangeError::Overflow { offset: actual_offset, len: actual_len })
+                        if actual_offset == offset && actual_len == len),
+                    "expected overflow for offset={offset}, len={len}"
+                );
+            }
+            Expected::OutOfBounds => {
+                assert!(
+                    matches!(
+                        result,
+                        Err(MmapRangeError::OutOfBounds {
+                            offset: actual_offset,
+                            len: actual_len,
+                            mapping_len: actual_mapping_len,
+                        }) if actual_offset == offset
+                            && actual_len == len
+                            && actual_mapping_len == mapping_len
+                    ),
+                    "expected out-of-bounds for offset={offset}, len={len}"
+                );
+            }
+        }
+    }
+}

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -712,7 +712,7 @@ impl HAService for DefaultHAService {
             connections
                 .values()
                 .find(|connection| connection.remote_address() == remote_addr)
-                .and_then(GeneralHAConnection::runtime_handle)
+                .map(GeneralHAConnection::runtime_handle)
         };
         match connection_runtime {
             Some(connection) => Some(connection.current_state().await),
@@ -806,9 +806,9 @@ impl AcceptSocketService {
         let default_connection =
             DefaultHAConnection::new(runtime_scope, connection_context, stream, message_store_config, addr).await?;
         let general_connection = if is_auto_switch {
-            GeneralHAConnection::new_with_auto_switch_ha_connection(AutoSwitchHAConnection::new(default_connection))
+            GeneralHAConnection::AutoSwitch(AutoSwitchHAConnection::new(default_connection))
         } else {
-            GeneralHAConnection::new_with_default_ha_connection(default_connection)
+            GeneralHAConnection::Default(default_connection)
         };
         Ok(general_connection)
     }
@@ -1091,10 +1091,48 @@ mod tests {
         .await
         .expect("build auto-switch connection");
 
+        assert!(matches!(&connection, GeneralHAConnection::AutoSwitch(_)));
         assert!(connection.is_auto_switch());
         assert_eq!(connection.slave_broker_id(), None);
+        let runtime_handle = connection.runtime_handle();
+        assert_eq!(runtime_handle.remote_address(), remote_addr.to_string());
+        assert_eq!(runtime_handle.slave_broker_id(), None);
         connection.set_slave_broker_id(Some(9));
         assert_eq!(connection.slave_broker_id(), Some(9));
+        assert_eq!(runtime_handle.slave_broker_id(), Some(9));
+
+        connection.shutdown().await;
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn build_connection_uses_default_variant_when_auto_switch_is_disabled() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-build-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, false);
+        let service = new_default_ha_service(&store);
+        let (server_stream, remote_addr, _client) = new_server_stream().await;
+
+        let mut connection = AcceptSocketService::build_connection(
+            service.runtime_scope.clone(),
+            service.connection_context(),
+            service.replica_store().message_store_config(),
+            server_stream,
+            remote_addr,
+            false,
+        )
+        .await
+        .expect("build default connection");
+
+        assert!(matches!(&connection, GeneralHAConnection::Default(_)));
+        assert!(!connection.is_auto_switch());
+        assert_eq!(connection.slave_broker_id(), None);
+        let runtime_handle = connection.runtime_handle();
+        assert_eq!(runtime_handle.remote_address(), remote_addr.to_string());
+        assert_eq!(runtime_handle.slave_broker_id(), None);
+        connection.set_slave_broker_id(Some(9));
+        assert_eq!(connection.slave_broker_id(), None);
+        assert_eq!(runtime_handle.slave_broker_id(), None);
 
         connection.shutdown().await;
 

--- a/rocketmq-store/src/ha/general_ha_connection.rs
+++ b/rocketmq-store/src/ha/general_ha_connection.rs
@@ -22,178 +22,113 @@ use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::HAConnectionError;
 
-#[derive(Default)]
-pub struct GeneralHAConnection {
-    default_ha_connection: Option<DefaultHAConnection>,
-    auto_switch_ha_connection: Option<AutoSwitchHAConnection>,
+pub enum GeneralHAConnection {
+    Default(DefaultHAConnection),
+    AutoSwitch(AutoSwitchHAConnection),
 }
 
 impl GeneralHAConnection {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn new_with_default_ha_connection(default_ha_connection: DefaultHAConnection) -> Self {
-        GeneralHAConnection {
-            default_ha_connection: Some(default_ha_connection),
-            auto_switch_ha_connection: None,
-        }
-    }
-
-    pub fn new_with_auto_switch_ha_connection(auto_switch_ha_connection: AutoSwitchHAConnection) -> Self {
-        GeneralHAConnection {
-            default_ha_connection: None,
-            auto_switch_ha_connection: Some(auto_switch_ha_connection),
-        }
-    }
-
-    pub fn set_default_ha_connection(&mut self, connection: DefaultHAConnection) {
-        self.default_ha_connection = Some(connection);
-    }
-
-    pub fn set_auto_switch_ha_connection(&mut self, connection: AutoSwitchHAConnection) {
-        self.auto_switch_ha_connection = Some(connection);
-    }
-
     pub fn is_auto_switch(&self) -> bool {
-        self.auto_switch_ha_connection.is_some()
+        matches!(self, Self::AutoSwitch(_))
     }
 
     pub fn set_slave_broker_id(&self, slave_broker_id: Option<i64>) {
-        if let Some(connection) = &self.auto_switch_ha_connection {
-            connection.set_slave_broker_id(slave_broker_id);
+        match self {
+            Self::Default(_) => {}
+            Self::AutoSwitch(connection) => connection.set_slave_broker_id(slave_broker_id),
         }
     }
 
     pub fn slave_broker_id(&self) -> Option<i64> {
-        self.auto_switch_ha_connection
-            .as_ref()
-            .and_then(|connection| connection.slave_broker_id())
+        match self {
+            Self::Default(_) => None,
+            Self::AutoSwitch(connection) => connection.slave_broker_id(),
+        }
     }
 
-    pub(crate) fn runtime_handle(&self) -> Option<HAConnectionRuntimeHandle> {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => Some(connection.runtime_handle()),
-            (_, Some(connection)) => Some(connection.runtime_handle()),
-            (None, None) => None,
+    pub(crate) fn runtime_handle(&self) -> HAConnectionRuntimeHandle {
+        match self {
+            Self::Default(connection) => connection.runtime_handle(),
+            Self::AutoSwitch(connection) => connection.runtime_handle(),
         }
     }
 }
 
 impl HAConnection for GeneralHAConnection {
     async fn start(&mut self) -> Result<(), HAConnectionError> {
-        match (&mut self.default_ha_connection, &mut self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.start().await,
-            (_, Some(connection)) => connection.start().await,
-            (None, None) => Err(HAConnectionError::Connection("No HA connection set".to_string())),
+        match self {
+            Self::Default(connection) => connection.start().await,
+            Self::AutoSwitch(connection) => connection.start().await,
         }
     }
 
     async fn shutdown(&mut self) {
-        match (&mut self.default_ha_connection, &mut self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.shutdown().await,
-            (_, Some(connection)) => connection.shutdown().await,
-            (None, None) => {
-                tracing::warn!("No HA connection to shutdown");
-            }
+        match self {
+            Self::Default(connection) => connection.shutdown().await,
+            Self::AutoSwitch(connection) => connection.shutdown().await,
         }
     }
 
     fn close(&self) {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.close(),
-            (_, Some(connection)) => connection.close(),
-            (None, None) => {
-                tracing::warn!("No HA connection to close");
-            }
+        match self {
+            Self::Default(connection) => connection.close(),
+            Self::AutoSwitch(connection) => connection.close(),
         }
     }
 
     fn get_socket(&self) -> &TcpStream {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_socket(),
-            (_, Some(connection)) => connection.get_socket(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get socket from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_socket(),
+            Self::AutoSwitch(connection) => connection.get_socket(),
         }
     }
 
     async fn get_current_state(&self) -> HAConnectionState {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_current_state().await,
-            (_, Some(connection)) => connection.get_current_state().await,
-            (None, None) => {
-                tracing::warn!("No HA connection to get current state from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_current_state().await,
+            Self::AutoSwitch(connection) => connection.get_current_state().await,
         }
     }
 
     fn get_client_address(&self) -> &str {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_client_address(),
-            (_, Some(connection)) => connection.get_client_address(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get client address from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_client_address(),
+            Self::AutoSwitch(connection) => connection.get_client_address(),
         }
     }
 
     fn get_transferred_byte_in_second(&self) -> i64 {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_transferred_byte_in_second(),
-            (_, Some(connection)) => connection.get_transferred_byte_in_second(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get transferred bytes from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_transferred_byte_in_second(),
+            Self::AutoSwitch(connection) => connection.get_transferred_byte_in_second(),
         }
     }
 
     fn get_transfer_from_where(&self) -> i64 {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_transfer_from_where(),
-            (_, Some(connection)) => connection.get_transfer_from_where(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get transfer offset from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_transfer_from_where(),
+            Self::AutoSwitch(connection) => connection.get_transfer_from_where(),
         }
     }
 
     fn get_slave_ack_offset(&self) -> i64 {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_slave_ack_offset(),
-            (_, Some(connection)) => connection.get_slave_ack_offset(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get slave ack offset from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_slave_ack_offset(),
+            Self::AutoSwitch(connection) => connection.get_slave_ack_offset(),
         }
     }
 
     fn get_ha_connection_id(&self) -> &HAConnectionId {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.get_ha_connection_id(),
-            (_, Some(connection)) => connection.get_ha_connection_id(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get ID from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.get_ha_connection_id(),
+            Self::AutoSwitch(connection) => connection.get_ha_connection_id(),
         }
     }
 
     fn remote_address(&self) -> String {
-        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
-            (Some(connection), _) => connection.remote_address(),
-            (_, Some(connection)) => connection.remote_address(),
-            (None, None) => {
-                tracing::warn!("No HA connection to get remote address from");
-                panic!("No HA connection available");
-            }
+        match self {
+            Self::Default(connection) => connection.remote_address(),
+            Self::AutoSwitch(connection) => connection.remote_address(),
         }
     }
 }

--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -30,6 +30,7 @@ mod builder;
 mod memory;
 
 pub use builder::MappedFileBuilder;
+pub use memory::MmapRangeError;
 pub use memory::MmapRegionSlice;
 pub use memory::StoreMappedMemory;
 pub use rocketmq_store_local::mapped_file::io_uring_backend_status;

--- a/rocketmq-store/src/log_file/mapped_file/memory.rs
+++ b/rocketmq-store/src/log_file/mapped_file/memory.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use rocketmq_store_local::mapped_file::MmapRangeError;
 pub use rocketmq_store_local::mapped_file::MmapRegionSlice;
 pub use rocketmq_store_local::mapped_file::NativeMappedMemory as StoreMappedMemory;

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -135,6 +135,7 @@ pub use crate::log_file::mapped_file::MappedFileBuilder;
 pub use crate::log_file::mapped_file::MappedFileError;
 pub use crate::log_file::mapped_file::MappedFileMetrics;
 pub use crate::log_file::mapped_file::MappedFileResult;
+pub use crate::log_file::mapped_file::MmapRangeError;
 pub use crate::log_file::mapped_file::MmapRegionSlice;
 pub use crate::log_file::mapped_file::StoreMappedMemory;
 pub use crate::log_file::MAX_PULL_MSG_SIZE;

--- a/rocketmq-store/tests/ha_connection_state.rs
+++ b/rocketmq-store/tests/ha_connection_state.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const GENERAL_HA_CONNECTION: &str = include_str!("../src/ha/general_ha_connection.rs");
+
+#[test]
+fn general_ha_connection_has_only_two_constructible_states() {
+    let normalized = GENERAL_HA_CONNECTION.replace("\r\n", "\n");
+    assert!(
+        normalized.contains(concat!(
+            "pub enum GeneralHAConnection {\n",
+            "    Default(DefaultHAConnection),\n",
+            "    AutoSwitch(AutoSwitchHAConnection),\n",
+            "}"
+        )),
+        "GeneralHAConnection must expose exactly the two valid variants"
+    );
+
+    for removed_api in [
+        "pub fn new()",
+        "new_with_default_ha_connection",
+        "new_with_auto_switch_ha_connection",
+        "set_default_ha_connection",
+        "set_auto_switch_ha_connection",
+    ] {
+        assert!(
+            !GENERAL_HA_CONNECTION.contains(removed_api),
+            "obsolete HA state API remains: {removed_api}"
+        );
+    }
+
+    assert!(
+        !GENERAL_HA_CONNECTION.contains("panic!("),
+        "exhaustive HA delegation must not contain impossible-state panic arms"
+    );
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8857

### Brief Description

- Replace the dual-`Option` `GeneralHAConnection` representation with exhaustive `Default` and `AutoSwitch` variants.
- Remove the empty HA constructor, implementation setters, and impossible-state panic branches.
- Add a typed `MmapRangeError` and make `MmapRegionSlice::try_new` reject arithmetic overflow and out-of-bounds ranges before a safe region can be constructed.
- Make `MappedMemory::region` fallible and update the native and test backends without adding unsafe code.
- Add state-shape, HA behavior, mmap boundary, Miri-safe range-core, public API, and storage-layout regression coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-store-local -p rocketmq-store -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-store-local`
- `cargo test -p rocketmq-store-local --test mmap_region_bounds`
- `cargo test -p rocketmq-store-local --test storage_layout_golden`
- `cargo test -p rocketmq-store ha`
- `cargo test -p rocketmq-store --test ha_connection_state`
- `cargo test -p rocketmq-store build_connection_`
- `cargo test -p rocketmq-store --test public_api_contract`
- `cargo +nightly-2026-07-05 miri test -p rocketmq-store-local --lib mapped_file::memory::tests::checked_ranges_distinguish_valid_overflow_and_out_of_bounds -- --exact`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo doc -p rocketmq-store-local -p rocketmq-store --no-deps`
- `git diff --check`

The root `cargo fmt --all -- --check` command cannot start on this Windows checkout because the process command line exceeds the platform limit (OS error 206). The package-scoped non-mutating format check passed for both affected crates.

The exact mmap integration test under Miri was also attempted. Windows Miri rejects the `memmap2` `CreateFileMappingW` foreign call as an unsupported interpreter operation, explicitly noting that this is not a program defect. The same boundary table passes against a real anonymous mapping in the normal test runner, while Miri passes against the pure checked-range function used by the constructor.

The full Store suite reports 548 passing tests and the same two TaskGroup restart-count failures reproduced individually on the PR04 baseline. All 110 HA-filtered tests pass. The repository-wide `pr_static` runner retains eight pre-existing stale-baseline failures; this change adds no unsafe code or architecture-baseline update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapped-memory range validation to detect arithmetic overflow and out-of-bounds access without panics.
  * Added clear error reporting for invalid memory-region requests.
  * Improved high-availability connection handling with consistent runtime-handle access and safer connection state management.
* **Reliability**
  * Expanded coverage for valid, empty, overflowing, and out-of-bounds memory ranges.
  * Added verification for default and auto-switch high-availability connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->