### PR TITLE
[ISSUE #8884]♻️Enforce typed HA authority and replicated ACK contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,6 +4330,7 @@ dependencies = [
  "rocketmq-protocol",
  "rocketmq-runtime",
  "rocketmq-security-api",
+ "rocketmq-store-api",
  "rocketmq-transport",
  "rocksdb",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3108,6 +3108,7 @@ dependencies = [
  "rocketmq-protocol",
  "rocketmq-runtime",
  "rocketmq-security-api",
+ "rocketmq-store-api",
  "rocketmq-transport",
  "serde",
  "serde_json",

--- a/rocketmq-broker/src/controller/replicas_manager.rs
+++ b/rocketmq-broker/src/controller/replicas_manager.rs
@@ -26,6 +26,10 @@ use rocketmq_model::common::mix_all::MASTER_ID;
 use rocketmq_protocol::protocol::body::epoch_entry_cache::EpochEntry;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::MessageStoreConfig;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::SyncStateSet as HaSyncStateSet;
+use rocketmq_store_api::SyncStateSetEpoch;
+use rocketmq_store_api::WriteAuthority;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::info;
@@ -167,8 +171,8 @@ pub struct ReplicasManager {
     controller_leader_address: Option<CheetahString>,
     master_broker_id: Option<u64>,
     master_address: Option<CheetahString>,
-    master_epoch: i32,
-    sync_state_set_epoch: i32,
+    write_authority: Option<WriteAuthority>,
+    sync_state_set_epoch: Option<SyncStateSetEpoch>,
     sync_state_set: HashSet<i64>,
     metadata_path: PathBuf,
     temp_metadata_path: PathBuf,
@@ -193,8 +197,8 @@ impl ReplicasManager {
             controller_leader_address: None,
             master_broker_id: None,
             master_address: None,
-            master_epoch: 0,
-            sync_state_set_epoch: 0,
+            write_authority: None,
+            sync_state_set_epoch: None,
             sync_state_set: HashSet::new(),
             metadata_path,
             temp_metadata_path,
@@ -224,10 +228,9 @@ impl ReplicasManager {
     }
 
     pub fn get_epoch_entries(&self) -> Vec<EpochEntry> {
-        if self.master_epoch <= 0 {
-            return Vec::new();
-        }
-        vec![EpochEntry::new(self.master_epoch, 0)]
+        self.write_authority
+            .map(|authority| vec![EpochEntry::new(authority.master_epoch().get(), 0)])
+            .unwrap_or_default()
     }
 
     pub fn broker_controller_id(&self) -> u64 {
@@ -279,11 +282,19 @@ impl ReplicasManager {
     }
 
     pub fn master_epoch(&self) -> i32 {
-        self.master_epoch
+        self.write_authority
+            .map(|authority| authority.master_epoch().get())
+            .unwrap_or_default()
     }
 
     pub fn sync_state_set_epoch(&self) -> i32 {
         self.sync_state_set_epoch
+            .map(SyncStateSetEpoch::get)
+            .unwrap_or_default()
+    }
+
+    pub fn write_authority(&self) -> Option<WriteAuthority> {
+        self.write_authority
     }
 
     pub fn sync_state_set(&self) -> &HashSet<i64> {
@@ -294,7 +305,7 @@ impl ReplicasManager {
         ControllerHeartbeatState {
             controller_targets: self.heartbeat_targets(),
             broker_id: self.broker_controller_id as i64,
-            epoch: (self.master_epoch > 0).then_some(self.master_epoch),
+            epoch: self.write_authority.map(|authority| authority.master_epoch().get()),
         }
     }
 
@@ -563,48 +574,95 @@ impl ReplicasManager {
             self.set_controller_leader_address(controller_leader_address);
         }
 
-        let Some(new_master_epoch) = new_master_epoch else {
+        let Some(new_master_epoch_value) = new_master_epoch else {
             return Err(RocketMQError::illegal_argument(
                 "notify broker role change missing master epoch",
             ));
         };
-
-        if new_master_epoch < self.master_epoch {
-            return Ok(self.outcome(None, false));
-        }
-
-        let next_sync_state_set_epoch = sync_state_set_epoch.unwrap_or(self.sync_state_set_epoch);
-        let sync_state_set_changed = next_sync_state_set_epoch > self.sync_state_set_epoch;
-        if sync_state_set_changed {
-            self.sync_state_set_epoch = next_sync_state_set_epoch;
-            self.sync_state_set = sync_state_set.cloned().unwrap_or_default();
-        }
-
-        if new_master_epoch == self.master_epoch {
-            return Ok(self.outcome(None, sync_state_set_changed));
-        }
-
         let Some(master_broker_id) = new_master_broker_id else {
             return Err(RocketMQError::illegal_argument(
                 "notify broker role change missing master broker id",
             ));
         };
+        let new_master_epoch = MasterEpoch::try_from(new_master_epoch_value).map_err(|_| {
+            RocketMQError::illegal_argument("notify broker role change carries an invalid master epoch")
+        })?;
+        let requested_authority = WriteAuthority::try_from_u64(master_broker_id, new_master_epoch).map_err(|_| {
+            RocketMQError::illegal_argument("notify broker role change carries an invalid master broker id")
+        })?;
 
-        self.master_epoch = new_master_epoch;
-        self.master_broker_id = Some(master_broker_id);
-
-        let role = if master_broker_id == self.broker_controller_id {
-            self.master_address = Some(self.broker_address.clone());
-            Some(BrokerReplicaRole::Master)
-        } else {
-            let Some(master_address) = new_master_address else {
+        if let Some(current_authority) = self.write_authority {
+            if requested_authority.master_epoch() < current_authority.master_epoch() {
+                return Ok(self.outcome(None, false));
+            }
+            if requested_authority.master_epoch() == current_authority.master_epoch()
+                && requested_authority != current_authority
+            {
                 return Err(RocketMQError::illegal_argument(
-                    "notify broker role change missing master address for slave transition",
+                    "notify broker role change conflicts with the installed authority at the same epoch",
                 ));
-            };
-            self.master_address = Some(master_address);
-            Some(BrokerReplicaRole::Slave)
+            }
+        }
+
+        let next_sync_state_set_epoch = match sync_state_set_epoch {
+            Some(epoch) => Some(SyncStateSetEpoch::try_from(epoch).map_err(|_| {
+                RocketMQError::illegal_argument("notify broker role change carries an invalid sync-state-set epoch")
+            })?),
+            None => self.sync_state_set_epoch,
         };
+        if self
+            .sync_state_set_epoch
+            .zip(next_sync_state_set_epoch)
+            .is_some_and(|(current, next)| next < current)
+        {
+            return Err(RocketMQError::illegal_argument(
+                "notify broker role change carries a stale sync-state-set epoch",
+            ));
+        }
+        let sync_state_set_changed = next_sync_state_set_epoch > self.sync_state_set_epoch;
+        let next_sync_state_set = if sync_state_set_changed {
+            let members = sync_state_set.ok_or_else(|| {
+                RocketMQError::illegal_argument(
+                    "notify broker role change advances sync-state-set epoch without membership",
+                )
+            })?;
+            let validated = HaSyncStateSet::try_new(members.iter().copied()).map_err(|_| {
+                RocketMQError::illegal_argument("notify broker role change carries an invalid sync-state set")
+            })?;
+            if !validated.contains(requested_authority.broker_id()) {
+                return Err(RocketMQError::illegal_argument(
+                    "notify broker role change sync-state set does not contain the authorized master",
+                ));
+            }
+            Some(members.clone())
+        } else {
+            None
+        };
+
+        if self.write_authority == Some(requested_authority) {
+            if let Some(next_sync_state_set) = next_sync_state_set {
+                self.sync_state_set_epoch = next_sync_state_set_epoch;
+                self.sync_state_set = next_sync_state_set;
+            }
+            return Ok(self.outcome(None, sync_state_set_changed));
+        }
+
+        let (role, master_address) = if master_broker_id == self.broker_controller_id {
+            (BrokerReplicaRole::Master, self.broker_address.clone())
+        } else {
+            let master_address = new_master_address.ok_or_else(|| {
+                RocketMQError::illegal_argument("notify broker role change missing master address for slave transition")
+            })?;
+            (BrokerReplicaRole::Slave, master_address)
+        };
+
+        self.write_authority = Some(requested_authority);
+        self.master_broker_id = Some(master_broker_id);
+        self.master_address = Some(master_address);
+        if let Some(next_sync_state_set) = next_sync_state_set {
+            self.sync_state_set_epoch = next_sync_state_set_epoch;
+            self.sync_state_set = next_sync_state_set;
+        }
 
         info!(
             "Apply controller role change, broker_controller_id={}, new_role={:?}, master_broker_id={:?}, \
@@ -613,11 +671,11 @@ impl ReplicasManager {
             role,
             self.master_broker_id,
             self.master_address,
-            self.master_epoch,
-            self.sync_state_set_epoch
+            new_master_epoch.get(),
+            self.sync_state_set_epoch()
         );
 
-        Ok(self.outcome(role, sync_state_set_changed))
+        Ok(self.outcome(Some(role), sync_state_set_changed))
     }
 
     fn outcome(&self, role: Option<BrokerReplicaRole>, sync_state_set_changed: bool) -> RoleChangeOutcome {
@@ -627,8 +685,8 @@ impl ReplicasManager {
             sync_state_set_changed,
             master_broker_id: self.master_broker_id,
             master_address: self.master_address.clone(),
-            master_epoch: self.master_epoch,
-            sync_state_set_epoch: self.sync_state_set_epoch,
+            master_epoch: self.master_epoch(),
+            sync_state_set_epoch: self.sync_state_set_epoch(),
             sync_state_set: self.sync_state_set.clone(),
             local_broker_id: if should_start_special_service {
                 MASTER_ID
@@ -1037,6 +1095,51 @@ mod tests {
             manager.controller_leader_address(),
             Some(&CheetahString::from("127.0.0.4:9878"))
         );
+    }
+
+    #[test]
+    fn change_broker_role_rejects_conflicting_authority_at_same_epoch() {
+        let config = broker_config_with_controller_addr("127.0.0.1:9878", 2);
+        let message_store_config = message_store_config_with_identity_path("conflicting-authority");
+        let mut manager = ReplicasManager::new(&config, &message_store_config, "127.0.0.1:10911".into());
+
+        manager
+            .change_broker_role(None, Some(2), None, Some(3), Some(3), Some(&HashSet::from([2_i64])))
+            .expect("initial authority should be installed");
+        let installed = manager.write_authority().expect("installed authority");
+
+        let error = manager
+            .change_broker_role(
+                None,
+                Some(1),
+                Some("127.0.0.9:10911".into()),
+                Some(3),
+                Some(4),
+                Some(&HashSet::from([1_i64])),
+            )
+            .expect_err("same epoch must not authorize a different master");
+
+        assert!(error.to_string().contains("conflicts with the installed authority"));
+        assert_eq!(manager.write_authority(), Some(installed));
+        assert_eq!(manager.master_broker_id(), Some(2));
+        assert_eq!(manager.sync_state_set(), &HashSet::from([2_i64]));
+    }
+
+    #[test]
+    fn change_broker_role_rejects_non_positive_epochs_without_mutation() {
+        let config = broker_config_with_controller_addr("127.0.0.1:9878", 2);
+        let message_store_config = message_store_config_with_identity_path("invalid-epoch");
+        let mut manager = ReplicasManager::new(&config, &message_store_config, "127.0.0.1:10911".into());
+
+        for epoch in [-1, 0] {
+            manager
+                .change_broker_role(None, Some(2), None, Some(epoch), Some(1), Some(&HashSet::from([2_i64])))
+                .expect_err("non-positive epoch must fail closed");
+        }
+
+        assert_eq!(manager.write_authority(), None);
+        assert_eq!(manager.master_broker_id(), None);
+        assert!(manager.sync_state_set().is_empty());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -719,6 +719,63 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
             "storeSyncFlushOldestWaitMillis".to_string(),
             store_health.sync_flush.oldest_wait_millis.to_string(),
         );
+        if let Some(ha) = message_store.get_ha_runtime_info() {
+            runtime_info.insert("haDiagnosticsSupported".to_string(), "true".to_string());
+            runtime_info.insert(
+                "haRole".to_string(),
+                if ha.master { "master" } else { "replica" }.to_string(),
+            );
+            runtime_info.insert(
+                "haMaxReplicaLagBytes".to_string(),
+                ha.ha_connection_info
+                    .iter()
+                    .map(|connection| connection.diff.max(0) as u64)
+                    .max()
+                    .unwrap_or_default()
+                    .to_string(),
+            );
+            runtime_info.insert(
+                "haDecisionCode".to_string(),
+                if ha.pending_group_transfer_request_count > 0 {
+                    "waiting_for_replica_progress"
+                } else {
+                    "not_observed"
+                }
+                .to_string(),
+            );
+            let store_config = generation.store();
+            let (ack_policy, required_ack_count) = if store_config.all_ack_in_sync_state_set {
+                ("all_in_sync_set", None)
+            } else if store_config.in_sync_replicas <= 1 {
+                ("local_durable", Some(1_u64))
+            } else {
+                ("replica_count", u64::try_from(store_config.in_sync_replicas).ok())
+            };
+            runtime_info.insert("haAckPolicy".to_string(), ack_policy.to_string());
+            if let Some(required_ack_count) = required_ack_count {
+                runtime_info.insert("haRequiredAckCount".to_string(), required_ack_count.to_string());
+            }
+            if let Some(replicas_manager) = self.broker_runtime_inner.replicas_manager() {
+                if let Some(authority) = replicas_manager.write_authority() {
+                    runtime_info.insert("haMasterEpoch".to_string(), authority.master_epoch().get().to_string());
+                }
+                let sync_state_set_epoch = replicas_manager.sync_state_set_epoch();
+                if sync_state_set_epoch > 0 {
+                    runtime_info.insert("haSyncStateSetEpoch".to_string(), sync_state_set_epoch.to_string());
+                }
+                runtime_info.insert(
+                    "haSyncStateSetSize".to_string(),
+                    replicas_manager.sync_state_set().len().to_string(),
+                );
+            } else {
+                runtime_info.insert(
+                    "haSyncStateSetSize".to_string(),
+                    (ha.in_sync_slave_nums.max(0) as u64 + u64::from(ha.master)).to_string(),
+                );
+            }
+        } else {
+            runtime_info.insert("haDiagnosticsSupported".to_string(), "false".to_string());
+        }
         if let Some(auth) = self.auth_admin_service.as_ref() {
             let auth = auth.diagnostics_snapshot();
             runtime_info.insert("authDiagnosticsSupported".to_string(), "true".to_string());

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
@@ -42,15 +42,37 @@ impl NotifyBrokerRoleChangeHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_header = request.decode_command_custom_header::<NotifyBrokerRoleChangedRequestHeader>();
-
-        let sync_state_set_info = SyncStateSet::decode(request.get_body().unwrap()).unwrap_or_default();
-
         let response = RemotingCommand::create_response_command();
+
+        let request_header = match request.decode_command_custom_header::<NotifyBrokerRoleChangedRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!("invalid role-change header: {error}"),
+                )));
+            }
+        };
+
+        let Some(body) = request.get_body() else {
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                "notify broker role change is missing the sync-state-set body",
+            )));
+        };
+        let sync_state_set_info = match SyncStateSet::decode(body) {
+            Ok(sync_state_set) => sync_state_set,
+            Err(error) => {
+                return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!("invalid sync-state-set body: {error}"),
+                )));
+            }
+        };
 
         info!(
             "Receive notifyBrokerRoleChanged request, try to change brokerRole, request:{}",
-            request_header.as_ref().expect("null")
+            request_header
         );
 
         if broker_config_request_handler
@@ -62,26 +84,24 @@ impl NotifyBrokerRoleChangeHandler {
             return Ok(Some(response.set_code(ResponseCode::Success)));
         }
 
-        if let Ok(request_header) = request_header {
-            let sync_state_set = sync_state_set_info.get_sync_state_set().cloned().unwrap_or_default();
-            let controller_leader_address = channel.remote_address().to_string().into();
+        let sync_state_set = sync_state_set_info.get_sync_state_set().cloned().unwrap_or_default();
+        let controller_leader_address = channel.remote_address().to_string().into();
 
-            if let Err(error) = broker_config_request_handler
-                .apply_controller_role_change(
-                    Some(controller_leader_address),
-                    request_header.master_broker_id,
-                    request_header.master_address,
-                    request_header.master_epoch,
-                    request_header.sync_state_set_epoch,
-                    sync_state_set,
-                )
-                .await
-            {
-                return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::SystemError,
-                    error.to_string(),
-                )));
-            }
+        if let Err(error) = broker_config_request_handler
+            .apply_controller_role_change(
+                Some(controller_leader_address),
+                request_header.master_broker_id,
+                request_header.master_address,
+                request_header.master_epoch,
+                request_header.sync_state_set_epoch,
+                sync_state_set,
+            )
+            .await
+        {
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                error.to_string(),
+            )));
         }
 
         Ok(Some(response.set_code(ResponseCode::Success)))
@@ -132,7 +152,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn uninitialized_controller_returns_success_without_retaining_runtime_owner() {
+    async fn uninitialized_controller_fails_closed_without_retaining_runtime_owner() {
         let runtime = BrokerRuntime::new(
             Arc::new(BrokerConfig::default()),
             Arc::new(MessageStoreConfig::default()),
@@ -164,9 +184,9 @@ mod tests {
                 &mut request,
             )
             .await
-            .expect("uninitialized controller notification should not fail")
+            .expect("uninitialized controller notification should return a response")
             .expect("notification should return a response");
 
-        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
     }
 }

--- a/rocketmq-broker/tests/controller_epoch_fault_smoke.rs
+++ b/rocketmq-broker/tests/controller_epoch_fault_smoke.rs
@@ -1,0 +1,60 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broker-side consumer tests for the canonical Controller authority contract.
+
+use rocketmq_store_api::decide_replication;
+use rocketmq_store_api::AckPolicy;
+use rocketmq_store_api::HaRejectReason;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::ReplicationDecision;
+use rocketmq_store_api::ReplicationObservation;
+use rocketmq_store_api::SyncStateSet;
+use rocketmq_store_api::WriteAuthority;
+
+fn authority(broker_id: i64, epoch: i32) -> WriteAuthority {
+    WriteAuthority::try_new(broker_id, MasterEpoch::try_from(epoch).expect("positive epoch"))
+        .expect("non-negative broker id")
+}
+
+fn evaluate(current: WriteAuthority, requested: WriteAuthority) -> ReplicationDecision {
+    decide_replication(
+        &ReplicationObservation::try_new(
+            current,
+            requested,
+            AckPolicy::LocalDurable,
+            32,
+            32,
+            Vec::new(),
+            SyncStateSet::try_new([current.broker_id()]).expect("leader ISR"),
+        )
+        .expect("valid Broker authority observation"),
+    )
+}
+
+#[test]
+fn broker_rejects_the_previous_master_after_epoch_advance() {
+    assert_eq!(
+        evaluate(authority(2, 8), authority(1, 7)),
+        ReplicationDecision::Reject(HaRejectReason::StaleAuthority)
+    );
+}
+
+#[test]
+fn broker_rejects_a_different_master_without_an_installed_epoch_advance() {
+    assert_eq!(
+        evaluate(authority(1, 8), authority(2, 8)),
+        ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch)
+    );
+}

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -31,6 +31,7 @@ rocketmq-error    = { workspace = true }
 rocketmq-model    = { workspace = true }
 rocketmq-protocol = { workspace = true }
 rocketmq-runtime  = { workspace = true }
+rocketmq-store-api = { workspace = true }
 rocketmq-security-api = { workspace = true }
 rocketmq-observability = { workspace = true }
 rocketmq-transport = { workspace = true }

--- a/rocketmq-controller/src/controller/broker_role_notifier.rs
+++ b/rocketmq-controller/src/controller/broker_role_notifier.rs
@@ -20,6 +20,10 @@ use cheetah_string::CheetahString;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::header::notify_broker_role_change_request_header::NotifyBrokerRoleChangedRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store_api::HaContractError;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::SyncStateSetEpoch;
+use rocketmq_store_api::WriteAuthority;
 
 pub(crate) use actor::BrokerRoleNotifier;
 pub(crate) use actor::NotifySnapshot;
@@ -34,19 +38,31 @@ pub(crate) struct NotifyKey {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NotifyState {
-    pub master_broker_id: u64,
-    pub master_epoch: i32,
-    pub sync_state_set_epoch: i32,
+    pub authority: WriteAuthority,
+    pub sync_state_set_epoch: SyncStateSetEpoch,
     pub master_address: Option<String>,
 }
 
 impl NotifyState {
+    pub(crate) fn try_new(
+        master_broker_id: u64,
+        master_epoch: MasterEpoch,
+        sync_state_set_epoch: SyncStateSetEpoch,
+        master_address: Option<String>,
+    ) -> Result<Self, HaContractError> {
+        Ok(Self {
+            authority: WriteAuthority::try_from_u64(master_broker_id, master_epoch)?,
+            sync_state_set_epoch,
+            master_address,
+        })
+    }
+
     fn is_same_or_newer_than(&self, current: &Self) -> bool {
-        self.master_epoch > current.master_epoch
-            || (self.master_epoch == current.master_epoch
-                && self.sync_state_set_epoch >= current.sync_state_set_epoch
-                && self.master_broker_id == current.master_broker_id
-                && self.master_address == current.master_address)
+        self.authority.master_epoch() > current.authority.master_epoch()
+            || (self.authority.master_epoch() == current.authority.master_epoch()
+                && (self.authority != current.authority
+                    || (self.sync_state_set_epoch >= current.sync_state_set_epoch
+                        && self.master_address == current.master_address)))
     }
 }
 
@@ -83,9 +99,9 @@ impl NotifyTask {
     fn build_request(&self) -> RemotingCommand {
         let request_header = NotifyBrokerRoleChangedRequestHeader {
             master_address: self.master_address.clone(),
-            master_epoch: Some(self.state.master_epoch),
-            sync_state_set_epoch: Some(self.state.sync_state_set_epoch),
-            master_broker_id: Some(self.state.master_broker_id),
+            master_epoch: Some(self.state.authority.master_epoch().get()),
+            sync_state_set_epoch: Some(self.state.sync_state_set_epoch.get()),
+            master_broker_id: Some(self.state.authority.broker_id() as u64),
         };
         RemotingCommand::create_request_command(RequestCode::NotifyBrokerRoleChanged, request_header)
             .set_body(self.sync_state_set.clone())

--- a/rocketmq-controller/src/controller/broker_role_notifier/tests.rs
+++ b/rocketmq-controller/src/controller/broker_role_notifier/tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::SyncStateSetEpoch;
 use tokio::sync::mpsc;
 
 use super::actor::Mailbox;
@@ -29,12 +31,13 @@ fn key(broker_id: u64) -> NotifyKey {
 }
 
 fn state(master_epoch: i32, sync_state_set_epoch: i32) -> NotifyState {
-    NotifyState {
-        master_broker_id: 1,
-        master_epoch,
-        sync_state_set_epoch,
-        master_address: Some("127.0.0.1:10911".to_string()),
-    }
+    NotifyState::try_new(
+        1,
+        MasterEpoch::try_from(master_epoch).expect("positive master epoch"),
+        SyncStateSetEpoch::try_from(sync_state_set_epoch).expect("positive sync-state-set epoch"),
+        Some("127.0.0.1:10911".to_string()),
+    )
+    .expect("valid notify state")
 }
 
 #[test]
@@ -165,4 +168,40 @@ fn broker_role_notifier_reset_invalidates_queued_generation() {
     assert!(mailbox.take(&notify_key).is_none());
     assert_eq!(mailbox.snapshot().retained_keys, 0);
     assert!(!mailbox.notified_contains(&notify_key));
+}
+
+#[test]
+fn broker_role_notifier_rejects_conflicting_master_at_same_epoch() {
+    let (sender, mut receiver) = mpsc::channel(1);
+    let mut mailbox = Mailbox::new(1);
+    mailbox.mark_started();
+    let notify_key = key(1);
+    let installed = state(7, 4);
+    let conflicting = NotifyState::try_new(
+        2,
+        MasterEpoch::try_from(7).expect("positive master epoch"),
+        SyncStateSetEpoch::try_from(5).expect("positive sync-state-set epoch"),
+        Some("127.0.0.2:10911".to_string()),
+    )
+    .expect("valid but conflicting authority");
+
+    assert_eq!(
+        mailbox.submit(
+            NotifyTask::new_for_test(notify_key.clone(), installed.clone()),
+            false,
+            &sender,
+        ),
+        SubmitOutcome::Accepted
+    );
+    assert_eq!(
+        mailbox.submit(
+            NotifyTask::new_for_test(notify_key.clone(), conflicting),
+            false,
+            &sender
+        ),
+        SubmitOutcome::Stale
+    );
+
+    assert_eq!(receiver.try_recv(), Ok(notify_key.clone()));
+    assert_eq!(mailbox.take(&notify_key).map(|task| task.state), Some(installed));
 }

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -1154,10 +1154,24 @@ impl ControllerManager {
             return Ok(());
         };
 
-        let sync_state_set_epoch = response_header.sync_state_set_epoch.unwrap_or_default();
-        let master_epoch = response_header.master_epoch.unwrap_or_default();
+        let Some(master_epoch) = response_header.master_epoch else {
+            warn!(broker = %member_group.broker_name, "Skip broker role notify because master epoch is absent");
+            return Ok(());
+        };
+        let Ok(master_epoch) = rocketmq_store_api::MasterEpoch::try_from(master_epoch) else {
+            warn!(broker = %member_group.broker_name, master_epoch, "Skip broker role notify because master epoch is invalid");
+            return Ok(());
+        };
+        let Some(sync_state_set_epoch) = response_header.sync_state_set_epoch else {
+            warn!(broker = %member_group.broker_name, "Skip broker role notify because sync-state-set epoch is absent");
+            return Ok(());
+        };
+        let Ok(sync_state_set_epoch) = rocketmq_store_api::SyncStateSetEpoch::try_from(sync_state_set_epoch) else {
+            warn!(broker = %member_group.broker_name, sync_state_set_epoch, "Skip broker role notify because sync-state-set epoch is invalid");
+            return Ok(());
+        };
         let master_address = response_header.master_address.clone().map(|value| value.to_string());
-        let sync_state_set = SyncStateSet::with_values(response_body.sync_state_set, sync_state_set_epoch)
+        let sync_state_set = SyncStateSet::with_values(response_body.sync_state_set, sync_state_set_epoch.get())
             .encode()
             .map_err(|error| {
                 ControllerError::serialization_source("encode sync state set for broker role notify", error)
@@ -1177,11 +1191,17 @@ impl ControllerManager {
                 broker_name: member_group.broker_name.to_string(),
                 broker_id,
             };
-            let state = NotifyState {
+            let state = match NotifyState::try_new(
                 master_broker_id,
                 master_epoch,
                 sync_state_set_epoch,
-                master_address: master_address.clone(),
+                master_address.clone(),
+            ) {
+                Ok(state) => state,
+                Err(error) => {
+                    warn!(%error, broker = %member_group.broker_name, "Skip broker role notify because authority is invalid");
+                    return Ok(());
+                }
             };
             let task = NotifyTask::new(
                 key,

--- a/rocketmq-controller/src/manager/replicas_info_manager.rs
+++ b/rocketmq-controller/src/manager/replicas_info_manager.rs
@@ -57,6 +57,10 @@ use rocketmq_protocol::protocol::header::controller::register_broker_to_controll
 use rocketmq_protocol::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::SyncStateSet as HaSyncStateSet;
+use rocketmq_store_api::SyncStateSetEpoch;
+use rocketmq_store_api::WriteAuthority;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -151,6 +155,53 @@ impl ReplicasInfoManager {
     ) -> ControllerResult<AlterSyncStateSetResponseHeader> {
         let mut result = ControllerResult::new(Some(AlterSyncStateSetResponseHeader::default()));
 
+        let Ok(master_epoch) = MasterEpoch::try_from(master_epoch) else {
+            result.set_code_and_remark(
+                ResponseCode::ControllerFencedMasterEpoch,
+                "Master epoch must be positive",
+            );
+            return result;
+        };
+        let Ok(sync_state_set_epoch) = SyncStateSetEpoch::try_from(sync_state_set_epoch) else {
+            result.set_code_and_remark(
+                ResponseCode::ControllerFencedSyncStateSetEpoch,
+                "Sync-state-set epoch must be positive",
+            );
+            return result;
+        };
+        let Ok(requested_authority) = WriteAuthority::try_from_u64(master_broker_id, master_epoch) else {
+            result.set_code_and_remark(
+                ResponseCode::ControllerInvalidMaster,
+                "Master broker id is out of range",
+            );
+            return result;
+        };
+        let mut canonical_members = Vec::with_capacity(new_sync_state_set.len());
+        for broker_id in &new_sync_state_set {
+            let Ok(broker_id) = i64::try_from(*broker_id) else {
+                result.set_code_and_remark(
+                    ResponseCode::ControllerInvalidReplicas,
+                    "Sync-state-set broker id is out of range",
+                );
+                return result;
+            };
+            canonical_members.push(broker_id);
+        }
+        let Ok(canonical_sync_state_set) = HaSyncStateSet::try_new(canonical_members) else {
+            result.set_code_and_remark(
+                ResponseCode::ControllerInvalidReplicas,
+                "Sync-state set must contain valid broker ids",
+            );
+            return result;
+        };
+        if !canonical_sync_state_set.contains(requested_authority.broker_id()) {
+            result.set_code_and_remark(
+                ResponseCode::ControllerAlterSyncStateSetFailed,
+                "Sync-state set must contain the authorized master",
+            );
+            return result;
+        }
+
         // Check if broker exists
         if !self.is_contains_broker(broker_name) {
             result.set_code_and_remark(
@@ -194,11 +245,11 @@ impl ReplicasInfoManager {
         }
 
         // Check master epoch
-        if master_epoch != sync_state_info.master_epoch() {
+        if MasterEpoch::try_from(sync_state_info.master_epoch()).ok() != Some(master_epoch) {
             let err = format!(
                 "Rejecting alter syncStateSet request because the current master epoch is:{}, not {}",
                 sync_state_info.master_epoch(),
-                master_epoch
+                master_epoch.get()
             );
             error!("{}", err);
             result.set_code_and_remark(ResponseCode::ControllerFencedMasterEpoch, &err);
@@ -206,11 +257,11 @@ impl ReplicasInfoManager {
         }
 
         // Check syncStateSet epoch
-        if sync_state_set_epoch != sync_state_info.sync_state_set_epoch() {
+        if SyncStateSetEpoch::try_from(sync_state_info.sync_state_set_epoch()).ok() != Some(sync_state_set_epoch) {
             let err = format!(
                 "Rejecting alter syncStateSet request because the current syncStateSet epoch is:{}, not {}",
                 sync_state_info.sync_state_set_epoch(),
-                sync_state_set_epoch
+                sync_state_set_epoch.get()
             );
             error!("{}", err);
             result.set_code_and_remark(ResponseCode::ControllerFencedSyncStateSetEpoch, &err);

--- a/rocketmq-doc/en/ha-rpo-rto-support-matrix.md
+++ b/rocketmq-doc/en/ha-rpo-rto-support-matrix.md
@@ -1,0 +1,67 @@
+<!--
+  Copyright 2023 The RocketMQ Rust Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# HA, RPO, and RTO Support Matrix
+
+This document records the guarantees that the current implementation and automated tests actually establish. It does not turn a process-level smoke test into a production RPO or RTO commitment.
+
+## Canonical acknowledgement contract
+
+A primary append can report `Replicated` only when the canonical HA decision proves all of the following:
+
+1. The requested `WriteAuthority` exactly matches the authority installed by the Controller.
+2. The local durable watermark covers the complete appended range.
+3. The configured `AckPolicy` is satisfied by unique, current sync-state-set members whose durable offsets cover the appended range.
+
+An older epoch is rejected as stale. A future epoch or a different master at the installed epoch is rejected until that exact authority is installed. Missing, slow, duplicate, and removed replica acknowledgements never silently downgrade a replicated request to local durability.
+
+## Support matrix
+
+| Backend / topology | ACK policy | Code-level guarantee | Deterministic faults covered | Current RPO/RTO statement | Follow-up validation |
+|---|---|---|---|---|---|
+| Local Store / single Broker | `LocalDurable` | Acknowledgement requires the local durable watermark to cover the append. A local-only decision cannot construct `Replicated`. | Local fsync watermark behind append; invalid/truncated tail; reopen from a complete-record watermark. | No HA claim. RPO and RTO are not quantified by this PR. | Measure storage-device failure and restart recovery on supported production filesystems. |
+| Local Store / default master-replica HA | `ReplicaCount(n)` | The leader and `n-1` unique current members must cover the append after local durability. | Replica stops before ACK; slow ACK; duplicate ACK; removed-member ACK; bounded group-transfer queue and deadline cleanup. | Process-level ACK safety is verified. No zero-loss or time-bound recovery claim is made. | Multi-process network partition, reconnect, sustained load, and 6-hour soak. |
+| Local Store / Controller HA | `ReplicaCount(n)` or `AllInSyncSet` | Positive typed epochs, exact write authority, monotonic role transition, and current ISR membership are enforced before replicated acknowledgement. | Stale master; same-epoch conflicting master; unavailable Controller cannot pre-authorize a future leader; missing ISR progress; Controller durable-state write failures. | Fencing and process-level recovery smoke are verified. Cross-node RPO/RTO remain unquantified. | Full multi-node partition matrix, Controller quorum loss/recovery, node recreation, and complete DR exercise. |
+| RocksDB message store | Delegates primary-log HA to the Local Store path | The implementation delegates HA runtime and primary-log replication to its Local Store component. | Generic contract tests apply; no RocksDB-specific HA fault matrix was added by this PR. | Not production-qualified by this PR for a distinct RPO/RTO claim. | Run the RocksDB feature matrix with multi-process HA faults before claiming parity. |
+| Tiered / derived storage | Not a primary append ACK source | Derived or tiered progress cannot satisfy or upgrade primary append durability. | Contract tests prevent derived progress and local append state from constructing replicated durability. | Unsupported as an independent HA durability or RPO/RTO guarantee. | Define and test an explicit restore/read-continuity contract before making a tiered recovery claim. |
+
+## Verified smoke inventory
+
+The fast deterministic suite covers seven required categories without retry loops or arbitrary sleeps:
+
+1. Replica stops before acknowledgement.
+2. Stale master continues to request writes after a newer epoch is installed.
+3. Controller authority is unavailable and competing future leaders are proposed.
+4. Slow, duplicate, and removed replica acknowledgements are observed.
+5. Local fsync progress remains behind the append.
+6. A segment contains a complete record followed by an invalid tail.
+7. A recovered complete-record watermark accepts the next complete record.
+
+Existing Store restart tests additionally exercise dirty-tail truncation, reopen, produce/read continuity, and Local/RocksDB double-write compatibility. Existing Controller storage-fault tests verify that failed state, vote, and log persistence do not publish candidate in-memory state.
+
+## Read-only SRE projection
+
+Broker diagnostics expose only bounded, non-sensitive HA fields: role, master epoch, sync-state-set epoch and size, maximum replica lag, ACK policy, required ACK count, and a stable decision code. Missing observations remain absent or `not_observed`; connection addresses, credentials, message bodies, and full configuration are not included.
+
+## Explicitly deferred
+
+The following items are useful follow-up evidence but do not block this code-focused stage:
+
+- Six-hour soak or chaos execution.
+- Complete disaster-recovery and regional-loss exercises.
+- Docker or Kubernetes image/deployment validation.
+- Rolling upgrade and N-1 compatibility validation.
+- Quantitative production RPO and RTO certification.

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/auth_security_diagnostics.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/auth_security_diagnostics.rs
@@ -119,6 +119,7 @@ fn millis_to_datetime(value: u64) -> Option<DateTime<Utc>> {
 mod tests {
     use rocketmq_admin_core::core::broker::AuthSecurityDiagnostics;
     use rocketmq_admin_core::core::broker::BrokerDiagnostics;
+    use rocketmq_admin_core::core::broker::HaDiagnostics;
     use rocketmq_admin_core::core::broker::RocksDbMaintenanceDiagnostics;
     use rocketmq_admin_core::core::broker::TieredDispatchDiagnostics;
 
@@ -137,6 +138,7 @@ mod tests {
                 readiness: None,
                 config: None,
                 store_health: None,
+                ha: HaDiagnostics::default(),
                 recovery: None,
                 background_index_rebuild: None,
                 rocksdb: RocksDbMaintenanceDiagnostics {

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/broker_store_diagnostics.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/broker_store_diagnostics.rs
@@ -20,6 +20,7 @@ use rocketmq_admin_core::core::broker::BrokerDiagnosticsCoverage;
 use rocketmq_admin_core::core::broker::QueryBrokerDiagnosticsResult;
 use rocketmq_sre_contracts::CoverageStatus;
 use rocketmq_sre_contracts::EvidenceExposure;
+use rocketmq_sre_contracts::HaStatusProjection;
 use serde_json::Value;
 use serde_json::json;
 
@@ -89,6 +90,17 @@ fn validate_schema(schema_version: &str) -> Result<(), ConnectorError> {
 }
 
 fn project_broker(broker: BrokerDiagnostics) -> Value {
+    let ha = HaStatusProjection {
+        supported: broker.ha.supported,
+        role: broker.ha.role,
+        master_epoch: broker.ha.master_epoch,
+        sync_state_set_epoch: broker.ha.sync_state_set_epoch,
+        sync_state_set_size: broker.ha.sync_state_set_size,
+        max_replica_lag_bytes: broker.ha.max_replica_lag_bytes,
+        ack_policy: broker.ha.ack_policy,
+        required_ack_count: broker.ha.required_ack_count,
+        decision_code: broker.ha.decision_code,
+    };
     json!({
         "broker_name": broker.broker_name,
         "broker_id": broker.broker_id,
@@ -97,6 +109,7 @@ fn project_broker(broker: BrokerDiagnostics) -> Value {
         "readiness": broker.readiness,
         "config": broker.config,
         "store_health": broker.store_health,
+        "ha": ha,
         "recovery": broker.recovery,
         "background_index_rebuild": broker.background_index_rebuild,
         "rocksdb": broker.rocksdb,
@@ -118,6 +131,7 @@ fn brokers_are_all_unsupported(unsupported: usize, brokers: Option<&Vec<Value>>)
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_admin_core::core::broker::HaDiagnostics;
     use rocketmq_admin_core::core::broker::RocksDbMaintenanceDiagnostics;
     use rocketmq_admin_core::core::broker::TieredDispatchDiagnostics;
 
@@ -136,6 +150,7 @@ mod tests {
                 readiness: None,
                 config: None,
                 store_health: None,
+                ha: HaDiagnostics::default(),
                 recovery: None,
                 background_index_rebuild: None,
                 rocksdb: RocksDbMaintenanceDiagnostics {
@@ -185,5 +200,68 @@ mod tests {
         .expect_err("unknown major must fail closed");
 
         assert_eq!(error.code, ConnectorErrorCode::UnsupportedSchemaMajor);
+    }
+
+    #[test]
+    fn ha_projection_exposes_only_bounded_non_sensitive_status() {
+        let output = project(QueryBrokerDiagnosticsResult {
+            schema_version: BROKER_DIAGNOSTICS_SCHEMA_VERSION.to_owned(),
+            observed_at_millis: 1_700_000_000_000,
+            brokers: vec![BrokerDiagnostics {
+                broker_name: "broker-a".to_owned(),
+                broker_id: 1,
+                observed_at_millis: Some(1_700_000_000_000),
+                coverage: BrokerDiagnosticsCoverage::Available,
+                readiness: None,
+                config: None,
+                store_health: None,
+                ha: HaDiagnostics {
+                    supported: true,
+                    role: Some("master".to_owned()),
+                    master_epoch: Some(7),
+                    sync_state_set_epoch: Some(4),
+                    sync_state_set_size: Some(3),
+                    max_replica_lag_bytes: Some(128),
+                    ack_policy: Some("all_in_sync_set".to_owned()),
+                    required_ack_count: None,
+                    decision_code: Some("not_observed".to_owned()),
+                },
+                recovery: None,
+                background_index_rebuild: None,
+                rocksdb: RocksDbMaintenanceDiagnostics {
+                    supported: false,
+                    maintenance_running: None,
+                    message_maintenance_running: None,
+                },
+                tiered: TieredDispatchDiagnostics {
+                    configured: false,
+                    dispatch_ready: None,
+                    minimum_pinned_wal_segment: None,
+                },
+                auth: rocketmq_admin_core::core::broker::AuthSecurityDiagnostics {
+                    supported: false,
+                    authentication_enabled: None,
+                    authorization_enabled: None,
+                    acl_file_watch_enabled: None,
+                    acl_generation: None,
+                    acl_reload_attempts: None,
+                    acl_reload_successes: None,
+                    acl_reload_failures: None,
+                    acl_reload_skipped: None,
+                    credential_rotation_supported: false,
+                },
+                warnings: Vec::new(),
+            }],
+            unavailable_brokers: 0,
+            partial: false,
+        })
+        .expect("supported diagnostics schema");
+
+        let ha = &output.content["brokers"][0]["ha"];
+        assert_eq!(ha["master_epoch"], 7);
+        assert_eq!(ha["sync_state_set_size"], 3);
+        assert_eq!(ha["max_replica_lag_bytes"], 128);
+        assert!(ha.get("address").is_none());
+        assert!(ha.get("config").is_none());
     }
 }

--- a/rocketmq-sre/crates/rocketmq-sre-contracts/src/connector.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-contracts/src/connector.rs
@@ -62,6 +62,20 @@ pub struct ConnectorCapabilityState {
     pub sources: Vec<ConnectorSourceCapability>,
 }
 
+/// Non-sensitive, read-only Broker HA status exposed by the Connector.
+#[derive(Clone, Debug, Eq, JsonSchema, PartialEq, Serialize, Deserialize)]
+pub struct HaStatusProjection {
+    pub supported: bool,
+    pub role: Option<String>,
+    pub master_epoch: Option<i32>,
+    pub sync_state_set_epoch: Option<i32>,
+    pub sync_state_set_size: Option<u64>,
+    pub max_replica_lag_bytes: Option<u64>,
+    pub ack_policy: Option<String>,
+    pub required_ack_count: Option<u64>,
+    pub decision_code: Option<String>,
+}
+
 /// Signal kind declared by a Required Signals manifest.
 #[derive(Clone, Copy, Debug, Eq, JsonSchema, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/rocketmq-sre/crates/rocketmq-sre-contracts/src/lib.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-contracts/src/lib.rs
@@ -121,6 +121,7 @@ pub use connector::ConnectorRegister;
 pub use connector::ConnectorResponseEnvelope;
 pub use connector::ConnectorSourceCapability;
 pub use connector::ConnectorSourceStatus;
+pub use connector::HaStatusProjection;
 pub use connector::REQUIRED_SIGNALS_EVIDENCE_SCHEMA_VERSION;
 pub use connector::RequiredSignalObservation;
 pub use connector::RequiredSignalStatus;

--- a/rocketmq-store-api/src/ha_contract.rs
+++ b/rocketmq-store-api/src/ha_contract.rs
@@ -1,0 +1,457 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Backend-neutral high-availability value types and acknowledgement decisions.
+
+use std::collections::BTreeSet;
+use std::error::Error as StdError;
+use std::fmt;
+use std::num::NonZeroUsize;
+
+use crate::Durability;
+
+/// A positive Controller-issued master epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MasterEpoch(i32);
+
+impl MasterEpoch {
+    /// Returns the wire-compatible epoch value.
+    pub const fn get(self) -> i32 {
+        self.0
+    }
+}
+
+impl TryFrom<i32> for MasterEpoch {
+    type Error = HaContractError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value <= 0 {
+            return Err(HaContractError::InvalidMasterEpoch(value));
+        }
+        Ok(Self(value))
+    }
+}
+
+/// A positive Controller-issued sync-state-set epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SyncStateSetEpoch(i32);
+
+impl SyncStateSetEpoch {
+    /// Returns the wire-compatible epoch value.
+    pub const fn get(self) -> i32 {
+        self.0
+    }
+}
+
+impl TryFrom<i32> for SyncStateSetEpoch {
+    type Error = HaContractError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value <= 0 {
+            return Err(HaContractError::InvalidSyncStateSetEpoch(value));
+        }
+        Ok(Self(value))
+    }
+}
+
+/// A replication acknowledgement count greater than the local leader alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ReplicaCount(NonZeroUsize);
+
+impl ReplicaCount {
+    /// Creates a replica count that necessarily requires at least one remote acknowledgement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HaContractError::InvalidReplicaCount`] when `value` is less than two.
+    pub fn try_new(value: usize) -> Result<Self, HaContractError> {
+        if value < 2 {
+            return Err(HaContractError::InvalidReplicaCount(value));
+        }
+        Ok(Self(NonZeroUsize::new(value).expect("value is proven non-zero")))
+    }
+
+    /// Returns the number of acknowledgements, including the local leader.
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+}
+
+/// The explicit durability condition requested by a synchronous append.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AckPolicy {
+    /// Require only the local durable watermark.
+    LocalDurable,
+    /// Require the local leader and the configured number of unique in-sync members.
+    ReplicaCount(ReplicaCount),
+    /// Require the local leader and every member of the current sync-state set.
+    AllInSyncSet,
+}
+
+impl AckPolicy {
+    /// Converts a legacy ACK count or sentinel at a wire/configuration boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HaContractError::InvalidAckPolicy`] for zero, negative values other than
+    /// `all_in_sync_state_set`, or values that cannot be represented as `usize`.
+    pub fn try_from_legacy(value: i32, all_in_sync_state_set: i32) -> Result<Self, HaContractError> {
+        if value == all_in_sync_state_set {
+            return Ok(Self::AllInSyncSet);
+        }
+        if value == 1 {
+            return Ok(Self::LocalDurable);
+        }
+        if value <= 0 {
+            return Err(HaContractError::InvalidAckPolicy(value));
+        }
+        let count = usize::try_from(value).map_err(|_| HaContractError::InvalidAckPolicy(value))?;
+        Ok(Self::ReplicaCount(ReplicaCount::try_new(count)?))
+    }
+}
+
+/// The Controller authority required to accept a write or role transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WriteAuthority {
+    broker_id: i64,
+    master_epoch: MasterEpoch,
+}
+
+impl WriteAuthority {
+    /// Creates an authority for a non-negative broker identifier and positive epoch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HaContractError::InvalidBrokerId`] when `broker_id` is negative.
+    pub fn try_new(broker_id: i64, master_epoch: MasterEpoch) -> Result<Self, HaContractError> {
+        if broker_id < 0 {
+            return Err(HaContractError::InvalidBrokerId(broker_id));
+        }
+        Ok(Self {
+            broker_id,
+            master_epoch,
+        })
+    }
+
+    /// Creates an authority from a wire broker identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HaContractError::BrokerIdOutOfRange`] when the identifier cannot be represented
+    /// by the canonical signed broker-id type.
+    pub fn try_from_u64(broker_id: u64, master_epoch: MasterEpoch) -> Result<Self, HaContractError> {
+        let broker_id = i64::try_from(broker_id).map_err(|_| HaContractError::BrokerIdOutOfRange(broker_id))?;
+        Self::try_new(broker_id, master_epoch)
+    }
+
+    /// Returns the authorized broker identifier.
+    pub const fn broker_id(self) -> i64 {
+        self.broker_id
+    }
+
+    /// Returns the authorized master epoch.
+    pub const fn master_epoch(self) -> MasterEpoch {
+        self.master_epoch
+    }
+}
+
+/// One remote replica's durable acknowledgement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ReplicaAck {
+    broker_id: i64,
+    durable_offset: i64,
+}
+
+impl ReplicaAck {
+    /// Creates a validated remote acknowledgement.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for a negative broker identifier or durable offset.
+    pub fn try_new(broker_id: i64, durable_offset: i64) -> Result<Self, HaContractError> {
+        if broker_id < 0 {
+            return Err(HaContractError::InvalidBrokerId(broker_id));
+        }
+        if durable_offset < 0 {
+            return Err(HaContractError::InvalidOffset(durable_offset));
+        }
+        Ok(Self {
+            broker_id,
+            durable_offset,
+        })
+    }
+
+    /// Returns the acknowledging broker identifier.
+    pub const fn broker_id(self) -> i64 {
+        self.broker_id
+    }
+
+    /// Returns the exclusive durable offset reported by the replica.
+    pub const fn durable_offset(self) -> i64 {
+        self.durable_offset
+    }
+}
+
+/// A non-empty set of non-negative broker identifiers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyncStateSet(BTreeSet<i64>);
+
+impl SyncStateSet {
+    /// Creates a validated, de-duplicated sync-state set.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error when the set is empty or contains a negative broker identifier.
+    pub fn try_new(members: impl IntoIterator<Item = i64>) -> Result<Self, HaContractError> {
+        let members = members.into_iter().collect::<BTreeSet<_>>();
+        if members.is_empty() {
+            return Err(HaContractError::EmptySyncStateSet);
+        }
+        if let Some(broker_id) = members.iter().copied().find(|broker_id| *broker_id < 0) {
+            return Err(HaContractError::InvalidBrokerId(broker_id));
+        }
+        Ok(Self(members))
+    }
+
+    /// Returns whether the set contains a broker identifier.
+    pub fn contains(&self, broker_id: i64) -> bool {
+        self.0.contains(&broker_id)
+    }
+
+    /// Returns the number of unique members.
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = i64> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+/// A complete, validated observation used for one acknowledgement decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReplicationObservation {
+    current_authority: WriteAuthority,
+    requested_authority: WriteAuthority,
+    policy: AckPolicy,
+    required_offset: i64,
+    local_durable_watermark: i64,
+    replica_acks: Vec<ReplicaAck>,
+    sync_state_set: SyncStateSet,
+}
+
+impl ReplicationObservation {
+    /// Creates a complete replication observation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for negative offsets or when the current leader is absent from the
+    /// supplied sync-state set.
+    pub fn try_new(
+        current_authority: WriteAuthority,
+        requested_authority: WriteAuthority,
+        policy: AckPolicy,
+        required_offset: i64,
+        local_durable_watermark: i64,
+        replica_acks: Vec<ReplicaAck>,
+        sync_state_set: SyncStateSet,
+    ) -> Result<Self, HaContractError> {
+        if required_offset < 0 {
+            return Err(HaContractError::InvalidOffset(required_offset));
+        }
+        if local_durable_watermark < 0 {
+            return Err(HaContractError::InvalidOffset(local_durable_watermark));
+        }
+        if !sync_state_set.contains(current_authority.broker_id()) {
+            return Err(HaContractError::LeaderMissingFromSyncStateSet(
+                current_authority.broker_id(),
+            ));
+        }
+        Ok(Self {
+            current_authority,
+            requested_authority,
+            policy,
+            required_offset,
+            local_durable_watermark,
+            replica_acks,
+            sync_state_set,
+        })
+    }
+}
+
+/// A proof produced only after the canonical acknowledgement decision succeeds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplicationAcknowledgement {
+    durability: Durability,
+    acknowledged_offset: i64,
+}
+
+impl ReplicationAcknowledgement {
+    /// Returns the durability proven by the decision.
+    pub const fn durability(self) -> Durability {
+        self.durability
+    }
+
+    /// Returns the exclusive offset covered by the decision.
+    pub const fn acknowledged_offset(self) -> i64 {
+        self.acknowledged_offset
+    }
+}
+
+/// Why a write authority or replica policy was rejected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HaRejectReason {
+    /// The request belongs to an older Controller epoch.
+    StaleAuthority,
+    /// The request does not exactly match the currently installed authority.
+    AuthorityMismatch,
+}
+
+/// Canonical outcome of evaluating authority, local durability, and replica acknowledgements.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplicationDecision {
+    /// The requested durability was proven.
+    Acknowledge(ReplicationAcknowledgement),
+    /// The authority and membership are valid, but progress has not reached this offset.
+    Wait {
+        /// Exclusive offset required from local storage and applicable replicas.
+        required_offset: i64,
+    },
+    /// The request must fail closed rather than wait or downgrade durability.
+    Reject(HaRejectReason),
+}
+
+/// Evaluates one append without I/O, mutation, retry, or implicit durability downgrade.
+pub fn decide_replication(observation: &ReplicationObservation) -> ReplicationDecision {
+    let current = observation.current_authority;
+    let requested = observation.requested_authority;
+    if requested.master_epoch() < current.master_epoch() {
+        return ReplicationDecision::Reject(HaRejectReason::StaleAuthority);
+    }
+    if requested != current {
+        return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
+    }
+    if observation.local_durable_watermark < observation.required_offset {
+        return ReplicationDecision::Wait {
+            required_offset: observation.required_offset,
+        };
+    }
+
+    let acknowledge = |durability| {
+        ReplicationDecision::Acknowledge(ReplicationAcknowledgement {
+            durability,
+            acknowledged_offset: observation.required_offset,
+        })
+    };
+    match observation.policy {
+        AckPolicy::LocalDurable => acknowledge(Durability::Local),
+        AckPolicy::ReplicaCount(required) => {
+            let mut acknowledged = BTreeSet::from([current.broker_id()]);
+            for replica in &observation.replica_acks {
+                if replica.broker_id() != current.broker_id()
+                    && observation.sync_state_set.contains(replica.broker_id())
+                    && replica.durable_offset() >= observation.required_offset
+                {
+                    acknowledged.insert(replica.broker_id());
+                }
+            }
+            if acknowledged.len() >= required.get() {
+                acknowledge(Durability::Replicated)
+            } else {
+                ReplicationDecision::Wait {
+                    required_offset: observation.required_offset,
+                }
+            }
+        }
+        AckPolicy::AllInSyncSet => {
+            if observation.sync_state_set.len() == 1 {
+                return acknowledge(Durability::Local);
+            }
+            let acknowledged = observation
+                .replica_acks
+                .iter()
+                .filter(|replica| {
+                    replica.broker_id() != current.broker_id()
+                        && observation.sync_state_set.contains(replica.broker_id())
+                        && replica.durable_offset() >= observation.required_offset
+                })
+                .map(|replica| replica.broker_id())
+                .collect::<BTreeSet<_>>();
+            if observation
+                .sync_state_set
+                .iter()
+                .filter(|broker_id| *broker_id != current.broker_id())
+                .all(|broker_id| acknowledged.contains(&broker_id))
+            {
+                acknowledge(Durability::Replicated)
+            } else {
+                ReplicationDecision::Wait {
+                    required_offset: observation.required_offset,
+                }
+            }
+        }
+    }
+}
+
+/// Invalid HA value rejected at an adapter or capability boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HaContractError {
+    /// A master epoch was not positive.
+    InvalidMasterEpoch(i32),
+    /// A sync-state-set epoch was not positive.
+    InvalidSyncStateSetEpoch(i32),
+    /// A broker identifier was negative.
+    InvalidBrokerId(i64),
+    /// An unsigned wire broker identifier exceeded the canonical representation.
+    BrokerIdOutOfRange(u64),
+    /// A replica policy did not require a remote replica.
+    InvalidReplicaCount(usize),
+    /// A legacy ACK count or sentinel was unknown.
+    InvalidAckPolicy(i32),
+    /// A physical offset was negative.
+    InvalidOffset(i64),
+    /// The sync-state set was empty.
+    EmptySyncStateSet,
+    /// The current leader was absent from the sync-state set.
+    LeaderMissingFromSyncStateSet(i64),
+}
+
+impl fmt::Display for HaContractError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMasterEpoch(value) => write!(formatter, "master epoch must be positive, got {value}"),
+            Self::InvalidSyncStateSetEpoch(value) => {
+                write!(formatter, "sync-state-set epoch must be positive, got {value}")
+            }
+            Self::InvalidBrokerId(value) => write!(formatter, "broker id must be non-negative, got {value}"),
+            Self::BrokerIdOutOfRange(value) => {
+                write!(formatter, "broker id exceeds the canonical signed range, got {value}")
+            }
+            Self::InvalidReplicaCount(value) => {
+                write!(
+                    formatter,
+                    "replica ACK count must include a remote replica, got {value}"
+                )
+            }
+            Self::InvalidAckPolicy(value) => write!(formatter, "unsupported legacy ACK policy value {value}"),
+            Self::InvalidOffset(value) => write!(formatter, "HA offset must be non-negative, got {value}"),
+            Self::EmptySyncStateSet => formatter.write_str("sync-state set must not be empty"),
+            Self::LeaderMissingFromSyncStateSet(value) => {
+                write!(formatter, "leader broker {value} is absent from the sync-state set")
+            }
+        }
+    }
+}
+
+impl StdError for HaContractError {}

--- a/rocketmq-store-api/src/lib.rs
+++ b/rocketmq-store-api/src/lib.rs
@@ -20,6 +20,7 @@ mod capability;
 pub mod checkpoint;
 mod checkpoint_artifact;
 mod error;
+mod ha_contract;
 mod progress;
 mod wal;
 
@@ -51,6 +52,19 @@ pub use error::StoreComponent;
 pub use error::StoreError;
 pub use error::StoreErrorKind;
 pub use error::StoreOperation;
+pub use ha_contract::decide_replication;
+pub use ha_contract::AckPolicy;
+pub use ha_contract::HaContractError;
+pub use ha_contract::HaRejectReason;
+pub use ha_contract::MasterEpoch;
+pub use ha_contract::ReplicaAck;
+pub use ha_contract::ReplicaCount;
+pub use ha_contract::ReplicationAcknowledgement;
+pub use ha_contract::ReplicationDecision;
+pub use ha_contract::ReplicationObservation;
+pub use ha_contract::SyncStateSet;
+pub use ha_contract::SyncStateSetEpoch;
+pub use ha_contract::WriteAuthority;
 pub use progress::CursorAdvance;
 pub use progress::CursorAdvanceDisposition;
 pub use progress::CursorAdvanceError;
@@ -162,6 +176,10 @@ pub enum AppendReceiptError {
     DurableWatermarkAheadOfAppended,
     /// Represents the memory durability already covered case.
     MemoryDurabilityAlreadyCovered,
+    /// Represents a replicated claim without a canonical acknowledgement decision.
+    ReplicatedDurabilityRequiresDecision,
+    /// Represents an acknowledgement decision that does not cover the appended range.
+    ReplicationDecisionBehindRange,
 }
 
 impl fmt::Display for AppendReceiptError {
@@ -175,6 +193,10 @@ impl fmt::Display for AppendReceiptError {
             Self::DurableWatermarkBehindRange => "durable watermark does not cover the claimed durability",
             Self::DurableWatermarkAheadOfAppended => "durable watermark exceeds appended progress",
             Self::MemoryDurabilityAlreadyCovered => "memory durability under-reports reached local durability",
+            Self::ReplicatedDurabilityRequiresDecision => {
+                "replicated durability requires a canonical replication acknowledgement"
+            }
+            Self::ReplicationDecisionBehindRange => "replication acknowledgement does not cover the appended range",
         };
         formatter.write_str(message)
     }
@@ -210,6 +232,9 @@ impl AppendReceipt {
         if durable_watermark > appended_watermark {
             return Err(AppendReceiptError::DurableWatermarkAheadOfAppended);
         }
+        if durability == Durability::Replicated {
+            return Err(AppendReceiptError::ReplicatedDurabilityRequiresDecision);
+        }
         match durability {
             Durability::Memory if durable_watermark >= appended_range.end => {
                 return Err(AppendReceiptError::MemoryDurabilityAlreadyCovered);
@@ -226,6 +251,33 @@ impl AppendReceipt {
             durable_watermark,
             durability,
         })
+    }
+
+    /// Creates a receipt from a proof produced by [`decide_replication`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppendReceiptError`] when receipt fields contradict each other or the supplied
+    /// acknowledgement does not cover the complete appended range.
+    pub fn try_new_with_replication(
+        status: AppendStatus,
+        appended_range: Range<i64>,
+        appended_watermark: i64,
+        durable_watermark: i64,
+        acknowledgement: ReplicationAcknowledgement,
+    ) -> Result<Self, AppendReceiptError> {
+        if acknowledgement.acknowledged_offset() < appended_range.end {
+            return Err(AppendReceiptError::ReplicationDecisionBehindRange);
+        }
+        let mut receipt = Self::try_new(
+            status,
+            appended_range,
+            appended_watermark,
+            durable_watermark,
+            Durability::Local,
+        )?;
+        receipt.durability = acknowledgement.durability();
+        Ok(receipt)
     }
 
     /// Creates a rejected receipt after validating status and watermark invariants.

--- a/rocketmq-store-api/tests/ha_contracts.rs
+++ b/rocketmq-store-api/tests/ha_contracts.rs
@@ -1,0 +1,248 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store_api::decide_replication;
+use rocketmq_store_api::AckPolicy;
+use rocketmq_store_api::AppendReceipt;
+use rocketmq_store_api::AppendStatus;
+use rocketmq_store_api::Durability;
+use rocketmq_store_api::HaContractError;
+use rocketmq_store_api::HaRejectReason;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::ReplicaAck;
+use rocketmq_store_api::ReplicaCount;
+use rocketmq_store_api::ReplicationDecision;
+use rocketmq_store_api::ReplicationObservation;
+use rocketmq_store_api::SyncStateSet;
+use rocketmq_store_api::SyncStateSetEpoch;
+use rocketmq_store_api::WriteAuthority;
+
+fn authority(broker_id: i64, epoch: i32) -> WriteAuthority {
+    WriteAuthority::try_new(broker_id, MasterEpoch::try_from(epoch).expect("positive epoch"))
+        .expect("non-negative broker id")
+}
+
+fn observation(
+    current: WriteAuthority,
+    requested: WriteAuthority,
+    policy: AckPolicy,
+    local_durable_watermark: i64,
+    replica_acks: Vec<ReplicaAck>,
+    members: &[i64],
+) -> ReplicationObservation {
+    ReplicationObservation::try_new(
+        current,
+        requested,
+        policy,
+        100,
+        local_durable_watermark,
+        replica_acks,
+        SyncStateSet::try_new(members.iter().copied()).expect("non-empty sync-state set"),
+    )
+    .expect("valid observation")
+}
+
+#[test]
+fn epochs_and_authority_reject_invalid_values() {
+    for epoch in [i32::MIN, -1, 0] {
+        assert_eq!(
+            Err(HaContractError::InvalidMasterEpoch(epoch)),
+            MasterEpoch::try_from(epoch)
+        );
+        assert_eq!(
+            Err(HaContractError::InvalidSyncStateSetEpoch(epoch)),
+            SyncStateSetEpoch::try_from(epoch)
+        );
+    }
+
+    assert_eq!(
+        Err(HaContractError::InvalidBrokerId(-1)),
+        WriteAuthority::try_new(-1, MasterEpoch::try_from(1).expect("positive epoch"))
+    );
+}
+
+#[test]
+fn ack_policy_rejects_unknown_or_local_only_replica_counts() {
+    assert_eq!(
+        Err(HaContractError::InvalidAckPolicy(0)),
+        AckPolicy::try_from_legacy(0, -1)
+    );
+    assert_eq!(
+        Err(HaContractError::InvalidAckPolicy(-2)),
+        AckPolicy::try_from_legacy(-2, -1)
+    );
+    assert_eq!(Err(HaContractError::InvalidReplicaCount(1)), ReplicaCount::try_new(1));
+    assert_eq!(Ok(AckPolicy::AllInSyncSet), AckPolicy::try_from_legacy(-1, -1));
+    assert_eq!(Ok(AckPolicy::LocalDurable), AckPolicy::try_from_legacy(1, -1));
+}
+
+#[test]
+fn sync_state_set_is_non_empty_and_requires_the_current_leader() {
+    assert_eq!(
+        Err(HaContractError::EmptySyncStateSet),
+        SyncStateSet::try_new(std::iter::empty())
+    );
+    let current = authority(1, 7);
+    assert_eq!(
+        Err(HaContractError::LeaderMissingFromSyncStateSet(1)),
+        ReplicationObservation::try_new(
+            current,
+            current,
+            AckPolicy::LocalDurable,
+            100,
+            100,
+            Vec::new(),
+            SyncStateSet::try_new([2]).expect("non-empty set"),
+        )
+    );
+}
+
+#[test]
+fn stale_and_uninstalled_authorities_fail_closed() {
+    let current = authority(1, 8);
+    let stale = observation(current, authority(1, 7), AckPolicy::LocalDurable, 100, Vec::new(), &[1]);
+    assert_eq!(
+        ReplicationDecision::Reject(HaRejectReason::StaleAuthority),
+        decide_replication(&stale)
+    );
+
+    for requested in [authority(2, 8), authority(1, 9)] {
+        let not_installed = observation(current, requested, AckPolicy::LocalDurable, 100, Vec::new(), &[1, 2]);
+        assert_eq!(
+            ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch),
+            decide_replication(&not_installed)
+        );
+    }
+}
+
+#[test]
+fn replicated_ack_requires_local_durability_before_replica_progress() {
+    let current = authority(1, 8);
+    let decision = decide_replication(&observation(
+        current,
+        current,
+        AckPolicy::ReplicaCount(ReplicaCount::try_new(2).expect("replicated policy")),
+        99,
+        vec![ReplicaAck::try_new(2, 100).expect("replica ACK")],
+        &[1, 2],
+    ));
+
+    assert_eq!(ReplicationDecision::Wait { required_offset: 100 }, decision);
+}
+
+#[test]
+fn duplicate_slow_and_non_member_acks_never_satisfy_replica_policy() {
+    let current = authority(1, 8);
+    let policy = AckPolicy::ReplicaCount(ReplicaCount::try_new(3).expect("replicated policy"));
+    for replica_acks in [
+        vec![
+            ReplicaAck::try_new(2, 100).expect("replica ACK"),
+            ReplicaAck::try_new(2, 100).expect("duplicate replica ACK"),
+        ],
+        vec![
+            ReplicaAck::try_new(2, 100).expect("replica ACK"),
+            ReplicaAck::try_new(3, 99).expect("slow replica ACK"),
+        ],
+        vec![
+            ReplicaAck::try_new(2, 100).expect("replica ACK"),
+            ReplicaAck::try_new(4, 100).expect("non-member ACK"),
+        ],
+    ] {
+        assert_eq!(
+            ReplicationDecision::Wait { required_offset: 100 },
+            decide_replication(&observation(current, current, policy, 100, replica_acks, &[1, 2, 3]))
+        );
+    }
+}
+
+#[test]
+fn missing_members_and_progress_wait_without_downgrade() {
+    let current = authority(1, 8);
+    let policy = AckPolicy::ReplicaCount(ReplicaCount::try_new(3).expect("replicated policy"));
+    assert_eq!(
+        ReplicationDecision::Wait { required_offset: 100 },
+        decide_replication(&observation(current, current, policy, 100, Vec::new(), &[1, 2]))
+    );
+
+    assert_eq!(
+        ReplicationDecision::Wait { required_offset: 100 },
+        decide_replication(&observation(
+            current,
+            current,
+            AckPolicy::AllInSyncSet,
+            100,
+            vec![ReplicaAck::try_new(2, 100).expect("replica ACK")],
+            &[1, 2, 3],
+        ))
+    );
+}
+
+#[test]
+fn acknowledgement_durability_matches_the_policy_and_membership() {
+    let current = authority(1, 8);
+    let local = decide_replication(&observation(
+        current,
+        current,
+        AckPolicy::AllInSyncSet,
+        100,
+        Vec::new(),
+        &[1],
+    ));
+    let replicated = decide_replication(&observation(
+        current,
+        current,
+        AckPolicy::AllInSyncSet,
+        100,
+        vec![ReplicaAck::try_new(2, 100).expect("replica ACK")],
+        &[1, 2],
+    ));
+
+    assert!(matches!(
+        local,
+        ReplicationDecision::Acknowledge(ack) if ack.durability() == Durability::Local
+    ));
+    assert!(matches!(
+        replicated,
+        ReplicationDecision::Acknowledge(ack) if ack.durability() == Durability::Replicated
+    ));
+
+    let ReplicationDecision::Acknowledge(acknowledgement) = replicated else {
+        panic!("replica policy should produce an acknowledgement");
+    };
+    let receipt = AppendReceipt::try_new_with_replication(AppendStatus::PutOk, 0..100, 100, 100, acknowledgement)
+        .expect("canonical decision should authorize a replicated receipt");
+    assert_eq!(receipt.durability(), Durability::Replicated);
+}
+
+#[test]
+fn replica_order_does_not_change_the_decision() {
+    let current = authority(1, 8);
+    let policy = AckPolicy::ReplicaCount(ReplicaCount::try_new(3).expect("replicated policy"));
+    let permutations = [
+        [(2, 100), (3, 100), (4, 99)],
+        [(4, 99), (2, 100), (3, 100)],
+        [(3, 100), (4, 99), (2, 100)],
+    ];
+
+    for permutation in permutations {
+        let acks = permutation
+            .into_iter()
+            .map(|(broker_id, offset)| ReplicaAck::try_new(broker_id, offset).expect("replica ACK"))
+            .collect();
+        assert!(matches!(
+            decide_replication(&observation(current, current, policy, 100, acks, &[1, 2, 3, 4])),
+            ReplicationDecision::Acknowledge(ack) if ack.durability() == Durability::Replicated
+        ));
+    }
+}

--- a/rocketmq-store-api/tests/result_contracts.rs
+++ b/rocketmq-store-api/tests/result_contracts.rs
@@ -98,13 +98,25 @@ fn receipt_rejects_a_durable_watermark_ahead_of_appended_progress() {
 
 #[test]
 fn receipt_requires_local_and_replicated_durability_to_be_reached() {
-    for durability in [Durability::Local, Durability::Replicated] {
-        assert_eq!(
-            AppendReceiptError::DurableWatermarkBehindRange,
-            AppendReceipt::try_new(AppendStatus::PutOk, 40..60, 80, 59, durability)
-                .expect_err("claimed durability must cover range")
-        );
-    }
+    assert_eq!(
+        AppendReceiptError::DurableWatermarkBehindRange,
+        AppendReceipt::try_new(AppendStatus::PutOk, 40..60, 80, 59, Durability::Local)
+            .expect_err("claimed durability must cover range")
+    );
+    assert_eq!(
+        AppendReceiptError::ReplicatedDurabilityRequiresDecision,
+        AppendReceipt::try_new(AppendStatus::PutOk, 40..60, 80, 59, Durability::Replicated)
+            .expect_err("replicated durability requires a canonical decision")
+    );
+}
+
+#[test]
+fn local_receipt_constructor_cannot_claim_replicated_durability() {
+    assert_eq!(
+        AppendReceiptError::ReplicatedDurabilityRequiresDecision,
+        AppendReceipt::try_new(AppendStatus::PutOk, 40..60, 80, 60, Durability::Replicated)
+            .expect_err("local watermarks alone cannot prove replication")
+    );
 }
 
 #[test]

--- a/rocketmq-store-local/src/ha/replication.rs
+++ b/rocketmq-store-local/src/ha/replication.rs
@@ -21,6 +21,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 
+use rocketmq_store_api::MasterEpoch;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HAAckedReplicaSnapshot {
     pub slave_broker_id: Option<i64>,
@@ -44,7 +46,7 @@ pub struct GroupTransferRuntimeInfo {
 pub enum EpochTransition {
     Rejected,
     Unchanged,
-    Advanced { epoch: i32 },
+    Advanced { epoch: MasterEpoch },
 }
 
 #[derive(Default)]
@@ -255,18 +257,19 @@ impl ReplicationStateRoot {
         }
     }
 
-    pub fn apply_epoch_transition(&self, next_epoch: i32) -> EpochTransition {
+    pub fn apply_epoch_transition(&self, next_epoch: MasterEpoch) -> EpochTransition {
+        let next_epoch_value = next_epoch.get();
         loop {
             let current_epoch = self.current_master_epoch.load(Ordering::SeqCst);
-            if next_epoch < current_epoch {
+            if next_epoch_value < current_epoch {
                 return EpochTransition::Rejected;
             }
-            if next_epoch == current_epoch {
+            if next_epoch_value == current_epoch {
                 return EpochTransition::Unchanged;
             }
             if self
                 .current_master_epoch
-                .compare_exchange(current_epoch, next_epoch, Ordering::SeqCst, Ordering::SeqCst)
+                .compare_exchange(current_epoch, next_epoch_value, Ordering::SeqCst, Ordering::SeqCst)
                 .is_ok()
             {
                 return EpochTransition::Advanced { epoch: next_epoch };
@@ -274,49 +277,9 @@ impl ReplicationStateRoot {
         }
     }
 
-    pub fn current_master_epoch(&self) -> i32 {
-        self.current_master_epoch.load(Ordering::SeqCst)
+    pub fn current_master_epoch(&self) -> Option<MasterEpoch> {
+        MasterEpoch::try_from(self.current_master_epoch.load(Ordering::SeqCst)).ok()
     }
-}
-
-pub fn has_required_sync_state_set_acks(
-    sync_state_set: &HashSet<i64>,
-    acked_replicas: &[HAAckedReplicaSnapshot],
-    next_offset: i64,
-) -> bool {
-    if sync_state_set.len() <= 1 {
-        return true;
-    }
-    let mut ack_count = 1;
-    for replica in acked_replicas {
-        if replica
-            .slave_broker_id
-            .is_some_and(|broker_id| sync_state_set.contains(&broker_id))
-            && replica.slave_ack_offset >= next_offset
-        {
-            ack_count += 1;
-        }
-        if ack_count >= sync_state_set.len() {
-            return true;
-        }
-    }
-    false
-}
-
-pub fn has_required_acks(required_acks: i32, acked_replicas: &[HAAckedReplicaSnapshot], next_offset: i64) -> bool {
-    if required_acks <= 1 {
-        return true;
-    }
-    let mut ack_count = 1;
-    for replica in acked_replicas {
-        if replica.slave_ack_offset >= next_offset {
-            ack_count += 1;
-        }
-        if ack_count >= required_acks {
-            return true;
-        }
-    }
-    false
 }
 
 pub fn compute_confirm_offset(
@@ -351,27 +314,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ack_policy_counts_master_and_filters_sync_state_members() {
-        let replicas = [
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(2),
-                slave_ack_offset: 100,
-            },
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(3),
-                slave_ack_offset: 50,
-            },
-        ];
-        assert!(has_required_acks(2, &replicas, 100));
-        assert!(has_required_sync_state_set_acks(&HashSet::from([1, 2]), &replicas, 100));
-        assert!(!has_required_sync_state_set_acks(
-            &HashSet::from([1, 2, 3]),
-            &replicas,
-            100
-        ));
-    }
-
-    #[test]
     fn replication_root_tracks_pending_membership_and_epoch_monotonically() {
         let root = ReplicationStateRoot::new(true);
         root.set_local_broker_id(1);
@@ -379,8 +321,15 @@ mod tests {
         assert_eq!(root.maybe_expand_sync_state_set(2, 64, 64), Some(HashSet::from([1, 2])));
         assert!(root.is_synchronizing_sync_state_set());
         assert_eq!(root.sync_state_set(), HashSet::from([1, 2]));
-        assert_eq!(root.apply_epoch_transition(3), EpochTransition::Advanced { epoch: 3 });
-        assert_eq!(root.apply_epoch_transition(2), EpochTransition::Rejected);
+        let epoch_three = MasterEpoch::try_from(3).expect("positive epoch");
+        assert_eq!(
+            root.apply_epoch_transition(epoch_three),
+            EpochTransition::Advanced { epoch: epoch_three }
+        );
+        assert_eq!(
+            root.apply_epoch_transition(MasterEpoch::try_from(2).expect("positive epoch")),
+            EpochTransition::Rejected
+        );
     }
 
     #[test]

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 use rocketmq_protocol::protocol::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
 use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::WriteAuthority;
 use tokio::sync::Notify;
 
 use crate::ha::auto_switch::auto_switch_ha_client::AutoSwitchHAClient;
@@ -100,6 +102,10 @@ impl AutoSwitchHAService {
         self.replication.set_local_broker_id(local_broker_id);
         self.delegate
             .set_ha_client_reported_broker_id((local_broker_id >= 0).then_some(local_broker_id));
+    }
+
+    pub fn local_broker_id(&self) -> i64 {
+        self.replication.local_broker_id()
     }
 
     pub fn get_local_sync_state_set(&self) -> HashSet<i64> {
@@ -210,6 +216,9 @@ impl AutoSwitchHAService {
     }
 
     fn apply_epoch_transition(&self, next_epoch: i32) -> bool {
+        let Ok(next_epoch) = MasterEpoch::try_from(next_epoch) else {
+            return false;
+        };
         match self.replication.apply_epoch_transition(next_epoch) {
             EpochTransition::Rejected => return false,
             EpochTransition::Unchanged => {}
@@ -218,7 +227,7 @@ impl AutoSwitchHAService {
                 let epoch_start_offset = replica_store
                     .get_max_phy_offset()
                     .max(replica_store.get_min_phy_offset());
-                replica_store.publish_state_machine_version(epoch as i64);
+                replica_store.publish_state_machine_version(i64::from(epoch.get()));
                 replica_store.publish_controller_epoch_start_offset(epoch_start_offset);
             }
         }
@@ -237,8 +246,15 @@ impl AutoSwitchHAService {
         replica_store.publish_confirm_offset(next_confirm_offset.clamp(min_phy_offset, max_phy_offset));
     }
 
-    pub fn current_master_epoch(&self) -> i32 {
+    pub fn current_master_epoch(&self) -> Option<MasterEpoch> {
         self.replication.current_master_epoch()
+    }
+
+    pub fn write_authority(&self) -> Option<WriteAuthority> {
+        if !self.replication.is_master() {
+            return None;
+        }
+        WriteAuthority::try_new(self.local_broker_id(), self.current_master_epoch()?).ok()
     }
 }
 
@@ -670,7 +686,7 @@ mod tests {
         assert_eq!(service.get_local_sync_state_set(), HashSet::from([7_i64]));
         assert_eq!(service.get_sync_state_set(), HashSet::from([7_i64]));
         assert!(!service.is_synchronizing_sync_state_set());
-        assert_eq!(service.current_master_epoch(), 3);
+        assert_eq!(service.current_master_epoch().map(MasterEpoch::get), Some(3));
         assert_eq!(store.get_state_machine_version(), 3);
         assert_eq!(store.get_controller_epoch_start_offset(), 4);
         assert_eq!(
@@ -700,7 +716,7 @@ mod tests {
         let switched = service.change_to_master(5).await.expect("change to master");
 
         assert!(switched);
-        assert_eq!(service.current_master_epoch(), 5);
+        assert_eq!(service.current_master_epoch().map(MasterEpoch::get), Some(5));
         assert_eq!(store.get_state_machine_version(), 5);
         assert_eq!(store.get_controller_epoch_start_offset(), 4);
         assert_eq!(store.get_confirm_offset(), 4);
@@ -726,7 +742,7 @@ mod tests {
 
         assert!(!stale);
         assert!(service.get_runtime_info(0).master);
-        assert_eq!(service.current_master_epoch(), 6);
+        assert_eq!(service.current_master_epoch().map(MasterEpoch::get), Some(6));
         assert_eq!(store.get_state_machine_version(), 6);
         assert_eq!(service.get_ha_client().expect("ha client").get_master_address(), "");
 

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -19,6 +19,8 @@ use std::sync::OnceLock;
 use std::sync::Weak;
 
 use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::WriteAuthority;
 use tokio::sync::Notify;
 
 use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
@@ -141,6 +143,25 @@ impl GeneralHAService {
         match self {
             GeneralHAService::DefaultHAService(_) => None,
             GeneralHAService::AutoSwitchHAService(service) => Some(service.get_sync_state_set()),
+        }
+    }
+
+    pub(crate) fn local_durable_watermark(&self) -> i64 {
+        match self {
+            GeneralHAService::DefaultHAService(service) => service.replica_store().get_flushed_where(),
+            GeneralHAService::AutoSwitchHAService(service) => {
+                service.default_delegate().replica_store().get_flushed_where()
+            }
+        }
+    }
+
+    pub(crate) fn write_authority(&self) -> Option<WriteAuthority> {
+        match self {
+            GeneralHAService::DefaultHAService(_) => {
+                let epoch = MasterEpoch::try_from(1).ok()?;
+                WriteAuthority::try_new(0, epoch).ok()
+            }
+            GeneralHAService::AutoSwitchHAService(service) => service.write_authority(),
         }
     }
 

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -28,6 +28,13 @@ use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::RateLimit;
 use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_store_api::decide_replication;
+use rocketmq_store_api::AckPolicy;
+use rocketmq_store_api::HaRejectReason;
+use rocketmq_store_api::ReplicaAck;
+use rocketmq_store_api::ReplicationDecision;
+use rocketmq_store_api::ReplicationObservation;
+use rocketmq_store_api::SyncStateSet;
 use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::error;
@@ -41,8 +48,6 @@ use crate::ha::ha_service::HAService;
 use crate::log_file::group_commit_request::GroupCommitRequest;
 use crate::store_error::HAError;
 use crate::store_error::HAResult;
-use rocketmq_store_local::ha::replication::has_required_acks;
-use rocketmq_store_local::ha::replication::has_required_sync_state_set_acks;
 pub(crate) use rocketmq_store_local::ha::replication::GroupTransferRuntimeInfo;
 
 pub struct GroupTransferService {
@@ -178,6 +183,49 @@ impl GroupTransferServiceInner {
         ha_service.snapshot_acked_replicas().await
     }
 
+    fn decide_transfer(
+        ha_service: &GeneralHAService,
+        policy: AckPolicy,
+        next_offset: i64,
+        snapshots: &[HAAckedReplicaSnapshot],
+    ) -> ReplicationDecision {
+        let Some(authority) = ha_service.write_authority() else {
+            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
+        };
+        let mut members = ha_service
+            .sync_state_set()
+            .unwrap_or_else(|| std::collections::HashSet::from([authority.broker_id()]));
+        let require_controller_ids = ha_service.is_auto_switch_enabled();
+        let replica_acks = snapshots
+            .iter()
+            .enumerate()
+            .filter_map(|(index, snapshot)| {
+                let broker_id = match snapshot.slave_broker_id {
+                    Some(broker_id) => broker_id,
+                    None if !require_controller_ids => i64::try_from(index).ok()?.checked_add(1)?,
+                    None => return None,
+                };
+                members.insert(broker_id);
+                ReplicaAck::try_new(broker_id, snapshot.slave_ack_offset).ok()
+            })
+            .collect::<Vec<_>>();
+        let Ok(sync_state_set) = SyncStateSet::try_new(members) else {
+            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
+        };
+        let Ok(observation) = ReplicationObservation::try_new(
+            authority,
+            authority,
+            policy,
+            next_offset,
+            ha_service.local_durable_watermark().max(0),
+            replica_acks,
+            sync_state_set,
+        ) else {
+            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
+        };
+        decide_replication(&observation)
+    }
+
     async fn do_wait_transfer(&self) {
         let ha_service = self.ha_service.upgrade();
 
@@ -186,7 +234,15 @@ impl GroupTransferServiceInner {
             let request = pending.request_mut();
             let mut transfer_ok = false;
             let deadline = request.get_deadline();
-            let all_ack_in_sync_state_set = request.get_ack_nums() == mix_all::ALL_ACK_IN_SYNC_STATE_SET;
+            let policy = match AckPolicy::try_from_legacy(request.get_ack_nums(), mix_all::ALL_ACK_IN_SYNC_STATE_SET) {
+                Ok(policy) => policy,
+                Err(error) => {
+                    warn!(error = %error, "HA group-transfer request has an invalid ACK policy");
+                    request.wakeup_customer(PutMessageStatus::FlushSlaveTimeout);
+                    pending.complete();
+                    continue;
+                }
+            };
             let mut index = 0;
             while !transfer_ok && Instant::now() < deadline {
                 if index > 0
@@ -205,25 +261,17 @@ impl GroupTransferServiceInner {
                 let Some(ha_service) = ha_service.as_ref() else {
                     break;
                 };
-                //handle only one slave ack, ackNums <= 2 means master + 1 slave
-                if !all_ack_in_sync_state_set && request.get_ack_nums() <= 2 {
-                    transfer_ok = ha_service.get_push_to_slave_max_offset() >= request.get_next_offset();
-                    continue;
-                }
-                if all_ack_in_sync_state_set && ha_service.is_auto_switch_enabled() {
-                    if let Some(sync_state_set) = ha_service.sync_state_set() {
-                        let acked_replicas = Self::load_acked_replicas(ha_service).await;
-                        transfer_ok = has_required_sync_state_set_acks(
-                            &sync_state_set,
-                            &acked_replicas,
-                            request.get_next_offset(),
+                let acked_replicas = Self::load_acked_replicas(ha_service).await;
+                match Self::decide_transfer(ha_service, policy, request.get_next_offset(), &acked_replicas) {
+                    ReplicationDecision::Acknowledge(_) => transfer_ok = true,
+                    ReplicationDecision::Wait { .. } => {}
+                    ReplicationDecision::Reject(reason) => {
+                        warn!(
+                            ?reason,
+                            "HA group-transfer request was rejected by the canonical decision"
                         );
-                        continue;
+                        break;
                     }
-                    transfer_ok = ha_service.in_sync_replicas_nums(request.get_next_offset()) >= request.get_ack_nums();
-                } else {
-                    let acked_replicas = Self::load_acked_replicas(ha_service).await;
-                    transfer_ok = has_required_acks(request.get_ack_nums(), &acked_replicas, request.get_next_offset());
                 }
             }
             if !transfer_ok {
@@ -294,7 +342,6 @@ mod tests {
     use super::*;
     use crate::ha::default_ha_service::DefaultHAService;
     use crate::ha::test_support::new_test_message_store;
-    use std::collections::HashSet;
 
     fn new_test_ha_service() -> GeneralHAService {
         let temp_root = tempfile::tempdir().expect("create temp root dir");
@@ -305,47 +352,6 @@ mod tests {
         ));
         service.init().expect("init default ha service");
         service
-    }
-
-    #[test]
-    fn sync_state_set_ack_requires_all_members() {
-        let sync_state_set = HashSet::from([7_i64, 9_i64, 10_i64]);
-        let acked_replicas = vec![
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(9),
-                slave_ack_offset: 128,
-            },
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(10),
-                slave_ack_offset: 64,
-            },
-        ];
-
-        assert!(!has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 96));
-        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 64));
-    }
-
-    #[test]
-    fn all_ack_in_sync_state_set_requires_controller_members() {
-        let request_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
-        let sync_state_set = HashSet::from([7_i64, 9_i64, 10_i64]);
-        let mut acked_replicas = vec![
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(9),
-                slave_ack_offset: 128,
-            },
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(10),
-                slave_ack_offset: 127,
-            },
-        ];
-
-        assert!(request_ack_nums < 0);
-        assert!(!has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
-
-        acked_replicas[1].slave_ack_offset = 128;
-
-        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
     }
 
     #[tokio::test]
@@ -427,6 +433,24 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn invalid_ack_policy_fails_closed_and_drains_the_request() {
+        let ha_service = new_test_ha_service();
+        let reference = GeneralHAServiceReference::new();
+        reference.bind(&ha_service).expect("bind general ha service");
+        let inner = GroupTransferServiceInner::try_new(reference).expect("group transfer service");
+        let (request, mut response) = GroupCommitRequest::with_ack_nums(0, 5_000, 0);
+
+        inner.put_request(request).await;
+        inner.do_wait_transfer().await;
+
+        assert_eq!(
+            response.wait_for_result_with_timeout().await.expect("rejected status"),
+            PutMessageStatus::FlushSlaveTimeout
+        );
+        assert_eq!(inner.runtime_info().pending_request_count, 0);
+    }
+
     #[test]
     fn general_service_reference_does_not_retain_root() {
         let ha_service = new_test_ha_service();
@@ -436,40 +460,5 @@ mod tests {
         assert!(reference.upgrade().is_some());
         drop(ha_service);
         assert!(reference.upgrade().is_none());
-    }
-
-    #[test]
-    fn sync_state_set_ack_ignores_non_members() {
-        let sync_state_set = HashSet::from([7_i64, 9_i64]);
-        let acked_replicas = vec![
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(11),
-                slave_ack_offset: 256,
-            },
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(9),
-                slave_ack_offset: 256,
-            },
-        ];
-
-        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
-    }
-
-    #[test]
-    fn required_acks_count_master_and_acked_slaves() {
-        let acked_replicas = vec![
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(9),
-                slave_ack_offset: 32,
-            },
-            HAAckedReplicaSnapshot {
-                slave_broker_id: Some(10),
-                slave_ack_offset: 96,
-            },
-        ];
-
-        assert!(!has_required_acks(3, &acked_replicas, 64));
-        assert!(has_required_acks(2, &acked_replicas, 64));
-        assert!(has_required_acks(3, &acked_replicas, 32));
     }
 }

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -113,6 +113,10 @@ impl CommitLogReadHandle {
         self.mapped_file_queue.get_min_offset()
     }
 
+    pub(crate) fn get_flushed_where(&self) -> i64 {
+        self.mapped_file_queue.get_flushed_where()
+    }
+
     pub(crate) fn pickup_store_timestamp(&self, offset: i64, size: i32) -> i64 {
         if offset < self.get_min_offset() || offset + size as i64 > self.get_max_offset() {
             return -1;
@@ -270,6 +274,11 @@ impl CommitLogReplicaHandle {
     #[inline]
     pub(crate) fn get_min_offset(&self) -> i64 {
         self.read.get_min_offset()
+    }
+
+    #[inline]
+    pub(crate) fn get_flushed_where(&self) -> i64 {
+        self.read.get_flushed_where()
     }
 
     #[inline]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -277,6 +277,11 @@ impl HAReplicaStoreHandle {
     }
 
     #[inline]
+    pub(crate) fn get_flushed_where(&self) -> i64 {
+        self.commit_log.get_flushed_where()
+    }
+
+    #[inline]
     pub(crate) fn get_confirm_offset(&self) -> i64 {
         self.commit_log.get_confirm_offset()
     }

--- a/rocketmq-store/tests/ha_fault_smoke.rs
+++ b/rocketmq-store/tests/ha_fault_smoke.rs
@@ -1,0 +1,192 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Deterministic, process-level HA decision and recovery smoke tests.
+
+use rocketmq_store_api::decide_replication;
+use rocketmq_store_api::AckPolicy;
+use rocketmq_store_api::AppendReceipt;
+use rocketmq_store_api::AppendReceiptError;
+use rocketmq_store_api::AppendStatus;
+use rocketmq_store_api::Durability;
+use rocketmq_store_api::HaRejectReason;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::ReplicaAck;
+use rocketmq_store_api::ReplicaCount;
+use rocketmq_store_api::ReplicationDecision;
+use rocketmq_store_api::ReplicationObservation;
+use rocketmq_store_api::SyncStateSet;
+use rocketmq_store_api::WriteAuthority;
+use rocketmq_store_local::commit_log::recovery::AbnormalRecoveryAction;
+use rocketmq_store_local::commit_log::recovery::AbnormalRecoveryDispatchGate;
+use rocketmq_store_local::commit_log::recovery::AbnormalRecoveryEvent;
+use rocketmq_store_local::commit_log::recovery::AbnormalRecoveryPolicy;
+use rocketmq_store_local::commit_log::recovery::AbnormalRecoveryState;
+
+fn authority(broker_id: i64, epoch: i32) -> WriteAuthority {
+    WriteAuthority::try_new(broker_id, MasterEpoch::try_from(epoch).expect("positive epoch"))
+        .expect("non-negative broker id")
+}
+
+fn decision(
+    current: WriteAuthority,
+    requested: WriteAuthority,
+    policy: AckPolicy,
+    local_durable_watermark: i64,
+    replica_acks: Vec<ReplicaAck>,
+    members: &[i64],
+) -> ReplicationDecision {
+    let observation = ReplicationObservation::try_new(
+        current,
+        requested,
+        policy,
+        128,
+        local_durable_watermark,
+        replica_acks,
+        SyncStateSet::try_new(members.iter().copied()).expect("non-empty ISR"),
+    )
+    .expect("valid fault observation");
+    decide_replication(&observation)
+}
+
+#[test]
+fn stopped_replica_before_ack_never_produces_replicated_success() {
+    let current = authority(1, 9);
+    assert_eq!(
+        decision(
+            current,
+            current,
+            AckPolicy::ReplicaCount(ReplicaCount::try_new(2).expect("replicated policy")),
+            128,
+            Vec::new(),
+            &[1, 2],
+        ),
+        ReplicationDecision::Wait { required_offset: 128 }
+    );
+}
+
+#[test]
+fn stale_master_write_is_fenced_after_new_epoch_is_installed() {
+    assert_eq!(
+        decision(
+            authority(2, 10),
+            authority(1, 9),
+            AckPolicy::LocalDurable,
+            128,
+            Vec::new(),
+            &[1, 2],
+        ),
+        ReplicationDecision::Reject(HaRejectReason::StaleAuthority)
+    );
+}
+
+#[test]
+fn unavailable_controller_cannot_pre_authorize_competing_future_leaders() {
+    let installed = authority(1, 10);
+    for proposed in [authority(1, 11), authority(2, 11)] {
+        assert_eq!(
+            decision(installed, proposed, AckPolicy::LocalDurable, 128, Vec::new(), &[1, 2],),
+            ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch)
+        );
+    }
+}
+
+#[test]
+fn slow_duplicate_and_removed_replica_acks_do_not_form_a_quorum() {
+    let current = authority(1, 10);
+    let policy = AckPolicy::ReplicaCount(ReplicaCount::try_new(3).expect("replicated policy"));
+    let acks = vec![
+        ReplicaAck::try_new(2, 128).expect("replica ACK"),
+        ReplicaAck::try_new(2, 128).expect("duplicate ACK"),
+        ReplicaAck::try_new(3, 127).expect("slow ACK"),
+        ReplicaAck::try_new(4, 128).expect("removed replica ACK"),
+    ];
+
+    assert_eq!(
+        decision(current, current, policy, 128, acks, &[1, 2, 3]),
+        ReplicationDecision::Wait { required_offset: 128 }
+    );
+}
+
+#[test]
+fn local_fsync_failure_cannot_be_reported_as_replicated_durability() {
+    let current = authority(1, 10);
+    let replica_ack = ReplicaAck::try_new(2, 128).expect("replica ACK");
+    assert_eq!(
+        decision(
+            current,
+            current,
+            AckPolicy::ReplicaCount(ReplicaCount::try_new(2).expect("replicated policy")),
+            127,
+            vec![replica_ack],
+            &[1, 2],
+        ),
+        ReplicationDecision::Wait { required_offset: 128 }
+    );
+    assert_eq!(
+        AppendReceipt::try_new(AppendStatus::PutOk, 0..128, 128, 127, Durability::Replicated)
+            .expect_err("local fsync failure cannot produce a replicated receipt"),
+        AppendReceiptError::ReplicatedDurabilityRequiresDecision
+    );
+}
+
+#[test]
+fn truncated_segment_tail_recovers_only_the_last_complete_record() {
+    let mut recovery =
+        AbnormalRecoveryState::try_new(0, AbnormalRecoveryPolicy::Optimized).expect("valid recovery state");
+    recovery
+        .apply(AbnormalRecoveryEvent::SegmentStarted { base_offset: 0 })
+        .expect("start segment");
+    assert_eq!(
+        recovery
+            .apply(AbnormalRecoveryEvent::MessageAccepted {
+                segment_base: 0,
+                relative_start: 0,
+                validated_size: 64,
+                confirm_candidate_end: 64,
+                dispatch_gate: AbnormalRecoveryDispatchGate::Ungated,
+            })
+            .expect("accept complete record"),
+        AbnormalRecoveryAction::DispatchMessage
+    );
+    assert_eq!(
+        recovery
+            .apply(AbnormalRecoveryEvent::InvalidRecord)
+            .expect("reject truncated tail"),
+        AbnormalRecoveryAction::ContinueNextSegment
+    );
+    assert_eq!(recovery.summary().truncate_offset, 64);
+}
+
+#[test]
+fn restored_fixture_accepts_a_new_complete_record_after_recovery() {
+    let mut restored = AbnormalRecoveryState::try_new(64, AbnormalRecoveryPolicy::Optimized)
+        .expect("restore complete-record watermark");
+    restored
+        .apply(AbnormalRecoveryEvent::SegmentStarted { base_offset: 64 })
+        .expect("start restored segment");
+    assert_eq!(
+        restored
+            .apply(AbnormalRecoveryEvent::MessageAccepted {
+                segment_base: 64,
+                relative_start: 0,
+                validated_size: 32,
+                confirm_candidate_end: 96,
+                dispatch_gate: AbnormalRecoveryDispatchGate::Ungated,
+            })
+            .expect("append complete record after restore"),
+        AbnormalRecoveryAction::DispatchMessage
+    );
+    assert_eq!(restored.summary().truncate_offset, 96);
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
@@ -145,6 +145,19 @@ pub struct StoreHealthDiagnostics {
     pub sync_flush: SyncFlushDiagnostics,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HaDiagnostics {
+    pub supported: bool,
+    pub role: Option<String>,
+    pub master_epoch: Option<i32>,
+    pub sync_state_set_epoch: Option<i32>,
+    pub sync_state_set_size: Option<u64>,
+    pub max_replica_lag_bytes: Option<u64>,
+    pub ack_policy: Option<String>,
+    pub required_ack_count: Option<u64>,
+    pub decision_code: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecoveryDiagnostics {
     pub available: bool,
@@ -230,6 +243,8 @@ pub struct BrokerDiagnostics {
     pub readiness: Option<BrokerReadinessDiagnostics>,
     pub config: Option<BrokerConfigSummary>,
     pub store_health: Option<StoreHealthDiagnostics>,
+    #[serde(default)]
+    pub ha: HaDiagnostics,
     pub recovery: Option<RecoveryDiagnostics>,
     pub background_index_rebuild: Option<BackgroundIndexRebuildDiagnostics>,
     pub rocksdb: RocksDbMaintenanceDiagnostics,
@@ -642,6 +657,7 @@ pub(crate) fn project_broker_diagnostics(broker_name: String, broker_id: u64, ru
         readiness,
         config,
         store_health,
+        ha: parse_ha(runtime),
         recovery: parse_recovery(runtime),
         background_index_rebuild,
         rocksdb: RocksDbMaintenanceDiagnostics {
@@ -683,6 +699,7 @@ fn unsupported_diagnostics(broker_name: String, broker_id: u64) -> BrokerDiagnos
         readiness: None,
         config: None,
         store_health: None,
+        ha: HaDiagnostics::default(),
         recovery: None,
         background_index_rebuild: None,
         rocksdb: RocksDbMaintenanceDiagnostics {
@@ -754,6 +771,28 @@ fn parse_store_health(runtime: &KVTable) -> Option<StoreHealthDiagnostics> {
 }
 
 #[cfg(any(feature = "read-client-adapter", test))]
+fn parse_ha(runtime: &KVTable) -> HaDiagnostics {
+    let supported = runtime_bool(runtime, "haDiagnosticsSupported").unwrap_or(false);
+    HaDiagnostics {
+        supported,
+        role: supported
+            .then(|| runtime_value(runtime, "haRole").map(str::to_owned))
+            .flatten(),
+        master_epoch: runtime_i32(runtime, "haMasterEpoch"),
+        sync_state_set_epoch: runtime_i32(runtime, "haSyncStateSetEpoch"),
+        sync_state_set_size: runtime_u64(runtime, "haSyncStateSetSize"),
+        max_replica_lag_bytes: runtime_u64(runtime, "haMaxReplicaLagBytes"),
+        ack_policy: supported
+            .then(|| runtime_value(runtime, "haAckPolicy").map(str::to_owned))
+            .flatten(),
+        required_ack_count: runtime_u64(runtime, "haRequiredAckCount"),
+        decision_code: supported
+            .then(|| runtime_value(runtime, "haDecisionCode").map(str::to_owned))
+            .flatten(),
+    }
+}
+
+#[cfg(any(feature = "read-client-adapter", test))]
 fn parse_recovery(runtime: &KVTable) -> Option<RecoveryDiagnostics> {
     let available = runtime_bool(runtime, "recoveryReportAvailable")?;
     Some(RecoveryDiagnostics {
@@ -809,6 +848,11 @@ fn runtime_u64(runtime: &KVTable, key: &str) -> Option<u64> {
 
 #[cfg(any(feature = "read-client-adapter", test))]
 fn runtime_i64(runtime: &KVTable, key: &str) -> Option<i64> {
+    runtime_value(runtime, key)?.parse().ok()
+}
+
+#[cfg(any(feature = "read-client-adapter", test))]
+fn runtime_i32(runtime: &KVTable, key: &str) -> Option<i32> {
     runtime_value(runtime, key)?.parse().ok()
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-that-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #8884

### Brief Description

Introduces backend-neutral, validated HA authority and acknowledgement contracts, then applies them at Controller, Broker, and Store boundaries. Replicated append receipts now require canonical proof of both local durability and the configured replica policy; stale, conflicting, missing, or invalid role state fails closed without partial publication.

Adds deterministic seven-case HA fault/recovery smoke coverage, bounded HA diagnostics through Admin Core and the single SRE read gateway, and an evidence-based backend/topology support matrix. Six-hour soak and full disaster-recovery exercises remain explicit follow-up validation items.

### How Did You Test This Change?

- `cargo fmt` checks for every affected root package; workspace-wide fmt remains blocked only by the existing Windows error 206 path-length limit.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Full Store API, Store Local, Protocol, Admin Core, and focused HA/Controller/Broker test suites.
- Store full suite: only the same three TaskGroup lifecycle failures reproduced on the exact parent commit; all new seven-case fault smokes pass.
- Controller full suite: only the same five TaskGroup lifecycle failures reproduced on the exact parent commit.
- Broker full suite: 739 passed, 2 ignored, with only the established 11 TaskGroup lifecycle baseline failures.
- `runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `check-error-hygiene.ps1` and `check-agents-routing.ps1`
- Fixed-nightly `fuzz` all-target/all-feature locked check.
- Full `rocketmq-sre` fmt, locked check, all-feature tests, strict Clippy, rustdoc, source-layout, execution-dependency, and read-gateway boundary checks.
- Store API and Admin Core rustdoc; `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical high-availability replication decisions, acknowledgments, and durability validation.
  * Added read-only HA diagnostics to broker runtime information, administration tools, and SRE outputs.
  * Added HA/RPO/RTO support documentation and operational status details.

* **Bug Fixes**
  * Rejected stale, conflicting, malformed, or unauthorized broker role and replication updates.
  * Prevented invalid replicated durability claims and failed closed on invalid role-change requests.

* **Tests**
  * Added coverage for quorum behavior, authority conflicts, stale updates, durability failures, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->