### PR TITLE
[ISSUE #8861]🚀Bound producer one-way egress by process memory and socket completion

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -97,6 +97,10 @@ name    = "oneway_benchmark"
 harness = false
 
 [[bench]]
+name    = "producer_oneway_egress"
+harness = false
+
+[[bench]]
 name    = "select_queue_benchmark"
 harness = false
 

--- a/rocketmq-client/benches/producer_oneway_egress.rs
+++ b/rocketmq-client/benches/producer_oneway_egress.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudgetTree;
+use std::hint::black_box;
+
+const PAYLOAD_BYTES: usize = 1024;
+
+fn benchmark_oneway_reservation_transfer(criterion: &mut Criterion) {
+    let root = ResourceBudgetTree::new(
+        "process",
+        BudgetLimit::new(65_536, 256 * 1024 * 1024, FullPolicy::Reject),
+    )
+    .expect("process budget")
+    .root();
+    let producer = root
+        .child(
+            "producer-egress",
+            BudgetLimit::new(16_384, 64 * 1024 * 1024, FullPolicy::Reject),
+        )
+        .expect("producer budget");
+    let transport = root
+        .child(
+            "transport-writer",
+            BudgetLimit::new(16_384, 64 * 1024 * 1024, FullPolicy::Reject),
+        )
+        .expect("transport budget");
+
+    criterion.bench_function("producer_oneway_egress/rebind_1kib", |bencher| {
+        bencher.iter(|| {
+            let mut permit = producer
+                .try_acquire(black_box(PAYLOAD_BYTES), BudgetClass::Data)
+                .expect("producer admission");
+            permit.try_rebind(black_box(&transport)).expect("writer rebind");
+            black_box(permit);
+        });
+    });
+}
+
+criterion_group!(benches, benchmark_oneway_reservation_transfer);
+criterion_main!(benches);

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -289,8 +289,11 @@ impl MQClientInstance {
         telemetry_handle: TelemetryHandle,
         request_future_holder: Arc<RequestFutureHolder>,
     ) -> Arc<MQClientInstance> {
-        let resource_budget = crate::runtime::standalone_client_resource_budget()
-            .expect("standalone MQClientInstance resource budget must be valid");
+        let resource_budget = crate::runtime::build_client_resource_budget(
+            &crate::runtime::ClientRuntimeConfig::default(),
+            &service_context.process_budget(),
+        )
+        .expect("service-context MQClientInstance resource budget must be valid");
         let client_metrics = ClientMetrics::from_handle(&telemetry_handle);
         Self::new_arc_with_resource_budget(
             client_config,

--- a/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
@@ -146,36 +146,26 @@ impl MQClientAPIImpl {
         }
     }
 
-    /// **High-Performance** unbounded oneway send without timeout control.
+    /// Sends a one-way request while transferring an existing resource reservation.
     ///
-    /// This method provides **maximum throughput** by spawning background tasks immediately
-    /// without waiting for network send completion, achieving near-zero latency overhead.
+    /// The returned future completes only after the transport writer accepts the frame or
+    /// reports an error. The permit remains charged for the complete queued-write lifetime and
+    /// is released by RAII on success, timeout, cancellation, or connection failure.
     ///
-    /// # Performance Characteristics
-    /// - **Latency**: < 10μs per send (tokio spawn overhead only)
-    /// - **Throughput**: 100K+ messages/second per producer
-    /// - **Memory**: ~1KB per spawned task
-    /// - **Zero blocking**: Returns immediately after task spawn
+    /// # Errors
     ///
-    /// # When to Use
-    /// Ideal for high-throughput scenarios where:
-    /// - **Fire-and-forget** semantics are required
-    /// - Message loss is acceptable (e.g., metrics, logs, telemetry)
-    /// - **Maximum throughput** is the priority over reliability
-    /// - Latency is critical (< 10μs send overhead)
-    ///
-    /// # Use Cases
-    /// - Log collection and aggregation
-    /// - Metrics reporting
-    /// - Real-time telemetry
-    /// - High-frequency event streaming
-    pub async fn send_oneway_unbounded(
+    /// Returns an error when the deadline expires, the connection cannot be established, the
+    /// reservation cannot be transferred into the transport budget, or the writer fails.
+    pub async fn send_oneway_with_permit(
         &self,
         addr: &CheetahString,
         request: RemotingCommand,
+        deadline: rocketmq_transport::RequestDeadline,
+        permit: rocketmq_runtime::ResourcePermit,
     ) -> rocketmq_error::RocketMQResult<()> {
-        self.remoting_client.invoke_oneway_unbounded(addr.clone(), request);
-        Ok(())
+        self.remoting_client
+            .invoke_oneway_with_permit(addr, request, deadline, permit)
+            .await
     }
 
     pub async fn send_message_simple<T>(

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -172,8 +172,11 @@ impl ProduceAccumulator {
     }
 
     pub fn new(service_context: ChildServiceContext, instance_name: &str) -> Self {
-        let resource_budget = crate::runtime::standalone_client_resource_budget()
-            .expect("standalone produce accumulator resource budget must be valid");
+        let resource_budget = crate::runtime::build_client_resource_budget(
+            &crate::runtime::ClientRuntimeConfig::default(),
+            &service_context.process_budget(),
+        )
+        .expect("service-context produce accumulator resource budget must be valid");
         Self::with_resource_budget(service_context, instance_name, resource_budget)
     }
 

--- a/rocketmq-client/src/producer/producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod default_mq_producer_impl;
+pub(crate) mod egress;
 pub(crate) mod mq_producer_inner;
 pub mod queue_filter;
 pub mod topic_publish_info;

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -96,6 +96,9 @@ use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::default_mq_producer::MIN_BACK_PRESSURE_FOR_ASYNC_SEND_NUM;
 use crate::producer::default_mq_producer::MIN_BACK_PRESSURE_FOR_ASYNC_SEND_SIZE;
 use crate::producer::local_transaction_state::LocalTransactionState;
+use crate::producer::producer_impl::egress::BoundedEgress;
+use crate::producer::producer_impl::egress::OnewayEgressSnapshot;
+use crate::producer::producer_impl::egress::OnewayEnvelope;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInner;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
@@ -374,6 +377,7 @@ pub struct DefaultMQProducerImpl {
     producer_task_tracker: TaskTracker,
     producer_task_shutdown: CancellationToken,
     task_admission: ParkingLotMutex<()>,
+    oneway_egress: OnceLock<BoundedEgress>,
     compressor_missing_logged: AtomicBool,
 }
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
@@ -103,6 +103,7 @@ impl DefaultMQProducerImpl {
             producer_task_tracker: TaskTracker::new(),
             producer_task_shutdown: CancellationToken::new(),
             task_admission: ParkingLotMutex::new(()),
+            oneway_egress: OnceLock::new(),
             compressor_missing_logged: AtomicBool::new(false),
         }
     }
@@ -246,6 +247,51 @@ impl DefaultMQProducerImpl {
             &self.producer_task_shutdown,
             task,
         )
+    }
+
+    pub(super) fn initialize_oneway_egress(
+        &self,
+        runtime: &ProducerRuntimeSnapshot,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        if self.oneway_egress.get().is_some() {
+            return Ok(());
+        }
+        let count_limit = runtime
+            .producer_config
+            .back_pressure_for_async_send_num()
+            .max(MIN_BACK_PRESSURE_FOR_ASYNC_SEND_NUM) as usize;
+        let byte_limit = runtime
+            .producer_config
+            .back_pressure_for_async_send_size()
+            .max(MIN_BACK_PRESSURE_FOR_ASYNC_SEND_SIZE) as usize;
+        let egress = BoundedEgress::new(
+            &self.service_context,
+            runtime.producer_config.producer_group(),
+            count_limit,
+            byte_limit,
+            &self.producer_task_tracker,
+            &self.producer_task_shutdown,
+            self.client_runtime
+                .as_ref()
+                .map(|runtime| runtime.client_metrics().clone())
+                .unwrap_or_default(),
+        )?;
+        self.oneway_egress
+            .set(egress)
+            .map_err(|_| mq_client_err!("producer one-way egress initialization raced"))
+    }
+
+    pub(super) fn oneway_egress(&self) -> rocketmq_error::RocketMQResult<&BoundedEgress> {
+        self.oneway_egress
+            .get()
+            .ok_or_else(|| mq_client_err!("producer one-way egress is not initialized"))
+    }
+
+    pub(crate) fn oneway_egress_snapshot(&self) -> OnewayEgressSnapshot {
+        self.oneway_egress
+            .get()
+            .map(BoundedEgress::snapshot)
+            .unwrap_or_default()
     }
 
     #[inline]
@@ -729,6 +775,10 @@ impl DefaultMQProducerImpl {
             self.store_state(ProducerState::StartFailed, Ordering::SeqCst);
             return Err(error);
         }
+        if let Err(error) = self.initialize_oneway_egress(&runtime) {
+            self.store_state(ProducerState::StartFailed, Ordering::SeqCst);
+            return Err(error);
+        }
 
         let producer_config = Arc::clone(&runtime.producer_config);
         let client_instance = if let Ok(instance) = self.client_instance() {
@@ -848,7 +898,15 @@ impl DefaultMQProducerImpl {
     pub async fn shutdown_with_factory(&self, shutdown_factory: bool) -> rocketmq_error::RocketMQResult<()> {
         let _transition = self.lifecycle_transition.lock().await;
         match self.load_state(Ordering::SeqCst) {
-            ProducerState::Stopped | ProducerState::Created | ProducerState::StartFailed => Ok(()),
+            ProducerState::Stopped => Ok(()),
+            ProducerState::Created | ProducerState::StartFailed => {
+                if let Some(egress) = self.oneway_egress.get() {
+                    egress.close();
+                }
+                self.producer_task_tracker.close();
+                self.shutdown_producer_tasks().await;
+                Ok(())
+            }
             ProducerState::Starting => {
                 self.begin_task_shutdown(ProducerState::Starting)?;
                 self.shutdown_producer_tasks().await;
@@ -873,6 +931,9 @@ impl DefaultMQProducerImpl {
         let _admission = self.task_admission.lock();
         self.compare_exchange_state(expected, ProducerState::Stopping, Ordering::SeqCst, Ordering::SeqCst)
             .map_err(|actual| mq_client_err!(format!("Cannot shutdown producer in state {:?}", actual)))?;
+        if let Some(egress) = self.oneway_egress.get() {
+            egress.close();
+        }
         self.producer_task_tracker.close();
         Ok(())
     }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs
@@ -116,26 +116,23 @@ impl DefaultMQProducerImpl {
         Ok(())
     }
 
-    /// **High-Performance** batch send messages in oneway mode (fire-and-forget).
+    /// Admits a batch of messages into the bounded one-way egress.
     ///
-    /// This API provides **extreme throughput** for scenarios where performance is more important
-    /// than reliability, such as log collection, metrics reporting, and telemetry.
+    /// Accepted messages are processed by the producer's fixed worker set. Each message keeps its
+    /// byte reservation until the transport writer completes, so the batch cannot create one task
+    /// or one independent memory allocation budget per message.
     ///
     /// # Arguments
     /// * `msgs` - Iterator of messages to send
     ///
-    /// # Semantics
-    /// - All messages are sent in parallel (background tasks)
-    /// - Returns immediately after spawning all send tasks
-    /// - No retry, no error propagation
-    /// - Errors are silently logged
-    /// - Uses `send_oneway_unbounded` for maximum throughput
+    /// The return value is the number of messages accepted by the egress. Invalid messages and
+    /// messages without a current publish route are skipped. Capacity or lifecycle rejection is
+    /// returned immediately and no request is built for that rejected message.
     ///
-    /// # Performance Characteristics
-    /// - **Throughput**: 100K+ messages/second per producer
-    /// - **Latency**: < 10μs per message (spawn overhead only)
-    /// - **Memory**: ~1KB per message (task structure)
-    /// - **Parallel**: All messages sent concurrently
+    /// # Errors
+    ///
+    /// Returns an error if the producer is not running, request construction fails, the deadline
+    /// has already expired, or the bounded egress rejects admission.
     ///
     /// # Example
     /// ```rust,ignore
@@ -152,7 +149,7 @@ impl DefaultMQProducerImpl {
         let timeout = runtime.producer_config.send_msg_timeout() as u64;
         let mut sent_count = 0;
 
-        for msg in msgs {
+        for mut msg in msgs {
             // Validate each message
             if let Err(e) = Validators::check_message(Some(&msg), runtime.producer_config.as_ref()) {
                 tracing::debug!("Message validation failed in batch oneway: {:?}", e);
@@ -165,8 +162,42 @@ impl DefaultMQProducerImpl {
             if let Some(info) = topic_publish_info {
                 if info.ok() {
                     if let Some(mq) = self.select_one_message_queue(&info, None, false) {
-                        // Spawn background task for each message
-                        self.spawn_oneway_send(msg, mq, timeout);
+                        let client_instance = self.client_instance()?;
+                        let broker_name = client_instance.get_broker_name_from_message_queue(&mq).await;
+                        let Some(broker_addr) = client_instance.find_broker_address_in_publish(broker_name.as_ref())
+                        else {
+                            continue;
+                        };
+                        let broker_addr = mix_all::broker_vip_channel(
+                            runtime.client_config.vip_channel_enabled,
+                            broker_addr.as_str(),
+                        );
+                        let mq_client_api = client_instance.get_mq_client_api_impl()?;
+                        let send_config = runtime.send_config.clone();
+                        let namespace = runtime.client_config.namespace.clone();
+                        let retained_bytes = Self::message_body_len_for_backpressure(&msg).saturating_add(4 * 1024);
+                        let deadline = rocketmq_transport::RequestDeadline::from_timeout_millis(timeout);
+                        let target = broker_addr.to_string();
+                        self.oneway_egress()?.try_admit(retained_bytes, &target, deadline, || {
+                            let request = build_oneway_request_internal(
+                                &mut msg,
+                                &mq,
+                                &broker_name,
+                                &send_config,
+                                namespace.as_deref(),
+                            )?;
+                            Ok(OnewayEnvelope {
+                                broker_addr,
+                                deadline,
+                                send: Box::new(move |broker_addr, deadline, permit| {
+                                    Box::pin(async move {
+                                        mq_client_api
+                                            .send_oneway_with_permit(&broker_addr, request, deadline, permit)
+                                            .await
+                                    })
+                                }),
+                            })
+                        })?;
                         sent_count += 1;
                     }
                 }
@@ -176,65 +207,6 @@ impl DefaultMQProducerImpl {
         Ok(sent_count)
     }
 
-    /// Spawn a background task for oneway message sending.
-    ///
-    /// This is a helper method for send_oneway_batch to avoid code duplication.
-    pub(super) fn spawn_oneway_send<T>(&self, msg: T, mq: MessageQueue, _timeout: u64)
-    where
-        T: MessageTrait + Send + Sync + 'static,
-    {
-        let Ok(client_instance) = self.client_instance() else {
-            tracing::debug!("Oneway batch send skipped: MQClientInstance is not available");
-            return;
-        };
-        let runtime = self.runtime_snapshot();
-        let send_config = runtime.send_config.clone();
-        let client_config = runtime.client_config.clone();
-
-        let task = async move {
-            // Prepare message in background task
-            let mut msg = msg;
-
-            // Get broker address
-            let broker_name = client_instance.get_broker_name_from_message_queue(&mq).await;
-            let broker_addr = client_instance.find_broker_address_in_publish(broker_name.as_ref());
-
-            let Some(broker_addr) = broker_addr else {
-                return;
-            };
-            let broker_addr = mix_all::broker_vip_channel(client_config.vip_channel_enabled, broker_addr.as_str());
-
-            // Build request (simplified for oneway)
-            let request = match build_oneway_request_internal(
-                &mut msg,
-                &mq,
-                &broker_name,
-                &send_config,
-                client_config.namespace.as_deref(),
-            ) {
-                Ok(req) => req,
-                Err(e) => {
-                    tracing::debug!("Failed to build oneway request: {:?}", e);
-                    return;
-                }
-            };
-
-            // Fire and forget (use unbounded method for maximum batch throughput)
-            match client_instance.get_mq_client_api_impl() {
-                Ok(mq_client_api) => {
-                    let send_start = Instant::now();
-                    if let Err(e) = mq_client_api.send_oneway_unbounded(&broker_addr, request).await {
-                        tracing::debug!("Oneway batch send failed: {:?}", e);
-                    }
-                    client_instance.client_metrics().record_send(send_start.elapsed());
-                }
-                Err(e) => tracing::debug!("Oneway batch send skipped: {:?}", e),
-            }
-        };
-        if let Err(error) = self.spawn_tracked_task("rocketmq-client-producer-oneway-batch", task) {
-            warn!("Failed to spawn batch oneway send task: {}", error);
-        }
-    }
     #[inline]
     pub async fn sync_send_with_message_queue_timeout<T>(
         &self,

--- a/rocketmq-client/src/producer/producer_impl/egress.rs
+++ b/rocketmq-client/src/producer/producer_impl/egress.rs
@@ -1,0 +1,379 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourcePermit;
+use rocketmq_transport::RequestDeadline;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use crate::runtime::ClientMetrics;
+
+const DEFAULT_EGRESS_WORKERS: usize = 2;
+
+pub(crate) type OnewaySendFuture = Pin<Box<dyn Future<Output = RocketMQResult<()>> + Send + 'static>>;
+pub(crate) type OnewaySend =
+    Box<dyn FnOnce(CheetahString, RequestDeadline, ResourcePermit) -> OnewaySendFuture + Send + 'static>;
+
+pub(crate) struct OnewayEnvelope {
+    pub(crate) broker_addr: CheetahString,
+    pub(crate) deadline: RequestDeadline,
+    pub(crate) send: OnewaySend,
+}
+
+struct ReservedEnvelope {
+    envelope: OnewayEnvelope,
+    permit: ResourcePermit,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct OnewayEgressSnapshot {
+    pub(crate) current_items: usize,
+    pub(crate) current_bytes: usize,
+    pub(crate) accepted: u64,
+    pub(crate) delivered: u64,
+    pub(crate) failed: u64,
+    pub(crate) cancelled: u64,
+    pub(crate) rejected: u64,
+    pub(crate) closed: bool,
+}
+
+#[derive(Default)]
+struct OnewayEgressMetrics {
+    accepted: AtomicU64,
+    delivered: AtomicU64,
+    failed: AtomicU64,
+    cancelled: AtomicU64,
+    rejected: AtomicU64,
+}
+
+pub(crate) struct BoundedEgress {
+    budget: ResourceBudget,
+    sender: Mutex<Option<mpsc::Sender<ReservedEnvelope>>>,
+    metrics: Arc<OnewayEgressMetrics>,
+    client_metrics: ClientMetrics,
+}
+
+impl BoundedEgress {
+    pub(crate) fn new(
+        service_context: &ChildServiceContext,
+        producer_group: &str,
+        count_limit: usize,
+        byte_limit: usize,
+        tracker: &TaskTracker,
+        cancellation: &CancellationToken,
+        client_metrics: ClientMetrics,
+    ) -> RocketMQResult<Self> {
+        let process_budget = service_context.process_budget();
+        let process_capacity = process_budget.limit().capacity;
+        let count_limit = count_limit.min(process_capacity.count).max(1);
+        let byte_limit = byte_limit.min(process_capacity.bytes).max(1);
+        let producer_name = format!("producer-{}", sanitize_budget_name(producer_group));
+        let producer_budget = process_budget
+            .child(
+                producer_name,
+                BudgetLimit::new(count_limit, byte_limit, FullPolicy::Reject),
+            )
+            .and_then(|producer| {
+                producer.child(
+                    "oneway-egress",
+                    BudgetLimit::new(count_limit, byte_limit, FullPolicy::Reject),
+                )
+            })
+            .map_err(|error| RocketMQError::ConfigInvalidValue {
+                key: "producer.onewayEgress",
+                value: format!("{count_limit} items/{byte_limit} bytes"),
+                reason: error.to_string(),
+            })?;
+        let (sender, receiver) = mpsc::channel(count_limit);
+        let receiver = Arc::new(tokio::sync::Mutex::new(receiver));
+        let metrics = Arc::new(OnewayEgressMetrics::default());
+
+        for worker_index in 0..DEFAULT_EGRESS_WORKERS {
+            let receiver = Arc::clone(&receiver);
+            let metrics = Arc::clone(&metrics);
+            let client_metrics = client_metrics.clone();
+            let worker_budget = producer_budget.clone();
+            let cancellation = cancellation.clone();
+            let task = tracker.track_future(async move {
+                run_worker(receiver, metrics, cancellation, client_metrics, worker_budget).await;
+            });
+            service_context
+                .spawn_service(format!("producer.oneway-egress.worker-{worker_index}"), task)
+                .map_err(|error| {
+                    RocketMQError::response_process_failed("producer.onewayEgress.worker", error.to_string())
+                })?;
+        }
+
+        Ok(Self {
+            budget: producer_budget,
+            sender: Mutex::new(Some(sender)),
+            metrics,
+            client_metrics,
+        })
+    }
+
+    pub(crate) fn try_admit<F>(
+        &self,
+        retained_bytes: usize,
+        target: &str,
+        deadline: RequestDeadline,
+        build: F,
+    ) -> RocketMQResult<()>
+    where
+        F: FnOnce() -> RocketMQResult<OnewayEnvelope>,
+    {
+        deadline.ensure_before_send(target.to_owned())?;
+        let sender = self.sender.lock();
+        let sender = sender.as_ref().ok_or_else(|| {
+            self.metrics.rejected.fetch_add(1, Ordering::Relaxed);
+            self.client_metrics.record_oneway_egress_event("rejected");
+            RocketMQError::network_connection_failed(target.to_owned(), "producer one-way egress is closed")
+        })?;
+        let permit = self.budget.try_acquire_data(retained_bytes).map_err(|_| {
+            self.metrics.rejected.fetch_add(1, Ordering::Relaxed);
+            self.client_metrics.record_oneway_egress_event("rejected");
+            RocketMQError::network_queue_full(target.to_owned())
+        })?;
+        let envelope = build()?;
+        envelope.deadline.ensure_before_send(target.to_owned())?;
+        sender
+            .try_send(ReservedEnvelope { envelope, permit })
+            .map_err(|error| {
+                self.metrics.rejected.fetch_add(1, Ordering::Relaxed);
+                self.client_metrics.record_oneway_egress_event("rejected");
+                match error {
+                    mpsc::error::TrySendError::Full(_) => RocketMQError::network_queue_full(target.to_owned()),
+                    mpsc::error::TrySendError::Closed(_) => {
+                        RocketMQError::network_connection_failed(target.to_owned(), "producer one-way egress is closed")
+                    }
+                }
+            })?;
+        self.metrics.accepted.fetch_add(1, Ordering::Relaxed);
+        self.client_metrics.record_oneway_egress_event("accepted");
+        self.record_state();
+        Ok(())
+    }
+
+    pub(crate) fn close(&self) {
+        self.sender.lock().take();
+        self.record_state();
+    }
+
+    pub(crate) fn snapshot(&self) -> OnewayEgressSnapshot {
+        let budget = self.budget.snapshot();
+        OnewayEgressSnapshot {
+            current_items: budget.current_count,
+            current_bytes: budget.current_bytes,
+            accepted: self.metrics.accepted.load(Ordering::Relaxed),
+            delivered: self.metrics.delivered.load(Ordering::Relaxed),
+            failed: self.metrics.failed.load(Ordering::Relaxed),
+            cancelled: self.metrics.cancelled.load(Ordering::Relaxed),
+            rejected: self.metrics.rejected.load(Ordering::Relaxed),
+            closed: self.sender.lock().is_none(),
+        }
+    }
+
+    #[cfg(test)]
+    fn try_reserve(&self, retained_bytes: usize) -> Result<ResourcePermit, rocketmq_runtime::BudgetAcquireError> {
+        self.budget.try_acquire_data(retained_bytes)
+    }
+
+    fn record_state(&self) {
+        let snapshot = self.budget.snapshot();
+        self.client_metrics.record_oneway_egress_state(
+            u64::try_from(snapshot.current_count).unwrap_or(u64::MAX),
+            u64::try_from(snapshot.current_bytes).unwrap_or(u64::MAX),
+            0,
+            0,
+        );
+    }
+}
+
+async fn run_worker(
+    receiver: Arc<tokio::sync::Mutex<mpsc::Receiver<ReservedEnvelope>>>,
+    metrics: Arc<OnewayEgressMetrics>,
+    cancellation: CancellationToken,
+    client_metrics: ClientMetrics,
+    budget: ResourceBudget,
+) {
+    loop {
+        let next = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                client_metrics.record_oneway_egress_event("cancelled");
+                return;
+            }
+            next = async {
+                let mut receiver = receiver.lock().await;
+                receiver.recv().await
+            } => next,
+        };
+        let Some(reserved) = next else {
+            return;
+        };
+        let OnewayEnvelope {
+            broker_addr,
+            deadline,
+            send,
+        } = reserved.envelope;
+        let remote_addr = broker_addr.clone();
+        let send = send(broker_addr, deadline, reserved.permit);
+        tokio::pin!(send);
+        let result = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                client_metrics.record_oneway_egress_event("cancelled");
+                return;
+            }
+            result = &mut send => result,
+        };
+        match result {
+            Ok(()) => {
+                metrics.delivered.fetch_add(1, Ordering::Relaxed);
+                client_metrics.record_oneway_egress_event("delivered");
+            }
+            Err(error) => {
+                metrics.failed.fetch_add(1, Ordering::Relaxed);
+                client_metrics.record_oneway_egress_event("failed");
+                tracing::warn!(remote_addr = %remote_addr, error = ?error, "producer one-way egress send failed");
+            }
+        }
+        let snapshot = budget.snapshot();
+        client_metrics.record_oneway_egress_state(
+            u64::try_from(snapshot.current_count).unwrap_or(u64::MAX),
+            u64::try_from(snapshot.current_bytes).unwrap_or(u64::MAX),
+            0,
+            0,
+        );
+    }
+}
+
+fn sanitize_budget_name(name: &str) -> String {
+    let sanitized = name
+        .chars()
+        .map(|character| if character == '/' { '_' } else { character })
+        .collect::<String>();
+    if sanitized.trim().is_empty() {
+        "default".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::AssertUnwindSafe;
+    use std::time::Duration;
+
+    use rocketmq_runtime::ProcessMemoryLimit;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+
+    use super::*;
+
+    fn fixture() -> (RuntimeOwner, BoundedEgress, TaskTracker, CancellationToken) {
+        let owner = RuntimeOwner::new_with_memory_limit(
+            RuntimeConfig::default(),
+            ProcessMemoryLimit::configured(64).expect("memory limit"),
+        )
+        .expect("runtime owner");
+        let tracker = TaskTracker::new();
+        let cancellation = CancellationToken::new();
+        let egress = BoundedEgress::new(
+            &owner.root_context().component("egress-test"),
+            "test",
+            1,
+            64,
+            &tracker,
+            &cancellation,
+            ClientMetrics::noop(),
+        )
+        .expect("egress");
+        (owner, egress, tracker, cancellation)
+    }
+
+    #[test]
+    fn overload_rejects_before_materializing_another_envelope() {
+        let (_owner, egress, _tracker, _cancellation) = fixture();
+        let permit = egress.try_reserve(64).expect("fill byte budget");
+        let built = AtomicU64::new(0);
+        let result = egress.try_admit(1, "broker", RequestDeadline::after(Duration::from_secs(1)), || {
+            built.fetch_add(1, Ordering::Relaxed);
+            unreachable!("overload must reject before building")
+        });
+
+        assert!(result.is_err());
+        assert_eq!(built.load(Ordering::Relaxed), 0);
+        drop(permit);
+    }
+
+    #[test]
+    fn closed_and_expired_admission_do_not_run_the_builder() {
+        let (_owner, egress, _tracker, _cancellation) = fixture();
+        egress.close();
+        let closed = egress.try_admit(1, "broker", RequestDeadline::after(Duration::from_secs(1)), || {
+            unreachable!("closed egress must reject before building")
+        });
+        assert!(closed.is_err());
+
+        let (_owner, open, _tracker, _cancellation) = fixture();
+        let expired = open.try_admit(1, "broker", RequestDeadline::from_timeout_millis(0), || {
+            unreachable!("expired egress admission must reject before building")
+        });
+        assert!(expired.is_err());
+    }
+
+    #[test]
+    fn builder_panic_releases_the_process_reservation() {
+        let (_owner, egress, _tracker, _cancellation) = fixture();
+        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let _ = egress.try_admit(32, "broker", RequestDeadline::after(Duration::from_secs(1)), || {
+                panic!("synthetic builder panic")
+            });
+        }));
+
+        assert!(panic.is_err());
+        assert_eq!(egress.snapshot().current_bytes, 0);
+    }
+
+    #[test]
+    fn close_joins_the_fixed_worker_set() {
+        let (owner, egress, tracker, _cancellation) = fixture();
+        assert_eq!(tracker.len(), DEFAULT_EGRESS_WORKERS);
+        egress.close();
+        tracker.close();
+
+        owner
+            .block_on(async { tokio::time::timeout(Duration::from_secs(1), tracker.wait()).await })
+            .expect("fixed egress workers must drain after admission closes");
+        assert!(egress.snapshot().closed);
+    }
+}

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -30,7 +30,6 @@ use rocketmq_runtime::BudgetCapacity;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::FullPolicy;
-use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ResourceBudgetTree;
 use rocketmq_runtime::ScheduledTaskConfig;
@@ -50,7 +49,8 @@ use crate::implementation::mq_client_manager::ClientPool;
 pub struct ClientRuntimeConfig {
     /// Maximum duration used by [`ClientRuntime::shutdown`].
     pub shutdown_timeout: Duration,
-    /// Process/Pod hard memory limit. Zero selects automatic detection.
+    /// Optional cap below the injected process memory limit. Zero uses the
+    /// complete process budget supplied by the runtime owner.
     pub process_memory_limit_bytes: u64,
     /// Share of the process hard limit managed by client resource budgets.
     pub managed_memory_numerator: u64,
@@ -91,7 +91,7 @@ impl ClientRuntime {
         config: ClientRuntimeConfig,
         telemetry_handle: TelemetryHandle,
     ) -> RocketMQResult<Arc<Self>> {
-        let resource_budget = build_client_resource_budget(&config)?;
+        let resource_budget = build_client_resource_budget(&config, &service_context.process_budget())?;
         let client_metrics = ClientMetrics::from_handle(&telemetry_handle);
         let pool = ClientPool::new(
             service_context.component("pool"),
@@ -161,47 +161,64 @@ impl ClientRuntime {
     }
 }
 
-fn build_client_resource_budget(config: &ClientRuntimeConfig) -> RocketMQResult<ResourceBudget> {
+pub(crate) fn build_client_resource_budget(
+    config: &ClientRuntimeConfig,
+    process_budget: &ResourceBudget,
+) -> RocketMQResult<ResourceBudget> {
     const CLIENT_ITEM_LIMIT: usize = 262_144;
     const CONTROL_RESERVE_COUNT: usize = 1_024;
 
-    let process_limit = if config.process_memory_limit_bytes == 0 {
-        ProcessMemoryLimit::detect()
+    let process_bytes = process_budget.limit().capacity.bytes;
+    let configured_bytes = if config.process_memory_limit_bytes == 0 {
+        process_bytes
     } else {
-        ProcessMemoryLimit::configured(config.process_memory_limit_bytes)
-    }
-    .map_err(|error| RocketMQError::ConfigInvalidValue {
-        key: "client.runtime.processMemoryLimitBytes",
-        value: config.process_memory_limit_bytes.to_string(),
-        reason: error.to_string(),
-    })?;
-    let managed_bytes = process_limit
-        .fraction(config.managed_memory_numerator, config.managed_memory_denominator)
-        .map_err(|error| RocketMQError::ConfigInvalidValue {
+        usize::try_from(config.process_memory_limit_bytes)
+            .unwrap_or(usize::MAX)
+            .min(process_bytes)
+    };
+    if config.managed_memory_numerator == 0
+        || config.managed_memory_denominator == 0
+        || config.managed_memory_numerator > config.managed_memory_denominator
+    {
+        return Err(RocketMQError::ConfigInvalidValue {
             key: "client.runtime.managedMemoryFraction",
             value: format!(
                 "{}/{}",
                 config.managed_memory_numerator, config.managed_memory_denominator
             ),
-            reason: error.to_string(),
-        })?;
-    let managed_bytes = usize::try_from(managed_bytes).unwrap_or(usize::MAX).max(1);
+            reason: "numerator and denominator must be positive and numerator must not exceed denominator".to_string(),
+        });
+    }
+    let managed_bytes = ((configured_bytes as u128 * u128::from(config.managed_memory_numerator))
+        / u128::from(config.managed_memory_denominator)) as usize;
+    let managed_bytes = managed_bytes.max(1);
     let control_bytes = (managed_bytes / 16).max(1);
-    ResourceBudgetTree::new(
-        "client",
-        BudgetLimit::new(CLIENT_ITEM_LIMIT, managed_bytes, FullPolicy::Reject)
-            .with_control_reserve(BudgetCapacity::new(CONTROL_RESERVE_COUNT, control_bytes)),
-    )
-    .map(|tree| tree.root())
-    .map_err(|error| RocketMQError::ConfigInvalidValue {
-        key: "client.runtime.resourceBudget",
-        value: managed_bytes.to_string(),
-        reason: error.to_string(),
-    })
+    process_budget
+        .child(
+            "client",
+            BudgetLimit::new(CLIENT_ITEM_LIMIT, managed_bytes, FullPolicy::Reject)
+                .with_control_reserve(BudgetCapacity::new(CONTROL_RESERVE_COUNT, control_bytes)),
+        )
+        .map_err(|error| RocketMQError::ConfigInvalidValue {
+            key: "client.runtime.resourceBudget",
+            value: managed_bytes.to_string(),
+            reason: error.to_string(),
+        })
 }
 
 pub(crate) fn standalone_client_resource_budget() -> RocketMQResult<ResourceBudget> {
-    build_client_resource_budget(&ClientRuntimeConfig::default())
+    const STANDALONE_TEST_BYTES: usize = 256 * 1024 * 1024;
+    let process_budget = ResourceBudgetTree::new(
+        "standalone-client-process",
+        BudgetLimit::new(usize::MAX, STANDALONE_TEST_BYTES, FullPolicy::Reject),
+    )
+    .map_err(|error| RocketMQError::ConfigInvalidValue {
+        key: "client.runtime.standaloneResourceBudget",
+        value: STANDALONE_TEST_BYTES.to_string(),
+        reason: error.to_string(),
+    })?
+    .root();
+    build_client_resource_budget(&ClientRuntimeConfig::default(), &process_budget)
 }
 
 #[cfg(test)]

--- a/rocketmq-client/tests/producer_oneway_egress.rs
+++ b/rocketmq-client/tests/producer_oneway_egress.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ProcessMemoryLimit;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+fn producer_to_writer_transfer_keeps_one_process_charge() {
+    let owner = RuntimeOwner::new_with_memory_limit(
+        RuntimeConfig::default(),
+        ProcessMemoryLimit::configured(4096).expect("memory limit"),
+    )
+    .expect("runtime owner");
+    let process = owner.root_context().component("client").process_budget();
+    let producer = process
+        .child("producer-egress", BudgetLimit::new(8, 4096, FullPolicy::Reject))
+        .expect("producer budget");
+    let writer = process
+        .child("transport-writer", BudgetLimit::new(8, 4096, FullPolicy::Reject))
+        .expect("writer budget");
+    let mut permit = producer
+        .try_acquire(1024, BudgetClass::Data)
+        .expect("producer admission");
+
+    assert_eq!(process.snapshot().current_bytes, 1024);
+    permit.try_rebind(&writer).expect("writer rebind");
+    assert_eq!(process.snapshot().current_bytes, 1024);
+    assert_eq!(producer.snapshot().current_bytes, 0);
+    assert_eq!(writer.snapshot().current_bytes, 1024);
+
+    drop(permit);
+    assert_eq!(process.snapshot().current_bytes, 0);
+}
+
+#[test]
+fn aggregate_producer_and_writer_usage_cannot_exceed_process_ceiling() {
+    let owner = RuntimeOwner::new_with_memory_limit(
+        RuntimeConfig::default(),
+        ProcessMemoryLimit::configured(1024).expect("memory limit"),
+    )
+    .expect("runtime owner");
+    let process = owner.root_context().component("client").process_budget();
+    let producer = process
+        .child("producer-egress", BudgetLimit::new(8, 1024, FullPolicy::Reject))
+        .expect("producer budget");
+    let writer = process
+        .child("transport-writer", BudgetLimit::new(8, 1024, FullPolicy::Reject))
+        .expect("writer budget");
+    let _in_writer = writer.try_acquire(768, BudgetClass::Data).expect("writer reservation");
+
+    assert!(producer.try_acquire(512, BudgetClass::Data).is_err());
+}

--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -929,6 +929,41 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         source: MetricSource::Client,
     },
     MetricDescriptor {
+        name: metrics::CLIENT_ONEWAY_EGRESS_ITEMS,
+        kind: MetricKind::Gauge,
+        unit: "{message}",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_ONEWAY_EGRESS_BYTES,
+        kind: MetricKind::Gauge,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_ONEWAY_EGRESS_OLDEST_AGE,
+        kind: MetricKind::Gauge,
+        unit: "ms",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_ONEWAY_EGRESS_WAITERS,
+        kind: MetricKind::Gauge,
+        unit: "{waiter}",
+        labels: &[],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
+        name: metrics::CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{event}",
+        labels: &[labels::RESULT],
+        source: MetricSource::Client,
+    },
+    MetricDescriptor {
         name: metrics::NAMESRV_ROUTE_REQUEST_TOTAL,
         kind: MetricKind::Counter,
         unit: "{request}",
@@ -1342,8 +1377,8 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(JAVA_METRICS.len(), 94);
-        assert_eq!(RUST_METRICS.len(), 54);
-        assert_eq!(combined.len(), 148, "duplicate metric names across catalogs");
+        assert_eq!(RUST_METRICS.len(), 59);
+        assert_eq!(combined.len(), 153, "duplicate metric names across catalogs");
     }
 
     #[test]

--- a/rocketmq-observability/src/metrics/client.rs
+++ b/rocketmq-observability/src/metrics/client.rs
@@ -14,6 +14,11 @@
 
 pub use crate::semantic::metrics::CLIENT_CONSUME_LATENCY;
 pub use crate::semantic::metrics::CLIENT_CONSUME_TOTAL;
+pub use crate::semantic::metrics::CLIENT_ONEWAY_EGRESS_BYTES;
+pub use crate::semantic::metrics::CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL;
+pub use crate::semantic::metrics::CLIENT_ONEWAY_EGRESS_ITEMS;
+pub use crate::semantic::metrics::CLIENT_ONEWAY_EGRESS_OLDEST_AGE;
+pub use crate::semantic::metrics::CLIENT_ONEWAY_EGRESS_WAITERS;
 pub use crate::semantic::metrics::CLIENT_REBALANCE_TOTAL;
 pub use crate::semantic::metrics::CLIENT_SEND_LATENCY;
 pub use crate::semantic::metrics::CLIENT_SEND_TOTAL;
@@ -73,6 +78,12 @@ impl ClientMetrics {
 
     #[inline]
     pub fn record_rebalance(&self) {}
+
+    #[inline]
+    pub fn record_oneway_egress_state(&self, _items: u64, _bytes: u64, _oldest_age_ms: u64, _waiters: u64) {}
+
+    #[inline]
+    pub fn record_oneway_egress_event(&self, _result: &'static str) {}
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -90,6 +101,11 @@ struct ClientMetricInstruments {
     consume_total: opentelemetry::metrics::Counter<u64>,
     consume_latency: opentelemetry::metrics::Histogram<u64>,
     rebalance_total: opentelemetry::metrics::Counter<u64>,
+    oneway_egress_items: opentelemetry::metrics::Gauge<u64>,
+    oneway_egress_bytes: opentelemetry::metrics::Gauge<u64>,
+    oneway_egress_oldest_age: opentelemetry::metrics::Gauge<u64>,
+    oneway_egress_waiters: opentelemetry::metrics::Gauge<u64>,
+    oneway_egress_events_total: opentelemetry::metrics::Counter<u64>,
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -192,6 +208,30 @@ impl ClientMetrics {
     pub fn record_rebalance(&self) {
         self.record_rebalance_total(1, &[]);
     }
+
+    #[inline]
+    pub fn record_oneway_egress_state(&self, items: u64, bytes: u64, oldest_age_ms: u64, waiters: u64) {
+        if self.is_enabled() {
+            if let Some(instruments) = &self.instruments {
+                instruments.oneway_egress_items.record(items, &[]);
+                instruments.oneway_egress_bytes.record(bytes, &[]);
+                instruments.oneway_egress_oldest_age.record(oldest_age_ms, &[]);
+                instruments.oneway_egress_waiters.record(waiters, &[]);
+            }
+        }
+    }
+
+    #[inline]
+    pub fn record_oneway_egress_event(&self, result: &'static str) {
+        if self.is_enabled() {
+            if let Some(instruments) = &self.instruments {
+                instruments.oneway_egress_events_total.add(
+                    1,
+                    &[opentelemetry::KeyValue::new(crate::semantic::labels::RESULT, result)],
+                );
+            }
+        }
+    }
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -226,6 +266,31 @@ impl ClientMetricInstruments {
             .with_description("Total number of client rebalance events")
             .with_unit("{event}")
             .build();
+        let oneway_egress_items = meter
+            .u64_gauge(CLIENT_ONEWAY_EGRESS_ITEMS)
+            .with_description("Current one-way egress messages charged to the process budget")
+            .with_unit("{message}")
+            .build();
+        let oneway_egress_bytes = meter
+            .u64_gauge(CLIENT_ONEWAY_EGRESS_BYTES)
+            .with_description("Current one-way egress retained bytes charged to the process budget")
+            .with_unit("By")
+            .build();
+        let oneway_egress_oldest_age = meter
+            .u64_gauge(CLIENT_ONEWAY_EGRESS_OLDEST_AGE)
+            .with_description("Age of the oldest one-way egress message")
+            .with_unit("ms")
+            .build();
+        let oneway_egress_waiters = meter
+            .u64_gauge(CLIENT_ONEWAY_EGRESS_WAITERS)
+            .with_description("Current one-way egress admission waiters")
+            .with_unit("{waiter}")
+            .build();
+        let oneway_egress_events_total = meter
+            .u64_counter(CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL)
+            .with_description("One-way egress accepted, delivered, failed, cancelled, and rejected events")
+            .with_unit("{event}")
+            .build();
 
         Self {
             send_total,
@@ -233,6 +298,11 @@ impl ClientMetricInstruments {
             consume_total,
             consume_latency,
             rebalance_total,
+            oneway_egress_items,
+            oneway_egress_bytes,
+            oneway_egress_oldest_age,
+            oneway_egress_waiters,
+            oneway_egress_events_total,
         }
     }
 }

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -112,6 +112,11 @@ pub mod metrics {
     pub const CLIENT_CONSUME_TOTAL: &str = "rocketmq_client_consume_total";
     pub const CLIENT_CONSUME_LATENCY: &str = "rocketmq_client_consume_latency";
     pub const CLIENT_REBALANCE_TOTAL: &str = "rocketmq_client_rebalance_total";
+    pub const CLIENT_ONEWAY_EGRESS_ITEMS: &str = "rocketmq_client_oneway_egress_items";
+    pub const CLIENT_ONEWAY_EGRESS_BYTES: &str = "rocketmq_client_oneway_egress_bytes";
+    pub const CLIENT_ONEWAY_EGRESS_OLDEST_AGE: &str = "rocketmq_client_oneway_egress_oldest_age";
+    pub const CLIENT_ONEWAY_EGRESS_WAITERS: &str = "rocketmq_client_oneway_egress_waiters";
+    pub const CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL: &str = "rocketmq_client_oneway_egress_events_total";
     pub const NAMESRV_ROUTE_REQUEST_TOTAL: &str = "rocketmq_namesrv_route_request_total";
     pub const NAMESRV_ROUTE_REQUEST_LATENCY: &str = "rocketmq_namesrv_route_request_latency";
     pub const NAMESRV_BROKER_REGISTRATIONS: &str = "rocketmq_namesrv_broker_registrations";

--- a/rocketmq-runtime/src/context.rs
+++ b/rocketmq-runtime/src/context.rs
@@ -24,6 +24,8 @@ use crate::diagnostics::RuntimeDiagnosticsSnapshot;
 use crate::error::RuntimeError;
 use crate::error::RuntimeResult;
 use crate::handle::RuntimeHandle;
+use crate::resource_budget::ProcessMemoryLimit;
+use crate::resources::RuntimeResources;
 use crate::service_context::ChildServiceContext;
 use crate::service_context::RootServiceContext;
 use crate::service_context::ScopeId;
@@ -67,6 +69,10 @@ impl RuntimeContext {
         let global_blocking_capacity = blocking_policies.total_max_concurrency();
         let root_group = TaskGroup::root(name.clone(), runtime.clone());
         let diagnostics = RuntimeDiagnostics::new();
+        let resources = RuntimeResources::from_memory_limit(
+            ProcessMemoryLimit::configured(u64::MAX)
+                .map_err(|error| RuntimeError::InvalidConfig(format!("invalid harness memory limit: {error}")))?,
+        )?;
         let root = RootServiceContext::new(
             name,
             runtime,
@@ -74,6 +80,7 @@ impl RuntimeContext {
             blocking_policies,
             global_blocking_capacity,
             diagnostics,
+            resources,
         )?;
         Ok(Self { root: Arc::new(root) })
     }

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -56,6 +56,8 @@ pub mod prelude;
 mod public_api;
 /// Resource budget types and operations.
 pub mod resource_budget;
+/// Process-wide runtime resource capabilities.
+pub mod resources;
 /// Schedule types and operations.
 pub mod schedule;
 /// Scheduled types and operations.
@@ -138,6 +140,7 @@ pub use resource_budget::FullPolicy;
 pub use resource_budget::MemoryLimitError;
 pub use resource_budget::MemoryLimitSource;
 pub use resource_budget::MonotonicClock;
+pub use resource_budget::PermitRebindError;
 pub use resource_budget::ProcessMemoryLimit;
 pub use resource_budget::QueuePushError;
 pub use resource_budget::QueuePushErrorKind;
@@ -147,6 +150,7 @@ pub use resource_budget::RateLimit;
 pub use resource_budget::ResourceBudgetTree;
 pub use resource_budget::ResourcePermit;
 pub use resource_budget::SystemMonotonicClock;
+pub use resources::RuntimeResources;
 pub use schedule::executor::ExecutorConfig;
 pub use schedule::executor::ExecutorPool;
 pub use schedule::executor::TaskExecutor;

--- a/rocketmq-runtime/src/owner.rs
+++ b/rocketmq-runtime/src/owner.rs
@@ -19,6 +19,9 @@ use crate::diagnostics::RuntimeDiagnostics;
 use crate::error::RuntimeError;
 use crate::error::RuntimeResult;
 use crate::handle::RuntimeHandle;
+use crate::resource_budget::MemoryLimitError;
+use crate::resource_budget::ProcessMemoryLimit;
+use crate::resources::RuntimeResources;
 use crate::service_context::RootServiceContext;
 use crate::shutdown_deadline::ShutdownDeadline;
 use crate::shutdown_report::ShutdownReport;
@@ -32,6 +35,7 @@ use crate::task_group::TaskGroupLifecycleState;
 pub struct RuntimeOwner {
     config: RuntimeConfig,
     runtime: Option<tokio::runtime::Runtime>,
+    resources: RuntimeResources,
     root_context: RootServiceContext,
 }
 
@@ -41,9 +45,36 @@ impl RuntimeOwner {
     /// # Errors
     ///
     /// Returns an error when the configuration is invalid, the Tokio runtime
-    /// cannot be built, or the root blocking executor cannot be initialized.
+    /// cannot be built, the process memory limit cannot be detected, or the
+    /// root blocking executor cannot be initialized.
     pub fn new(config: RuntimeConfig) -> RuntimeResult<Self> {
+        Self::try_new_with_memory_detector(config, ProcessMemoryLimit::detect)
+    }
+
+    /// Creates a runtime owner with an explicit process memory limit.
+    ///
+    /// Composition roots with an authoritative container or service limit can
+    /// use this constructor to avoid platform discovery. The resulting budget
+    /// is still owned once by this runtime owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configuration or process budget is invalid,
+    /// the Tokio runtime cannot be built, or the root blocking executor cannot
+    /// be initialized.
+    pub fn new_with_memory_limit(config: RuntimeConfig, memory_limit: ProcessMemoryLimit) -> RuntimeResult<Self> {
+        Self::try_new_with_memory_detector(config, || Ok(memory_limit))
+    }
+
+    fn try_new_with_memory_detector<F>(config: RuntimeConfig, detector: F) -> RuntimeResult<Self>
+    where
+        F: FnOnce() -> Result<ProcessMemoryLimit, MemoryLimitError>,
+    {
         config.validate()?;
+        let memory_limit = detector().map_err(|error| {
+            RuntimeError::InvalidConfig(format!("failed to determine process memory limit: {error}"))
+        })?;
+        let resources = RuntimeResources::from_memory_limit(memory_limit)?;
 
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder
@@ -72,10 +103,12 @@ impl RuntimeOwner {
             config.blocking_lane_policies.clone(),
             config.max_blocking_threads,
             diagnostics,
+            resources.clone(),
         )?;
         Ok(Self {
             config,
             runtime: Some(runtime),
+            resources,
             root_context,
         })
     }
@@ -88,6 +121,11 @@ impl RuntimeOwner {
     /// Returns the validated runtime configuration.
     pub fn config(&self) -> &RuntimeConfig {
         &self.config
+    }
+
+    /// Returns the process-wide resource capabilities.
+    pub fn resources(&self) -> &RuntimeResources {
+        &self.resources
     }
 
     /// Blocks the current thread until `future` completes.
@@ -195,5 +233,26 @@ impl RuntimeOwner {
             report.merge_blocking(snapshot);
         }
         report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[test]
+    fn runtime_owner_invokes_the_memory_detector_once() {
+        let calls = AtomicUsize::new(0);
+        let owner = RuntimeOwner::try_new_with_memory_detector(RuntimeConfig::default(), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            ProcessMemoryLimit::configured(4 * 1024 * 1024)
+        })
+        .expect("runtime owner");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(owner.resources().memory_limit().bytes(), 4 * 1024 * 1024);
     }
 }

--- a/rocketmq-runtime/src/resource_budget/budget.rs
+++ b/rocketmq-runtime/src/resource_budget/budget.rs
@@ -90,6 +90,22 @@ impl BudgetAcquireError {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+/// Error returned when a resource permit cannot move to another budget.
+pub enum PermitRebindError {
+    #[error("cannot rebind resource permit from {source_path} to a different budget tree at {target_path}")]
+    /// The target does not share the permit's root budget.
+    DifferentTree {
+        /// The current permit budget path.
+        source_path: Arc<str>,
+        /// The requested target budget path.
+        target_path: Arc<str>,
+    },
+    #[error(transparent)]
+    /// The target budget cannot admit the reservation.
+    Budget(#[from] BudgetAcquireError),
+}
+
 /// Represents resource budget tree.
 pub struct ResourceBudgetTree {
     root: ResourceBudget,
@@ -346,6 +362,68 @@ impl ResourcePermit {
     /// Returns the class.
     pub const fn class(&self) -> BudgetClass {
         self.class
+    }
+
+    /// Moves this reservation to another budget in the same resource tree.
+    ///
+    /// Reservations for the common ancestor chain remain owned throughout the
+    /// transfer. Target-only reservations are acquired before source-only
+    /// reservations are released, so the payload is always covered without
+    /// charging common ancestors twice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PermitRebindError::DifferentTree`] for an unrelated target.
+    /// Returns [`PermitRebindError::Budget`] when the target is full. On every
+    /// error, this permit remains unchanged and valid for its source budget.
+    pub fn try_rebind(&mut self, target: &ResourceBudget) -> Result<(), PermitRebindError> {
+        let common_ancestors = self
+            .reservations
+            .iter()
+            .zip(target.chain.iter())
+            .take_while(|(reservation, target_node)| Arc::ptr_eq(&reservation.node, target_node))
+            .count();
+        if common_ancestors == 0 {
+            return Err(PermitRebindError::DifferentTree {
+                source_path: Arc::clone(
+                    &self
+                        .reservations
+                        .last()
+                        .expect("resource permit always owns its root reservation")
+                        .node
+                        .path,
+                ),
+                target_path: Arc::clone(&target.node.path),
+            });
+        }
+        if common_ancestors == self.reservations.len() && common_ancestors == target.chain.len() {
+            return Ok(());
+        }
+
+        let mut target_reservations =
+            SmallVec::<[NodeReservation; 4]>::with_capacity(target.chain.len() - common_ancestors);
+        for node in target.chain.iter().skip(common_ancestors) {
+            match node.try_reserve(self.bytes, self.class) {
+                Ok(reservation) => target_reservations.push(reservation),
+                Err(dimension) => {
+                    target.record_rejection(node, dimension);
+                    return Err(PermitRebindError::Budget(BudgetAcquireError {
+                        path: Arc::clone(&target.node.path),
+                        exhausted_path: Arc::clone(&node.path),
+                        dimension,
+                        policy: target.node.limit.full_policy,
+                    }));
+                }
+            }
+        }
+        for reservation in &mut target_reservations {
+            reservation.commit();
+        }
+
+        self.reservations.truncate(common_ancestors);
+        self.reservations.extend(target_reservations);
+        self.capacity_notify.notify_waiters();
+        Ok(())
     }
 }
 

--- a/rocketmq-runtime/src/resource_budget/mod.rs
+++ b/rocketmq-runtime/src/resource_budget/mod.rs
@@ -20,6 +20,7 @@ mod queue;
 
 pub use budget::BudgetAcquireError;
 pub use budget::BudgetSnapshot;
+pub use budget::PermitRebindError;
 pub use budget::ResourceBudget;
 pub use budget::ResourceBudgetTree;
 pub use budget::ResourcePermit;

--- a/rocketmq-runtime/src/resources.rs
+++ b/rocketmq-runtime/src/resources.rs
@@ -1,0 +1,60 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::resource_budget::BudgetLimit;
+use crate::resource_budget::FullPolicy;
+use crate::resource_budget::ProcessMemoryLimit;
+use crate::resource_budget::ResourceBudget;
+use crate::resource_budget::ResourceBudgetTree;
+
+/// Process-wide resource capabilities owned by [`crate::RuntimeOwner`].
+///
+/// Clones share the same budget tree. Components derive narrower child
+/// budgets from [`Self::process_budget`] instead of detecting process limits
+/// or creating independent roots.
+#[derive(Debug, Clone)]
+pub struct RuntimeResources {
+    memory_limit: ProcessMemoryLimit,
+    process_budget: ResourceBudget,
+}
+
+impl RuntimeResources {
+    pub(crate) fn from_memory_limit(memory_limit: ProcessMemoryLimit) -> RuntimeResult<Self> {
+        let managed_bytes = usize::try_from(memory_limit.bytes()).unwrap_or(usize::MAX);
+        let process_budget = ResourceBudgetTree::new(
+            "process",
+            BudgetLimit::new(usize::MAX, managed_bytes, FullPolicy::Reject),
+        )
+        .map_err(|error| RuntimeError::InvalidConfig(format!("invalid process resource budget: {error}")))?
+        .root();
+        Ok(Self {
+            memory_limit,
+            process_budget,
+        })
+    }
+
+    /// Returns the detected or explicitly configured process memory limit.
+    #[must_use]
+    pub const fn memory_limit(&self) -> ProcessMemoryLimit {
+        self.memory_limit
+    }
+
+    /// Returns the shared process resource-budget root.
+    #[must_use]
+    pub fn process_budget(&self) -> ResourceBudget {
+        self.process_budget.clone()
+    }
+}

--- a/rocketmq-runtime/src/service_context.rs
+++ b/rocketmq-runtime/src/service_context.rs
@@ -24,6 +24,8 @@ use crate::diagnostics::RuntimeDiagnosticsSnapshot;
 use crate::error::RuntimeError;
 use crate::error::RuntimeResult;
 use crate::handle::RuntimeHandle;
+use crate::resource_budget::ResourceBudget;
+use crate::resources::RuntimeResources;
 use crate::scheduled::ScheduledTaskGroup;
 use crate::task_group::TaskGroup;
 use crate::task_group::TaskId;
@@ -134,6 +136,7 @@ pub struct RootServiceContext {
     task_group: TaskGroup,
     blocking_lanes: BlockingLanes,
     diagnostics: RuntimeDiagnostics,
+    resources: RuntimeResources,
     _sealed: RootContextSeal,
 }
 
@@ -148,6 +151,7 @@ impl RootServiceContext {
         blocking_policies: BlockingLanePolicies,
         global_blocking_capacity: usize,
         diagnostics: RuntimeDiagnostics,
+        resources: RuntimeResources,
     ) -> RuntimeResult<Self> {
         let blocking_lanes = BlockingLanes::new(blocking_policies, global_blocking_capacity)?;
         Ok(Self {
@@ -156,6 +160,7 @@ impl RootServiceContext {
             task_group,
             blocking_lanes,
             diagnostics,
+            resources,
             _sealed: RootContextSeal,
         })
     }
@@ -172,7 +177,18 @@ impl RootServiceContext {
             &self.task_group,
             self.blocking_lanes.clone(),
             self.diagnostics.clone(),
+            self.resources.clone(),
         )
+    }
+
+    /// Returns the shared process resource-budget root.
+    pub fn process_budget(&self) -> ResourceBudget {
+        self.resources.process_budget()
+    }
+
+    /// Returns the process-wide runtime resource capabilities.
+    pub fn resources(&self) -> &RuntimeResources {
+        &self.resources
     }
 
     /// Returns the diagnostics snapshot.
@@ -222,6 +238,7 @@ pub struct ChildServiceContext {
     task_group: TaskGroup,
     blocking_lanes: BlockingLanes,
     diagnostics: RuntimeDiagnostics,
+    resources: RuntimeResources,
     _sealed: Arc<ChildContextSeal>,
 }
 
@@ -234,6 +251,7 @@ impl ChildServiceContext {
         parent_group: &TaskGroup,
         blocking_lanes: BlockingLanes,
         diagnostics: RuntimeDiagnostics,
+        resources: RuntimeResources,
     ) -> Self {
         let name = scope.into_inner();
         Self {
@@ -241,6 +259,7 @@ impl ChildServiceContext {
             task_group: parent_group.component(name),
             blocking_lanes,
             diagnostics,
+            resources,
             _sealed: Arc::new(ChildContextSeal),
         }
     }
@@ -285,6 +304,16 @@ impl ChildServiceContext {
         &self.diagnostics
     }
 
+    /// Returns the shared process resource-budget root.
+    pub fn process_budget(&self) -> ResourceBudget {
+        self.resources.process_budget()
+    }
+
+    /// Returns the process-wide runtime resource capabilities.
+    pub fn resources(&self) -> &RuntimeResources {
+        &self.resources
+    }
+
     /// Returns the diagnostics snapshot.
     pub fn diagnostics_snapshot(&self) -> RuntimeDiagnosticsSnapshot {
         self.diagnostics
@@ -307,6 +336,7 @@ impl ChildServiceContext {
             &self.task_group,
             self.blocking_lanes.clone(),
             self.diagnostics.clone(),
+            self.resources.clone(),
         )
     }
 

--- a/rocketmq-runtime/tests/resource_budget_tree.rs
+++ b/rocketmq-runtime/tests/resource_budget_tree.rs
@@ -25,6 +25,7 @@ use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::BudgetedQueue;
 use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::MonotonicClock;
+use rocketmq_runtime::PermitRebindError;
 use rocketmq_runtime::QueuePushErrorKind;
 use rocketmq_runtime::QueuePushOutcome;
 use rocketmq_runtime::RateLimit;
@@ -128,6 +129,83 @@ fn parent_budget_bounds_the_sum_of_independent_children() {
     assert_eq!(second.snapshot().rejected_count, 1);
     drop(first_permit);
     assert!(second.try_acquire_data(60).is_ok());
+}
+
+#[test]
+fn rebind_between_siblings_preserves_common_ancestor_accounting() {
+    let tree = ResourceBudgetTree::new("process", limit(4, 64, FullPolicy::Reject)).expect("root budget");
+    let source = tree
+        .root()
+        .child("producer", limit(2, 32, FullPolicy::Reject))
+        .expect("source budget");
+    let target = tree
+        .root()
+        .child("transport", limit(2, 32, FullPolicy::Reject))
+        .expect("target budget");
+    let mut permit = source.try_acquire_data(8).expect("source permit");
+
+    permit.try_rebind(&target).expect("same-tree rebind");
+
+    assert_eq!(tree.root().snapshot().current_count, 1);
+    assert_eq!(tree.root().snapshot().current_bytes, 8);
+    assert_eq!(source.snapshot().current_count, 0);
+    assert_eq!(source.snapshot().current_bytes, 0);
+    assert_eq!(target.snapshot().current_count, 1);
+    assert_eq!(target.snapshot().current_bytes, 8);
+
+    drop(permit);
+    assert_eq!(tree.root().snapshot().current_count, 0);
+    assert_eq!(target.snapshot().current_count, 0);
+}
+
+#[test]
+fn failed_rebind_keeps_the_source_permit_valid() {
+    let tree = ResourceBudgetTree::new("process", limit(3, 64, FullPolicy::Reject)).expect("root budget");
+    let source = tree
+        .root()
+        .child("producer", limit(2, 32, FullPolicy::Reject))
+        .expect("source budget");
+    let target = tree
+        .root()
+        .child("transport", limit(1, 32, FullPolicy::Reject))
+        .expect("target budget");
+    let target_owner = target.try_acquire_data(8).expect("fill target");
+    let mut source_owner = source.try_acquire_data(8).expect("source permit");
+
+    let error = source_owner
+        .try_rebind(&target)
+        .expect_err("full target must reject rebind");
+    assert!(matches!(
+        error,
+        PermitRebindError::Budget(ref error) if error.dimension() == BudgetDimension::Count
+    ));
+    assert_eq!(source.snapshot().current_count, 1);
+    assert_eq!(source.snapshot().current_bytes, 8);
+    assert_eq!(target.snapshot().current_count, 1);
+    assert_eq!(tree.root().snapshot().current_count, 2);
+    assert_eq!(tree.root().snapshot().current_bytes, 16);
+
+    drop((source_owner, target_owner));
+    assert_eq!(tree.root().snapshot().current_count, 0);
+    assert_eq!(tree.root().snapshot().current_bytes, 0);
+}
+
+#[test]
+fn rebind_rejects_a_target_from_another_tree() {
+    let source_tree = ResourceBudgetTree::new("source-process", limit(1, 16, FullPolicy::Reject)).expect("source tree");
+    let target_tree = ResourceBudgetTree::new("target-process", limit(1, 16, FullPolicy::Reject)).expect("target tree");
+    let source = source_tree.root();
+    let mut permit = source.try_acquire_data(8).expect("source permit");
+
+    let error = permit
+        .try_rebind(&target_tree.root())
+        .expect_err("cross-tree rebind must fail");
+
+    assert!(matches!(error, PermitRebindError::DifferentTree { .. }));
+    assert_eq!(source.snapshot().current_count, 1);
+    assert_eq!(source.snapshot().current_bytes, 8);
+    drop(permit);
+    assert_eq!(source.snapshot().current_count, 0);
 }
 
 #[test]

--- a/rocketmq-runtime/tests/runtime_resource_ownership.rs
+++ b/rocketmq-runtime/tests/runtime_resource_ownership.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::ProcessMemoryLimit;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+fn child_contexts_share_the_runtime_owners_process_budget() {
+    let memory_limit = ProcessMemoryLimit::configured(1024).expect("configured memory limit");
+    let owner = RuntimeOwner::new_with_memory_limit(RuntimeConfig::default(), memory_limit).expect("runtime owner");
+    let producer = owner.root_context().component("producer");
+    let transport = owner.root_context().component("transport");
+
+    assert_eq!(owner.resources().memory_limit(), memory_limit);
+    let producer_budget = producer.process_budget();
+    let transport_budget = transport.process_budget();
+    let permit = producer_budget
+        .try_acquire(768, BudgetClass::Data)
+        .expect("producer reservation");
+
+    assert_eq!(transport_budget.snapshot().current_bytes, 768);
+    let exhausted = transport_budget
+        .try_acquire(300, BudgetClass::Data)
+        .expect_err("shared process ceiling must reject aggregate overcommit");
+    assert_eq!(exhausted.exhausted_path(), "process");
+
+    drop(permit);
+    assert_eq!(owner.resources().process_budget().snapshot().current_bytes, 0);
+}

--- a/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.stderr
@@ -11,10 +11,11 @@ error[E0624]: associated function `new` is private
   | |         parent_group: &TaskGroup,
   | |         blocking_lanes: BlockingLanes,
   | |         diagnostics: RuntimeDiagnostics,
+  | |         resources: RuntimeResources,
   | |     ) -> Self {
   | |_____________- private associated function defined here
 
-error[E0061]: this function takes 4 arguments but 0 arguments were supplied
+error[E0061]: this function takes 5 arguments but 0 arguments were supplied
  --> tests/ui/service_context/child_raw_constructor_is_private.rs:4:5
   |
 4 |     ChildServiceContext::new()
@@ -27,5 +28,5 @@ note: associated function defined here
   |        ^^^
 help: provide the arguments
   |
-4 |     ChildServiceContext::new(/* ScopeId */, /* &TaskGroup */, /* service_context::BlockingLanes */, /* RuntimeDiagnostics */)
-  |                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+4 |     ChildServiceContext::new(/* ScopeId */, /* &TaskGroup */, /* service_context::BlockingLanes */, /* RuntimeDiagnostics */, /* RuntimeResources */)
+  |                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
@@ -11,11 +11,11 @@ error[E0624]: associated function `new` is private
   | |         runtime: RuntimeHandle,
   | |         task_group: TaskGroup,
 ... |
-  | |         diagnostics: RuntimeDiagnostics,
+  | |         resources: RuntimeResources,
   | |     ) -> RuntimeResult<Self> {
   | |____________________________- private associated function defined here
 
-error[E0061]: this function takes 6 arguments but 0 arguments were supplied
+error[E0061]: this function takes 7 arguments but 0 arguments were supplied
  --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:5
   |
 4 |     RootServiceContext::new()
@@ -28,8 +28,8 @@ note: associated function defined here
   |                   ^^^
 help: provide the arguments
   |
-4 |     RootServiceContext::new(/* Arc<str> */, /* rocketmq_runtime::handle::RuntimeHandle */, /* TaskGroup */, /* BlockingLanePolicies */, /* usize */, /* RuntimeDiagnostics */)
-  |                             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+4 |     RootServiceContext::new(/* Arc<str> */, /* rocketmq_runtime::handle::RuntimeHandle */, /* TaskGroup */, /* BlockingLanePolicies */, /* usize */, /* RuntimeDiagnostics */, /* RuntimeResources */)
+  |                             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
  --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:5

--- a/rocketmq-transport/src/admission.rs
+++ b/rocketmq-transport/src/admission.rs
@@ -24,8 +24,6 @@ use rocketmq_runtime::BudgetConfigError;
 use rocketmq_runtime::BudgetDimension;
 use rocketmq_runtime::BudgetLimit;
 pub use rocketmq_runtime::FullPolicy;
-use rocketmq_runtime::MemoryLimitError;
-use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ResourceBudgetTree;
 use rocketmq_runtime::ResourcePermit;
@@ -219,7 +217,6 @@ impl std::error::Error for AdmissionError {}
 #[derive(Debug)]
 pub enum AdmissionConfigError {
     Budget(BudgetConfigError),
-    Memory(MemoryLimitError),
     ZeroScopeCapacity {
         scope: &'static str,
         dimension: BudgetDimension,
@@ -231,7 +228,6 @@ impl fmt::Display for AdmissionConfigError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Budget(error) => error.fmt(formatter),
-            Self::Memory(error) => error.fmt(formatter),
             Self::ZeroScopeCapacity { scope, dimension } => {
                 write!(formatter, "{scope} admission limit has zero {dimension:?} capacity")
             }
@@ -246,7 +242,6 @@ impl std::error::Error for AdmissionConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Budget(error) => Some(error),
-            Self::Memory(error) => Some(error),
             Self::ZeroScopeCapacity { .. } | Self::ZeroMaxScopeKeys => None,
         }
     }
@@ -255,12 +250,6 @@ impl std::error::Error for AdmissionConfigError {
 impl From<BudgetConfigError> for AdmissionConfigError {
     fn from(error: BudgetConfigError) -> Self {
         Self::Budget(error)
-    }
-}
-
-impl From<MemoryLimitError> for AdmissionConfigError {
-    fn from(error: MemoryLimitError) -> Self {
-        Self::Memory(error)
     }
 }
 
@@ -273,7 +262,7 @@ struct GlobalBudgets {
 }
 
 impl GlobalBudgets {
-    fn new(limits: AdmissionLimits) -> Result<Self, AdmissionConfigError> {
+    fn new(limits: AdmissionLimits, process_budget: &ResourceBudget) -> Result<Self, AdmissionConfigError> {
         let resources = [
             limits.connections,
             limits.handshakes,
@@ -287,22 +276,24 @@ impl GlobalBudgets {
         let requested_root_bytes = resources
             .iter()
             .fold(0usize, |total, limit| total.saturating_add(limit.bytes));
-        let managed_bytes = ProcessMemoryLimit::detect()?.fraction(1, 8)?;
-        let managed_bytes = usize::try_from(managed_bytes).unwrap_or(usize::MAX).max(1);
-        let root_bytes = requested_root_bytes.min(managed_bytes).max(1);
-        let reserve_count = resources.iter().fold(0usize, |total, limit| {
-            total.saturating_add(effective_reserve(limits.control_reserve.count, limit.count))
-        });
+        let process_capacity = process_budget.limit().capacity;
+        let root_count = root_count.min(process_capacity.count).max(1);
+        let root_bytes = requested_root_bytes.min(process_capacity.bytes).max(1);
+        let reserve_count = resources
+            .iter()
+            .fold(0usize, |total, limit| {
+                total.saturating_add(effective_reserve(limits.control_reserve.count, limit.count))
+            })
+            .min(root_count);
         let requested_reserve_bytes = resources.iter().fold(0usize, |total, limit| {
             total.saturating_add(effective_reserve(limits.control_reserve.bytes, limit.bytes))
         });
         let reserve_bytes = effective_reserve(requested_reserve_bytes, root_bytes);
-        let tree = ResourceBudgetTree::new(
+        let root = process_budget.child(
             "transport",
             BudgetLimit::new(root_count, root_bytes, FullPolicy::Reject)
                 .with_control_reserve(BudgetCapacity::new(reserve_count, reserve_bytes)),
         )?;
-        let root = tree.root();
         Ok(Self {
             connections: global_budget(
                 &root,
@@ -410,7 +401,21 @@ impl AdmissionController {
     }
 
     pub fn try_new(limits: AdmissionLimits) -> Result<Self, AdmissionConfigError> {
-        Self::build(limits, None)
+        let process_budget = standalone_process_budget(limits)?;
+        Self::build(limits, &process_budget, None)
+    }
+
+    /// Creates a controller whose transport budgets derive from the injected
+    /// process resource root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any transport or derived child limit is invalid.
+    pub fn try_new_with_budget(
+        limits: AdmissionLimits,
+        process_budget: &ResourceBudget,
+    ) -> Result<Self, AdmissionConfigError> {
+        Self::build(limits, process_budget, None)
     }
 
     /// Creates an observed transport admission controller.
@@ -427,17 +432,32 @@ impl AdmissionController {
         limits: AdmissionLimits,
         observer: tokio::sync::mpsc::Sender<AdmissionEvent>,
     ) -> Result<Self, AdmissionConfigError> {
-        Self::build(limits, Some(observer))
+        let process_budget = standalone_process_budget(limits)?;
+        Self::build(limits, &process_budget, Some(observer))
+    }
+
+    /// Creates an observed controller under an injected process resource root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any transport or derived child limit is invalid.
+    pub fn try_with_budget_and_observer(
+        limits: AdmissionLimits,
+        process_budget: &ResourceBudget,
+        observer: tokio::sync::mpsc::Sender<AdmissionEvent>,
+    ) -> Result<Self, AdmissionConfigError> {
+        Self::build(limits, process_budget, Some(observer))
     }
 
     fn build(
         limits: AdmissionLimits,
+        process_budget: &ResourceBudget,
         observer: Option<tokio::sync::mpsc::Sender<AdmissionEvent>>,
     ) -> Result<Self, AdmissionConfigError> {
         validate_scope_limits(limits)?;
         Ok(Self {
             limits,
-            global: GlobalBudgets::new(limits)?,
+            global: GlobalBudgets::new(limits, process_budget)?,
             scoped: Mutex::new(HashMap::new()),
             observer,
         })
@@ -466,6 +486,42 @@ impl AdmissionController {
             }
             AdmissionError { resource, policy }
         })?;
+        if let Some(observer) = &self.observer {
+            let _ = observer.try_send(AdmissionEvent {
+                resource,
+                outcome: AdmissionOutcome::Acquired,
+                bytes,
+            });
+        }
+        Ok(AdmissionPermit {
+            _permit: permit,
+            observer: self.observer.clone(),
+            resource,
+            bytes,
+        })
+    }
+
+    pub(crate) fn rebind_permit(
+        &self,
+        resource: AdmissionResource,
+        scope: AdmissionScope,
+        mut permit: ResourcePermit,
+    ) -> Result<AdmissionPermit, AdmissionError> {
+        let budget = self.scoped_budget(resource, scope)?;
+        permit.try_rebind(&budget).map_err(|_| {
+            if let Some(observer) = &self.observer {
+                let _ = observer.try_send(AdmissionEvent {
+                    resource,
+                    outcome: AdmissionOutcome::Rejected,
+                    bytes: permit.bytes(),
+                });
+            }
+            AdmissionError {
+                resource,
+                policy: policy_for(resource),
+            }
+        })?;
+        let bytes = permit.bytes();
         if let Some(observer) = &self.observer {
             let _ = observer.try_send(AdmissionEvent {
                 resource,
@@ -562,6 +618,29 @@ impl AdmissionController {
             processors: resource_snapshot(&self.global.processors),
         }
     }
+}
+
+fn standalone_process_budget(limits: AdmissionLimits) -> Result<ResourceBudget, AdmissionConfigError> {
+    let resources = [
+        limits.connections,
+        limits.handshakes,
+        limits.inflight,
+        limits.queued,
+        limits.processors,
+    ];
+    let count = resources
+        .iter()
+        .fold(0usize, |total, limit| total.saturating_add(limit.count))
+        .max(1);
+    let bytes = resources
+        .iter()
+        .fold(0usize, |total, limit| total.saturating_add(limit.bytes))
+        .max(1);
+    Ok(ResourceBudgetTree::new(
+        "standalone-transport-process",
+        BudgetLimit::new(count, bytes, FullPolicy::Reject),
+    )?
+    .root())
 }
 
 fn global_budget(

--- a/rocketmq-transport/src/base/pending_request_table.rs
+++ b/rocketmq-transport/src/base/pending_request_table.rs
@@ -27,7 +27,6 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::BudgetDimension;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::FullPolicy;
-use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::RateLimit;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ResourceBudgetTree;
@@ -225,37 +224,51 @@ impl PendingRequestTable {
     ///
     /// # Errors
     ///
-    /// Returns a typed configuration error when process-memory detection or
-    /// budget validation fails.
+    /// Returns a typed configuration error when budget validation fails.
     pub fn try_with_limits(limits: PendingRequestLimits) -> RocketMQResult<Self> {
-        let max_count = limits.max_count.max(1);
-        let process_bytes = ProcessMemoryLimit::detect()
-            .and_then(|limit| limit.fraction(1, 16))
-            .map_err(|error| RocketMQError::ConfigInvalidValue {
-                key: "transport.pendingRequest.processMemoryLimit",
-                value: limits.max_bytes.to_string(),
-                reason: error.to_string(),
-            })?;
-        let process_bytes = usize::try_from(process_bytes).unwrap_or(usize::MAX).max(1);
-        let max_bytes = limits.max_bytes.min(process_bytes).max(1);
-        let request_rate = limits.admission_rate_per_second.max(1);
-        let max_request_age = limits.max_request_age;
-        let table_id = NEXT_TABLE_ID.fetch_add(1, Ordering::Relaxed);
-        let budget = ResourceBudgetTree::new(
-            format!("pending-request-table-{table_id}"),
-            BudgetLimit::new(max_count, max_bytes, FullPolicy::Reject)
-                .with_rate(RateLimit::new(request_rate, request_rate))
-                .with_max_age(max_request_age),
+        let process_budget = ResourceBudgetTree::new(
+            "standalone-pending-request-process",
+            BudgetLimit::new(limits.max_count.max(1), limits.max_bytes.max(1), FullPolicy::Reject),
         )
         .map_err(|error| RocketMQError::ConfigInvalidValue {
-            key: "transport.pendingRequest",
-            value: format!(
-                "count={max_count},bytes={max_bytes},rate={request_rate},age_ms={}",
-                max_request_age.as_millis()
-            ),
+            key: "transport.pendingRequest.standalone",
+            value: limits.max_bytes.to_string(),
             reason: error.to_string(),
         })?
         .root();
+        Self::try_with_limits_and_budget(limits, &process_budget)
+    }
+
+    /// Builds a table below an injected process resource root.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed configuration error when the derived budget is invalid.
+    pub fn try_with_limits_and_budget(
+        limits: PendingRequestLimits,
+        process_budget: &ResourceBudget,
+    ) -> RocketMQResult<Self> {
+        let process_capacity = process_budget.limit().capacity;
+        let max_count = limits.max_count.max(1).min(process_capacity.count);
+        let max_bytes = limits.max_bytes.max(1).min(process_capacity.bytes);
+        let request_rate = limits.admission_rate_per_second.max(1);
+        let max_request_age = limits.max_request_age;
+        let table_id = NEXT_TABLE_ID.fetch_add(1, Ordering::Relaxed);
+        let budget = process_budget
+            .child(
+                format!("pending-request-table-{table_id}"),
+                BudgetLimit::new(max_count, max_bytes, FullPolicy::Reject)
+                    .with_rate(RateLimit::new(request_rate, request_rate))
+                    .with_max_age(max_request_age),
+            )
+            .map_err(|error| RocketMQError::ConfigInvalidValue {
+                key: "transport.pendingRequest",
+                value: format!(
+                    "count={max_count},bytes={max_bytes},rate={request_rate},age_ms={}",
+                    max_request_age.as_millis()
+                ),
+                reason: error.to_string(),
+            })?;
         Ok(Self {
             inner: Arc::new(PendingRequestTableInner {
                 table_id,

--- a/rocketmq-transport/src/client.rs
+++ b/rocketmq-transport/src/client.rs
@@ -169,14 +169,18 @@ impl TransportClient {
         admission: Arc<AdmissionController>,
         security: Arc<TransportSecurity>,
     ) -> RocketMQResult<Self> {
+        let process_budget = service_context.process_budget();
         Ok(Self {
             _service_context: service_context,
             admission,
-            pending: PendingRequestTable::try_with_limits(PendingRequestLimits {
-                max_count: 65_536,
-                max_bytes: 256 * 1024 * 1024,
-                ..PendingRequestLimits::default()
-            })?,
+            pending: PendingRequestTable::try_with_limits_and_budget(
+                PendingRequestLimits {
+                    max_count: 65_536,
+                    max_bytes: 256 * 1024 * 1024,
+                    ..PendingRequestLimits::default()
+                },
+                &process_budget,
+            )?,
             next_opaque: AtomicI32::new(1),
             security,
             telemetry: TransportTelemetry::noop(),

--- a/rocketmq-transport/src/clients.rs
+++ b/rocketmq-transport/src/clients.rs
@@ -87,20 +87,6 @@ pub trait RemotingClient: RemotingService {
     /// * `timeout_millis` - The timeout for the operation in milliseconds.
     async fn invoke_request_oneway(&self, addr: &CheetahString, request: RemotingCommand, timeout_millis: u64);
 
-    /// Invokes a command on a specified address without waiting for a response or confirmation.
-    /// This is a true fire-and-forget method that returns immediately after spawning the send task.
-    ///
-    /// # Arguments
-    /// * `addr` - The address to invoke the command on.
-    /// * `request` - The `RemotingCommand` to be sent.
-    ///
-    /// # Semantics
-    /// - Returns immediately after spawning background task
-    /// - Does NOT wait for the message to be sent
-    /// - Does NOT wait for network I/O
-    /// - Errors are silently dropped (logged only)
-    fn invoke_oneway_unbounded(&self, addr: CheetahString, request: RemotingCommand);
-
     /// Checks if a specified address is reachable.
     ///
     /// # Arguments

--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -24,6 +24,8 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::OperationContext;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourcePermit;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_security_api::PeerInfo;
@@ -176,6 +178,7 @@ fn connect<PR>(
     tls_config: TlsConfig,
     task_group: TaskGroup,
     operation: OperationContext,
+    process_budget: ResourceBudget,
     deadline: RequestDeadline,
     telemetry: TransportTelemetry,
 ) -> ClientConnectFuture
@@ -205,7 +208,10 @@ where
             local_addr,
             remote_address,
             session_task_group,
-            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(
+                AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+                    .map_err(|error| remote_error(format!("invalid client transport admission budget: {error}")))?,
+            ),
             Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
             None,
             Duration::from_secs(120),
@@ -268,6 +274,7 @@ where
             tls_config,
             task_group,
             operation,
+            context.process_budget(),
             deadline,
             telemetry,
         )
@@ -283,6 +290,7 @@ where
         tls_config: TlsConfig,
         task_group: TaskGroup,
         operation: OperationContext,
+        process_budget: ResourceBudget,
         deadline: RequestDeadline,
         telemetry: TransportTelemetry,
     ) -> RocketMQResult<Client<PR>> {
@@ -303,6 +311,7 @@ where
             tls_config,
             task_group,
             operation,
+            process_budget,
             deadline,
             telemetry,
         )
@@ -349,6 +358,21 @@ where
     async fn send_transport(&self, mut request: RemotingCommand, deadline: RequestDeadline) -> RocketMQResult<()> {
         self.prepare_transport_request(&mut request, deadline)?;
         self.send_prepared_transport(request, deadline).await
+    }
+
+    async fn send_transport_with_permit(
+        &self,
+        mut request: RemotingCommand,
+        deadline: RequestDeadline,
+        permit: ResourcePermit,
+    ) -> RocketMQResult<()> {
+        self.prepare_transport_request(&mut request, deadline)?;
+        let target = self.peer.address().to_string();
+        deadline.ensure_before_send(target.clone())?;
+        let mut connection = self.session.connection();
+        connection
+            .send_command_with_deadline_and_permit(request, deadline, target, permit)
+            .await
     }
 
     /// Invokes a remote operation with the given `RemotingCommand`.
@@ -449,6 +473,16 @@ where
     /// Sends a request using the caller's existing immutable deadline.
     pub async fn send_until(&mut self, request: RemotingCommand, deadline: RequestDeadline) -> RocketMQResult<()> {
         self.send_transport(request, deadline).await
+    }
+
+    /// Sends a request under an existing deadline and process reservation.
+    pub async fn send_until_with_permit(
+        &mut self,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+        permit: ResourcePermit,
+    ) -> RocketMQResult<()> {
+        self.send_transport_with_permit(request, deadline, permit).await
     }
 
     /// Sends multiple requests in a batch (fire-and-forget, no response expected).

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -26,6 +26,7 @@ use rocketmq_error::NetworkError;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::ResourcePermit;
 use rocketmq_runtime::RuntimeResult;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::ShutdownReport;
@@ -314,10 +315,18 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         service_context: ChildServiceContext,
         telemetry: TransportTelemetry,
     ) -> Self {
+        let process_budget = service_context.process_budget();
         let handler = RemotingGeneralHandler::new_with_telemetry(
             processor,
             vec![],
-            PendingRequestTable::with_capacity(512),
+            PendingRequestTable::try_with_limits_and_budget(
+                crate::base::pending_request_table::PendingRequestLimits {
+                    max_count: 512,
+                    ..Default::default()
+                },
+                &process_budget,
+            )
+            .expect("clamped remoting client pending-request budget must be valid"),
             telemetry.clone(),
         );
         Self {
@@ -1108,6 +1117,36 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for Rocketmq
     }
 }
 
+impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
+    /// Sends a one-way command while transferring an existing process-budget
+    /// reservation into the transport writer.
+    pub async fn invoke_oneway_with_permit(
+        &self,
+        addr: &CheetahString,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+        permit: ResourcePermit,
+    ) -> RocketMQResult<()> {
+        let Some(mut client) = self.get_and_create_client_until(Some(addr), deadline).await? else {
+            return Err(RocketMQError::network_connection_failed(
+                addr.to_string(),
+                "one-way client unavailable",
+            ));
+        };
+        let mut request = request;
+        request.mark_oneway_rpc_ref();
+        if self.cmd_handler.has_rpc_hooks() {
+            let remote_address = client.remote_address();
+            deadline.ensure_before_send(remote_address.to_string())?;
+            request.make_custom_header_to_net();
+            self.cmd_handler
+                .do_before_rpc_hooks_with_addr(remote_address, Some(&mut request))?;
+            deadline.ensure_before_send(remote_address.to_string())?;
+        }
+        client.send_until_with_permit(request, deadline, permit).await
+    }
+}
+
 #[allow(unused_variables)]
 impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqDefaultClient<PR> {
     async fn update_name_server_address_list(&self, addrs: Vec<CheetahString>) {
@@ -1330,87 +1369,16 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                         return;
                     }
                 }
-                let addr_clone = addr.clone();
-                let Some(task_group) = self.get_or_create_worker_task_group() else {
-                    warn!(remote_addr = %addr, "invoke oneway skipped because client is shut down");
-                    return;
-                };
-                if let Err(error) = task_group.spawn_service("remoting.client.oneway-send", async move {
-                    let mut request = request;
-                    request.mark_oneway_rpc_ref();
-                    match client.send_until(request, deadline).await {
-                        Ok(()) => {}
-                        Err(error) => {
-                            warn!(
-                                remote_addr = %addr_clone,
-                                error = ?error,
-                                "invoke oneway send failed"
-                            );
-                        }
-                    }
-                }) {
+                let mut request = request;
+                request.mark_oneway_rpc_ref();
+                if let Err(error) = client.send_until(request, deadline).await {
                     warn!(
                         remote_addr = %addr,
                         error = ?error,
-                        "invoke oneway send task spawn failed"
+                        "invoke oneway send failed"
                     );
                 }
             }
-        }
-    }
-
-    fn invoke_oneway_unbounded(&self, addr: CheetahString, request: RemotingCommand) {
-        let client_owner = self.clone();
-        let addr_for_spawn_error = addr.clone();
-        let Some(task_group) = self.get_or_create_worker_task_group() else {
-            tracing::debug!(
-                "invoke_oneway_unbounded: client is shut down, skipping send to {}",
-                addr
-            );
-            return;
-        };
-
-        if let Err(error) = task_group.spawn_service("remoting.client.oneway-unbounded", async move {
-            if client_owner.shutdown_token.is_cancelled() {
-                tracing::debug!(
-                    "invoke_oneway_unbounded: client is shut down, skipping send to {}",
-                    addr
-                );
-                return;
-            }
-
-            let Some(mut client) = client_owner.get_and_create_client(Some(&addr)).await else {
-                tracing::warn!("invoke_oneway_unbounded: failed to get or create client for {}", addr);
-                return;
-            };
-
-            let mut request = request;
-            request.mark_oneway_rpc_ref();
-            if client_owner.cmd_handler.has_rpc_hooks() {
-                let remote_address = client.remote_address();
-                request.make_custom_header_to_net();
-                if let Err(error) = client_owner
-                    .cmd_handler
-                    .do_before_rpc_hooks_with_addr(remote_address, Some(&mut request))
-                {
-                    tracing::warn!(
-                        "invoke_oneway_unbounded: before RPC hook failed for {}: {:?}",
-                        addr,
-                        error
-                    );
-                    return;
-                }
-            }
-
-            if let Err(error) = client.send(request).await {
-                tracing::warn!("invoke_oneway_unbounded: send request to {} failed: {:?}", addr, error);
-            }
-        }) {
-            tracing::warn!(
-                "invoke_oneway_unbounded: failed to spawn send task for {}: {:?}",
-                addr_for_spawn_error,
-                error
-            );
         }
     }
 
@@ -1755,7 +1723,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invoke_oneway_unbounded_creates_connection_before_sending() {
+    async fn invoke_oneway_waits_for_writer_completion() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
         let addr = listener.local_addr().expect("listener addr");
         let (received_tx, received_rx) = tokio::sync::oneshot::channel();
@@ -1787,18 +1755,11 @@ mod tests {
 
         let target = CheetahString::from_string(addr.to_string());
         let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo);
-        client.invoke_oneway_unbounded(target, request);
-        let worker_task_group = client
-            .worker_task_group
-            .lock()
-            .as_ref()
-            .cloned()
-            .expect("worker task group");
-        assert_eq!(worker_task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
+        client.invoke_request_oneway(&target, request, 3_000).await;
 
         let (code, is_oneway, hooked) = time::timeout(Duration::from_secs(3), received_rx)
             .await
-            .expect("server should receive unbounded oneway request")
+            .expect("server should receive oneway request")
             .expect("server should report received request");
 
         assert_eq!(code, RequestCode::GetBrokerClusterInfo.to_i32());
@@ -1809,10 +1770,6 @@ mod tests {
 
         server.await.expect("server task");
         client.shutdown();
-        assert_eq!(
-            worker_task_group.lifecycle_state(),
-            TaskGroupLifecycleState::ShutdownCompleted
-        );
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -53,6 +53,7 @@ use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::QueuedWriteProgress;
 use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::ResourcePermit;
 use std::sync::Arc;
 
 pub(crate) struct SessionLifecycle {
@@ -668,6 +669,7 @@ impl Connection {
         &mut self,
         payload: OutboundPayload,
         class: AdmissionClass,
+        reservation: Option<ResourcePermit>,
         deadline: Option<RequestDeadline>,
         target: String,
     ) -> rocketmq_error::RocketMQResult<()> {
@@ -704,13 +706,20 @@ impl Connection {
                     resume.notified().await;
                 }
             }
-            let permit = queued
-                .admission
-                .try_acquire(AdmissionResource::Queued, queued.scope, encoded_len, class)
-                .map_err(|_| {
-                    queued.writer_diagnostics.record_rejected(None);
-                    rocketmq_error::RocketMQError::network_queue_full(target.clone())
-                })?;
+            let permit = match reservation {
+                Some(reservation) => {
+                    queued
+                        .admission
+                        .rebind_permit(AdmissionResource::Queued, queued.scope, reservation)
+                }
+                None => queued
+                    .admission
+                    .try_acquire(AdmissionResource::Queued, queued.scope, encoded_len, class),
+            }
+            .map_err(|_| {
+                queued.writer_diagnostics.record_rejected(None);
+                rocketmq_error::RocketMQError::network_queue_full(target.clone())
+            })?;
             if let Some(deadline) = deadline {
                 deadline.ensure_before_send(target.clone())?;
             }
@@ -846,6 +855,7 @@ impl Connection {
             OutboundPayload::Frame(frame),
             class,
             None,
+            None,
             "transport-session-writer".to_string(),
         )
         .await
@@ -875,8 +885,41 @@ impl Connection {
         deadline.ensure_before_send(target.clone())?;
 
         self.telemetry.record_network_bytes(frame.encoded_len());
-        self.send_payload(OutboundPayload::Frame(frame), class, Some(deadline), target)
+        self.send_payload(OutboundPayload::Frame(frame), class, None, Some(deadline), target)
             .await
+    }
+
+    /// Sends one command while transferring an existing process-budget
+    /// reservation into the session writer queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed queue, before-send, write-timeout, budget-rebind, or
+    /// transport error.
+    pub async fn send_command_with_deadline_and_permit(
+        &mut self,
+        command: RemotingCommand,
+        deadline: RequestDeadline,
+        target: impl Into<String>,
+        permit: ResourcePermit,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let target = target.into();
+        deadline.ensure_before_send(target.clone())?;
+        let class = self
+            .response_class()
+            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
+        let frame = EncodedFrame::from_command(command)?;
+        deadline.ensure_before_send(target.clone())?;
+
+        self.telemetry.record_network_bytes(frame.encoded_len());
+        self.send_payload(
+            OutboundPayload::Frame(frame),
+            class,
+            Some(permit),
+            Some(deadline),
+            target,
+        )
+        .await
     }
 
     /// Sends a `RemotingCommand` to the peer (borrows command).
@@ -909,6 +952,7 @@ impl Connection {
         self.send_payload(
             OutboundPayload::Frame(frame),
             class,
+            None,
             None,
             "transport-session-writer".to_string(),
         )
@@ -951,6 +995,7 @@ impl Connection {
             payload,
             AdmissionClass::Data,
             None,
+            None,
             "transport-session-writer".to_string(),
         )
         .await
@@ -980,6 +1025,7 @@ impl Connection {
         self.send_payload(
             OutboundPayload::Contiguous(bytes),
             AdmissionClass::Data,
+            None,
             None,
             "transport-session-writer".to_string(),
         )
@@ -1013,6 +1059,7 @@ impl Connection {
         self.send_payload(
             OutboundPayload::Contiguous(bytes),
             AdmissionClass::Control,
+            None,
             None,
             "transport-session-writer".to_string(),
         )

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -637,6 +637,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
             RemotingServerRunCapabilities {
                 tls_runtime,
                 task_group,
+                process_budget: self.service_context.process_budget(),
                 transport_security: self.transport_security.clone(),
                 transport_principal: self.transport_principal.clone(),
                 admission: self.admission.clone(),
@@ -758,6 +759,7 @@ pub async fn run_with_report_with_service_context_and_telemetry<RP: RequestProce
         RemotingServerRunCapabilities {
             tls_runtime,
             task_group: remoting_context.task_group().clone(),
+            process_budget: service_context.process_budget(),
             transport_security: None,
             transport_principal: None,
             admission: None,
@@ -771,6 +773,7 @@ pub async fn run_with_report_with_service_context_and_telemetry<RP: RequestProce
 struct RemotingServerRunCapabilities {
     tls_runtime: TlsServerRuntime,
     task_group: TaskGroup,
+    process_budget: rocketmq_runtime::ResourceBudget,
     transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
     admission: Option<Arc<AdmissionController>>,
@@ -790,6 +793,7 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     let RemotingServerRunCapabilities {
         tls_runtime,
         task_group,
+        process_budget,
         transport_security,
         transport_principal,
         admission,
@@ -802,7 +806,19 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     let handler = RemotingGeneralHandler::new_with_telemetry(
         request_processor,
         rpc_hooks,
-        PendingRequestTable::with_capacity(512),
+        match PendingRequestTable::try_with_limits_and_budget(
+            crate::base::pending_request_table::PendingRequestLimits {
+                max_count: 512,
+                ..Default::default()
+            },
+            &process_budget,
+        ) {
+            Ok(table) => table,
+            Err(error) => {
+                error!(%error, "failed to initialize remoting pending-request budget");
+                return None;
+            }
+        },
         telemetry.clone(),
     );
     let mut admission_limits = AdmissionLimits::default();
@@ -816,7 +832,7 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     };
     let admission = match admission {
         Some(admission) => admission,
-        None => match AdmissionController::try_new(admission_limits) {
+        None => match AdmissionController::try_new_with_budget(admission_limits, &process_budget) {
             Ok(admission) => Arc::new(admission),
             Err(error) => {
                 error!(%error, "failed to initialize transport admission budgets");
@@ -1719,6 +1735,7 @@ mod tests {
             RemotingServerRunCapabilities {
                 tls_runtime,
                 task_group: service.component("remoting-server").task_group().clone(),
+                process_budget: service.process_budget(),
                 transport_security: None,
                 transport_principal: None,
                 admission: None,

--- a/rocketmq-transport/tests/resource_budget_ownership.rs
+++ b/rocketmq-transport/tests/resource_budget_ownership.rs
@@ -1,0 +1,57 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+
+use rocketmq_runtime::ProcessMemoryLimit;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_transport::AdmissionClass;
+use rocketmq_transport::AdmissionController;
+use rocketmq_transport::AdmissionLimits;
+use rocketmq_transport::AdmissionResource;
+use rocketmq_transport::AdmissionScope;
+use rocketmq_transport::ResourceLimit;
+
+#[test]
+fn transport_controllers_share_the_injected_process_ceiling() {
+    let memory_limit = ProcessMemoryLimit::configured(12).expect("configured memory limit");
+    let owner = RuntimeOwner::new_with_memory_limit(RuntimeConfig::default(), memory_limit).expect("runtime owner");
+    let process_budget = owner.root_context().component("transport").process_budget();
+    let limits = AdmissionLimits {
+        inflight: ResourceLimit { count: 4, bytes: 12 },
+        per_ip: ResourceLimit { count: 4, bytes: 12 },
+        per_tenant: ResourceLimit { count: 4, bytes: 12 },
+        per_session: ResourceLimit { count: 4, bytes: 12 },
+        control_reserve: ResourceLimit { count: 0, bytes: 0 },
+        ..AdmissionLimits::default()
+    };
+    let first = AdmissionController::try_new_with_budget(limits, &process_budget).expect("first controller");
+    let second = AdmissionController::try_new_with_budget(limits, &process_budget).expect("second controller");
+    let scope = AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+
+    let permit = first
+        .try_acquire(AdmissionResource::Inflight, scope, 8, AdmissionClass::Data)
+        .expect("first controller reservation");
+    assert!(second
+        .try_acquire(AdmissionResource::Inflight, scope, 8, AdmissionClass::Data)
+        .is_err());
+    assert_eq!(process_budget.snapshot().current_bytes, 8);
+
+    drop(permit);
+    assert!(second
+        .try_acquire(AdmissionResource::Inflight, scope, 8, AdmissionClass::Data)
+        .is_ok());
+}

--- a/scripts/telemetry-semantic-guard-violations.json
+++ b/scripts/telemetry-semantic-guard-violations.json
@@ -42,7 +42,7 @@
       "operation": "delete",
       "path": [
         "signals",
-        163,
+        168,
         "sampling",
         "max_per_second"
       ],
@@ -53,7 +53,7 @@
       "operation": "set",
       "path": [
         "signals",
-        163,
+        168,
         "deprecation"
       ],
       "value": {

--- a/scripts/telemetry-semantic-registry.json
+++ b/scripts/telemetry-semantic-registry.json
@@ -3563,6 +3563,123 @@
       }
     },
     {
+      "id": "rocketmq_client_oneway_egress_items",
+      "source_symbol": "CLIENT_ONEWAY_EGRESS_ITEMS",
+      "signal_type": "metric",
+      "kind": "gauge",
+      "unit": "{message}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_oneway_egress_bytes",
+      "source_symbol": "CLIENT_ONEWAY_EGRESS_BYTES",
+      "signal_type": "metric",
+      "kind": "gauge",
+      "unit": "By",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_oneway_egress_oldest_age",
+      "source_symbol": "CLIENT_ONEWAY_EGRESS_OLDEST_AGE",
+      "signal_type": "metric",
+      "kind": "gauge",
+      "unit": "ms",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_oneway_egress_waiters",
+      "source_symbol": "CLIENT_ONEWAY_EGRESS_WAITERS",
+      "signal_type": "metric",
+      "kind": "gauge",
+      "unit": "{waiter}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_client_oneway_egress_events_total",
+      "source_symbol": "CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{event}",
+      "owner": "client",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "result"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
       "id": "rocketmq_namesrv_route_request_total",
       "source_symbol": "NAMESRV_ROUTE_REQUEST_TOTAL",
       "signal_type": "metric",

--- a/scripts/tests/test_telemetry_semantic_guard.py
+++ b/scripts/tests/test_telemetry_semantic_guard.py
@@ -40,10 +40,10 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
 
     def test_live_registry_matches_every_rust_signal(self) -> None:
         self.assertEqual([], guard.validate_registry(self.registry, self.inventory))
-        self.assertEqual(148, len(self.inventory["metrics"]))
+        self.assertEqual(153, len(self.inventory["metrics"]))
         self.assertEqual(15, len(self.inventory["spans"]))
         self.assertEqual(11, len(self.inventory["events"]))
-        self.assertEqual(174, len(self.registry["signals"]))
+        self.assertEqual(179, len(self.registry["signals"]))
 
     def test_log_filter_metrics_have_stable_registry_contracts(self) -> None:
         symbols = {
@@ -84,7 +84,7 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn("metrics=148 spans=15 logs=11 attributes=74", result.stdout)
+        self.assertIn("metrics=153 spans=15 logs=11 attributes=74", result.stdout)
 
     def test_committed_violation_fixtures_are_rejected(self) -> None:
         fixture_ids = {fixture["id"] for fixture in self.fixtures}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8861

### Brief Description

- Make `RuntimeOwner` own the single process memory limit and root resource budget shared by client and transport service contexts.
- Add atomic same-tree `ResourcePermit` rebinding so producer reservations transfer to the socket writer without charging common ancestors twice.
- Replace per-message one-way tasks with a count-and-byte bounded producer egress driven by two lifecycle-owned workers.
- Await actual writer completion, preserve end-to-end deadlines, and expose one-way egress state and outcome metrics.
- Add focused ownership, transfer, overload, shutdown, integration, and benchmark coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-runtime -p rocketmq-transport -p rocketmq-client-rust -p rocketmq-observability -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-runtime`
- `cargo test -p rocketmq-transport --test resource_budget_ownership`
- `cargo test -p rocketmq-client-rust --test producer_oneway_egress`
- `python -m unittest scripts.tests.test_telemetry_semantic_guard`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`
- Validated the affected example, MCP, SRE, Tauri backend, and web backend standalone consumers.
- Full transport, client, and observability feature-suite runs introduced no new failures. The remaining TaskGroup lifecycle failures reproduce unchanged on the exact pre-change commit.
- Workspace-wide `cargo fmt --all -- --check` is blocked only by the existing Windows path-length error 206; the affected packages pass their scoped format check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded one-way message sending with capacity limits, deadlines, cancellation, and transport error reporting.
  * Added shared process-level resource accounting across client and transport operations.
  * Added runtime resource access and permit transfer support.
  * Added telemetry for one-way egress queue state and delivery outcomes.

* **Bug Fixes**
  * One-way sends now await completion and report failures instead of always returning success.

* **Tests**
  * Added coverage for overload handling, resource limits, permit transfers, shutdown, and queue draining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->