### PR TITLE
[ISSUE #8882]♻️Enforce a single SRE RocketMQ read gateway

### DIFF
--- a/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
+++ b/rocketmq-doc/en/07-rocketmq-mcp-architecture-adr.md
@@ -2,7 +2,7 @@
 title: "RocketMQ MCP Architecture ADR"
 permalink: /docs/rocketmq-mcp-architecture-adr/
 excerpt: "Accepted clean-break architecture and public contract for the RocketMQ MCP server refactor."
-last_modified_at: 2026-07-10T00:00:00+08:00
+last_modified_at: 2026-07-31T00:00:00+08:00
 toc: true
 classes: wide
 ---
@@ -36,6 +36,7 @@ diagnosis efficient without creating a global connection pool prematurely.
 | ADR-008 | Target MCP `2025-11-25` only. The refactor does not promise a dual-version protocol bridge with MCP `2025-06-18`. |
 | ADR-009 | Replace the current implementation with a clean break because it is unused. Do not retain legacy Tool, URI, schema, configuration, or feature aliases. |
 | ADR-010 | Keep a bounded, process-local TTL cache inside the shared `QueryFacade`. Keys include schema version, visibility class, query kind, resolved cluster, and normalized parameters; failures are not cached, and identical concurrent misses use singleflight. |
+| ADR-011 | AI SRE consumes MCP through the Connector's private `ReadGateway`. The Control Plane uses ConnectorChannel only; MCP and direct Admin remain internal read-only adapters behind one authorization, admission, deadline, cancellation, redaction, output, and audit policy. |
 
 ## Frozen Public Contract
 
@@ -89,6 +90,13 @@ transport and protocol
 normalization, and read-model construction. Resources and Tools are different
 MCP presentations of the same query results. Diagnosis consumes the same
 facade, adds versioned evidence, and evaluates versioned rules.
+
+AI SRE does not import this server's Rust DTOs. Its Connector verifies the
+public MCP wire capability and routes fixed `EvidenceOperation` values through
+a crate-private `ReadGateway`. Direct Admin fallback is compiled only with
+`rocketmq-admin-core/read-client-adapter`; it is not a second Control Plane
+path and cannot expose mutation capabilities. The detailed Connector contract
+is maintained in `rocketmq-sre/docs/read-gateway-contract.md`.
 
 The cache stores normalized query results, not protocol envelopes. This keeps
 request identifiers and output policy request-specific while allowing Tools

--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -47,8 +47,11 @@ flowchart LR
     CLI --> CP
 
     CP <--> Connector["Connector"]
-    Connector --> MCP["RocketMQ MCP<br/>read-only"]
+    Connector --> ReadGateway["Private ReadGateway<br/>auth / budget / audit"]
+    ReadGateway --> MCP["RocketMQ MCP<br/>read-only adapter"]
+    ReadGateway --> Admin["Admin read-client<br/>read-only adapter"]
     MCP --> Cluster["RocketMQ Rust cluster"]
+    Admin --> Cluster
 
     CP --> Evidence["Evidence / Knowledge"]
     Evidence --> PostgreSQL["PostgreSQL"]
@@ -73,6 +76,10 @@ sessions or raw mutation APIs.
 
 - MCP and Connector are read-only. They never expose RocketMQ apply, delete,
   reset, clean, or arbitrary Admin operations.
+- Every RocketMQ read crosses one private Connector
+  [ReadGateway](docs/read-gateway-contract.md). MCP and Admin adapters share
+  tenant/cluster authorization, rate and concurrency admission, deadline,
+  cancellation, output bounding, redaction, and typed audit policy.
 - Evidence, logs, diagnostics, errors, and model requests are bounded and
   sanitized. Credentials, tokens, ACL/TLS material, private keys, message
   bodies, and full configuration values are excluded.
@@ -189,6 +196,7 @@ Run Rust commands from `rocketmq-sre/`:
 ```powershell
 python scripts/check_source_layout.py
 python scripts/check_execution_dependency_boundary.py
+python scripts/check_read_gateway_boundary.py
 cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check
 cargo check --locked --workspace
 cargo test --locked --workspace --all-features
@@ -224,6 +232,7 @@ design is intentionally outside the current scope.
 - [Read-only MCP boundary](docs/decisions/0002-read-only-mcp-boundary.md)
 - [Control Plane–Connector mTLS](docs/control-plane-connector-mtls.md)
 - [Connector transport](docs/connector-control-plane-transport-adr.md)
+- [Connector ReadGateway](docs/read-gateway-contract.md)
 - [Diagnostic Pack catalog](docs/phase02-diagnostic-packs.md)
 - [Execution contracts](docs/phase03-execution-contracts.md)
 - [Plan, policy, approval, and audit](docs/phase03-plan-policy-approval.md)

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/api.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/api.rs
@@ -207,7 +207,7 @@ where
             "internal evidence query body is not valid JSON",
         )
     })?;
-    engine.evidence(request).await.map(Json)
+    engine.evidence(request, "internal-api").await.map(Json)
 }
 
 fn bearer_header(headers: &HeaderMap) -> Option<&str> {

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/channel.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/channel.rs
@@ -313,7 +313,12 @@ where
                 let spawn_result = context.spawn(format!("connector-query-{sequence}"), TaskKind::Worker, async move {
                     let result = channel
                         .connector
-                        .collect_contract_query(envelope.query, envelope.deadline, &cancel)
+                        .collect_contract_query(
+                            envelope.query,
+                            &channel.config.connector_subject,
+                            envelope.deadline,
+                            &cancel,
+                        )
                         .await;
                     let response = match result {
                         Ok(evidence) => ConnectorResponseEnvelope {
@@ -409,7 +414,10 @@ where
         {
             return Ok(());
         }
-        let inventory = self.connector.inventory(self.config.cluster_id).await?;
+        let inventory = self
+            .connector
+            .inventory(self.config.cluster_id, &self.config.connector_subject)
+            .await?;
         let path = format!("/internal/v1/connectors/v1/{}/inventory", self.session_id);
         let response = self.send(&path, &inventory).await?;
         let cancel = CancelSignal::default();

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/engine.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/engine.rs
@@ -214,13 +214,18 @@ where
         self.sources.capabilities().await
     }
 
-    pub(crate) async fn evidence(&self, request: EvidenceQueryRequest) -> Result<EvidenceSnapshot, ConnectorError> {
+    pub(crate) async fn evidence(
+        &self,
+        request: EvidenceQueryRequest,
+        subject: &str,
+    ) -> Result<EvidenceSnapshot, ConnectorError> {
         self.validate_request(&request)?;
         let deadline = Utc::now()
             + chrono::Duration::from_std(self.config.request_timeout).unwrap_or_else(|_| chrono::Duration::seconds(15));
         self.collect(
             request.query,
             &request.mcp_cluster,
+            subject,
             Some(&request.operation),
             deadline,
             &CancelSignal::default(),
@@ -231,6 +236,7 @@ where
     pub(crate) async fn collect_contract_query(
         &self,
         query: EvidenceQuery,
+        subject: &str,
         deadline: DateTime<Utc>,
         cancel: &CancelSignal,
     ) -> Result<EvidenceSnapshot, ConnectorError> {
@@ -248,12 +254,14 @@ where
                 .with_correlation_id(query.correlation_id)
             })?;
         self.validate_query_boundary(&query, &external_cluster)?;
-        self.collect(query, &external_cluster, None, deadline, cancel).await
+        self.collect(query, &external_cluster, subject, None, deadline, cancel)
+            .await
     }
 
     pub(crate) async fn inventory(
         &self,
         cluster_id: rocketmq_sre_contracts::ClusterId,
+        subject: &str,
     ) -> Result<InventoryUpload, ConnectorError> {
         let external_cluster = self
             .config
@@ -277,7 +285,13 @@ where
         let deadline = Utc::now()
             + chrono::Duration::from_std(self.config.request_timeout).unwrap_or_else(|_| chrono::Duration::seconds(15));
         self.sources
-            .inventory(cluster_id, external_cluster, deadline, &CancelSignal::default())
+            .inventory(
+                cluster_id,
+                external_cluster,
+                subject,
+                deadline,
+                &CancelSignal::default(),
+            )
             .await
     }
 
@@ -285,6 +299,7 @@ where
         &self,
         query: EvidenceQuery,
         external_cluster: &str,
+        subject: &str,
         operation: Option<&EvidenceOperation>,
         deadline: DateTime<Utc>,
         cancel: &CancelSignal,
@@ -303,7 +318,7 @@ where
             return Err(error.with_correlation_id(query.correlation_id));
         }
         self.sources
-            .query(query, external_cluster, operation, deadline, cancel)
+            .query(query, external_cluster, subject, operation, deadline, cancel)
             .await
     }
 
@@ -552,8 +567,11 @@ mod tests {
             },
         };
 
-        let evidence = engine.evidence(request.clone()).await.expect("evidence");
-        let cached = engine.evidence(request).await.expect("cached evidence");
+        let evidence = engine
+            .evidence(request.clone(), "test-subject")
+            .await
+            .expect("evidence");
+        let cached = engine.evidence(request, "test-subject").await.expect("cached evidence");
         assert!(engine.is_ready().await);
         assert_eq!(evidence.freshness_seconds, 2);
         assert!(evidence.partial);
@@ -592,7 +610,11 @@ mod tests {
             operation: EvidenceOperation::ClusterOverview,
         };
         assert_eq!(
-            engine.evidence(request).await.expect_err("tenant mismatch").code,
+            engine
+                .evidence(request, "test-subject")
+                .await
+                .expect_err("tenant mismatch")
+                .code,
             ConnectorErrorCode::TenantMismatch
         );
     }
@@ -619,14 +641,14 @@ mod tests {
         };
 
         engine
-            .evidence(request.clone())
+            .evidence(request.clone(), "test-subject")
             .await
             .expect("active cluster should collect");
         assert_eq!(gateway.query_count.load(Ordering::SeqCst), 1);
 
         gateway.active.store(false, Ordering::SeqCst);
         let error = engine
-            .evidence(request)
+            .evidence(request, "test-subject")
             .await
             .expect_err("offboarded cluster must not collect");
         assert_eq!(error.code, ConnectorErrorCode::ClusterNotAllowed);
@@ -655,7 +677,10 @@ mod tests {
             operation: EvidenceOperation::ClusterOverview,
         };
 
-        let evidence = engine.evidence(request).await.expect("missing evidence");
+        let evidence = engine
+            .evidence(request, "test-subject")
+            .await
+            .expect("missing evidence");
         assert!(evidence.partial);
         assert_eq!(evidence.coverage, CoverageStatus::Missing);
         assert_eq!(

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/lib.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/lib.rs
@@ -28,6 +28,7 @@ mod config;
 mod engine;
 mod error;
 mod mcp;
+mod read_gateway;
 mod sources;
 mod wire;
 

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/main.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_sre_connector::ConnectorConfig;

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway.rs
@@ -1,0 +1,777 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod admin;
+mod audit;
+mod mcp;
+mod policy;
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use chrono::DateTime;
+use chrono::Utc;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_sre_contracts::ClusterId;
+use rocketmq_sre_contracts::CorrelationId;
+use rocketmq_sre_contracts::TenantId;
+use tokio::sync::SemaphorePermit;
+
+use self::admin::AdminReadAdapter;
+use self::audit::ReadAudit;
+use self::audit::ReadAuditOutcome;
+use self::mcp::McpReadAdapter;
+use self::policy::ReadPolicy;
+use crate::ConnectorConfig;
+use crate::ConnectorError;
+use crate::EvidenceOperation;
+use crate::mcp::McpGateway;
+use crate::sources::CancelSignal;
+use crate::sources::SourceOutput;
+use crate::sources::bounded_future;
+use crate::sources::sanitize_and_bound;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReadAdapterKind {
+    Mcp,
+    Admin,
+}
+
+impl ReadAdapterKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mcp => "mcp",
+            Self::Admin => "admin",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ReadAuditTarget {
+    adapter: ReadAdapterKind,
+    resource_class: &'static str,
+}
+
+impl ReadAuditTarget {
+    pub(crate) const fn new(adapter: ReadAdapterKind, resource_class: &'static str) -> Self {
+        Self {
+            adapter,
+            resource_class,
+        }
+    }
+}
+
+pub(crate) struct ReadContext<'a> {
+    pub tenant_id: TenantId,
+    pub cluster_id: ClusterId,
+    pub external_cluster: &'a str,
+    pub subject: &'a str,
+    pub correlation_id: CorrelationId,
+    pub time_range_start: DateTime<Utc>,
+    pub time_range_end: DateTime<Utc>,
+    pub deadline: DateTime<Utc>,
+    pub cancel: &'a CancelSignal,
+}
+
+pub(crate) struct ReadSession<'policy, 'context> {
+    context: &'context ReadContext<'context>,
+    _permit: SemaphorePermit<'policy>,
+}
+
+impl ReadSession<'_, '_> {
+    pub(crate) const fn context(&self) -> &ReadContext<'_> {
+        self.context
+    }
+}
+
+pub(crate) enum CanonicalRead<'a> {
+    Mcp(&'a EvidenceOperation),
+    McpSystemResource(&'a str),
+    Admin(&'a str),
+    AdminProducerConnections { max_rows: usize },
+    AdminConsumerConnections { consumer_group: &'a str, max_rows: usize },
+}
+
+impl CanonicalRead<'_> {
+    const fn adapter_kind(&self) -> ReadAdapterKind {
+        match self {
+            Self::Mcp(_) | Self::McpSystemResource(_) => ReadAdapterKind::Mcp,
+            Self::Admin(_) | Self::AdminProducerConnections { .. } | Self::AdminConsumerConnections { .. } => {
+                ReadAdapterKind::Admin
+            }
+        }
+    }
+
+    const fn resource_class(&self) -> &'static str {
+        match self {
+            Self::Mcp(_) => "mcp_operation",
+            Self::McpSystemResource(_) => "mcp_system_resource",
+            Self::Admin(_) => "admin_resource",
+            Self::AdminProducerConnections { .. } => "admin_producer_connections",
+            Self::AdminConsumerConnections { .. } => "admin_consumer_connections",
+        }
+    }
+}
+
+pub(crate) trait ReadAdapter: Send + Sync {
+    fn kind(&self) -> ReadAdapterKind;
+
+    async fn read(
+        &self,
+        context: &ReadContext<'_>,
+        request: &CanonicalRead<'_>,
+    ) -> Result<SourceOutput, ConnectorError>;
+}
+
+pub(crate) struct ReadGateway<M, A> {
+    policy: ReadPolicy,
+    mcp: M,
+    admin: A,
+    audit: ReadAudit,
+}
+
+pub(crate) type ConnectorReadGateway<G> = ReadGateway<McpReadAdapter<G>, AdminReadAdapter>;
+
+impl<M, A> ReadGateway<M, A>
+where
+    M: ReadAdapter,
+    A: ReadAdapter,
+{
+    fn with_adapters(policy: ReadPolicy, mcp: M, admin: A) -> Self {
+        debug_assert_eq!(mcp.kind(), ReadAdapterKind::Mcp);
+        debug_assert_eq!(admin.kind(), ReadAdapterKind::Admin);
+        Self {
+            policy,
+            mcp,
+            admin,
+            audit: ReadAudit::default(),
+        }
+    }
+
+    pub(crate) async fn admit<'policy, 'context>(
+        &'policy self,
+        context: &'context ReadContext<'context>,
+        audit_target: Option<ReadAuditTarget>,
+    ) -> Result<ReadSession<'policy, 'context>, ConnectorError> {
+        let started_at = Instant::now();
+        if let Err(error) = self.policy.authorize(context) {
+            self.audit_denial(audit_target, error.code, started_at, context.correlation_id)
+                .await;
+            return Err(error);
+        }
+        let permit = match self.policy.enter(context).await {
+            Ok(permit) => permit,
+            Err(error) => {
+                self.audit_denial(audit_target, error.code, started_at, context.correlation_id)
+                    .await;
+                return Err(error);
+            }
+        };
+        Ok(ReadSession {
+            context,
+            _permit: permit,
+        })
+    }
+
+    pub(crate) async fn mcp_query(
+        &self,
+        session: &ReadSession<'_, '_>,
+        operation: &EvidenceOperation,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.read(session, CanonicalRead::Mcp(operation)).await
+    }
+
+    pub(crate) async fn mcp_system_resource(
+        &self,
+        session: &ReadSession<'_, '_>,
+        uri: &str,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.read(session, CanonicalRead::McpSystemResource(uri)).await
+    }
+
+    pub(crate) async fn admin_query(
+        &self,
+        session: &ReadSession<'_, '_>,
+        resource: &str,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.read(session, CanonicalRead::Admin(resource)).await
+    }
+
+    pub(crate) async fn admin_producer_connections(
+        &self,
+        session: &ReadSession<'_, '_>,
+        max_rows: usize,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.read(session, CanonicalRead::AdminProducerConnections { max_rows })
+            .await
+    }
+
+    pub(crate) async fn admin_consumer_connections(
+        &self,
+        session: &ReadSession<'_, '_>,
+        consumer_group: &str,
+        max_rows: usize,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.read(
+            session,
+            CanonicalRead::AdminConsumerConnections {
+                consumer_group,
+                max_rows,
+            },
+        )
+        .await
+    }
+
+    async fn read(
+        &self,
+        session: &ReadSession<'_, '_>,
+        request: CanonicalRead<'_>,
+    ) -> Result<SourceOutput, ConnectorError> {
+        let context = session.context();
+        let started_at = Instant::now();
+        let adapter_kind = request.adapter_kind();
+        let resource_class = request.resource_class();
+        let adapter_result = match adapter_kind {
+            ReadAdapterKind::Mcp => {
+                bounded_future(context.deadline, context.cancel, self.mcp.read(context, &request)).await
+            }
+            ReadAdapterKind::Admin => {
+                bounded_future(context.deadline, context.cancel, self.admin.read(context, &request)).await
+            }
+        };
+        let result = match adapter_result {
+            Ok(output) => self.finish_output(context, output),
+            Err(error) => Err(error.with_correlation_id(context.correlation_id)),
+        };
+        let outcome = result
+            .as_ref()
+            .map(|_| ReadAuditOutcome::Allowed)
+            .unwrap_or_else(|error| ReadAuditOutcome::from_error(error.code));
+        self.audit
+            .record(
+                adapter_kind,
+                resource_class,
+                outcome,
+                started_at.elapsed(),
+                context.correlation_id,
+            )
+            .await;
+        result
+    }
+
+    async fn audit_denial(
+        &self,
+        target: Option<ReadAuditTarget>,
+        code: crate::ConnectorErrorCode,
+        started_at: Instant,
+        correlation_id: CorrelationId,
+    ) {
+        if let Some(target) = target {
+            self.audit
+                .record(
+                    target.adapter,
+                    target.resource_class,
+                    ReadAuditOutcome::from_error(code),
+                    started_at.elapsed(),
+                    correlation_id,
+                )
+                .await;
+        }
+    }
+
+    fn finish_output(
+        &self,
+        context: &ReadContext<'_>,
+        mut output: SourceOutput,
+    ) -> Result<SourceOutput, ConnectorError> {
+        self.policy.validate_completion(context)?;
+        let (content, bounded) = sanitize_and_bound(
+            output.content,
+            self.policy.max_rows,
+            self.policy.max_bytes,
+            self.policy.pseudonymization_key(),
+        )
+        .map_err(|error| error.with_correlation_id(context.correlation_id))?;
+        output.content = content;
+        if bounded {
+            output.partial = true;
+            output.warnings.push("read_gateway_output_bounded".to_owned());
+        }
+        Ok(output)
+    }
+
+    #[cfg(test)]
+    async fn audit_events(&self) -> Vec<audit::ReadAuditEvent> {
+        self.audit.events().await
+    }
+}
+
+impl<G> ReadGateway<McpReadAdapter<G>, AdminReadAdapter>
+where
+    G: McpGateway,
+{
+    pub(crate) fn new(config: &ConnectorConfig, gateway: Arc<G>) -> Self {
+        Self::with_adapters(
+            ReadPolicy::from_config(config),
+            McpReadAdapter::new(gateway),
+            AdminReadAdapter::new(config.admin_source.clone()),
+        )
+    }
+
+    pub(crate) fn admin_configured(&self) -> bool {
+        self.admin.configured()
+    }
+
+    pub(crate) async fn initialize(&self, context: ChildServiceContext) -> Result<(), ConnectorError> {
+        self.admin.initialize(context.component("admin-query")).await
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.admin.shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use chrono::Duration as ChronoDuration;
+    use serde_json::json;
+
+    use super::*;
+    use crate::ConnectorErrorCode;
+
+    #[derive(Clone, Copy)]
+    enum FakeBehavior {
+        Available,
+        Partial,
+        Sensitive,
+        Oversized,
+        Failed,
+        Pending,
+    }
+
+    struct FakeAdapter {
+        kind: ReadAdapterKind,
+        behavior: FakeBehavior,
+        calls: AtomicUsize,
+    }
+
+    impl FakeAdapter {
+        const fn new(kind: ReadAdapterKind, behavior: FakeBehavior) -> Self {
+            Self {
+                kind,
+                behavior,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl ReadAdapter for FakeAdapter {
+        fn kind(&self) -> ReadAdapterKind {
+            self.kind
+        }
+
+        async fn read(
+            &self,
+            _context: &ReadContext<'_>,
+            _request: &CanonicalRead<'_>,
+        ) -> Result<SourceOutput, ConnectorError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            match self.behavior {
+                FakeBehavior::Available => Ok(SourceOutput::available(json!({"rows": [1, 2]}), Utc::now())),
+                FakeBehavior::Partial => {
+                    let mut output = SourceOutput::available(json!({"rows": [1]}), Utc::now());
+                    output.partial = true;
+                    output.warnings.push("source_partial".to_owned());
+                    Ok(output)
+                }
+                FakeBehavior::Sensitive => Ok(SourceOutput::available(
+                    json!({
+                        "access_token": "must-not-leave-gateway",
+                        "rows": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    }),
+                    Utc::now(),
+                )),
+                FakeBehavior::Oversized => Ok(SourceOutput::available(
+                    json!({"diagnostic": "x".repeat(5000)}),
+                    Utc::now(),
+                )),
+                FakeBehavior::Failed => Err(ConnectorError::source("fake adapter unavailable")),
+                FakeBehavior::Pending => pending().await,
+            }
+        }
+    }
+
+    fn gateway(
+        tenant_id: TenantId,
+        cluster_id: ClusterId,
+        max_per_minute: usize,
+        mcp_behavior: FakeBehavior,
+        admin_behavior: FakeBehavior,
+    ) -> ReadGateway<FakeAdapter, FakeAdapter> {
+        gateway_with_limits(tenant_id, cluster_id, 2, max_per_minute, mcp_behavior, admin_behavior)
+    }
+
+    fn gateway_with_limits(
+        tenant_id: TenantId,
+        cluster_id: ClusterId,
+        max_concurrency: usize,
+        max_per_minute: usize,
+        mcp_behavior: FakeBehavior,
+        admin_behavior: FakeBehavior,
+    ) -> ReadGateway<FakeAdapter, FakeAdapter> {
+        ReadGateway::with_adapters(
+            ReadPolicy::for_test(tenant_id, cluster_id, max_concurrency, max_per_minute),
+            FakeAdapter::new(ReadAdapterKind::Mcp, mcp_behavior),
+            FakeAdapter::new(ReadAdapterKind::Admin, admin_behavior),
+        )
+    }
+
+    fn context<'a>(
+        tenant_id: TenantId,
+        cluster_id: ClusterId,
+        subject: &'a str,
+        deadline: DateTime<Utc>,
+        cancel: &'a CancelSignal,
+    ) -> ReadContext<'a> {
+        let now = Utc::now();
+        ReadContext {
+            tenant_id,
+            cluster_id,
+            external_cluster: "local",
+            subject,
+            correlation_id: CorrelationId::new(),
+            time_range_start: now - ChronoDuration::seconds(1),
+            time_range_end: now,
+            deadline,
+            cancel,
+        }
+    }
+
+    fn future_deadline() -> DateTime<Utc> {
+        Utc::now() + ChronoDuration::seconds(1)
+    }
+
+    async fn mcp_read<'a>(
+        gateway: &ReadGateway<FakeAdapter, FakeAdapter>,
+        context: &'a ReadContext<'a>,
+    ) -> Result<SourceOutput, ConnectorError> {
+        let session = gateway
+            .admit(
+                context,
+                Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "logical_query")),
+            )
+            .await?;
+        gateway.mcp_query(&session, &EvidenceOperation::ClusterOverview).await
+    }
+
+    async fn admin_read<'a>(
+        gateway: &ReadGateway<FakeAdapter, FakeAdapter>,
+        context: &'a ReadContext<'a>,
+    ) -> Result<SourceOutput, ConnectorError> {
+        let session = gateway
+            .admit(
+                context,
+                Some(ReadAuditTarget::new(ReadAdapterKind::Admin, "logical_query")),
+            )
+            .await?;
+        gateway.admin_query(&session, "admin/brokers").await
+    }
+
+    #[tokio::test]
+    async fn authorized_read_is_bounded_redacted_and_audited() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Sensitive,
+            FakeBehavior::Available,
+        );
+        let cancel = CancelSignal::default();
+        let context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+
+        let output = mcp_read(&gateway, &context).await.expect("authorized read");
+
+        assert!(output.content.get("access_token").is_none());
+        assert_eq!(output.content["rows"].as_array().map(Vec::len), Some(8));
+        assert!(output.partial);
+        let events = gateway.audit_events().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].outcome, ReadAuditOutcome::Allowed);
+        assert_eq!(events[0].correlation_id, context.correlation_id);
+        let audit_debug = format!("{events:?}");
+        for sensitive in [
+            "operator",
+            "must-not-leave-gateway",
+            "access_token",
+            "message body",
+            "private key",
+        ] {
+            assert!(!audit_debug.contains(sensitive));
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_and_admin_share_output_and_audit_policy() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Sensitive,
+            FakeBehavior::Sensitive,
+        );
+        let cancel = CancelSignal::default();
+        let context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+
+        let mcp = mcp_read(&gateway, &context).await.expect("MCP read");
+        let admin = admin_read(&gateway, &context).await.expect("Admin read");
+
+        for output in [mcp, admin] {
+            assert!(output.content.get("access_token").is_none());
+            assert_eq!(output.content["rows"].as_array().map(Vec::len), Some(8));
+            assert!(output.partial);
+        }
+        let events = gateway.audit_events().await;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].adapter, ReadAdapterKind::Mcp);
+        assert_eq!(events[1].adapter, ReadAdapterKind::Admin);
+        assert!(events.iter().all(|event| event.outcome == ReadAuditOutcome::Allowed));
+    }
+
+    #[tokio::test]
+    async fn tenant_cluster_and_subject_checks_fail_before_adapter_dispatch() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Available,
+            FakeBehavior::Available,
+        );
+        let cancel = CancelSignal::default();
+        for denied in [
+            context(TenantId::new(), cluster_id, "operator", future_deadline(), &cancel),
+            context(tenant_id, ClusterId::new(), "operator", future_deadline(), &cancel),
+            context(tenant_id, cluster_id, "", future_deadline(), &cancel),
+        ] {
+            let error = mcp_read(&gateway, &denied).await.expect_err("scope must be denied");
+            assert!(matches!(
+                error.code,
+                ConnectorErrorCode::TenantMismatch
+                    | ConnectorErrorCode::ClusterNotAllowed
+                    | ConnectorErrorCode::UnauthorizedScope
+            ));
+        }
+        assert_eq!(gateway.mcp.calls.load(Ordering::Relaxed), 0);
+        assert!(
+            gateway
+                .audit_events()
+                .await
+                .iter()
+                .all(|event| event.outcome == ReadAuditOutcome::Denied)
+        );
+    }
+
+    #[tokio::test]
+    async fn time_range_and_deadline_bounds_fail_before_adapter_dispatch() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Available,
+            FakeBehavior::Available,
+        );
+        let cancel = CancelSignal::default();
+        let mut wide_range = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+        wide_range.time_range_start = wide_range.time_range_end - ChronoDuration::seconds(61);
+        let long_deadline = context(
+            tenant_id,
+            cluster_id,
+            "operator",
+            Utc::now() + ChronoDuration::seconds(6),
+            &cancel,
+        );
+
+        for denied in [&wide_range, &long_deadline] {
+            let error = mcp_read(&gateway, denied)
+                .await
+                .expect_err("bounded context must be denied");
+            assert_eq!(error.code, ConnectorErrorCode::InvalidEvidenceQuery);
+        }
+        assert_eq!(gateway.mcp.calls.load(Ordering::Relaxed), 0);
+        assert!(
+            gateway
+                .audit_events()
+                .await
+                .iter()
+                .all(|event| event.outcome == ReadAuditOutcome::Denied)
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_and_admin_share_one_rate_budget() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(
+            tenant_id,
+            cluster_id,
+            1,
+            FakeBehavior::Available,
+            FakeBehavior::Available,
+        );
+        let cancel = CancelSignal::default();
+        let context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+
+        mcp_read(&gateway, &context).await.expect("first read");
+        let error = admin_read(&gateway, &context).await.expect_err("shared rate limit");
+
+        assert_eq!(error.code, ConnectorErrorCode::RateLimited);
+        assert_eq!(gateway.admin.calls.load(Ordering::Relaxed), 0);
+        assert_eq!(gateway.audit_events().await[1].outcome, ReadAuditOutcome::RateLimited);
+    }
+
+    #[tokio::test]
+    async fn mcp_and_admin_share_one_concurrency_budget() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway_with_limits(
+            tenant_id,
+            cluster_id,
+            1,
+            8,
+            FakeBehavior::Available,
+            FakeBehavior::Available,
+        );
+        let first_cancel = CancelSignal::default();
+        let first_context = context(tenant_id, cluster_id, "operator-a", future_deadline(), &first_cancel);
+        let held = gateway
+            .admit(
+                &first_context,
+                Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "logical_query")),
+            )
+            .await
+            .expect("first admission");
+        let second_cancel = CancelSignal::default();
+        let second_context = context(tenant_id, cluster_id, "operator-b", future_deadline(), &second_cancel);
+
+        let error = admin_read(&gateway, &second_context)
+            .await
+            .expect_err("shared concurrency limit");
+        assert_eq!(error.code, ConnectorErrorCode::RateLimited);
+        assert_eq!(gateway.admin.calls.load(Ordering::Relaxed), 0);
+
+        drop(held);
+        admin_read(&gateway, &second_context)
+            .await
+            .expect("admission recovers after permit release");
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_timeout_are_fail_closed_and_audited() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let cancelled_gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Available,
+            FakeBehavior::Available,
+        );
+        let cancel = CancelSignal::default();
+        cancel.cancel();
+        let cancelled_context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+        let error = mcp_read(&cancelled_gateway, &cancelled_context)
+            .await
+            .expect_err("cancelled read");
+        assert_eq!(error.code, ConnectorErrorCode::QueryCancelled);
+        assert_eq!(
+            cancelled_gateway.audit_events().await[0].outcome,
+            ReadAuditOutcome::Cancelled
+        );
+
+        let timeout_gateway = gateway(tenant_id, cluster_id, 8, FakeBehavior::Pending, FakeBehavior::Available);
+        let active = CancelSignal::default();
+        let timeout_context = context(
+            tenant_id,
+            cluster_id,
+            "operator",
+            Utc::now() + ChronoDuration::milliseconds(20),
+            &active,
+        );
+        let error = mcp_read(&timeout_gateway, &timeout_context)
+            .await
+            .expect_err("timed out read");
+        assert_eq!(error.code, ConnectorErrorCode::DeadlineExceeded);
+        assert_eq!(
+            timeout_gateway.audit_events().await[0].outcome,
+            ReadAuditOutcome::TimedOut
+        );
+    }
+
+    #[tokio::test]
+    async fn source_failure_is_typed_and_audited_without_sensitive_context() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let gateway = gateway(tenant_id, cluster_id, 8, FakeBehavior::Failed, FakeBehavior::Available);
+        let cancel = CancelSignal::default();
+        let context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+
+        let error = mcp_read(&gateway, &context).await.expect_err("source failure");
+
+        assert_eq!(error.code, ConnectorErrorCode::SourceUnavailable);
+        let events = gateway.audit_events().await;
+        let event = &events[0];
+        assert_eq!(event.outcome, ReadAuditOutcome::SourceFailed);
+        assert_eq!(event.resource_class, "mcp_operation");
+    }
+
+    #[tokio::test]
+    async fn partial_output_is_preserved_and_oversized_output_fails_closed() {
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let partial_gateway = gateway(tenant_id, cluster_id, 8, FakeBehavior::Partial, FakeBehavior::Available);
+        let cancel = CancelSignal::default();
+        let context = context(tenant_id, cluster_id, "operator", future_deadline(), &cancel);
+
+        let output = mcp_read(&partial_gateway, &context).await.expect("partial output");
+        assert!(output.partial);
+        assert_eq!(output.warnings, vec!["source_partial"]);
+
+        let oversized_gateway = gateway(
+            tenant_id,
+            cluster_id,
+            8,
+            FakeBehavior::Oversized,
+            FakeBehavior::Available,
+        );
+        let error = mcp_read(&oversized_gateway, &context)
+            .await
+            .expect_err("oversized output");
+        assert_eq!(error.code, ConnectorErrorCode::OutputTooLarge);
+        assert_eq!(
+            oversized_gateway.audit_events().await[0].outcome,
+            ReadAuditOutcome::SourceFailed
+        );
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/admin.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/admin.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_runtime::ChildServiceContext;
+
+use super::CanonicalRead;
+use super::ReadAdapter;
+use super::ReadAdapterKind;
+use super::ReadContext;
+use crate::ConnectorError;
+use crate::ConnectorErrorCode;
+use crate::config::AdminSourceConfig;
+use crate::sources::AdminQuerySource;
+use crate::sources::SourceOutput;
+
+pub(crate) struct AdminReadAdapter {
+    source: AdminQuerySource,
+}
+
+impl AdminReadAdapter {
+    pub(crate) fn new(config: Option<AdminSourceConfig>) -> Self {
+        Self {
+            source: AdminQuerySource::new(config),
+        }
+    }
+
+    pub(crate) fn configured(&self) -> bool {
+        self.source.configured()
+    }
+
+    pub(crate) async fn initialize(&self, context: ChildServiceContext) -> Result<(), ConnectorError> {
+        self.source.start(context).await
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.source.shutdown().await;
+    }
+}
+
+impl ReadAdapter for AdminReadAdapter {
+    fn kind(&self) -> ReadAdapterKind {
+        ReadAdapterKind::Admin
+    }
+
+    async fn read(
+        &self,
+        context: &ReadContext<'_>,
+        request: &CanonicalRead<'_>,
+    ) -> Result<SourceOutput, ConnectorError> {
+        match request {
+            CanonicalRead::Admin(resource) => {
+                self.source
+                    .query(context.external_cluster, resource, context.deadline, context.cancel)
+                    .await
+            }
+            CanonicalRead::AdminProducerConnections { max_rows } => {
+                self.source
+                    .query_producer_connections(context.external_cluster, *max_rows, context.deadline, context.cancel)
+                    .await
+            }
+            CanonicalRead::AdminConsumerConnections {
+                consumer_group,
+                max_rows,
+            } => {
+                self.source
+                    .query_consumer_connections(
+                        context.external_cluster,
+                        consumer_group,
+                        *max_rows,
+                        context.deadline,
+                        context.cancel,
+                    )
+                    .await
+            }
+            CanonicalRead::Mcp(_) | CanonicalRead::McpSystemResource(_) => Err(ConnectorError::new(
+                ConnectorErrorCode::InvalidEvidenceQuery,
+                false,
+                "MCP request cannot be routed to the Admin read adapter",
+            )
+            .with_correlation_id(context.correlation_id)),
+        }
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/audit.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/audit.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use rocketmq_sre_contracts::CorrelationId;
+use tokio::sync::Mutex;
+
+use super::ReadAdapterKind;
+use crate::ConnectorErrorCode;
+
+const MAX_AUDIT_EVENTS: usize = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReadAuditOutcome {
+    Allowed,
+    Denied,
+    RateLimited,
+    TimedOut,
+    Cancelled,
+    SourceFailed,
+}
+
+impl ReadAuditOutcome {
+    pub(crate) fn from_error(code: ConnectorErrorCode) -> Self {
+        match code {
+            ConnectorErrorCode::UnauthorizedScope
+            | ConnectorErrorCode::TenantMismatch
+            | ConnectorErrorCode::ClusterNotAllowed
+            | ConnectorErrorCode::InvalidEvidenceQuery => Self::Denied,
+            ConnectorErrorCode::RateLimited => Self::RateLimited,
+            ConnectorErrorCode::DeadlineExceeded => Self::TimedOut,
+            ConnectorErrorCode::QueryCancelled => Self::Cancelled,
+            _ => Self::SourceFailed,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Denied => "denied",
+            Self::RateLimited => "rate_limited",
+            Self::TimedOut => "timed_out",
+            Self::Cancelled => "cancelled",
+            Self::SourceFailed => "source_failed",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReadAuditEvent {
+    pub adapter: ReadAdapterKind,
+    pub resource_class: &'static str,
+    pub outcome: ReadAuditOutcome,
+    pub latency_bucket: &'static str,
+    pub correlation_id: CorrelationId,
+}
+
+#[derive(Default)]
+pub(crate) struct ReadAudit {
+    events: Mutex<VecDeque<ReadAuditEvent>>,
+}
+
+impl ReadAudit {
+    pub(crate) async fn record(
+        &self,
+        adapter: ReadAdapterKind,
+        resource_class: &'static str,
+        outcome: ReadAuditOutcome,
+        latency: Duration,
+        correlation_id: CorrelationId,
+    ) {
+        let event = ReadAuditEvent {
+            adapter,
+            resource_class,
+            outcome,
+            latency_bucket: latency_bucket(latency),
+            correlation_id,
+        };
+        tracing::info!(
+            adapter = adapter.as_str(),
+            resource_class,
+            outcome = outcome.as_str(),
+            latency_bucket = event.latency_bucket,
+            correlation_id = %correlation_id,
+            "read gateway request completed"
+        );
+        let mut events = self.events.lock().await;
+        if events.len() == MAX_AUDIT_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(event);
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn events(&self) -> Vec<ReadAuditEvent> {
+        self.events.lock().await.iter().cloned().collect()
+    }
+}
+
+fn latency_bucket(latency: Duration) -> &'static str {
+    match latency.as_millis() {
+        0..=9 => "lt_10ms",
+        10..=99 => "lt_100ms",
+        100..=999 => "lt_1s",
+        _ => "gte_1s",
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/mcp.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/mcp.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use super::CanonicalRead;
+use super::ReadAdapter;
+use super::ReadAdapterKind;
+use super::ReadContext;
+use crate::ConnectorError;
+use crate::ConnectorErrorCode;
+use crate::mcp::McpGateway;
+use crate::sources::McpSource;
+use crate::sources::SourceOutput;
+
+pub(crate) struct McpReadAdapter<G> {
+    source: McpSource<G>,
+}
+
+impl<G> McpReadAdapter<G>
+where
+    G: McpGateway,
+{
+    pub(crate) fn new(gateway: Arc<G>) -> Self {
+        Self {
+            source: McpSource::new(gateway),
+        }
+    }
+}
+
+impl<G> ReadAdapter for McpReadAdapter<G>
+where
+    G: McpGateway,
+{
+    fn kind(&self) -> ReadAdapterKind {
+        ReadAdapterKind::Mcp
+    }
+
+    async fn read(
+        &self,
+        context: &ReadContext<'_>,
+        request: &CanonicalRead<'_>,
+    ) -> Result<SourceOutput, ConnectorError> {
+        match request {
+            CanonicalRead::Mcp(operation) => {
+                self.source
+                    .query(context.external_cluster, operation, context.deadline, context.cancel)
+                    .await
+            }
+            CanonicalRead::McpSystemResource(uri) => {
+                self.source.system_resource(uri, context.deadline, context.cancel).await
+            }
+            CanonicalRead::Admin(_)
+            | CanonicalRead::AdminProducerConnections { .. }
+            | CanonicalRead::AdminConsumerConnections { .. } => Err(ConnectorError::new(
+                ConnectorErrorCode::InvalidEvidenceQuery,
+                false,
+                "Admin request cannot be routed to the MCP read adapter",
+            )
+            .with_correlation_id(context.correlation_id)),
+        }
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/policy.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/read_gateway/policy.rs
@@ -1,0 +1,218 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::VecDeque;
+use std::time::Duration;
+use std::time::Instant;
+
+use chrono::Utc;
+use rocketmq_sre_contracts::ClusterId;
+use rocketmq_sre_contracts::TenantId;
+use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
+use tokio::sync::SemaphorePermit;
+
+use super::ReadContext;
+use crate::ConnectorConfig;
+use crate::ConnectorError;
+use crate::ConnectorErrorCode;
+
+pub(crate) struct ReadPolicy {
+    tenant_id: TenantId,
+    cluster_allowlist: BTreeSet<String>,
+    cluster_ids: BTreeMap<String, ClusterId>,
+    concurrency: Semaphore,
+    recent: Mutex<VecDeque<Instant>>,
+    max_per_minute: usize,
+    pub(crate) max_rows: usize,
+    pub(crate) max_bytes: usize,
+    max_time_range: Duration,
+    max_deadline: Duration,
+    pseudonymization_key: Vec<u8>,
+}
+
+impl ReadPolicy {
+    pub(crate) fn from_config(config: &ConnectorConfig) -> Self {
+        Self {
+            tenant_id: config.tenant_id,
+            cluster_allowlist: config.cluster_allowlist.clone(),
+            cluster_ids: config.cluster_ids.clone(),
+            concurrency: Semaphore::new(config.source_limits.max_concurrency),
+            recent: Mutex::new(VecDeque::with_capacity(
+                config.source_limits.max_requests_per_minute.min(1024),
+            )),
+            max_per_minute: config.source_limits.max_requests_per_minute,
+            max_rows: config.source_limits.max_rows,
+            max_bytes: config.source_limits.max_bytes,
+            max_time_range: config.source_limits.max_time_range,
+            max_deadline: config.source_limits.max_deadline,
+            pseudonymization_key: config.pseudonymization_key().to_vec(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        tenant_id: TenantId,
+        cluster_id: ClusterId,
+        max_concurrency: usize,
+        max_per_minute: usize,
+    ) -> Self {
+        Self {
+            tenant_id,
+            cluster_allowlist: BTreeSet::from(["local".to_owned()]),
+            cluster_ids: BTreeMap::from([("local".to_owned(), cluster_id)]),
+            concurrency: Semaphore::new(max_concurrency),
+            recent: Mutex::new(VecDeque::with_capacity(max_per_minute.min(1024))),
+            max_per_minute,
+            max_rows: 8,
+            max_bytes: 4096,
+            max_time_range: Duration::from_secs(60),
+            max_deadline: Duration::from_secs(5),
+            pseudonymization_key: b"read-gateway-test-key".to_vec(),
+        }
+    }
+
+    pub(crate) fn authorize(&self, context: &ReadContext<'_>) -> Result<(), ConnectorError> {
+        if context.tenant_id != self.tenant_id {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::TenantMismatch,
+                "read context tenant differs from the connector boundary",
+            ));
+        }
+        if self.cluster_ids.get(context.external_cluster) != Some(&context.cluster_id)
+            || !self.cluster_allowlist.contains(context.external_cluster)
+        {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::ClusterNotAllowed,
+                "read context cluster differs from the connector boundary",
+            ));
+        }
+        if context.subject.trim().is_empty() || context.subject.len() > 256 {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::UnauthorizedScope,
+                "read context subject is missing or invalid",
+            ));
+        }
+        if context.time_range_start > context.time_range_end
+            || context
+                .time_range_end
+                .signed_duration_since(context.time_range_start)
+                .to_std()
+                .map_or(true, |duration| duration > self.max_time_range)
+        {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::InvalidEvidenceQuery,
+                "read context time range exceeds the configured bound",
+            ));
+        }
+        let now = Utc::now();
+        let remaining = context.deadline.signed_duration_since(now).to_std().map_err(|_| {
+            scoped_error(
+                context,
+                ConnectorErrorCode::DeadlineExceeded,
+                "read context deadline elapsed",
+            )
+        })?;
+        if remaining.is_zero() {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::DeadlineExceeded,
+                "read context deadline elapsed",
+            ));
+        }
+        if remaining > self.max_deadline {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::InvalidEvidenceQuery,
+                "read context deadline exceeds the configured bound",
+            ));
+        }
+        if context.cancel.is_cancelled() {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::QueryCancelled,
+                "read context was cancelled before admission",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn enter(&self, context: &ReadContext<'_>) -> Result<SemaphorePermit<'_>, ConnectorError> {
+        let now = Instant::now();
+        {
+            let mut recent = self.recent.lock().await;
+            while recent
+                .front()
+                .is_some_and(|instant| now.duration_since(*instant) >= Duration::from_secs(60))
+            {
+                recent.pop_front();
+            }
+            if recent.len() >= self.max_per_minute {
+                return Err(scoped_error(
+                    context,
+                    ConnectorErrorCode::RateLimited,
+                    "read gateway rate budget is exhausted",
+                ));
+            }
+            recent.push_back(now);
+        }
+        self.concurrency.try_acquire().map_err(|_| {
+            scoped_error(
+                context,
+                ConnectorErrorCode::RateLimited,
+                "read gateway concurrency budget is exhausted",
+            )
+        })
+    }
+
+    pub(crate) fn validate_completion(&self, context: &ReadContext<'_>) -> Result<(), ConnectorError> {
+        if context.cancel.is_cancelled() {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::QueryCancelled,
+                "read context was cancelled before completion",
+            ));
+        }
+        if Utc::now() >= context.deadline {
+            return Err(scoped_error(
+                context,
+                ConnectorErrorCode::DeadlineExceeded,
+                "read context deadline elapsed before completion",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn pseudonymization_key(&self) -> &[u8] {
+        &self.pseudonymization_key
+    }
+}
+
+fn scoped_error(context: &ReadContext<'_>, code: ConnectorErrorCode, detail: &'static str) -> ConnectorError {
+    ConnectorError::new(
+        code,
+        matches!(
+            code,
+            ConnectorErrorCode::DeadlineExceeded | ConnectorErrorCode::RateLimited
+        ),
+        detail,
+    )
+    .with_correlation_id(context.correlation_id)
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
@@ -35,7 +35,6 @@ mod tempo;
 mod topology;
 
 use std::collections::BTreeMap;
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -58,21 +57,21 @@ use serde_json::Value;
 use sha2::Digest;
 use sha2::Sha256;
 use tokio::sync::Mutex;
-use tokio::sync::Semaphore;
 
-use self::admin_query::AdminQuerySource;
+pub(crate) use self::admin_query::AdminQuerySource;
 use self::alertmanager::AlertmanagerSource;
 use self::canonical::CanonicalQuery;
 use self::canonical::CanonicalResourceRoute;
 pub(crate) use self::common::CancelSignal;
-use self::common::SourceOutput;
+pub(crate) use self::common::SourceOutput;
+pub(crate) use self::common::bounded_future;
 pub(crate) use self::common::bounded_response;
 use self::common::max_duration;
-use self::common::sanitize_and_bound;
+pub(crate) use self::common::sanitize_and_bound;
 pub(crate) use self::inventory::InventoryUpload;
 use self::kubernetes::KubernetesSource;
 use self::loki::LokiSource;
-use self::mcp::McpSource;
+pub(crate) use self::mcp::McpSource;
 use self::prometheus::PrometheusSource;
 use self::required_signals::RequiredSignalsSource;
 use self::runtime_diagnostics::RuntimeDiagnosticsSource;
@@ -83,6 +82,11 @@ use crate::ConnectorError;
 use crate::ConnectorErrorCode;
 use crate::EvidenceOperation;
 use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadAdapterKind;
+use crate::read_gateway::ReadAuditTarget;
+use crate::read_gateway::ReadContext;
+use crate::read_gateway::ReadSession;
 
 const CACHE_MAX_ENTRIES: usize = 1024;
 const CONSUMER_LAG_HISTORY_MIN_INTERVAL: Duration = Duration::from_secs(1);
@@ -120,56 +124,18 @@ struct SourceRuntimeState {
     freshness_seconds: Option<u64>,
 }
 
-struct QueryAdmission {
-    concurrency: Semaphore,
-    recent: Mutex<VecDeque<Instant>>,
-    max_per_minute: usize,
-}
-
-impl QueryAdmission {
-    fn new(max_concurrency: usize, max_per_minute: usize) -> Self {
-        Self {
-            concurrency: Semaphore::new(max_concurrency),
-            recent: Mutex::new(VecDeque::with_capacity(max_per_minute.min(1024))),
-            max_per_minute,
-        }
-    }
-
-    async fn rate_limit(&self) -> Result<(), ConnectorError> {
-        let now = Instant::now();
-        let mut recent = self.recent.lock().await;
-        while recent
-            .front()
-            .is_some_and(|instant| now.duration_since(*instant) >= Duration::from_secs(60))
-        {
-            recent.pop_front();
-        }
-        if recent.len() >= self.max_per_minute {
-            return Err(ConnectorError::new(
-                ConnectorErrorCode::RateLimited,
-                true,
-                "connector evidence rate budget is exhausted",
-            ));
-        }
-        recent.push_back(now);
-        Ok(())
-    }
-}
-
 /// Read-only evidence registry with one canonical bounding, caching and
 /// missing-evidence path, including the fixed component Required Signals
 /// composition.
 pub(crate) struct SourceManager<G> {
     config: Arc<ConnectorConfig>,
-    mcp: McpSource<G>,
-    admin: AdminQuerySource,
+    read_gateway: ConnectorReadGateway<G>,
     alertmanager: AlertmanagerSource,
     prometheus: PrometheusSource,
     loki: LokiSource,
     tempo: TempoSource,
     kubernetes: KubernetesSource,
     runtime: RuntimeDiagnosticsSource,
-    admission: QueryAdmission,
     cache: Mutex<BTreeMap<String, CacheEntry>>,
     consumer_lag_history: Mutex<BTreeMap<String, ConsumerLagSample>>,
     state: Mutex<BTreeMap<&'static str, SourceRuntimeState>>,
@@ -187,7 +153,7 @@ where
             .user_agent(concat!("rocketmq-sre-connector/", env!("CARGO_PKG_VERSION")))
             .build()
             .map_err(|_| ConnectorError::configuration("evidence source HTTP client cannot be built"))?;
-        let admin = AdminQuerySource::new(config.admin_source.clone());
+        let read_gateway = ConnectorReadGateway::new(&config, gateway);
         let alertmanager = AlertmanagerSource::new(
             http.clone(),
             config.alertmanager_url.clone(),
@@ -213,7 +179,7 @@ where
         let runtime = RuntimeDiagnosticsSource::new(http, &config);
         let mut state = BTreeMap::new();
         state.insert("rocketmq-mcp", initial_state(true));
-        state.insert("admin-query", initial_state(admin.configured()));
+        state.insert("admin-query", initial_state(read_gateway.admin_configured()));
         state.insert("alertmanager", initial_state(alertmanager.configured()));
         state.insert("prometheus", initial_state(prometheus.configured()));
         state.insert("loki", initial_state(loki.configured()));
@@ -223,12 +189,7 @@ where
         state.insert("required-signals", initial_state(true));
         state.insert("topology", initial_state(true));
         Ok(Self {
-            admission: QueryAdmission::new(
-                config.source_limits.max_concurrency,
-                config.source_limits.max_requests_per_minute,
-            ),
-            mcp: McpSource::new(gateway),
-            admin,
+            read_gateway,
             alertmanager,
             prometheus,
             loki,
@@ -244,7 +205,7 @@ where
 
     pub(crate) async fn initialize(&self, context: ChildServiceContext) {
         self.kubernetes.initialize(context.metadata_io().clone());
-        if let Err(error) = self.admin.start(context.component("admin-query")).await {
+        if let Err(error) = self.read_gateway.initialize(context).await {
             self.record_failure("admin-query", error.code).await;
             tracing::warn!(
                 code = error.code.as_str(),
@@ -281,30 +242,32 @@ where
         &self,
         query: EvidenceQuery,
         external_cluster: &str,
+        subject: &str,
         operation: Option<&EvidenceOperation>,
         deadline: DateTime<Utc>,
         cancel: &CancelSignal,
     ) -> Result<EvidenceSnapshot, ConnectorError> {
         self.validate_bounds(&query, deadline)?;
+        let context = ReadContext {
+            tenant_id: query.tenant_id,
+            cluster_id: query.cluster_id,
+            external_cluster,
+            subject,
+            correlation_id: query.correlation_id,
+            time_range_start: query.time_range.start,
+            time_range_end: query.time_range.end,
+            deadline,
+            cancel,
+        };
         let source = normalize_source(&query.source)?;
+        let session = self.read_gateway.admit(&context, gateway_audit_target(source)).await?;
         let cache_key = cache_key(&query, external_cluster)?;
         if let Some(output) = self.cached(&cache_key).await {
             return capture(query, output);
         }
 
-        self.admission.rate_limit().await?;
-        let _permit = common::bounded_future(deadline, cancel, async {
-            self.admission
-                .concurrency
-                .acquire()
-                .await
-                .map_err(|_| ConnectorError::source("connector concurrency limiter is closed"))
-        })
-        .await?;
         let started_at = Instant::now();
-        let result = self
-            .query_uncached(source, &query, external_cluster, operation, deadline, cancel)
-            .await;
+        let result = self.query_uncached(source, &query, operation, &session).await;
         let mut output = match result {
             Ok(output) => {
                 self.record_success(source, output.freshness_seconds).await;
@@ -346,6 +309,7 @@ where
             partial = output.partial,
             "bounded evidence source query completed"
         );
+        validate_query_completion(&context)?;
         self.insert_cache(cache_key, output.clone()).await;
         capture(query, output)
     }
@@ -354,29 +318,34 @@ where
         &self,
         cluster_id: ClusterId,
         external_cluster: &str,
+        subject: &str,
         deadline: DateTime<Utc>,
         cancel: &CancelSignal,
     ) -> Result<InventoryUpload, ConnectorError> {
-        self.admission.rate_limit().await?;
-        let _permit = common::bounded_future(deadline, cancel, async {
-            self.admission
-                .concurrency
-                .acquire()
-                .await
-                .map_err(|_| ConnectorError::source("connector concurrency limiter is closed"))
-        })
-        .await?;
-        inventory::collect(
-            &self.mcp,
-            &self.admin,
-            &self.kubernetes,
+        let observed_at = Utc::now();
+        let context = ReadContext {
+            tenant_id: self.config.tenant_id,
             cluster_id,
             external_cluster,
+            subject,
+            correlation_id: rocketmq_sre_contracts::CorrelationId::new(),
+            time_range_start: observed_at,
+            time_range_end: observed_at,
+            deadline,
+            cancel,
+        };
+        let session = self
+            .read_gateway
+            .admit(&context, Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "inventory")))
+            .await?;
+        inventory::collect(
+            &self.read_gateway,
+            &self.kubernetes,
+            cluster_id,
             self.config.source_limits.max_rows,
             self.config.source_limits.max_bytes,
             self.config.pseudonymization_key(),
-            deadline,
-            cancel,
+            &session,
         )
         .await
     }
@@ -389,18 +358,13 @@ where
         &self,
         source: &'static str,
         query: &EvidenceQuery,
-        external_cluster: &str,
         operation: Option<&EvidenceOperation>,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
+        session: &ReadSession<'_, '_>,
     ) -> Result<SourceOutput, ConnectorError> {
         if let Some(route) = canonical::resolve(source, &query.resource) {
-            return self
-                .query_canonical(source, route, external_cluster, query, deadline, cancel)
-                .await;
+            return self.query_canonical(source, route, query, session).await;
         }
-        self.query_legacy_uncached(source, query, external_cluster, operation, deadline, cancel)
-            .await
+        self.query_legacy_uncached(source, query, operation, session).await
     }
 
     #[allow(
@@ -411,11 +375,10 @@ where
         &self,
         source: &'static str,
         route: CanonicalResourceRoute,
-        external_cluster: &str,
         query: &EvidenceQuery,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
+        session: &ReadSession<'_, '_>,
     ) -> Result<SourceOutput, ConnectorError> {
+        let context = session.context();
         let CanonicalResourceRoute::Query {
             query: canonical_query,
             projection,
@@ -428,36 +391,36 @@ where
         };
 
         let output = match canonical_query {
-            CanonicalQuery::Mcp(operation) => self.mcp.query(external_cluster, &operation, deadline, cancel).await,
-            CanonicalQuery::Admin(resource) => self.admin.query(external_cluster, &resource, deadline, cancel).await,
+            CanonicalQuery::Mcp(operation) => self.read_gateway.mcp_query(session, &operation).await,
+            CanonicalQuery::Admin(resource) => self.read_gateway.admin_query(session, &resource).await,
             CanonicalQuery::Prometheus { resource, matchers } => {
                 self.prometheus
                     .query_with_matchers(
-                        external_cluster,
+                        context.external_cluster,
                         &resource,
                         &matchers,
                         query.time_range.start,
                         query.time_range.end,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
             CanonicalQuery::Kubernetes(resource) => {
                 self.kubernetes
                     .query(
-                        external_cluster,
+                        context.external_cluster,
                         &resource,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
-            CanonicalQuery::Runtime(resource) => self.runtime.query(&self.mcp, &resource, deadline, cancel).await,
+            CanonicalQuery::Runtime(resource) => self.runtime.query(&self.read_gateway, session, &resource).await,
         }
         .inspect_err(|error| {
             tracing::warn!(
@@ -481,8 +444,13 @@ where
             );
         })?;
         if projection == canonical::CanonicalProjection::ConsumerLag {
-            self.enrich_consumer_lag_rates(external_cluster, &query.resource, &mut projected, source_was_partial)
-                .await?;
+            self.enrich_consumer_lag_rates(
+                context.external_cluster,
+                &query.resource,
+                &mut projected,
+                source_was_partial,
+            )
+            .await?;
         }
         Ok(projected)
     }
@@ -524,11 +492,10 @@ where
         &self,
         source: &'static str,
         query: &EvidenceQuery,
-        external_cluster: &str,
         operation: Option<&EvidenceOperation>,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
+        session: &ReadSession<'_, '_>,
     ) -> Result<SourceOutput, ConnectorError> {
+        let context = session.context();
         match source {
             "rocketmq-mcp" => {
                 let derived;
@@ -539,29 +506,27 @@ where
                         &derived
                     }
                 };
-                self.mcp.query(external_cluster, operation, deadline, cancel).await
+                self.read_gateway.mcp_query(session, operation).await
             }
             "admin-query" => {
                 if let Ok(operation) = mcp_operation(&query.resource) {
-                    match self.mcp.query(external_cluster, &operation, deadline, cancel).await {
+                    match self.read_gateway.mcp_query(session, &operation).await {
                         Ok(output) => return Ok(output),
                         Err(error) if error.code == ConnectorErrorCode::SourceUnavailable => {}
                         Err(error) => return Err(error),
                     }
                 }
-                self.admin
-                    .query(external_cluster, &query.resource, deadline, cancel)
-                    .await
+                self.read_gateway.admin_query(session, &query.resource).await
             }
             "alertmanager" => {
                 self.alertmanager
                     .query(
-                        external_cluster,
+                        context.external_cluster,
                         &query.resource,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
@@ -569,40 +534,40 @@ where
                 "proxy/diagnostics" | "proxy-diagnostics" => {
                     proxy_diagnostics::query(
                         &self.prometheus,
-                        external_cluster,
+                        context.external_cluster,
                         query.time_range.start,
                         query.time_range.end,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
                 }
                 "remoting/diagnostics" | "remoting-diagnostics" => {
                     remoting_diagnostics::query(
                         &self.prometheus,
-                        external_cluster,
+                        context.external_cluster,
                         query.time_range.start,
                         query.time_range.end,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
                 }
                 _ => {
                     self.prometheus
                         .query(
-                            external_cluster,
+                            context.external_cluster,
                             &query.resource,
                             query.time_range.start,
                             query.time_range.end,
                             self.config.source_limits.max_rows,
                             self.config.source_limits.max_bytes,
-                            deadline,
-                            cancel,
+                            context.deadline,
+                            context.cancel,
                         )
                         .await
                 }
@@ -610,73 +575,61 @@ where
             "loki" => {
                 self.loki
                     .query(
-                        external_cluster,
+                        context.external_cluster,
                         &query.resource,
                         query.time_range.start,
                         query.time_range.end,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
             "tempo" => {
                 self.tempo
                     .query(
-                        external_cluster,
+                        context.external_cluster,
                         &query.resource,
                         query.time_range.start,
                         query.time_range.end,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
             "kubernetes" => {
                 self.kubernetes
                     .query(
-                        external_cluster,
+                        context.external_cluster,
                         &query.resource,
                         self.config.source_limits.max_rows,
                         self.config.source_limits.max_bytes,
-                        deadline,
-                        cancel,
+                        context.deadline,
+                        context.cancel,
                     )
                     .await
             }
-            "runtime" => self.runtime.query(&self.mcp, &query.resource, deadline, cancel).await,
+            "runtime" => self.runtime.query(&self.read_gateway, session, &query.resource).await,
             "required-signals" => {
                 RequiredSignalsSource::query(
                     &self.prometheus,
                     &self.loki,
                     &self.tempo,
-                    &self.mcp,
+                    &self.read_gateway,
                     &self.runtime,
-                    external_cluster,
+                    session,
                     &query.resource,
                     query.time_range.start,
                     query.time_range.end,
                     self.config.source_limits.max_rows,
                     self.config.source_limits.max_bytes,
-                    deadline,
-                    cancel,
                 )
                 .await
             }
-            "topology" => {
-                TopologySource::query(
-                    &self.mcp,
-                    &self.admin,
-                    external_cluster,
-                    &query.resource,
-                    deadline,
-                    cancel,
-                )
-                .await
-            }
+            "topology" => TopologySource::query(&self.read_gateway, session, &query.resource).await,
             _ => Err(ConnectorError::new(
                 ConnectorErrorCode::InvalidEvidenceQuery,
                 false,
@@ -766,8 +719,28 @@ where
     }
 
     pub(crate) async fn shutdown(&self) {
-        self.admin.shutdown().await;
+        self.read_gateway.shutdown().await;
     }
+}
+
+fn validate_query_completion(context: &ReadContext<'_>) -> Result<(), ConnectorError> {
+    if context.cancel.is_cancelled() {
+        return Err(ConnectorError::new(
+            ConnectorErrorCode::QueryCancelled,
+            false,
+            "evidence query was cancelled before cache publication",
+        )
+        .with_correlation_id(context.correlation_id));
+    }
+    if Utc::now() >= context.deadline {
+        return Err(ConnectorError::new(
+            ConnectorErrorCode::DeadlineExceeded,
+            true,
+            "evidence deadline elapsed before cache publication",
+        )
+        .with_correlation_id(context.correlation_id));
+    }
+    Ok(())
 }
 
 fn consumer_lag_sample(content: &Value, observed_at: Instant) -> Result<ConsumerLagSample, ConnectorError> {
@@ -886,6 +859,17 @@ fn normalize_source(source: &str) -> Result<&'static str, ConnectorError> {
             false,
             "evidence source is not registered",
         )),
+    }
+}
+
+fn gateway_audit_target(source: &'static str) -> Option<ReadAuditTarget> {
+    match source {
+        "rocketmq-mcp" => Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "logical_query")),
+        "admin-query" => Some(ReadAuditTarget::new(ReadAdapterKind::Admin, "logical_query")),
+        "runtime" => Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "runtime_diagnostics")),
+        "required-signals" => Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "required_signals")),
+        "topology" => Some(ReadAuditTarget::new(ReadAdapterKind::Mcp, "topology")),
+        _ => None,
     }
 }
 
@@ -1222,6 +1206,7 @@ mod tests {
                     time_range: TimeRange::new(at, at).expect("range"),
                 },
                 "local",
+                "test-subject",
                 None,
                 Utc::now() + chrono::Duration::seconds(2),
                 &CancelSignal::default(),

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/admin_query.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/admin_query.rs
@@ -70,6 +70,10 @@ struct ClientConnectionsResult {
 /// this crate's resolved feature graph.
 pub(crate) struct AdminQuerySource {
     config: Option<AdminSourceConfig>,
+    // ReadAdminSession is intentionally single-owner and exposes its read
+    // operations through `&mut self`. A Tokio mutex serializes those bounded
+    // network futures without blocking a runtime worker; lifecycle paths take
+    // the session out of the state before awaiting shutdown.
     state: Mutex<AdminState>,
 }
 

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/common.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/common.rs
@@ -315,11 +315,24 @@ fn pseudonymize_value(value: Value, key: &[u8]) -> Value {
 }
 
 pub(super) fn pseudonymize_identifier(value: &str, key: &[u8]) -> String {
+    if is_canonical_pseudonym(value) {
+        return value.to_owned();
+    }
     let mut digest = Sha256::new();
     digest.update(key);
     digest.update(b"\0");
     digest.update(value.as_bytes());
     format!("sha256:{:x}", digest.finalize())
+}
+
+fn is_canonical_pseudonym(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .as_bytes()
+                .iter()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+    })
 }
 
 fn truncate_utf8(value: &str, max_bytes: usize) -> String {
@@ -456,6 +469,17 @@ mod tests {
                 .is_some_and(|value| value.starts_with("sha256:"))
         );
         assert_eq!(value["rows"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn sanitizer_is_idempotent_for_canonical_pseudonyms() {
+        let first = pseudonymize_identifier("message-a", b"test-key");
+        let second = pseudonymize_identifier(&first, b"test-key");
+        let malformed = pseudonymize_identifier("sha256:not-a-digest", b"test-key");
+
+        assert_eq!(second, first);
+        assert_ne!(malformed, "sha256:not-a-digest");
+        assert!(is_canonical_pseudonym(&malformed));
     }
 
     #[test]

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory.rs
@@ -28,13 +28,12 @@ use serde_json::Value;
 use serde_json::json;
 
 use self::coverage::InventoryCoverage;
-use super::admin_query::AdminQuerySource;
-use super::common::CancelSignal;
 use super::kubernetes::KubernetesSource;
-use super::mcp::McpSource;
 use crate::ConnectorError;
 use crate::ConnectorErrorCode;
 use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 
 const INVENTORY_UPLOAD_MAX_BYTES: usize = 512 * 1024;
 const MAX_EDGE_MULTIPLIER: usize = 2;
@@ -380,46 +379,42 @@ pub(super) fn recoverable_gap(error: &ConnectorError) -> bool {
     reason = "inventory collection keeps all source, security, and resource bounds explicit"
 )]
 pub(super) async fn collect<G>(
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
+    read_gateway: &ConnectorReadGateway<G>,
     kubernetes: &KubernetesSource,
     cluster_id: ClusterId,
-    external_cluster: &str,
     max_rows: usize,
     max_bytes: usize,
     pseudonymization_key: &[u8],
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
+    session: &ReadSession<'_, '_>,
 ) -> Result<InventoryUpload, ConnectorError>
 where
     G: McpGateway,
 {
+    let context = session.context();
     let observed_at = Utc::now();
-    let mut inventory = InventoryAccumulator::new(cluster_id, external_cluster, observed_at);
-    let consumer_groups = rocketmq::collect(&mut inventory, mcp, admin, external_cluster, max_rows, deadline, cancel)
+    let mut inventory = InventoryAccumulator::new(cluster_id, context.external_cluster, observed_at);
+    let consumer_groups = rocketmq::collect(&mut inventory, read_gateway, session, max_rows)
         .await
         .inspect_err(|error| log_collection_error("rocketmq", "collect", error))?;
     client_connections::collect(
         &mut inventory,
-        admin,
-        external_cluster,
+        read_gateway,
+        session,
         &consumer_groups,
         max_rows,
         pseudonymization_key,
-        deadline,
-        cancel,
     )
     .await
     .inspect_err(|error| log_collection_error("rocketmq", "client_connections", error))?;
     k8s::collect(
         &mut inventory,
         kubernetes,
-        external_cluster,
+        context.external_cluster,
         max_rows,
         max_bytes,
         pseudonymization_key,
-        deadline,
-        cancel,
+        context.deadline,
+        context.cancel,
     )
     .await
     .inspect_err(|error| log_collection_error("kubernetes", "collect", error))?;

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/client_connections.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/client_connections.rs
@@ -31,8 +31,9 @@ use super::schema_mismatch;
 use super::validate_inventory_name;
 use crate::ConnectorError;
 use crate::ConnectorErrorCode;
-use crate::sources::admin_query::AdminQuerySource;
-use crate::sources::common::CancelSignal;
+use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 use crate::sources::common::SourceOutput;
 use crate::sources::common::pseudonymize_identifier;
 
@@ -75,17 +76,18 @@ struct ClientConnectionWire {
     clippy::too_many_arguments,
     reason = "connection collection keeps scope, identity, and resource bounds explicit"
 )]
-pub(super) async fn collect(
+pub(super) async fn collect<G>(
     inventory: &mut InventoryAccumulator,
-    admin: &AdminQuerySource,
-    cluster: &str,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
     consumer_groups: &[String],
     max_rows: usize,
     pseudonymization_key: &[u8],
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
-) -> Result<(), ConnectorError> {
-    if !admin.configured() {
+) -> Result<(), ConnectorError>
+where
+    G: McpGateway,
+{
+    if !read_gateway.admin_configured() {
         inventory.mark_gap("producer", "admin_read_connection_source_not_configured");
         inventory.mark_gap("connection", "admin_read_connection_source_not_configured");
         inventory.mark_partial("client_connection_query_not_configured");
@@ -93,10 +95,7 @@ pub(super) async fn collect(
     }
 
     let row_limit = max_rows.clamp(1, CLIENT_CONNECTION_QUERY_LIMIT);
-    match admin
-        .query_producer_connections(cluster, row_limit, deadline, cancel)
-        .await
-    {
+    match read_gateway.admin_producer_connections(session, row_limit).await {
         Ok(output) => {
             add_producer_connections(inventory, output, row_limit, pseudonymization_key)?;
         }
@@ -115,8 +114,8 @@ pub(super) async fn collect(
             inventory.mark_partial("client_connection_row_budget_applied");
             break;
         }
-        match admin
-            .query_consumer_connections(cluster, consumer_group, remaining_rows, deadline, cancel)
+        match read_gateway
+            .admin_consumer_connections(session, consumer_group, remaining_rows)
             .await
         {
             Ok(output) => {

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/rocketmq.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/inventory/rocketmq.rs
@@ -32,10 +32,9 @@ use crate::ConnectorError;
 use crate::ConnectorErrorCode;
 use crate::EvidenceOperation;
 use crate::mcp::McpGateway;
-use crate::sources::admin_query::AdminQuerySource;
-use crate::sources::common::CancelSignal;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 use crate::sources::common::SourceOutput;
-use crate::sources::mcp::McpSource;
 
 const INVENTORY_PAGE_LIMIT: usize = 200;
 const INVENTORY_DETAIL_QUERY_LIMIT: usize = 32;
@@ -191,23 +190,20 @@ struct QueueLagWire {
 
 pub(super) async fn collect<G>(
     inventory: &mut InventoryAccumulator,
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
-    cluster: &str,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
     max_rows: usize,
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
 ) -> Result<Vec<String>, ConnectorError>
 where
     G: McpGateway,
 {
-    collect_overview(inventory, mcp, admin, cluster, deadline, cancel)
+    collect_overview(inventory, read_gateway, session)
         .await
         .inspect_err(|error| log_stage_error("overview", error))?;
-    let topics = collect_topics(inventory, mcp, admin, cluster, max_rows, deadline, cancel)
+    let topics = collect_topics(inventory, read_gateway, session, max_rows)
         .await
         .inspect_err(|error| log_stage_error("topics", error))?;
-    let discovered_consumers = collect_consumers(inventory, mcp, admin, cluster, max_rows, deadline, cancel)
+    let discovered_consumers = collect_consumers(inventory, read_gateway, session, max_rows)
         .await
         .inspect_err(|error| log_stage_error("consumers", error))?;
 
@@ -215,17 +211,14 @@ where
     for topic in topics.topics.iter().take(remaining_detail_queries) {
         remaining_detail_queries = remaining_detail_queries.saturating_sub(1);
         match query_preferred(
-            mcp,
-            admin,
-            cluster,
+            read_gateway,
+            session,
             &EvidenceOperation::TopicDescribe {
                 topic: topic.clone(),
                 limit: Some(page_limit(max_rows)),
                 cursor: None,
             },
             &format!("admin/topic-route/{topic}"),
-            deadline,
-            cancel,
         )
         .await
         {
@@ -257,9 +250,8 @@ where
     let consumer_query_budget = remaining_detail_queries;
     for consumer_topic in topics.consumer_topics.iter().take(consumer_query_budget) {
         match query_preferred(
-            mcp,
-            admin,
-            cluster,
+            read_gateway,
+            session,
             &EvidenceOperation::ConsumerLag {
                 topic: consumer_topic.topic.clone(),
                 consumer_group: consumer_topic.group.clone(),
@@ -267,8 +259,6 @@ where
                 cursor: None,
             },
             &format!("admin/consumer-lag/{}/{}", consumer_topic.group, consumer_topic.topic),
-            deadline,
-            cancel,
         )
         .await
         {
@@ -315,29 +305,24 @@ fn log_stage_error(stage: &'static str, error: &ConnectorError) {
 
 async fn collect_overview<G>(
     inventory: &mut InventoryAccumulator,
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
-    cluster: &str,
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
 ) -> Result<(), ConnectorError>
 where
     G: McpGateway,
 {
+    let context = session.context();
     let observed = query_preferred(
-        mcp,
-        admin,
-        cluster,
+        read_gateway,
+        session,
         &EvidenceOperation::ClusterOverview,
         "admin/brokers",
-        deadline,
-        cancel,
     )
     .await;
     match observed {
-        Ok(observed) if observed.is_mcp => add_cluster_overview(inventory, cluster, observed.output)
+        Ok(observed) if observed.is_mcp => add_cluster_overview(inventory, context.external_cluster, observed.output)
             .inspect_err(|error| log_stage_error("overview_projection", error)),
-        Ok(observed) => add_admin_brokers(inventory, cluster, observed.output)
+        Ok(observed) => add_admin_brokers(inventory, context.external_cluster, observed.output)
             .inspect_err(|error| log_stage_error("overview_projection", error)),
         Err(error) if recoverable_gap(&error) => {
             inventory.mark_gap("broker", "broker_inventory_source_unavailable");
@@ -354,28 +339,22 @@ where
 
 async fn collect_topics<G>(
     inventory: &mut InventoryAccumulator,
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
-    cluster: &str,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
     max_rows: usize,
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
 ) -> Result<TopicDiscovery, ConnectorError>
 where
     G: McpGateway,
 {
     match query_preferred(
-        mcp,
-        admin,
-        cluster,
+        read_gateway,
+        session,
         &EvidenceOperation::TopicList {
             filter: None,
             limit: Some(page_limit(max_rows)),
             cursor: None,
         },
         "admin/topics",
-        deadline,
-        cancel,
     )
     .await
     {
@@ -398,28 +377,22 @@ where
 
 async fn collect_consumers<G>(
     inventory: &mut InventoryAccumulator,
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
-    cluster: &str,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
     max_rows: usize,
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
 ) -> Result<Vec<String>, ConnectorError>
 where
     G: McpGateway,
 {
     match query_preferred(
-        mcp,
-        admin,
-        cluster,
+        read_gateway,
+        session,
         &EvidenceOperation::ConsumerGroupList {
             filter: None,
             limit: Some(page_limit(max_rows)),
             cursor: None,
         },
         "admin/consumer-groups",
-        deadline,
-        cancel,
     )
     .await
     {
@@ -435,21 +408,18 @@ where
 }
 
 async fn query_preferred<G>(
-    mcp: &McpSource<G>,
-    admin: &AdminQuerySource,
-    cluster: &str,
+    read_gateway: &ConnectorReadGateway<G>,
+    session: &ReadSession<'_, '_>,
     operation: &EvidenceOperation,
     admin_resource: &str,
-    deadline: DateTime<Utc>,
-    cancel: &CancelSignal,
 ) -> Result<ObservedOutput, ConnectorError>
 where
     G: McpGateway,
 {
-    match mcp.query(cluster, operation, deadline, cancel).await {
+    match read_gateway.mcp_query(session, operation).await {
         Ok(output) => Ok(ObservedOutput { output, is_mcp: true }),
-        Err(error) if recoverable_gap(&error) && admin.configured() => admin
-            .query(cluster, admin_resource, deadline, cancel)
+        Err(error) if recoverable_gap(&error) && read_gateway.admin_configured() => read_gateway
+            .admin_query(session, admin_resource)
             .await
             .map(|output| ObservedOutput { output, is_mcp: false }),
         Err(error) => Err(error),

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
@@ -26,16 +26,16 @@ use rocketmq_sre_contracts::RequiredSignalsEvidenceV1;
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::common::CancelSignal;
 use super::common::SourceOutput;
 use super::loki::LokiSource;
-use super::mcp::McpSource;
 use super::prometheus::PrometheusSource;
 use super::runtime_diagnostics::RuntimeDiagnosticsSource;
 use super::tempo::TempoSource;
 use crate::ConnectorError;
 use crate::ConnectorErrorCode;
 use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 
 const MANIFEST_SCHEMA_VERSION: &str = "rocketmq.sre.required-signals.v1";
 const BROKER_MANIFEST: &str = include_str!("../../../../config/observability/required-signals/broker.yaml");
@@ -109,20 +109,19 @@ impl RequiredSignalsSource {
         prometheus: &PrometheusSource,
         loki: &LokiSource,
         tempo: &TempoSource,
-        mcp: &McpSource<G>,
+        read_gateway: &ConnectorReadGateway<G>,
         runtime: &RuntimeDiagnosticsSource,
-        external_cluster: &str,
+        session: &ReadSession<'_, '_>,
         resource: &str,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
         max_rows: usize,
         max_bytes: usize,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
     ) -> Result<SourceOutput, ConnectorError>
     where
         G: McpGateway,
     {
+        let context = session.context();
         let component = normalize_component(resource)?;
         let manifest = parse_manifest(component, manifest_source(component)?)?;
         let mut shared = SharedReads::default();
@@ -139,14 +138,14 @@ impl RequiredSignalsSource {
                         "prometheus",
                         prometheus
                             .query(
-                                external_cluster,
+                                context.external_cluster,
                                 metric_resource,
                                 start,
                                 end,
                                 max_rows,
                                 max_bytes,
-                                deadline,
-                                cancel,
+                                context.deadline,
+                                context.cancel,
                             )
                             .await,
                     )?;
@@ -157,14 +156,14 @@ impl RequiredSignalsSource {
                         shared.logs = Some(normalize_read(
                             "loki",
                             loki.query(
-                                external_cluster,
+                                context.external_cluster,
                                 log_resource,
                                 start,
                                 end,
                                 max_rows,
                                 max_bytes,
-                                deadline,
-                                cancel,
+                                context.deadline,
+                                context.cancel,
                             )
                             .await,
                         )?);
@@ -181,14 +180,14 @@ impl RequiredSignalsSource {
                             "tempo",
                             tempo
                                 .query(
-                                    external_cluster,
+                                    context.external_cluster,
                                     trace_resource,
                                     start,
                                     end,
                                     max_rows,
                                     max_bytes,
-                                    deadline,
-                                    cancel,
+                                    context.deadline,
+                                    context.cancel,
                                 )
                                 .await,
                         )?);
@@ -200,7 +199,7 @@ impl RequiredSignalsSource {
                     observation_from_read(signal, read)
                 }
                 FixedQuery::Runtime(runtime_resource) => {
-                    let read = normalize_read("runtime", runtime.query(mcp, runtime_resource, deadline, cancel).await)?;
+                    let read = normalize_read("runtime", runtime.query(read_gateway, session, runtime_resource).await)?;
                     observation_from_read(signal, read)
                 }
             };

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/runtime_diagnostics.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/runtime_diagnostics.rs
@@ -26,13 +26,14 @@ use serde_json::json;
 use super::common;
 use super::common::CancelSignal;
 use super::common::SourceOutput;
-use super::mcp::McpSource;
 use crate::ConnectorConfig;
 use crate::ConnectorError;
 use crate::ConnectorErrorCode;
 use crate::config::RuntimeDiagnosticsSourceConfig;
 use crate::config::SecretValue;
 use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 
 const RUNTIME_RESOURCE_URI: &str = "rocketmq://system/runtime/v1";
 const OBSERVABILITY_RESOURCE_URI: &str = "rocketmq://system/observability/v1";
@@ -78,29 +79,31 @@ impl RuntimeDiagnosticsSource {
 
     pub(crate) async fn query<G>(
         &self,
-        mcp: &McpSource<G>,
+        read_gateway: &ConnectorReadGateway<G>,
+        session: &ReadSession<'_, '_>,
         resource: &str,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
     ) -> Result<SourceOutput, ConnectorError>
     where
         G: McpGateway,
     {
+        let context = session.context();
         match resource {
             "runtime" | "runtime/diagnostics" | RUNTIME_RESOURCE_URI => {
-                let wire = mcp.system_resource(RUNTIME_RESOURCE_URI, deadline, cancel).await?;
+                let wire = read_gateway.mcp_system_resource(session, RUNTIME_RESOURCE_URI).await?;
                 project_runtime(wire.content)
             }
             "runtime/observability" | "observability" | OBSERVABILITY_RESOURCE_URI => {
-                let wire = mcp
-                    .system_resource(OBSERVABILITY_RESOURCE_URI, deadline, cancel)
+                let wire = read_gateway
+                    .mcp_system_resource(session, OBSERVABILITY_RESOURCE_URI)
                     .await?;
                 project_observability(wire.content)
             }
-            COMPONENTS_RESOURCE | "components" => self.query_components(deadline, cancel).await,
+            COMPONENTS_RESOURCE | "components" => self.query_components(context.deadline, context.cancel).await,
             _ if resource.starts_with("runtime/") => {
                 let component = resource.trim_start_matches("runtime/");
-                let view = self.fetch_component(component, deadline, cancel).await?;
+                let view = self
+                    .fetch_component(component, context.deadline, context.cancel)
+                    .await?;
                 Ok(project_component_runtime(view))
             }
             _ => Err(ConnectorError::new(

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/topology.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/topology.rs
@@ -12,29 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::DateTime;
-use chrono::Utc;
 use serde_json::json;
 
-use super::admin_query::AdminQuerySource;
-use super::common::CancelSignal;
 use super::common::SourceOutput;
 use super::common::validate_identifier;
-use super::mcp::McpSource;
 use crate::ConnectorError;
 use crate::EvidenceOperation;
 use crate::mcp::McpGateway;
+use crate::read_gateway::ConnectorReadGateway;
+use crate::read_gateway::ReadSession;
 
 pub(crate) struct TopologySource;
 
 impl TopologySource {
     pub(crate) async fn query<G>(
-        mcp: &McpSource<G>,
-        admin: &AdminQuerySource,
-        cluster: &str,
+        read_gateway: &ConnectorReadGateway<G>,
+        session: &ReadSession<'_, '_>,
         resource: &str,
-        deadline: DateTime<Utc>,
-        cancel: &CancelSignal,
     ) -> Result<SourceOutput, ConnectorError>
     where
         G: McpGateway,
@@ -59,10 +53,12 @@ impl TopologySource {
             ));
         };
 
-        let mut output = match mcp.query(cluster, &operation, deadline, cancel).await {
+        let mut output = match read_gateway.mcp_query(session, &operation).await {
             Ok(output) => output,
-            Err(error) if error.code == crate::ConnectorErrorCode::SourceUnavailable && admin.configured() => {
-                admin.query(cluster, &admin_resource, deadline, cancel).await?
+            Err(error)
+                if error.code == crate::ConnectorErrorCode::SourceUnavailable && read_gateway.admin_configured() =>
+            {
+                read_gateway.admin_query(session, &admin_resource).await?
             }
             Err(error) => return Err(error),
         };

--- a/rocketmq-sre/crates/rocketmq-sre-connector/tests/read_gateway_contract.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/tests/read_gateway_contract.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::Path;
+
+fn adapter_bypasses(root: &Path) -> Vec<String> {
+    let source_root = root.join("src");
+    let allowed = [
+        "read_gateway/admin.rs",
+        "read_gateway/mcp.rs",
+        "sources.rs",
+        "sources/admin_query.rs",
+        "sources/mcp.rs",
+    ];
+    let forbidden = [
+        "McpSource",
+        "AdminQuerySource",
+        ".query_producer_connections(",
+        ".query_consumer_connections(",
+    ];
+    let mut pending = vec![source_root.clone()];
+    let mut findings = Vec::new();
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory).expect("connector source directory") {
+            let path = entry.expect("connector source entry").path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+                continue;
+            }
+            let relative = path
+                .strip_prefix(&source_root)
+                .expect("connector source path")
+                .to_string_lossy()
+                .replace('\\', "/");
+            if allowed.contains(&relative.as_str()) {
+                continue;
+            }
+            let source = fs::read_to_string(&path).expect("connector source");
+            for marker in forbidden {
+                if source.contains(marker) {
+                    findings.push(format!("{relative}:{marker}"));
+                }
+            }
+        }
+    }
+    findings
+}
+
+#[test]
+fn source_manager_owns_one_read_gateway_without_adapter_bypasses() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let sources = fs::read_to_string(root.join("src/sources.rs")).expect("sources.rs");
+
+    assert!(sources.contains("read_gateway: ConnectorReadGateway"));
+    assert!(sources.contains("read_gateway.mcp_query"));
+    assert!(sources.contains("read_gateway.admin_query"));
+    for forbidden in [
+        "mcp: McpSource",
+        "admin: AdminQuerySource",
+        "self.mcp.query",
+        "self.admin.query",
+    ] {
+        assert!(!sources.contains(forbidden), "adapter bypass remains: {forbidden}");
+    }
+    assert_eq!(adapter_bypasses(root), Vec::<String>::new());
+}
+
+#[test]
+fn connector_admin_dependency_is_read_only() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("connector manifest");
+    assert!(manifest.contains(r#"features = ["read-client-adapter"]"#));
+    for forbidden in ["mutation-client-adapter", "dangerous-tools", "admin-full"] {
+        assert!(
+            !manifest.contains(forbidden),
+            "mutation feature is reachable: {forbidden}"
+        );
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/service.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/connector_channel/service.rs
@@ -1063,6 +1063,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mismatched_query_scope_is_rejected_before_enqueue() {
+        let store = MemoryStore::default();
+        let service = ConnectorChannelService::new(store.clone(), "test-token").expect("test service");
+        let tenant_id = TenantId::new();
+        let cluster_id = ClusterId::new();
+        let session_id = ConnectorSessionId::new();
+        service
+            .register(&principal(), &registration(tenant_id, cluster_id, session_id))
+            .await
+            .expect("register");
+
+        for mismatched in [query(TenantId::new(), cluster_id), query(tenant_id, ClusterId::new())] {
+            assert!(
+                service
+                    .enqueue_query(
+                        tenant_id,
+                        cluster_id,
+                        mismatched,
+                        Utc::now() + chrono::Duration::seconds(30),
+                    )
+                    .await
+                    .is_err()
+            );
+        }
+
+        assert!(
+            store
+                .state
+                .lock()
+                .await
+                .commands
+                .get(&session_id)
+                .is_none_or(Vec::is_empty)
+        );
+    }
+
+    #[tokio::test]
     async fn auxiliary_upload_scope_comes_from_the_live_registered_session() {
         let service = ConnectorChannelService::new(MemoryStore::default(), "test-token").expect("test service");
         let tenant_id = TenantId::new();

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/tests/read_gateway_boundary.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/tests/read_gateway_boundary.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn control_plane_has_no_connector_or_rocketmq_client_dependency() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("control-plane manifest");
+    for forbidden in ["rocketmq-admin-core", "rocketmq-mcp", "rocketmq-sre-connector"] {
+        assert!(
+            !manifest.contains(forbidden),
+            "control plane must use ConnectorChannel instead of {forbidden}"
+        );
+    }
+}

--- a/rocketmq-sre/docs/read-gateway-contract.md
+++ b/rocketmq-sre/docs/read-gateway-contract.md
@@ -1,0 +1,128 @@
+# Connector ReadGateway Contract
+
+## Status
+
+Accepted as the private RocketMQ read boundary of `rocketmq-sre-connector`.
+The contract is intentionally crate-private: the Control Plane exchanges only
+versioned `EvidenceQuery` and response contracts over ConnectorChannel.
+
+## Trust boundary
+
+```mermaid
+flowchart LR
+    CP["Control Plane"] -->|"tenant/cluster-scoped EvidenceQuery"| CH["ConnectorChannel"]
+    API["Authenticated internal HTTP"] --> ENG["ConnectorEngine"]
+    CH --> ENG
+    ENG -->|"trusted subject + query scope"| RG["ReadGateway"]
+    RG --> POL["ReadPolicy"]
+    POL --> MCP["MCP read adapter"]
+    POL --> ADMIN["Admin read-client adapter"]
+    MCP --> RMCP["RocketMQ MCP wire contract"]
+    ADMIN --> RAC["rocketmq-admin-core<br/>read-client-adapter only"]
+```
+
+The Control Plane does not link an MCP client, Admin client, Connector
+implementation, or target credential. HTTP bearer validation and
+ConnectorChannel session validation complete before a `ReadContext` is
+constructed.
+
+## Request and admission contract
+
+Every logical RocketMQ read obtains one `ReadSession`. Composite inventory,
+topology, runtime, and Required Signals reads reuse that session for all MCP
+and Admin sub-reads. The session proves that these checks completed:
+
+- configured tenant and internal cluster identifiers match;
+- the external cluster is both mapped and allowlisted;
+- the authenticated subject is present and bounded;
+- the time range and absolute deadline are within configured maxima;
+- cancellation has not occurred;
+- the shared requests-per-minute and concurrency budgets admit the request.
+
+MCP and Admin adapters cannot construct a session or change a budget. A
+deadline or cancellation observed before completion returns a typed error and
+prevents cache publication.
+
+## Fixed adapter surface
+
+The MCP adapter accepts only the `EvidenceOperation` enum and the two protected
+system resource URIs. MCP initialization verifies protocol and business schema
+versions, the task-forbidden read-only tool surface, resources, cluster, and
+surface digest.
+
+The Admin adapter accepts only the fixed resources implemented by
+`AdminQuerySource`, plus typed producer and consumer connection reads. Its
+dependency enables only `rocketmq-admin-core/read-client-adapter`; mutation,
+`admin-full`, and dangerous tool features are not reachable.
+
+`ReadAdminSession` requires mutable single-owner access. The adapter therefore
+uses a Tokio mutex to serialize bounded read futures. It never holds a
+synchronous lock across `.await`, and shutdown removes the session and runtime
+from state before awaiting lifecycle completion.
+
+## Output policy
+
+Adapter output passes through `sanitize_and_bound` before it leaves the
+gateway. The policy:
+
+- rejects message bodies and payloads;
+- removes credentials, tokens, ACL/TLS material, private keys, configuration
+  secrets, and client addresses;
+- pseudonymizes message and trace identifiers;
+- limits rows, strings, warning count, and encoded bytes;
+- preserves explicit partial coverage without inventing missing data.
+
+Sanitization is idempotent for the connector's canonical
+`sha256:<64 lowercase hex>` pseudonyms, so composite reads do not hash an
+already protected identifier a second time.
+
+## Error and audit contract
+
+Stable failure codes include `tenant_mismatch`, `cluster_not_allowed`,
+`unauthorized_scope`, `rate_limited`, `deadline_exceeded`, `query_cancelled`,
+`output_too_large`, `capability_mismatch`, and `source_unavailable`.
+
+Each adapter attempt records only:
+
+- adapter kind;
+- fixed resource class;
+- typed outcome (`Allowed`, `Denied`, `RateLimited`, `TimedOut`, `Cancelled`,
+  or `SourceFailed`);
+- latency bucket;
+- correlation identifier.
+
+Audit events and errors never contain a bearer token, Admin credential,
+message body, request/config dump, TLS certificate, ACL material, tenant
+subject, or raw adapter response.
+
+## Credential ownership
+
+| Credential | Owner | Visibility |
+| --- | --- | --- |
+| Control Plane channel identity | Connector channel transport | Used before `ReadContext`; never passed to adapters |
+| MCP bearer/OAuth material | Connector MCP transport | Private to token provider and transport |
+| Admin access/secret/security token | Connector Admin adapter | Converted to read-client credentials; never logged |
+| Target mutation credentials | Execution Agent | Not linked into Connector or ReadGateway |
+
+## Validation
+
+Run from `rocketmq-sre/`:
+
+```powershell
+python scripts/check_read_gateway_boundary.py
+cargo test --locked -p rocketmq-sre-connector --test read_gateway_contract
+cargo test --locked -p rocketmq-sre-connector --lib read_gateway::tests
+cargo test --locked -p rocketmq-sre-control-plane connector_channel
+```
+
+The boundary script fails when Control Plane gains an MCP/Admin/Connector
+dependency, the Admin mutation feature graph becomes reachable, SourceManager
+owns an adapter directly, or any connector module outside the gateway and
+adapter implementations uses those sources.
+
+## Explicitly deferred
+
+Organization IdP/OIDC integration, real commercial model providers, production
+object storage, Docker image validation, six-hour soak, and full disaster
+recovery exercises remain later validation or integration work. None broadens
+this read-only contract.

--- a/rocketmq-sre/scripts/check_read_gateway_boundary.py
+++ b/rocketmq-sre/scripts/check_read_gateway_boundary.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Fail closed when RocketMQ read adapters bypass the connector ReadGateway."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONNECTOR = ROOT / "crates" / "rocketmq-sre-connector"
+CONTROL_PLANE = ROOT / "crates" / "rocketmq-sre-control-plane"
+
+
+def source_text(root: Path) -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in sorted((root / "src").rglob("*.rs")))
+
+
+def connector_adapter_bypasses() -> list[str]:
+    allowed = {
+        Path("read_gateway/admin.rs"),
+        Path("read_gateway/mcp.rs"),
+        Path("sources.rs"),
+        Path("sources/admin_query.rs"),
+        Path("sources/mcp.rs"),
+    }
+    bypasses: list[str] = []
+    source_root = CONNECTOR / "src"
+    forbidden = (
+        "McpSource",
+        "AdminQuerySource",
+        ".query_producer_connections(",
+        ".query_consumer_connections(",
+    )
+    for path in sorted(source_root.rglob("*.rs")):
+        relative = path.relative_to(source_root)
+        if relative in allowed:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for marker in forbidden:
+            if marker in text:
+                bypasses.append(f"connector-adapter-bypass:{relative.as_posix()}:{marker}")
+    return bypasses
+
+
+def findings() -> list[str]:
+    result: list[str] = []
+    control_manifest = (CONTROL_PLANE / "Cargo.toml").read_text(encoding="utf-8")
+    for forbidden in ("rocketmq-admin-core", "rocketmq-mcp", "rocketmq-sre-connector"):
+        if forbidden in control_manifest:
+            result.append(f"control-plane-forbidden-dependency:{forbidden}")
+
+    connector_manifest = (CONNECTOR / "Cargo.toml").read_text(encoding="utf-8")
+    if 'features = ["read-client-adapter"]' not in connector_manifest:
+        result.append("connector-admin-read-feature-missing")
+    for forbidden in ("mutation-client-adapter", "dangerous-tools", "admin-full"):
+        if forbidden in connector_manifest:
+            result.append(f"connector-mutation-feature:{forbidden}")
+
+    sources = (CONNECTOR / "src" / "sources.rs").read_text(encoding="utf-8")
+    required = (
+        "read_gateway: ConnectorReadGateway",
+        "ReadContext",
+        "read_gateway.mcp_query",
+        "read_gateway.admin_query",
+    )
+    for marker in required:
+        if marker not in sources:
+            result.append(f"source-manager-gateway-contract-missing:{marker}")
+    for forbidden in ("mcp: McpSource", "admin: AdminQuerySource", "self.mcp.query", "self.admin.query"):
+        if forbidden in sources:
+            result.append(f"source-manager-direct-adapter:{forbidden}")
+
+    connector_sources = source_text(CONNECTOR)
+    if "mod read_gateway;" not in connector_sources:
+        result.append("read-gateway-module-missing")
+    result.extend(connector_adapter_bypasses())
+    return result
+
+
+def main() -> int:
+    violations = findings()
+    if violations:
+        for violation in violations:
+            print(f"READ_GATEWAY_BOUNDARY_FINDING {violation}")
+        print(f"READ_GATEWAY_BOUNDARY_FAILED findings={len(violations)}")
+        return 1
+    print("READ_GATEWAY_BOUNDARY_OK direct_adapter_calls=0 mutation_features=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8882

### Brief Description

Introduce a crate-private Connector `ReadGateway` as the only RocketMQ read boundary. MCP and direct Admin are internal typed adapters behind one tenant/cluster/subject authorization, rate and concurrency admission, deadline, cancellation, output bounding, redaction, and audit policy.

Route canonical evidence, inventory, topology, runtime diagnostics, and Required Signals through the gateway. Keep Control Plane access on ConnectorChannel, preserve the Admin read-only feature graph, add fail-closed dependency/bypass guards, and document the trust boundary and credential ownership.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features` (passed; environment-dependent PostgreSQL and live-provider tests remain explicitly ignored by the suite)
- `cargo doc --locked --workspace --no-deps`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python scripts/check_read_gateway_boundary.py`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized, read-only gateway for RocketMQ MCP and administrative queries.
  * Added request authorization, rate and concurrency controls, deadlines, cancellation, output limits, redaction, pseudonymization, partial-result handling, and audit records.
  * Added administrative read support with safe fallback behavior when configured.

* **Bug Fixes**
  * Preserved already-pseudonymized identifiers without reprocessing them.
  * Added scope validation to reject mismatched tenant or cluster queries.

* **Documentation**
  * Documented the read-gateway contract, safety model, boundaries, and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->