### PR TITLE
[ISSUE #8878]♻️Enforce hotspot module ownership decisions

### DIFF
--- a/rocketmq-doc/en/hotspot-module-decisions.md
+++ b/rocketmq-doc/en/hotspot-module-decisions.md
@@ -1,0 +1,203 @@
+# Hotspot module decisions
+
+Status: Accepted
+
+This ADR records the architecture decision for every hotspot on the original
+top-20 board and for the replacement that entered the current board. A high
+multi-factor score is a review signal, not an instruction to split a file by
+line count. `decomposed` means domain-owned private child modules already carry
+independent use cases. `retained` means the reviewed parent remains the safest
+single public schema, protocol, storage, or mutable-state owner.
+
+The implementation baseline is commit
+`9b7af257d3315e3ac48616ae3d0f1d8acccf7835`. Metrics below were regenerated
+from that checkout. Retention is conditional: each entry has an explicit
+trigger that returns it to active decomposition review.
+
+## Decision rules
+
+- A child module must own a named use case, not merely re-export its parent.
+- Mutable state, lock guards, task handles, and concrete storage backends stay
+  with one parent owner unless a narrow value boundary exists.
+- Public item and re-export counts must not grow as a side effect of a split.
+- New production modules remain at or below 800 production lines.
+- `misc.rs`, `utils2.rs`, and `impl_2.rs` are not valid domain boundaries.
+
+## Decisions
+
+### `rocketmq-broker/src/broker_runtime.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ broker runtime maintainers.
+- State owner: `BrokerRuntime` remains the only composition and lifecycle state owner.
+- Evidence: Seven private children own composition, control plane, data plane, lifecycle, metadata, request pipeline, and shutdown reporting; the parent is 767 production lines.
+- Revisit when: The parent crosses 800 production lines, adds another state owner, or implements request algorithms outside those children.
+
+### `rocketmq-client/src/producer/default_mq_producer.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ client producer API maintainers.
+- State owner: `DefaultMQProducer` remains the public façade and delegates mutable execution state to one producer implementation.
+- Evidence: The 2,138 production lines are dominated by 182 intentional public configuration and delegation methods; lifecycle, retry, send, and transaction algorithms live under `default_mq_producer_impl/`.
+- Revisit when: A façade method gains non-delegating send or retry logic, fan-out exceeds 10, or the public surface grows without an API decision.
+
+### `rocketmq-store/src/message_store/local_file_message_store.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ local message store maintainers.
+- State owner: `LocalFileMessageStore` remains the single owner of commit log, queues, checkpoints, and lifecycle state.
+- Evidence: Seven private children own composition, dispatch, health, lifecycle, read, recovery, and write paths while the parent preserves one storage owner.
+- Revisit when: A child duplicates an `Arc` storage root, exposes a lock guard, or the parent adds an eighth unrelated use case.
+
+### `rocketmq-store/src/log_file/commit_log.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ CommitLog maintainers.
+- State owner: `CommitLog` remains the single owner of persisted segment state and recovery ordering.
+- Evidence: Append sequencing, context, and handles already have private children; the remaining 2,277 production lines jointly enforce append, recovery, flush, and replication invariants over one on-disk format.
+- Revisit when: A recovery or flush value boundary can be tested without sharing mapped-file state, or lock sites grow beyond the current 10.
+
+### `rocketmq-client/src/consumer/default_mq_push_consumer.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ push-consumer public API maintainers.
+- State owner: `DefaultMQPushConsumer` remains the public configuration façade and owns no second consume state machine.
+- Evidence: Its 1,152 production lines and 190 public items express configuration and delegation; execution, rebalance, offset, and consume state stay in `DefaultMQPushConsumerImpl`.
+- Revisit when: The façade starts owning background work, lock sites appear, or public items grow without an API decision.
+
+### `rocketmq-client/src/factory/mq_client_instance.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ client runtime maintainers.
+- State owner: `MQClientInstance` remains the only client-session and shared-factory state owner.
+- Evidence: Connection listener and route conversion are private child modules, and producer, consumer, route, and shutdown work is reached through narrow capability paths rather than a second factory owner.
+- Revisit when: Fan-out exceeds the current 13, lock sites exceed 12, or route conversion returns mutable factory state.
+
+### `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ Admin TUI maintainers.
+- State owner: `TuiAdminFacade` remains a stateless command façade over one admin client owner.
+- Evidence: Despite 2,916 production lines and 203 public operations, the module has fan-out 3, no lock site, and no state owner; splitting it would create method containers without reducing dependencies or mutable ownership.
+- Revisit when: A command family acquires independent state, fan-out exceeds 3, a lock is introduced, or focused family fixtures justify a value boundary.
+
+### `rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ lite-pull implementation maintainers.
+- State owner: `DefaultLitePullConsumerImpl` remains the only assignment, poll, and offset state owner.
+- Evidence: Assignment registry, configuration, and model already have private children; the parent coordinates 43 lock sites without exporting guards and has 40 focused tests.
+- Revisit when: Assignment, polling, or offset transitions can cross a value-only boundary, or lock sites exceed 43.
+
+### `rocketmq-store/src/config/message_store_config.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ store configuration maintainers.
+- State owner: `MessageStoreConfig` remains the canonical serialized configuration schema.
+- Evidence: The module has no lock or mutable service owner; 1,982 production lines and 126 public items are schema fields, defaults, validation, and compatibility projection with 39 focused tests.
+- Revisit when: Validation becomes independently stateful, a projection can use a typed value object, or the schema gains a second owner.
+
+### `rocketmq-broker/src/config/broker_config.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ broker configuration maintainers.
+- State owner: `BrokerConfig` remains the canonical serialized broker configuration schema.
+- Evidence: The module has no lock or service state owner; 1,794 production lines and 181 public items keep fields, defaults, validation, and serialization discoverable in one schema.
+- Revisit when: Validation requires external I/O, a typed projection becomes independently reusable, or the schema gains a second owner.
+
+### `rocketmq-client/src/implementation/mq_client_api_impl.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ client remoting API maintainers.
+- State owner: `MQClientAPIImpl` remains the one remoting composition owner.
+- Evidence: Eight private children own admin, consumer, producer, request building, response decoding, route, transaction, and transport use cases; the root is 401 production lines.
+- Revisit when: The root crosses 500 production lines, fan-out exceeds 13, or a child reaches across another child's private state.
+
+### `rocketmq-observability/src/semantic.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ observability maintainers.
+- State owner: The module is a stateless canonical semantic-name registry.
+- Evidence: All 234 production lines and 229 public items are unique metric, trace, log, and resource names; it has no lock, state owner, dependency fan-out, or executable algorithm to isolate.
+- Revisit when: Executable registration logic enters the module, a semantic namespace exceeds a reviewable value boundary, or duplicate names are introduced.
+
+### `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ push-consumer implementation maintainers.
+- State owner: `DefaultMQPushConsumerImpl` remains the only lifecycle, rebalance, consume, and offset state owner.
+- Evidence: The module coordinates 19 lock sites and delegates to dedicated rebalance and consume services; keeping transitions together avoids exporting guards or cloning mutable roots.
+- Revisit when: A lifecycle or offset transition can be expressed as an owned input/output value, or lock sites exceed 19.
+
+### `rocketmq-client/src/consumer/default_lite_pull_consumer.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ lite-pull public API maintainers.
+- State owner: `DefaultLitePullConsumer` remains a public delegation façade over one implementation owner.
+- Evidence: Separate capability trait implementations group subscription, assignment, polling, offsets, and lifecycle without adding state; the façade has only four lock references and no background-task owner.
+- Revisit when: Any capability implementation begins owning independent mutable state, fan-out exceeds 9, or the public surface grows.
+
+### `rocketmq-broker/src/out_api/broker_outer_api.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ broker outbound API maintainers.
+- State owner: `BrokerOuterAPI` remains the single owner of remoting client and nameserver address state.
+- Evidence: The 1,491 production lines cover controller, nameserver, and broker requests over the same client and address snapshot; the module has no lock site and fan-out is 7.
+- Revisit when: A request family gains independent lifecycle state, fan-out exceeds 7, or a value-only transport boundary becomes reusable.
+
+### `rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ producer implementation maintainers.
+- State owner: `DefaultMQProducerImpl` remains the only producer execution and task-lifecycle owner.
+- Evidence: Four private children own lifecycle, retry, send, and transaction behavior; the composition root is 334 production lines.
+- Revisit when: The root crosses 500 production lines, lock sites exceed 10, or child modules expose task handles.
+
+### `rocketmq-broker/src/processor/send_message_processor.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ broker send-path maintainers.
+- State owner: `SendMessageProcessor` remains one request processor over injected store and runtime capabilities.
+- Evidence: Capability and message construction already have private children; the parent preserves validation, routing, store dispatch, and response ordering without locks or a second state owner.
+- Revisit when: A value-only validation or response mapper reaches 100 production lines, fan-out exceeds 13, or another defect is traced to mixed response ordering.
+
+### `rocketmq-broker/src/schedule/schedule_message_service.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ delayed-message maintainers.
+- State owner: `ScheduleMessageService` remains the only owner of delay offsets, delivery lifecycle, and persistence coordination.
+- Evidence: The module's 22 lock sites and three state owners form one ordered scheduler; moving methods without an owned state transition would export guards or duplicate cancellation state.
+- Revisit when: Delivery or persistence can accept an immutable snapshot and return a complete transition, or lock sites exceed 22.
+
+### `rocketmq-client/src/producer/produce_accumulator.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ producer batching maintainers.
+- State owner: `ProduceAccumulator` remains the only admission, batch, flush, and shutdown owner.
+- Evidence: Four state owners and 47 lock or atomic sites coordinate permit release, synchronous and asynchronous guards, deadlines, and shutdown; all helpers remain private and guards never cross the module.
+- Revisit when: Batch transitions can be represented by an owned command/result pair, lock sites exceed 47, or a guard task handle becomes public.
+
+### `rocketmq-client/src/admin/default_mq_admin_ext_impl.rs`
+
+- Decision: `decomposed`.
+- Owner: RocketMQ client admin maintainers.
+- State owner: `DefaultMQAdminExtImpl` remains the single admin composition owner.
+- Evidence: Seven private children own generic admin API, broker, group, lifecycle, mutation, security, and topic capabilities; the root is 252 production lines with one public item and has left the current top-20 board.
+- Revisit when: The root crosses 500 production lines, a new command family stays in the root, or a child duplicates admin client state.
+
+### `rocketmq-broker/src/processor/pop_message_processor.rs`
+
+- Decision: `retained`.
+- Owner: RocketMQ broker POP-path maintainers.
+- State owner: `PopMessageProcessor` remains the single POP request and offset-transition owner.
+- Evidence: The capability boundary is already private; the current replacement hotspot has 1,534 production lines, fan-out 9, and 19 lock or atomic sites that participate in one ordered POP transition.
+- Revisit when: Validation or response mapping can use owned values without offset state, lock sites exceed 19, or fan-out exceeds 9.
+
+## Outcome
+
+The original twenty hotspots all have a reviewed decision. Six are confirmed as
+domain decomposition roots and fourteen are retained single-owner boundaries.
+The original Client admin entry is one of the decomposed roots and has left the
+current board. The retained Broker POP processor that replaced it is also governed.
+Future board regeneration therefore cannot silently introduce an unowned
+ranked hotspot.

--- a/rocketmq-doc/en/module-maintainability-board.md
+++ b/rocketmq-doc/en/module-maintainability-board.md
@@ -8,26 +8,26 @@ A high rank is a review priority, not evidence that line count alone is a defect
 
 | Rank | File | Score | Production LOC | Churn | Authors | Defects | Public | Locks | State owners | Fan-out |
 |---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | `rocketmq-broker/src/broker_runtime.rs` | 725.425 | 767 | 227 | 12 | 2 | 1 | 9 | 2 | 29 |
-| 2 | `rocketmq-client/src/producer/default_mq_producer.rs` | 656.954 | 2120 | 97 | 14 | 1 | 181 | 0 | 0 | 9 |
-| 3 | `rocketmq-store/src/message_store/local_file_message_store.rs` | 565.400 | 1906 | 160 | 5 | 4 | 5 | 21 | 0 | 25 |
-| 4 | `rocketmq-store/src/log_file/commit_log.rs` | 504.090 | 2277 | 103 | 7 | 4 | 64 | 10 | 0 | 15 |
+| 1 | `rocketmq-broker/src/broker_runtime.rs` | 730.425 | 767 | 229 | 12 | 2 | 1 | 9 | 2 | 29 |
+| 2 | `rocketmq-client/src/producer/default_mq_producer.rs` | 663.404 | 2138 | 98 | 14 | 1 | 182 | 0 | 0 | 10 |
+| 3 | `rocketmq-store/src/message_store/local_file_message_store.rs` | 574.775 | 1981 | 163 | 5 | 4 | 5 | 21 | 0 | 25 |
+| 4 | `rocketmq-store/src/log_file/commit_log.rs` | 500.090 | 2277 | 103 | 6 | 4 | 64 | 10 | 0 | 15 |
 | 5 | `rocketmq-client/src/consumer/default_mq_push_consumer.rs` | 430.892 | 1152 | 31 | 3 | 0 | 190 | 0 | 0 | 9 |
-| 6 | `rocketmq-client/src/factory/mq_client_instance.rs` | 408.066 | 2256 | 71 | 3 | 2 | 72 | 12 | 0 | 13 |
-| 7 | `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs` | 399.900 | 2916 | 5 | 1 | 0 | 203 | 0 | 0 | 3 |
-| 8 | `rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs` | 390.549 | 2406 | 38 | 1 | 0 | 95 | 47 | 0 | 11 |
-| 9 | `rocketmq-store/src/config/message_store_config.rs` | 354.040 | 1982 | 32 | 2 | 1 | 126 | 0 | 0 | 5 |
-| 10 | `rocketmq-broker/src/config/broker_config.rs` | 353.333 | 1794 | 5 | 1 | 1 | 181 | 0 | 0 | 4 |
-| 11 | `rocketmq-client/src/implementation/mq_client_api_impl.rs` | 342.400 | 346 | 103 | 10 | 0 | 6 | 3 | 1 | 13 |
-| 12 | `rocketmq-observability/src/semantic.rs` | 325.950 | 198 | 11 | 1 | 0 | 193 | 0 | 0 | 0 |
-| 13 | `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs` | 318.325 | 2143 | 53 | 2 | 1 | 41 | 19 | 0 | 12 |
-| 14 | `rocketmq-client/src/consumer/default_lite_pull_consumer.rs` | 297.537 | 1235 | 17 | 1 | 0 | 125 | 4 | 0 | 8 |
-| 15 | `rocketmq-broker/src/out_api/broker_outer_api.rs` | 288.432 | 1491 | 56 | 6 | 0 | 45 | 0 | 0 | 7 |
-| 16 | `rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs` | 288.250 | 330 | 80 | 5 | 1 | 1 | 10 | 3 | 13 |
-| 17 | `rocketmq-broker/src/processor/send_message_processor.rs` | 285.310 | 1693 | 63 | 6 | 3 | 8 | 0 | 0 | 13 |
-| 18 | `rocketmq-broker/src/schedule/schedule_message_service.rs` | 279.515 | 1594 | 32 | 5 | 0 | 48 | 22 | 3 | 8 |
-| 19 | `rocketmq-client/src/producer/produce_accumulator.rs` | 275.058 | 1849 | 27 | 3 | 1 | 30 | 47 | 4 | 5 |
-| 20 | `rocketmq-client/src/admin/default_mq_admin_ext_impl.rs` | 273.300 | 192 | 80 | 9 | 0 | 7 | 0 | 0 | 11 |
+| 6 | `rocketmq-client/src/factory/mq_client_instance.rs` | 415.691 | 2261 | 74 | 3 | 2 | 72 | 12 | 0 | 13 |
+| 7 | `rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs` | 400.031 | 2499 | 41 | 1 | 0 | 99 | 43 | 0 | 11 |
+| 8 | `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs` | 399.900 | 2916 | 5 | 1 | 0 | 203 | 0 | 0 | 3 |
+| 9 | `rocketmq-observability/src/semantic.rs` | 385.850 | 234 | 13 | 1 | 0 | 229 | 0 | 0 | 0 |
+| 10 | `rocketmq-store/src/config/message_store_config.rs` | 354.040 | 1982 | 32 | 2 | 1 | 126 | 0 | 0 | 5 |
+| 11 | `rocketmq-broker/src/config/broker_config.rs` | 353.333 | 1794 | 5 | 1 | 1 | 181 | 0 | 0 | 4 |
+| 12 | `rocketmq-client/src/implementation/mq_client_api_impl.rs` | 346.275 | 401 | 104 | 10 | 0 | 6 | 3 | 1 | 13 |
+| 13 | `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs` | 320.825 | 2143 | 54 | 2 | 1 | 41 | 19 | 0 | 12 |
+| 14 | `rocketmq-client/src/consumer/default_lite_pull_consumer.rs` | 302.462 | 1252 | 18 | 1 | 0 | 125 | 4 | 0 | 9 |
+| 15 | `rocketmq-broker/src/out_api/broker_outer_api.rs` | 293.432 | 1491 | 58 | 6 | 0 | 45 | 0 | 0 | 7 |
+| 16 | `rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs` | 290.850 | 334 | 81 | 5 | 1 | 1 | 10 | 3 | 13 |
+| 17 | `rocketmq-broker/src/processor/send_message_processor.rs` | 287.960 | 1699 | 64 | 6 | 3 | 8 | 0 | 0 | 13 |
+| 18 | `rocketmq-broker/src/schedule/schedule_message_service.rs` | 284.515 | 1594 | 34 | 5 | 0 | 48 | 22 | 3 | 8 |
+| 19 | `rocketmq-client/src/producer/produce_accumulator.rs` | 280.133 | 1852 | 29 | 3 | 1 | 30 | 47 | 4 | 5 |
+| 20 | `rocketmq-broker/src/processor/pop_message_processor.rs` | 277.481 | 1534 | 47 | 3 | 2 | 29 | 19 | 1 | 9 |
 
 ## Ownership and extraction contracts
 
@@ -79,6 +79,14 @@ A high rank is a review priority, not evidence that line count alone is a defect
 - Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
+### `rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs`
+
+- Owner: rocketmq-client maintainers.
+- Use-case boundaries: `lifecycle`, `assignment and routing`, `message flow`, `offset and shutdown`.
+- State ownership: `default_lite_pull_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
+- Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
+- Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
+
 ### `rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs`
 
 - Owner: rocketmq-admin-tui maintainers.
@@ -87,12 +95,12 @@ A high rank is a review priority, not evidence that line count alone is a defect
 - Tests: Run focused `rocketmq-admin-tui` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
-### `rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs`
+### `rocketmq-observability/src/semantic.rs`
 
-- Owner: rocketmq-client maintainers.
-- Use-case boundaries: `lifecycle`, `assignment and routing`, `message flow`, `offset and shutdown`.
-- State ownership: `default_lite_pull_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
-- Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
+- Owner: rocketmq-observability maintainers.
+- Use-case boundaries: `semantic`, `lifecycle`, `request execution`, `result projection`.
+- State ownership: `semantic` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
+- Tests: Run focused `rocketmq-observability` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
 ### `rocketmq-store/src/config/message_store_config.rs`
@@ -117,14 +125,6 @@ A high rank is a review priority, not evidence that line count alone is a defect
 - Use-case boundaries: `mq client api impl`, `lifecycle`, `request execution`, `result projection`.
 - State ownership: `mq_client_api_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
 - Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
-- Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
-
-### `rocketmq-observability/src/semantic.rs`
-
-- Owner: rocketmq-observability maintainers.
-- Use-case boundaries: `semantic`, `lifecycle`, `request execution`, `result projection`.
-- State ownership: `semantic` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
-- Tests: Run focused `rocketmq-observability` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
 ### `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs`
@@ -183,10 +183,10 @@ A high rank is a review priority, not evidence that line count alone is a defect
 - Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
-### `rocketmq-client/src/admin/default_mq_admin_ext_impl.rs`
+### `rocketmq-broker/src/processor/pop_message_processor.rs`
 
-- Owner: rocketmq-client maintainers.
-- Use-case boundaries: `request validation`, `admin dispatch`, `response projection`, `error mapping`.
-- State ownership: `default_mq_admin_ext_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
-- Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
+- Owner: rocketmq-broker maintainers.
+- Use-case boundaries: `pop message processor`, `lifecycle`, `request execution`, `result projection`.
+- State ownership: `pop_message_processor` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
+- Tests: Run focused `rocketmq-broker` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -5,27 +5,27 @@
       "reexports": 3
     },
     "rocketmq-admin-core": {
-      "public_items": 1281,
-      "reexports": 106
+      "public_items": 1410,
+      "reexports": 114
     },
     "rocketmq-admin-tui": {
       "public_items": 356,
       "reexports": 2
     },
     "rocketmq-auth": {
-      "public_items": 647,
+      "public_items": 649,
       "reexports": 172
     },
     "rocketmq-broker": {
-      "public_items": 1379,
+      "public_items": 1383,
       "reexports": 76
     },
     "rocketmq-client": {
-      "public_items": 2342,
-      "reexports": 393
+      "public_items": 2371,
+      "reexports": 372
     },
     "rocketmq-controller": {
-      "public_items": 461,
+      "public_items": 470,
       "reexports": 77
     },
     "rocketmq-dashboard-common": {
@@ -61,7 +61,7 @@
       "reexports": 0
     },
     "rocketmq-mcp": {
-      "public_items": 257,
+      "public_items": 277,
       "reexports": 0
     },
     "rocketmq-model": {
@@ -73,44 +73,48 @@
       "reexports": 19
     },
     "rocketmq-observability": {
-      "public_items": 1258,
-      "reexports": 201
+      "public_items": 1413,
+      "reexports": 262
     },
     "rocketmq-protocol": {
-      "public_items": 1557,
+      "public_items": 1578,
       "reexports": 264
     },
     "rocketmq-proxy": {
-      "public_items": 121,
+      "public_items": 126,
       "reexports": 167
     },
     "rocketmq-proxy-cluster": {
-      "public_items": 39,
+      "public_items": 41,
       "reexports": 13
     },
     "rocketmq-proxy-core": {
-      "public_items": 381,
-      "reexports": 42
+      "public_items": 396,
+      "reexports": 48
     },
     "rocketmq-proxy-local": {
       "public_items": 36,
       "reexports": 5
     },
     "rocketmq-runtime": {
-      "public_items": 647,
-      "reexports": 150
+      "public_items": 673,
+      "reexports": 162
     },
     "rocketmq-security-api": {
       "public_items": 191,
       "reexports": 55
     },
+    "rocketmq-sre": {
+      "public_items": 1400,
+      "reexports": 919
+    },
     "rocketmq-store": {
-      "public_items": 1284,
-      "reexports": 471
+      "public_items": 1253,
+      "reexports": 479
     },
     "rocketmq-store-api": {
-      "public_items": 138,
-      "reexports": 43
+      "public_items": 145,
+      "reexports": 50
     },
     "rocketmq-store-inspect": {
       "public_items": 5,
@@ -118,19 +122,19 @@
     },
     "rocketmq-store-local": {
       "public_items": 1354,
-      "reexports": 48
+      "reexports": 49
     },
     "rocketmq-store-rocksdb": {
       "public_items": 338,
       "reexports": 6
     },
     "rocketmq-tieredstore": {
-      "public_items": 197,
+      "public_items": 196,
       "reexports": 68
     },
     "rocketmq-transport": {
-      "public_items": 565,
-      "reexports": 160
+      "public_items": 586,
+      "reexports": 169
     }
   },
   "files": {
@@ -345,7 +349,7 @@
       "reexports": 0
     },
     "rocketmq-auth/src/authorization/builder/default_authorization_context_builder.rs": {
-      "production_lines": 725,
+      "production_lines": 729,
       "public_items": 2,
       "reexports": 0
     },
@@ -560,8 +564,8 @@
       "reexports": 0
     },
     "rocketmq-auth/src/migration/alc/plain_access_config.rs": {
-      "production_lines": 106,
-      "public_items": 18,
+      "production_lines": 116,
+      "public_items": 20,
       "reexports": 0
     },
     "rocketmq-auth/src/migration/alc/plain_access_data.rs": {
@@ -580,12 +584,12 @@
       "reexports": 0
     },
     "rocketmq-auth/src/permission.rs": {
-      "production_lines": 49,
+      "production_lines": 52,
       "public_items": 9,
       "reexports": 0
     },
     "rocketmq-auth/src/runtime.rs": {
-      "production_lines": 954,
+      "production_lines": 984,
       "public_items": 42,
       "reexports": 0
     },
@@ -620,7 +624,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/auth/auth_admin_service.rs": {
-      "production_lines": 382,
+      "production_lines": 406,
       "public_items": 18,
       "reexports": 0
     },
@@ -640,7 +644,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/broker/broker_admin_runtime.rs": {
-      "production_lines": 443,
+      "production_lines": 467,
       "public_items": 0,
       "reexports": 0
     },
@@ -690,12 +694,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/broker/log_filter_control.rs": {
-      "production_lines": 599,
+      "production_lines": 641,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/broker_bootstrap.rs": {
-      "production_lines": 237,
+      "production_lines": 196,
       "public_items": 12,
       "reexports": 0
     },
@@ -715,17 +719,17 @@
       "reexports": 0
     },
     "rocketmq-broker/src/broker_runtime/control_plane.rs": {
-      "production_lines": 712,
+      "production_lines": 740,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/broker_runtime/data_plane.rs": {
-      "production_lines": 264,
+      "production_lines": 265,
       "public_items": 1,
       "reexports": 0
     },
     "rocketmq-broker/src/broker_runtime/lifecycle.rs": {
-      "production_lines": 983,
+      "production_lines": 987,
       "public_items": 2,
       "reexports": 0
     },
@@ -735,12 +739,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/broker_runtime/request_pipeline.rs": {
-      "production_lines": 567,
+      "production_lines": 572,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs": {
-      "production_lines": 200,
+      "production_lines": 229,
       "public_items": 0,
       "reexports": 0
     },
@@ -760,7 +764,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/client/client_housekeeping_service.rs": {
-      "production_lines": 177,
+      "production_lines": 178,
       "public_items": 5,
       "reexports": 0
     },
@@ -905,12 +909,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/failover/escape_bridge.rs": {
-      "production_lines": 624,
+      "production_lines": 654,
       "public_items": 6,
       "reexports": 0
     },
     "rocketmq-broker/src/failover/escape_bridge_capability.rs": {
-      "production_lines": 458,
+      "production_lines": 498,
       "public_items": 0,
       "reexports": 0
     },
@@ -985,13 +989,13 @@
       "reexports": 0
     },
     "rocketmq-broker/src/latency/broker_fast_failure.rs": {
-      "production_lines": 564,
+      "production_lines": 583,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/lib.rs": {
-      "production_lines": 656,
-      "public_items": 22,
+      "production_lines": 747,
+      "public_items": 24,
       "reexports": 18
     },
     "rocketmq-broker/src/lifecycle.rs": {
@@ -1020,7 +1024,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/lite/lite_lifecycle_manager.rs": {
-      "production_lines": 50,
+      "production_lines": 54,
       "public_items": 0,
       "reexports": 0
     },
@@ -1055,12 +1059,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs": {
-      "production_lines": 387,
+      "production_lines": 388,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs": {
-      "production_lines": 494,
+      "production_lines": 495,
       "public_items": 11,
       "reexports": 0
     },
@@ -1180,7 +1184,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/offset/manager/consumer_offset_manager.rs": {
-      "production_lines": 864,
+      "production_lines": 920,
       "public_items": 21,
       "reexports": 0
     },
@@ -1235,7 +1239,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor.rs": {
-      "production_lines": 596,
+      "production_lines": 608,
       "public_items": 8,
       "reexports": 0
     },
@@ -1245,7 +1249,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor.rs": {
-      "production_lines": 676,
+      "production_lines": 697,
       "public_items": 2,
       "reexports": 0
     },
@@ -1255,7 +1259,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs": {
-      "production_lines": 715,
+      "production_lines": 903,
       "public_items": 10,
       "reexports": 0
     },
@@ -1270,7 +1274,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs": {
-      "production_lines": 882,
+      "production_lines": 881,
       "public_items": 14,
       "reexports": 0
     },
@@ -1330,12 +1334,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs": {
-      "production_lines": 211,
+      "production_lines": 218,
       "public_items": 5,
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs": {
-      "production_lines": 419,
+      "production_lines": 417,
       "public_items": 9,
       "reexports": 0
     },
@@ -1350,13 +1354,13 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs": {
-      "production_lines": 208,
-      "public_items": 5,
+      "production_lines": 383,
+      "public_items": 6,
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs": {
-      "production_lines": 677,
-      "public_items": 12,
+      "production_lines": 854,
+      "public_items": 13,
       "reexports": 0
     },
     "rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs": {
@@ -1450,12 +1454,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/pop_message_processor.rs": {
-      "production_lines": 1530,
+      "production_lines": 1534,
       "public_items": 29,
       "reexports": 0
     },
     "rocketmq-broker/src/processor/pop_message_processor/capability.rs": {
-      "production_lines": 478,
+      "production_lines": 479,
       "public_items": 0,
       "reexports": 0
     },
@@ -1475,7 +1479,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/pull_message_processor.rs": {
-      "production_lines": 915,
+      "production_lines": 914,
       "public_items": 6,
       "reexports": 0
     },
@@ -1505,7 +1509,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/reply_message_processor.rs": {
-      "production_lines": 506,
+      "production_lines": 507,
       "public_items": 3,
       "reexports": 0
     },
@@ -1515,12 +1519,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/processor/send_message_processor.rs": {
-      "production_lines": 1693,
+      "production_lines": 1699,
       "public_items": 8,
       "reexports": 0
     },
     "rocketmq-broker/src/processor/send_message_processor/capability.rs": {
-      "production_lines": 622,
+      "production_lines": 640,
       "public_items": 0,
       "reexports": 0
     },
@@ -1530,7 +1534,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/proxy_facade.rs": {
-      "production_lines": 216,
+      "production_lines": 222,
       "public_items": 12,
       "reexports": 56
     },
@@ -1585,7 +1589,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/subscription/manager/subscription_group_manager.rs": {
-      "production_lines": 947,
+      "production_lines": 1083,
       "public_items": 35,
       "reexports": 0
     },
@@ -1600,12 +1604,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/topic/manager/topic_config_coordinator.rs": {
-      "production_lines": 431,
+      "production_lines": 438,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/topic/manager/topic_config_manager.rs": {
-      "production_lines": 1207,
+      "production_lines": 1276,
       "public_items": 21,
       "reexports": 0
     },
@@ -1615,7 +1619,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs": {
-      "production_lines": 333,
+      "production_lines": 334,
       "public_items": 8,
       "reexports": 0
     },
@@ -1625,7 +1629,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs": {
-      "production_lines": 486,
+      "production_lines": 487,
       "public_items": 3,
       "reexports": 0
     },
@@ -1645,12 +1649,12 @@
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs": {
-      "production_lines": 121,
+      "production_lines": 118,
       "public_items": 2,
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs": {
-      "production_lines": 1062,
+      "production_lines": 1063,
       "public_items": 7,
       "reexports": 0
     },
@@ -1665,17 +1669,17 @@
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/transaction_message_store.rs": {
-      "production_lines": 74,
+      "production_lines": 82,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/transaction_topic_registration.rs": {
-      "production_lines": 239,
+      "production_lines": 256,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs": {
-      "production_lines": 274,
+      "production_lines": 289,
       "public_items": 15,
       "reexports": 0
     },
@@ -1685,7 +1689,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/queue/transactional_op_batch_service.rs": {
-      "production_lines": 99,
+      "production_lines": 100,
       "public_items": 5,
       "reexports": 0
     },
@@ -1700,7 +1704,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/transaction/transactional_message_check_service.rs": {
-      "production_lines": 97,
+      "production_lines": 98,
       "public_items": 5,
       "reexports": 0
     },
@@ -1725,22 +1729,27 @@
       "reexports": 0
     },
     "rocketmq-client/src/admin.rs": {
-      "production_lines": 6,
-      "public_items": 3,
-      "reexports": 3
+      "production_lines": 42,
+      "public_items": 2,
+      "reexports": 18
+    },
+    "rocketmq-client/src/admin/capability.rs": {
+      "production_lines": 1898,
+      "public_items": 6,
+      "reexports": 0
     },
     "rocketmq-client/src/admin/default_mq_admin_ext.rs": {
-      "production_lines": 168,
-      "public_items": 19,
+      "production_lines": 262,
+      "public_items": 20,
       "reexports": 0
     },
     "rocketmq-client/src/admin/default_mq_admin_ext_impl.rs": {
-      "production_lines": 192,
-      "public_items": 7,
+      "production_lines": 252,
+      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-client/src/admin/default_mq_admin_ext_impl/admin_api.rs": {
-      "production_lines": 2406,
+      "production_lines": 2360,
       "public_items": 0,
       "reexports": 0
     },
@@ -1754,6 +1763,21 @@
       "public_items": 0,
       "reexports": 0
     },
+    "rocketmq-client/src/admin/default_mq_admin_ext_impl/lifecycle.rs": {
+      "production_lines": 123,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api.rs": {
+      "production_lines": 722,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api/log_filter.rs": {
+      "production_lines": 106,
+      "public_items": 0,
+      "reexports": 0
+    },
     "rocketmq-client/src/admin/default_mq_admin_ext_impl/security.rs": {
       "production_lines": 116,
       "public_items": 4,
@@ -1764,9 +1788,14 @@
       "public_items": 3,
       "reexports": 0
     },
-    "rocketmq-client/src/admin/mq_admin_ext_async.rs": {
-      "production_lines": 1860,
-      "public_items": 1,
+    "rocketmq-client/src/admin/mq_admin_mutation_ext.rs": {
+      "production_lines": 436,
+      "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-client/src/admin/mq_admin_read_ext.rs": {
+      "production_lines": 353,
+      "public_items": 4,
       "reexports": 0
     },
     "rocketmq-client/src/base.rs": {
@@ -1875,9 +1904,9 @@
       "reexports": 0
     },
     "rocketmq-client/src/consumer.rs": {
-      "production_lines": 77,
+      "production_lines": 81,
       "public_items": 26,
-      "reexports": 50
+      "reexports": 54
     },
     "rocketmq-client/src/consumer/ack_callback.rs": {
       "production_lines": 7,
@@ -1935,9 +1964,14 @@
       "reexports": 0
     },
     "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs": {
-      "production_lines": 2406,
-      "public_items": 92,
-      "reexports": 3
+      "production_lines": 2499,
+      "public_items": 95,
+      "reexports": 4
+    },
+    "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/assignment_registry.rs": {
+      "production_lines": 250,
+      "public_items": 1,
+      "reexports": 0
     },
     "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/config.rs": {
       "production_lines": 129,
@@ -2035,7 +2069,7 @@
       "reexports": 0
     },
     "rocketmq-client/src/consumer/default_lite_pull_consumer.rs": {
-      "production_lines": 1235,
+      "production_lines": 1252,
       "public_items": 125,
       "reexports": 0
     },
@@ -2100,8 +2134,8 @@
       "reexports": 0
     },
     "rocketmq-client/src/consumer/lite_pull_consumer.rs": {
-      "production_lines": 130,
-      "public_items": 1,
+      "production_lines": 147,
+      "public_items": 5,
       "reexports": 0
     },
     "rocketmq-client/src/consumer/message_queue_listener.rs": {
@@ -2265,7 +2299,7 @@
       "reexports": 0
     },
     "rocketmq-client/src/factory/mq_client_instance.rs": {
-      "production_lines": 2256,
+      "production_lines": 2261,
       "public_items": 66,
       "reexports": 6
     },
@@ -2375,13 +2409,18 @@
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl.rs": {
-      "production_lines": 346,
+      "production_lines": 401,
       "public_items": 1,
       "reexports": 5
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/admin.rs": {
-      "production_lines": 3183,
+      "production_lines": 3320,
       "public_items": 29,
+      "reexports": 0
+    },
+    "rocketmq-client/src/implementation/mq_client_api_impl/admin/versioned_config.rs": {
+      "production_lines": 476,
+      "public_items": 0,
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs": {
@@ -2390,12 +2429,12 @@
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/producer.rs": {
-      "production_lines": 789,
+      "production_lines": 792,
       "public_items": 14,
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/request_builder.rs": {
-      "production_lines": 59,
+      "production_lines": 64,
       "public_items": 0,
       "reexports": 0
     },
@@ -2420,7 +2459,7 @@
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_manager.rs": {
-      "production_lines": 232,
+      "production_lines": 234,
       "public_items": 9,
       "reexports": 0
     },
@@ -2455,14 +2494,14 @@
       "reexports": 0
     },
     "rocketmq-client/src/legacy.rs": {
-      "production_lines": 381,
+      "production_lines": 384,
       "public_items": 55,
       "reexports": 0
     },
     "rocketmq-client/src/lib.rs": {
-      "production_lines": 844,
-      "public_items": 34,
-      "reexports": 230
+      "production_lines": 721,
+      "public_items": 32,
+      "reexports": 158
     },
     "rocketmq-client/src/lock.rs": {
       "production_lines": 54,
@@ -2470,28 +2509,28 @@
       "reexports": 0
     },
     "rocketmq-client/src/prelude.rs": {
-      "production_lines": 5,
+      "production_lines": 6,
       "public_items": 0,
-      "reexports": 5
+      "reexports": 6
     },
     "rocketmq-client/src/producer.rs": {
       "production_lines": 61,
-      "public_items": 18,
+      "public_items": 17,
       "reexports": 41
     },
     "rocketmq-client/src/producer/capability.rs": {
-      "production_lines": 718,
-      "public_items": 23,
+      "production_lines": 736,
+      "public_items": 24,
       "reexports": 0
     },
     "rocketmq-client/src/producer/default_mq_produce_builder.rs": {
-      "production_lines": 304,
+      "production_lines": 307,
       "public_items": 31,
       "reexports": 0
     },
     "rocketmq-client/src/producer/default_mq_producer.rs": {
-      "production_lines": 2120,
-      "public_items": 181,
+      "production_lines": 2138,
+      "public_items": 182,
       "reexports": 0
     },
     "rocketmq-client/src/producer/local_transaction_state.rs": {
@@ -2504,14 +2543,14 @@
       "public_items": 2,
       "reexports": 0
     },
-    "rocketmq-client/src/producer/mq_producer.rs": {
-      "production_lines": 312,
-      "public_items": 1,
+    "rocketmq-client/src/producer/produce_accumulator.rs": {
+      "production_lines": 1852,
+      "public_items": 30,
       "reexports": 0
     },
-    "rocketmq-client/src/producer/produce_accumulator.rs": {
-      "production_lines": 1849,
-      "public_items": 30,
+    "rocketmq-client/src/producer/producer_backend.rs": {
+      "production_lines": 312,
+      "public_items": 0,
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_config_validation.rs": {
@@ -2520,17 +2559,17 @@
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl.rs": {
-      "production_lines": 5,
+      "production_lines": 6,
       "public_items": 3,
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs": {
-      "production_lines": 330,
+      "production_lines": 334,
       "public_items": 1,
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs": {
-      "production_lines": 1016,
+      "production_lines": 1074,
       "public_items": 26,
       "reexports": 0
     },
@@ -2540,13 +2579,18 @@
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs": {
-      "production_lines": 1728,
+      "production_lines": 1716,
       "public_items": 39,
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/transaction.rs": {
       "production_lines": 344,
       "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-client/src/producer/producer_impl/egress.rs": {
+      "production_lines": 256,
+      "public_items": 0,
       "reexports": 0
     },
     "rocketmq-client/src/producer/producer_impl/mq_producer_inner.rs": {
@@ -2625,13 +2669,13 @@
       "reexports": 0
     },
     "rocketmq-client/src/producer/transaction_mq_produce_builder.rs": {
-      "production_lines": 291,
+      "production_lines": 294,
       "public_items": 32,
       "reexports": 0
     },
     "rocketmq-client/src/producer/transaction_mq_producer.rs": {
-      "production_lines": 592,
-      "public_items": 25,
+      "production_lines": 603,
+      "public_items": 26,
       "reexports": 0
     },
     "rocketmq-client/src/producer/transaction_send_result.rs": {
@@ -2640,14 +2684,19 @@
       "reexports": 0
     },
     "rocketmq-client/src/public_api.rs": {
-      "production_lines": 7,
+      "production_lines": 55,
       "public_items": 0,
-      "reexports": 7
+      "reexports": 37
     },
     "rocketmq-client/src/runtime.rs": {
-      "production_lines": 426,
+      "production_lines": 481,
       "public_items": 12,
       "reexports": 2
+    },
+    "rocketmq-client/src/session.rs": {
+      "production_lines": 33,
+      "public_items": 5,
+      "reexports": 0
     },
     "rocketmq-client/src/stat.rs": {
       "production_lines": 1,
@@ -2755,7 +2804,7 @@
       "reexports": 0
     },
     "rocketmq-controller/src/bin/controller_bootstrap.rs": {
-      "production_lines": 486,
+      "production_lines": 507,
       "public_items": 1,
       "reexports": 0
     },
@@ -2800,17 +2849,17 @@
       "reexports": 0
     },
     "rocketmq-controller/src/controller/controller_manager.rs": {
-      "production_lines": 824,
+      "production_lines": 827,
       "public_items": 22,
       "reexports": 0
     },
     "rocketmq-controller/src/controller/open_raft_controller.rs": {
-      "production_lines": 1021,
+      "production_lines": 1077,
       "public_items": 18,
       "reexports": 0
     },
     "rocketmq-controller/src/controller/raft_controller.rs": {
-      "production_lines": 179,
+      "production_lines": 219,
       "public_items": 17,
       "reexports": 0
     },
@@ -2910,7 +2959,7 @@
       "reexports": 0
     },
     "rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs": {
-      "production_lines": 347,
+      "production_lines": 337,
       "public_items": 3,
       "reexports": 0
     },
@@ -2950,8 +2999,8 @@
       "reexports": 0
     },
     "rocketmq-controller/src/manager/replicas_info_manager.rs": {
-      "production_lines": 984,
-      "public_items": 23,
+      "production_lines": 993,
+      "public_items": 24,
       "reexports": 0
     },
     "rocketmq-controller/src/manager/sync_state_info.rs": {
@@ -2970,8 +3019,8 @@
       "reexports": 1
     },
     "rocketmq-controller/src/metrics/controller_metrics_manager.rs": {
-      "production_lines": 103,
-      "public_items": 20,
+      "production_lines": 119,
+      "public_items": 28,
       "reexports": 1
     },
     "rocketmq-controller/src/openraft.rs": {
@@ -4585,12 +4634,12 @@
       "reexports": 0
     },
     "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs": {
-      "production_lines": 648,
+      "production_lines": 651,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-namesrv/src/bootstrap.rs": {
-      "production_lines": 1425,
+      "production_lines": 1416,
       "public_items": 26,
       "reexports": 2
     },
@@ -4630,12 +4679,12 @@
       "reexports": 0
     },
     "rocketmq-namesrv/src/processor.rs": {
-      "production_lines": 122,
+      "production_lines": 144,
       "public_items": 6,
       "reexports": 2
     },
     "rocketmq-namesrv/src/processor/client_request_processor.rs": {
-      "production_lines": 139,
+      "production_lines": 168,
       "public_items": 1,
       "reexports": 0
     },
@@ -4665,7 +4714,7 @@
       "reexports": 0
     },
     "rocketmq-namesrv/src/route/batch_unregistration_service.rs": {
-      "production_lines": 110,
+      "production_lines": 105,
       "public_items": 4,
       "reexports": 0
     },
@@ -4675,7 +4724,7 @@
       "reexports": 2
     },
     "rocketmq-namesrv/src/route/route_info_manager.rs": {
-      "production_lines": 1129,
+      "production_lines": 1148,
       "public_items": 25,
       "reexports": 0
     },
@@ -4754,6 +4803,11 @@
       "public_items": 22,
       "reexports": 0
     },
+    "rocketmq-observability/src/environment.rs": {
+      "production_lines": 58,
+      "public_items": 5,
+      "reexports": 0
+    },
     "rocketmq-observability/src/error.rs": {
       "production_lines": 1,
       "public_items": 0,
@@ -4775,7 +4829,7 @@
       "reexports": 0
     },
     "rocketmq-observability/src/exporter/prometheus.rs": {
-      "production_lines": 292,
+      "production_lines": 311,
       "public_items": 0,
       "reexports": 0
     },
@@ -4805,19 +4859,19 @@
       "reexports": 0
     },
     "rocketmq-observability/src/handle.rs": {
-      "production_lines": 331,
-      "public_items": 26,
+      "production_lines": 343,
+      "public_items": 29,
       "reexports": 0
     },
     "rocketmq-observability/src/init.rs": {
-      "production_lines": 630,
-      "public_items": 7,
+      "production_lines": 650,
+      "public_items": 8,
       "reexports": 0
     },
     "rocketmq-observability/src/lib.rs": {
-      "production_lines": 200,
+      "production_lines": 229,
       "public_items": 9,
-      "reexports": 66
+      "reexports": 92
     },
     "rocketmq-observability/src/log_filter.rs": {
       "production_lines": 235,
@@ -4825,8 +4879,8 @@
       "reexports": 0
     },
     "rocketmq-observability/src/logging.rs": {
-      "production_lines": 607,
-      "public_items": 31,
+      "production_lines": 611,
+      "public_items": 32,
       "reexports": 0
     },
     "rocketmq-observability/src/logs.rs": {
@@ -4840,8 +4894,8 @@
       "reexports": 0
     },
     "rocketmq-observability/src/metrics.rs": {
-      "production_lines": 38,
-      "public_items": 24,
+      "production_lines": 40,
+      "public_items": 26,
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/auth.rs": {
@@ -4850,34 +4904,34 @@
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/broker.rs": {
-      "production_lines": 177,
-      "public_items": 14,
-      "reexports": 25
+      "production_lines": 192,
+      "public_items": 16,
+      "reexports": 26
     },
     "rocketmq-observability/src/metrics/broker_constants.rs": {
-      "production_lines": 243,
-      "public_items": 107,
+      "production_lines": 245,
+      "public_items": 109,
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/broker_manager.rs": {
-      "production_lines": 870,
-      "public_items": 43,
+      "production_lines": 940,
+      "public_items": 46,
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/catalog.rs": {
-      "production_lines": 1035,
+      "production_lines": 1231,
       "public_items": 7,
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/client.rs": {
-      "production_lines": 226,
-      "public_items": 24,
-      "reexports": 5
+      "production_lines": 292,
+      "public_items": 28,
+      "reexports": 10
     },
     "rocketmq-observability/src/metrics/controller.rs": {
-      "production_lines": 143,
-      "public_items": 12,
-      "reexports": 12
+      "production_lines": 197,
+      "public_items": 18,
+      "reexports": 15
     },
     "rocketmq-observability/src/metrics/controller_constants.rs": {
       "production_lines": 77,
@@ -4885,8 +4939,8 @@
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/controller_manager.rs": {
-      "production_lines": 394,
-      "public_items": 10,
+      "production_lines": 420,
+      "public_items": 14,
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/instruments.rs": {
@@ -4904,10 +4958,15 @@
       "public_items": 1,
       "reexports": 0
     },
+    "rocketmq-observability/src/metrics/mcp.rs": {
+      "production_lines": 436,
+      "public_items": 24,
+      "reexports": 8
+    },
     "rocketmq-observability/src/metrics/namesrv.rs": {
-      "production_lines": 173,
-      "public_items": 20,
-      "reexports": 4
+      "production_lines": 241,
+      "public_items": 27,
+      "reexports": 6
     },
     "rocketmq-observability/src/metrics/noop_instruments.rs": {
       "production_lines": 28,
@@ -4940,9 +4999,9 @@
       "reexports": 0
     },
     "rocketmq-observability/src/metrics/proxy.rs": {
-      "production_lines": 321,
-      "public_items": 24,
-      "reexports": 5
+      "production_lines": 349,
+      "public_items": 26,
+      "reexports": 6
     },
     "rocketmq-observability/src/metrics/release_identity.rs": {
       "production_lines": 344,
@@ -4959,8 +5018,13 @@
       "public_items": 23,
       "reexports": 8
     },
+    "rocketmq-observability/src/metrics/runtime.rs": {
+      "production_lines": 282,
+      "public_items": 9,
+      "reexports": 7
+    },
     "rocketmq-observability/src/metrics/store.rs": {
-      "production_lines": 852,
+      "production_lines": 892,
       "public_items": 79,
       "reexports": 27
     },
@@ -4989,14 +5053,19 @@
       "public_items": 4,
       "reexports": 0
     },
+    "rocketmq-observability/src/runtime_diagnostics.rs": {
+      "production_lines": 493,
+      "public_items": 15,
+      "reexports": 0
+    },
     "rocketmq-observability/src/sampling.rs": {
       "production_lines": 44,
       "public_items": 4,
       "reexports": 0
     },
     "rocketmq-observability/src/semantic.rs": {
-      "production_lines": 198,
-      "public_items": 193,
+      "production_lines": 234,
+      "public_items": 229,
       "reexports": 0
     },
     "rocketmq-observability/src/statistics.rs": {
@@ -5050,7 +5119,7 @@
       "reexports": 0
     },
     "rocketmq-observability/src/statistics/statistics_manager.rs": {
-      "production_lines": 192,
+      "production_lines": 193,
       "public_items": 11,
       "reexports": 0
     },
@@ -5065,12 +5134,12 @@
       "reexports": 0
     },
     "rocketmq-observability/src/stats/moment_stats_item.rs": {
-      "production_lines": 100,
+      "production_lines": 109,
       "public_items": 9,
       "reexports": 0
     },
     "rocketmq-observability/src/stats/moment_stats_item_set.rs": {
-      "production_lines": 134,
+      "production_lines": 147,
       "public_items": 11,
       "reexports": 0
     },
@@ -5089,9 +5158,14 @@
       "public_items": 10,
       "reexports": 0
     },
+    "rocketmq-observability/src/status.rs": {
+      "production_lines": 274,
+      "public_items": 8,
+      "reexports": 0
+    },
     "rocketmq-observability/src/trace.rs": {
-      "production_lines": 160,
-      "public_items": 14,
+      "production_lines": 163,
+      "public_items": 17,
       "reexports": 0
     },
     "rocketmq-observability/src/trace/broker.rs": {
@@ -5104,15 +5178,30 @@
       "public_items": 5,
       "reexports": 2
     },
+    "rocketmq-observability/src/trace/controller.rs": {
+      "production_lines": 26,
+      "public_items": 2,
+      "reexports": 2
+    },
     "rocketmq-observability/src/trace/hooks.rs": {
       "production_lines": 2,
       "public_items": 1,
       "reexports": 0
     },
+    "rocketmq-observability/src/trace/mcp.rs": {
+      "production_lines": 33,
+      "public_items": 3,
+      "reexports": 2
+    },
     "rocketmq-observability/src/trace/namesrv.rs": {
-      "production_lines": 2,
+      "production_lines": 22,
       "public_items": 2,
-      "reexports": 0
+      "reexports": 2
+    },
+    "rocketmq-observability/src/trace/proxy.rs": {
+      "production_lines": 52,
+      "public_items": 4,
+      "reexports": 2
     },
     "rocketmq-observability/src/trace/remoting.rs": {
       "production_lines": 1,
@@ -5120,8 +5209,8 @@
       "reexports": 0
     },
     "rocketmq-observability/src/trace/span_names.rs": {
-      "production_lines": 6,
-      "public_items": 6,
+      "production_lines": 15,
+      "public_items": 15,
       "reexports": 0
     },
     "rocketmq-observability/src/trace/store.rs": {
@@ -5140,7 +5229,7 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/code/request_code.rs": {
-      "production_lines": 230,
+      "production_lines": 236,
       "public_items": 5,
       "reexports": 0
     },
@@ -5245,8 +5334,8 @@
       "reexports": 87
     },
     "rocketmq-protocol/src/protocol/body.rs": {
-      "production_lines": 60,
-      "public_items": 60,
+      "production_lines": 61,
+      "public_items": 61,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/body/acl_info.rs": {
@@ -5469,6 +5558,11 @@
       "public_items": 5,
       "reexports": 0
     },
+    "rocketmq-protocol/src/protocol/body/proxy_drain.rs": {
+      "production_lines": 33,
+      "public_items": 4,
+      "reexports": 0
+    },
     "rocketmq-protocol/src/protocol/body/query_assignment_request_body.rs": {
       "production_lines": 13,
       "public_items": 1,
@@ -5635,8 +5729,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/header.rs": {
-      "production_lines": 108,
-      "public_items": 108,
+      "production_lines": 115,
+      "public_items": 115,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/header/ack_message_request_header.rs": {
@@ -5864,13 +5958,18 @@
       "public_items": 1,
       "reexports": 0
     },
+    "rocketmq-protocol/src/protocol/header/get_broker_config_response_header.rs": {
+      "production_lines": 8,
+      "public_items": 1,
+      "reexports": 0
+    },
     "rocketmq-protocol/src/protocol/header/get_consume_stats_in_broker_header.rs": {
       "production_lines": 9,
       "public_items": 1,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs": {
-      "production_lines": 28,
+      "production_lines": 29,
       "public_items": 5,
       "reexports": 0
     },
@@ -5925,7 +6024,7 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/header/get_max_offset_request_header.rs": {
-      "production_lines": 89,
+      "production_lines": 91,
       "public_items": 1,
       "reexports": 0
     },
@@ -5940,7 +6039,7 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/header/get_min_offset_request_header.rs": {
-      "production_lines": 88,
+      "production_lines": 90,
       "public_items": 1,
       "reexports": 0
     },
@@ -6264,6 +6363,16 @@
       "public_items": 1,
       "reexports": 0
     },
+    "rocketmq-protocol/src/protocol/header/update_broker_config_request_header.rs": {
+      "production_lines": 8,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/header/update_broker_config_response_header.rs": {
+      "production_lines": 8,
+      "public_items": 1,
+      "reexports": 0
+    },
     "rocketmq-protocol/src/protocol/header/update_consumer_offset_header.rs": {
       "production_lines": 96,
       "public_items": 2,
@@ -6276,6 +6385,26 @@
     },
     "rocketmq-protocol/src/protocol/header/update_group_forbidden_request_header.rs": {
       "production_lines": 16,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/header/update_subscription_group_config_cas_request_header.rs": {
+      "production_lines": 15,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/header/update_subscription_group_config_cas_response_header.rs": {
+      "production_lines": 8,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/header/update_topic_config_cas_request_header.rs": {
+      "production_lines": 15,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/header/update_topic_config_cas_response_header.rs": {
+      "production_lines": 8,
       "public_items": 1,
       "reexports": 0
     },
@@ -6360,8 +6489,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command.rs": {
-      "production_lines": 867,
-      "public_items": 92,
+      "production_lines": 889,
+      "public_items": 94,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command_compat.rs": {
@@ -6570,13 +6699,13 @@
       "reexports": 0
     },
     "rocketmq-proxy-cluster/src/cluster_admission.rs": {
-      "production_lines": 805,
+      "production_lines": 806,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-proxy-cluster/src/cluster_bench_support.rs": {
-      "production_lines": 84,
-      "public_items": 3,
+      "production_lines": 352,
+      "public_items": 5,
       "reexports": 0
     },
     "rocketmq-proxy-cluster/src/cluster_execution.rs": {
@@ -6624,8 +6753,13 @@
       "public_items": 24,
       "reexports": 0
     },
+    "rocketmq-proxy-core/src/drain.rs": {
+      "production_lines": 212,
+      "public_items": 14,
+      "reexports": 0
+    },
     "rocketmq-proxy-core/src/error.rs": {
-      "production_lines": 161,
+      "production_lines": 165,
       "public_items": 19,
       "reexports": 0
     },
@@ -6705,14 +6839,14 @@
       "reexports": 0
     },
     "rocketmq-proxy-core/src/ingress/remoting.rs": {
-      "production_lines": 178,
+      "production_lines": 187,
       "public_items": 11,
       "reexports": 0
     },
     "rocketmq-proxy-core/src/lib.rs": {
-      "production_lines": 65,
-      "public_items": 16,
-      "reexports": 35
+      "production_lines": 72,
+      "public_items": 17,
+      "reexports": 41
     },
     "rocketmq-proxy-core/src/message.rs": {
       "production_lines": 156,
@@ -6745,7 +6879,7 @@
       "reexports": 0
     },
     "rocketmq-proxy-core/src/status.rs": {
-      "production_lines": 252,
+      "production_lines": 253,
       "public_items": 15,
       "reexports": 0
     },
@@ -6775,7 +6909,7 @@
       "reexports": 0
     },
     "rocketmq-proxy/src/auth.rs": {
-      "production_lines": 772,
+      "production_lines": 787,
       "public_items": 40,
       "reexports": 0
     },
@@ -6785,12 +6919,12 @@
       "reexports": 0
     },
     "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs": {
-      "production_lines": 483,
+      "production_lines": 493,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-proxy/src/bootstrap.rs": {
-      "production_lines": 623,
+      "production_lines": 643,
       "public_items": 16,
       "reexports": 0
     },
@@ -6835,12 +6969,12 @@
       "reexports": 0
     },
     "rocketmq-proxy/src/grpc/service.rs": {
-      "production_lines": 1452,
-      "public_items": 16,
+      "production_lines": 1517,
+      "public_items": 17,
       "reexports": 0
     },
     "rocketmq-proxy/src/grpc/service/observation.rs": {
-      "production_lines": 66,
+      "production_lines": 84,
       "public_items": 0,
       "reexports": 0
     },
@@ -6850,7 +6984,7 @@
       "reexports": 0
     },
     "rocketmq-proxy/src/lib.rs": {
-      "production_lines": 266,
+      "production_lines": 269,
       "public_items": 5,
       "reexports": 124
     },
@@ -6865,8 +6999,8 @@
       "reexports": 0
     },
     "rocketmq-proxy/src/observability.rs": {
-      "production_lines": 177,
-      "public_items": 17,
+      "production_lines": 187,
+      "public_items": 18,
       "reexports": 1
     },
     "rocketmq-proxy/src/processor.rs": {
@@ -6880,8 +7014,8 @@
       "reexports": 1
     },
     "rocketmq-proxy/src/remoting.rs": {
-      "production_lines": 1289,
-      "public_items": 7,
+      "production_lines": 1519,
+      "public_items": 10,
       "reexports": 1
     },
     "rocketmq-proxy/src/service.rs": {
@@ -6985,13 +7119,13 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/context.rs": {
-      "production_lines": 97,
+      "production_lines": 104,
       "public_items": 12,
       "reexports": 0
     },
     "rocketmq-runtime/src/diagnostics.rs": {
-      "production_lines": 51,
-      "public_items": 4,
+      "production_lines": 286,
+      "public_items": 17,
       "reexports": 0
     },
     "rocketmq-runtime/src/error.rs": {
@@ -7015,18 +7149,23 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/lib.rs": {
-      "production_lines": 124,
-      "public_items": 24,
-      "reexports": 94
+      "production_lines": 122,
+      "public_items": 13,
+      "reexports": 90
     },
     "rocketmq-runtime/src/metadata_io.rs": {
-      "production_lines": 913,
+      "production_lines": 910,
       "public_items": 38,
       "reexports": 0
     },
+    "rocketmq-runtime/src/operation.rs": {
+      "production_lines": 217,
+      "public_items": 13,
+      "reexports": 0
+    },
     "rocketmq-runtime/src/owner.rs": {
-      "production_lines": 126,
-      "public_items": 11,
+      "production_lines": 148,
+      "public_items": 13,
       "reexports": 0
     },
     "rocketmq-runtime/src/prelude.rs": {
@@ -7035,13 +7174,13 @@
       "reexports": 8
     },
     "rocketmq-runtime/src/public_api.rs": {
-      "production_lines": 8,
+      "production_lines": 23,
       "public_items": 0,
-      "reexports": 8
+      "reexports": 23
     },
     "rocketmq-runtime/src/resource_budget/budget.rs": {
-      "production_lines": 463,
-      "public_items": 25,
+      "production_lines": 597,
+      "public_items": 27,
       "reexports": 0
     },
     "rocketmq-runtime/src/resource_budget/clock.rs": {
@@ -7050,7 +7189,7 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/resource_budget/limit.rs": {
-      "production_lines": 222,
+      "production_lines": 223,
       "public_items": 14,
       "reexports": 0
     },
@@ -7060,17 +7199,22 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/resource_budget/mod.rs": {
-      "production_lines": 28,
+      "production_lines": 29,
       "public_items": 0,
-      "reexports": 23
+      "reexports": 24
     },
     "rocketmq-runtime/src/resource_budget/queue.rs": {
-      "production_lines": 423,
+      "production_lines": 540,
       "public_items": 28,
       "reexports": 0
     },
+    "rocketmq-runtime/src/resources.rs": {
+      "production_lines": 35,
+      "public_items": 3,
+      "reexports": 0
+    },
     "rocketmq-runtime/src/schedule.rs": {
-      "production_lines": 528,
+      "production_lines": 530,
       "public_items": 38,
       "reexports": 5
     },
@@ -7095,18 +7239,18 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/scheduled.rs": {
-      "production_lines": 407,
-      "public_items": 17,
+      "production_lines": 536,
+      "public_items": 21,
       "reexports": 0
     },
     "rocketmq-runtime/src/service_context.rs": {
-      "production_lines": 223,
-      "public_items": 22,
+      "production_lines": 259,
+      "public_items": 28,
       "reexports": 0
     },
     "rocketmq-runtime/src/service_lifecycle.rs": {
-      "production_lines": 456,
-      "public_items": 29,
+      "production_lines": 489,
+      "public_items": 31,
       "reexports": 0
     },
     "rocketmq-runtime/src/shutdown.rs": {
@@ -7115,7 +7259,7 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/shutdown_deadline.rs": {
-      "production_lines": 25,
+      "production_lines": 32,
       "public_items": 6,
       "reexports": 0
     },
@@ -7140,13 +7284,23 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/task_group.rs": {
-      "production_lines": 727,
-      "public_items": 38,
+      "production_lines": 789,
+      "public_items": 31,
+      "reexports": 0
+    },
+    "rocketmq-runtime/src/task_group/registry.rs": {
+      "production_lines": 48,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-runtime/src/task_group/shutdown.rs": {
+      "production_lines": 60,
+      "public_items": 0,
       "reexports": 0
     },
     "rocketmq-runtime/src/task_spawner.rs": {
-      "production_lines": 41,
-      "public_items": 7,
+      "production_lines": 38,
+      "public_items": 6,
       "reexports": 0
     },
     "rocketmq-runtime/src/tokio_lock.rs": {
@@ -7182,6 +7336,2206 @@
     "rocketmq-security-api/src/secure_deployment.rs": {
       "production_lines": 542,
       "public_items": 56,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-cli/src/lib.rs": {
+      "production_lines": 465,
+      "public_items": 15,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-cli/src/main.rs": {
+      "production_lines": 50,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-client/src/lib.rs": {
+      "production_lines": 301,
+      "public_items": 24,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/api.rs": {
+      "production_lines": 169,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/auth.rs": {
+      "production_lines": 130,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/capability.rs": {
+      "production_lines": 264,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/channel.rs": {
+      "production_lines": 563,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/config.rs": {
+      "production_lines": 968,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/engine.rs": {
+      "production_lines": 361,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/error.rs": {
+      "production_lines": 143,
+      "public_items": 11,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/lib.rs": {
+      "production_lines": 30,
+      "public_items": 1,
+      "reexports": 15
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/main.rs": {
+      "production_lines": 22,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/mcp.rs": {
+      "production_lines": 1146,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs": {
+      "production_lines": 954,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/admin_query.rs": {
+      "production_lines": 405,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/alertmanager.rs": {
+      "production_lines": 152,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/auth_security_diagnostics.rs": {
+      "production_lines": 96,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/broker_store_diagnostics.rs": {
+      "production_lines": 97,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs": {
+      "production_lines": 364,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/change_timeline.rs": {
+      "production_lines": 36,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/common.rs": {
+      "production_lines": 376,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/deployment_state.rs": {
+      "production_lines": 239,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory.rs": {
+      "production_lines": 388,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/client_connections.rs": {
+      "production_lines": 396,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/coverage.rs": {
+      "production_lines": 238,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/k8s.rs": {
+      "production_lines": 663,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/rocketmq.rs": {
+      "production_lines": 1144,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/kubernetes.rs": {
+      "production_lines": 416,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/kubernetes_events.rs": {
+      "production_lines": 26,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/loki.rs": {
+      "production_lines": 101,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/mcp.rs": {
+      "production_lines": 55,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/projection.rs": {
+      "production_lines": 565,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/prometheus.rs": {
+      "production_lines": 398,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/proxy_diagnostics.rs": {
+      "production_lines": 104,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/remoting_diagnostics.rs": {
+      "production_lines": 98,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs": {
+      "production_lines": 481,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/runtime_diagnostics.rs": {
+      "production_lines": 330,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/tempo.rs": {
+      "production_lines": 92,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/topology.rs": {
+      "production_lines": 57,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-connector/src/wire.rs": {
+      "production_lines": 297,
+      "public_items": 7,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/action.rs": {
+      "production_lines": 190,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/agent.rs": {
+      "production_lines": 119,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/alert.rs": {
+      "production_lines": 107,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/api.rs": {
+      "production_lines": 51,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/approval.rs": {
+      "production_lines": 48,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/audit.rs": {
+      "production_lines": 62,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/automation.rs": {
+      "production_lines": 335,
+      "public_items": 20,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/autonomy.rs": {
+      "production_lines": 461,
+      "public_items": 25,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/canonical.rs": {
+      "production_lines": 32,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/connector.rs": {
+      "production_lines": 176,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/correlation.rs": {
+      "production_lines": 69,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/critic.rs": {
+      "production_lines": 146,
+      "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/descriptor.rs": {
+      "production_lines": 194,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/dr.rs": {
+      "production_lines": 246,
+      "public_items": 20,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/error.rs": {
+      "production_lines": 75,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/evidence.rs": {
+      "production_lines": 201,
+      "public_items": 16,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/execution.rs": {
+      "production_lines": 261,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/fencing.rs": {
+      "production_lines": 208,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/finops.rs": {
+      "production_lines": 244,
+      "public_items": 19,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/fleet.rs": {
+      "production_lines": 342,
+      "public_items": 27,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/governance.rs": {
+      "production_lines": 192,
+      "public_items": 16,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/ids.rs": {
+      "production_lines": 190,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/incident.rs": {
+      "production_lines": 125,
+      "public_items": 7,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/integration.rs": {
+      "production_lines": 264,
+      "public_items": 21,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/lib.rs": {
+      "production_lines": 489,
+      "public_items": 6,
+      "reexports": 440
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/notification.rs": {
+      "production_lines": 69,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/operations.rs": {
+      "production_lines": 299,
+      "public_items": 21,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/operator_workbench.rs": {
+      "production_lines": 133,
+      "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/plan.rs": {
+      "production_lines": 265,
+      "public_items": 11,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/policy.rs": {
+      "production_lines": 32,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/postmortem.rs": {
+      "production_lines": 94,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/prediction.rs": {
+      "production_lines": 189,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/readiness.rs": {
+      "production_lines": 60,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/release.rs": {
+      "production_lines": 238,
+      "public_items": 16,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/resource.rs": {
+      "production_lines": 36,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/runbook.rs": {
+      "production_lines": 203,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/simulation.rs": {
+      "production_lines": 66,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/slo.rs": {
+      "production_lines": 169,
+      "public_items": 13,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/topology.rs": {
+      "production_lines": 35,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/verification.rs": {
+      "production_lines": 60,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-contracts/src/version.rs": {
+      "production_lines": 59,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/alerting.rs": {
+      "production_lines": 13,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/alerting/model.rs": {
+      "production_lines": 373,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/alerting/notification.rs": {
+      "production_lines": 139,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/alerting/repository.rs": {
+      "production_lines": 1209,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/alerting/service.rs": {
+      "production_lines": 629,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/api.rs": {
+      "production_lines": 1361,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets.rs": {
+      "production_lines": 28,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/hash.rs": {
+      "production_lines": 353,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/model.rs": {
+      "production_lines": 509,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/repository.rs": {
+      "production_lines": 504,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/service.rs": {
+      "production_lines": 138,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/auth.rs": {
+      "production_lines": 290,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation.rs": {
+      "production_lines": 16,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/adapter.rs": {
+      "production_lines": 384,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/api.rs": {
+      "production_lines": 91,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/model.rs": {
+      "production_lines": 101,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/preventive.rs": {
+      "production_lines": 501,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/preventive_repository.rs": {
+      "production_lines": 344,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/repository.rs": {
+      "production_lines": 378,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/automation/service.rs": {
+      "production_lines": 292,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy.rs": {
+      "production_lines": 19,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/api.rs": {
+      "production_lines": 275,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/model.rs": {
+      "production_lines": 333,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/operations.rs": {
+      "production_lines": 302,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/operations_analytics_repository.rs": {
+      "production_lines": 165,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/operations_repository.rs": {
+      "production_lines": 376,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/operations_repository/metrics.rs": {
+      "production_lines": 130,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/operations_service.rs": {
+      "production_lines": 436,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/reconciler.rs": {
+      "production_lines": 42,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository.rs": {
+      "production_lines": 1601,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/service.rs": {
+      "production_lines": 1440,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management.rs": {
+      "production_lines": 9,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/api.rs": {
+      "production_lines": 304,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/model.rs": {
+      "production_lines": 141,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/repository.rs": {
+      "production_lines": 603,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/scheduler.rs": {
+      "production_lines": 280,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/service.rs": {
+      "production_lines": 661,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/change_management/service/support.rs": {
+      "production_lines": 193,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/config.rs": {
+      "production_lines": 335,
+      "public_items": 20,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel.rs": {
+      "production_lines": 23,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/http.rs": {
+      "production_lines": 122,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/model.rs": {
+      "production_lines": 220,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/repository.rs": {
+      "production_lines": 641,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/repository/retention.rs": {
+      "production_lines": 311,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/service.rs": {
+      "production_lines": 411,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/coverage.rs": {
+      "production_lines": 421,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr.rs": {
+      "production_lines": 8,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/api.rs": {
+      "production_lines": 223,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/model.rs": {
+      "production_lines": 180,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/repository.rs": {
+      "production_lines": 13,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/repository/exercise.rs": {
+      "production_lines": 340,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/repository/plan.rs": {
+      "production_lines": 172,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/repository/support.rs": {
+      "production_lines": 367,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/service.rs": {
+      "production_lines": 543,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/dr/service/support.rs": {
+      "production_lines": 240,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/error.rs": {
+      "production_lines": 130,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence.rs": {
+      "production_lines": 9,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/blob.rs": {
+      "production_lines": 174,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/model.rs": {
+      "production_lines": 52,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/repository.rs": {
+      "production_lines": 409,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/service.rs": {
+      "production_lines": 180,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_authority.rs": {
+      "production_lines": 353,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_authority/api.rs": {
+      "production_lines": 98,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_authority/repository.rs": {
+      "production_lines": 396,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_verification.rs": {
+      "production_lines": 133,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops.rs": {
+      "production_lines": 8,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/api.rs": {
+      "production_lines": 112,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/model.rs": {
+      "production_lines": 138,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/repository.rs": {
+      "production_lines": 14,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/repository/budget.rs": {
+      "production_lines": 246,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/repository/ledger.rs": {
+      "production_lines": 131,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/repository/report.rs": {
+      "production_lines": 141,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/repository/support.rs": {
+      "production_lines": 262,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/finops/service.rs": {
+      "production_lines": 632,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet.rs": {
+      "production_lines": 11,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/api.rs": {
+      "production_lines": 275,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/model.rs": {
+      "production_lines": 289,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases.rs": {
+      "production_lines": 7,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases/api.rs": {
+      "production_lines": 189,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases/model.rs": {
+      "production_lines": 107,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases/repository.rs": {
+      "production_lines": 513,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases/service.rs": {
+      "production_lines": 572,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/releases/service/support.rs": {
+      "production_lines": 331,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository.rs": {
+      "production_lines": 15,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository/assets.rs": {
+      "production_lines": 308,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository/onboarding.rs": {
+      "production_lines": 267,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository/regional.rs": {
+      "production_lines": 80,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository/scope.rs": {
+      "production_lines": 202,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/repository/support.rs": {
+      "production_lines": 329,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/fleet/service.rs": {
+      "production_lines": 974,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast.rs": {
+      "production_lines": 6,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/policy.rs": {
+      "production_lines": 312,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/projection.rs": {
+      "production_lines": 414,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/repository.rs": {
+      "production_lines": 340,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/service.rs": {
+      "production_lines": 705,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance.rs": {
+      "production_lines": 12,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/admission.rs": {
+      "production_lines": 296,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/api.rs": {
+      "production_lines": 178,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/model.rs": {
+      "production_lines": 150,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/repository.rs": {
+      "production_lines": 14,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/repository/registry.rs": {
+      "production_lines": 316,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/repository/reporting.rs": {
+      "production_lines": 185,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/repository/support.rs": {
+      "production_lines": 251,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/service.rs": {
+      "production_lines": 492,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/governance/signer.rs": {
+      "production_lines": 73,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/inspection.rs": {
+      "production_lines": 7,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/inspection/model.rs": {
+      "production_lines": 30,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/inspection/service.rs": {
+      "production_lines": 466,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/knowledge.rs": {
+      "production_lines": 13,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/knowledge/chunk.rs": {
+      "production_lines": 91,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/knowledge/model.rs": {
+      "production_lines": 132,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/knowledge/repository.rs": {
+      "production_lines": 404,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/knowledge/service.rs": {
+      "production_lines": 218,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/lib.rs": {
+      "production_lines": 59,
+      "public_items": 5,
+      "reexports": 18
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/main.rs": {
+      "production_lines": 24,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/model.rs": {
+      "production_lines": 291,
+      "public_items": 11,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models.rs": {
+      "production_lines": 18,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/config.rs": {
+      "production_lines": 276,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/lifecycle.rs": {
+      "production_lines": 131,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/lifecycle_repository.rs": {
+      "production_lines": 563,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/model.rs": {
+      "production_lines": 224,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/repository.rs": {
+      "production_lines": 465,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service.rs": {
+      "production_lines": 1748,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/critic.rs": {
+      "production_lines": 472,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/lifecycle.rs": {
+      "production_lines": 158,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/smoke.rs": {
+      "production_lines": 349,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/smoke_repository.rs": {
+      "production_lines": 233,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/observability.rs": {
+      "production_lines": 30,
+      "public_items": 0,
+      "reexports": 24
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/observability/correlation.rs": {
+      "production_lines": 34,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/observability/health.rs": {
+      "production_lines": 344,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/observability/metrics.rs": {
+      "production_lines": 616,
+      "public_items": 16,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/observability/spans.rs": {
+      "production_lines": 118,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/openapi.rs": {
+      "production_lines": 9,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench.rs": {
+      "production_lines": 12,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/api.rs": {
+      "production_lines": 124,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/model.rs": {
+      "production_lines": 26,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/report_repository.rs": {
+      "production_lines": 651,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/report_support.rs": {
+      "production_lines": 66,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/repository.rs": {
+      "production_lines": 639,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/operator_workbench/service.rs": {
+      "production_lines": 188,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/orchestrator.rs": {
+      "production_lines": 5,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/orchestrator/citation.rs": {
+      "production_lines": 27,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/orchestrator/limits.rs": {
+      "production_lines": 66,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/orchestrator/service.rs": {
+      "production_lines": 671,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/phase1_api.rs": {
+      "production_lines": 1041,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/phase2_repository.rs": {
+      "production_lines": 482,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem.rs": {
+      "production_lines": 17,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem/api.rs": {
+      "production_lines": 128,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem/model.rs": {
+      "production_lines": 107,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem/repository.rs": {
+      "production_lines": 672,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem/service.rs": {
+      "production_lines": 516,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/postmortem/worker.rs": {
+      "production_lines": 6,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/read_audit.rs": {
+      "production_lines": 292,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management.rs": {
+      "production_lines": 12,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/adapters.rs": {
+      "production_lines": 149,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/api.rs": {
+      "production_lines": 554,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/descriptors.rs": {
+      "production_lines": 175,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/model.rs": {
+      "production_lines": 288,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/repository.rs": {
+      "production_lines": 4,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/repository/enterprise_integration.rs": {
+      "production_lines": 260,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/repository/integration.rs": {
+      "production_lines": 578,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/repository/release.rs": {
+      "production_lines": 301,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/repository/support.rs": {
+      "production_lines": 203,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/secret_provider.rs": {
+      "production_lines": 67,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service.rs": {
+      "production_lines": 42,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/enterprise_integration.rs": {
+      "production_lines": 376,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/integration.rs": {
+      "production_lines": 443,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/release.rs": {
+      "production_lines": 299,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/release_execution.rs": {
+      "production_lines": 482,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/release_rollback.rs": {
+      "production_lines": 261,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/release_validation.rs": {
+      "production_lines": 236,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/release_management/service/support.rs": {
+      "production_lines": 290,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/repository.rs": {
+      "production_lines": 491,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/slo.rs": {
+      "production_lines": 5,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/slo/policy.rs": {
+      "production_lines": 195,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/slo/repository.rs": {
+      "production_lines": 214,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/slo/service.rs": {
+      "production_lines": 581,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution.rs": {
+      "production_lines": 28,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/api.rs": {
+      "production_lines": 266,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/catalog.rs": {
+      "production_lines": 247,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/executor_client.rs": {
+      "production_lines": 224,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/model.rs": {
+      "production_lines": 215,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/policy.rs": {
+      "production_lines": 195,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/repository.rs": {
+      "production_lines": 582,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/repository/critic.rs": {
+      "production_lines": 147,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/repository/support.rs": {
+      "production_lines": 157,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service.rs": {
+      "production_lines": 716,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service/critic.rs": {
+      "production_lines": 181,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service/support.rs": {
+      "production_lines": 430,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service/workflow.rs": {
+      "production_lines": 570,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/signing.rs": {
+      "production_lines": 368,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_repository.rs": {
+      "production_lines": 298,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow.rs": {
+      "production_lines": 36,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/diagnosis_confirmation.rs": {
+      "production_lines": 253,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/event_entry_model.rs": {
+      "production_lines": 318,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/event_entry_repository.rs": {
+      "production_lines": 463,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/event_entry_service.rs": {
+      "production_lines": 81,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/events.rs": {
+      "production_lines": 35,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/model.rs": {
+      "production_lines": 296,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/repository.rs": {
+      "production_lines": 1875,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/service.rs": {
+      "production_lines": 401,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/action_catalog.rs": {
+      "production_lines": 144,
+      "public_items": 7,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/automation_state.rs": {
+      "production_lines": 122,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/autonomy_policy.rs": {
+      "production_lines": 122,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/canonical_hash.rs": {
+      "production_lines": 5,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/change_calendar.rs": {
+      "production_lines": 284,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/correlation.rs": {
+      "production_lines": 10,
+      "public_items": 0,
+      "reexports": 6
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/correlation/fingerprint.rs": {
+      "production_lines": 87,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/correlation/graph.rs": {
+      "production_lines": 47,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/correlation/merge.rs": {
+      "production_lines": 25,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/correlation/window.rs": {
+      "production_lines": 9,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics.rs": {
+      "production_lines": 34,
+      "public_items": 1,
+      "reexports": 28
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/confidence.rs": {
+      "production_lines": 62,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/engine.rs": {
+      "production_lines": 394,
+      "public_items": 13,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/error.rs": {
+      "production_lines": 70,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs.rs": {
+      "production_lines": 114,
+      "public_items": 5,
+      "reexports": 8
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/broker_ha.rs": {
+      "production_lines": 209,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/broker_health_v1.rs": {
+      "production_lines": 217,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/catalog.rs": {
+      "production_lines": 165,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/client_message.rs": {
+      "production_lines": 314,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/cluster_topology_v1.rs": {
+      "production_lines": 167,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/common.rs": {
+      "production_lines": 37,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/consumer_lag_v2.rs": {
+      "production_lines": 185,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/consumer_runtime_v1.rs": {
+      "production_lines": 183,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/deployment_drift_v1.rs": {
+      "production_lines": 193,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/message_path_v1.rs": {
+      "production_lines": 200,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/prevention.rs": {
+      "production_lines": 383,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/producer_connectivity_v1.rs": {
+      "production_lines": 196,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/routing_proxy.rs": {
+      "production_lines": 277,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/security_runtime.rs": {
+      "production_lines": 144,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/storage.rs": {
+      "production_lines": 256,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/telemetry_pipeline_v1.rs": {
+      "production_lines": 209,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/registry.rs": {
+      "production_lines": 181,
+      "public_items": 11,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/types.rs": {
+      "production_lines": 198,
+      "public_items": 23,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/eligibility.rs": {
+      "production_lines": 218,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/embedded_actions.rs": {
+      "production_lines": 27,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/execution_state.rs": {
+      "production_lines": 39,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/fleet.rs": {
+      "production_lines": 156,
+      "public_items": 12,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/health.rs": {
+      "production_lines": 5,
+      "public_items": 0,
+      "reexports": 4
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/health/score.rs": {
+      "production_lines": 227,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/incident_manager.rs": {
+      "production_lines": 56,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/integration.rs": {
+      "production_lines": 270,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/lib.rs": {
+      "production_lines": 63,
+      "public_items": 6,
+      "reexports": 42
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/plan.rs": {
+      "production_lines": 56,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/postmortem.rs": {
+      "production_lines": 11,
+      "public_items": 0,
+      "reexports": 8
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/postmortem/assembler.rs": {
+      "production_lines": 248,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/postmortem/template.rs": {
+      "production_lines": 60,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/postmortem/validation.rs": {
+      "production_lines": 163,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction.rs": {
+      "production_lines": 8,
+      "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/backlog_eta.rs": {
+      "production_lines": 49,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/baseline.rs": {
+      "production_lines": 178,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/capacity.rs": {
+      "production_lines": 38,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/change_point.rs": {
+      "production_lines": 67,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/disk_runway.rs": {
+      "production_lines": 15,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/readiness.rs": {
+      "production_lines": 127,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/trend.rs": {
+      "production_lines": 325,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/prediction/what_if.rs": {
+      "production_lines": 138,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/registry.rs": {
+      "production_lines": 191,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/release.rs": {
+      "production_lines": 233,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/runbook.rs": {
+      "production_lines": 322,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/slo.rs": {
+      "production_lines": 9,
+      "public_items": 0,
+      "reexports": 8
+    },
+    "rocketmq-sre/crates/rocketmq-sre-core/src/slo/burn_rate.rs": {
+      "production_lines": 271,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/assertions.rs": {
+      "production_lines": 65,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase00_dev_issuer.rs": {
+      "production_lines": 279,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase01_model_mock.rs": {
+      "production_lines": 302,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase01_shadow_eval.rs": {
+      "production_lines": 87,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase3_schema_export.rs": {
+      "production_lines": 8,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/schema_export.rs": {
+      "production_lines": 8,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/lib.rs": {
+      "production_lines": 675,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow.rs": {
+      "production_lines": 23,
+      "public_items": 0,
+      "reexports": 17
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/error.rs": {
+      "production_lines": 48,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/fixture.rs": {
+      "production_lines": 138,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/manifest.rs": {
+      "production_lines": 160,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/provider.rs": {
+      "production_lines": 135,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/runner.rs": {
+      "production_lines": 293,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase1_shadow/security.rs": {
+      "production_lines": 88,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/phase2.rs": {
+      "production_lines": 84,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-eval/src/replay.rs": {
+      "production_lines": 376,
+      "public_items": 25,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/api.rs": {
+      "production_lines": 449,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/authority_client.rs": {
+      "production_lines": 215,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/config.rs": {
+      "production_lines": 508,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/credential_owner.rs": {
+      "production_lines": 49,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/dispatch_barrier.rs": {
+      "production_lines": 86,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers.rs": {
+      "production_lines": 126,
+      "public_items": 3,
+      "reexports": 64
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/admin_core.rs": {
+      "production_lines": 191,
+      "public_items": 23,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/broker_config_patch.rs": {
+      "production_lines": 284,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/config.rs": {
+      "production_lines": 87,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/credential_rotation.rs": {
+      "production_lines": 273,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/kubernetes.rs": {
+      "production_lines": 164,
+      "public_items": 17,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/logger_level_ttl.rs": {
+      "production_lines": 266,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config.rs": {
+      "production_lines": 524,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config/logger_level.rs": {
+      "production_lines": 377,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_credential_rotation.rs": {
+      "production_lines": 590,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_credential_rotation/journal.rs": {
+      "production_lines": 162,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_image_canary.rs": {
+      "production_lines": 631,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_restart.rs": {
+      "production_lines": 795,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_scale.rs": {
+      "production_lines": 326,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_subscription_group.rs": {
+      "production_lines": 597,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_subscription_group/journal.rs": {
+      "production_lines": 240,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_telemetry_collector_restart.rs": {
+      "production_lines": 252,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_topic_config.rs": {
+      "production_lines": 533,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_topic_config/journal.rs": {
+      "production_lines": 222,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_image_canary.rs": {
+      "production_lines": 269,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_restart_one.rs": {
+      "production_lines": 288,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_scale_out_one.rs": {
+      "production_lines": 247,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/subscription_group_patch.rs": {
+      "production_lines": 276,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/telemetry_collector_restart_one.rs": {
+      "production_lines": 239,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/topic_config_patch.rs": {
+      "production_lines": 266,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/effect_store.rs": {
+      "production_lines": 389,
+      "public_items": 16,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/error.rs": {
+      "production_lines": 87,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/fence.rs": {
+      "production_lines": 77,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/lib.rs": {
+      "production_lines": 117,
+      "public_items": 2,
+      "reexports": 97
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/main.rs": {
+      "production_lines": 24,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/registry.rs": {
+      "production_lines": 145,
+      "public_items": 7,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/service.rs": {
+      "production_lines": 434,
+      "public_items": 12,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/agent_client.rs": {
+      "production_lines": 188,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/api.rs": {
+      "production_lines": 290,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/authority_client.rs": {
+      "production_lines": 274,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/config.rs": {
+      "production_lines": 139,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/engine.rs": {
+      "production_lines": 729,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/error.rs": {
+      "production_lines": 90,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/execution_flow.rs": {
+      "production_lines": 791,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/journal.rs": {
+      "production_lines": 835,
+      "public_items": 25,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/lease.rs": {
+      "production_lines": 214,
+      "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/lib.rs": {
+      "production_lines": 74,
+      "public_items": 4,
+      "reexports": 40
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/lock.rs": {
+      "production_lines": 294,
+      "public_items": 11,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/main.rs": {
+      "production_lines": 22,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/precheck.rs": {
+      "production_lines": 52,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/production_verification.rs": {
+      "production_lines": 157,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/reconcile.rs": {
+      "production_lines": 23,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/registry.rs": {
+      "production_lines": 171,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/sli_client.rs": {
+      "production_lines": 128,
+      "public_items": 4,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-executor/src/verifier.rs": {
+      "production_lines": 260,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/adapters.rs": {
+      "production_lines": 1076,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/async_client.rs": {
+      "production_lines": 90,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/aws_sigv4.rs": {
+      "production_lines": 200,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/critic.rs": {
+      "production_lines": 58,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/error.rs": {
+      "production_lines": 115,
+      "public_items": 12,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/fixtures.rs": {
+      "production_lines": 108,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/grpc_spi.rs": {
+      "production_lines": 530,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/http_transport.rs": {
+      "production_lines": 533,
+      "public_items": 15,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/ir.rs": {
+      "production_lines": 318,
+      "public_items": 27,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/lib.rs": {
+      "production_lines": 117,
+      "public_items": 0,
+      "reexports": 100
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/profile.rs": {
+      "production_lines": 574,
+      "public_items": 18,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/provider.rs": {
+      "production_lines": 90,
+      "public_items": 6,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/router.rs": {
+      "production_lines": 608,
+      "public_items": 22,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/secret.rs": {
+      "production_lines": 346,
+      "public_items": 21,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/spi.rs": {
+      "production_lines": 287,
+      "public_items": 21,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/stream.rs": {
+      "production_lines": 141,
+      "public_items": 10,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/transport.rs": {
+      "production_lines": 69,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/vault_agent.rs": {
+      "production_lines": 280,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/cleanup.rs": {
+      "production_lines": 37,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/consumer.rs": {
+      "production_lines": 14,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/evidence.rs": {
+      "production_lines": 61,
+      "public_items": 2,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/lib.rs": {
+      "production_lines": 230,
+      "public_items": 26,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/main.rs": {
+      "production_lines": 485,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/producer.rs": {
+      "production_lines": 24,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/rocketmq_driver.rs": {
+      "production_lines": 281,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-sre/crates/rocketmq-sre-probe/src/scenario.rs": {
+      "production_lines": 262,
+      "public_items": 15,
       "reexports": 0
     },
     "rocketmq-store-api/src/capability/admin.rs": {
@@ -7239,19 +9593,29 @@
       "public_items": 14,
       "reexports": 0
     },
+    "rocketmq-store-api/src/checkpoint_artifact.rs": {
+      "production_lines": 160,
+      "public_items": 6,
+      "reexports": 0
+    },
     "rocketmq-store-api/src/error.rs": {
       "production_lines": 273,
       "public_items": 28,
       "reexports": 0
     },
     "rocketmq-store-api/src/lib.rs": {
-      "production_lines": 451,
+      "production_lines": 460,
       "public_items": 52,
-      "reexports": 34
+      "reexports": 41
     },
     "rocketmq-store-api/src/progress.rs": {
       "production_lines": 355,
       "public_items": 35,
+      "reexports": 0
+    },
+    "rocketmq-store-api/src/wal.rs": {
+      "production_lines": 8,
+      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-store-local/src/base.rs": {
@@ -7260,8 +9624,8 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/base/allocate_mapped_file_service.rs": {
-      "production_lines": 683,
-      "public_items": 16,
+      "production_lines": 777,
+      "public_items": 17,
       "reexports": 0
     },
     "rocketmq-store-local/src/base/memory_lock_manager.rs": {
@@ -7275,8 +9639,8 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/commit_log.rs": {
-      "production_lines": 17,
-      "public_items": 17,
+      "production_lines": 16,
+      "public_items": 16,
       "reexports": 0
     },
     "rocketmq-store-local/src/commit_log/abnormal_recovery.rs": {
@@ -7305,7 +9669,7 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/commit_log/append/sequencer.rs": {
-      "production_lines": 213,
+      "production_lines": 215,
       "public_items": 14,
       "reexports": 0
     },
@@ -7347,11 +9711,6 @@
     "rocketmq-store-local/src/commit_log/normal_recovery.rs": {
       "production_lines": 136,
       "public_items": 4,
-      "reexports": 0
-    },
-    "rocketmq-store-local/src/commit_log/read.rs": {
-      "production_lines": 8,
-      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-store-local/src/commit_log/record.rs": {
@@ -7470,8 +9829,8 @@
       "reexports": 2
     },
     "rocketmq-store-local/src/flush/group_commit.rs": {
-      "production_lines": 330,
-      "public_items": 22,
+      "production_lines": 486,
+      "public_items": 27,
       "reexports": 0
     },
     "rocketmq-store-local/src/flush/queue.rs": {
@@ -7585,9 +9944,9 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/mapped_file.rs": {
-      "production_lines": 58,
+      "production_lines": 59,
       "public_items": 15,
-      "reexports": 23
+      "reexports": 24
     },
     "rocketmq-store-local/src/mapped_file/allocation_policy.rs": {
       "production_lines": 77,
@@ -7650,8 +10009,8 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/mapped_file/memory.rs": {
-      "production_lines": 86,
-      "public_items": 5,
+      "production_lines": 111,
+      "public_items": 6,
       "reexports": 0
     },
     "rocketmq-store-local/src/mapped_file/metrics.rs": {
@@ -7760,8 +10119,8 @@
       "reexports": 0
     },
     "rocketmq-store-local/src/release_checkpoint.rs": {
-      "production_lines": 592,
-      "public_items": 14,
+      "production_lines": 516,
+      "public_items": 9,
       "reexports": 0
     },
     "rocketmq-store-local/src/services.rs": {
@@ -7940,7 +10299,7 @@
       "reexports": 0
     },
     "rocketmq-store-rocksdb/src/release_checkpoint.rs": {
-      "production_lines": 297,
+      "production_lines": 298,
       "public_items": 3,
       "reexports": 0
     },
@@ -7976,7 +10335,7 @@
     },
     "rocketmq-store/src/base.rs": {
       "production_lines": 41,
-      "public_items": 27,
+      "public_items": 26,
       "reexports": 0
     },
     "rocketmq-store/src/base/allocate_mapped_file_service.rs": {
@@ -7987,6 +10346,11 @@
     "rocketmq-store/src/base/append_message_callback.rs": {
       "production_lines": 553,
       "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-store/src/base/backend_ops.rs": {
+      "production_lines": 426,
+      "public_items": 11,
       "reexports": 0
     },
     "rocketmq-store/src/base/commit_log_dispatcher.rs": {
@@ -8039,11 +10403,6 @@
       "public_items": 2,
       "reexports": 1
     },
-    "rocketmq-store/src/base/message_store.rs": {
-      "production_lines": 426,
-      "public_items": 11,
-      "reexports": 0
-    },
     "rocketmq-store/src/base/put_message_context.rs": {
       "production_lines": 1,
       "public_items": 0,
@@ -8090,8 +10449,8 @@
       "reexports": 1
     },
     "rocketmq-store/src/capability.rs": {
-      "production_lines": 463,
-      "public_items": 27,
+      "production_lines": 922,
+      "public_items": 35,
       "reexports": 0
     },
     "rocketmq-store/src/config.rs": {
@@ -8170,7 +10529,7 @@
       "reexports": 0
     },
     "rocketmq-store/src/ha/default_ha_client.rs": {
-      "production_lines": 625,
+      "production_lines": 624,
       "public_items": 17,
       "reexports": 0
     },
@@ -8195,8 +10554,8 @@
       "reexports": 0
     },
     "rocketmq-store/src/ha/general_ha_connection.rs": {
-      "production_lines": 163,
-      "public_items": 9,
+      "production_lines": 103,
+      "public_items": 4,
       "reexports": 0
     },
     "rocketmq-store/src/ha/general_ha_service.rs": {
@@ -8330,8 +10689,8 @@
       "reexports": 0
     },
     "rocketmq-store/src/lib.rs": {
-      "production_lines": 1207,
-      "public_items": 34,
+      "production_lines": 37,
+      "public_items": 1,
       "reexports": 1
     },
     "rocketmq-store/src/log_file.rs": {
@@ -8380,7 +10739,7 @@
       "reexports": 0
     },
     "rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs": {
-      "production_lines": 673,
+      "production_lines": 689,
       "public_items": 12,
       "reexports": 1
     },
@@ -8395,9 +10754,9 @@
       "reexports": 0
     },
     "rocketmq-store/src/log_file/mapped_file.rs": {
-      "production_lines": 120,
+      "production_lines": 121,
       "public_items": 2,
-      "reexports": 15
+      "reexports": 16
     },
     "rocketmq-store/src/log_file/mapped_file/builder.rs": {
       "production_lines": 103,
@@ -8415,9 +10774,9 @@
       "reexports": 0
     },
     "rocketmq-store/src/log_file/mapped_file/memory.rs": {
-      "production_lines": 2,
+      "production_lines": 3,
       "public_items": 0,
-      "reexports": 2
+      "reexports": 3
     },
     "rocketmq-store/src/message_encoder.rs": {
       "production_lines": 1,
@@ -8430,17 +10789,17 @@
       "reexports": 0
     },
     "rocketmq-store/src/message_store.rs": {
-      "production_lines": 645,
+      "production_lines": 644,
       "public_items": 8,
-      "reexports": 3
+      "reexports": 2
     },
     "rocketmq-store/src/message_store/local_file_message_store.rs": {
-      "production_lines": 1906,
+      "production_lines": 1981,
       "public_items": 1,
       "reexports": 4
     },
     "rocketmq-store/src/message_store/local_file_message_store/composition.rs": {
-      "production_lines": 634,
+      "production_lines": 635,
       "public_items": 14,
       "reexports": 0
     },
@@ -8474,11 +10833,6 @@
       "public_items": 0,
       "reexports": 0
     },
-    "rocketmq-store/src/message_store/owned_message_store.rs": {
-      "production_lines": 37,
-      "public_items": 5,
-      "reexports": 0
-    },
     "rocketmq-store/src/message_store/recovery.rs": {
       "production_lines": 331,
       "public_items": 44,
@@ -8490,7 +10844,7 @@
       "reexports": 0
     },
     "rocketmq-store/src/message_store/rocksdb_message_store.rs": {
-      "production_lines": 1079,
+      "production_lines": 1090,
       "public_items": 26,
       "reexports": 0
     },
@@ -8525,9 +10879,9 @@
       "reexports": 1
     },
     "rocketmq-store/src/public_api.rs": {
-      "production_lines": 287,
+      "production_lines": 294,
       "public_items": 0,
-      "reexports": 280
+      "reexports": 287
     },
     "rocketmq-store/src/queue.rs": {
       "production_lines": 102,
@@ -8680,7 +11034,7 @@
       "reexports": 6
     },
     "rocketmq-store/src/runtime.rs": {
-      "production_lines": 112,
+      "production_lines": 158,
       "public_items": 0,
       "reexports": 0
     },
@@ -8722,6 +11076,11 @@
     "rocketmq-store/src/store_path_config_helper.rs": {
       "production_lines": 70,
       "public_items": 13,
+      "reexports": 0
+    },
+    "rocketmq-store/src/store_ports.rs": {
+      "production_lines": 36,
+      "public_items": 5,
       "reexports": 0
     },
     "rocketmq-store/src/telemetry.rs": {
@@ -8835,7 +11194,7 @@
       "reexports": 0
     },
     "rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs": {
-      "production_lines": 628,
+      "production_lines": 633,
       "public_items": 14,
       "reexports": 2
     },
@@ -8950,18 +11309,18 @@
       "reexports": 0
     },
     "rocketmq-tieredstore/src/runtime.rs": {
-      "production_lines": 13,
+      "production_lines": 53,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tieredstore/src/service.rs": {
-      "production_lines": 109,
+      "production_lines": 112,
       "public_items": 9,
       "reexports": 2
     },
     "rocketmq-tieredstore/src/service/cleanup_service.rs": {
-      "production_lines": 121,
-      "public_items": 6,
+      "production_lines": 125,
+      "public_items": 5,
       "reexports": 0
     },
     "rocketmq-tieredstore/src/service/commit_log_recover_service.rs": {
@@ -9570,7 +11929,7 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_sub_command.rs": {
-      "production_lines": 132,
+      "production_lines": 137,
       "public_items": 1,
       "reexports": 0
     },
@@ -9640,12 +11999,12 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter.rs": {
-      "production_lines": 16,
+      "production_lines": 34,
       "public_items": 1,
       "reexports": 6
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/broker.rs": {
-      "production_lines": 159,
+      "production_lines": 255,
       "public_items": 0,
       "reexports": 0
     },
@@ -9665,7 +12024,7 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/dashboard.rs": {
-      "production_lines": 744,
+      "production_lines": 746,
       "public_items": 0,
       "reexports": 0
     },
@@ -9700,9 +12059,9 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lifecycle.rs": {
-      "production_lines": 209,
-      "public_items": 21,
-      "reexports": 0
+      "production_lines": 249,
+      "public_items": 22,
+      "reexports": 3
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lite.rs": {
       "production_lines": 33,
@@ -9713,6 +12072,16 @@
       "production_lines": 499,
       "public_items": 0,
       "reexports": 0
+    },
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation.rs": {
+      "production_lines": 1051,
+      "public_items": 21,
+      "reexports": 2
+    },
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs": {
+      "production_lines": 1144,
+      "public_items": 21,
+      "reexports": 3
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/security.rs": {
       "production_lines": 60,
@@ -9870,8 +12239,8 @@
       "reexports": 30
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/operations.rs": {
-      "production_lines": 532,
-      "public_items": 24,
+      "production_lines": 564,
+      "public_items": 25,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/types.rs": {
@@ -9885,12 +12254,12 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs": {
-      "production_lines": 622,
+      "production_lines": 593,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic/producer.rs": {
-      "production_lines": 117,
+      "production_lines": 160,
       "public_items": 0,
       "reexports": 0
     },
@@ -9900,13 +12269,18 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs": {
-      "production_lines": 113,
+      "production_lines": 133,
       "public_items": 14,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs": {
-      "production_lines": 58,
-      "public_items": 8,
+      "production_lines": 697,
+      "public_items": 43,
+      "reexports": 0
+    },
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/client_connection.rs": {
+      "production_lines": 106,
+      "public_items": 13,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/clock.rs": {
@@ -9915,13 +12289,13 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs": {
-      "production_lines": 287,
-      "public_items": 29,
+      "production_lines": 490,
+      "public_items": 39,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/dashboard.rs": {
-      "production_lines": 381,
-      "public_items": 39,
+      "production_lines": 385,
+      "public_items": 41,
       "reexports": 1
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/error.rs": {
@@ -9940,14 +12314,19 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs": {
-      "production_lines": 160,
-      "public_items": 20,
+      "production_lines": 216,
+      "public_items": 22,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs": {
-      "production_lines": 22,
-      "public_items": 15,
+      "production_lines": 24,
+      "public_items": 17,
       "reexports": 5
+    },
+    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/proxy.rs": {
+      "production_lines": 116,
+      "public_items": 9,
+      "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/queue.rs": {
       "production_lines": 8,
@@ -9975,13 +12354,13 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic.rs": {
-      "production_lines": 237,
-      "public_items": 31,
+      "production_lines": 395,
+      "public_items": 41,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs": {
-      "production_lines": 4,
-      "public_items": 2,
+      "production_lines": 12,
+      "public_items": 4,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/action.rs": {
@@ -10055,23 +12434,23 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/adapter/admin_session.rs": {
-      "production_lines": 258,
+      "production_lines": 262,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs": {
-      "production_lines": 706,
+      "production_lines": 710,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/app.rs": {
-      "production_lines": 319,
-      "public_items": 15,
+      "production_lines": 460,
+      "public_items": 16,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/config.rs": {
-      "production_lines": 473,
-      "public_items": 20,
+      "production_lines": 730,
+      "public_items": 21,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/error.rs": {
@@ -10080,43 +12459,43 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard.rs": {
-      "production_lines": 334,
-      "public_items": 26,
+      "production_lines": 494,
+      "public_items": 29,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/audit.rs": {
-      "production_lines": 653,
+      "production_lines": 669,
       "public_items": 15,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/context.rs": {
-      "production_lines": 35,
+      "production_lines": 40,
       "public_items": 4,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/http_auth.rs": {
-      "production_lines": 273,
+      "production_lines": 286,
       "public_items": 9,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/jwks.rs": {
-      "production_lines": 226,
+      "production_lines": 238,
       "public_items": 9,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/policy.rs": {
-      "production_lines": 149,
-      "public_items": 8,
+      "production_lines": 167,
+      "public_items": 10,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/rate_limit.rs": {
-      "production_lines": 44,
+      "production_lines": 49,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/guard/sanitizer.rs": {
-      "production_lines": 59,
-      "public_items": 3,
+      "production_lines": 153,
+      "public_items": 4,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/infrastructure.rs": {
@@ -10125,7 +12504,7 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/infrastructure/cache.rs": {
-      "production_lines": 231,
+      "production_lines": 238,
       "public_items": 0,
       "reexports": 0
     },
@@ -10135,7 +12514,7 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/main.rs": {
-      "production_lines": 192,
+      "production_lines": 197,
       "public_items": 0,
       "reexports": 0
     },
@@ -10180,28 +12559,38 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/protocol/server.rs": {
-      "production_lines": 187,
+      "production_lines": 362,
       "public_items": 3,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/resources.rs": {
-      "production_lines": 3,
-      "public_items": 3,
+      "production_lines": 5,
+      "public_items": 5,
+      "reexports": 0
+    },
+    "rocketmq-tools/rocketmq-mcp/src/resources/capability.rs": {
+      "production_lines": 113,
+      "public_items": 5,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/resources/reader.rs": {
-      "production_lines": 266,
+      "production_lines": 287,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/resources/registry.rs": {
-      "production_lines": 109,
+      "production_lines": 118,
       "public_items": 3,
       "reexports": 0
     },
+    "rocketmq-tools/rocketmq-mcp/src/resources/system.rs": {
+      "production_lines": 29,
+      "public_items": 1,
+      "reexports": 0
+    },
     "rocketmq-tools/rocketmq-mcp/src/resources/uri.rs": {
-      "production_lines": 164,
-      "public_items": 10,
+      "production_lines": 228,
+      "public_items": 14,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/service.rs": {
@@ -10260,12 +12649,12 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/tools/executor.rs": {
-      "production_lines": 566,
+      "production_lines": 805,
       "public_items": 0,
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/tools/output_policy.rs": {
-      "production_lines": 37,
+      "production_lines": 111,
       "public_items": 0,
       "reexports": 0
     },
@@ -10285,7 +12674,7 @@
       "reexports": 0
     },
     "rocketmq-tools/rocketmq-mcp/src/transport/streamable_http.rs": {
-      "production_lines": 255,
+      "production_lines": 260,
       "public_items": 5,
       "reexports": 0
     },
@@ -10310,8 +12699,8 @@
       "reexports": 0
     },
     "rocketmq-transport/src/admission.rs": {
-      "production_lines": 600,
-      "public_items": 24,
+      "production_lines": 665,
+      "public_items": 26,
       "reexports": 1
     },
     "rocketmq-transport/src/base.rs": {
@@ -10330,8 +12719,8 @@
       "reexports": 0
     },
     "rocketmq-transport/src/base/pending_request_table.rs": {
-      "production_lines": 526,
-      "public_items": 29,
+      "production_lines": 534,
+      "public_items": 30,
       "reexports": 0
     },
     "rocketmq-transport/src/base/response_future.rs": {
@@ -10350,23 +12739,23 @@
       "reexports": 0
     },
     "rocketmq-transport/src/client.rs": {
-      "production_lines": 259,
+      "production_lines": 263,
       "public_items": 16,
       "reexports": 0
     },
     "rocketmq-transport/src/clients.rs": {
-      "production_lines": 51,
+      "production_lines": 50,
       "public_items": 4,
       "reexports": 1
     },
     "rocketmq-transport/src/clients/client.rs": {
-      "production_lines": 444,
-      "public_items": 10,
+      "production_lines": 489,
+      "public_items": 11,
       "reexports": 0
     },
     "rocketmq-transport/src/clients/connection_pool.rs": {
-      "production_lines": 395,
-      "public_items": 43,
+      "production_lines": 356,
+      "public_items": 36,
       "reexports": 0
     },
     "rocketmq-transport/src/clients/nameserver_selector.rs": {
@@ -10375,13 +12764,13 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/reconnect.rs": {
-      "production_lines": 138,
-      "public_items": 16,
+      "production_lines": 95,
+      "public_items": 8,
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 919,
-      "public_items": 18,
+      "production_lines": 895,
+      "public_items": 19,
       "reexports": 0
     },
     "rocketmq-transport/src/codec.rs": {
@@ -10435,8 +12824,8 @@
       "reexports": 0
     },
     "rocketmq-transport/src/connection.rs": {
-      "production_lines": 722,
-      "public_items": 36,
+      "production_lines": 764,
+      "public_items": 37,
       "reexports": 0
     },
     "rocketmq-transport/src/connection_context.rs": {
@@ -10474,6 +12863,26 @@
       "public_items": 1,
       "reexports": 0
     },
+    "rocketmq-transport/src/dispatch.rs": {
+      "production_lines": 13,
+      "public_items": 0,
+      "reexports": 10
+    },
+    "rocketmq-transport/src/dispatch/authorized_dispatcher.rs": {
+      "production_lines": 282,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/dispatch/request_context.rs": {
+      "production_lines": 59,
+      "public_items": 9,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/dispatch/response_sink.rs": {
+      "production_lines": 135,
+      "public_items": 9,
+      "reexports": 0
+    },
     "rocketmq-transport/src/error_helpers.rs": {
       "production_lines": 68,
       "public_items": 12,
@@ -10485,9 +12894,9 @@
       "reexports": 0
     },
     "rocketmq-transport/src/lib.rs": {
-      "production_lines": 167,
-      "public_items": 1,
-      "reexports": 135
+      "production_lines": 160,
+      "public_items": 2,
+      "reexports": 124
     },
     "rocketmq-transport/src/local.rs": {
       "production_lines": 61,
@@ -10500,7 +12909,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/net/channel.rs": {
-      "production_lines": 610,
+      "production_lines": 665,
       "public_items": 37,
       "reexports": 0
     },
@@ -10510,9 +12919,9 @@
       "reexports": 5
     },
     "rocketmq-transport/src/public_api.rs": {
-      "production_lines": 7,
+      "production_lines": 17,
       "public_items": 0,
-      "reexports": 7
+      "reexports": 17
     },
     "rocketmq-transport/src/remoting.rs": {
       "production_lines": 292,
@@ -10525,8 +12934,8 @@
       "reexports": 0
     },
     "rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs": {
-      "production_lines": 727,
-      "public_items": 16,
+      "production_lines": 750,
+      "public_items": 17,
       "reexports": 0
     },
     "rocketmq-transport/src/request_ordering.rs": {
@@ -10625,12 +13034,12 @@
       "reexports": 0
     },
     "rocketmq-transport/src/server.rs": {
-      "production_lines": 917,
-      "public_items": 29,
+      "production_lines": 902,
+      "public_items": 30,
       "reexports": 0
     },
     "rocketmq-transport/src/session_executor.rs": {
-      "production_lines": 142,
+      "production_lines": 154,
       "public_items": 0,
       "reexports": 0
     },
@@ -10653,7 +13062,7 @@
   "hotspots": [
     {
       "metrics": {
-        "churn_commits": 227,
+        "churn_commits": 229,
         "contributors": 12,
         "crate": "rocketmq-broker",
         "defect_commits": 2,
@@ -10663,7 +13072,7 @@
         "production_lines": 767,
         "public_items": 1,
         "reexports": 0,
-        "score": 725.425,
+        "score": 730.425,
         "state_owners": 2,
         "test_functions": 0
       },
@@ -10681,17 +13090,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 97,
+        "churn_commits": 98,
         "contributors": 14,
         "crate": "rocketmq-client",
         "defect_commits": 1,
-        "fan_out": 9,
+        "fan_out": 10,
         "lock_sites": 0,
         "path": "rocketmq-client/src/producer/default_mq_producer.rs",
-        "production_lines": 2120,
-        "public_items": 181,
+        "production_lines": 2138,
+        "public_items": 182,
         "reexports": 0,
-        "score": 656.954,
+        "score": 663.404,
         "state_owners": 0,
         "test_functions": 30
       },
@@ -10709,17 +13118,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 160,
+        "churn_commits": 163,
         "contributors": 5,
         "crate": "rocketmq-store",
         "defect_commits": 4,
         "fan_out": 25,
         "lock_sites": 21,
         "path": "rocketmq-store/src/message_store/local_file_message_store.rs",
-        "production_lines": 1906,
+        "production_lines": 1981,
         "public_items": 1,
         "reexports": 4,
-        "score": 565.4,
+        "score": 574.775,
         "state_owners": 0,
         "test_functions": 0
       },
@@ -10738,7 +13147,7 @@
     {
       "metrics": {
         "churn_commits": 103,
-        "contributors": 7,
+        "contributors": 6,
         "crate": "rocketmq-store",
         "defect_commits": 4,
         "fan_out": 15,
@@ -10747,7 +13156,7 @@
         "production_lines": 2277,
         "public_items": 60,
         "reexports": 4,
-        "score": 504.09,
+        "score": 500.09,
         "state_owners": 0,
         "test_functions": 21
       },
@@ -10793,17 +13202,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 71,
+        "churn_commits": 74,
         "contributors": 3,
         "crate": "rocketmq-client",
         "defect_commits": 2,
         "fan_out": 13,
         "lock_sites": 12,
         "path": "rocketmq-client/src/factory/mq_client_instance.rs",
-        "production_lines": 2256,
+        "production_lines": 2261,
         "public_items": 66,
         "reexports": 6,
-        "score": 408.066,
+        "score": 415.691,
         "state_owners": 0,
         "test_functions": 37
       },
@@ -10817,6 +13226,34 @@
         "lifecycle",
         "request execution",
         "result projection"
+      ]
+    },
+    {
+      "metrics": {
+        "churn_commits": 41,
+        "contributors": 1,
+        "crate": "rocketmq-client",
+        "defect_commits": 0,
+        "fan_out": 11,
+        "lock_sites": 43,
+        "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
+        "production_lines": 2499,
+        "public_items": 95,
+        "reexports": 4,
+        "score": 400.031,
+        "state_owners": 0,
+        "test_functions": 41
+      },
+      "owner": "rocketmq-client maintainers",
+      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
+      "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
+      "state_owner": "`default_lite_pull_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
+      "test_strategy": "Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
+      "use_cases": [
+        "lifecycle",
+        "assignment and routing",
+        "message flow",
+        "offset and shutdown"
       ]
     },
     {
@@ -10849,30 +13286,30 @@
     },
     {
       "metrics": {
-        "churn_commits": 38,
+        "churn_commits": 13,
         "contributors": 1,
-        "crate": "rocketmq-client",
+        "crate": "rocketmq-observability",
         "defect_commits": 0,
-        "fan_out": 11,
-        "lock_sites": 47,
-        "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
-        "production_lines": 2406,
-        "public_items": 92,
-        "reexports": 3,
-        "score": 390.549,
+        "fan_out": 0,
+        "lock_sites": 0,
+        "path": "rocketmq-observability/src/semantic.rs",
+        "production_lines": 234,
+        "public_items": 229,
+        "reexports": 0,
+        "score": 385.85,
         "state_owners": 0,
-        "test_functions": 40
+        "test_functions": 0
       },
-      "owner": "rocketmq-client maintainers",
-      "path": "rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs",
+      "owner": "rocketmq-observability maintainers",
+      "path": "rocketmq-observability/src/semantic.rs",
       "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
-      "state_owner": "`default_lite_pull_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
-      "test_strategy": "Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
+      "state_owner": "`semantic` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
+      "test_strategy": "Run focused `rocketmq-observability` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
       "use_cases": [
+        "semantic",
         "lifecycle",
-        "assignment and routing",
-        "message flow",
-        "offset and shutdown"
+        "request execution",
+        "result projection"
       ]
     },
     {
@@ -10933,17 +13370,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 103,
+        "churn_commits": 104,
         "contributors": 10,
         "crate": "rocketmq-client",
         "defect_commits": 0,
         "fan_out": 13,
         "lock_sites": 3,
         "path": "rocketmq-client/src/implementation/mq_client_api_impl.rs",
-        "production_lines": 346,
+        "production_lines": 401,
         "public_items": 1,
         "reexports": 5,
-        "score": 342.4,
+        "score": 346.275,
         "state_owners": 1,
         "test_functions": 0
       },
@@ -10961,35 +13398,7 @@
     },
     {
       "metrics": {
-        "churn_commits": 11,
-        "contributors": 1,
-        "crate": "rocketmq-observability",
-        "defect_commits": 0,
-        "fan_out": 0,
-        "lock_sites": 0,
-        "path": "rocketmq-observability/src/semantic.rs",
-        "production_lines": 198,
-        "public_items": 193,
-        "reexports": 0,
-        "score": 325.95,
-        "state_owners": 0,
-        "test_functions": 0
-      },
-      "owner": "rocketmq-observability maintainers",
-      "path": "rocketmq-observability/src/semantic.rs",
-      "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
-      "state_owner": "`semantic` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
-      "test_strategy": "Run focused `rocketmq-observability` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
-      "use_cases": [
-        "semantic",
-        "lifecycle",
-        "request execution",
-        "result projection"
-      ]
-    },
-    {
-      "metrics": {
-        "churn_commits": 53,
+        "churn_commits": 54,
         "contributors": 2,
         "crate": "rocketmq-client",
         "defect_commits": 1,
@@ -10999,7 +13408,7 @@
         "production_lines": 2143,
         "public_items": 41,
         "reexports": 0,
-        "score": 318.325,
+        "score": 320.825,
         "state_owners": 0,
         "test_functions": 25
       },
@@ -11017,17 +13426,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 17,
+        "churn_commits": 18,
         "contributors": 1,
         "crate": "rocketmq-client",
         "defect_commits": 0,
-        "fan_out": 8,
+        "fan_out": 9,
         "lock_sites": 4,
         "path": "rocketmq-client/src/consumer/default_lite_pull_consumer.rs",
-        "production_lines": 1235,
+        "production_lines": 1252,
         "public_items": 125,
         "reexports": 0,
-        "score": 297.537,
+        "score": 302.462,
         "state_owners": 0,
         "test_functions": 34
       },
@@ -11045,7 +13454,7 @@
     },
     {
       "metrics": {
-        "churn_commits": 56,
+        "churn_commits": 58,
         "contributors": 6,
         "crate": "rocketmq-broker",
         "defect_commits": 0,
@@ -11055,7 +13464,7 @@
         "production_lines": 1491,
         "public_items": 45,
         "reexports": 0,
-        "score": 288.432,
+        "score": 293.432,
         "state_owners": 0,
         "test_functions": 8
       },
@@ -11073,17 +13482,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 80,
+        "churn_commits": 81,
         "contributors": 5,
         "crate": "rocketmq-client",
         "defect_commits": 1,
         "fan_out": 13,
         "lock_sites": 10,
         "path": "rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs",
-        "production_lines": 330,
+        "production_lines": 334,
         "public_items": 1,
         "reexports": 0,
-        "score": 288.25,
+        "score": 290.85,
         "state_owners": 3,
         "test_functions": 0
       },
@@ -11101,17 +13510,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 63,
+        "churn_commits": 64,
         "contributors": 6,
         "crate": "rocketmq-broker",
         "defect_commits": 3,
         "fan_out": 13,
         "lock_sites": 0,
         "path": "rocketmq-broker/src/processor/send_message_processor.rs",
-        "production_lines": 1693,
+        "production_lines": 1699,
         "public_items": 8,
         "reexports": 0,
-        "score": 285.31,
+        "score": 287.96,
         "state_owners": 0,
         "test_functions": 18
       },
@@ -11129,7 +13538,7 @@
     },
     {
       "metrics": {
-        "churn_commits": 32,
+        "churn_commits": 34,
         "contributors": 5,
         "crate": "rocketmq-broker",
         "defect_commits": 0,
@@ -11139,7 +13548,7 @@
         "production_lines": 1594,
         "public_items": 48,
         "reexports": 0,
-        "score": 279.515,
+        "score": 284.515,
         "state_owners": 3,
         "test_functions": 21
       },
@@ -11157,17 +13566,17 @@
     },
     {
       "metrics": {
-        "churn_commits": 27,
+        "churn_commits": 29,
         "contributors": 3,
         "crate": "rocketmq-client",
         "defect_commits": 1,
         "fan_out": 5,
         "lock_sites": 47,
         "path": "rocketmq-client/src/producer/produce_accumulator.rs",
-        "production_lines": 1849,
+        "production_lines": 1852,
         "public_items": 30,
         "reexports": 0,
-        "score": 275.058,
+        "score": 280.133,
         "state_owners": 4,
         "test_functions": 28
       },
@@ -11185,39 +13594,40 @@
     },
     {
       "metrics": {
-        "churn_commits": 80,
-        "contributors": 9,
-        "crate": "rocketmq-client",
-        "defect_commits": 0,
-        "fan_out": 11,
-        "lock_sites": 0,
-        "path": "rocketmq-client/src/admin/default_mq_admin_ext_impl.rs",
-        "production_lines": 192,
-        "public_items": 7,
+        "churn_commits": 47,
+        "contributors": 3,
+        "crate": "rocketmq-broker",
+        "defect_commits": 2,
+        "fan_out": 9,
+        "lock_sites": 19,
+        "path": "rocketmq-broker/src/processor/pop_message_processor.rs",
+        "production_lines": 1534,
+        "public_items": 29,
         "reexports": 0,
-        "score": 273.3,
-        "state_owners": 0,
-        "test_functions": 0
+        "score": 277.481,
+        "state_owners": 1,
+        "test_functions": 22
       },
-      "owner": "rocketmq-client maintainers",
-      "path": "rocketmq-client/src/admin/default_mq_admin_ext_impl.rs",
+      "owner": "rocketmq-broker maintainers",
+      "path": "rocketmq-broker/src/processor/pop_message_processor.rs",
       "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
-      "state_owner": "`default_mq_admin_ext_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
-      "test_strategy": "Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
+      "state_owner": "`pop_message_processor` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
+      "test_strategy": "Run focused `rocketmq-broker` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
       "use_cases": [
-        "request validation",
-        "admin dispatch",
-        "response projection",
-        "error mapping"
+        "pop message processor",
+        "lifecycle",
+        "request execution",
+        "result projection"
       ]
     }
   ],
   "policy": {
     "line_growth": "Existing hotspots may shrink but not grow; new production modules must stay at or below 800 lines.",
+    "ownership": "State owners, lock sites, and dependency fan-out may shrink but not grow without review.",
     "public_surface": "Per-file and per-crate public item and re-export counts may shrink but not grow without review.",
     "ranking": "Ranking combines production LOC, history, contributors, defects, public surface, state/lock ownership, fan-out, and test cost."
   },
-  "schema_version": 1,
+  "schema_version": 2,
   "thresholds": {
     "hard_lines": 800,
     "ranked_hotspots": 20,

--- a/scripts/module_maintainability_guard.py
+++ b/scripts/module_maintainability_guard.py
@@ -37,9 +37,11 @@ import environment_write_guard as rust_source  # noqa: E402
 ROOT = Path(__file__).resolve().parents[1]
 BASELINE = ROOT / "scripts" / "module-maintainability-baseline.json"
 REPORT = ROOT / "rocketmq-doc" / "en" / "module-maintainability-board.md"
+DECISIONS = ROOT / "rocketmq-doc" / "en" / "hotspot-module-decisions.md"
 REVIEW_LINES = 500
 HARD_LINES = 800
 RANKED_HOTSPOTS = 20
+FORBIDDEN_FRAGMENT_NAMES = {"impl_2.rs", "misc.rs", "utils2.rs"}
 
 PUBLIC_ITEM = re.compile(
     r"(?m)^\s*pub\s+(?:(?:async|unsafe)\s+)?(?:fn|struct|enum|trait|type|const|static|mod)\b"
@@ -51,6 +53,8 @@ STATE_OWNER = re.compile(
 )
 TEST_FUNCTION = re.compile(r"(?m)^\s*#\[(?:tokio::)?test[^\]]*\]\s*(?:\r?\n\s*#\[[^\]]+\]\s*)*")
 USE_TARGET = re.compile(r"(?m)^\s*use\s+(?:crate::([A-Za-z0-9_]+)|(rocketmq_[A-Za-z0-9_]+))")
+DECISION_HEADING = re.compile(r"(?m)^### `([^`\r\n]+)`\s*$")
+DECISION_FIELD = re.compile(r"(?m)^- (Decision|Owner|State owner|Evidence|Revisit when):\s*(.+?)\s*$")
 
 
 @dataclass(frozen=True)
@@ -259,6 +263,45 @@ def scan_tree(root: Path) -> list[FileMetrics]:
     return sorted(metrics, key=lambda item: (-item.score, -item.production_lines, item.path))
 
 
+def validate_decision_ledger(hotspots: list[FileMetrics], document: str) -> list[Finding]:
+    """Require an explicit, reviewable decision for every ranked hotspot."""
+    headings = list(DECISION_HEADING.finditer(document))
+    sections: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for index, heading in enumerate(headings):
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(document)
+        fields = {key.lower(): value.strip() for key, value in DECISION_FIELD.findall(document[heading.end() : end])}
+        sections[heading.group(1)].append(fields)
+
+    findings = []
+    required = {"decision", "owner", "state owner", "evidence", "revisit when"}
+    for hotspot in hotspots:
+        entries = sections.get(hotspot.path, [])
+        if not entries:
+            findings.append(Finding("missing-hotspot-decision", hotspot.path, "ranked hotspot lacks an ADR decision"))
+            continue
+        if len(entries) != 1:
+            findings.append(
+                Finding("duplicate-hotspot-decision", hotspot.path, f"expected one ADR section, found {len(entries)}")
+            )
+            continue
+        fields = entries[0]
+        decision = fields.get("decision", "").rstrip(".").strip("`")
+        incomplete = required - fields.keys()
+        if decision not in {"decomposed", "retained"}:
+            incomplete.add("decision=decomposed|retained")
+        if any(len(fields.get(field, "").strip()) < 12 for field in required - {"decision"}):
+            incomplete.add("substantive field content")
+        if incomplete:
+            findings.append(
+                Finding(
+                    "incomplete-hotspot-decision",
+                    hotspot.path,
+                    f"missing or invalid: {', '.join(sorted(incomplete))}",
+                )
+            )
+    return findings
+
+
 def inferred_use_cases(path: str) -> list[str]:
     stem = Path(path).stem.replace("_", " ")
     if "consumer" in path:
@@ -313,7 +356,7 @@ def baseline_payload(metrics: list[FileMetrics]) -> dict[str, Any]:
         crate_totals[item.crate]["public_items"] += item.public_items
         crate_totals[item.crate]["reexports"] += item.reexports
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "thresholds": {
             "review_lines": REVIEW_LINES,
             "hard_lines": HARD_LINES,
@@ -322,6 +365,7 @@ def baseline_payload(metrics: list[FileMetrics]) -> dict[str, Any]:
         "policy": {
             "line_growth": "Existing hotspots may shrink but not grow; new production modules must stay at or below 800 lines.",
             "public_surface": "Per-file and per-crate public item and re-export counts may shrink but not grow without review.",
+            "ownership": "State owners, lock sites, and dependency fan-out may shrink but not grow without review.",
             "ranking": "Ranking combines production LOC, history, contributors, defects, public surface, state/lock ownership, fan-out, and test cost.",
         },
         "files": files,
@@ -332,8 +376,8 @@ def baseline_payload(metrics: list[FileMetrics]) -> dict[str, Any]:
 
 def validate_schema(payload: dict[str, Any]) -> list[Finding]:
     findings = []
-    if payload.get("schema_version") != 1:
-        return [Finding("baseline-schema", "scripts/module-maintainability-baseline.json", "expected schema 1")]
+    if payload.get("schema_version") != 2:
+        return [Finding("baseline-schema", "scripts/module-maintainability-baseline.json", "expected schema 2")]
     thresholds = payload.get("thresholds", {})
     if thresholds != {
         "review_lines": REVIEW_LINES,
@@ -356,14 +400,31 @@ def validate_schema(payload: dict[str, Any]) -> list[Finding]:
             findings.append(Finding("hotspot-governance", path, "owner and contracts must be explicit"))
         if not isinstance(entry["use_cases"], list) or len(entry["use_cases"]) < 2:
             findings.append(Finding("hotspot-use-cases", path, "at least two use-case boundaries are required"))
+        metrics = entry.get("metrics")
+        required_metrics = {"lock_sites", "state_owners", "fan_out"}
+        if not isinstance(metrics, dict) or not required_metrics.issubset(metrics):
+            findings.append(Finding("hotspot-metrics-schema", path, "ownership and fan-out metrics are required"))
     return findings
 
 
 def compare(metrics: list[FileMetrics], baseline: dict[str, Any]) -> list[Finding]:
     findings = validate_schema(baseline)
     files = baseline.get("files", {})
-    governed = {entry.get("path") for entry in baseline.get("hotspots", []) if isinstance(entry, dict)}
+    governed_metrics = {
+        entry.get("path"): entry.get("metrics", {})
+        for entry in baseline.get("hotspots", [])
+        if isinstance(entry, dict)
+    }
+    governed = set(governed_metrics)
     for item in metrics:
+        if Path(item.path).name in FORBIDDEN_FRAGMENT_NAMES:
+            findings.append(
+                Finding(
+                    "mechanical-module-fragment",
+                    item.path,
+                    "use a domain use-case name instead of a numbered or miscellaneous fragment",
+                )
+            )
         previous = files.get(item.path)
         if previous is None:
             if item.production_lines > HARD_LINES:
@@ -393,6 +454,21 @@ def compare(metrics: list[FileMetrics], baseline: dict[str, Any]) -> list[Findin
                         "public-surface-growth",
                         item.path,
                         f"{field} baseline={previous[field]} current={getattr(item, field)}",
+                    )
+                )
+        for field, code in (
+            ("lock_sites", "lock-site-growth"),
+            ("state_owners", "state-owner-growth"),
+            ("fan_out", "fan-out-growth"),
+        ):
+            governed_previous = governed_metrics.get(item.path)
+            baseline_value = governed_previous.get(field) if governed_previous is not None else None
+            if baseline_value is not None and int(getattr(item, field)) > int(baseline_value):
+                findings.append(
+                    Finding(
+                        code,
+                        item.path,
+                        f"{field} baseline={baseline_value} current={getattr(item, field)}",
                     )
                 )
     for item in metrics[:RANKED_HOTSPOTS]:
@@ -470,13 +546,24 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--baseline", type=Path, default=BASELINE)
     parser.add_argument("--report", type=Path, default=REPORT)
+    parser.add_argument("--decisions", type=Path, default=DECISIONS)
     parser.add_argument("--write-baseline", action="store_true")
     parser.add_argument("--write-report", action="store_true")
     args = parser.parse_args()
 
     root = args.root.resolve()
     metrics = scan_tree(root)
+    try:
+        decision_document = args.decisions.read_text(encoding="utf-8")
+    except OSError:
+        decision_document = ""
+    decision_findings = validate_decision_ledger(metrics[:RANKED_HOTSPOTS], decision_document)
     if args.write_baseline:
+        if decision_findings:
+            for finding in decision_findings:
+                print(f"MODULE_FINDING code={finding.code} path={finding.path} detail={finding.detail}", file=sys.stderr)
+            print(f"MODULE_MAINTAINABILITY_FAILED findings={len(decision_findings)}", file=sys.stderr)
+            return 1
         payload = baseline_payload(metrics)
         write_json(args.baseline, payload)
         args.report.parent.mkdir(parents=True, exist_ok=True)
@@ -493,6 +580,7 @@ def main() -> int:
         print(f"MODULE_MAINTAINABILITY_FAILED baseline={error}", file=sys.stderr)
         return 1
     findings = compare(metrics, baseline)
+    findings.extend(decision_findings)
     expected_report = render_report(baseline)
     if args.write_report:
         args.report.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tests/test_module_maintainability_guard.py
+++ b/scripts/tests/test_module_maintainability_guard.py
@@ -27,6 +27,9 @@ def metric(
     *,
     public_items: int = 0,
     reexports: int = 0,
+    lock_sites: int = 1,
+    state_owners: int = 1,
+    fan_out: int = 2,
     score: float | None = None,
 ) -> guard.FileMetrics:
     return guard.FileMetrics(
@@ -35,9 +38,9 @@ def metric(
         production_lines=lines,
         public_items=public_items,
         reexports=reexports,
-        lock_sites=1,
-        state_owners=1,
-        fan_out=2,
+        lock_sites=lock_sites,
+        state_owners=state_owners,
+        fan_out=fan_out,
         test_functions=2,
         churn_commits=3,
         contributors=2,
@@ -48,6 +51,18 @@ def metric(
 
 def baseline_metrics() -> list[guard.FileMetrics]:
     return [metric(f"crate-{index}/src/hotspot_{index}.rs", 900 - index, score=1000 - index) for index in range(20)]
+
+
+def decision_section(path: str, *, outcome: str = "retained") -> str:
+    return f"""
+### `{path}`
+
+- Decision: `{outcome}`.
+- Owner: crate maintainers.
+- State owner: the parent module remains the only mutable state owner.
+- Evidence: focused behavior tests cover the retained boundary.
+- Revisit when: public surface, fan-out, locks, or production lines grow.
+"""
 
 
 class ModuleMaintainabilityGuardTests(unittest.TestCase):
@@ -124,6 +139,55 @@ pub struct RuntimeState;
 
         self.assertEqual([], guard.compare(reduced, baseline))
 
+    def test_state_owner_and_fan_out_growth_fail(self) -> None:
+        metrics = baseline_metrics()
+        baseline = guard.baseline_payload(metrics)
+        changed = list(metrics)
+        changed[0] = metric(
+            metrics[0].path,
+            metrics[0].production_lines,
+            state_owners=metrics[0].state_owners + 1,
+            fan_out=metrics[0].fan_out + 1,
+        )
+
+        findings = guard.compare(changed, baseline)
+        codes = {finding.code for finding in findings}
+
+        self.assertIn("state-owner-growth", codes)
+        self.assertIn("fan-out-growth", codes)
+
+    def test_mechanical_fragment_names_fail(self) -> None:
+        metrics = baseline_metrics()
+        baseline = guard.baseline_payload(metrics)
+        current = list(metrics) + [metric("crate/src/impl_2.rs", 20)]
+
+        findings = guard.compare(current, baseline)
+
+        self.assertIn("mechanical-module-fragment", {finding.code for finding in findings})
+
+    def test_decision_ledger_requires_every_ranked_hotspot(self) -> None:
+        metrics = baseline_metrics()
+        document = "\n".join(decision_section(item.path) for item in metrics[:-1])
+
+        findings = guard.validate_decision_ledger(metrics, document)
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual("missing-hotspot-decision", findings[0].code)
+        self.assertEqual(metrics[-1].path, findings[0].path)
+
+    def test_decision_ledger_requires_complete_evidence(self) -> None:
+        hotspot = metric("crate/src/hotspot.rs", 900)
+        document = """
+### `crate/src/hotspot.rs`
+
+- Decision: `retained`.
+- Owner: crate maintainers.
+"""
+
+        findings = guard.validate_decision_ledger([hotspot], document)
+
+        self.assertEqual({"incomplete-hotspot-decision"}, {finding.code for finding in findings})
+
 
 class RepositoryModuleMaintainabilityContracts(unittest.TestCase):
     def test_repository_baseline_and_report_are_current(self) -> None:
@@ -135,6 +199,12 @@ class RepositoryModuleMaintainabilityContracts(unittest.TestCase):
         self.assertEqual(
             guard.render_report(baseline),
             (root / "rocketmq-doc/en/module-maintainability-board.md").read_text(encoding="utf-8"),
+        )
+        decision_path = root / "rocketmq-doc/en/hotspot-module-decisions.md"
+        decision_document = decision_path.read_text(encoding="utf-8") if decision_path.is_file() else ""
+        self.assertEqual(
+            [],
+            guard.validate_decision_ledger(metrics[: guard.RANKED_HOTSPOTS], decision_document),
         )
 
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8878

### Brief Description

- Add an accepted ADR for every original top-20 hotspot and the Broker POP processor that entered the current board.
- Require each current ranked hotspot to have one complete decision with an owner, state owner, evidence, and measurable review trigger.
- Extend the maintainability guard so ranked modules cannot gain lock sites, mutable state owners, or dependency fan-out.
- Reject mechanical module fragments named `impl_2.rs`, `misc.rs`, or `utils2.rs`.
- Regenerate the schema-v2 maintainability baseline and human-readable board after reviewing the 393 findings accumulated by prior intentional architecture changes.
- Preserve single-owner public facade, configuration schema, persisted-format, and high-lock state boundaries where a file split would increase ownership complexity.

### How Did You Test This Change?

- Passed all 11 tests in `python -m unittest scripts.tests.test_module_maintainability_guard -v`.
- Passed `python scripts/module_maintainability_guard.py` with 2,584 production Rust files and all 20 ranked hotspots governed.
- Passed `python scripts/stable_surface_guard.py --mode baseline`.
- Passed `.\scripts\check-agents-routing.ps1`.
- Passed `git diff --check`.
- Ran `python scripts/run_architecture_tests.py --tier pr_static`; the module-maintainability suite now passes and the aggregate retains 5 known baseline failures for error-evidence, release, SLO, lint-debt, and trait-policy governance.
- `cargo fmt --all -- --check` could not enumerate the Windows workspace because the operating system returned error 206. This PR changes no Rust or Cargo file; the merged base commit already passed root all-target, all-feature strict Clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an accepted decision record covering decomposition and retention of key maintainability hotspots.
  * Updated maintainability rankings, ownership contracts, and hotspot metrics.
  * Expanded coverage across client, admin, observability, protocol, runtime, storage, transport, proxy, and MCP modules.

* **Chores**
  * Strengthened maintainability checks with ownership-growth metrics, hotspot decision validation, and detection of generic module fragments.

* **Tests**
  * Added coverage for ownership growth, missing or incomplete hotspot decisions, and mechanical module fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->