### PR TITLE
[ISSUE #8865]🚀Bound Store queues by count and retained bytes

### DIFF
--- a/rocketmq-store-local/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store-local/src/base/allocate_mapped_file_service.rs
@@ -17,16 +17,22 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex as StdMutex;
 use std::thread;
 use std::time::Duration;
+use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use parking_lot::RwLock;
 use rocketmq_error::RocketMQError;
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetSnapshot;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourcePermit;
 use tokio::sync::Notify;
 use tracing::error;
 use tracing::info;
@@ -42,6 +48,23 @@ use crate::mapped_file::MappedFile;
 
 /// Timeout for waiting on file allocation (matches Java: 5 seconds)
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bounded mapped-file allocation queue diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MappedFileAllocationQueueSnapshot {
+    /// Requests currently holding mapped-file allocation budget.
+    pub current_count: usize,
+    /// File bytes charged to accepted requests.
+    pub charged_bytes: usize,
+    /// Requests waiting in the priority heap, including harmless stale keys.
+    pub queued_count: usize,
+    /// Age of the oldest request still owned by the table.
+    pub oldest_age: Option<Duration>,
+    /// Requests rejected by count or byte admission.
+    pub rejected_count: u64,
+    /// Accepted requests explicitly abandoned by timeout or shutdown.
+    pub abandoned_count: u64,
+}
 
 struct WorkerCompletion {
     completed: Arc<AtomicBool>,
@@ -73,7 +96,13 @@ pub struct AllocateMappedFileService {
     request_table: Arc<RwLock<HashMap<String, Arc<AllocateRequest>>>>,
 
     /// Priority queue for ordered processing
-    request_queue: Arc<RwLock<BinaryHeap<Arc<AllocateRequest>>>>,
+    request_queue: Arc<RwLock<BinaryHeap<AllocationQueueEntry>>>,
+
+    /// Count and charged-file-byte budget derived from the Store runtime.
+    allocation_budget: ResourceBudget,
+
+    /// Accepted requests removed before normal completion.
+    abandoned_count: Arc<AtomicU64>,
 
     /// Exception flag (set when allocation fails)
     has_exception: Arc<AtomicBool>,
@@ -117,6 +146,8 @@ impl Clone for AllocateMappedFileService {
         Self {
             request_table: self.request_table.clone(),
             request_queue: self.request_queue.clone(),
+            allocation_budget: self.allocation_budget.clone(),
+            abandoned_count: self.abandoned_count.clone(),
             has_exception: self.has_exception.clone(),
             stopped: self.stopped.clone(),
             notify: self.notify.clone(),
@@ -134,12 +165,6 @@ impl Clone for AllocateMappedFileService {
     }
 }
 
-impl Default for AllocateMappedFileService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AllocateMappedFileService {
     /// Create a new AllocateMappedFileService with full configuration
     ///
@@ -151,6 +176,7 @@ impl AllocateMappedFileService {
         transient_store_pool: Option<Arc<TransientStorePool>>,
         transient_store_pool_enable: bool,
         fast_fail_if_no_buffer: bool,
+        allocation_budget: ResourceBudget,
     ) -> Self {
         let request_table = Arc::new(RwLock::new(HashMap::new()));
         let request_queue = Arc::new(RwLock::new(BinaryHeap::new()));
@@ -162,6 +188,8 @@ impl AllocateMappedFileService {
         Self {
             request_table,
             request_queue,
+            allocation_budget,
+            abandoned_count: Arc::new(AtomicU64::new(0)),
             has_exception,
             stopped,
             notify,
@@ -194,6 +222,7 @@ impl AllocateMappedFileService {
         transient_store_pool_enable: bool,
         fast_fail_if_no_buffer: bool,
         message_store_config: &C,
+        allocation_budget: ResourceBudget,
     ) -> Self
     where
         C: AllocateMappedFileServiceConfig,
@@ -202,15 +231,10 @@ impl AllocateMappedFileService {
             transient_store_pool,
             transient_store_pool_enable,
             fast_fail_if_no_buffer,
+            allocation_budget,
         );
         service.warm_mapped_file_config = message_store_config.mapped_file_warmup_config();
         service
-    }
-
-    /// Create a new AllocateMappedFileService with default configuration
-    /// (no TransientStorePool)
-    pub fn new() -> Self {
-        Self::new_with_config(None, false, false)
     }
 
     pub fn is_started(&self) -> bool {
@@ -281,7 +305,7 @@ impl AllocateMappedFileService {
     /// Main worker loop - corresponds to Java's run() method
     fn run_worker(
         request_table: Arc<RwLock<HashMap<String, Arc<AllocateRequest>>>>,
-        request_queue: Arc<RwLock<BinaryHeap<Arc<AllocateRequest>>>>,
+        request_queue: Arc<RwLock<BinaryHeap<AllocationQueueEntry>>>,
         has_exception: Arc<AtomicBool>,
         stopped: Arc<AtomicBool>,
         transient_store_pool: Option<Arc<TransientStorePool>>,
@@ -328,7 +352,7 @@ impl AllocateMappedFileService {
     /// Returns false if interrupted or no requests available
     fn mmap_operation(
         request_table: &Arc<RwLock<HashMap<String, Arc<AllocateRequest>>>>,
-        request_queue: &Arc<RwLock<BinaryHeap<Arc<AllocateRequest>>>>,
+        request_queue: &Arc<RwLock<BinaryHeap<AllocationQueueEntry>>>,
         has_exception: &Arc<AtomicBool>,
         transient_store_pool: &Option<Arc<TransientStorePool>>,
         warm_mapped_file_config: MappedFileWarmupConfig,
@@ -340,38 +364,29 @@ impl AllocateMappedFileService {
             queue.pop()
         };
 
-        let req = match req {
-            Some(r) => r,
+        let entry = match req {
+            Some(entry) => entry,
             None => return false, // No requests available
         };
 
         // Check if request still valid in table
         let expected_request = {
             let table = request_table.read();
-            table.get(req.file_path()).cloned()
+            table.get(entry.file_path()).cloned()
         };
 
-        let expected_request = match expected_request {
-            Some(r) => r,
+        let req = match expected_request {
+            Some(request) if request.file_size() == entry.file_size() => request,
             None => {
                 warn!(
                     "this mmap request expired, maybe cause timeout {} {}",
-                    req.file_path(),
-                    req.file_size()
+                    entry.file_path(),
+                    entry.file_size()
                 );
                 return true;
             }
+            Some(_) => return true,
         };
-
-        // Verify it's the same request object
-        if !Arc::ptr_eq(&expected_request, &req) {
-            warn!(
-                "never expected here, maybe cause timeout {} {}",
-                req.file_path(),
-                req.file_size()
-            );
-            return true;
-        }
 
         // Check if already allocated
         if req.mapped_file.read().is_some() {
@@ -389,7 +404,27 @@ impl AllocateMappedFileService {
 
         match result {
             Ok(mapped_file) => {
+                let request_is_owned = request_table
+                    .read()
+                    .get(req.file_path())
+                    .is_some_and(|request| Arc::ptr_eq(request, &req));
+                if !request_is_owned {
+                    mapped_file.destroy(1000);
+                    req.complete();
+                    return true;
+                }
                 *req.mapped_file.write() = Some(mapped_file);
+                let request_is_still_owned = request_table
+                    .read()
+                    .get(req.file_path())
+                    .is_some_and(|request| Arc::ptr_eq(request, &req));
+                if !request_is_still_owned {
+                    if let Some(mapped_file) = req.mapped_file.write().take() {
+                        mapped_file.destroy(1000);
+                    }
+                    req.complete();
+                    return true;
+                }
                 has_exception.store(false, Ordering::Relaxed);
 
                 // Signal completion (like CountDownLatch.countDown())
@@ -406,7 +441,7 @@ impl AllocateMappedFileService {
                 has_exception.store(true, Ordering::Relaxed);
 
                 // Re-queue the request for retry
-                request_queue.write().push(req);
+                request_queue.write().push(entry);
 
                 // Small delay before retry
                 thread::sleep(Duration::from_millis(1));
@@ -476,6 +511,77 @@ impl AllocateMappedFileService {
         condvar.notify_one();
     }
 
+    fn admit_request(&self, file_path: String, file_size: i32) -> AllocationAdmission {
+        if let Some(existing) = self.request_table.read().get(&file_path) {
+            return AllocationAdmission::Existing(existing.clone());
+        }
+        let charged_bytes = usize::try_from(file_size).unwrap_or_default().max(1);
+        let permit = match self.allocation_budget.try_acquire(charged_bytes, BudgetClass::Data) {
+            Ok(permit) => permit,
+            Err(error) => {
+                warn!(
+                    queue = "mapped-file-allocation",
+                    reason = %error,
+                    charged_bytes,
+                    "mapped-file allocation request rejected by Store budget"
+                );
+                return AllocationAdmission::Rejected;
+            }
+        };
+        let mut table = self.request_table.write();
+        if let Some(existing) = table.get(&file_path) {
+            return AllocationAdmission::Existing(existing.clone());
+        }
+        let request = Arc::new(AllocateRequest::new(file_path.clone(), file_size, permit));
+        table.insert(file_path, request.clone());
+        drop(table);
+        self.request_queue
+            .write()
+            .push(AllocationQueueEntry::from_request(&request));
+        self.notify_worker();
+        AllocationAdmission::Inserted(request)
+    }
+
+    fn remove_request_if_owned(&self, request: &Arc<AllocateRequest>, abandoned: bool) {
+        let mut table = self.request_table.write();
+        let removed = if table
+            .get(request.file_path())
+            .is_some_and(|current| Arc::ptr_eq(current, request))
+        {
+            table.remove(request.file_path());
+            if abandoned {
+                self.abandoned_count.fetch_add(1, Ordering::Relaxed);
+            }
+            true
+        } else {
+            false
+        };
+        drop(table);
+
+        if removed && abandoned {
+            if let Some(mapped_file) = request.mapped_file.write().take() {
+                mapped_file.destroy(1000);
+            }
+        }
+    }
+
+    /// Returns count, charged bytes, oldest age, rejection, and abandonment
+    /// diagnostics for the mapped-file allocation boundary.
+    #[must_use]
+    pub fn queue_snapshot(&self) -> MappedFileAllocationQueueSnapshot {
+        let budget: BudgetSnapshot = self.allocation_budget.snapshot();
+        let table = self.request_table.read();
+        let oldest_age = table.values().map(|request| request.enqueued_at.elapsed()).max();
+        MappedFileAllocationQueueSnapshot {
+            current_count: budget.current_count,
+            charged_bytes: budget.current_bytes,
+            queued_count: self.request_queue.read().len(),
+            oldest_age,
+            rejected_count: budget.rejected_count,
+            abandoned_count: self.abandoned_count.load(Ordering::Relaxed),
+        }
+    }
+
     /// Submit pre-allocation request and wait for result
     ///
     /// **This is the primary API - corresponds to Java's `putRequestAndReturnMappedFile()`**
@@ -497,66 +603,45 @@ impl AllocateMappedFileService {
     ) -> Result<Option<Arc<DefaultMappedFile>>, RocketMQError> {
         // Check available buffer capacity if using TransientStorePool
         let mut can_submit_requests = self.allocation_capacity(2);
-
-        // Submit request for next file
-        let next_req = Arc::new(AllocateRequest::new(next_file_path.clone(), file_size));
-        let next_put_ok = {
-            let mut table = self.request_table.write();
-            if table.contains_key(&next_file_path) {
-                false
-            } else {
-                table.insert(next_file_path.clone(), next_req.clone());
-                true
-            }
-        };
-
-        if next_put_ok {
-            if can_submit_requests == 0 {
-                warn!(
-                    "[NOTIFYME]TransientStorePool is not enough, so create mapped file error, RequestQueueSize: {}, \
-                     StorePoolSize: {}",
-                    self.request_queue.read().len(),
-                    self.transient_store_pool
-                        .as_ref()
-                        .map_or(0, |p| p.available_buffer_nums())
-                );
-                self.request_table.write().remove(&next_file_path);
-                return Ok(None);
-            }
-
-            self.request_queue.write().push(next_req.clone());
-            self.notify_worker();
-            can_submit_requests -= 1;
+        let existing_request = self.request_table.read().get(&next_file_path).cloned();
+        if can_submit_requests == 0 && existing_request.is_none() {
+            warn!(
+                "[NOTIFYME]TransientStorePool is not enough, so create mapped file error, RequestQueueSize: {}, \
+                 StorePoolSize: {}",
+                self.request_queue.read().len(),
+                self.transient_store_pool
+                    .as_ref()
+                    .map_or(0, |pool| pool.available_buffer_nums())
+            );
+            return Ok(None);
         }
+
+        // Submit request for next file.
+        let next_req = match existing_request {
+            Some(request) => request,
+            None => match self.admit_request(next_file_path.clone(), file_size) {
+                AllocationAdmission::Inserted(request) => {
+                    can_submit_requests -= 1;
+                    request
+                }
+                AllocationAdmission::Existing(request) => request,
+                AllocationAdmission::Rejected => return Ok(None),
+            },
+        };
 
         // Submit request for next-next file (pre-allocation)
         if !next_next_file_path.is_empty() {
-            let next_next_req = Arc::new(AllocateRequest::new(next_next_file_path.clone(), file_size));
-            let next_next_put_ok = {
-                let mut table = self.request_table.write();
-                if table.contains_key(&next_next_file_path) {
-                    false
-                } else {
-                    table.insert(next_next_file_path.clone(), next_next_req.clone());
-                    true
-                }
-            };
-
-            if next_next_put_ok {
-                if can_submit_requests == 0 {
-                    warn!(
-                        "[NOTIFYME]TransientStorePool is not enough, so skip preallocate mapped file, \
-                         RequestQueueSize: {}, StorePoolSize: {}",
-                        self.request_queue.read().len(),
-                        self.transient_store_pool
-                            .as_ref()
-                            .map_or(0, |p| p.available_buffer_nums())
-                    );
-                    self.request_table.write().remove(&next_next_file_path);
-                } else {
-                    self.request_queue.write().push(next_next_req);
-                    self.notify_worker();
-                }
+            if can_submit_requests == 0 {
+                warn!(
+                    "[NOTIFYME]TransientStorePool is not enough, so skip preallocate mapped file, \
+                     RequestQueueSize: {}, StorePoolSize: {}",
+                    self.request_queue.read().len(),
+                    self.transient_store_pool
+                        .as_ref()
+                        .map_or(0, |pool| pool.available_buffer_nums())
+                );
+            } else if let AllocationAdmission::Rejected = self.admit_request(next_next_file_path, file_size) {
+                warn!("mapped-file preallocation skipped because its Store budget is exhausted");
             }
         }
 
@@ -566,31 +651,22 @@ impl AllocateMappedFileService {
             return Ok(None);
         }
 
-        // Wait for the next file to be allocated
-        let result = {
-            let table = self.request_table.read();
-            table.get(&next_file_path).cloned()
-        };
+        // Wait for allocation to complete (with timeout).
+        let mut wait_guard = AllocationWaitGuard::new(self.clone(), next_req.clone());
+        let wait_result = tokio::time::timeout(WAIT_TIMEOUT, next_req.wait()).await;
 
-        if let Some(req) = result {
-            // Wait for allocation to complete (with timeout)
-            let wait_result = tokio::time::timeout(WAIT_TIMEOUT, req.wait()).await;
-
-            match wait_result {
-                Ok(()) => {
-                    // Remove from table and return result
-                    self.request_table.write().remove(&next_file_path);
-                    let mapped_file = req.mapped_file.read().clone();
-                    Ok(mapped_file)
-                }
-                Err(_) => {
-                    warn!("create mmap timeout {} {}", req.file_path(), req.file_size());
-                    Ok(None)
-                }
+        match wait_result {
+            Ok(()) => {
+                // Remove from table and return result
+                wait_guard.finish(false);
+                let mapped_file = next_req.mapped_file.read().clone();
+                Ok(mapped_file)
             }
-        } else {
-            error!("find preallocate mmap failed, this never happen");
-            Ok(None)
+            Err(_) => {
+                warn!("create mmap timeout {} {}", next_req.file_path(), next_req.file_size());
+                wait_guard.finish(true);
+                Ok(None)
+            }
         }
     }
 
@@ -646,37 +722,14 @@ impl AllocateMappedFileService {
         next_next_file_path: String,
         file_size: i32,
     ) -> Result<Option<Arc<DefaultMappedFile>>, RocketMQError> {
-        let next_req = Arc::new(AllocateRequest::new(next_file_path.clone(), file_size));
-        let next_put_ok = {
-            let mut table = self.request_table.write();
-            if table.contains_key(&next_file_path) {
-                false
-            } else {
-                table.insert(next_file_path.clone(), next_req.clone());
-                true
-            }
+        let next_req = match self.admit_request(next_file_path.clone(), file_size) {
+            AllocationAdmission::Inserted(request) | AllocationAdmission::Existing(request) => request,
+            AllocationAdmission::Rejected => return Ok(None),
         };
 
-        if next_put_ok {
-            self.request_queue.write().push(next_req.clone());
-            self.notify_worker();
-        }
-
         if !next_next_file_path.is_empty() {
-            let next_next_req = Arc::new(AllocateRequest::new(next_next_file_path.clone(), file_size));
-            let next_next_put_ok = {
-                let mut table = self.request_table.write();
-                if table.contains_key(&next_next_file_path) {
-                    false
-                } else {
-                    table.insert(next_next_file_path.clone(), next_next_req.clone());
-                    true
-                }
-            };
-
-            if next_next_put_ok {
-                self.request_queue.write().push(next_next_req);
-                self.notify_worker();
+            if let AllocationAdmission::Rejected = self.admit_request(next_next_file_path, file_size) {
+                warn!("mapped-file blocking preallocation skipped because its Store budget is exhausted");
             }
         }
 
@@ -685,21 +738,12 @@ impl AllocateMappedFileService {
             return Ok(None);
         }
 
-        let result = {
-            let table = self.request_table.read();
-            table.get(&next_file_path).cloned()
-        };
-
-        if let Some(req) = result {
-            if req.wait_blocking(WAIT_TIMEOUT) {
-                self.request_table.write().remove(&next_file_path);
-                Ok(req.mapped_file.read().clone())
-            } else {
-                warn!("create mmap timeout {} {}", req.file_path(), req.file_size());
-                Ok(None)
-            }
+        if next_req.wait_blocking(WAIT_TIMEOUT) {
+            self.remove_request_if_owned(&next_req, false);
+            Ok(next_req.mapped_file.read().clone())
         } else {
-            error!("find preallocate mmap failed, this never happen");
+            warn!("create mmap timeout {} {}", next_req.file_path(), next_req.file_size());
+            self.remove_request_if_owned(&next_req, true);
             Ok(None)
         }
     }
@@ -719,20 +763,8 @@ impl AllocateMappedFileService {
             return;
         }
 
-        let req = Arc::new(AllocateRequest::new(file_path.clone(), file_size as i32));
-        let put_ok = {
-            let mut table = self.request_table.write();
-            if let std::collections::hash_map::Entry::Vacant(entry) = table.entry(file_path) {
-                entry.insert(req.clone());
-                true
-            } else {
-                false
-            }
-        };
-
-        if put_ok {
-            self.request_queue.write().push(req);
-            self.notify_worker();
+        if let AllocationAdmission::Rejected = self.admit_request(file_path, file_size as i32) {
+            warn!("background mapped-file allocation rejected by Store budget");
         }
     }
 
@@ -779,9 +811,14 @@ impl AllocateMappedFileService {
             }
         }
 
-        // Clean up pre-allocated files
-        let table = self.request_table.read();
-        for req in table.values() {
+        // Clean up pre-allocated files and release every request permit.
+        let requests = {
+            let mut table = self.request_table.write();
+            std::mem::take(&mut *table)
+        };
+        self.request_queue.write().clear();
+        self.abandoned_count.fetch_add(requests.len() as u64, Ordering::Relaxed);
+        for req in requests.values() {
             if let Some(ref mapped_file) = *req.mapped_file.read() {
                 info!("delete pre allocated mapped file, {}", req.file_path());
                 mapped_file.destroy(1000);
@@ -802,6 +839,74 @@ impl AllocateMappedFileService {
     }
 }
 
+enum AllocationAdmission {
+    Inserted(Arc<AllocateRequest>),
+    Existing(Arc<AllocateRequest>),
+    Rejected,
+}
+
+struct AllocationWaitGuard {
+    service: AllocateMappedFileService,
+    request: Arc<AllocateRequest>,
+    disarmed: bool,
+}
+
+impl AllocationWaitGuard {
+    fn new(service: AllocateMappedFileService, request: Arc<AllocateRequest>) -> Self {
+        Self {
+            service,
+            request,
+            disarmed: false,
+        }
+    }
+
+    fn finish(&mut self, abandoned: bool) {
+        self.service.remove_request_if_owned(&self.request, abandoned);
+        self.disarmed = true;
+    }
+}
+
+impl Drop for AllocationWaitGuard {
+    fn drop(&mut self) {
+        if !self.disarmed {
+            self.service.remove_request_if_owned(&self.request, true);
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AllocationQueueEntry {
+    key: MappedFileAllocationRequestKey,
+}
+
+impl AllocationQueueEntry {
+    fn from_request(request: &AllocateRequest) -> Self {
+        Self {
+            key: request.key.clone(),
+        }
+    }
+
+    fn file_path(&self) -> &str {
+        self.key.file_path()
+    }
+
+    fn file_size(&self) -> i32 {
+        self.key.file_size()
+    }
+}
+
+impl PartialOrd for AllocationQueueEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AllocationQueueEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
 /// Request to allocate a new MappedFile
 ///
 /// Corresponds to Java's AllocateRequest inner class:
@@ -810,6 +915,12 @@ impl AllocateMappedFileService {
 struct AllocateRequest {
     /// Runtime-neutral path, size, and ordering identity.
     key: MappedFileAllocationRequestKey,
+
+    /// Count and charged-file-byte ownership for this canonical request.
+    _permit: ResourcePermit,
+
+    /// Monotonic enqueue time used by queue saturation diagnostics.
+    enqueued_at: Instant,
 
     /// Completion notification (equivalent to Java's CountDownLatch)
     completion: Arc<Notify>,
@@ -825,9 +936,11 @@ struct AllocateRequest {
 }
 
 impl AllocateRequest {
-    fn new(file_path: String, file_size: i32) -> Self {
+    fn new(file_path: String, file_size: i32, permit: ResourcePermit) -> Self {
         Self {
             key: MappedFileAllocationRequestKey::new(file_path, file_size),
+            _permit: permit,
+            enqueued_at: Instant::now(),
             completion: Arc::new(Notify::new()),
             blocking_completion: Arc::new((StdMutex::new(()), Condvar::new())),
             completed: Arc::new(AtomicBool::new(false)),
@@ -904,9 +1017,35 @@ impl Ord for AllocateRequest {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_runtime::BudgetLimit;
+    use rocketmq_runtime::FullPolicy;
+    use rocketmq_runtime::ResourceBudget;
+    use rocketmq_runtime::ResourceBudgetTree;
     use tempfile::tempdir;
 
     use super::*;
+
+    fn test_allocation_budget() -> ResourceBudget {
+        ResourceBudgetTree::new(
+            "allocation-service-test",
+            BudgetLimit::new(16, 64 * 1024, FullPolicy::Reject),
+        )
+        .expect("test allocation budget")
+        .root()
+    }
+
+    fn test_request(file_path: String, file_size: i32) -> Arc<AllocateRequest> {
+        let budget = ResourceBudgetTree::new(
+            "allocation-request-test",
+            BudgetLimit::new(4, 8_192, FullPolicy::Reject),
+        )
+        .expect("test budget")
+        .root();
+        let permit = budget
+            .try_acquire_data(usize::try_from(file_size).expect("positive file size"))
+            .expect("request budget");
+        Arc::new(AllocateRequest::new(file_path, file_size, permit))
+    }
 
     struct TestAllocationServiceConfig;
 
@@ -920,8 +1059,8 @@ mod tests {
     fn allocate_request_delegates_identity_display_and_priority_to_local_key() {
         let lower_path = std::path::Path::new("root").join("00000000000000000100");
         let higher_path = std::path::Path::new("root").join("00000000000000000200");
-        let lower = Arc::new(AllocateRequest::new(lower_path.to_string_lossy().into_owned(), 1024));
-        let higher = Arc::new(AllocateRequest::new(higher_path.to_string_lossy().into_owned(), 2048));
+        let lower = test_request(lower_path.to_string_lossy().into_owned(), 1024);
+        let higher = test_request(higher_path.to_string_lossy().into_owned(), 2048);
         let mut requests = BinaryHeap::from([higher, lower.clone()]);
 
         let first = requests.pop().expect("lower offset request");
@@ -941,7 +1080,7 @@ mod tests {
     async fn allocate_mapped_file_blocking_works_inside_runtime() {
         let temp_dir = tempdir().expect("temp dir");
         let file_path = temp_dir.path().join("00000000000000000000");
-        let service = AllocateMappedFileService::new();
+        let service = AllocateMappedFileService::new_with_config(None, false, false, test_allocation_budget());
         assert!(!service.is_started());
         service.start();
         assert!(service.is_started());
@@ -976,7 +1115,13 @@ mod tests {
     #[test]
     fn warm_mapped_file_config_follows_commitlog_file_size_threshold() {
         let config = TestAllocationServiceConfig;
-        let service = AllocateMappedFileService::new_with_message_store_config(None, false, false, &config);
+        let service = AllocateMappedFileService::new_with_message_store_config(
+            None,
+            false,
+            false,
+            &config,
+            test_allocation_budget(),
+        );
 
         assert!(!service.should_warm_mapped_file(1023));
         assert!(service.should_warm_mapped_file(1024));
@@ -987,16 +1132,20 @@ mod tests {
         let pool = Arc::new(TransientStorePool::new(2, 16));
         pool.return_buffer(vec![0; 16]);
         pool.return_buffer(vec![0; 16]);
-        let service = AllocateMappedFileService::new_with_config(Some(pool), true, true);
+        let service = AllocateMappedFileService::new_with_config(Some(pool), true, true, test_allocation_budget());
 
         assert_eq!(service.allocation_capacity(2), 2);
-        service.request_queue.write().push(Arc::new(AllocateRequest::new(
+        let request = test_request(
             std::path::Path::new("root")
                 .join("00000000000000000100")
                 .to_string_lossy()
                 .into_owned(),
             16,
-        )));
+        );
+        service
+            .request_queue
+            .write()
+            .push(AllocationQueueEntry::from_request(&request));
         assert_eq!(service.allocation_capacity(2), 1);
     }
 }

--- a/rocketmq-store-local/src/flush/group_commit.rs
+++ b/rocketmq-store-local/src/flush/group_commit.rs
@@ -17,6 +17,7 @@
 use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,15 +25,17 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use parking_lot::Mutex;
-use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
+use rocketmq_runtime::BudgetedItem;
+use rocketmq_runtime::BudgetedQueue;
+use rocketmq_runtime::ResourcePermit;
+
 use crate::flush::FlushProgress;
 
-/// Frozen request-channel capacity used by the R0 group-commit worker.
-pub const GROUP_COMMIT_CHANNEL_CAPACITY: usize = 1024;
+const GROUP_COMMIT_COMPLETION_STATE_BYTES: usize = 256;
 
 /// Neutral completion state for a Local group-commit request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -56,6 +59,56 @@ pub struct GroupCommitRequest<E> {
     result_sender: Option<oneshot::Sender<GroupCommitResult<E>>>,
     deadline_nanos: u64,
     enqueue_time_millis: u64,
+}
+
+/// Store-owned count-and-byte bounded group commit queue.
+pub type GroupCommitQueue<E> = BudgetedQueue<GroupCommitRequest<E>>;
+
+struct BudgetedGroupCommitRequest<E> {
+    request: Option<GroupCommitRequest<E>>,
+    _permit: ResourcePermit,
+    stats: SyncFlushStats,
+}
+
+impl<E> BudgetedGroupCommitRequest<E> {
+    fn from_item(item: BudgetedItem<GroupCommitRequest<E>>, stats: SyncFlushStats) -> Self {
+        let (request, permit, _) = item.into_parts();
+        Self {
+            request: Some(request),
+            _permit: permit,
+            stats,
+        }
+    }
+
+    fn next_offset(&self) -> i64 {
+        self.request.as_ref().map_or(0, GroupCommitRequest::next_offset)
+    }
+
+    fn is_expired(&self) -> bool {
+        self.request.as_ref().is_none_or(GroupCommitRequest::is_expired)
+    }
+
+    fn complete(mut self, status: GroupCommitStatus) {
+        if let Some(request) = self.request.take() {
+            self.stats.record_completion(&request, status);
+            request.complete(status);
+        }
+    }
+
+    fn complete_error(mut self, error: Arc<E>) {
+        if let Some(request) = self.request.take() {
+            self.stats.record_completion(&request, GroupCommitStatus::TimedOut);
+            request.complete_error(error);
+        }
+    }
+}
+
+impl<E> Drop for BudgetedGroupCommitRequest<E> {
+    fn drop(&mut self) {
+        if let Some(request) = self.request.as_ref() {
+            self.stats.record_abandoned_request(request);
+        }
+    }
 }
 
 impl<E> GroupCommitRequest<E> {
@@ -89,6 +142,20 @@ impl<E> GroupCommitRequest<E> {
         current_nanos() >= self.deadline_nanos
     }
 
+    /// Returns the conservative retained cost of this request and its oneshot
+    /// completion state. Message bodies already resident in mmap are excluded.
+    #[must_use]
+    pub const fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>() + GROUP_COMMIT_COMPLETION_STATE_BYTES
+    }
+
+    /// Returns the absolute Tokio deadline used for queue admission.
+    #[must_use]
+    pub fn admission_deadline(&self) -> tokio::time::Instant {
+        let remaining = self.deadline_nanos.saturating_sub(current_nanos());
+        tokio::time::Instant::now() + Duration::from_nanos(remaining)
+    }
+
     /// Completes the request with a neutral flush status.
     pub fn complete(mut self, status: GroupCommitStatus) {
         if let Some(sender) = self.result_sender.take() {
@@ -108,9 +175,12 @@ impl<E> GroupCommitRequest<E> {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SyncFlushRuntimeInfo {
     pub queue_depth: u64,
+    pub charged_bytes: u64,
     pub enqueue_total: u64,
     pub completed_total: u64,
     pub timeout_total: u64,
+    pub rejected_total: u64,
+    pub abandoned_total: u64,
     pub oldest_wait_millis: u64,
     pub max_wait_millis: u64,
     pub wait_total_millis: u64,
@@ -126,21 +196,64 @@ pub struct SyncFlushStats {
 #[derive(Default)]
 struct SyncFlushStatsInner {
     queue_depth: AtomicU64,
+    charged_bytes: AtomicUsize,
     enqueue_total: AtomicU64,
     completed_total: AtomicU64,
     timeout_total: AtomicU64,
+    rejected_total: AtomicU64,
+    abandoned_total: AtomicU64,
     max_wait_millis: AtomicU64,
     wait_total_millis: AtomicU64,
     pending_enqueue_times: Mutex<VecDeque<u64>>,
 }
 
 impl SyncFlushStats {
-    /// Records a successfully enqueued request.
+    /// Records provisional ownership before queue admission becomes visible.
     #[doc(hidden)]
-    pub fn record_enqueue(&self, enqueue_time_millis: u64) {
+    pub fn record_enqueue(&self, enqueue_time_millis: u64, retained_bytes: usize) {
         self.inner.pending_enqueue_times.lock().push_back(enqueue_time_millis);
         self.inner.queue_depth.fetch_add(1, Ordering::Relaxed);
+        self.inner.charged_bytes.fetch_add(retained_bytes, Ordering::Relaxed);
         self.inner.enqueue_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a request rejected before queue ownership transfer.
+    #[doc(hidden)]
+    pub fn record_rejected(&self) {
+        self.inner.rejected_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Removes an admission record that never transferred queue ownership.
+    #[doc(hidden)]
+    pub fn rollback_enqueue(&self, enqueue_time_millis: u64, retained_bytes: usize) {
+        let _ = self
+            .inner
+            .queue_depth
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |depth| {
+                Some(depth.saturating_sub(1))
+            });
+        let _ = self
+            .inner
+            .charged_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |bytes| {
+                Some(bytes.saturating_sub(retained_bytes))
+            });
+        let mut pending = self.inner.pending_enqueue_times.lock();
+        if let Some(position) = pending.iter().position(|queued_at| *queued_at == enqueue_time_millis) {
+            pending.remove(position);
+        }
+        let _ = self
+            .inner
+            .enqueue_total
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |total| {
+                Some(total.saturating_sub(1))
+            });
+    }
+
+    /// Records a request abandoned because its lifecycle owner stopped.
+    #[doc(hidden)]
+    pub fn record_abandoned(&self) {
+        self.inner.abandoned_total.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Returns the current diagnostic snapshot.
@@ -156,9 +269,12 @@ impl SyncFlushStats {
 
         SyncFlushRuntimeInfo {
             queue_depth: self.inner.queue_depth.load(Ordering::Relaxed),
+            charged_bytes: self.inner.charged_bytes.load(Ordering::Relaxed) as u64,
             enqueue_total: self.inner.enqueue_total.load(Ordering::Relaxed),
             completed_total: self.inner.completed_total.load(Ordering::Relaxed),
             timeout_total: self.inner.timeout_total.load(Ordering::Relaxed),
+            rejected_total: self.inner.rejected_total.load(Ordering::Relaxed),
+            abandoned_total: self.inner.abandoned_total.load(Ordering::Relaxed),
             oldest_wait_millis,
             max_wait_millis: self.inner.max_wait_millis.load(Ordering::Relaxed),
             wait_total_millis: self.inner.wait_total_millis.load(Ordering::Relaxed),
@@ -173,6 +289,12 @@ impl SyncFlushStats {
                 Some(depth.saturating_sub(1))
             });
         self.inner.pending_enqueue_times.lock().pop_front();
+        let _ = self
+            .inner
+            .charged_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |bytes| {
+                Some(bytes.saturating_sub(request.retained_bytes()))
+            });
 
         let wait_millis = current_millis().saturating_sub(request.enqueue_time_millis());
         self.inner.completed_total.fetch_add(1, Ordering::Relaxed);
@@ -181,6 +303,29 @@ impl SyncFlushStats {
             self.inner.timeout_total.fetch_add(1, Ordering::Relaxed);
         }
         update_atomic_max(&self.inner.max_wait_millis, wait_millis);
+    }
+
+    fn record_abandoned_request<E>(&self, request: &GroupCommitRequest<E>) {
+        let _ = self
+            .inner
+            .queue_depth
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |depth| {
+                Some(depth.saturating_sub(1))
+            });
+        let _ = self
+            .inner
+            .charged_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |bytes| {
+                Some(bytes.saturating_sub(request.retained_bytes()))
+            });
+        let mut pending = self.inner.pending_enqueue_times.lock();
+        if let Some(position) = pending
+            .iter()
+            .position(|queued_at| *queued_at == request.enqueue_time_millis())
+        {
+            pending.remove(position);
+        }
+        self.record_abandoned();
     }
 }
 
@@ -282,7 +427,7 @@ pub async fn run_group_commit_worker<
     Delay,
     DelayFuture,
 >(
-    mut request_receiver: mpsc::Receiver<GroupCommitRequest<E>>,
+    request_queue: GroupCommitQueue<E>,
     notified: Arc<Notify>,
     shutdown_token: CancellationToken,
     sync_flush_stats: SyncFlushStats,
@@ -302,18 +447,22 @@ pub async fn run_group_commit_worker<
     loop {
         tokio::select! {
             _ = shutdown_token.cancelled() => {
+                request_queue.close();
                 let mut remaining = Vec::new();
-                while let Ok(request) = request_receiver.try_recv() {
-                    remaining.push(request);
+                while let Some(request) = request_queue.try_pop_budgeted() {
+                    remaining.push(BudgetedGroupCommitRequest::from_item(
+                        request,
+                        sync_flush_stats.clone(),
+                    ));
                 }
                 if !remaining.is_empty() {
                     match (ports.flush)().await {
                         Ok(progress) => {
-                            complete_group_commit_batch(remaining, progress.durable, &sync_flush_stats);
+                            complete_budgeted_group_commit_batch(remaining, progress.durable);
                         }
                         Err(error) => {
                             (ports.flush_failure)(error.clone());
-                            complete_group_commit_batch_error(remaining, error, &sync_flush_stats);
+                            complete_budgeted_group_commit_batch_error(remaining, error);
                         }
                     }
                 }
@@ -329,19 +478,32 @@ pub async fn run_group_commit_worker<
                 };
                 checkpoint_if_present(progress.store_timestamp, &mut ports.checkpoint);
             }
-            maybe_request = request_receiver.recv() => match maybe_request {
+            maybe_request = request_queue.recv_budgeted() => match maybe_request {
                 None => break,
                 Some(first_request) => {
-                    let mut requests = vec![first_request];
-                    while let Ok(request) = request_receiver.try_recv() {
-                        requests.push(request);
+                    let mut requests = vec![BudgetedGroupCommitRequest::from_item(
+                        first_request,
+                        sync_flush_stats.clone(),
+                    )];
+                    while let Some(request) = request_queue.try_pop_budgeted() {
+                        requests.push(BudgetedGroupCommitRequest::from_item(
+                            request,
+                            sync_flush_stats.clone(),
+                        ));
                     }
 
-                    let target_offset = requests.iter().map(GroupCommitRequest::next_offset).max().unwrap_or(0);
+                    let target_offset = requests
+                        .iter()
+                        .map(BudgetedGroupCommitRequest::next_offset)
+                        .max()
+                        .unwrap_or(0);
                     let mut flush_ok = (ports.current_flushed_where)() >= target_offset;
                     let mut flush_error = forced_flush_error.clone();
                     for _ in 0..config.max_flush_attempts {
-                        if flush_ok || flush_error.is_some() || requests.iter().all(GroupCommitRequest::is_expired) {
+                        if flush_ok
+                            || flush_error.is_some()
+                            || requests.iter().all(BudgetedGroupCommitRequest::is_expired)
+                        {
                             break;
                         }
                         match (ports.flush)().await {
@@ -353,7 +515,7 @@ pub async fn run_group_commit_worker<
                                 break;
                             }
                         }
-                        if flush_ok || requests.iter().all(GroupCommitRequest::is_expired) {
+                        if flush_ok || requests.iter().all(BudgetedGroupCommitRequest::is_expired) {
                             break;
                         }
                         (ports.retry_delay)(config.retry_interval).await;
@@ -361,16 +523,33 @@ pub async fn run_group_commit_worker<
 
                     if let Some(error) = flush_error {
                         (ports.flush_failure)(error.clone());
-                        complete_group_commit_batch_error(requests, error, &sync_flush_stats);
+                        complete_budgeted_group_commit_batch_error(requests, error);
                         continue;
                     }
 
                     let flushed_where = (ports.current_flushed_where)();
                     checkpoint_if_present((ports.current_store_timestamp)(), &mut ports.checkpoint);
-                    complete_group_commit_batch(requests, flushed_where, &sync_flush_stats);
+                    complete_budgeted_group_commit_batch(requests, flushed_where);
                 }
             }
         }
+    }
+}
+
+fn complete_budgeted_group_commit_batch<E>(requests: Vec<BudgetedGroupCommitRequest<E>>, flushed_where: i64) {
+    for request in requests {
+        let status = if flushed_where >= request.next_offset() {
+            GroupCommitStatus::Flushed
+        } else {
+            GroupCommitStatus::TimedOut
+        };
+        request.complete(status);
+    }
+}
+
+fn complete_budgeted_group_commit_batch_error<E>(requests: Vec<BudgetedGroupCommitRequest<E>>, error: Arc<E>) {
+    for request in requests {
+        request.complete_error(error.clone());
     }
 }
 

--- a/rocketmq-store-local/tests/flush_group_commit.rs
+++ b/rocketmq-store-local/tests/flush_group_commit.rs
@@ -17,26 +17,36 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudgetTree;
 use rocketmq_store_local::flush::group_commit::complete_group_commit_batch;
 use rocketmq_store_local::flush::group_commit::complete_group_commit_batch_error;
 use rocketmq_store_local::flush::group_commit::run_group_commit_worker;
+use rocketmq_store_local::flush::group_commit::GroupCommitQueue;
 use rocketmq_store_local::flush::group_commit::GroupCommitRequest;
 use rocketmq_store_local::flush::group_commit::GroupCommitStatus;
 use rocketmq_store_local::flush::group_commit::GroupCommitWorkerConfig;
 use rocketmq_store_local::flush::group_commit::GroupCommitWorkerPorts;
 use rocketmq_store_local::flush::group_commit::SyncFlushStats;
 use rocketmq_store_local::flush::FlushProgress;
-use tokio::sync::mpsc;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
+
+fn group_commit_queue<E>(count: usize, bytes: usize) -> GroupCommitQueue<E> {
+    let budget = ResourceBudgetTree::new("group-commit-test", BudgetLimit::new(count, bytes, FullPolicy::Reject))
+        .expect("group commit test budget")
+        .root();
+    GroupCommitQueue::new(budget)
+}
 
 #[tokio::test]
 async fn batch_completion_uses_final_durable_watermark_for_every_waiter() {
     let stats = SyncFlushStats::default();
     let (request_64, response_64) = GroupCommitRequest::<&'static str>::new(64, 5_000);
     let (request_96, response_96) = GroupCommitRequest::<&'static str>::new(96, 5_000);
-    stats.record_enqueue(request_64.enqueue_time_millis());
-    stats.record_enqueue(request_96.enqueue_time_millis());
+    stats.record_enqueue(request_64.enqueue_time_millis(), request_64.retained_bytes());
+    stats.record_enqueue(request_96.enqueue_time_millis(), request_96.retained_bytes());
 
     complete_group_commit_batch(vec![request_64, request_96], 80, &stats);
 
@@ -76,12 +86,14 @@ async fn worker_batches_waiters_and_applies_checkpoint_after_completion() {
     let stats = SyncFlushStats::default();
     let (first, first_response) = GroupCommitRequest::<String>::new(64, 5_000);
     let (second, second_response) = GroupCommitRequest::<String>::new(96, 5_000);
-    stats.record_enqueue(first.enqueue_time_millis());
-    stats.record_enqueue(second.enqueue_time_millis());
-    let (sender, receiver) = mpsc::channel(2);
-    sender.send(first).await.unwrap();
-    sender.send(second).await.unwrap();
-    drop(sender);
+    let first_bytes = first.retained_bytes();
+    let second_bytes = second.retained_bytes();
+    stats.record_enqueue(first.enqueue_time_millis(), first.retained_bytes());
+    stats.record_enqueue(second.enqueue_time_millis(), second.retained_bytes());
+    let queue = group_commit_queue(2, 4_096);
+    queue.try_push_data(first, first_bytes).unwrap();
+    queue.try_push_data(second, second_bytes).unwrap();
+    queue.close();
 
     let durable = Arc::new(AtomicI64::new(96));
     let timestamp = Arc::new(AtomicU64::new(77));
@@ -120,7 +132,7 @@ async fn worker_batches_waiters_and_applies_checkpoint_after_completion() {
     );
 
     run_group_commit_worker(
-        receiver,
+        queue,
         Arc::new(Notify::new()),
         CancellationToken::new(),
         stats,
@@ -140,10 +152,11 @@ async fn worker_batches_waiters_and_applies_checkpoint_after_completion() {
 async fn worker_propagates_forced_error_once_to_the_whole_batch() {
     let stats = SyncFlushStats::default();
     let (request, response) = GroupCommitRequest::<String>::new(64, 5_000);
-    stats.record_enqueue(request.enqueue_time_millis());
-    let (sender, receiver) = mpsc::channel(1);
-    sender.send(request).await.unwrap();
-    drop(sender);
+    let retained_bytes = request.retained_bytes();
+    stats.record_enqueue(request.enqueue_time_millis(), request.retained_bytes());
+    let queue = group_commit_queue(1, 2_048);
+    queue.try_push_data(request, retained_bytes).unwrap();
+    queue.close();
 
     let error = Arc::new(String::from("injected flush failure"));
     let failure_calls = Arc::new(AtomicU64::new(0));
@@ -169,7 +182,7 @@ async fn worker_propagates_forced_error_once_to_the_whole_batch() {
     );
 
     run_group_commit_worker(
-        receiver,
+        queue,
         Arc::new(Notify::new()),
         CancellationToken::new(),
         stats,
@@ -183,4 +196,44 @@ async fn worker_propagates_forced_error_once_to_the_whole_batch() {
     assert!(Arc::ptr_eq(&received, &error));
     assert_eq!(failure_calls.load(Ordering::Relaxed), 1);
     assert_eq!(flush_calls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn worker_panic_drops_request_permit_and_records_abandonment() {
+    let stats = SyncFlushStats::default();
+    let (request, response) = GroupCommitRequest::<String>::new(64, 5_000);
+    let retained_bytes = request.retained_bytes();
+    stats.record_enqueue(request.enqueue_time_millis(), retained_bytes);
+    let queue = group_commit_queue(1, retained_bytes);
+    queue.try_push_data(request, retained_bytes).expect("request fits");
+    queue.close();
+    let diagnostics = queue.clone();
+    let ports = GroupCommitWorkerPorts::new(
+        || async { Ok::<_, Arc<String>>(FlushProgress::default()) },
+        || panic!("injected group commit worker panic"),
+        || 0,
+        |_| {},
+        |_| {},
+        |_| async {},
+    );
+
+    let worker = tokio::spawn(run_group_commit_worker(
+        queue,
+        Arc::new(Notify::new()),
+        CancellationToken::new(),
+        stats.clone(),
+        None,
+        GroupCommitWorkerConfig::legacy(),
+        ports,
+    ));
+    let failure = worker.await.expect_err("worker must panic");
+
+    assert!(failure.is_panic());
+    assert!(response.await.is_err(), "abandoned request drops its response sender");
+    assert_eq!(diagnostics.snapshot().reserved_count, 0);
+    assert_eq!(diagnostics.snapshot().retained_bytes, 0);
+    let snapshot = stats.snapshot();
+    assert_eq!(snapshot.queue_depth, 0);
+    assert_eq!(snapshot.charged_bytes, 0);
+    assert_eq!(snapshot.abandoned_total, 1);
 }

--- a/rocketmq-store-local/tests/store_queue_budget_tests.rs
+++ b/rocketmq-store-local/tests/store_queue_budget_tests.rs
@@ -1,0 +1,125 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_store_local::base::allocate_mapped_file_service::AllocateMappedFileService;
+
+fn allocation_budget(name: &str, count: usize, bytes: usize) -> ResourceBudget {
+    ResourceBudgetTree::new(name, BudgetLimit::new(count, bytes, FullPolicy::Reject))
+        .expect("allocation test budget")
+        .root()
+}
+
+#[tokio::test]
+async fn mapped_file_queue_rejects_at_count_limit_and_releases_on_shutdown() {
+    let service =
+        AllocateMappedFileService::new_with_config(None, false, false, allocation_budget("mapped-count", 1, 4_096));
+
+    service.submit_request_in_background("root/00000000000000000000".to_owned(), 1_024);
+    service.submit_request_in_background("root/00000000000000001024".to_owned(), 1_024);
+
+    let saturated = service.queue_snapshot();
+    assert_eq!(saturated.current_count, 1);
+    assert_eq!(saturated.charged_bytes, 1_024);
+    assert_eq!(saturated.rejected_count, 1);
+
+    service.shutdown().await;
+    let released = service.queue_snapshot();
+    assert_eq!(released.current_count, 0);
+    assert_eq!(released.charged_bytes, 0);
+    assert_eq!(released.abandoned_count, 1);
+}
+
+#[tokio::test]
+async fn duplicate_mapped_file_request_reuses_existing_budget_owner() {
+    let service =
+        AllocateMappedFileService::new_with_config(None, false, false, allocation_budget("mapped-duplicate", 1, 1_024));
+    let path = "root/00000000000000000000".to_owned();
+
+    service.submit_request_in_background(path.clone(), 1_024);
+    service.submit_request_in_background(path, 1_024);
+
+    let snapshot = service.queue_snapshot();
+    assert_eq!(snapshot.current_count, 1);
+    assert_eq!(snapshot.charged_bytes, 1_024);
+    assert_eq!(snapshot.queued_count, 1);
+    assert_eq!(snapshot.rejected_count, 0);
+
+    service.shutdown().await;
+    assert_eq!(service.queue_snapshot().current_count, 0);
+}
+
+#[tokio::test]
+async fn mapped_file_queue_rejects_at_byte_limit_before_count_limit() {
+    let service =
+        AllocateMappedFileService::new_with_config(None, false, false, allocation_budget("mapped-bytes", 2, 1_200));
+
+    service.submit_request_in_background("root/00000000000000000000".to_owned(), 1_024);
+    service.submit_request_in_background("root/00000000000000001024".to_owned(), 512);
+
+    let saturated = service.queue_snapshot();
+    assert_eq!(saturated.current_count, 1);
+    assert_eq!(saturated.charged_bytes, 1_024);
+    assert_eq!(saturated.rejected_count, 1);
+
+    service.shutdown().await;
+    assert_eq!(service.queue_snapshot().charged_bytes, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn mapped_file_timeout_abandons_table_ownership_and_releases_permit() {
+    let service =
+        AllocateMappedFileService::new_with_config(None, false, false, allocation_budget("mapped-timeout", 1, 1_024));
+
+    let result = service
+        .put_request_and_return_mapped_file("root/00000000000000000000".to_owned(), String::new(), 1_024)
+        .await
+        .expect("timeout is represented by an empty allocation result");
+
+    assert!(result.is_none());
+    let snapshot = service.queue_snapshot();
+    assert_eq!(snapshot.current_count, 0);
+    assert_eq!(snapshot.charged_bytes, 0);
+    assert_eq!(snapshot.abandoned_count, 1);
+    assert_eq!(snapshot.queued_count, 1, "the stale heap key owns no permit");
+
+    service.shutdown().await;
+    assert_eq!(service.queue_snapshot().queued_count, 0);
+}
+
+#[tokio::test]
+async fn cancelling_mapped_file_wait_releases_table_and_budget_ownership() {
+    let service =
+        AllocateMappedFileService::new_with_config(None, false, false, allocation_budget("mapped-cancel", 1, 1_024));
+
+    {
+        let pending =
+            service.put_request_and_return_mapped_file("root/00000000000000000000".to_owned(), String::new(), 1_024);
+        tokio::pin!(pending);
+        tokio::select! {
+            biased;
+            _ = &mut pending => panic!("allocation unexpectedly completed"),
+            () = tokio::task::yield_now() => {}
+        }
+    }
+
+    let snapshot = service.queue_snapshot();
+    assert_eq!(snapshot.current_count, 0);
+    assert_eq!(snapshot.charged_bytes, 0);
+    assert_eq!(snapshot.abandoned_count, 1);
+    service.shutdown().await;
+}

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -1607,7 +1607,12 @@ mod tests {
         );
         first_file.set_wrote_position(820);
 
-        let service = AllocateMappedFileService::new();
+        let service = AllocateMappedFileService::new_with_config(
+            None,
+            false,
+            false,
+            crate::runtime::test_scope("mapped-file-queue-preallocation-test").mapped_file_allocation_budget(),
+        );
         service.start();
         let queue = MappedFileQueue::new(
             temp_dir.path().to_string_lossy().to_string(),

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -18,15 +18,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_runtime::BudgetClass;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskId;
 use rocketmq_store_local::flush::group_commit::run_group_commit_worker;
+use rocketmq_store_local::flush::group_commit::GroupCommitQueue;
 use rocketmq_store_local::flush::group_commit::GroupCommitStatus;
 use rocketmq_store_local::flush::group_commit::GroupCommitWorkerConfig;
 use rocketmq_store_local::flush::group_commit::GroupCommitWorkerPorts;
 use rocketmq_store_local::flush::group_commit::SyncFlushStats;
-use rocketmq_store_local::flush::group_commit::GROUP_COMMIT_CHANNEL_CAPACITY;
 use rocketmq_store_local::flush::root::FlushManagerRoot;
 use rocketmq_store_local::flush::worker::run_commit_real_time_worker;
 use rocketmq_store_local::flush::worker::run_flush_real_time_worker;
@@ -149,7 +150,7 @@ impl DefaultFlushManager {
                     runtime_scope: runtime_scope.clone(),
                     store_checkpoint: store_checkpoint.clone(),
                     notified: Arc::new(Notify::new()),
-                    tx_in: None,
+                    request_queue: None,
                     shutdown_token: CancellationToken::new(),
                     worker_group: None,
                     worker_task: None,
@@ -407,7 +408,7 @@ struct GroupCommitService {
     runtime_scope: crate::runtime::StoreRuntimeScope,
     store_checkpoint: Arc<StoreCheckpoint>,
     notified: Arc<Notify>,
-    tx_in: Option<tokio::sync::mpsc::Sender<GroupCommitRequest>>,
+    request_queue: Option<GroupCommitQueue<StoreError>>,
     shutdown_token: CancellationToken,
     worker_group: Option<TaskGroup>,
     worker_task: Option<TaskId>,
@@ -426,19 +427,28 @@ impl GroupCommitService {
             return false;
         }
 
-        let Some(tx_in) = self.tx_in.as_ref() else {
+        let Some(request_queue) = self.request_queue.as_ref() else {
             return false;
         };
         let enqueue_time_millis = request.enqueue_time_millis();
+        let retained_bytes = request.retained_bytes();
+        let deadline = request.admission_deadline();
+        self.sync_flush_stats
+            .record_enqueue(enqueue_time_millis, retained_bytes);
         tokio::select! {
-            result = tx_in.send(request) => {
+            result = request_queue.push_until(request, retained_bytes, BudgetClass::Data, deadline) => {
                 let sent = result.is_ok();
-                if sent {
-                    self.sync_flush_stats.record_enqueue(enqueue_time_millis);
+                if !sent {
+                    self.sync_flush_stats.rollback_enqueue(enqueue_time_millis, retained_bytes);
+                    self.sync_flush_stats.record_rejected();
                 }
                 sent
             },
-            _ = self.shutdown_token.cancelled() => false,
+            _ = self.shutdown_token.cancelled() => {
+                self.sync_flush_stats.rollback_enqueue(enqueue_time_millis, retained_bytes);
+                self.sync_flush_stats.record_abandoned();
+                false
+            },
         }
     }
 
@@ -449,8 +459,8 @@ impl GroupCommitService {
 
         let worker_group = crate::runtime::task_group(&self.runtime_scope, "rocketmq-store.commit-log.group-commit");
         self.shutdown_token = CancellationToken::new();
-        let (tx_in, rx_in) = tokio::sync::mpsc::channel::<GroupCommitRequest>(GROUP_COMMIT_CHANNEL_CAPACITY);
-        self.tx_in = Some(tx_in);
+        let request_queue = GroupCommitQueue::new(self.runtime_scope.group_commit_budget());
+        self.request_queue = Some(request_queue.clone());
         let shutdown_token = self.shutdown_token.clone();
         let store_checkpoint = self.store_checkpoint.clone();
         let notified = Arc::clone(&self.notified);
@@ -471,7 +481,7 @@ impl GroupCommitService {
                 time::sleep,
             );
             run_group_commit_worker(
-                rx_in,
+                request_queue,
                 notified,
                 shutdown_token,
                 sync_flush_stats,
@@ -484,7 +494,9 @@ impl GroupCommitService {
             Ok(task_id) => task_id,
             Err(error) => {
                 warn!("GroupCommitService cannot start because task spawn failed: {error}");
-                self.tx_in.take();
+                if let Some(queue) = self.request_queue.take() {
+                    queue.close();
+                }
                 return;
             }
         };
@@ -497,14 +509,18 @@ impl GroupCommitService {
     }
 
     pub fn shutdown(&mut self) {
+        if let Some(queue) = self.request_queue.take() {
+            queue.close();
+        }
         self.shutdown_token.cancel();
-        self.tx_in.take();
         shutdown_worker_now("GroupCommitService", &mut self.worker_group, &mut self.worker_task);
     }
 
     pub async fn shutdown_gracefully(&mut self) {
+        if let Some(queue) = self.request_queue.take() {
+            queue.close();
+        }
         self.shutdown_token.cancel();
-        self.tx_in.take();
         shutdown_worker_gracefully("GroupCommitService", &mut self.worker_group, &mut self.worker_task).await;
     }
 }
@@ -811,8 +827,8 @@ mod tests {
         let sync_flush_stats = SyncFlushStats::default();
         let (request_64, mut response_64) = GroupCommitRequest::new(64, 5_000);
         let (request_96, mut response_96) = GroupCommitRequest::new(96, 5_000);
-        sync_flush_stats.record_enqueue(request_64.enqueue_time_millis());
-        sync_flush_stats.record_enqueue(request_96.enqueue_time_millis());
+        sync_flush_stats.record_enqueue(request_64.enqueue_time_millis(), request_64.retained_bytes());
+        sync_flush_stats.record_enqueue(request_96.enqueue_time_millis(), request_96.retained_bytes());
         let requests = vec![request_64, request_96];
 
         complete_group_commit_batch(requests, 80, &sync_flush_stats);
@@ -860,7 +876,7 @@ mod tests {
         let sync_flush_stats = SyncFlushStats::default();
         let (request, _response) = GroupCommitRequest::new(64, 5_000);
 
-        sync_flush_stats.record_enqueue(request.enqueue_time_millis());
+        sync_flush_stats.record_enqueue(request.enqueue_time_millis(), request.retained_bytes());
 
         let runtime_info = sync_flush_stats.snapshot();
         assert_eq!(runtime_info.queue_depth, 1);
@@ -998,7 +1014,7 @@ mod tests {
             runtime_scope: crate::runtime::test_scope("group-commit-service-test"),
             store_checkpoint,
             notified: Arc::new(Notify::new()),
-            tx_in: None,
+            request_queue: None,
             shutdown_token: CancellationToken::new(),
             worker_group: None,
             worker_task: None,
@@ -1031,7 +1047,7 @@ mod tests {
             Some(crate::store_error::StoreErrorKind::Storage)
         );
 
-        let (pending_request, pending_response) = GroupCommitRequest::new(2, 0);
+        let (pending_request, pending_response) = GroupCommitRequest::new(2, 5_000);
         assert!(service.put_request(pending_request).await);
         service.shutdown_gracefully().await;
         assert!(service.worker_group.is_none());

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -141,6 +141,7 @@ impl LocalFileMessageStore {
             transient_store_pool_enable,
             message_store_config.fast_fail_if_no_buffer_in_store_pool,
             message_store_config.as_ref(),
+            runtime_scope.mapped_file_allocation_budget(),
         );
         #[cfg(feature = "observability")]
         let allocate_mapped_file_service = allocate_mapped_file_service.with_store_metrics(telemetry.store().clone());

--- a/rocketmq-store/src/runtime.rs
+++ b/rocketmq-store/src/runtime.rs
@@ -15,7 +15,10 @@
 use rocketmq_error::RocketMQError;
 use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::BlockingExecutorSnapshot;
+use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
@@ -26,14 +29,64 @@ use rocketmq_runtime::TaskKind;
 pub(crate) struct StoreRuntimeScope {
     service_context: ChildServiceContext,
     blocking_executor: BlockingExecutor,
+    resource_budget: ResourceBudget,
+    mapped_file_allocation_budget: ResourceBudget,
+    group_commit_budget: ResourceBudget,
 }
 
 impl StoreRuntimeScope {
     pub(crate) fn new(service_context: ChildServiceContext) -> Self {
+        const STORE_ITEM_LIMIT: usize = usize::MAX;
+        const MAPPED_FILE_ALLOCATION_ITEM_LIMIT: usize = 1_024;
+        const GROUP_COMMIT_ITEM_LIMIT: usize = 1_024;
+
+        let process_budget = service_context.process_budget();
+        let managed_bytes = process_budget.limit().capacity.bytes;
+        // These static names and limits are constrained to the already
+        // validated RuntimeOwner root, so child construction cannot fail.
+        let resource_budget = process_budget
+            .child(
+                "store",
+                BudgetLimit::new(STORE_ITEM_LIMIT, managed_bytes, FullPolicy::Reject),
+            )
+            .expect("Store budget must fit the RuntimeOwner process budget");
+        let mapped_file_allocation_budget = resource_budget
+            .child(
+                "mapped-file-allocation",
+                BudgetLimit::new(MAPPED_FILE_ALLOCATION_ITEM_LIMIT, managed_bytes, FullPolicy::Reject),
+            )
+            .expect("mapped-file allocation budget must fit the Store budget");
+        let group_commit_budget = resource_budget
+            .child(
+                "group-commit",
+                BudgetLimit::new(GROUP_COMMIT_ITEM_LIMIT, managed_bytes, FullPolicy::WaitUntilDeadline),
+            )
+            .expect("group-commit budget must fit the Store budget");
+        tracing::info!(
+            store_budget_bytes = managed_bytes,
+            mapped_file_allocation_items = MAPPED_FILE_ALLOCATION_ITEM_LIMIT,
+            group_commit_items = GROUP_COMMIT_ITEM_LIMIT,
+            "initialized RuntimeOwner-derived Store queue budgets"
+        );
         Self {
             service_context: service_context.clone(),
             blocking_executor: service_context.storage_io().clone(),
+            resource_budget,
+            mapped_file_allocation_budget,
+            group_commit_budget,
         }
+    }
+
+    pub(crate) fn resource_budget(&self) -> ResourceBudget {
+        self.resource_budget.clone()
+    }
+
+    pub(crate) fn mapped_file_allocation_budget(&self) -> ResourceBudget {
+        self.mapped_file_allocation_budget.clone()
+    }
+
+    pub(crate) fn group_commit_budget(&self) -> ResourceBudget {
+        self.group_commit_budget.clone()
     }
 
     pub(crate) async fn spawn_io<F, R>(&self, name: &'static str, operation: F) -> Result<R, RocketMQError>
@@ -139,4 +192,39 @@ pub(crate) fn test_service_context(name: &'static str) -> ChildServiceContext {
 #[cfg(test)]
 pub(crate) fn test_scope(name: &'static str) -> StoreRuntimeScope {
     StoreRuntimeScope::new(test_service_context(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_runtime::BudgetClass;
+
+    use super::test_scope;
+
+    #[test]
+    fn store_queue_budgets_share_one_runtime_owned_parent() {
+        let scope = test_scope("store-budget-tree-test");
+        assert!(scope.resource_budget().path().ends_with("/store"));
+        assert!(scope
+            .mapped_file_allocation_budget()
+            .path()
+            .ends_with("/store/mapped-file-allocation"));
+        assert!(scope.group_commit_budget().path().ends_with("/store/group-commit"));
+
+        let mapped_permit = scope
+            .mapped_file_allocation_budget()
+            .try_acquire(64, BudgetClass::Data)
+            .expect("mapped-file child budget");
+        let group_permit = scope
+            .group_commit_budget()
+            .try_acquire(32, BudgetClass::Data)
+            .expect("group-commit child budget");
+        let parent = scope.resource_budget().snapshot();
+        assert_eq!(parent.current_count, 2);
+        assert_eq!(parent.current_bytes, 96);
+
+        drop((mapped_permit, group_permit));
+        let released = scope.resource_budget().snapshot();
+        assert_eq!(released.current_count, 0);
+        assert_eq!(released.current_bytes, 0);
+    }
 }

--- a/rocketmq-store/tests/group_commit_budget_tests.rs
+++ b/rocketmq-store/tests/group_commit_budget_tests.rs
@@ -1,0 +1,114 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetDimension;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::QueuePushErrorKind;
+use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_store_local::flush::group_commit::GroupCommitQueue;
+use rocketmq_store_local::flush::group_commit::GroupCommitRequest;
+
+fn group_commit_queue<E>(name: &str, count: usize, bytes: usize, policy: FullPolicy) -> GroupCommitQueue<E> {
+    let budget = ResourceBudgetTree::new(name, BudgetLimit::new(count, bytes, policy))
+        .expect("group commit test budget")
+        .root();
+    GroupCommitQueue::new(budget)
+}
+
+#[test]
+fn group_commit_queue_enforces_count_and_holds_permit_until_owner_drop() {
+    let queue = group_commit_queue::<()>("group-count", 1, 4_096, FullPolicy::Reject);
+    let (first, _first_response) = GroupCommitRequest::new(10, 5_000);
+    let (second, _second_response) = GroupCommitRequest::new(20, 5_000);
+    let first_bytes = first.retained_bytes();
+    let second_bytes = second.retained_bytes();
+
+    queue.try_push_data(first, first_bytes).expect("first request fits");
+    let error = queue
+        .try_push_data(second, second_bytes)
+        .expect_err("second request exceeds count");
+    assert!(matches!(
+        error.kind(),
+        QueuePushErrorKind::BudgetExhausted(error)
+            if error.dimension() == BudgetDimension::Count
+    ));
+
+    let owned = queue.try_pop_budgeted().expect("accepted request");
+    assert_eq!(queue.snapshot().reserved_count, 1);
+    drop(owned);
+    assert_eq!(queue.snapshot().reserved_count, 0);
+    assert_eq!(queue.snapshot().retained_bytes, 0);
+}
+
+#[test]
+fn group_commit_queue_enforces_retained_bytes_before_count() {
+    let (first, _first_response) = GroupCommitRequest::<()>::new(10, 5_000);
+    let retained_bytes = first.retained_bytes();
+    let queue = group_commit_queue("group-bytes", 2, retained_bytes + 1, FullPolicy::Reject);
+    let (second, _second_response) = GroupCommitRequest::new(20, 5_000);
+    let second_bytes = second.retained_bytes();
+
+    queue.try_push_data(first, retained_bytes).expect("first request fits");
+    let error = queue
+        .try_push_data(second, second_bytes)
+        .expect_err("second request exceeds retained bytes");
+    assert!(matches!(
+        error.kind(),
+        QueuePushErrorKind::BudgetExhausted(error)
+            if error.dimension() == BudgetDimension::Bytes
+    ));
+
+    drop(queue.try_pop_budgeted());
+    assert_eq!(queue.snapshot().retained_bytes, 0);
+}
+
+#[test]
+fn group_commit_queue_preserves_fifo_and_close_releases_drained_permits() {
+    let queue = group_commit_queue::<()>("group-fifo", 2, 4_096, FullPolicy::Reject);
+    let (first, _first_response) = GroupCommitRequest::new(10, 5_000);
+    let (second, _second_response) = GroupCommitRequest::new(20, 5_000);
+    let first_bytes = first.retained_bytes();
+    let second_bytes = second.retained_bytes();
+    queue.try_push_data(first, first_bytes).expect("first request fits");
+    queue.try_push_data(second, second_bytes).expect("second request fits");
+    queue.close();
+
+    let first = queue.try_pop_budgeted().expect("first request").into_item();
+    let second = queue.try_pop_budgeted().expect("second request").into_item();
+    assert_eq!(first.next_offset(), 10);
+    assert_eq!(second.next_offset(), 20);
+    assert_eq!(queue.snapshot().reserved_count, 0);
+}
+
+#[tokio::test]
+async fn group_commit_admission_deadline_is_typed_and_does_not_leak_capacity() {
+    let queue = group_commit_queue::<()>("group-deadline", 1, 4_096, FullPolicy::WaitUntilDeadline);
+    let (first, _first_response) = GroupCommitRequest::new(10, 5_000);
+    let (second, _second_response) = GroupCommitRequest::new(20, 0);
+    let first_bytes = first.retained_bytes();
+    let second_bytes = second.retained_bytes();
+    queue.try_push_data(first, first_bytes).expect("first request fits");
+
+    let error = queue
+        .push_until(second, second_bytes, BudgetClass::Data, tokio::time::Instant::now())
+        .await
+        .expect_err("expired admission deadline");
+    assert_eq!(error.kind(), &QueuePushErrorKind::DeadlineExceeded);
+    assert_eq!(queue.snapshot().reserved_count, 1);
+
+    drop(queue.try_pop_budgeted());
+    assert_eq!(queue.snapshot().reserved_count, 0);
+}

--- a/rocketmq-store/tests/store_local_allocate_service_identity.rs
+++ b/rocketmq-store/tests/store_local_allocate_service_identity.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudgetTree;
 use rocketmq_store::AllocateMappedFileService as LegacyAllocateService;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_store_local::base::allocate_mapped_file_service::AllocateMappedFileService as CanonicalAllocateService;
@@ -28,7 +31,13 @@ fn legacy_allocation_service_path_is_the_local_canonical_type() {
         ..MessageStoreConfig::default()
     };
 
-    let service = LegacyAllocateService::new_with_message_store_config(None, false, false, &config);
+    let budget = ResourceBudgetTree::new(
+        "allocation-identity-test",
+        BudgetLimit::new(4, 4_096, FullPolicy::Reject),
+    )
+    .expect("allocation identity budget")
+    .root();
+    let service = LegacyAllocateService::new_with_message_store_config(None, false, false, &config, budget);
     let service = canonical_service(service);
 
     assert_eq!(service.get_service_name(), "AllocateMappedFileService");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8865

### Brief Description

- Derives Store queue budgets from the process-owned runtime budget and injects explicit child budgets into mapped-file allocation and Group Commit.
- Replaces mapped-file request ownership duplication with one canonical table owner, stable heap keys, cancellation-safe RAII permits, and count/byte queue diagnostics.
- Replaces the fixed Group Commit channel capacity with deadline-aware count/retained-byte admission while preserving FIFO completion and graceful shutdown drain semantics.
- Adds deterministic coverage for saturation, duplicate requests, timeout, cancellation, stale queue entries, worker panic, FIFO order, and permit release.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-store-local -p rocketmq-store -- --check`
- `cargo clippy -p rocketmq-store-local -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-store-local`
- `cargo test -p rocketmq-store-local --test store_queue_budget_tests`
- `cargo test -p rocketmq-store-local --test flush_group_commit`
- `cargo test -p rocketmq-store --test group_commit_budget_tests`
- `cargo test -p rocketmq-store` (549 passed; the 2 failing TaskGroup lifecycle assertions reproduce unchanged on the exact parent commit)
- `cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests`
- `cargo test -p rocketmq-broker --features rocksdb_store rocksdb`
- `cargo test -p rocketmq-broker --features rocksdb_store pop_consumer`
- `cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings` (the only finding is a pre-existing `needless_return` in unchanged `broker_runtime/control_plane.rs`)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `python scripts/run_architecture_tests.py --tier pr_static` (the existing 8 baseline modules fail; no PR-owned finding was introduced)
- `cargo doc -p rocketmq-store-local -p rocketmq-store --no-deps --all-features`
- `git diff --check`

The workspace-wide `cargo fmt --all -- --check` remains blocked by Windows error 206; the exact affected-package format check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource budgets for mapped-file allocation and group-commit processing, limiting both request counts and retained memory.
  * Added queue diagnostics covering pending requests, charged bytes, request age, rejections, and abandoned work.
* **Bug Fixes**
  * Improved cleanup during shutdown, cancellation, timeouts, worker failures, and allocation ownership changes.
  * Prevented stale or duplicate requests from retaining unintended resources.
* **Tests**
  * Added coverage for budget limits, FIFO behavior, permit release, abandonment, and shutdown cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->