### PR TITLE
[ISSUE #8859]🚀Add deadline-aware budgeted queue admission

### DIFF
--- a/rocketmq-observability/src/exporter/outage.rs
+++ b/rocketmq-observability/src/exporter/outage.rs
@@ -323,6 +323,7 @@ impl<T> TelemetryOutageQueue<T> {
         if let Err(error) = self.queue.try_push_data(record, estimated_bytes) {
             let reason = match error.kind() {
                 QueuePushErrorKind::Closed | QueuePushErrorKind::SlowConsumerClosed => TelemetryDropReason::Closed,
+                QueuePushErrorKind::DeadlineExceeded => TelemetryDropReason::ItemLimit,
                 QueuePushErrorKind::BudgetExhausted(error) => match error.dimension() {
                     BudgetDimension::Bytes => TelemetryDropReason::ByteLimit,
                     // This queue has no rate budget. Keep the exhaustive fallback fail-closed if

--- a/rocketmq-proxy-cluster/src/cluster_admission.rs
+++ b/rocketmq-proxy-cluster/src/cluster_admission.rs
@@ -226,7 +226,7 @@ impl ClusterExecutionLanes {
                     "proxy cluster command admission rejected"
                 );
                 match kind {
-                    QueuePushErrorKind::BudgetExhausted(_) => {
+                    QueuePushErrorKind::BudgetExhausted(_) | QueuePushErrorKind::DeadlineExceeded => {
                         Err(ProxyError::too_many_requests("proxy-cluster-command-queue"))
                     }
                     QueuePushErrorKind::Closed | QueuePushErrorKind::SlowConsumerClosed => Err(ProxyError::Transport {

--- a/rocketmq-runtime/Cargo.toml
+++ b/rocketmq-runtime/Cargo.toml
@@ -77,3 +77,7 @@ harness = false
 [[bench]]
 name    = "blocking_executor_bench"
 harness = false
+
+[[bench]]
+name    = "budgeted_queue_bench"
+harness = false

--- a/rocketmq-runtime/benches/budgeted_queue_bench.rs
+++ b/rocketmq-runtime/benches/budgeted_queue_bench.rs
@@ -1,0 +1,118 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::BudgetedQueue;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudgetTree;
+use tokio::task::JoinSet;
+use tokio::time::Instant;
+
+fn queue(capacity: usize, policy: FullPolicy) -> BudgetedQueue<usize> {
+    let budget = ResourceBudgetTree::new("budgeted-queue-bench", BudgetLimit::new(capacity, capacity, policy))
+        .expect("benchmark budget should be valid");
+    BudgetedQueue::new(budget.root())
+}
+
+fn reject_batch(size: usize) {
+    let queue = queue(size, FullPolicy::Reject);
+    for item in 0..size {
+        black_box(queue.try_push_data(black_box(item), 1).expect("batch item should fit"));
+    }
+    black_box(
+        queue
+            .try_push_data(size, 1)
+            .expect_err("full reject queue should reject"),
+    );
+    for _ in 0..size {
+        black_box(queue.try_pop().expect("queued item"));
+    }
+}
+
+async fn wait_release_batch(size: usize) {
+    let queue = queue(size, FullPolicy::WaitUntilDeadline);
+    for item in 0..size {
+        queue.try_push_data(item, 1).expect("initial batch should fit");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut producers = JoinSet::new();
+    for item in size..size.saturating_mul(2) {
+        let queue = queue.clone();
+        producers.spawn(async move {
+            queue
+                .push_until(item, 1, BudgetClass::Data, deadline)
+                .await
+                .expect("released capacity should admit waiter");
+        });
+    }
+
+    while queue.snapshot().waiters < size {
+        tokio::task::yield_now().await;
+    }
+    for _ in 0..size {
+        black_box(queue.try_pop().expect("initial queued item"));
+    }
+    while let Some(result) = producers.join_next().await {
+        result.expect("benchmark producer should complete");
+    }
+    for _ in 0..size {
+        black_box(queue.try_pop().expect("waiter queued item"));
+    }
+
+    let snapshot = queue.snapshot();
+    assert_eq!(snapshot.wait_count, size as u64);
+    assert_eq!(snapshot.reserved_count, 0);
+    assert_eq!(snapshot.retained_bytes, 0);
+}
+
+fn bench_budgeted_queue(criterion: &mut Criterion) {
+    let mut reject = criterion.benchmark_group("budgeted_queue_reject");
+    for size in [128usize, 1024] {
+        reject.bench_with_input(BenchmarkId::new("push_pop", size), &size, |bencher, size| {
+            bencher.iter(|| reject_batch(black_box(*size)));
+        });
+    }
+    reject.finish();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("benchmark runtime");
+    let mut wait = criterion.benchmark_group("budgeted_queue_wait_release");
+    for size in [128usize, 1024] {
+        wait.bench_with_input(BenchmarkId::new("contended", size), &size, |bencher, size| {
+            bencher.iter(|| runtime.block_on(wait_release_batch(black_box(*size))));
+        });
+    }
+    wait.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(500));
+    targets = bench_budgeted_queue
+}
+criterion_main!(benches);

--- a/rocketmq-runtime/src/resource_budget/budget.rs
+++ b/rocketmq-runtime/src/resource_budget/budget.rs
@@ -18,6 +18,7 @@ use std::sync::Mutex;
 
 use smallvec::SmallVec;
 use std::time::Duration;
+use tokio::sync::Notify;
 
 use super::clock::MonotonicClock;
 use super::clock::SystemMonotonicClock;
@@ -118,10 +119,12 @@ impl ResourceBudgetTree {
         let name = validated_name(name.into())?;
         limit.validate(&name)?;
         let node = Arc::new(BudgetNode::new(Arc::from(name.as_str()), limit, clock));
+        let capacity_notify = Arc::new(Notify::new());
         Ok(Self {
             root: ResourceBudget {
                 node: Arc::clone(&node),
                 chain: Arc::from([node]),
+                capacity_notify,
             },
         })
     }
@@ -138,6 +141,7 @@ impl ResourceBudgetTree {
 pub struct ResourceBudget {
     node: Arc<BudgetNode>,
     chain: Arc<[Arc<BudgetNode>]>,
+    capacity_notify: Arc<Notify>,
 }
 
 impl fmt::Debug for ResourceBudget {
@@ -163,18 +167,36 @@ impl ResourceBudget {
         Ok(Self {
             node,
             chain: Arc::from(chain),
+            capacity_notify: Arc::clone(&self.capacity_notify),
         })
     }
 
     /// Attempts to acquire.
     pub fn try_acquire(&self, bytes: usize, class: BudgetClass) -> Result<ResourcePermit, BudgetAcquireError> {
+        self.try_acquire_internal(bytes, class, true)
+    }
+
+    pub(crate) fn try_acquire_waiting(
+        &self,
+        bytes: usize,
+        class: BudgetClass,
+    ) -> Result<ResourcePermit, BudgetAcquireError> {
+        self.try_acquire_internal(bytes, class, false)
+    }
+
+    fn try_acquire_internal(
+        &self,
+        bytes: usize,
+        class: BudgetClass,
+        record_failure: bool,
+    ) -> Result<ResourcePermit, BudgetAcquireError> {
         let mut reservations = SmallVec::<[NodeReservation; 4]>::with_capacity(self.chain.len());
         for node in self.chain.iter() {
             match node.try_reserve(bytes, class) {
                 Ok(reservation) => reservations.push(reservation),
                 Err(dimension) => {
-                    if !Arc::ptr_eq(node, &self.node) {
-                        self.node.record_rejection(dimension);
+                    if record_failure {
+                        self.record_rejection(node, dimension);
                     }
                     return Err(BudgetAcquireError {
                         path: Arc::clone(&self.node.path),
@@ -192,7 +214,42 @@ impl ResourceBudget {
             reservations,
             bytes,
             class,
+            capacity_notify: Arc::clone(&self.capacity_notify),
         })
+    }
+
+    pub(crate) fn permanent_acquire_error(&self, bytes: usize, class: BudgetClass) -> Option<BudgetAcquireError> {
+        self.chain.iter().find_map(|node| {
+            let dimension = node.permanent_exhaustion_dimension(bytes, class)?;
+            self.record_rejection(node, dimension);
+            Some(BudgetAcquireError {
+                path: Arc::clone(&self.node.path),
+                exhausted_path: Arc::clone(&node.path),
+                dimension,
+                policy: self.node.limit.full_policy,
+            })
+        })
+    }
+
+    pub(crate) fn record_acquire_error(&self, error: &BudgetAcquireError) {
+        if let Some(node) = self
+            .chain
+            .iter()
+            .find(|node| node.path.as_ref() == error.exhausted_path())
+        {
+            self.record_rejection(node, error.dimension());
+        }
+    }
+
+    fn record_rejection(&self, exhausted_node: &Arc<BudgetNode>, dimension: BudgetDimension) {
+        exhausted_node.record_rejection(dimension);
+        if !Arc::ptr_eq(exhausted_node, &self.node) {
+            self.node.record_rejection(dimension);
+        }
+    }
+
+    pub(crate) fn capacity_notify(&self) -> &Notify {
+        &self.capacity_notify
     }
 
     /// Attempts to acquire data.
@@ -261,6 +318,7 @@ pub struct ResourcePermit {
     reservations: SmallVec<[NodeReservation; 4]>,
     bytes: usize,
     class: BudgetClass,
+    capacity_notify: Arc<Notify>,
 }
 
 impl fmt::Debug for ResourcePermit {
@@ -288,6 +346,13 @@ impl ResourcePermit {
     /// Returns the class.
     pub const fn class(&self) -> BudgetClass {
         self.class
+    }
+}
+
+impl Drop for ResourcePermit {
+    fn drop(&mut self) {
+        self.reservations.clear();
+        self.capacity_notify.notify_waiters();
     }
 }
 
@@ -349,10 +414,6 @@ impl BudgetNode {
         };
 
         if let Some(dimension) = dimension {
-            state.rejected_count = state.rejected_count.saturating_add(1);
-            if dimension == BudgetDimension::Rate {
-                state.throttled_count = state.throttled_count.saturating_add(1);
-            }
             return Err(dimension);
         }
 
@@ -371,6 +432,29 @@ impl BudgetNode {
             class,
             committed: false,
         })
+    }
+
+    fn permanent_exhaustion_dimension(&self, bytes: usize, class: BudgetClass) -> Option<BudgetDimension> {
+        let (count_capacity, byte_capacity) = match class {
+            BudgetClass::Data => (
+                self.limit
+                    .capacity
+                    .count
+                    .saturating_sub(self.limit.control_reserve.count),
+                self.limit
+                    .capacity
+                    .bytes
+                    .saturating_sub(self.limit.control_reserve.bytes),
+            ),
+            BudgetClass::Control => (self.limit.capacity.count, self.limit.capacity.bytes),
+        };
+        if count_capacity == 0 {
+            Some(BudgetDimension::Count)
+        } else if bytes > byte_capacity {
+            Some(BudgetDimension::Bytes)
+        } else {
+            None
+        }
     }
 
     fn record_rejection(&self, dimension: BudgetDimension) {

--- a/rocketmq-runtime/src/resource_budget/limit.rs
+++ b/rocketmq-runtime/src/resource_budget/limit.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 pub enum FullPolicy {
     /// Represents the reject case.
     Reject,
+    /// Waits for capacity until the caller-provided absolute deadline.
+    WaitUntilDeadline,
     /// Represents the coalesce latest case.
     CoalesceLatest,
     /// Represents the drop stale case.

--- a/rocketmq-runtime/src/resource_budget/queue.rs
+++ b/rocketmq-runtime/src/resource_budget/queue.rs
@@ -14,11 +14,15 @@
 
 use std::collections::VecDeque;
 use std::fmt;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
 use tokio::sync::Notify;
+use tokio::time::Instant;
 
 use super::budget::BudgetAcquireError;
 use super::budget::ResourceBudget;
@@ -49,6 +53,8 @@ pub enum QueuePushOutcome {
 pub enum QueuePushErrorKind {
     /// Represents the budget exhausted case.
     BudgetExhausted(BudgetAcquireError),
+    /// The absolute admission deadline elapsed before capacity became available.
+    DeadlineExceeded,
     /// Represents the closed case.
     Closed,
     /// Represents the slow consumer closed case.
@@ -88,6 +94,9 @@ impl<T> fmt::Display for QueuePushError<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
             QueuePushErrorKind::BudgetExhausted(error) => error.fmt(formatter),
+            QueuePushErrorKind::DeadlineExceeded => {
+                formatter.write_str("resource-budgeted queue admission deadline exceeded")
+            }
             QueuePushErrorKind::Closed => formatter.write_str("resource-budgeted queue is closed"),
             QueuePushErrorKind::SlowConsumerClosed => {
                 formatter.write_str("resource-budgeted queue closed its slow consumer")
@@ -154,6 +163,12 @@ pub struct QueueSnapshot {
     pub coalesced_count: u64,
     /// The number of closed slow consumer entries.
     pub closed_slow_consumer_count: u64,
+    /// The number of producers currently waiting for admission.
+    pub waiters: usize,
+    /// The cumulative number of producers that waited for admission.
+    pub wait_count: u64,
+    /// The number of items returned because their admission deadline elapsed.
+    pub deadline_exceeded_count: u64,
     /// Whether closed.
     pub closed: bool,
 }
@@ -193,6 +208,7 @@ impl<T> BudgetedQueue<T> {
                 }),
                 coalesce_push: Mutex::new(()),
                 notify: Notify::new(),
+                metrics: QueueMetrics::default(),
             }),
         }
     }
@@ -242,6 +258,101 @@ impl<T> BudgetedQueue<T> {
     /// Attempts to push control.
     pub fn try_push_control(&self, item: T, retained_bytes: usize) -> Result<QueuePushOutcome, QueuePushError<T>> {
         self.try_push(item, retained_bytes, BudgetClass::Control)
+    }
+
+    /// Pushes one item, waiting for count and byte capacity until an absolute
+    /// Tokio deadline when this queue uses [`FullPolicy::WaitUntilDeadline`].
+    ///
+    /// Other full policies retain their existing immediate behavior. Rate
+    /// exhaustion remains an immediate [`QueuePushErrorKind::BudgetExhausted`]
+    /// result because capacity-release notifications do not represent token
+    /// refill time.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original item with [`QueuePushErrorKind::DeadlineExceeded`]
+    /// when the deadline elapses, [`QueuePushErrorKind::Closed`] when the queue
+    /// closes, or [`QueuePushErrorKind::BudgetExhausted`] when the item can
+    /// never fit or rate capacity is unavailable.
+    pub async fn push_until(
+        &self,
+        item: T,
+        retained_bytes: usize,
+        class: BudgetClass,
+        deadline: Instant,
+    ) -> Result<QueuePushOutcome, QueuePushError<T>> {
+        if self.inner.budget.limit().full_policy != FullPolicy::WaitUntilDeadline {
+            return self.try_push(item, retained_bytes, class);
+        }
+        if self.is_closed() {
+            return Err(QueuePushError {
+                kind: QueuePushErrorKind::Closed,
+                item,
+            });
+        }
+        if let Some(error) = self.inner.budget.permanent_acquire_error(retained_bytes, class) {
+            return Err(QueuePushError {
+                kind: QueuePushErrorKind::BudgetExhausted(error),
+                item,
+            });
+        }
+
+        let mut waiter = None;
+        loop {
+            let capacity_notified = self.inner.budget.capacity_notify().notified();
+            tokio::pin!(capacity_notified);
+            capacity_notified.as_mut().enable();
+            let state_notified = self.inner.notify.notified();
+            tokio::pin!(state_notified);
+            state_notified.as_mut().enable();
+
+            if self.is_closed() {
+                return Err(QueuePushError {
+                    kind: QueuePushErrorKind::Closed,
+                    item,
+                });
+            }
+            if Instant::now() >= deadline {
+                self.inner.metrics.record_deadline_exceeded();
+                return Err(QueuePushError {
+                    kind: QueuePushErrorKind::DeadlineExceeded,
+                    item,
+                });
+            }
+
+            match self.inner.budget.try_acquire_waiting(retained_bytes, class) {
+                Ok(permit) => {
+                    self.enqueue(item, permit)?;
+                    return Ok(QueuePushOutcome::Enqueued);
+                }
+                Err(error) if error.dimension() == BudgetDimension::Rate => {
+                    self.inner.budget.record_acquire_error(&error);
+                    return Err(QueuePushError {
+                        kind: QueuePushErrorKind::BudgetExhausted(error),
+                        item,
+                    });
+                }
+                Err(_) => {}
+            }
+
+            if waiter.is_none() {
+                waiter = Some(self.inner.metrics.begin_wait());
+            }
+            let deadline_sleep = tokio::time::sleep_until(deadline);
+            tokio::pin!(deadline_sleep);
+            tokio::select! {
+                biased;
+                () = &mut deadline_sleep => {
+                    self.inner.metrics.record_deadline_exceeded();
+                    return Err(QueuePushError {
+                        kind: QueuePushErrorKind::DeadlineExceeded,
+                        item,
+                    });
+                }
+                () = &mut state_notified => {}
+                () = &mut capacity_notified => {}
+            }
+        }
     }
 
     /// Attempts to pop.
@@ -354,6 +465,9 @@ impl<T> BudgetedQueue<T> {
             dropped_count: budget.dropped_count,
             coalesced_count: budget.coalesced_count,
             closed_slow_consumer_count: budget.closed_slow_consumer_count,
+            waiters: self.inner.metrics.waiters.load(Ordering::Acquire),
+            wait_count: self.inner.metrics.wait_count.load(Ordering::Relaxed),
+            deadline_exceeded_count: self.inner.metrics.deadline_exceeded_count.load(Ordering::Relaxed),
             closed: state.closed,
         }
     }
@@ -388,7 +502,7 @@ impl<T> BudgetedQueue<T> {
         error: BudgetAcquireError,
     ) -> Result<QueuePushOutcome, QueuePushError<T>> {
         match self.inner.budget.limit().full_policy {
-            FullPolicy::Reject | FullPolicy::DropStale => Err(QueuePushError {
+            FullPolicy::Reject | FullPolicy::WaitUntilDeadline | FullPolicy::DropStale => Err(QueuePushError {
                 kind: QueuePushErrorKind::BudgetExhausted(error),
                 item,
             }),
@@ -518,9 +632,40 @@ struct QueueInner<T> {
     state: Mutex<QueueState<T>>,
     coalesce_push: Mutex<()>,
     notify: Notify,
+    metrics: QueueMetrics,
 }
 
 struct QueueState<T> {
     items: VecDeque<BudgetedItem<T>>,
     closed: bool,
+}
+
+#[derive(Default)]
+struct QueueMetrics {
+    waiters: AtomicUsize,
+    wait_count: AtomicU64,
+    deadline_exceeded_count: AtomicU64,
+}
+
+impl QueueMetrics {
+    fn begin_wait(&self) -> WaiterGuard<'_> {
+        self.wait_count.fetch_add(1, Ordering::Relaxed);
+        self.waiters.fetch_add(1, Ordering::AcqRel);
+        WaiterGuard { metrics: self }
+    }
+
+    fn record_deadline_exceeded(&self) {
+        self.deadline_exceeded_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+struct WaiterGuard<'a> {
+    metrics: &'a QueueMetrics,
+}
+
+impl Drop for WaiterGuard<'_> {
+    fn drop(&mut self) {
+        let previous = self.metrics.waiters.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0);
+    }
 }

--- a/rocketmq-runtime/tests/resource_budget_loom.rs
+++ b/rocketmq-runtime/tests/resource_budget_loom.rs
@@ -15,6 +15,7 @@
 //! Loom model for ResourceBudgetTree permit acquisition and Drop recovery.
 
 use loom::sync::Arc;
+use loom::sync::Condvar;
 use loom::sync::Mutex;
 use loom::thread;
 
@@ -24,11 +25,14 @@ struct BudgetState {
     current_bytes: usize,
     acquired_count: usize,
     released_count: usize,
+    waiters: usize,
+    closed: bool,
 }
 
 #[derive(Clone)]
 struct Budget {
     state: Arc<Mutex<BudgetState>>,
+    capacity: Arc<Condvar>,
     max_count: usize,
     max_bytes: usize,
 }
@@ -37,6 +41,7 @@ impl Budget {
     fn new(max_count: usize, max_bytes: usize) -> Self {
         Self {
             state: Arc::new(Mutex::new(BudgetState::default())),
+            capacity: Arc::new(Condvar::new()),
             max_count,
             max_bytes,
         }
@@ -44,16 +49,57 @@ impl Budget {
 
     fn try_acquire(&self, bytes: usize) -> Option<Permit> {
         let mut state = self.state.lock().expect("budget state");
-        if state.current_count == self.max_count || state.current_bytes + bytes > self.max_bytes {
+        if state.closed
+            || state.current_count == self.max_count
+            || state
+                .current_bytes
+                .checked_add(bytes)
+                .is_none_or(|total| total > self.max_bytes)
+        {
             return None;
         }
         state.current_count += 1;
         state.current_bytes += bytes;
         state.acquired_count += 1;
+        assert_state_invariants(&state, self.max_count, self.max_bytes);
         Some(Permit {
             budget: self.clone(),
             bytes,
         })
+    }
+
+    fn acquire_or_wait(&self, bytes: usize) -> Option<Permit> {
+        let mut state = self.state.lock().expect("budget state");
+        loop {
+            if state.closed {
+                return None;
+            }
+            if state.current_count < self.max_count
+                && state
+                    .current_bytes
+                    .checked_add(bytes)
+                    .is_some_and(|total| total <= self.max_bytes)
+            {
+                state.current_count += 1;
+                state.current_bytes += bytes;
+                state.acquired_count += 1;
+                assert_state_invariants(&state, self.max_count, self.max_bytes);
+                return Some(Permit {
+                    budget: self.clone(),
+                    bytes,
+                });
+            }
+            state.waiters += 1;
+            state = self.capacity.wait(state).expect("capacity wait");
+            state.waiters -= 1;
+        }
+    }
+
+    fn close(&self) {
+        let mut state = self.state.lock().expect("budget state");
+        state.closed = true;
+        drop(state);
+        self.capacity.notify_all();
     }
 }
 
@@ -70,7 +116,16 @@ impl Drop for Permit {
         state.current_count -= 1;
         state.current_bytes -= self.bytes;
         state.released_count += 1;
+        assert_state_invariants(&state, self.budget.max_count, self.budget.max_bytes);
+        drop(state);
+        self.budget.capacity.notify_all();
     }
+}
+
+fn assert_state_invariants(state: &BudgetState, max_count: usize, max_bytes: usize) {
+    assert!(state.current_count <= max_count);
+    assert!(state.current_bytes <= max_bytes);
+    assert_eq!(state.acquired_count, state.released_count + state.current_count);
 }
 
 #[test]
@@ -97,6 +152,42 @@ fn task_completion_and_cancellation_release_every_permit() {
         drop(retry);
 
         let state = budget.state.lock().expect("final budget state");
+        assert_eq!(state.current_count, 0);
+        assert_eq!(state.current_bytes, 0);
+        assert_eq!(state.acquired_count, state.released_count);
+    });
+}
+
+#[test]
+fn queue_waiter_owner_cancellation_and_close_preserve_permit_conservation() {
+    let mut model = loom::model::Builder::new();
+    model.preemption_bound = Some(2);
+    model.max_permutations = Some(10_000);
+    model.check(|| {
+        let budget = Budget::new(1, 8);
+        let owner = budget.try_acquire(8).expect("owner permit");
+
+        let waiter_budget = budget.clone();
+        let waiter = thread::spawn(move || {
+            if let Some(permit) = waiter_budget.acquire_or_wait(8) {
+                thread::yield_now();
+                drop(permit);
+            }
+        });
+
+        let closer_budget = budget.clone();
+        let closer = thread::spawn(move || {
+            closer_budget.close();
+        });
+
+        drop(owner);
+        waiter.join().expect("waiter thread");
+        closer.join().expect("closer thread");
+
+        assert!(budget.try_acquire(1).is_none(), "closed budget accepted new work");
+        let state = budget.state.lock().expect("final budget state");
+        assert!(state.closed);
+        assert_eq!(state.waiters, 0);
         assert_eq!(state.current_count, 0);
         assert_eq!(state.current_bytes, 0);
         assert_eq!(state.acquired_count, state.released_count);

--- a/rocketmq-runtime/tests/resource_budget_tree.rs
+++ b/rocketmq-runtime/tests/resource_budget_tree.rs
@@ -392,3 +392,279 @@ async fn aborted_owner_releases_raii_permit() {
     assert_eq!(budget.snapshot().current_count, 0);
     assert!(budget.try_acquire_data(8).is_ok());
 }
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_observes_item_capacity_release() {
+    let tree = ResourceBudgetTree::new("wait-count", limit(1, 16, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    queue.try_push_data("held", 1).expect("fill item capacity");
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until(
+                "waiting",
+                1,
+                BudgetClass::Data,
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let waiting = queue.snapshot();
+    assert_eq!(waiting.waiters, 1);
+    assert_eq!(waiting.wait_count, 1);
+    assert_eq!(queue.try_pop(), Some("held"));
+    assert_eq!(
+        waiter
+            .await
+            .expect("join waiter")
+            .expect("capacity release admits item"),
+        QueuePushOutcome::Enqueued
+    );
+    assert_eq!(queue.try_pop(), Some("waiting"));
+    assert_eq!(queue.snapshot().reserved_count, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_observes_byte_capacity_release() {
+    let tree = ResourceBudgetTree::new("wait-bytes", limit(2, 8, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    queue.try_push_data("held", 8).expect("fill byte capacity");
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until(
+                "waiting",
+                1,
+                BudgetClass::Data,
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    assert_eq!(queue.snapshot().waiters, 1);
+    assert_eq!(queue.try_pop(), Some("held"));
+    waiter
+        .await
+        .expect("join waiter")
+        .expect("byte capacity release admits item");
+    assert_eq!(queue.try_pop(), Some("waiting"));
+    assert_eq!(queue.snapshot().retained_bytes, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_returns_original_item_when_deadline_wins() {
+    let tree =
+        ResourceBudgetTree::new("wait-deadline", limit(1, 8, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    queue.try_push_data("held", 8).expect("fill queue");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until("original", 1, BudgetClass::Data, deadline)
+            .await
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+
+    let error = waiter
+        .await
+        .expect("join waiter")
+        .expect_err("deadline must reject waiting item");
+    assert_eq!(error.kind(), &QueuePushErrorKind::DeadlineExceeded);
+    assert_eq!(error.into_item(), "original");
+    let snapshot = queue.snapshot();
+    assert_eq!(snapshot.waiters, 0);
+    assert_eq!(snapshot.wait_count, 1);
+    assert_eq!(snapshot.deadline_exceeded_count, 1);
+    assert_eq!(queue.try_pop(), Some("held"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_close_wakes_waiter_and_returns_original_item() {
+    let tree = ResourceBudgetTree::new("wait-close", limit(1, 8, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    queue.try_push_data("held", 8).expect("fill queue");
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until(
+                "original",
+                1,
+                BudgetClass::Data,
+                tokio::time::Instant::now() + Duration::from_secs(30),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+    assert_eq!(queue.snapshot().waiters, 1);
+    queue.close();
+
+    let error = waiter
+        .await
+        .expect("join waiter")
+        .expect_err("closed queue must reject waiting item");
+    assert_eq!(error.kind(), &QueuePushErrorKind::Closed);
+    assert_eq!(error.into_item(), "original");
+    assert_eq!(queue.snapshot().waiters, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_oversized_item_fails_without_waiting() {
+    let tree =
+        ResourceBudgetTree::new("wait-oversized", limit(2, 8, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    let before = tokio::time::Instant::now();
+
+    let error = queue
+        .push_until("oversized", 9, BudgetClass::Data, before + Duration::from_secs(30))
+        .await
+        .expect_err("item can never fit byte capacity");
+
+    assert!(matches!(error.kind(), QueuePushErrorKind::BudgetExhausted(_)));
+    assert_eq!(error.into_item(), "oversized");
+    assert_eq!(tokio::time::Instant::now(), before);
+    assert_eq!(queue.snapshot().wait_count, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_rejects_item_that_cannot_fit_ancestor_data_reserve() {
+    let root_limit = limit(2, 8, FullPolicy::Reject).with_control_reserve(BudgetCapacity::new(1, 4));
+    let tree = ResourceBudgetTree::new("reserved-root", root_limit).expect("root budget");
+    let child = tree
+        .root()
+        .child("waiting", limit(2, 8, FullPolicy::WaitUntilDeadline))
+        .expect("waiting child");
+    let queue = BudgetedQueue::new(child);
+    let before = tokio::time::Instant::now();
+
+    let error = queue
+        .push_until(
+            "too-large-for-data",
+            5,
+            BudgetClass::Data,
+            before + Duration::from_secs(30),
+        )
+        .await
+        .expect_err("ancestor data reserve permanently excludes item");
+
+    match error.kind() {
+        QueuePushErrorKind::BudgetExhausted(error) => {
+            assert_eq!(error.dimension(), BudgetDimension::Bytes);
+            assert_eq!(error.exhausted_path(), "reserved-root");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(error.into_item(), "too-large-for-data");
+    assert_eq!(tokio::time::Instant::now(), before);
+    assert_eq!(queue.snapshot().wait_count, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_until_deadline_returns_rate_exhaustion_without_capacity_wait() {
+    let clock = Arc::new(ManualClock::default());
+    let wait_limit = limit(1, 8, FullPolicy::WaitUntilDeadline).with_rate(RateLimit::new(1, 1));
+    let tree = ResourceBudgetTree::with_clock("rate-wait", wait_limit, clock).expect("budget tree");
+    let queue = BudgetedQueue::new(tree.root());
+    queue.try_push_data("first", 1).expect("consume initial rate token");
+    assert_eq!(queue.try_pop(), Some("first"));
+    let before = tokio::time::Instant::now();
+
+    let error = queue
+        .push_until("second", 1, BudgetClass::Data, before + Duration::from_secs(30))
+        .await
+        .expect_err("rate exhaustion is not capacity-release driven");
+
+    match error.kind() {
+        QueuePushErrorKind::BudgetExhausted(error) => {
+            assert_eq!(error.dimension(), BudgetDimension::Rate);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(error.into_item(), "second");
+    assert_eq!(tokio::time::Instant::now(), before);
+    let snapshot = queue.snapshot();
+    assert_eq!(snapshot.wait_count, 0);
+    assert_eq!(snapshot.throttled_count, 1);
+    assert_eq!(snapshot.rejected_count, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn ancestor_release_wakes_waiting_child() {
+    let tree = ResourceBudgetTree::new("shared", limit(1, 8, FullPolicy::Reject)).expect("root budget");
+    let waiting_budget = tree
+        .root()
+        .child("waiting", limit(1, 8, FullPolicy::WaitUntilDeadline))
+        .expect("waiting child");
+    let sibling = tree
+        .root()
+        .child("sibling", limit(1, 8, FullPolicy::Reject))
+        .expect("sibling child");
+    let sibling_permit = sibling.try_acquire_data(8).expect("fill ancestor from sibling");
+    let queue = BudgetedQueue::new(waiting_budget);
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until(
+                "child",
+                8,
+                BudgetClass::Data,
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+    assert_eq!(queue.snapshot().waiters, 1);
+    drop(sibling_permit);
+
+    waiter
+        .await
+        .expect("join waiter")
+        .expect("ancestor release must wake child");
+    assert_eq!(queue.try_pop(), Some("child"));
+    assert_eq!(tree.root().snapshot().current_count, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn cancelled_waiter_and_panicking_owner_restore_metrics_and_permits() {
+    let tree = ResourceBudgetTree::new("wait-cancel", limit(1, 8, FullPolicy::WaitUntilDeadline)).expect("budget tree");
+    let budget = tree.root();
+    let queue = BudgetedQueue::new(budget.clone());
+    queue.try_push_data("held", 8).expect("fill queue");
+
+    let waiting_queue = queue.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_queue
+            .push_until(
+                "cancelled",
+                1,
+                BudgetClass::Data,
+                tokio::time::Instant::now() + Duration::from_secs(30),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+    assert_eq!(queue.snapshot().waiters, 1);
+    waiter.abort();
+    assert!(waiter.await.expect_err("waiter must be cancelled").is_cancelled());
+    assert_eq!(queue.snapshot().waiters, 0);
+    assert_eq!(budget.snapshot().current_count, 1);
+
+    let owned = queue.try_pop_budgeted().expect("take owned permit");
+    let panicking_owner = tokio::spawn(async move {
+        let _owned = owned;
+        panic!("injected owner panic");
+    });
+    assert!(panicking_owner.await.expect_err("owner must panic").is_panic());
+    assert_eq!(budget.snapshot().current_count, 0);
+    assert_eq!(budget.snapshot().current_bytes, 0);
+    assert_eq!(budget.snapshot().admitted_count, budget.snapshot().released_count);
+}

--- a/rocketmq-store-local/src/commit_log/append/sequencer.rs
+++ b/rocketmq-store-local/src/commit_log/append/sequencer.rs
@@ -103,7 +103,9 @@ impl<T> AppendSequencerSender<T> {
             .map(|_| ())
             .map_err(|error| {
                 let kind = match error.kind() {
-                    QueuePushErrorKind::BudgetExhausted(_) => AppendAdmissionErrorKind::Saturated,
+                    QueuePushErrorKind::BudgetExhausted(_) | QueuePushErrorKind::DeadlineExceeded => {
+                        AppendAdmissionErrorKind::Saturated
+                    }
                     QueuePushErrorKind::Closed | QueuePushErrorKind::SlowConsumerClosed => {
                         AppendAdmissionErrorKind::Closed
                     }

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -97,7 +97,7 @@
       "reexports": 5
     },
     "rocketmq-runtime": {
-      "public_items": 646,
+      "public_items": 647,
       "reexports": 150
     },
     "rocketmq-security-api": {
@@ -4770,7 +4770,7 @@
       "reexports": 0
     },
     "rocketmq-observability/src/exporter/outage.rs": {
-      "production_lines": 923,
+      "production_lines": 924,
       "public_items": 24,
       "reexports": 0
     },
@@ -7066,7 +7066,7 @@
     },
     "rocketmq-runtime/src/resource_budget/queue.rs": {
       "production_lines": 423,
-      "public_items": 27,
+      "public_items": 28,
       "reexports": 0
     },
     "rocketmq-runtime/src/schedule.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8859

### Brief Description

- Add `FullPolicy::WaitUntilDeadline` and an absolute-deadline `BudgetedQueue::push_until` admission API that always returns ownership of a rejected item.
- Share a tree-scoped capacity notification across ancestor and sibling budgets, while keeping count, byte, rate, and control-reserve accounting under the existing RAII permit model.
- Expose low-cardinality waiter, wait, and deadline counters, and cover close, cancellation, panic recovery, ancestor release, oversized items, and rate exhaustion.
- Add a bounded Loom model and Criterion coverage for Reject and contended wait/release paths at 128 and 1,024 items.
- Keep exhaustive downstream error mappings fail-closed and record only the reviewed public-surface and hotspot increments in the maintainability baseline.

### How Did You Test This Change?

- `cargo test -p rocketmq-runtime --test resource_budget_tree` - passed, 25/25.
- `cargo test -p rocketmq-runtime --test resource_budget_loom` - passed, 2/2.
- `cargo test -p rocketmq-runtime` - passed.
- `cargo bench -p rocketmq-runtime --bench budgeted_queue_bench` - passed:
  - Reject 128: 27.845-29.384 us; Reject 1,024: 206.67-213.45 us.
  - Wait/release 128: 192.07-197.99 us; Wait/release 1,024: 1.6969-1.8798 ms.
- `cargo fmt -p rocketmq-runtime -p rocketmq-observability -p rocketmq-proxy-cluster -p rocketmq-store-local -- --check` - passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/` - passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `.\scripts\check-agents-routing.ps1` - passed.
- `cargo doc -p rocketmq-runtime --no-deps` - passed.
- `git diff --check` - passed.
- `cargo fmt --all -- --check` reproduces the same Windows filename/extension length failure on the PR-05 implementation baseline; all affected packages pass their non-mutating format check.
- `python scripts/run_architecture_tests.py --tier pr_static` reproduces the same eight failing guard modules on the PR-05 implementation baseline. The three PR-specific maintainability increments are narrowly recorded, so no new finding is hidden in the historical baseline.
- The default observability test set passes 188/191 and the combined OTLP/Prometheus set passes 282/286. The same three and four TaskGroup lifecycle tests, respectively, reproduce on the PR-05 implementation baseline; no new test fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deadline-aware queue admission, allowing operations to wait for capacity until a specified deadline.
  - Added queue metrics for waiting operations and deadline expirations.
  - Added clearer reporting when queue capacity or admission limits are reached.

- **Bug Fixes**
  - Deadline-expired requests are now consistently reported as throttled or saturated across telemetry, proxy admission, and message appending.
  - Improved cleanup and notification when queued capacity becomes available or queues close.

- **Tests**
  - Expanded coverage for waiting, timeouts, cancellation, closure, capacity release, and resource accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->