### PR TITLE
[ISSUE #8867]🚀Remove Admin serialization and unify LitePull assignment ownership

### DIFF
--- a/rocketmq-broker/src/broker/broker_admin_runtime.rs
+++ b/rocketmq-broker/src/broker/broker_admin_runtime.rs
@@ -325,10 +325,6 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
         &self.subscription_group_manager
     }
 
-    pub(crate) fn subscription_group_manager_mut(&mut self) -> &mut SubscriptionGroupManager {
-        &mut self.subscription_group_manager
-    }
-
     pub(crate) fn consumer_filter_manager(&self) -> &ConsumerFilterManager {
         &self.consumer_filter_manager
     }
@@ -474,7 +470,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
             .await
     }
 
-    pub(crate) fn set_broker_config(&mut self, broker_config: BrokerConfig) -> Result<(), BrokerConfigError> {
+    pub(crate) fn set_broker_config(&self, broker_config: BrokerConfig) -> Result<(), BrokerConfigError> {
         let update_lock = Arc::clone(&self.config_update_lock);
         let _update_guard = update_lock.lock();
         let generation = self.config.replace_broker(broker_config)?;
@@ -483,7 +479,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
     }
 
     pub(crate) fn commit_broker_config_patch(
-        &mut self,
+        &self,
         properties: &HashMap<CheetahString, CheetahString>,
     ) -> Result<ConfigGeneration, BrokerConfigError> {
         self.commit_broker_config_patch_inner(None, properties)
@@ -496,7 +492,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
     /// and legacy capability projection are serialized by one lock. A stale
     /// supervised operation therefore cannot overwrite a newer configuration.
     pub(crate) fn commit_broker_config_patch_if_generation(
-        &mut self,
+        &self,
         expected_generation: u64,
         properties: &HashMap<CheetahString, CheetahString>,
     ) -> Result<ConfigGeneration, BrokerConfigError> {
@@ -504,7 +500,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
     }
 
     fn commit_broker_config_patch_inner(
-        &mut self,
+        &self,
         expected_generation: Option<u64>,
         properties: &HashMap<CheetahString, CheetahString>,
     ) -> Result<ConfigGeneration, BrokerConfigError> {
@@ -527,7 +523,7 @@ impl<MS: MessageStore> BrokerAdminRuntime<MS> {
     }
 
     fn apply_broker_config_generation(
-        &mut self,
+        &self,
         generation: &crate::broker::broker_runtime_config_state::BrokerRuntimeConfigGeneration,
     ) {
         self.role_state

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -611,10 +611,7 @@ impl BrokerRuntime {
                     component: "auth_admin_service",
                     detail: "auth admin service must be initialized before request processors".to_owned(),
                 })?;
-        let admin_broker_processor = Arc::new(Mutex::new(AdminBrokerProcessor::new(
-            self.admin_runtime(),
-            auth_admin_service,
-        )));
+        let admin_broker_processor = Arc::new(AdminBrokerProcessor::new(self.admin_runtime(), auth_admin_service));
         broker_request_processor.register_default_processor(BrokerProcessorType::AdminBroker(admin_broker_processor));
 
         Ok((broker_request_processor.clone(), broker_request_processor))

--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -160,7 +160,7 @@ impl Broker2Client {
     /// Response command with result
     pub async fn reset_offset<MS: MessageStore>(
         &self,
-        broker_inner: &mut BrokerAdminRuntime<MS>,
+        broker_inner: &BrokerAdminRuntime<MS>,
         topic: &CheetahString,
         group: &CheetahString,
         timestamp: i64,
@@ -183,7 +183,7 @@ impl Broker2Client {
     /// Response command with result
     pub async fn reset_offset_for_c<MS: MessageStore>(
         &self,
-        broker_inner: &mut BrokerAdminRuntime<MS>,
+        broker_inner: &BrokerAdminRuntime<MS>,
         topic: &CheetahString,
         group: &CheetahString,
         timestamp: i64,
@@ -196,7 +196,7 @@ impl Broker2Client {
     /// Internal reset offset implementation.
     async fn reset_offset_inner<MS: MessageStore>(
         &self,
-        broker_inner: &mut BrokerAdminRuntime<MS>,
+        broker_inner: &BrokerAdminRuntime<MS>,
         topic: &CheetahString,
         group: &CheetahString,
         timestamp: i64,

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -31,7 +31,6 @@ use rocketmq_transport::ConnectionHandlerContext;
 use rocketmq_transport::RejectRequestResponse;
 use rocketmq_transport::RemotingRequestProcessor as RequestProcessor;
 use rocketmq_transport::RequestOrdering;
-use tokio::sync::Mutex;
 use tracing::warn;
 
 use self::client_manage_processor::ClientManageProcessor;
@@ -106,7 +105,7 @@ pub enum BrokerProcessorType<MS: MessageStore, TS> {
     LiteSubscriptionCtl(Arc<LiteSubscriptionCtlProcessor<MS>>),
     EndTransaction(Arc<EndTransactionProcessor<TS, MS>>),
     Maintenance(Arc<MaintenanceRequestProcessor>),
-    AdminBroker(Arc<Mutex<AdminBrokerProcessor<MS>>>),
+    AdminBroker(Arc<AdminBrokerProcessor<MS>>),
 }
 
 impl<MS, TS> Clone for BrokerProcessorType<MS, TS>
@@ -224,7 +223,7 @@ where
                 processor.process_request_shared(channel, ctx, request).await
             }
             BrokerProcessorType::AdminBroker(processor) => {
-                processor.lock().await.process_request(channel, ctx, request).await
+                processor.process_request_shared(channel, ctx, request).await
             }
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -124,6 +124,17 @@ where
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_request_shared(channel, ctx, request).await
+    }
+}
+
+impl<MS: MessageStore> AdminBrokerProcessor<MS> {
+    pub(crate) async fn process_request_shared(
+        &self,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         self.process_request_inner(channel, ctx, request_code, request).await
     }
@@ -203,7 +214,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
 
 impl<MS: MessageStore> AdminBrokerProcessor<MS> {
     async fn process_request_inner(
-        &mut self,
+        &self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
@@ -232,7 +243,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::DeleteTopicInBroker => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
                     .delete_topic(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -325,7 +336,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::UpdateAndCreateSubscriptionGroup => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
                     .update_and_create_subscription_group(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -337,7 +348,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::UpdateAndCreateSubscriptionGroupList => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
                     .update_and_create_subscription_group_list(
                         broker_runtime_inner,
@@ -355,7 +366,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::DeleteSubscriptionGroup => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
                     .delete_subscription_group(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -403,7 +414,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::InvokeBrokerToResetOffset => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
                     .invoke_broker_to_reset_offset(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -513,7 +524,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::UpdateAndGetGroupForbidden => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
                     .update_and_get_group_forbidden(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -542,7 +553,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::ResumeCheckHalfMessage => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
                     .resume_check_half_message(broker_runtime_inner, channel, ctx, request_code, request)
                     .await
@@ -571,7 +582,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .await
             }
             RequestCode::NotifyMinBrokerIdChange => {
-                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner_mut();
+                let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.notify_min_broker_handler
                     .notify_min_broker_id_change(broker_runtime_inner, channel, ctx, request_code, request)
                     .await

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -77,10 +77,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         &self.broker_runtime_inner
     }
 
-    pub(super) fn broker_runtime_inner_mut(&mut self) -> &mut BrokerAdminRuntime<MS> {
-        &mut self.broker_runtime_inner
-    }
-
     pub(super) async fn persist_and_register_topic_updates(
         &self,
         topic_config_list: Vec<Arc<TopicConfig>>,
@@ -132,7 +128,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
 }
 impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     pub async fn update_broker_config(
-        &mut self,
+        &self,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         request_code: RequestCode,
@@ -331,7 +327,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn get_broker_config(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -361,7 +357,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn get_broker_runtime_info(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -375,7 +371,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn set_commitlog_read_mode(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -429,7 +425,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn export_rocksdb_config_to_json(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -512,7 +508,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn get_timer_metrics(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -522,7 +518,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn get_timer_check_point(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -532,7 +528,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
 
     pub async fn switch_timer_engine(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -1132,7 +1128,7 @@ mod tests {
     async fn set_commitlog_read_mode_updates_store_config() {
         let runtime = new_test_runtime("commitlog-read-mode", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin.clone());
+        let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -1198,7 +1194,7 @@ mod tests {
 
         let mut next = admin.broker_config().as_ref().clone();
         next.max_client_event_count = next.max_client_event_count.saturating_add(1);
-        let mut admin = admin;
+        let admin = admin;
         admin
             .set_broker_config(next)
             .expect("valid configuration replacement should advance generation");
@@ -1220,7 +1216,7 @@ mod tests {
     async fn get_broker_config_binds_body_to_the_committed_generation() {
         let runtime = new_test_runtime("get-broker-config-generation", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin);
+        let handler = BrokerConfigRequestHandler::new(admin);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig);
@@ -1248,7 +1244,7 @@ mod tests {
     async fn update_broker_config_applies_supported_runtime_properties() {
         let runtime = new_test_runtime("update-broker-config", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin.clone());
+        let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -1278,7 +1274,7 @@ mod tests {
     async fn update_broker_config_cas_commits_once_and_rejects_stale_generation() {
         let runtime = new_test_runtime("update-broker-config-cas", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin.clone());
+        let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -1341,7 +1337,7 @@ mod tests {
     async fn update_log_filter_requires_broker_authentication_and_authorization() {
         let runtime = new_test_runtime("update-log-filter-auth-disabled", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin);
+        let handler = BrokerConfigRequestHandler::new(admin);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body(concat!(
@@ -1367,7 +1363,7 @@ mod tests {
     async fn update_broker_config_rejects_unsupported_or_invalid_keys() {
         let runtime = new_test_runtime("update-broker-config-invalid", false).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin.clone());
+        let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -1470,7 +1466,7 @@ mod tests {
     #[tokio::test]
     async fn export_rocksdb_config_without_rocksdb_returns_not_supported() {
         let runtime = new_test_runtime("export-config", false).await;
-        let mut handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
+        let handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -1526,11 +1522,11 @@ mod tests {
             let mut group_config = SubscriptionGroupConfig::new(group.clone());
             group_config.set_consume_broadcast_enable(false);
             inner_mut
-                .subscription_group_manager_mut()
+                .subscription_group_manager()
                 .update_subscription_group_config(&mut group_config);
         }
 
-        let mut handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
+        let handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -1571,7 +1567,7 @@ mod tests {
     async fn switch_timer_engine_accepts_file_time_wheel_and_rejects_rocksdb() {
         let runtime = new_test_runtime("switch-timer-engine", true).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = BrokerConfigRequestHandler::new(admin.clone());
+        let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
@@ -35,7 +35,7 @@ impl BrokerStatsHandler {
     }
 
     pub async fn view_broker_stats_data(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -66,7 +66,7 @@ impl ConsumerRequestHandler {
 
 impl ConsumerRequestHandler {
     pub async fn get_consumer_connection_list<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -109,7 +109,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn get_consume_stats<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -224,7 +224,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn get_broker_consume_stats<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -282,7 +282,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn query_correction_offset<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -319,7 +319,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn consume_message_directly<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -488,7 +488,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn get_all_consumer_offset<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -510,7 +510,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn get_all_message_request_mode<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -545,8 +545,8 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn invoke_broker_to_reset_offset<MS: MessageStore>(
-        &mut self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        &self,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -593,7 +593,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn invoke_broker_to_get_consumer_status<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -615,7 +615,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn query_subscription_by_consumer<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -639,7 +639,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn query_consume_time_span<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -715,7 +715,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn clone_group_offset<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -773,7 +773,7 @@ impl ConsumerRequestHandler {
     }
 
     pub async fn get_consumer_running_info<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
@@ -800,7 +800,7 @@ impl ConsumerRequestHandler {
     }
 
     async fn call_consumer<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         request: RemotingCommand,
         consumer_group: &str,
@@ -856,7 +856,7 @@ impl ConsumerRequestHandler {
     }
 
     async fn reset_offset_inner<MS: MessageStore>(
-        &mut self,
+        &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
         topic: &cheetah_string::CheetahString,
         group: &cheetah_string::CheetahString,
@@ -1119,7 +1119,7 @@ mod tests {
                 },
             );
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
@@ -1156,7 +1156,7 @@ mod tests {
     #[tokio::test]
     async fn get_broker_consume_stats_returns_grouped_offsets() {
         let runtime = new_test_runtime("broker-consume-stats").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let _ = admin
             .topic_config_manager()
             .update_topic_config(TopicConfig::with_queues("topic-a", 1, 1), 0);
@@ -1165,7 +1165,7 @@ mod tests {
                 CheetahString::from_static_str("group-a"),
             );
         admin
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .update_subscription_group_config(&mut group_config);
         admin.consumer_offset_manager().commit_offset(
             CheetahString::from_static_str("127.0.0.1"),
@@ -1175,7 +1175,7 @@ mod tests {
             6,
         );
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::GetBrokerConsumeStats,
             GetConsumeStatsInBrokerHeader { is_order: false },
@@ -1231,7 +1231,7 @@ mod tests {
             8,
         );
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::QueryCorrectionOffset,
             QueryCorrectionOffsetHeader {
@@ -1276,11 +1276,11 @@ mod tests {
                 CheetahString::from_static_str("group-a"),
             );
         admin
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .update_subscription_group_config(&mut group_config);
         let msg_id = put_test_message(&mut admin, "topic-a").await;
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::ConsumeMessageDirectly,
             ConsumeMessageDirectlyResultRequestHeader {
@@ -1316,7 +1316,7 @@ mod tests {
     #[tokio::test]
     async fn invoke_broker_to_reset_offset_assigns_server_side_offset() {
         let runtime = new_test_runtime("reset-offset").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let _ = admin
             .topic_config_manager()
             .update_topic_config(TopicConfig::with_queues("topic-a", 1, 1), 0);
@@ -1325,10 +1325,10 @@ mod tests {
                 CheetahString::from_static_str("group-a"),
             );
         admin
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .update_subscription_group_config(&mut group_config);
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -1347,7 +1347,7 @@ mod tests {
 
         let mut response = handler
             .invoke_broker_to_reset_offset(
-                &mut admin,
+                &admin,
                 channel,
                 ctx,
                 RequestCode::InvokeBrokerToResetOffset,
@@ -1376,7 +1376,7 @@ mod tests {
     #[tokio::test]
     async fn invoke_broker_to_get_consumer_status_returns_offline_group_error() {
         let runtime = new_test_runtime("consumer-status").await;
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -1434,7 +1434,7 @@ mod tests {
             false,
         );
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -1487,7 +1487,7 @@ mod tests {
             .topic_config_manager()
             .update_topic_config(TopicConfig::with_queues("topic-a", 1, 1), 0);
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::QueryConsumeTimeSpan,
             QueryConsumeTimeSpanRequestHeader {
@@ -1542,7 +1542,7 @@ mod tests {
             18,
         );
 
-        let mut handler = ConsumerRequestHandler::new();
+        let handler = ConsumerRequestHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::CloneGroupOffset,
             CloneGroupOffsetRequestHeader {

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -37,7 +37,7 @@ impl CreateAclRequestHandler {
     }
 
     pub async fn create_acl(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: rocketmq_transport::ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -25,7 +25,7 @@ impl CreateUserRequestHandler {
     }
 
     pub async fn create_user(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
@@ -21,7 +21,7 @@ impl DeleteAclRequestHandler {
     }
 
     pub async fn delete_acl(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -22,7 +22,7 @@ impl DeleteUserRequestHandler {
     }
 
     pub async fn delete_user(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -35,7 +35,7 @@ impl GetAclRequestHandler {
     }
 
     pub async fn get_acl(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: rocketmq_transport::ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -201,9 +201,9 @@ mod tests {
         alice.set_user_status(UserStatus::Enable);
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
-        let mut create_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
-        let mut update_handler = UpdateAclRequestHandler::new(auth_admin_service.clone());
-        let mut get_handler = GetAclRequestHandler::new(auth_admin_service.clone());
+        let create_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
+        let update_handler = UpdateAclRequestHandler::new(auth_admin_service.clone());
+        let get_handler = GetAclRequestHandler::new(auth_admin_service.clone());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -305,10 +305,10 @@ mod tests {
             .await
             .expect("create auth admin service"),
         );
-        let mut create_user_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
-        let mut update_user_handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
-        let mut create_acl_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
-        let mut update_acl_handler = UpdateAclRequestHandler::new(auth_admin_service);
+        let create_user_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
+        let update_user_handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
+        let create_acl_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
+        let update_acl_handler = UpdateAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -422,8 +422,8 @@ mod tests {
             .await
             .expect("create auth admin service"),
         );
-        let mut list_users_handler = ListUsersRequestHandler::new(auth_admin_service.clone());
-        let mut list_acl_handler = ListAclRequestHandler::new(auth_admin_service);
+        let list_users_handler = ListUsersRequestHandler::new(auth_admin_service.clone());
+        let list_acl_handler = ListAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
@@ -493,7 +493,7 @@ mod tests {
         alice.set_user_status(UserStatus::Enable);
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
-        let mut handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
+        let handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -556,7 +556,7 @@ mod tests {
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
-        let mut create_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
+        let create_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
         let mut create_request = RemotingCommand::create_request_command(
             RequestCode::AuthCreateUser,
             CreateUserRequestHeader {
@@ -592,7 +592,7 @@ mod tests {
             Some("The super user can only be create by super user")
         );
 
-        let mut update_handler = UpdateUserRequestHandler::new(auth_admin_service);
+        let update_handler = UpdateUserRequestHandler::new(auth_admin_service);
         let mut update_request = RemotingCommand::create_request_command(
             RequestCode::AuthUpdateUser,
             UpdateUserRequestHeader {
@@ -667,8 +667,8 @@ mod tests {
             .await
             .expect("create acl");
 
-        let mut delete_handler = DeleteAclRequestHandler::new(auth_admin_service.clone());
-        let mut get_handler = GetAclRequestHandler::new(auth_admin_service);
+        let delete_handler = DeleteAclRequestHandler::new(auth_admin_service.clone());
+        let get_handler = GetAclRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut delete_request = RemotingCommand::create_request_command(

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
@@ -34,7 +34,7 @@ impl GetUserRequestHandler {
     }
 
     pub async fn get_user(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -22,7 +22,7 @@ impl ListAclRequestHandler {
     }
 
     pub async fn list_acl(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -34,7 +34,7 @@ impl ListUsersRequestHandler {
     }
 
     pub async fn list_users(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -107,7 +107,7 @@ impl MessageRelatedHandler {
 
     pub async fn resume_check_half_message<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -602,7 +602,7 @@ mod tests {
     #[tokio::test]
     async fn resume_check_half_message_requeues_half_message() {
         let runtime = new_test_runtime("resume-half").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let mut half_message = MessageExtBrokerInner::default();
         half_message.set_topic(CheetahString::from_static_str(
             TransactionalMessageUtil::build_half_topic(),
@@ -638,13 +638,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .resume_check_half_message(
-                &mut admin,
-                channel,
-                ctx,
-                RequestCode::ResumeCheckHalfMessage,
-                &mut request,
-            )
+            .resume_check_half_message(&admin, channel, ctx, RequestCode::ResumeCheckHalfMessage, &mut request)
             .await
             .expect("resume check half message should succeed")
             .expect("resume check half message should return response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -61,8 +61,8 @@ impl NotifyMinBrokerChangeIdHandler {
     }
 
     pub async fn notify_min_broker_id_change<MS: MessageStore>(
-        &mut self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        &self,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -90,8 +90,8 @@ impl NotifyMinBrokerChangeIdHandler {
     }
 
     async fn update_min_broker<MS: MessageStore>(
-        &mut self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        &self,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         change_header: NotifyMinBrokerIdChangeRequestHeader,
     ) -> rocketmq_error::RocketMQResult<()> {
         let broker_config = broker_runtime_inner.broker_config();
@@ -126,7 +126,7 @@ impl NotifyMinBrokerChangeIdHandler {
 
     async fn on_min_broker_change<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         min_broker_id: u64,
         min_broker_addr: &str,
         offline_broker_addr: &Option<CheetahString>,
@@ -177,13 +177,13 @@ impl NotifyMinBrokerChangeIdHandler {
     }
 
     async fn change_special_service_status<MS: MessageStore>(
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         should_start: bool,
     ) {
         broker_runtime_inner.change_special_service_status(should_start).await;
     }
 
-    async fn on_master_offline<MS: MessageStore>(broker_runtime_inner: &mut BrokerAdminRuntime<MS>) {
+    async fn on_master_offline<MS: MessageStore>(broker_runtime_inner: &BrokerAdminRuntime<MS>) {
         if let Some(slave_synchronize) = broker_runtime_inner.slave_synchronize() {
             if let Some(master_addr) = slave_synchronize.master_addr() {
                 let vip_channel = mix_all::broker_vip_channel(true, master_addr.as_str());

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -47,7 +47,7 @@ impl SubscriptionGroupHandler {
 
     pub async fn update_and_create_subscription_group<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -64,7 +64,7 @@ impl SubscriptionGroupHandler {
         let mut config = SubscriptionGroupConfig::decode(request.get_body().unwrap());
         if let Ok(config) = config.as_mut() {
             broker_runtime_inner
-                .subscription_group_manager_mut()
+                .subscription_group_manager()
                 .update_subscription_group_config(config)
         }
         response.set_code_ref(ResponseCode::Success);
@@ -297,7 +297,7 @@ impl SubscriptionGroupHandler {
 
     pub async fn update_and_create_subscription_group_list<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -327,14 +327,14 @@ impl SubscriptionGroupHandler {
         }
 
         broker_runtime_inner
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .update_subscription_group_config_list(subscription_group_list.group_config_list);
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
     pub async fn delete_subscription_group<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -354,7 +354,7 @@ impl SubscriptionGroupHandler {
                 .is_some();
 
         broker_runtime_inner
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .delete_subscription_group_config(request_header.group_name.as_str());
 
         if should_clean_offset {
@@ -373,7 +373,7 @@ impl SubscriptionGroupHandler {
 
     pub async fn update_and_get_group_forbidden<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -390,13 +390,13 @@ impl SubscriptionGroupHandler {
 
         if let Some(readable) = request_header.readable {
             if readable {
-                broker_runtime_inner.subscription_group_manager_mut().clear_forbidden(
+                broker_runtime_inner.subscription_group_manager().clear_forbidden(
                     &request_header.group,
                     &request_header.topic,
                     PermName::INDEX_PERM_READ as i32,
                 );
             } else {
-                broker_runtime_inner.subscription_group_manager_mut().set_forbidden(
+                broker_runtime_inner.subscription_group_manager().set_forbidden(
                     &request_header.group,
                     &request_header.topic,
                     PermName::INDEX_PERM_READ as i32,
@@ -507,7 +507,7 @@ mod tests {
     #[tokio::test]
     async fn update_and_create_subscription_group_list_persists_multiple_groups() {
         let runtime = new_test_runtime("update-list").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let handler = SubscriptionGroupHandler::new();
 
         let body = SubscriptionGroupList {
@@ -524,7 +524,7 @@ mod tests {
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group_list(
-                &mut admin,
+                &admin,
                 channel,
                 ctx,
                 RequestCode::UpdateAndCreateSubscriptionGroupList,
@@ -550,7 +550,7 @@ mod tests {
     #[tokio::test]
     async fn delete_subscription_group_cleans_offsets_for_lite_group_even_without_flag() {
         let runtime = new_test_runtime("delete-group").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let mut config = SubscriptionGroupConfig::new(CheetahString::from_static_str("group-a"));
         config.set_lite_bind_topic(Some(CheetahString::from_static_str("parent-topic")));
         admin
@@ -585,13 +585,7 @@ mod tests {
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .delete_subscription_group(
-                &mut admin,
-                channel,
-                ctx,
-                RequestCode::DeleteSubscriptionGroup,
-                &mut request,
-            )
+            .delete_subscription_group(&admin, channel, ctx, RequestCode::DeleteSubscriptionGroup, &mut request)
             .await
             .expect("delete group request should succeed")
             .expect("delete group request should return response");
@@ -618,7 +612,7 @@ mod tests {
     #[tokio::test]
     async fn update_and_get_group_forbidden_updates_readable_flag() {
         let runtime = new_test_runtime("group-forbidden").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let handler = SubscriptionGroupHandler::new();
         let mut request = RemotingCommand::create_request_command(
             RequestCode::UpdateAndGetGroupForbidden,
@@ -635,7 +629,7 @@ mod tests {
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut response = handler
             .update_and_get_group_forbidden(
-                &mut admin,
+                &admin,
                 channel,
                 ctx,
                 RequestCode::UpdateAndGetGroupForbidden,
@@ -668,7 +662,7 @@ mod tests {
     #[tokio::test]
     async fn subscription_group_cas_commits_once_rejects_stale_and_reports_version() {
         let runtime = new_test_runtime("subscription-group-cas").await;
-        let mut admin = runtime.admin_runtime_for_test();
+        let admin = runtime.admin_runtime_for_test();
         let handler = SubscriptionGroupHandler::new();
         let group = CheetahString::from_static_str("sre-cas-group");
         let mut initial = SubscriptionGroupConfig::new(group.clone());
@@ -676,7 +670,7 @@ mod tests {
         initial.set_consume_broadcast_enable(false);
         initial.set_group_sys_flag(17);
         admin
-            .subscription_group_manager_mut()
+            .subscription_group_manager()
             .update_subscription_group_config(&mut initial);
         let (_, initial_version) = admin
             .subscription_group_manager()

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -562,7 +562,7 @@ impl TopicRequestHandler {
 
     pub async fn delete_topic<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -895,7 +895,7 @@ impl TopicRequestHandler {
 
     fn delete_topic_in_broker<MS: MessageStore>(
         &self,
-        broker_runtime_inner: &mut BrokerAdminRuntime<MS>,
+        broker_runtime_inner: &BrokerAdminRuntime<MS>,
         topic: &CheetahString,
     ) -> Result<(), MessageStoreUnavailable> {
         broker_runtime_inner

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -37,7 +37,7 @@ impl UpdateAclRequestHandler {
     }
 
     pub async fn update_acl(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: rocketmq_transport::ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
@@ -35,7 +35,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
     }
 
     pub async fn update_cold_data_flow_ctr_group_config(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -75,7 +75,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
     }
 
     pub async fn remove_cold_data_flow_ctr_group_config(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -101,7 +101,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
     }
 
     pub async fn get_cold_data_flow_ctr_info(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -185,7 +185,7 @@ mod tests {
     async fn update_and_get_cold_data_flow_ctr_info_round_trips_config() {
         let runtime = new_test_runtime("update-get", true).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
+        let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
         let mut request =
             RemotingCommand::create_request_command(RequestCode::UpdateColdDataFlowCtrConfig, EmptyHeader {})
                 .set_body("group-a=128\ngroup-b=256");
@@ -261,7 +261,7 @@ mod tests {
     async fn update_and_remove_cold_data_flow_ctr_empty_body_match_java_noop_success() {
         let runtime = new_test_runtime("empty-body", true).await;
         let admin = runtime.admin_runtime_for_test();
-        let mut handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
+        let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
 
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
@@ -307,7 +307,7 @@ mod tests {
             .cold_data_cg_ctr_service()
             .expect("cold data service")
             .add_or_update_group_config("group-a", 128);
-        let mut handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
+        let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
         let mut request =
             RemotingCommand::create_request_command(RequestCode::RemoveColdDataFlowCtrConfig, EmptyHeader {})
                 .set_body("group-a");
@@ -337,7 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_cold_data_service_returns_system_error() {
-        let mut handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(None);
+        let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(None);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -34,7 +34,7 @@ impl UpdateGlobalWhiteAddrsConfigRequestHandler {
     }
 
     pub async fn update_global_white_addrs_config(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: rocketmq_transport::ConnectionHandlerContext,
         _request_code: RequestCode,
@@ -170,7 +170,7 @@ mod tests {
         })
         .expect("create provider registry");
         let auth_admin_service = Arc::new(AuthAdminService::with_provider_registry(provider_registry.clone()));
-        let mut handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(auth_admin_service);
+        let handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(auth_admin_service);
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -23,7 +23,7 @@ impl UpdateUserRequestHandler {
     }
 
     pub async fn update_user(
-        &mut self,
+        &self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -354,12 +354,12 @@ impl SubscriptionGroupManager {
         true
     }
 
-    pub(crate) fn update_subscription_group_config(&mut self, config: &mut SubscriptionGroupConfig) {
+    pub(crate) fn update_subscription_group_config(&self, config: &mut SubscriptionGroupConfig) {
         self.update_subscription_group_config_without_persist(config);
         self.persist_after_mutation("update");
     }
 
-    fn update_subscription_group_config_without_persist(&mut self, config: &mut SubscriptionGroupConfig) {
+    fn update_subscription_group_config_without_persist(&self, config: &mut SubscriptionGroupConfig) {
         let _transition = self.metadata_transition.lock();
         let start_time = Instant::now();
         let new_attributes = self.request(config);
@@ -893,7 +893,7 @@ impl SubscriptionGroupManager {
     ///
     /// # Returns
     /// Returns the updated config if the group exists, None otherwise
-    pub fn disable_consume(&mut self, group_name: &CheetahString) -> Option<Arc<SubscriptionGroupConfig>> {
+    pub fn disable_consume(&self, group_name: &CheetahString) -> Option<Arc<SubscriptionGroupConfig>> {
         let result = {
             let _transition = self.metadata_transition.lock();
             let result = self.subscription_group_table.get_mut(group_name).map(|mut entry| {
@@ -927,7 +927,7 @@ impl SubscriptionGroupManager {
     ///
     /// # Returns
     /// Returns the updated config if the group exists, None otherwise
-    pub fn enable_consume(&mut self, group_name: &str) -> Option<Arc<SubscriptionGroupConfig>> {
+    pub fn enable_consume(&self, group_name: &str) -> Option<Arc<SubscriptionGroupConfig>> {
         let result = {
             let _transition = self.metadata_transition.lock();
             let result = self.subscription_group_table.get_mut(group_name).map(|mut entry| {
@@ -976,7 +976,7 @@ impl SubscriptionGroupManager {
     ///
     /// # Returns
     /// Returns the deleted config if it existed, None otherwise
-    pub fn delete_subscription_group_config(&mut self, group_name: &str) -> Option<Arc<SubscriptionGroupConfig>> {
+    pub fn delete_subscription_group_config(&self, group_name: &str) -> Option<Arc<SubscriptionGroupConfig>> {
         let old = {
             let _transition = self.metadata_transition.lock();
             let old = self.subscription_group_table.remove(group_name).map(|(_, v)| v);
@@ -1012,7 +1012,7 @@ impl SubscriptionGroupManager {
     /// * `config_list` - List of subscription group configs to update
     ///
     /// This method updates multiple subscription groups in a single persist operation
-    pub fn update_subscription_group_config_list(&mut self, config_list: Vec<SubscriptionGroupConfig>) {
+    pub fn update_subscription_group_config_list(&self, config_list: Vec<SubscriptionGroupConfig>) {
         if config_list.is_empty() {
             return;
         }
@@ -1033,7 +1033,7 @@ impl SubscriptionGroupManager {
     /// * `forbidden_index` - Forbidden flag bit index (0-31)
     ///
     /// Uses bitwise OR to set the forbidden flag at the specified index
-    pub fn set_forbidden(&mut self, group: &CheetahString, topic: &CheetahString, forbidden_index: i32) {
+    pub fn set_forbidden(&self, group: &CheetahString, topic: &CheetahString, forbidden_index: i32) {
         let topic_forbidden = self.get_forbidden_internal(group, topic);
         let new_forbidden = topic_forbidden | (1 << forbidden_index);
         self.update_forbidden_value(group, topic, new_forbidden);
@@ -1047,7 +1047,7 @@ impl SubscriptionGroupManager {
     /// * `forbidden_index` - Forbidden flag bit index (0-31)
     ///
     /// Uses bitwise AND with complement to clear the forbidden flag at the specified index
-    pub fn clear_forbidden(&mut self, group: &CheetahString, topic: &CheetahString, forbidden_index: i32) {
+    pub fn clear_forbidden(&self, group: &CheetahString, topic: &CheetahString, forbidden_index: i32) {
         if !Self::validate_forbidden_index(forbidden_index) {
             warn!("Invalid forbidden index: {}", forbidden_index);
             return;
@@ -1066,7 +1066,7 @@ impl SubscriptionGroupManager {
     ///
     /// Directly sets the forbidden value, replacing any existing value.
     /// If forbidden_value <= 0, removes the group from the forbidden table.
-    pub fn update_forbidden_value(&mut self, group: &CheetahString, topic: &CheetahString, forbidden_value: i32) {
+    pub fn update_forbidden_value(&self, group: &CheetahString, topic: &CheetahString, forbidden_value: i32) {
         {
             let _transition = self.metadata_transition.lock();
             if forbidden_value <= 0 {
@@ -1440,7 +1440,7 @@ mod tests {
         };
         let manager_config = SubscriptionGroupManagerConfig::from_configs(&broker_config, &message_store_config);
         let rocksdb_path = temp_dir.path().join("config").join("subscriptionGroups");
-        let mut manager = SubscriptionGroupManager::new_with_rocksdb_config_manager(
+        let manager = SubscriptionGroupManager::new_with_rocksdb_config_manager(
             manager_config.clone(),
             StateMachineVersionView::default(),
             Arc::new(
@@ -1496,7 +1496,7 @@ mod tests {
         };
         let manager_config = SubscriptionGroupManagerConfig::from_configs(&broker_config, &message_store_config);
         let rocksdb_path = temp_dir.path().join("config").join("subscriptionGroups-delete");
-        let mut manager = SubscriptionGroupManager::new_with_rocksdb_config_manager(
+        let manager = SubscriptionGroupManager::new_with_rocksdb_config_manager(
             manager_config.clone(),
             StateMachineVersionView::default(),
             Arc::new(
@@ -1566,7 +1566,7 @@ mod tests {
             ..MessageStoreConfig::default()
         };
         let manager_config = SubscriptionGroupManagerConfig::from_configs(&broker_config, &message_store_config);
-        let mut manager = SubscriptionGroupManager::new(manager_config, StateMachineVersionView::default(), None);
+        let manager = SubscriptionGroupManager::new(manager_config, StateMachineVersionView::default(), None);
         let group = CheetahString::from_static_str("SRE_CAS_GROUP");
         let mut config = SubscriptionGroupConfig::new(group.clone());
         config.set_consume_enable(false);

--- a/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
+++ b/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
@@ -1,0 +1,42 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn admin_dispatch_is_shared_without_a_request_wide_mutex() {
+    let processor = include_str!("../src/processor.rs");
+    let request_pipeline = include_str!("../src/broker_runtime/request_pipeline.rs");
+    let admin = include_str!("../src/processor/admin_broker_processor.rs");
+
+    assert!(processor.contains("AdminBroker(Arc<AdminBrokerProcessor<MS>>)"));
+    assert!(processor.contains("processor.process_request_shared(channel, ctx, request).await"));
+    assert!(!processor.contains("Mutex<AdminBrokerProcessor"));
+    assert!(!processor.contains("processor.lock().await.process_request"));
+    assert!(!request_pipeline.contains("Mutex::new(AdminBrokerProcessor::new"));
+    assert!(admin.contains("pub(crate) async fn process_request_shared(\n        &self,"));
+    assert!(admin.contains("async fn process_request_inner(\n        &self,"));
+}
+
+#[test]
+fn admin_mutations_use_domain_owned_synchronization() {
+    let runtime = include_str!("../src/broker/broker_admin_runtime.rs").replace("\r\n", "\n");
+    let subscription_groups =
+        include_str!("../src/subscription/manager/subscription_group_manager.rs").replace("\r\n", "\n");
+
+    assert!(runtime.contains("config_update_lock: Arc<parking_lot::Mutex<()>>"));
+    assert!(runtime.contains("pub(crate) fn commit_broker_config_patch(\n        &self,"));
+    assert!(!runtime.contains("subscription_group_manager_mut("));
+    assert!(subscription_groups.contains("metadata_transition: Arc<parking_lot::Mutex<()>>"));
+    assert!(subscription_groups.contains("pub(crate) fn update_subscription_group_config(&self,"));
+    assert!(subscription_groups.contains("pub fn delete_subscription_group_config(&self,"));
+}

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -93,9 +93,13 @@ use crate::runtime::ClientRuntime;
 use crate::runtime::ClientTrackedTaskHandle;
 use rocketmq_runtime::ChildServiceContext;
 
+mod assignment_registry;
 mod config;
 mod model;
 
+use assignment_registry::AssignmentEntry;
+use assignment_registry::AssignmentRegistry;
+pub use assignment_registry::AssignmentRegistrySnapshot;
 pub(crate) use config::default_lite_pull_consume_timestamp;
 pub(crate) use config::validate_lite_pull_consume_from_where;
 pub use config::LitePullConsumerConfig;
@@ -105,6 +109,7 @@ pub use model::SubscriptionType;
 const QUERY_UNIQ_KEY_LOOKBACK_MILLIS: u64 = 3 * 24 * 60 * 60 * 1000;
 const OFFSET_STORE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const REBALANCE_LISTENER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+const ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_CONSUME_REQUEST_CAPACITY: usize = 10_000;
 const MAX_CONSUME_REQUEST_CAPACITY: usize = 65_536;
 const CONSUME_REQUEST_MAX_AGE: Duration = Duration::from_secs(300);
@@ -117,17 +122,15 @@ enum LitePullTaskHandle {
 }
 
 impl LitePullTaskHandle {
-    fn abort(self) {
+    async fn abort_and_wait(self, timeout: Duration) -> bool {
         match self {
             Self::Tracked { handle, cancelled } => {
                 cancelled.store(true, Ordering::Release);
-                let report = handle.shutdown_now();
-                if !report.is_healthy() {
-                    warn!(
-                        report = %report.to_json(),
-                        "lite pull task immediate shutdown report is unhealthy"
-                    );
+                let stopped = handle.abort_and_wait(timeout).await;
+                if !stopped {
+                    warn!("lite pull task did not stop after abort");
                 }
+                stopped
             }
         }
     }
@@ -189,6 +192,44 @@ async fn sleep_or_cancel(shutdown_signal: &Arc<AtomicBool>, cancelled: &Arc<Atom
         }
 
         tokio::time::sleep((deadline - now).min(Duration::from_millis(50))).await;
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LitePullAssignmentRegistryProbe {
+    pub iterations: usize,
+    pub peak_entries: usize,
+    pub final_entries: usize,
+    pub final_owned_tasks: usize,
+    pub same_queue_serialized: bool,
+    pub different_queues_independent: bool,
+    pub stale_entry_rejected: bool,
+}
+
+async fn sleep_or_assignment_cancel(
+    shutdown_signal: &Arc<AtomicBool>,
+    cancelled: &Arc<AtomicBool>,
+    assignment_cancellation: &CancellationToken,
+    delay: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + delay;
+    loop {
+        if shutdown_signal.load(Ordering::Acquire)
+            || cancelled.load(Ordering::Acquire)
+            || assignment_cancellation.is_cancelled()
+        {
+            return false;
+        }
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return true;
+        }
+
+        tokio::select! {
+            _ = assignment_cancellation.cancelled() => return false,
+            _ = tokio::time::sleep((deadline - now).min(Duration::from_millis(50))) => {}
+        }
     }
 }
 
@@ -295,10 +336,7 @@ pub struct DefaultLitePullConsumerImpl {
 
     // Queue management
     assigned_message_queue: Arc<AssignedMessageQueue>,
-    message_queue_locks: Arc<RwLock<HashMap<MessageQueue, Arc<Mutex<()>>>>>,
-
-    // Pull task scheduling
-    task_handles: Arc<RwLock<HashMap<MessageQueue, LitePullTaskHandle>>>,
+    assignment_registry: Arc<AssignmentRegistry>,
 
     // Message flow
     consume_requests: BudgetedQueue<LitePullConsumeRequest>,
@@ -383,8 +421,7 @@ impl DefaultLitePullConsumerImpl {
             offset_store: StdRwLock::new(None),
             rpc_hook: StdRwLock::new(None),
             assigned_message_queue: Arc::new(AssignedMessageQueue::new()),
-            message_queue_locks: Arc::new(RwLock::new(HashMap::new())),
-            task_handles: Arc::new(RwLock::new(HashMap::new())),
+            assignment_registry: Arc::new(AssignmentRegistry::new()),
             consume_requests,
             poll_lock: Arc::new(Mutex::new(())),
             topic_to_sub_expression: Arc::new(RwLock::new(HashMap::new())),
@@ -738,27 +775,14 @@ impl DefaultLitePullConsumerImpl {
     }
 
     async fn update_pull_task_for_topic(&self, topic: &str, assigned: &HashSet<MessageQueue>) -> RocketMQResult<()> {
-        let to_start = {
-            let mut task_handles = self.task_handles.write().await;
-            let to_remove: Vec<MessageQueue> = task_handles
-                .keys()
-                .filter(|mq| mq.topic() == topic && !assigned.contains(*mq))
-                .cloned()
-                .collect();
-            for mq in to_remove {
-                if let Some(handle) = task_handles.remove(&mq) {
-                    handle.abort();
-                }
+        self.assignment_registry.reconcile_topic(topic, assigned).await;
+        for mq in assigned {
+            let Some(entry) = self.assignment_registry.ensure(mq.clone()).await else {
+                return Err(crate::mq_client_err!("LitePull assignment registry is closed"));
+            };
+            if !entry.has_task().await {
+                self.start_pull_task(mq.clone()).await?;
             }
-            assigned
-                .iter()
-                .filter(|mq| !task_handles.contains_key(*mq))
-                .cloned()
-                .collect::<Vec<_>>()
-        };
-
-        for mq in to_start {
-            self.start_pull_task(mq).await?;
         }
         Ok(())
     }
@@ -780,22 +804,10 @@ impl DefaultLitePullConsumerImpl {
     /// Updates assigned message queues for ASSIGN mode.
     async fn update_assigned_message_queue_for_assign(&self, assigned: &[MessageQueue]) {
         let assigned_set: HashSet<MessageQueue> = assigned.iter().cloned().collect();
-
-        let to_remove: Vec<MessageQueue> = {
-            let task_handles = self.task_handles.read().await;
-            task_handles
-                .keys()
-                .filter(|mq| !assigned_set.contains(mq))
-                .cloned()
-                .collect()
-        };
-
-        if !to_remove.is_empty() {
-            let mut task_handles = self.task_handles.write().await;
-            for mq in &to_remove {
-                if let Some(handle) = task_handles.remove(mq) {
-                    handle.abort();
-                }
+        self.assignment_registry.reconcile_all(&assigned_set).await;
+        for mq in &assigned_set {
+            if self.assignment_registry.ensure(mq.clone()).await.is_none() {
+                warn!("Skip registering LitePull assignment after shutdown: {}", mq);
             }
         }
 
@@ -806,17 +818,13 @@ impl DefaultLitePullConsumerImpl {
 
     /// Starts pull tasks for assigned queues in ASSIGN mode.
     async fn update_pull_task_for_assign(&self, assigned: &[MessageQueue]) -> RocketMQResult<()> {
-        let to_start: Vec<MessageQueue> = {
-            let task_handles = self.task_handles.read().await;
-            assigned
-                .iter()
-                .filter(|mq| !task_handles.contains_key(mq))
-                .cloned()
-                .collect()
-        };
-
-        for mq in to_start {
-            self.start_pull_task(mq).await?;
+        for mq in assigned {
+            let Some(entry) = self.assignment_registry.ensure(mq.clone()).await else {
+                return Err(crate::mq_client_err!("LitePull assignment registry is closed"));
+            };
+            if !entry.has_task().await {
+                self.start_pull_task(mq.clone()).await?;
+            }
         }
         Ok(())
     }
@@ -1231,10 +1239,13 @@ impl DefaultLitePullConsumerImpl {
                     }
                 }
 
-                // Wait for all pull tasks to complete (5s timeout)
-                let handles: Vec<_> = self.task_handles.write().await.drain().collect();
-                for (mq, handle) in handles {
-                    if !handle.wait(Duration::from_secs(5)).await {
+                // Close assignment admission, then cancel and await every owned pull task.
+                let reports = self
+                    .assignment_registry
+                    .close_and_shutdown(Duration::from_secs(5))
+                    .await;
+                for (mq, healthy) in reports {
+                    if !healthy {
                         warn!("Pull task for {:?} did not finish in time", mq);
                     }
                 }
@@ -1451,11 +1462,13 @@ impl DefaultLitePullConsumerImpl {
 
     /// Spawns an async pull task for a message queue.
     async fn start_pull_task(&self, mq: MessageQueue) -> RocketMQResult<()> {
-        {
-            let task_handles = self.task_handles.read().await;
-            if task_handles.contains_key(&mq) {
-                return Ok(());
-            }
+        let entry = self
+            .assignment_registry
+            .get(&mq)
+            .await
+            .ok_or_else(|| crate::mq_client_err!(format!("Message queue is not actively assigned: {mq}")))?;
+        if entry.has_task().await {
+            return Ok(());
         }
 
         let weak_default_impl = self
@@ -1466,6 +1479,10 @@ impl DefaultLitePullConsumerImpl {
         let shutdown_signal = self.shutdown_signal.clone();
         let task_cancelled = Arc::new(AtomicBool::new(false));
         let task_cancelled_for_task = task_cancelled.clone();
+        let assignment_cancellation = entry.cancellation();
+        let task_generation = entry.next_task_generation();
+        let assignment_entry = Arc::downgrade(&entry);
+        let (start_task_tx, start_task_rx) = tokio::sync::oneshot::channel();
         let assigned_mq = self.assigned_message_queue.clone();
         let mq_clone = mq.clone();
 
@@ -1474,8 +1491,14 @@ impl DefaultLitePullConsumerImpl {
             "rocketmq-client-lite-pull-task",
             task_cancelled,
             async move {
+                if start_task_rx.await.is_err() {
+                    return;
+                }
                 loop {
-                    if shutdown_signal.load(Ordering::Acquire) || task_cancelled_for_task.load(Ordering::Acquire) {
+                    if shutdown_signal.load(Ordering::Acquire)
+                        || task_cancelled_for_task.load(Ordering::Acquire)
+                        || assignment_cancellation.is_cancelled()
+                    {
                         break;
                     }
 
@@ -1489,9 +1512,10 @@ impl DefaultLitePullConsumerImpl {
                     };
 
                     if assigned_mq.is_paused(&mq_clone).await {
-                        if !sleep_or_cancel(
+                        if !sleep_or_assignment_cancel(
                             &shutdown_signal,
                             &task_cancelled_for_task,
+                            &assignment_cancellation,
                             Duration::from_millis(
                                 default_impl
                                     .consumer_config
@@ -1509,9 +1533,10 @@ impl DefaultLitePullConsumerImpl {
                     match default_impl.pull_inner(&mq_clone, &pq).await {
                         Ok(delay) => {
                             if delay > 0
-                                && !sleep_or_cancel(
+                                && !sleep_or_assignment_cancel(
                                     &shutdown_signal,
                                     &task_cancelled_for_task,
+                                    &assignment_cancellation,
                                     Duration::from_millis(delay),
                                 )
                                 .await
@@ -1521,9 +1546,10 @@ impl DefaultLitePullConsumerImpl {
                         }
                         Err(e) => {
                             tracing::error!("Pull error for {:?}: {}", mq_clone, e);
-                            if !sleep_or_cancel(
+                            if !sleep_or_assignment_cancel(
                                 &shutdown_signal,
                                 &task_cancelled_for_task,
+                                &assignment_cancellation,
                                 Duration::from_millis(
                                     default_impl
                                         .consumer_config
@@ -1538,17 +1564,28 @@ impl DefaultLitePullConsumerImpl {
                         }
                     }
                 }
+                if let Some(entry) = assignment_entry.upgrade() {
+                    entry.clear_task_if_generation(task_generation).await;
+                }
             },
         )
         .map_err(|error| crate::mq_client_err!(format!("failed to spawn pull task for {mq}: {error}")))?;
 
-        let mut task_handles = self.task_handles.write().await;
-        match task_handles.entry(mq) {
-            std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(handle);
+        match self
+            .assignment_registry
+            .install_task(&mq, &entry, task_generation, handle)
+            .await
+        {
+            Ok(()) => {
+                if start_task_tx.send(()).is_err() {
+                    if let Some(handle) = entry.take_task_if_generation(task_generation).await {
+                        handle.abort_and_wait(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
+                    }
+                }
             }
-            std::collections::hash_map::Entry::Occupied(_) => {
-                handle.abort();
+            Err(handle) => {
+                drop(start_task_tx);
+                handle.abort_and_wait(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
             }
         }
         Ok(())
@@ -1620,8 +1657,11 @@ impl DefaultLitePullConsumerImpl {
                     .into_iter()
                     .map(Arc::new)
                     .collect::<Vec<_>>();
-                let lock = self.message_queue_lock(mq).await;
+                let (entry, lock) = self.assignment_operation(mq).await?;
                 let _guard = lock.lock().await;
+                if entry.is_retired() {
+                    return Ok(0);
+                }
                 let result_is_current = self
                     .update_pull_offset_if_no_pending_seek(
                         mq,
@@ -1653,8 +1693,11 @@ impl DefaultLitePullConsumerImpl {
                 Ok(0)
             }
             PullStatus::NoNewMsg | PullStatus::NoMatchedMsg => {
-                let lock = self.message_queue_lock(mq).await;
+                let (entry, lock) = self.assignment_operation(mq).await?;
                 let _guard = lock.lock().await;
+                if entry.is_retired() {
+                    return Ok(0);
+                }
                 self.update_pull_offset_if_no_pending_seek(
                     mq,
                     pull_result.pull_result.next_begin_offset as i64,
@@ -1679,12 +1722,15 @@ impl DefaultLitePullConsumerImpl {
         }
     }
 
-    async fn message_queue_lock(&self, message_queue: &MessageQueue) -> Arc<Mutex<()>> {
-        let mut locks = self.message_queue_locks.write().await;
-        locks
-            .entry(message_queue.clone())
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
+    async fn assignment_operation(
+        &self,
+        message_queue: &MessageQueue,
+    ) -> RocketMQResult<(Arc<AssignmentEntry>, Arc<Mutex<()>>)> {
+        let entry =
+            self.assignment_registry.get(message_queue).await.ok_or_else(|| {
+                crate::mq_client_err!(format!("Message queue is not actively assigned: {message_queue}"))
+            })?;
+        Ok((entry.clone(), entry.operation_lock()))
     }
 
     async fn update_pull_offset_if_no_pending_seek(
@@ -1709,8 +1755,13 @@ impl DefaultLitePullConsumerImpl {
         process_queue: &Arc<crate::consumer::consumer_impl::process_queue::ProcessQueue>,
         next_pull_offset: i64,
     ) -> u64 {
-        let lock = self.message_queue_lock(mq).await;
+        let Ok((entry, lock)) = self.assignment_operation(mq).await else {
+            return self.consumer_config.load().pull_time_delay_millis_when_exception;
+        };
         let _guard = lock.lock().await;
+        if entry.is_retired() {
+            return self.consumer_config.load().pull_time_delay_millis_when_exception;
+        }
         self.update_pull_offset_if_no_pending_seek(mq, next_pull_offset, process_queue)
             .await;
         self.consumer_config.load().pull_time_delay_millis_when_exception
@@ -2087,6 +2138,12 @@ impl DefaultLitePullConsumerImpl {
         self.assigned_message_queue.message_queues().await
     }
 
+    /// Returns low-cardinality lifecycle diagnostics for LitePull assignments.
+    #[must_use]
+    pub async fn assignment_registry_snapshot(&self) -> AssignmentRegistrySnapshot {
+        self.assignment_registry.snapshot().await
+    }
+
     /// Registers a consume message hook for monitoring message consumption.
     pub fn register_consume_message_hook(&self, hook: Arc<dyn ConsumeMessageHook + Send + Sync>) {
         self.consume_message_hook_list
@@ -2179,8 +2236,13 @@ impl DefaultLitePullConsumerImpl {
             }
         }
 
-        let lock = self.message_queue_lock(message_queue).await;
+        let (entry, lock) = self.assignment_operation(message_queue).await?;
         let _guard = lock.lock().await;
+        if entry.is_retired() {
+            return Err(crate::mq_client_err!(format!(
+                "Message queue assignment was removed: {message_queue}"
+            )));
+        }
 
         // Check again under the queue lock in case rebalance changed assignment after offset lookup.
         self.ensure_message_queue_assigned(message_queue).await?;
@@ -2198,18 +2260,18 @@ impl DefaultLitePullConsumerImpl {
         let _poll_guard = self.poll_lock.lock().await;
         self.clear_message_queue_in_cache(message_queue).await;
 
-        // Stop old pull task
-        let mut task_handles = self.task_handles.write().await;
-        if let Some(handle) = task_handles.remove(message_queue) {
-            handle.abort();
+        // Stop and join the task owned by this assignment entry before restarting it.
+        if let Some(handle) = entry.take_task().await {
+            if !handle.abort_and_wait(Duration::from_secs(5)).await {
+                warn!("Pull task for {:?} did not finish before seek restart", message_queue);
+            }
         }
 
         // Set seek offset
         self.assigned_message_queue.set_seek_offset(message_queue, offset).await;
 
         // Start new pull task
-        if !task_handles.contains_key(message_queue) {
-            drop(task_handles); // Release write lock before starting pull task
+        if self.assignment_registry.is_current(message_queue, &entry).await {
             self.start_pull_task(message_queue.clone()).await?;
         }
 
@@ -2270,23 +2332,8 @@ impl DefaultLitePullConsumerImpl {
         // Remove from rebalance_impl subscription
         self.rebalance_impl.get_subscription_inner().remove(&topic);
 
-        // Stop and remove pull tasks for this topic
-        let to_remove = {
-            let task_handles = self.task_handles.read().await;
-            task_handles
-                .keys()
-                .filter(|mq| mq.topic() == topic.as_str())
-                .cloned()
-                .collect::<Vec<_>>()
-        };
-        if !to_remove.is_empty() {
-            let mut task_handles = self.task_handles.write().await;
-            for mq in to_remove {
-                if let Some(handle) = task_handles.remove(&mq) {
-                    handle.abort();
-                }
-            }
-        }
+        // Detach, cancel, and join every queue-scoped resource for this topic.
+        self.assignment_registry.remove_topic(topic.as_str()).await;
 
         // Remove from assigned_message_queue
         self.assigned_message_queue
@@ -3004,6 +3051,57 @@ pub async fn run_lite_pull_task_lifecycle_probe(service_context: ChildServiceCon
     }
 }
 
+#[doc(hidden)]
+pub async fn run_lite_pull_assignment_registry_probe(iterations: usize) -> LitePullAssignmentRegistryProbe {
+    let registry = AssignmentRegistry::new();
+    let mut peak_entries = 0;
+
+    for queue_id in 0..iterations {
+        let queue_id = i32::try_from(queue_id % i32::MAX as usize).unwrap_or_default();
+        let queue = MessageQueue::from_parts("assignment-churn", "broker-a", queue_id);
+        registry
+            .ensure(queue.clone())
+            .await
+            .expect("probe registry remains open");
+        peak_entries = peak_entries.max(registry.snapshot().await.entries);
+        assert!(registry.remove_and_wait(&queue).await);
+    }
+
+    let first_queue = MessageQueue::from_parts("assignment-lock", "broker-a", 0);
+    let second_queue = MessageQueue::from_parts("assignment-lock", "broker-a", 1);
+    let first_entry = registry
+        .ensure(first_queue.clone())
+        .await
+        .expect("probe registry remains open");
+    let second_entry = registry
+        .ensure(second_queue.clone())
+        .await
+        .expect("probe registry remains open");
+    let first_lock = first_entry.operation_lock();
+    let first_guard = first_lock.lock().await;
+    let same_queue_serialized = first_lock.try_lock().is_err();
+    let second_lock = second_entry.operation_lock();
+    let different_queues_independent = second_lock.try_lock().is_ok();
+    drop(first_guard);
+
+    let stale_entry = Arc::clone(&first_entry);
+    assert!(registry.remove_and_wait(&first_queue).await);
+    let stale_entry_rejected = !registry.is_current(&first_queue, &stale_entry).await;
+    assert!(registry.remove_and_wait(&second_queue).await);
+    registry.close_and_shutdown(Duration::from_secs(1)).await;
+    let final_snapshot = registry.snapshot().await;
+
+    LitePullAssignmentRegistryProbe {
+        iterations,
+        peak_entries,
+        final_entries: final_snapshot.entries,
+        final_owned_tasks: final_snapshot.owned_tasks,
+        same_queue_serialized,
+        different_queues_independent,
+        stale_entry_rejected,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;
@@ -3075,8 +3173,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn spawn_lite_pull_task_uses_injected_runtime_context() {
+    #[tokio::test]
+    async fn spawn_lite_pull_task_uses_injected_runtime_context() {
         let (tx, rx) = std::sync::mpsc::channel();
         let cancelled = Arc::new(AtomicBool::new(false));
 
@@ -3096,7 +3194,38 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("injected lite pull task should complete");
         assert_eq!(thread_name, "rocketmq-client-unit-test");
-        handle.abort();
+        assert!(handle.abort_and_wait(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await);
+    }
+
+    #[tokio::test]
+    async fn naturally_completed_pull_task_clears_its_owned_handle() {
+        let impl_ = Arc::new(DefaultLitePullConsumerImpl::new(
+            crate::runtime::test_client_runtime("lite-pull-natural-task-completion-test"),
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("natural-task-completion-group"),
+                ..Default::default()
+            }),
+        ));
+        impl_.bind_self();
+        let mq = MessageQueue::from_parts("natural-task-completion-topic", "broker-a", 0);
+        impl_
+            .assignment_registry
+            .ensure(mq.clone())
+            .await
+            .expect("assignment registry is open");
+
+        impl_.start_pull_task(mq.clone()).await.expect("pull task should start");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while impl_.assignment_registry_snapshot().await.owned_tasks != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("naturally completed task should clear its owned handle");
+
+        assert!(impl_.assignment_registry.remove_and_wait(&mq).await);
     }
 
     #[tokio::test]
@@ -3546,16 +3675,10 @@ mod tests {
             .await
             .expect("operate_after_running should start preassigned pull task");
 
-        assert!(impl_.task_handles.read().await.contains_key(&mq));
+        assert_eq!(impl_.assignment_registry_snapshot().await.owned_tasks, 1);
 
         impl_.shutdown_signal.store(true, Ordering::Release);
-        let handle = {
-            let mut task_handles = impl_.task_handles.write().await;
-            task_handles.remove(&mq)
-        };
-        if let Some(handle) = handle {
-            handle.abort();
-        }
+        impl_.assignment_registry.remove_and_wait(&mq).await;
     }
 
     #[tokio::test]
@@ -3593,7 +3716,20 @@ mod tests {
             },
         )
         .expect("lite pull assign abort test task should spawn");
-        impl_.task_handles.write().await.insert(removed_mq.clone(), handle);
+        let entry = impl_
+            .assignment_registry
+            .ensure(removed_mq.clone())
+            .await
+            .expect("assignment registry is open");
+        let task_generation = entry.next_task_generation();
+        assert!(
+            impl_
+                .assignment_registry
+                .install_task(&removed_mq, &entry, task_generation, handle)
+                .await
+                .is_ok(),
+            "test task should be installed"
+        );
         tokio::time::timeout(Duration::from_secs(1), started_rx)
             .await
             .expect("lite pull assign abort test task should start")
@@ -3603,7 +3739,7 @@ mod tests {
             .update_assigned_message_queue_for_assign(std::slice::from_ref(&retained_mq))
             .await;
 
-        assert!(!impl_.task_handles.read().await.contains_key(&removed_mq));
+        assert!(impl_.assignment_registry.get(&removed_mq).await.is_none());
         for _ in 0..20 {
             if task_aborted.load(AtomicOrdering::SeqCst) {
                 break;
@@ -4325,6 +4461,11 @@ mod tests {
         );
         let mq = MessageQueue::from_parts("topic-offset-illegal", "broker-a", 0);
         impl_.assigned_message_queue.put(mq.clone()).await;
+        impl_
+            .assignment_registry
+            .ensure(mq.clone())
+            .await
+            .expect("assignment registry is open");
         let process_queue = impl_
             .assigned_message_queue
             .get_process_queue(&mq)
@@ -4368,19 +4509,15 @@ mod tests {
         assert!(!assigned.contains(&mq0));
         assert!(assigned.contains(&mq1));
 
-        let task_handles = impl_.task_handles.read().await;
-        assert!(!task_handles.contains_key(&mq0));
-        assert!(task_handles.contains_key(&mq1));
-        drop(task_handles);
+        assert!(impl_.assignment_registry.get(&mq0).await.is_none());
+        assert!(impl_.assignment_registry.get(&mq1).await.is_some());
+        assert_eq!(impl_.assignment_registry_snapshot().await.owned_tasks, 1);
 
         impl_.shutdown_signal.store(true, Ordering::Release);
-        let handles = {
-            let mut task_handles = impl_.task_handles.write().await;
-            task_handles.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
-        };
-        for handle in handles {
-            handle.abort();
-        }
+        impl_
+            .assignment_registry
+            .close_and_shutdown(Duration::from_secs(1))
+            .await;
     }
 
     struct CountingMessageQueueListener {
@@ -4450,13 +4587,10 @@ mod tests {
         );
 
         impl_.shutdown_signal.store(true, Ordering::Release);
-        let handles = {
-            let mut task_handles = impl_.task_handles.write().await;
-            task_handles.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
-        };
-        for handle in handles {
-            handle.abort();
-        }
+        impl_
+            .assignment_registry
+            .close_and_shutdown(Duration::from_secs(1))
+            .await;
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/assignment_registry.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/assignment_registry.rs
@@ -1,0 +1,296 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_model::common::message::message_queue::MessageQueue;
+use tokio::sync::Mutex;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+use super::LitePullTaskHandle;
+use super::ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AssignmentRegistrySnapshot {
+    pub entries: usize,
+    pub owned_tasks: usize,
+    pub closed: bool,
+}
+
+/// Owns every queue-scoped resource for one active LitePull assignment.
+pub(super) struct AssignmentEntry {
+    operation_lock: Arc<Mutex<()>>,
+    task: Mutex<Option<OwnedLitePullTask>>,
+    next_task_generation: AtomicU64,
+    cancellation: CancellationToken,
+    retired: AtomicBool,
+}
+
+struct OwnedLitePullTask {
+    generation: u64,
+    handle: LitePullTaskHandle,
+}
+
+impl AssignmentEntry {
+    fn new() -> Self {
+        Self {
+            operation_lock: Arc::new(Mutex::new(())),
+            task: Mutex::new(None),
+            next_task_generation: AtomicU64::new(1),
+            cancellation: CancellationToken::new(),
+            retired: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) fn operation_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.operation_lock)
+    }
+
+    pub(super) fn cancellation(&self) -> CancellationToken {
+        self.cancellation.clone()
+    }
+
+    pub(super) fn is_retired(&self) -> bool {
+        self.retired.load(Ordering::Acquire)
+    }
+
+    fn retire(&self) {
+        self.retired.store(true, Ordering::Release);
+        self.cancellation.cancel();
+    }
+
+    pub(super) fn next_task_generation(&self) -> u64 {
+        self.next_task_generation.fetch_add(1, Ordering::Relaxed)
+    }
+
+    async fn install_task(&self, generation: u64, handle: LitePullTaskHandle) -> Result<(), LitePullTaskHandle> {
+        if self.is_retired() {
+            return Err(handle);
+        }
+        let mut task = self.task.lock().await;
+        if self.is_retired() || task.is_some() {
+            return Err(handle);
+        }
+        *task = Some(OwnedLitePullTask { generation, handle });
+        Ok(())
+    }
+
+    pub(super) async fn has_task(&self) -> bool {
+        self.task.lock().await.is_some()
+    }
+
+    pub(super) async fn take_task(&self) -> Option<LitePullTaskHandle> {
+        self.task.lock().await.take().map(|task| task.handle)
+    }
+
+    pub(super) async fn take_task_if_generation(&self, generation: u64) -> Option<LitePullTaskHandle> {
+        let mut task = self.task.lock().await;
+        if task.as_ref().is_some_and(|task| task.generation == generation) {
+            return task.take().map(|task| task.handle);
+        }
+        None
+    }
+
+    pub(super) async fn clear_task_if_generation(&self, generation: u64) {
+        drop(self.take_task_if_generation(generation).await);
+    }
+
+    async fn shutdown(&self, timeout: Duration) -> bool {
+        self.retire();
+        match self.take_task().await {
+            Some(handle) => handle.wait(timeout).await,
+            None => true,
+        }
+    }
+}
+
+/// Canonical lifecycle registry for LitePull queue assignments.
+pub(super) struct AssignmentRegistry {
+    entries: RwLock<HashMap<MessageQueue, Arc<AssignmentEntry>>>,
+    closed: AtomicBool,
+}
+
+impl AssignmentRegistry {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) async fn ensure(&self, message_queue: MessageQueue) -> Option<Arc<AssignmentEntry>> {
+        if self.closed.load(Ordering::Acquire) {
+            return None;
+        }
+        if let Some(entry) = self.entries.read().await.get(&message_queue) {
+            return Some(Arc::clone(entry));
+        }
+        let mut entries = self.entries.write().await;
+        if self.closed.load(Ordering::Acquire) {
+            return None;
+        }
+        Some(
+            entries
+                .entry(message_queue)
+                .or_insert_with(|| Arc::new(AssignmentEntry::new()))
+                .clone(),
+        )
+    }
+
+    pub(super) async fn get(&self, message_queue: &MessageQueue) -> Option<Arc<AssignmentEntry>> {
+        self.entries.read().await.get(message_queue).cloned()
+    }
+
+    pub(super) async fn is_current(&self, message_queue: &MessageQueue, expected: &Arc<AssignmentEntry>) -> bool {
+        self.entries
+            .read()
+            .await
+            .get(message_queue)
+            .is_some_and(|current| Arc::ptr_eq(current, expected))
+            && !expected.is_retired()
+    }
+
+    pub(super) async fn install_task(
+        &self,
+        message_queue: &MessageQueue,
+        expected: &Arc<AssignmentEntry>,
+        generation: u64,
+        handle: LitePullTaskHandle,
+    ) -> Result<(), LitePullTaskHandle> {
+        if !self.is_current(message_queue, expected).await {
+            return Err(handle);
+        }
+        expected.install_task(generation, handle).await
+    }
+
+    pub(super) async fn remove(&self, message_queue: &MessageQueue) -> Option<Arc<AssignmentEntry>> {
+        let removed = self.entries.write().await.remove(message_queue);
+        if let Some(entry) = removed.as_ref() {
+            entry.retire();
+        }
+        removed
+    }
+
+    pub(super) async fn remove_and_wait(&self, message_queue: &MessageQueue) -> bool {
+        if let Some(entry) = self.remove(message_queue).await {
+            return entry.shutdown(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
+        }
+        true
+    }
+
+    pub(super) async fn reconcile_topic(&self, topic: &str, assigned: &HashSet<MessageQueue>) -> Vec<MessageQueue> {
+        let removed = {
+            let mut entries = self.entries.write().await;
+            let queues = entries
+                .keys()
+                .filter(|queue| queue.topic() == topic && !assigned.contains(*queue))
+                .cloned()
+                .collect::<Vec<_>>();
+            queues
+                .into_iter()
+                .filter_map(|queue| entries.remove(&queue).map(|entry| (queue, entry)))
+                .collect::<Vec<_>>()
+        };
+        for (_, entry) in &removed {
+            entry.retire();
+        }
+        let mut removed_queues = Vec::with_capacity(removed.len());
+        for (queue, entry) in removed {
+            entry.shutdown(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
+            removed_queues.push(queue);
+        }
+        removed_queues
+    }
+
+    pub(super) async fn reconcile_all(&self, assigned: &HashSet<MessageQueue>) -> Vec<MessageQueue> {
+        let removed = {
+            let mut entries = self.entries.write().await;
+            let queues = entries
+                .keys()
+                .filter(|queue| !assigned.contains(*queue))
+                .cloned()
+                .collect::<Vec<_>>();
+            queues
+                .into_iter()
+                .filter_map(|queue| entries.remove(&queue).map(|entry| (queue, entry)))
+                .collect::<Vec<_>>()
+        };
+        for (_, entry) in &removed {
+            entry.retire();
+        }
+        let mut removed_queues = Vec::with_capacity(removed.len());
+        for (queue, entry) in removed {
+            entry.shutdown(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
+            removed_queues.push(queue);
+        }
+        removed_queues
+    }
+
+    pub(super) async fn remove_topic(&self, topic: &str) {
+        let removed = {
+            let mut entries = self.entries.write().await;
+            let queues = entries
+                .keys()
+                .filter(|queue| queue.topic() == topic)
+                .cloned()
+                .collect::<Vec<_>>();
+            queues
+                .into_iter()
+                .filter_map(|queue| entries.remove(&queue))
+                .collect::<Vec<_>>()
+        };
+        for entry in &removed {
+            entry.retire();
+        }
+        for entry in removed {
+            entry.shutdown(ASSIGNMENT_TASK_SHUTDOWN_TIMEOUT).await;
+        }
+    }
+
+    pub(super) async fn close_and_shutdown(&self, timeout: Duration) -> Vec<(MessageQueue, bool)> {
+        self.closed.store(true, Ordering::Release);
+        let removed = {
+            let mut entries = self.entries.write().await;
+            std::mem::take(&mut *entries)
+        };
+        for entry in removed.values() {
+            entry.retire();
+        }
+        let mut reports = Vec::with_capacity(removed.len());
+        for (queue, entry) in removed {
+            reports.push((queue, entry.shutdown(timeout).await));
+        }
+        reports
+    }
+
+    pub(super) async fn snapshot(&self) -> AssignmentRegistrySnapshot {
+        let entries = self.entries.read().await.values().cloned().collect::<Vec<_>>();
+        let mut owned_tasks = 0;
+        for entry in &entries {
+            owned_tasks += usize::from(entry.has_task().await);
+        }
+        AssignmentRegistrySnapshot {
+            entries: entries.len(),
+            owned_tasks,
+            closed: self.closed.load(Ordering::Acquire),
+        }
+    }
+}

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -854,7 +854,11 @@ pub use crate::consumer::consumer_impl::consume_message_pop_orderly_service::run
 #[doc(hidden)]
 pub use crate::consumer::consumer_impl::consume_message_pop_orderly_service::PopOrderlyLockRefreshLifecycleProbe;
 #[doc(hidden)]
+pub use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::run_lite_pull_assignment_registry_probe;
+#[doc(hidden)]
 pub use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::run_lite_pull_task_lifecycle_probe;
+#[doc(hidden)]
+pub use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::LitePullAssignmentRegistryProbe;
 #[doc(hidden)]
 pub use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::LitePullTaskLifecycleProbe;
 #[doc(hidden)]

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -364,6 +364,13 @@ impl ClientTrackedTaskHandle {
         timed_out_task_report(self.task_name, started_at.elapsed(), aborted)
     }
 
+    pub(crate) async fn abort_and_wait(self, timeout: Duration) -> bool {
+        if !self.task_group.contains_task(self.task_id) {
+            return true;
+        }
+        self.task_group.abort_task_and_wait(self.task_id, timeout).await || !self.task_group.contains_task(self.task_id)
+    }
+
     pub(crate) fn shutdown_blocking(self, timeout: Duration) -> (ShutdownReport, bool) {
         let started_at = Instant::now();
         let completed = match self.completion_rx.into_inner() {
@@ -680,6 +687,20 @@ mod tests {
         let report = second.shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
         assert_eq!(report.completed, 1);
+
+        let report = service_context.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn tracked_task_abort_waits_for_registry_removal() {
+        let service_context = test_service_context("client-tracked-task-abort-wait-test");
+        let handle =
+            spawn_client_tracked_task_with_context(&service_context, "abort-and-wait-task", std::future::pending())
+                .expect("tracked task should spawn");
+
+        assert!(handle.abort_and_wait(Duration::from_secs(1)).await);
+        assert_eq!(service_context.task_group().task_count(), 0);
 
         let report = service_context.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());

--- a/rocketmq-client/tests/lite_pull_assignment_registry_tests.rs
+++ b/rocketmq-client/tests/lite_pull_assignment_registry_tests.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_client_rust::run_lite_pull_assignment_registry_probe;
+
+#[tokio::test]
+async fn assignment_registry_releases_every_resource_after_100k_churn() {
+    const ITERATIONS: usize = 100_000;
+
+    let result = run_lite_pull_assignment_registry_probe(ITERATIONS).await;
+
+    assert_eq!(result.iterations, ITERATIONS);
+    assert_eq!(result.peak_entries, 1);
+    assert_eq!(result.final_entries, 0);
+    assert_eq!(result.final_owned_tasks, 0);
+    assert!(result.same_queue_serialized);
+    assert!(result.different_queues_independent);
+    assert!(result.stale_entry_rejected);
+}
+
+#[test]
+fn lite_pull_queue_resources_have_one_registry_owner() {
+    let source = include_str!("../src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs");
+
+    assert!(source.contains("assignment_registry: Arc<AssignmentRegistry>"));
+    assert!(!source.contains("message_queue_locks:"));
+    assert!(!source.contains("task_handles:"));
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8867

### Brief Description

- Removes request-wide serialization from the broker admin processor and dispatches shared handlers through `Arc<AdminBrokerProcessor<_>>`.
- Keeps mutable admin state behind existing domain-scoped synchronization instead of a processor-wide mutex.
- Introduces a LitePull assignment registry that owns each queue's operation lock, cancellation token, task handle, retirement state, and task generation.
- Makes assignment removal, seek, unsubscribe, and shutdown cancel and await owned pull tasks without holding the registry write lock across an await.
- Adds focused broker concurrency contracts and a 100,000-iteration LitePull assignment churn test.

### How Did You Test This Change?

- `cargo fmt --all -- --check` on the changed files: passed. The repository-wide Windows invocation still reaches OS error 206, so the final non-mutating check was scoped to every changed Rust file.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-broker --test admin_processor_concurrency_tests`: passed (2 tests).
- `cargo test -p rocketmq-client-rust --test lite_pull_assignment_registry_tests`: passed (2 tests, including 100,000 assignment churn iterations).
- `cargo test -p rocketmq-client-rust --all-targets --all-features`: 1,029 passed and one pre-existing `TaskGroup` lifecycle test failed; the same failure was reproduced on the exact base commit.
- `cargo test -p rocketmq-broker --all-targets --all-features`: 737 passed, 2 ignored, and 11 pre-existing `TaskGroup` lifecycle tests failed; the same set is present on the PR-03 implementation baseline.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `.\scripts\check-error-hygiene.ps1`: passed.
- `python scripts/run_architecture_tests.py --tier pr_static`: 10 modules passed; the same 8 baseline modules failed with no new failing module.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz`: passed.
- The `rocketmq-sre` workspace check, tests, Clippy, Rustdoc, source-layout guard, and execution-boundary guard passed; the final direct consumer check for `rocketmq-sre-probe` also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved broker administration request handling for safer concurrent configuration, topic, subscription, consumer, ACL, and user operations.
  - Enhanced LitePull consumer assignment management during rebalancing, seeking, unsubscription, and shutdown.
  - Improved cleanup of completed or cancelled pull tasks and stale queue assignments.
  - Added diagnostics for LitePull assignment state and task ownership.

- **Tests**
  - Added concurrency and lifecycle coverage for broker administration and LitePull consumers, including high-iteration cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->