### PR TITLE
[ISSUE #8863]🚀Replace embedded proxy loopback with authorized in-process dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,6 +4834,7 @@ dependencies = [
  "serde_json",
  "serde_json_any_key",
  "tempfile",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
  "tokio-util",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3387,6 +3387,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -106,6 +106,7 @@ crossbeam-skiplist = "0.1"
 futures = "0.3.32"
 
 [dev-dependencies]
+rocketmq-transport = { workspace = true, features = ["test-support"] }
 criterion            = { version = "0.8", features = ["html_reports"] }
 rocketmq-controller  = { workspace = true }
 rocketmq-namesrv     = { workspace = true }

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -18,6 +18,8 @@ mod startup;
 
 pub(super) struct BrokerRequestPipeline {
     pub(super) proxy_request_processor: Option<DefaultServerProcessor>,
+    pub(super) authorized_dispatcher:
+        Option<Arc<rocketmq_transport::AuthorizedCommandDispatcher<DefaultServerProcessor>>>,
     pub(super) consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
     pub(super) processor_wiring_complete: bool,
 }
@@ -28,6 +30,7 @@ impl BrokerRequestPipeline {
     ) -> Self {
         Self {
             proxy_request_processor: None,
+            authorized_dispatcher: None,
             consumer_ids_change_listener,
             processor_wiring_complete: false,
         }
@@ -619,5 +622,11 @@ impl BrokerRuntime {
 
     pub(crate) fn proxy_request_processor(&self) -> Option<DefaultServerProcessor> {
         self.composition.request_pipeline.proxy_request_processor.clone()
+    }
+
+    pub(crate) fn authorized_dispatcher(
+        &self,
+    ) -> Option<Arc<rocketmq_transport::AuthorizedCommandDispatcher<DefaultServerProcessor>>> {
+        self.composition.request_pipeline.authorized_dispatcher.clone()
     }
 }

--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
@@ -36,7 +36,43 @@ impl BrokerRuntime {
             });
         }
         let (request_processor, fast_request_processor) = self.init_processor_checked()?;
+        let service_context =
+            self.composition
+                .state
+                .service_context
+                .as_ref()
+                .ok_or_else(|| BrokerStartupError::Initialization {
+                    component: "service_context",
+                    detail: "broker remoting servers require an injected service context".to_owned(),
+                })?;
+        let admission = Arc::new(
+            rocketmq_transport::AdmissionController::try_new_with_budget(
+                rocketmq_transport::AdmissionLimits::default(),
+                &service_context.process_budget(),
+            )
+            .map_err(|error| BrokerStartupError::Initialization {
+                component: "authorized_dispatcher",
+                detail: format!("failed to create shared Broker admission boundary: {error}"),
+            })?,
+        );
+        let authorized_dispatcher = Arc::new(
+            rocketmq_transport::AuthorizedCommandDispatcher::try_new(
+                request_processor.clone(),
+                Vec::new(),
+                &service_context.process_budget(),
+                self.composition.state.transport_telemetry.clone(),
+                Arc::new(rocketmq_transport::TransportSecurity::development_insecure_loopback(
+                    None, None,
+                )),
+                admission,
+            )
+            .map_err(|error| BrokerStartupError::Initialization {
+                component: "authorized_dispatcher",
+                detail: error.to_string(),
+            })?,
+        );
         self.composition.request_pipeline.proxy_request_processor = Some(request_processor.clone());
+        self.composition.request_pipeline.authorized_dispatcher = Some(authorized_dispatcher.clone());
         self.lifecycle
             .startup_journal
             .complete(BrokerComponent::RequestProcessors);
@@ -53,20 +89,12 @@ impl BrokerRuntime {
         self.lifecycle.remoting_server_task_group = Some(remoting_server_task_group.clone());
 
         let broker_config = self.composition.state.broker_config();
-        let service_context =
-            self.composition
-                .state
-                .service_context
-                .as_ref()
-                .ok_or_else(|| BrokerStartupError::Initialization {
-                    component: "service_context",
-                    detail: "broker remoting servers require an injected service context".to_owned(),
-                })?;
         let mut server = RocketMQServer::new_with_telemetry(
             Arc::new(broker_config.broker_server_config.clone()),
             service_context.component("broker.remoting-server.normal"),
             self.composition.state.transport_telemetry.clone(),
-        );
+        )
+        .with_authorized_dispatcher(authorized_dispatcher.clone());
         // Start the normal Broker remoting server.
         let client_housekeeping_service_main = self
             .composition
@@ -103,7 +131,8 @@ impl BrokerRuntime {
             Arc::new(fast_server_config),
             service_context.component("broker.remoting-server.fast"),
             self.composition.state.transport_telemetry.clone(),
-        );
+        )
+        .with_authorized_dispatcher(authorized_dispatcher);
         let shutdown_token = remoting_server_task_group.cancellation_token();
         let (fast_report_tx, fast_report_rx) = oneshot::channel();
         let (fast_startup_tx, fast_startup_rx) = oneshot::channel();

--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -30,10 +30,10 @@ use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::TaskGroup;
+use rocketmq_security_api::Principal;
 use rocketmq_store::MessageStoreConfig;
-use rocketmq_transport::LocalRequestHarness;
-use rocketmq_transport::RemotingRequestProcessor as RequestProcessor;
-use tokio::time::timeout;
+use rocketmq_transport::RequestContext;
+use rocketmq_transport::RequestDeadline;
 
 use crate::broker_runtime::BrokerRuntime;
 use crate::lifecycle::BrokerReadiness;
@@ -195,42 +195,45 @@ impl ProxyBrokerFacade {
         mut request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<rocketmq_protocol::protocol::remoting_command::RemotingCommand> {
         request.make_custom_header_to_net();
-        let mut processor = self
+        let dispatcher = self
             .runtime
-            .proxy_request_processor()
+            .authorized_dispatcher()
             .ok_or_else(embedded_broker_request_processor_not_ready)?;
 
         let opaque = request.opaque();
-        let mut harness = LocalRequestHarness::new(self.local_request_tasks.clone()).await?;
-        if let Some(mut response) = processor
-            .process_request(harness.channel(), harness.context(), &mut request)
-            .await?
-        {
-            response.make_custom_header_to_net();
-            return Ok(response.set_opaque(opaque).mark_response_type());
-        }
-
-        let response = timeout(LOCAL_PROXY_RESPONSE_TIMEOUT, harness.receive_response())
+        let deadline = RequestDeadline::after(LOCAL_PROXY_RESPONSE_TIMEOUT);
+        let context =
+            RequestContext::try_embedded(Some(Principal::new("embedded-proxy")), Some(deadline)).map_err(|error| {
+                rocketmq_error::RocketMQError::response_process_failed(
+                    "embedded_broker_request_context",
+                    error.to_string(),
+                )
+            })?;
+        let response = dispatcher
+            .dispatch_embedded(&self.local_request_tasks, context, request)
             .await
-            .map_err(|_| rocketmq_error::RocketMQError::Timeout {
-                operation: "embedded_broker_response",
-                timeout_ms: LOCAL_PROXY_RESPONSE_TIMEOUT.as_millis() as u64,
-            })??;
-
-        response.ok_or_else(|| {
-            rocketmq_error::RocketMQError::response_process_failed(
-                "embedded_broker_response",
-                format!(
-                    "embedded broker produced no response for request code {}",
-                    request.code()
-                ),
-            )
-        })
+            .map_err(embedded_dispatch_error)?
+            .set_opaque(opaque)
+            .mark_response_type();
+        Ok(response)
     }
 }
 
 fn embedded_broker_request_processor_not_ready() -> rocketmq_error::RocketMQError {
     rocketmq_error::RocketMQError::not_initialized("embedded_broker_request_processor")
+}
+
+fn embedded_dispatch_error(error: rocketmq_transport::DispatchError) -> rocketmq_error::RocketMQError {
+    if matches!(
+        &error,
+        rocketmq_transport::DispatchError::Response(rocketmq_transport::ResponseSinkError::DeadlineExceeded)
+    ) {
+        return rocketmq_error::RocketMQError::Timeout {
+            operation: "embedded_broker_response",
+            timeout_ms: LOCAL_PROXY_RESPONSE_TIMEOUT.as_millis() as u64,
+        };
+    }
+    rocketmq_error::RocketMQError::response_process_failed("embedded_broker_dispatch", error.to_string())
 }
 
 fn build_topic_route(broker_config: &BrokerConfig, topic_config: &TopicConfig) -> TopicRouteData {

--- a/rocketmq-broker/tests/embedded_proxy_dispatch_tests.rs
+++ b/rocketmq-broker/tests/embedded_proxy_dispatch_tests.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_transport::RequestContext;
+use rocketmq_transport::RequestContextError;
+
+const PROXY_FACADE_SOURCE: &str = include_str!("../src/proxy_facade.rs");
+const PIPELINE_STARTUP_SOURCE: &str = include_str!("../src/broker_runtime/request_pipeline/startup.rs");
+
+#[test]
+fn embedded_proxy_production_path_uses_the_shared_in_process_dispatcher() {
+    for forbidden in ["LocalRequestHarness", "TcpListener", "TcpStream", "127.0.0.1:0"] {
+        assert!(
+            !PROXY_FACADE_SOURCE.contains(forbidden),
+            "production ProxyFacade must not contain loopback transport primitive {forbidden}"
+        );
+    }
+    for required in [
+        "authorized_dispatcher()",
+        "RequestContext::try_embedded",
+        "Principal::new(\"embedded-proxy\")",
+        "dispatch_embedded",
+        "RequestDeadline::after",
+    ] {
+        assert!(
+            PROXY_FACADE_SOURCE.contains(required),
+            "production ProxyFacade must retain shared dispatch invariant {required}"
+        );
+    }
+    assert!(
+        PIPELINE_STARTUP_SOURCE.contains("AuthorizedCommandDispatcher::try_new"),
+        "the Broker composition root must construct the shared dispatcher"
+    );
+    assert_eq!(
+        PIPELINE_STARTUP_SOURCE.matches("with_authorized_dispatcher").count(),
+        2,
+        "normal and fast remoting servers must receive the same Broker dispatcher"
+    );
+}
+
+#[test]
+fn embedded_request_context_fails_closed_without_a_trusted_identity() {
+    assert_eq!(
+        RequestContext::try_embedded(None, None).expect_err("missing principal must be rejected"),
+        RequestContextError::MissingEmbeddedPrincipal
+    );
+}

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -73,6 +73,7 @@ futures        = { workspace = true }
 cheetah-string = { workspace = true }
 
 [dev-dependencies]
+rocketmq-transport = { workspace = true, features = ["test-support"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 trybuild  = "1.0.116"
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -4366,6 +4366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2548,6 +2548,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -71,6 +71,7 @@ clap           = { version = "4.6.1", features = ["derive"] }
 cheetah-string = { workspace = true }
 
 [dev-dependencies]
+rocketmq-transport = { workspace = true, features = ["test-support"] }
 criterion = { version = "0.8", features = ["html_reports", "async_futures"] }
 futures   = "0.3"
 tempfile = "3.27.0"

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -77,6 +77,7 @@ prost-types = "0.14"
 tonic       = { version = "0.14.6", features = ["transport", "codegen"] }
 
 [dev-dependencies]
+rocketmq-transport = { workspace = true, features = ["test-support"] }
 hex = "0.4"
 hmac = "0.13.0"
 sha1 = "0.11"

--- a/rocketmq-sre/Cargo.lock
+++ b/rocketmq-sre/Cargo.lock
@@ -3960,6 +3960,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -3340,6 +3340,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-util",

--- a/rocketmq-transport/Cargo.toml
+++ b/rocketmq-transport/Cargo.toml
@@ -31,6 +31,7 @@ simd = ["rocketmq-protocol/simd"]
 tls = ["arc-swap", "rcgen", "rustls-native-certs", "tokio-rustls"]
 observability = ["dep:rocketmq-observability", "rocketmq-observability/otel-metrics"]
 observability-traces = ["dep:rocketmq-observability"]
+test-support = []
 
 [dependencies]
 rocketmq-error = { workspace = true }
@@ -61,6 +62,7 @@ serde_json.workspace = true
 serde_json_any_key.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
 uuid.workspace = true

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -335,6 +335,11 @@ pub struct ConnectionStateHandle {
 }
 
 impl ConnectionStateHandle {
+    pub(crate) fn healthy() -> Self {
+        let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
+        Self { state_tx, state_rx }
+    }
+
     /// Returns the most recently published connection state.
     #[inline]
     pub fn state(&self) -> ConnectionState {

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod authorized_dispatcher;
+mod request_context;
+mod response_sink;
+
+pub use authorized_dispatcher::AuthorizedCommandDispatcher;
+pub use authorized_dispatcher::AuthorizedDispatchBoundary;
+pub use authorized_dispatcher::DispatchError;
+pub use authorized_dispatcher::DispatchOutcome;
+pub use request_context::RequestContext;
+pub use request_context::RequestContextError;
+pub use request_context::RequestTransport;
+pub use response_sink::LocalResponseReceiver;
+#[doc(hidden)]
+pub use response_sink::LocalResponseSink;
+pub use response_sink::ResponseSink;
+pub use response_sink::ResponseSinkError;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -1,0 +1,347 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::OperationContext;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskId;
+use rocketmq_security_api::Action;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Resource;
+use rocketmq_security_api::ResourceKind;
+
+use super::LocalResponseReceiver;
+use super::RequestContext;
+use super::RequestTransport;
+use super::ResponseSink;
+use super::ResponseSinkError;
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionError;
+use crate::admission::AdmissionScope;
+use crate::admission::FullPolicy;
+use crate::base::pending_request_table::materialize_and_estimate_remoting_command_retained_bytes;
+use crate::base::pending_request_table::PendingRequestLimits;
+use crate::base::pending_request_table::PendingRequestTable;
+use crate::net::channel::Channel;
+use crate::net::channel::ChannelInner;
+use crate::remoting::inner::RemotingGeneralHandler;
+use crate::request_ordering::RequestOrdering;
+use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+use crate::runtime::processor::RequestProcessor;
+use crate::runtime::RPCHook;
+use crate::security::TransportSecurity;
+use crate::session_executor::SessionDispatchError;
+use crate::session_executor::SessionExecutor;
+use crate::telemetry::TransportTelemetry;
+
+/// Result of submitting a command to the shared dispatch boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// The lifecycle-owned processor task was accepted.
+    Accepted(TaskId),
+    /// Authorization, deadline, or reject-policy admission produced a response.
+    Rejected,
+}
+
+/// Typed failure returned by the shared dispatch boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum DispatchError {
+    /// The request session could not be created under its lifecycle owner.
+    #[error(transparent)]
+    Runtime(#[from] RuntimeError),
+    /// The request session stopped accepting work.
+    #[error("authorized dispatch session is closing: {0}")]
+    Closing(String),
+    /// A non-reject admission policy could not admit the request.
+    #[error("authorized dispatch admission failed: {0}")]
+    Admission(#[source] AdmissionError),
+    /// The selected response output failed.
+    #[error(transparent)]
+    Response(#[from] ResponseSinkError),
+    /// A local-only API received a network request context.
+    #[error("embedded dispatch requires an embedded request context")]
+    InvalidEmbeddedContext,
+}
+
+/// Security and admission capabilities shared by all command entry adapters.
+pub struct AuthorizedDispatchBoundary {
+    security: Arc<TransportSecurity>,
+    admission: Arc<AdmissionController>,
+}
+
+impl AuthorizedDispatchBoundary {
+    /// Creates one authoritative security and admission boundary.
+    #[must_use]
+    pub fn new(security: Arc<TransportSecurity>, admission: Arc<AdmissionController>) -> Self {
+        Self { security, admission }
+    }
+
+    /// Returns the shared admission controller used for connection, request,
+    /// and processor capacity.
+    #[must_use]
+    pub fn admission_controller(&self) -> Arc<AdmissionController> {
+        Arc::clone(&self.admission)
+    }
+
+    pub(crate) fn session(
+        self: &Arc<Self>,
+        task_group: &TaskGroup,
+        scope: AdmissionScope,
+    ) -> Result<AuthorizedDispatchSession, RuntimeError> {
+        Ok(AuthorizedDispatchSession {
+            boundary: Arc::clone(self),
+            executor: SessionExecutor::try_new(task_group, Arc::clone(&self.admission), scope)?,
+        })
+    }
+}
+
+pub(crate) struct AuthorizedDispatchSession {
+    boundary: Arc<AuthorizedDispatchBoundary>,
+    executor: SessionExecutor,
+}
+
+impl AuthorizedDispatchSession {
+    pub(crate) fn operation_context(&self) -> &OperationContext {
+        self.executor.operation_context()
+    }
+
+    pub(crate) async fn dispatch<F, Fut>(
+        &self,
+        context: RequestContext,
+        command: RemotingCommand,
+        retained_bytes: usize,
+        ordering: RequestOrdering,
+        response: ResponseSink,
+        execute: F,
+    ) -> Result<DispatchOutcome, DispatchError>
+    where
+        F: FnOnce(OperationContext, RemotingCommand) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let opaque = command.opaque();
+        if context.deadline().is_some_and(|deadline| deadline.is_expired()) {
+            response.send(deadline_response(opaque)).await?;
+            return Ok(DispatchOutcome::Rejected);
+        }
+        if let Decision::Deny { reason } = self.boundary.security.authorize(
+            &command,
+            context.peer(),
+            context.principal(),
+            Resource::new(ResourceKind::Other, command.code().to_string()),
+            Action::Manage,
+        ) {
+            response
+                .send(
+                    RemotingCommand::create_response_command_with_code_remark(
+                        ResponseCode::NoPermission,
+                        reason.to_string(),
+                    )
+                    .set_opaque(opaque),
+                )
+                .await?;
+            return Ok(DispatchOutcome::Rejected);
+        }
+
+        let deadline = context.deadline();
+        let timeout_response = response.clone();
+        let processor_rejection = response.clone();
+        match self.executor.try_execute(
+            retained_bytes,
+            AdmissionClass::for_request_code(command.code()),
+            ordering,
+            move |operation| async move {
+                let execution = execute(operation, command);
+                if let Some(deadline) = deadline {
+                    if deadline.timeout(execution).await.is_err() {
+                        let _ = timeout_response.send(deadline_response(opaque)).await;
+                    }
+                } else {
+                    execution.await;
+                }
+            },
+            move |_operation, error| async move {
+                let _ = processor_rejection.send(admission_response(opaque, &error)).await;
+            },
+        ) {
+            Ok(task_id) => Ok(DispatchOutcome::Accepted(task_id)),
+            Err(SessionDispatchError::Admission(error)) if error.policy() == FullPolicy::Reject => {
+                response.send(admission_response(opaque, &error)).await?;
+                Ok(DispatchOutcome::Rejected)
+            }
+            Err(SessionDispatchError::Admission(error)) => Err(DispatchError::Admission(error)),
+            Err(SessionDispatchError::Closing(error)) => Err(DispatchError::Closing(error.to_string())),
+        }
+    }
+
+    pub(crate) async fn drain_until(&self, deadline: ShutdownDeadline) -> ShutdownReport {
+        self.executor.drain_until(deadline).await
+    }
+}
+
+/// Shared RPC-hook, typed processor, security, admission, and error-mapping
+/// dispatcher used by network listeners and the embedded Proxy adapter.
+pub struct AuthorizedCommandDispatcher<RP> {
+    boundary: Arc<AuthorizedDispatchBoundary>,
+    handler: Arc<RemotingGeneralHandler<RP>>,
+    next_embedded_session: AtomicU64,
+}
+
+impl<RP> AuthorizedCommandDispatcher<RP>
+where
+    RP: RequestProcessor + Sync + Clone + 'static,
+{
+    /// Creates a dispatcher over an explicitly injected process budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the pending-request budget cannot be derived.
+    pub fn try_new(
+        request_processor: RP,
+        rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        process_budget: &ResourceBudget,
+        telemetry: TransportTelemetry,
+        security: Arc<TransportSecurity>,
+        admission: Arc<AdmissionController>,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        let response_table = PendingRequestTable::try_with_limits_and_budget(
+            PendingRequestLimits {
+                max_count: 512,
+                ..Default::default()
+            },
+            process_budget,
+        )
+        .map_err(|error| {
+            rocketmq_error::RocketMQError::response_process_failed(
+                "authorized_dispatcher.pending_requests",
+                error.to_string(),
+            )
+        })?;
+        Ok(Self {
+            boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
+            handler: Arc::new(RemotingGeneralHandler::new_with_telemetry(
+                request_processor,
+                rpc_hooks,
+                response_table,
+                telemetry,
+            )),
+            next_embedded_session: AtomicU64::new(1),
+        })
+    }
+
+    /// Returns the exact security and admission boundary used by this handler.
+    #[must_use]
+    pub fn boundary(&self) -> Arc<AuthorizedDispatchBoundary> {
+        Arc::clone(&self.boundary)
+    }
+
+    pub(crate) fn response_table(&self) -> PendingRequestTable {
+        self.handler.response_table.clone()
+    }
+
+    pub(crate) fn request_ordering(&self, command: &RemotingCommand) -> RequestOrdering {
+        self.handler.request_processor.request_ordering(command)
+    }
+
+    pub(crate) async fn process_network(
+        &self,
+        context: &crate::runtime::connection_handler_context::ConnectionHandlerContext,
+        command: RemotingCommand,
+    ) {
+        self.handler.process_message_received(context, command).await;
+    }
+
+    /// Dispatches one embedded command without creating a listener, socket
+    /// pair, transport stream, writer task, or detached task.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed context, runtime, admission, response, cancellation, or
+    /// deadline error.
+    pub async fn dispatch_embedded(
+        self: &Arc<Self>,
+        task_group: &TaskGroup,
+        context: RequestContext,
+        mut command: RemotingCommand,
+    ) -> Result<RemotingCommand, DispatchError> {
+        if context.transport() != RequestTransport::EmbeddedProxy {
+            return Err(DispatchError::InvalidEmbeddedContext);
+        }
+        let retained_bytes = materialize_and_estimate_remoting_command_retained_bytes(&mut command);
+        let session_id = self.next_embedded_session.fetch_add(1, Ordering::Relaxed).max(1);
+        let scope = AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST)).with_session(session_id);
+        let session = self.boundary.session(task_group, scope)?;
+        let (response, receiver): (ResponseSink, LocalResponseReceiver) = ResponseSink::local();
+        let local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let remote_address = local_address;
+        let mut channel = Channel::new(
+            Arc::new(ChannelInner::new_local(response.clone(), task_group.clone())),
+            local_address,
+            remote_address,
+        );
+        channel.set_channel_id(format!("embedded-proxy-{session_id}"));
+        let handler_context = Arc::new(ConnectionHandlerContextWrapper::new(channel));
+        let ordering = self.request_ordering(&command);
+        let handler = Arc::clone(&self.handler);
+        let deadline = context.deadline();
+        let cancellation = task_group.cancellation_token();
+
+        session
+            .dispatch(
+                context,
+                command,
+                retained_bytes,
+                ordering,
+                response,
+                move |_operation, command| async move {
+                    handler.process_message_received(&handler_context, command).await;
+                },
+            )
+            .await?;
+        let result = receiver.receive(&cancellation, deadline).await;
+        let drain_budget = deadline.map_or(Duration::from_secs(3), |deadline| deadline.remaining());
+        session
+            .drain_until(ShutdownDeadline::after(drain_budget))
+            .await
+            .log_if_unhealthy();
+        result.map_err(DispatchError::Response)
+    }
+}
+
+fn admission_response(opaque: i32, error: &AdmissionError) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemBusy, error.to_string())
+        .set_opaque(opaque)
+}
+
+fn deadline_response(opaque: i32) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(
+        ResponseCode::SystemError,
+        "request deadline exceeded".to_owned(),
+    )
+    .set_opaque(opaque)
+}

--- a/rocketmq-transport/src/dispatch/request_context.rs
+++ b/rocketmq-transport/src/dispatch/request_context.rs
@@ -1,0 +1,104 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_security_api::PeerInfo;
+use rocketmq_security_api::Principal;
+
+use crate::deadline::RequestDeadline;
+
+/// Trusted entry adapter that materialized a dispatch request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestTransport {
+    /// A command decoded from an accepted network session.
+    Network,
+    /// A command submitted by the Broker-owned embedded Proxy adapter.
+    EmbeddedProxy,
+}
+
+/// Error returned before an entry adapter can create a trusted request context.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RequestContextError {
+    /// Embedded dispatch is fail-closed when no trusted identity was injected.
+    #[error("embedded proxy dispatch requires an authenticated principal")]
+    MissingEmbeddedPrincipal,
+}
+
+/// Security and lifecycle metadata established by a trusted entry adapter.
+///
+/// Fields are private so command headers and bodies cannot self-assert an
+/// embedded identity. Network authentication and embedded composition are the
+/// only supported constructors.
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    transport: RequestTransport,
+    peer: Option<PeerInfo>,
+    principal: Option<Principal>,
+    deadline: Option<RequestDeadline>,
+}
+
+impl RequestContext {
+    /// Creates a context for a decoded network command.
+    #[must_use]
+    pub fn network(peer: PeerInfo, principal: Option<Principal>, deadline: Option<RequestDeadline>) -> Self {
+        Self {
+            transport: RequestTransport::Network,
+            peer: Some(peer),
+            principal,
+            deadline,
+        }
+    }
+
+    /// Creates a fail-closed context for a Broker-owned embedded adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestContextError::MissingEmbeddedPrincipal`] when the
+    /// composition root did not inject a trusted principal.
+    pub fn try_embedded(
+        principal: Option<Principal>,
+        deadline: Option<RequestDeadline>,
+    ) -> Result<Self, RequestContextError> {
+        let principal = principal.ok_or(RequestContextError::MissingEmbeddedPrincipal)?;
+        Ok(Self {
+            transport: RequestTransport::EmbeddedProxy,
+            peer: None,
+            principal: Some(principal),
+            deadline,
+        })
+    }
+
+    /// Returns the trusted entry type.
+    #[must_use]
+    pub const fn transport(&self) -> RequestTransport {
+        self.transport
+    }
+
+    /// Returns read-only peer metadata established by the network adapter.
+    #[must_use]
+    pub const fn peer(&self) -> Option<&PeerInfo> {
+        self.peer.as_ref()
+    }
+
+    /// Returns the authenticated identity established by the adapter.
+    #[must_use]
+    pub const fn principal(&self) -> Option<&Principal> {
+        self.principal.as_ref()
+    }
+
+    /// Returns the immutable end-to-end deadline, when supplied.
+    #[must_use]
+    pub const fn deadline(&self) -> Option<RequestDeadline> {
+        self.deadline
+    }
+}

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -1,0 +1,197 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use tokio::sync::oneshot;
+use tokio_util::codec::Decoder;
+use tokio_util::sync::CancellationToken;
+
+use crate::codec::remoting_command_codec::FrameLimits;
+use crate::codec::remoting_command_codec::RemotingCommandCodec;
+use crate::deadline::RequestDeadline;
+use crate::server::SessionHandle;
+
+/// Typed failure produced by a response output capability.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResponseSinkError {
+    /// A single-response sink was completed more than once.
+    #[error("response sink was already completed")]
+    AlreadyCompleted,
+    /// The caller stopped waiting before the response was delivered.
+    #[error("response receiver was dropped")]
+    ReceiverDropped,
+    /// The request owner cancelled the response wait.
+    #[error("response wait was cancelled")]
+    Cancelled,
+    /// The immutable request deadline expired.
+    #[error("response deadline expired")]
+    DeadlineExceeded,
+    /// A network writer rejected or failed the response.
+    #[error("response transport failed: {0}")]
+    Transport(String),
+    /// A processor-provided encoded response was malformed.
+    #[error("encoded local response failed to decode: {0}")]
+    Decode(String),
+}
+
+struct LocalResponseState {
+    sender: Option<oneshot::Sender<Result<RemotingCommand, ResponseSinkError>>>,
+    encoded: BytesMut,
+}
+
+#[derive(Clone)]
+/// Cloneable single-response capability used by the embedded adapter.
+///
+/// Construction remains private to [`ResponseSink::local`].
+pub struct LocalResponseSink {
+    state: Arc<parking_lot::Mutex<LocalResponseState>>,
+}
+
+impl LocalResponseSink {
+    fn complete(&self, result: Result<RemotingCommand, ResponseSinkError>) -> Result<(), ResponseSinkError> {
+        let sender = self
+            .state
+            .lock()
+            .sender
+            .take()
+            .ok_or(ResponseSinkError::AlreadyCompleted)?;
+        sender.send(result).map_err(|_| ResponseSinkError::ReceiverDropped)
+    }
+
+    fn send_bytes(&self, bytes: Bytes) -> Result<(), ResponseSinkError> {
+        let mut state = self.state.lock();
+        if state.sender.is_none() {
+            return Err(ResponseSinkError::AlreadyCompleted);
+        }
+        state.encoded.extend_from_slice(&bytes);
+        let decoded = RemotingCommandCodec::with_limits(FrameLimits::legacy_compatibility())
+            .decode(&mut state.encoded)
+            .map_err(|error| ResponseSinkError::Decode(error.to_string()))?;
+        let Some(command) = decoded else {
+            return Ok(());
+        };
+        if !state.encoded.is_empty() {
+            return Err(ResponseSinkError::Decode(
+                "multiple commands were written to a single-response local sink".to_owned(),
+            ));
+        }
+        let sender = state.sender.take().ok_or(ResponseSinkError::AlreadyCompleted)?;
+        drop(state);
+        sender.send(Ok(command)).map_err(|_| ResponseSinkError::ReceiverDropped)
+    }
+}
+
+/// Closed response output variants for network and in-process dispatch.
+#[derive(Clone)]
+pub enum ResponseSink {
+    /// A bounded canonical session writer.
+    Network(Arc<SessionHandle>),
+    /// A single-use in-process response channel.
+    Local(LocalResponseSink),
+}
+
+impl ResponseSink {
+    /// Creates an in-process sink and its single owner receiver.
+    #[must_use]
+    pub fn local() -> (Self, LocalResponseReceiver) {
+        let (sender, receiver) = oneshot::channel();
+        let sink = LocalResponseSink {
+            state: Arc::new(parking_lot::Mutex::new(LocalResponseState {
+                sender: Some(sender),
+                encoded: BytesMut::new(),
+            })),
+        };
+        (Self::Local(sink), LocalResponseReceiver { receiver })
+    }
+
+    /// Returns whether this sink performs no socket I/O.
+    #[must_use]
+    pub const fn is_local(&self) -> bool {
+        matches!(self, Self::Local(_))
+    }
+
+    /// Delivers one materialized response.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed lifecycle, duplicate-response, or writer error.
+    pub async fn send(&self, command: RemotingCommand) -> Result<(), ResponseSinkError> {
+        match self {
+            Self::Network(session) => session
+                .connection()
+                .send_command(command)
+                .await
+                .map_err(|error| ResponseSinkError::Transport(error.to_string())),
+            Self::Local(sink) => sink.complete(Ok(command)),
+        }
+    }
+
+    /// Delivers an already encoded response without introducing a local socket.
+    ///
+    /// The local branch incrementally decodes processor-generated response
+    /// segments into one command. It never encodes the inbound request.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed decoding, lifecycle, or writer error.
+    pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), ResponseSinkError> {
+        match self {
+            Self::Network(session) => session
+                .connection()
+                .send_bytes(bytes)
+                .await
+                .map_err(|error| ResponseSinkError::Transport(error.to_string())),
+            Self::Local(sink) => sink.send_bytes(bytes),
+        }
+    }
+}
+
+/// Single owner of an in-process response result.
+pub struct LocalResponseReceiver {
+    receiver: oneshot::Receiver<Result<RemotingCommand, ResponseSinkError>>,
+}
+
+impl LocalResponseReceiver {
+    /// Waits under the parent cancellation token and immutable request deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed cancellation, deadline, sender-drop, or response error.
+    pub async fn receive(
+        mut self,
+        cancellation: &CancellationToken,
+        deadline: Option<RequestDeadline>,
+    ) -> Result<RemotingCommand, ResponseSinkError> {
+        let result = if let Some(deadline) = deadline {
+            tokio::select! {
+                biased;
+                () = cancellation.cancelled() => return Err(ResponseSinkError::Cancelled),
+                result = deadline.timeout(&mut self.receiver) => {
+                    result.map_err(|_| ResponseSinkError::DeadlineExceeded)?
+                }
+            }
+        } else {
+            tokio::select! {
+                biased;
+                () = cancellation.cancelled() => return Err(ResponseSinkError::Cancelled),
+                result = &mut self.receiver => result,
+            }
+        };
+        result.map_err(|_| ResponseSinkError::ReceiverDropped)?
+    }
+}

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -27,8 +27,10 @@ mod connection;
 mod connection_context;
 mod deadline;
 mod discovery;
+mod dispatch;
 mod error_helpers;
 mod error_response;
+#[cfg(any(test, feature = "test-support"))]
 mod local;
 mod net;
 pub mod prelude;
@@ -97,6 +99,20 @@ pub use discovery::http_tiny_client::HttpResult;
 pub use discovery::http_tiny_client::HttpTinyClient;
 pub use discovery::name_server_update_callback::NameServerUpdateCallback;
 pub use discovery::top_addressing::TopAddressing;
+pub use dispatch::AuthorizedCommandDispatcher;
+pub use dispatch::AuthorizedDispatchBoundary;
+pub use dispatch::DispatchError;
+pub use dispatch::DispatchOutcome;
+pub use dispatch::LocalResponseReceiver;
+#[doc(hidden)]
+pub use dispatch::LocalResponseSink;
+pub use dispatch::RequestContext;
+pub use dispatch::RequestContextError;
+pub use dispatch::RequestTransport;
+pub use dispatch::ResponseSink;
+pub use dispatch::ResponseSinkError;
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
 pub use local::LocalRequestHarness;
 pub use net::channel::ArcChannel;
 pub use net::channel::Channel;

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -45,6 +45,7 @@ use crate::base::response_future::ResponseFuture;
 use crate::connection::Connection;
 use crate::connection::ConnectionStateHandle;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::ResponseSink;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 pub type ChannelId = CheetahString;
@@ -413,7 +414,7 @@ pub struct ChannelInner {
 
     // === I/O Transport ===
     /// Underlying network connection serialized by one async writer lock.
-    connection: Arc<tokio::sync::Mutex<Connection>>,
+    connection: ChannelIo,
 
     /// Cloneable lifecycle state without connection mutation capability.
     connection_state: ConnectionStateHandle,
@@ -438,6 +439,11 @@ pub struct ChannelInner {
     /// Tracks the outbound send task for shutdown diagnostics.
     send_task_group: TaskGroup,
     send_task_id: Option<TaskId>,
+}
+
+enum ChannelIo {
+    Network(Arc<tokio::sync::Mutex<Connection>>),
+    Local(ResponseSink),
 }
 
 /// Background task that processes the outbound message queue.
@@ -588,6 +594,21 @@ fn complete_send_error(
 }
 
 impl ChannelInner {
+    pub(crate) fn new_local(response: ResponseSink, task_group: TaskGroup) -> Self {
+        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(0);
+        drop(outbound_queue_rx);
+        Self {
+            outbound_queue_tx: parking_lot::Mutex::new(Some(outbound_queue_tx)),
+            connection: ChannelIo::Local(response),
+            connection_state: ConnectionStateHandle::healthy(),
+            response_table: PendingRequestTable::new(),
+            pending_request_owner: None,
+            legacy_response_table: None,
+            send_task_group: task_group,
+            send_task_id: None,
+        }
+    }
+
     /// Creates a new `ChannelInner` and spawns the background send task.
     ///
     /// # Arguments
@@ -728,7 +749,7 @@ impl ChannelInner {
         };
         Ok(Self {
             outbound_queue_tx: parking_lot::Mutex::new(Some(outbound_queue_tx)),
-            connection,
+            connection: ChannelIo::Network(connection),
             connection_state,
             response_table,
             pending_request_owner,
@@ -819,17 +840,30 @@ impl ChannelInner {
 
     /// Sends a command through the serialized writer capability.
     pub async fn send_command(&self, command: RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
-        self.connection.lock().await.send_command(command).await
+        match &self.connection {
+            ChannelIo::Network(connection) => connection.lock().await.send_command(command).await,
+            ChannelIo::Local(response) => response.send(command).await.map_err(response_sink_error),
+        }
     }
 
     /// Sends a borrowed command through the serialized writer capability.
     pub async fn send_command_ref(&self, command: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
-        self.connection.lock().await.send_command_ref(command).await
+        match &self.connection {
+            ChannelIo::Network(connection) => connection.lock().await.send_command_ref(command).await,
+            ChannelIo::Local(response) => {
+                let owned = command.clone();
+                let _ = command.take_body();
+                response.send(owned).await.map_err(response_sink_error)
+            }
+        }
     }
 
     /// Sends pre-encoded bytes through the serialized writer capability.
     pub async fn send_bytes(&self, bytes: Bytes) -> rocketmq_error::RocketMQResult<()> {
-        self.connection.lock().await.send_bytes(bytes).await
+        match &self.connection {
+            ChannelIo::Network(connection) => connection.lock().await.send_bytes(bytes).await,
+            ChannelIo::Local(response) => response.send_bytes(bytes).await.map_err(response_sink_error),
+        }
     }
 
     // === High-Level Send Methods ===
@@ -961,6 +995,10 @@ impl ChannelInner {
     ) -> rocketmq_error::RocketMQResult<()> {
         let deadline = RequestDeadline::from_timeout_millis(timeout_millis);
         let request = request.mark_oneway_rpc();
+        if let ChannelIo::Local(response) = &self.connection {
+            deadline.ensure_before_send("embedded-response")?;
+            return response.send(request).await.map_err(response_sink_error);
+        }
 
         let outbound_queue_tx = self.outbound_queue_sender()?;
         deadline.ensure_before_send("channel")?;
@@ -997,6 +1035,9 @@ impl ChannelInner {
         if let Some(deadline) = deadline {
             deadline.ensure_before_send("channel")?;
         }
+        if let ChannelIo::Local(response) = &self.connection {
+            return response.send(request).await.map_err(response_sink_error);
+        }
         let outbound_queue_tx = self.outbound_queue_sender()?;
         outbound_queue_tx
             .try_send((request, None, deadline, None))
@@ -1031,6 +1072,10 @@ impl ChannelInner {
     pub fn is_ok(&self) -> bool {
         self.connection_state.is_healthy()
     }
+}
+
+fn response_sink_error(error: crate::dispatch::ResponseSinkError) -> RocketMQError {
+    RocketMQError::response_process_failed("embedded_response_sink", error.to_string())
 }
 
 #[cfg(test)]
@@ -1204,7 +1249,10 @@ mod tests {
             )
             .expect("create channel"),
         );
-        let locked_connection = channel.connection.clone();
+        let locked_connection = match &channel.connection {
+            ChannelIo::Network(connection) => Arc::clone(connection),
+            ChannelIo::Local(_) => panic!("test requires a network channel"),
+        };
         let writer_lock = locked_connection.lock().await;
         let sending = channel.clone();
         let send = tokio::spawn(async move {
@@ -1252,7 +1300,10 @@ mod tests {
             )
             .expect("create channel"),
         );
-        let locked_connection = channel.connection.clone();
+        let locked_connection = match &channel.connection {
+            ChannelIo::Network(connection) => Arc::clone(connection),
+            ChannelIo::Local(_) => panic!("test requires a network channel"),
+        };
         let writer_lock = locked_connection.lock().await;
 
         channel

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::ServerConfig;
+use crate::dispatch::AuthorizedCommandDispatcher;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::wait_for_signal;
@@ -40,11 +41,9 @@ use crate::admission::AdmissionLimits;
 use crate::admission::ResourceLimit;
 use crate::base::channel_event_listener::ChannelEventListener;
 use crate::base::connection_net_event::ConnectionNetEvent;
-use crate::base::pending_request_table::PendingRequestTable;
 use crate::base::tokio_event::TokioEvent;
 use crate::net::channel::Channel;
 use crate::net::channel::ChannelInner;
-use crate::remoting::inner::RemotingGeneralHandler;
 use crate::runtime::connection_handler_context::ConnectionHandlerContext;
 use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
@@ -143,7 +142,7 @@ struct ConnectionListener<RP> {
     ///
     /// Contains request processor, RPC hooks, and response routing table.
     /// Arc-wrapped to share across all connection handlers efficiently.
-    cmd_handler: Arc<RemotingGeneralHandler<RP>>,
+    dispatcher: Arc<AuthorizedCommandDispatcher<RP>>,
 
     /// TLS mode and acceptor state for newly accepted connections.
     tls_runtime: TlsServerRuntime,
@@ -151,8 +150,6 @@ struct ConnectionListener<RP> {
     /// Tracks remoting event and connection tasks for shutdown diagnostics.
     task_group: TaskGroup,
 
-    admission: Arc<AdmissionController>,
-    transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
     command_interceptor: Arc<dyn SessionCommandInterceptor>,
     telemetry: TransportTelemetry,
@@ -223,23 +220,21 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
         let listener = self.listener.take().ok_or_else(|| {
             RocketMQError::network_connection_failed("remoting-server", "transport listener already started")
         })?;
-        let mut transport = TransportListener::new(
+        let transport = TransportListener::new(
             listener,
             self.task_group.clone(),
             self.tls_runtime.clone(),
-            self.admission.clone(),
+            self.dispatcher.boundary().admission_controller(),
             DEFAULT_TLS_HANDSHAKE_TIMEOUT,
         )
+        .with_authorized_dispatch(self.dispatcher.boundary(), self.transport_principal.clone())
         .with_telemetry(self.telemetry.clone());
-        if let Some(security) = self.transport_security.clone() {
-            transport = transport.with_security(security, self.transport_principal.clone());
-        }
         transport
             .run(Arc::new(InterceptingConnectionHandler {
                 inner: ConnectionHandler {
                     shutdown_complete_tx: self.shutdown_complete_tx.clone(),
                     conn_disconnect_notify: self.conn_disconnect_notify.clone(),
-                    cmd_handler: self.cmd_handler.clone(),
+                    dispatcher: self.dispatcher.clone(),
                     event_tx,
                     sessions: dashmap::DashMap::new(),
                 },
@@ -252,7 +247,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
 struct ConnectionHandler<RP> {
     shutdown_complete_tx: mpsc::Sender<()>,
     conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
-    cmd_handler: Arc<RemotingGeneralHandler<RP>>,
+    dispatcher: Arc<AuthorizedCommandDispatcher<RP>>,
     event_tx: mpsc::Sender<TokioEvent>,
     sessions: dashmap::DashMap<u64, RemotingSession<ConnectionHandlerContext>>,
 }
@@ -295,12 +290,12 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
         let channel_inner = match &action {
             RemotingSessionAction::Connect => ChannelInner::new_transport_session(
                 session.connection(),
-                self.cmd_handler.response_table.clone(),
+                self.dispatcher.response_table(),
                 session.task_group().clone(),
             ),
             RemotingSessionAction::Command(_) => ChannelInner::new_transport_session_with_task_group(
                 session.connection(),
-                self.cmd_handler.response_table.clone(),
+                self.dispatcher.response_table(),
                 session.task_group().clone(),
             ),
         };
@@ -333,10 +328,8 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                         return;
                     }
                 }
-                let cmd_handler = self.cmd_handler.clone();
-                cmd_handler
-                    .process_message_received(&remoting_session.context, command)
-                    .await;
+                let dispatcher = self.dispatcher.clone();
+                dispatcher.process_network(&remoting_session.context, command).await;
             }
         }
     }
@@ -353,7 +346,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
         &self,
         command: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
     ) -> crate::request_ordering::RequestOrdering {
-        self.cmd_handler.request_processor.request_ordering(command)
+        self.dispatcher.request_ordering(command)
     }
 
     fn command(
@@ -431,6 +424,7 @@ pub struct RocketMQServer<RP> {
     transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
     admission: Option<Arc<AdmissionController>>,
+    authorized_dispatcher: Option<Arc<AuthorizedCommandDispatcher<RP>>>,
     telemetry: TransportTelemetry,
     #[cfg(all(test, not(doctest)))]
     test_request_hook: Option<TestRequestHook>,
@@ -446,6 +440,7 @@ impl<RP> RocketMQServer<RP> {
             transport_security: None,
             transport_principal: None,
             admission: None,
+            authorized_dispatcher: None,
             telemetry: TransportTelemetry::noop(),
             #[cfg(all(test, not(doctest)))]
             test_request_hook: None,
@@ -498,6 +493,13 @@ impl<RP> RocketMQServer<RP> {
     #[doc(hidden)]
     pub fn with_admission_controller(mut self, admission: Arc<AdmissionController>) -> Self {
         self.admission = Some(admission);
+        self
+    }
+
+    /// Installs one dispatcher shared with another trusted entry adapter.
+    #[doc(hidden)]
+    pub fn with_authorized_dispatcher(mut self, dispatcher: Arc<AuthorizedCommandDispatcher<RP>>) -> Self {
+        self.authorized_dispatcher = Some(dispatcher);
         self
     }
 
@@ -634,6 +636,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
             Some(notify_conn_disconnect),
             rpc_hooks,
             channel_event_listener,
+            self.authorized_dispatcher.clone(),
             RemotingServerRunCapabilities {
                 tls_runtime,
                 task_group,
@@ -756,6 +759,7 @@ pub async fn run_with_report_with_service_context_and_telemetry<RP: RequestProce
         conn_disconnect_notify,
         rpc_hooks,
         channel_event_listener,
+        None,
         RemotingServerRunCapabilities {
             tls_runtime,
             task_group: remoting_context.task_group().clone(),
@@ -788,6 +792,7 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
     rpc_hooks: Vec<Arc<dyn RPCHook>>,
     channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
+    authorized_dispatcher: Option<Arc<AuthorizedCommandDispatcher<RP>>>,
     capabilities: RemotingServerRunCapabilities,
 ) -> Option<ShutdownReport> {
     let RemotingServerRunCapabilities {
@@ -802,25 +807,6 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     } = capabilities;
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
-    // Initialize the connection listener state
-    let handler = RemotingGeneralHandler::new_with_telemetry(
-        request_processor,
-        rpc_hooks,
-        match PendingRequestTable::try_with_limits_and_budget(
-            crate::base::pending_request_table::PendingRequestLimits {
-                max_count: 512,
-                ..Default::default()
-            },
-            &process_budget,
-        ) {
-            Ok(table) => table,
-            Err(error) => {
-                error!(%error, "failed to initialize remoting pending-request budget");
-                return None;
-            }
-        },
-        telemetry.clone(),
-    );
     let mut admission_limits = AdmissionLimits::default();
     admission_limits.connections = ResourceLimit {
         count: DEFAULT_MAX_CONNECTIONS,
@@ -830,15 +816,39 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
         count: DEFAULT_MAX_CONNECTIONS,
         ..admission_limits.handshakes
     };
-    let admission = match admission {
-        Some(admission) => admission,
-        None => match AdmissionController::try_new_with_budget(admission_limits, &process_budget) {
-            Ok(admission) => Arc::new(admission),
-            Err(error) => {
-                error!(%error, "failed to initialize transport admission budgets");
-                return None;
-            }
+    let admission = match authorized_dispatcher.as_ref() {
+        Some(dispatcher) => dispatcher.boundary().admission_controller(),
+        None => match admission {
+            Some(admission) => admission,
+            None => match AdmissionController::try_new_with_budget(admission_limits, &process_budget) {
+                Ok(admission) => Arc::new(admission),
+                Err(error) => {
+                    error!(%error, "failed to initialize transport admission budgets");
+                    return None;
+                }
+            },
         },
+    };
+    let dispatcher = match authorized_dispatcher {
+        Some(dispatcher) => dispatcher,
+        None => {
+            let security = transport_security
+                .unwrap_or_else(|| Arc::new(TransportSecurity::development_insecure_loopback(None, None)));
+            match AuthorizedCommandDispatcher::try_new(
+                request_processor,
+                rpc_hooks,
+                &process_budget,
+                telemetry.clone(),
+                security,
+                admission,
+            ) {
+                Ok(dispatcher) => Arc::new(dispatcher),
+                Err(error) => {
+                    error!(%error, "failed to initialize authorized command dispatcher");
+                    return None;
+                }
+            }
+        }
     };
     let mut listener = ConnectionListener {
         listener: Some(listener),
@@ -846,11 +856,9 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
         shutdown_complete_tx,
         conn_disconnect_notify,
         channel_event_listener,
-        cmd_handler: Arc::new(handler),
+        dispatcher,
         tls_runtime,
         task_group: task_group.clone(),
-        admission,
-        transport_security,
         transport_principal,
         command_interceptor,
         telemetry,
@@ -1731,6 +1739,7 @@ mod tests {
             DefaultRemotingRequestProcessor,
             None,
             Vec::new(),
+            None,
             None,
             RemotingServerRunCapabilities {
                 tls_runtime,

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -28,7 +28,6 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::OperationContext;
@@ -39,19 +38,14 @@ use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskId;
 use rocketmq_runtime::TaskKind;
-use rocketmq_security_api::Action;
-use rocketmq_security_api::Decision;
 use rocketmq_security_api::PeerInfo;
 use rocketmq_security_api::Principal;
-use rocketmq_security_api::Resource;
-use rocketmq_security_api::ResourceKind;
 use tokio_util::sync::CancellationToken;
 
 use crate::admission::AdmissionClass;
 use crate::admission::AdmissionController;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
-use crate::admission::FullPolicy;
 use crate::config::TlsConfig;
 use crate::config::TlsMode;
 use crate::connection::record_transport_write;
@@ -61,10 +55,11 @@ use crate::connection::ConnectionState;
 use crate::connection::SessionLifecycle;
 use crate::connection::SessionWriterDiagnostics;
 use crate::connection::SessionWriterSnapshot;
+use crate::dispatch::AuthorizedDispatchBoundary;
+use crate::dispatch::RequestContext;
+use crate::dispatch::ResponseSink;
 use crate::request_ordering::RequestOrdering;
 use crate::security::TransportSecurity;
-use crate::session_executor::SessionDispatchError;
-use crate::session_executor::SessionExecutor;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::NegotiatedConnection;
 use crate::tls::TlsServerRuntime;
@@ -160,7 +155,7 @@ impl SessionHandle {
         self.task_group.abort_task(self.writer_task_id);
     }
 
-    fn with_response_class(mut self, class: AdmissionClass) -> Self {
+    pub(crate) fn with_response_class(mut self, class: AdmissionClass) -> Self {
         self.response_class = Some(class);
         self
     }
@@ -331,10 +326,9 @@ pub struct TransportListener {
     listener: tokio::net::TcpListener,
     task_group: TaskGroup,
     tls: TlsServerRuntime,
-    admission: Arc<AdmissionController>,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
     handshake_timeout: Duration,
     idle_timeout: Duration,
-    security: Arc<TransportSecurity>,
     principal: Option<Principal>,
     next_session: AtomicU64,
     telemetry: TransportTelemetry,
@@ -348,14 +342,17 @@ impl TransportListener {
         admission: Arc<AdmissionController>,
         handshake_timeout: Duration,
     ) -> Self {
+        let dispatch = Arc::new(AuthorizedDispatchBoundary::new(
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            admission,
+        ));
         Self {
             listener,
             task_group,
             tls,
-            admission,
+            dispatch,
             handshake_timeout,
             idle_timeout: Duration::from_secs(120),
-            security: Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
             principal: None,
             next_session: AtomicU64::new(1),
             telemetry: TransportTelemetry::noop(),
@@ -368,7 +365,20 @@ impl TransportListener {
     }
 
     pub fn with_security(mut self, security: Arc<TransportSecurity>, principal: Option<Principal>) -> Self {
-        self.security = security;
+        self.dispatch = Arc::new(AuthorizedDispatchBoundary::new(
+            security,
+            self.dispatch.admission_controller(),
+        ));
+        self.principal = principal;
+        self
+    }
+
+    pub(crate) fn with_authorized_dispatch(
+        mut self,
+        dispatch: Arc<AuthorizedDispatchBoundary>,
+        principal: Option<Principal>,
+    ) -> Self {
+        self.dispatch = dispatch;
         self.principal = principal;
         self
     }
@@ -385,6 +395,7 @@ impl TransportListener {
         H: ConnectionHandler,
     {
         let cancellation = self.task_group.cancellation_token();
+        let admission = self.dispatch.admission_controller();
         loop {
             let accepted = tokio::select! {
                 () = cancellation.cancelled() => return Ok(()),
@@ -397,7 +408,7 @@ impl TransportListener {
             let local_addr = stream.local_addr()?;
             let session_id = self.next_session.fetch_add(1, Ordering::Relaxed);
             let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
-            let Ok(connection_permit) = self.admission.try_acquire(
+            let Ok(connection_permit) = admission.try_acquire(
                 AdmissionResource::Connection,
                 scope,
                 crate::admission::estimated_connection_retained_bytes(),
@@ -408,10 +419,10 @@ impl TransportListener {
             let session_operation = OperationContext::without_deadline(TaskKind::Service);
             let session_group = self.task_group.clone();
             let tls = self.tls.clone();
-            let admission = self.admission.clone();
+            let admission = admission.clone();
+            let dispatch = self.dispatch.clone();
             let handshake_timeout = self.handshake_timeout;
             let idle_timeout = self.idle_timeout;
-            let security = self.security.clone();
             let principal = self.principal.clone();
             let handler = handler.clone();
             let telemetry = self.telemetry.clone();
@@ -446,8 +457,7 @@ impl TransportListener {
                         session_id,
                         scope,
                         session_group,
-                        admission,
-                        security,
+                        dispatch,
                         principal,
                         peer_is_tls,
                         idle_timeout,
@@ -471,8 +481,7 @@ async fn run_framed_session<H>(
     session_id: u64,
     scope: AdmissionScope,
     task_group: TaskGroup,
-    admission: Arc<AdmissionController>,
-    security: Arc<TransportSecurity>,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
     principal: Option<Principal>,
     peer_is_tls: bool,
     idle_timeout: Duration,
@@ -483,10 +492,11 @@ async fn run_framed_session<H>(
     let connection_id = connection.connection_id().clone();
     let telemetry = connection.telemetry();
     let (mut frame_writer, mut stream) = connection.into_session_io();
-    let executor = match SessionExecutor::try_new(&task_group, admission.clone(), scope) {
+    let executor = match dispatch.session(&task_group, scope) {
         Ok(executor) => executor,
         Err(_) => return,
     };
+    let admission = dispatch.admission_controller();
     let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
     let lifecycle = Arc::new(SessionLifecycle::new());
     let (writer, mut writes) = tokio::sync::mpsc::channel::<QueuedWrite>(SESSION_WRITER_QUEUE_CAPACITY);
@@ -603,68 +613,28 @@ async fn run_framed_session<H>(
         let command = decoded.command;
         let class = AdmissionClass::for_request_code(command.code());
         let bytes = decoded.retained_frame_bytes;
-        let peer = PeerInfo::new(remote_addr, peer_is_tls);
-        if let Decision::Deny { reason } = security.authorize(
-            &command,
-            Some(&peer),
-            principal.as_ref(),
-            Resource::new(ResourceKind::Other, command.code().to_string()),
-            Action::Manage,
-        ) {
-            let mut connection = session.clone().with_response_class(class).connection();
-            let _ = connection
-                .send_command(
-                    RemotingCommand::create_response_command_with_code_remark(
-                        ResponseCode::NoPermission,
-                        reason.to_string(),
-                    )
-                    .set_opaque(command.opaque()),
-                )
-                .await;
-            continue;
-        }
+        let context = RequestContext::network(PeerInfo::new(remote_addr, peer_is_tls), principal.clone(), None);
         let ordering = handler.request_ordering(&command);
-        let opaque = command.opaque();
         let request_handler = handler.clone();
         let request_session = session.clone().with_response_class(class);
-        let rejection_session = session.clone().with_response_class(class);
-        match executor.try_execute(
-            bytes,
-            class,
-            ordering,
-            move |request_operation| async move {
-                request_handler
-                    .command(request_session.with_operation_context(request_operation), command)
-                    .await;
-            },
-            move |_request_operation, error| async move {
-                let mut connection = rejection_session.connection();
-                let _ = connection
-                    .send_command(
-                        RemotingCommand::create_response_command_with_code_remark(
-                            ResponseCode::SystemBusy,
-                            error.to_string(),
-                        )
-                        .set_opaque(opaque),
-                    )
-                    .await;
-            },
-        ) {
-            Ok(_) => {}
-            Err(SessionDispatchError::Admission(error)) if error.policy() == FullPolicy::Reject => {
-                let mut connection = session.clone().with_response_class(class).connection();
-                let _ = connection
-                    .send_command(
-                        RemotingCommand::create_response_command_with_code_remark(
-                            ResponseCode::SystemBusy,
-                            error.to_string(),
-                        )
-                        .set_opaque(opaque),
-                    )
-                    .await;
-                continue;
-            }
-            Err(SessionDispatchError::Admission(_)) | Err(SessionDispatchError::Closing(_)) => break,
+        let response = ResponseSink::Network(Arc::new(session.clone().with_response_class(class)));
+        if executor
+            .dispatch(
+                context,
+                command,
+                bytes,
+                ordering,
+                response,
+                move |request_operation, command| async move {
+                    request_handler
+                        .command(request_session.with_operation_context(request_operation), command)
+                        .await;
+                },
+            )
+            .await
+            .is_err()
+        {
+            break;
         }
     }
     let request_deadline = task_group
@@ -700,8 +670,7 @@ pub async fn run_connected_session<H>(
         session_id,
         scope,
         task_group,
-        admission,
-        security,
+        Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
         principal,
         false,
         idle_timeout,
@@ -743,12 +712,11 @@ pub struct TransportServer {
     service_context: ChildServiceContext,
     config: TransportServerConfig,
     processor: Arc<dyn RequestProcessor>,
-    admission: Arc<AdmissionController>,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
     tls: TlsServerRuntime,
     started: AtomicBool,
     next_session: AtomicU64,
     active_sessions: AtomicUsize,
-    security: Arc<TransportSecurity>,
     principal: Option<Principal>,
     telemetry: TransportTelemetry,
 }
@@ -884,12 +852,11 @@ impl TransportServer {
             service_context,
             config,
             processor,
-            admission,
+            dispatch: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
             tls,
             started: AtomicBool::new(false),
             next_session: AtomicU64::new(1),
             active_sessions: AtomicUsize::new(0),
-            security,
             principal,
             telemetry,
         }))
@@ -925,7 +892,7 @@ impl TransportServer {
                 };
                 let session_id = server.next_session.fetch_add(1, Ordering::Relaxed);
                 let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
-                let Ok(connection_permit) = server.admission.try_acquire(
+                let Ok(connection_permit) = server.dispatch.admission_controller().try_acquire(
                     AdmissionResource::Connection,
                     scope,
                     crate::admission::estimated_connection_retained_bytes(),
@@ -964,12 +931,13 @@ impl TransportServer {
         session_group: TaskGroup,
     ) {
         let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
+        let admission = self.dispatch.admission_controller();
         let handshake_cancellation = session_group.cancellation_token();
         let negotiated = tokio::select! {
             () = handshake_cancellation.cancelled() => return,
             negotiated = negotiate_transport_connection(
                 &self.tls,
-                &self.admission,
+                &admission,
                 scope,
                 stream,
                 remote_addr,
@@ -991,8 +959,7 @@ impl TransportServer {
             session_id,
             scope,
             session_group.clone(),
-            self.admission.clone(),
-            self.security.clone(),
+            self.dispatch.clone(),
             self.principal.clone(),
             peer_is_tls,
             self.config.request_timeout,

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -1,0 +1,370 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::headers::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::transport_io_snapshot;
+use rocketmq_transport::AdmissionClass;
+use rocketmq_transport::AdmissionController;
+use rocketmq_transport::AdmissionLimits;
+use rocketmq_transport::AdmissionResource;
+use rocketmq_transport::AdmissionScope;
+use rocketmq_transport::AuthorizedCommandDispatcher;
+use rocketmq_transport::Channel;
+use rocketmq_transport::Connection;
+use rocketmq_transport::ConnectionHandlerContext;
+use rocketmq_transport::DispatchError;
+use rocketmq_transport::RemotingRequestProcessor;
+use rocketmq_transport::RequestContext;
+use rocketmq_transport::RequestContextError;
+use rocketmq_transport::RequestDeadline;
+use rocketmq_transport::ResourceLimit;
+use rocketmq_transport::ResponseSinkError;
+use rocketmq_transport::RocketMQServer;
+use rocketmq_transport::ServerConfig;
+use rocketmq_transport::TransportSecurity;
+use rocketmq_transport::TransportTelemetry;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+
+#[derive(Clone, Copy)]
+enum ProcessorBehavior {
+    Echo,
+    DecodeRequiredHeader,
+    Error,
+    Pending,
+}
+
+#[derive(Clone)]
+struct ConformanceProcessor {
+    behavior: ProcessorBehavior,
+    calls: Arc<AtomicUsize>,
+    entered: Arc<tokio::sync::Notify>,
+}
+
+impl ConformanceProcessor {
+    fn new(behavior: ProcessorBehavior) -> Self {
+        Self {
+            behavior,
+            calls: Arc::new(AtomicUsize::new(0)),
+            entered: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+}
+
+impl RemotingRequestProcessor for ConformanceProcessor {
+    async fn process_request(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.entered.notify_waiters();
+        match self.behavior {
+            ProcessorBehavior::Echo => Ok(Some(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                    .set_body(request.body().cloned().unwrap_or_default()),
+            )),
+            ProcessorBehavior::DecodeRequiredHeader => {
+                let _: PullMessageRequestHeader = request.decode_command_custom_header()?;
+                Ok(Some(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::Success,
+                )))
+            }
+            ProcessorBehavior::Error => Err(RocketMQError::response_process_failed(
+                "authorized_dispatch_conformance",
+                "injected handler failure",
+            )),
+            ProcessorBehavior::Pending => future::pending().await,
+        }
+    }
+}
+
+struct AllowOnlyNamedPrincipal;
+
+impl RequestPolicy for AllowOnlyNamedPrincipal {
+    fn evaluate_authenticated(&self, context: AuthenticatedRequestContext<'_>) -> Decision {
+        if context.principal().id() == "allowed" {
+            Decision::Allow
+        } else {
+            Decision::deny("principal is not authorized")
+        }
+    }
+}
+
+struct DispatchFixture {
+    service: ChildServiceContext,
+    processor: ConformanceProcessor,
+    dispatcher: Arc<AuthorizedCommandDispatcher<ConformanceProcessor>>,
+    security: Arc<TransportSecurity>,
+    admission: Arc<AdmissionController>,
+}
+
+fn dispatch_fixture(
+    runtime: &RuntimeContext,
+    name: &'static str,
+    behavior: ProcessorBehavior,
+    limits: AdmissionLimits,
+) -> DispatchFixture {
+    let service = runtime.service_context(name);
+    let process_budget = service.process_budget();
+    let admission = Arc::new(
+        AdmissionController::try_new_with_budget(limits, &process_budget)
+            .expect("test admission limits should be valid"),
+    );
+    let security = Arc::new(TransportSecurity::secure_enforced(
+        Some(Arc::new(AllowOnlyNamedPrincipal)),
+        None,
+    ));
+    let processor = ConformanceProcessor::new(behavior);
+    let dispatcher = Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            processor.clone(),
+            Vec::new(),
+            &process_budget,
+            TransportTelemetry::noop(),
+            Arc::clone(&security),
+            Arc::clone(&admission),
+        )
+        .expect("test dispatcher should fit the process budget"),
+    );
+    DispatchFixture {
+        service,
+        processor,
+        dispatcher,
+        security,
+        admission,
+    }
+}
+
+fn embedded_context(principal: &str, deadline: Option<RequestDeadline>) -> RequestContext {
+    RequestContext::try_embedded(Some(Principal::new(principal)), deadline)
+        .expect("test principal should create an embedded context")
+}
+
+async fn dispatch_embedded(
+    fixture: &DispatchFixture,
+    principal: &str,
+    deadline: Option<RequestDeadline>,
+    command: RemotingCommand,
+) -> RemotingCommand {
+    fixture
+        .dispatcher
+        .dispatch_embedded(
+            fixture.service.task_group(),
+            embedded_context(principal, deadline),
+            command,
+        )
+        .await
+        .expect("embedded request should produce a protocol response")
+}
+
+async fn network_round_trip(fixture: &DispatchFixture, principal: &str, command: RemotingCommand) -> RemotingCommand {
+    let config = Arc::new(ServerConfig {
+        bind_address: "127.0.0.1".to_owned(),
+        listen_port: 0,
+        ..ServerConfig::default()
+    });
+    let mut server = RocketMQServer::new(config, fixture.service.component("network"))
+        .with_transport_security(Arc::clone(&fixture.security), Some(Principal::new(principal)))
+        .with_authorized_dispatcher(Arc::clone(&fixture.dispatcher));
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let processor = fixture.processor.clone();
+    let server_task = tokio::spawn(async move {
+        server
+            .run_with_shutdown_report_and_startup(
+                processor,
+                None,
+                async {
+                    let _ = shutdown_rx.await;
+                },
+                startup_tx,
+            )
+            .await
+    });
+    let address = startup_rx
+        .await
+        .expect("server should report startup")
+        .expect("server should bind");
+    let mut connection = Connection::new(TcpStream::connect(address).await.expect("client should connect"));
+    connection
+        .send_command(command)
+        .await
+        .expect("request frame should be written");
+    let response = tokio::time::timeout(Duration::from_secs(2), connection.receive_command())
+        .await
+        .expect("network request should complete before the test timeout")
+        .expect("network read should succeed")
+        .expect("server should return one response frame");
+    drop(connection);
+    let _ = shutdown_tx.send(());
+    let report = server_task
+        .await
+        .expect("server task should not panic")
+        .expect("server should report shutdown");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    response
+}
+
+fn assert_equivalent(actual: &RemotingCommand, expected: &RemotingCommand) {
+    assert_eq!(actual.code(), expected.code());
+    assert_eq!(actual.opaque(), expected.opaque());
+    assert_eq!(actual.remark(), expected.remark());
+    assert_eq!(actual.ext_fields(), expected.ext_fields());
+    assert_eq!(actual.body(), expected.body());
+}
+
+#[tokio::test]
+async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
+    let runtime = RuntimeContext::from_current("authorized-dispatch-conformance");
+
+    let valid = dispatch_fixture(&runtime, "valid", ProcessorBehavior::Echo, AdmissionLimits::default());
+    let request = RemotingCommand::create_remoting_command(RequestCode::SendMessage)
+        .set_opaque(41)
+        .set_body(b"shared-dispatch".to_vec());
+    let io_before = transport_io_snapshot();
+    let embedded = dispatch_embedded(&valid, "allowed", None, request.clone()).await;
+    let io_after = transport_io_snapshot();
+    assert_eq!(
+        io_after, io_before,
+        "embedded dispatch must not encode or write a network frame"
+    );
+    let network = network_round_trip(&valid, "allowed", request).await;
+    assert_equivalent(&embedded, &network);
+    assert_eq!(valid.processor.calls.load(Ordering::SeqCst), 2);
+
+    assert_eq!(
+        RequestContext::try_embedded(None, None).expect_err("missing embedded identity must fail closed"),
+        RequestContextError::MissingEmbeddedPrincipal
+    );
+    let denied = dispatch_fixture(&runtime, "denied", ProcessorBehavior::Echo, AdmissionLimits::default());
+    let denied_request = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(42);
+    let embedded_denied = dispatch_embedded(&denied, "denied", None, denied_request.clone()).await;
+    let network_denied = network_round_trip(&denied, "denied", denied_request).await;
+    assert_equivalent(&embedded_denied, &network_denied);
+    assert_eq!(embedded_denied.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(denied.processor.calls.load(Ordering::SeqCst), 0);
+
+    let malformed = dispatch_fixture(
+        &runtime,
+        "malformed",
+        ProcessorBehavior::DecodeRequiredHeader,
+        AdmissionLimits::default(),
+    );
+    let malformed_request = RemotingCommand::create_remoting_command(RequestCode::PullMessage).set_opaque(43);
+    let embedded_malformed = dispatch_embedded(&malformed, "allowed", None, malformed_request.clone()).await;
+    let network_malformed = network_round_trip(&malformed, "allowed", malformed_request).await;
+    assert_equivalent(&embedded_malformed, &network_malformed);
+    assert_eq!(embedded_malformed.code(), ResponseCode::SystemError.to_i32());
+
+    let handler_error = dispatch_fixture(
+        &runtime,
+        "handler-error",
+        ProcessorBehavior::Error,
+        AdmissionLimits::default(),
+    );
+    let error_request = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(44);
+    let embedded_error = dispatch_embedded(&handler_error, "allowed", None, error_request.clone()).await;
+    let network_error = network_round_trip(&handler_error, "allowed", error_request).await;
+    assert_equivalent(&embedded_error, &network_error);
+    assert_eq!(embedded_error.code(), ResponseCode::SystemError.to_i32());
+
+    let deadline = dispatch_fixture(
+        &runtime,
+        "deadline",
+        ProcessorBehavior::Echo,
+        AdmissionLimits::default(),
+    );
+    let deadline_response = dispatch_embedded(
+        &deadline,
+        "allowed",
+        Some(RequestDeadline::after(Duration::ZERO)),
+        RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(45),
+    )
+    .await;
+    assert_eq!(deadline_response.code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(deadline.processor.calls.load(Ordering::SeqCst), 0);
+
+    let limits = AdmissionLimits {
+        processors: ResourceLimit {
+            count: 1,
+            bytes: 1024 * 1024,
+        },
+        control_reserve: ResourceLimit { count: 0, bytes: 0 },
+        ..AdmissionLimits::default()
+    };
+    let overloaded = dispatch_fixture(&runtime, "overloaded", ProcessorBehavior::Echo, limits);
+    let _held_processor = overloaded
+        .admission
+        .try_acquire(
+            AdmissionResource::Processor,
+            AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST)).with_session(999),
+            1,
+            AdmissionClass::Data,
+        )
+        .expect("test should exhaust the single processor permit");
+    let overloaded_request = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(46);
+    let embedded_overloaded = dispatch_embedded(&overloaded, "allowed", None, overloaded_request.clone()).await;
+    let network_overloaded = network_round_trip(&overloaded, "allowed", overloaded_request).await;
+    assert_equivalent(&embedded_overloaded, &network_overloaded);
+    assert_eq!(embedded_overloaded.code(), ResponseCode::SystemBusy.to_i32());
+    assert_eq!(overloaded.processor.calls.load(Ordering::SeqCst), 0);
+
+    let cancelled = dispatch_fixture(
+        &runtime,
+        "cancelled",
+        ProcessorBehavior::Pending,
+        AdmissionLimits::default(),
+    );
+    let task_group = cancelled.service.task_group().clone();
+    let dispatcher = Arc::clone(&cancelled.dispatcher);
+    let dispatch_task_group = task_group.clone();
+    let dispatch_task = tokio::spawn(async move {
+        dispatcher
+            .dispatch_embedded(
+                &dispatch_task_group,
+                embedded_context("allowed", None),
+                RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(47),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), cancelled.processor.entered.notified())
+        .await
+        .expect("pending processor should start");
+    task_group.cancel();
+    let error = match dispatch_task.await.expect("dispatch task should not panic") {
+        Ok(_) => panic!("parent cancellation should stop embedded dispatch"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, DispatchError::Response(ResponseSinkError::Cancelled)));
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8863

### Brief Description

- Replace the Broker embedded Proxy loopback TCP harness with a lifecycle-owned in-process command dispatcher.
- Share the exact authorization, admission, request ordering, handler, response, and error-mapping boundary between network and embedded entry paths.
- Require an explicitly injected embedded principal and immutable deadline, with fail-closed handling for missing identity.
- Keep the legacy local request harness behind the explicit `test-support` feature so production builds no longer export or compile it by default.
- Add conformance coverage for equivalent network/embedded outcomes, denied and malformed requests, admission exhaustion, cancellation, deadline expiry, and zero local transport I/O.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --test authorized_dispatch_conformance_tests`
- `cargo test -p rocketmq-transport net::channel::tests`
- `cargo test -p rocketmq-broker --test embedded_proxy_dispatch_tests`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1`
- `.\scripts\check-agents-routing.ps1`
- Standalone fuzz, example, MCP, SRE, Tauri backend, and web backend validation passed for the changed shared dependency boundary.
- The full transport suite passed 154 tests and reproduced only the same 2 TaskGroup timing failures on the parent revision.
- The full Broker suite passed 762 tests and reproduced only the same 11 TaskGroup lifecycle failures already present in the PR-03 implementation baseline.
- The PR static architecture suite retained the existing 8-module baseline with no new failure.
- Workspace-wide `cargo fmt --all -- --check` remains blocked by the known Windows path-length error 206; `cargo fmt -p rocketmq-transport -p rocketmq-broker -- --check` and all affected standalone scoped format checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified authorized command dispatch layer for network and embedded requests.
  * Added consistent authentication, admission control, request deadlines, cancellation, and response handling.
  * Embedded proxy requests now use the same processing and security behavior as network requests.
  * Added support for in-process response delivery without loopback networking.

* **Bug Fixes**
  * Requests with missing embedded authentication now fail safely.
  * Dispatch, timeout, overload, cancellation, and processing failures return standardized responses.

* **Tests**
  * Added coverage confirming consistent behavior across embedded and network request paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->