### PR TITLE
[ISSUE #8886]🐛Fix TaskGroup owner cancellation in Broker lifecycle tests

### DIFF
--- a/rocketmq-broker/src/client/client_housekeeping_service.rs
+++ b/rocketmq-broker/src/client/client_housekeeping_service.rs
@@ -163,19 +163,11 @@ impl ClientHousekeepingService {
     }
 
     pub(crate) fn task_count(&self) -> usize {
-        let root_count = self
-            .task_group
+        self.task_group
             .lock()
             .as_ref()
             .map(TaskGroup::task_count)
-            .unwrap_or_default();
-        let scheduled_count = self
-            .scheduled_tasks
-            .lock()
-            .as_ref()
-            .map(|scheduled_tasks| scheduled_tasks.group().task_count())
-            .unwrap_or_default();
-        root_count + scheduled_count
+            .unwrap_or_default()
     }
 
     pub(crate) fn schedule_snapshot(&self) -> Vec<ScheduledTaskSnapshot> {

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -497,17 +497,11 @@ impl BrokerFastFailure {
 
     pub(crate) fn task_count(&self) -> usize {
         let lifecycle = self.inner.lifecycle.lock();
-        let root_count = lifecycle
+        lifecycle
             .task_group
             .as_ref()
             .map(TaskGroup::task_count)
-            .unwrap_or_default();
-        let scheduled_count = lifecycle
-            .scheduled_tasks
-            .as_ref()
-            .map(|scheduled_tasks| scheduled_tasks.group().task_count())
-            .unwrap_or_default();
-        root_count + scheduled_count
+            .unwrap_or_default()
     }
 
     pub(crate) fn schedule_snapshot(&self) -> Vec<ScheduledTaskSnapshot> {

--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -189,17 +189,11 @@ impl TopicQueueMappingCleanService {
 
     pub(crate) fn task_count(&self) -> usize {
         let lifecycle = self.inner.lifecycle.lock();
-        let root_count = lifecycle
+        lifecycle
             .task_group
             .as_ref()
             .map(TaskGroup::task_count)
-            .unwrap_or_default();
-        let scheduled_count = lifecycle
-            .scheduled_tasks
-            .as_ref()
-            .map(|scheduled_tasks| scheduled_tasks.group().task_count())
-            .unwrap_or_default();
-        root_count + scheduled_count
+            .unwrap_or_default()
     }
 
     pub(crate) fn schedule_snapshot(&self) -> Vec<ScheduledTaskSnapshot> {

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -558,9 +558,24 @@ async fn broker_runtime_service_context_parents_probe_task_groups() {
     assert!(report.timed_out_component_names().is_empty());
     assert!(report.component_names().contains(&"scheduled_tasks"));
 
+    let scheduled_task_group_report = runtime
+        .lifecycle
+        .scheduled_task_manager
+        .last_task_group_shutdown_report()
+        .expect("scheduled task group shutdown report should be retained by its owner");
+    assert!(
+        scheduled_task_group_report.is_healthy(),
+        "{}",
+        scheduled_task_group_report.to_json()
+    );
+    assert_eq!(
+        scheduled_task_group_report.name,
+        rocketmq_runtime::schedule::simple_scheduler::LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY
+    );
+
     let service_report = service.task_group().shutdown(Duration::from_secs(1)).await;
     assert!(
-        service_report
+        !service_report
             .children
             .iter()
             .any(|child| child.name

--- a/rocketmq-runtime/src/operation.rs
+++ b/rocketmq-runtime/src/operation.rs
@@ -367,4 +367,21 @@ mod tests {
         let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
     }
+
+    #[tokio::test]
+    async fn owner_shutdown_cancels_operation_tasks() {
+        let runtime = RuntimeContext::from_current("operation-owner-shutdown-test");
+        let owner = runtime.service_context("operations");
+        let operation = OperationContext::without_deadline(TaskKind::Worker);
+
+        owner
+            .task_group()
+            .spawn_operation(&operation, "owned-operation", std::future::pending())
+            .expect("operation task should spawn");
+
+        let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert_eq!(operation.active_task_count(), 0);
+    }
 }

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -418,9 +418,14 @@ impl TaskGroup {
         let registration = context.prepare_spawn(self.id())?;
         let guard = registration.guard();
         let operation = context.clone();
+        let owner_cancellation = self.cancellation_token();
         let task_id = self.spawn(name, context.task_kind(), async move {
             let _guard = guard;
-            operation.run(future).await;
+            tokio::select! {
+                biased;
+                _ = owner_cancellation.cancelled() => {}
+                _ = operation.run(future) => {}
+            }
         })?;
         registration.register(task_id);
         Ok(task_id)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8886

### Brief Description

Make operation tasks observe cancellation from both their operation context and their owning `TaskGroup`, so parent shutdown can stop and join scheduled Broker statistics workers without timing out and aborting them.

Correct Broker lifecycle task accounting to count each scheduled driver through its single `TaskGroup` owner. Update the legacy scheduler assertion to inspect the shutdown report retained by the scheduler owner, consistent with the active-only child registry. Add a runtime regression test for owner-driven operation cancellation.

### How Did You Test This Change?

- `cargo test -p rocketmq-runtime --all-features` passed, including unit, integration, UI, and doc tests.
- All 11 previously failing Broker tests passed individually with `cargo test -p rocketmq-broker --lib --all-features <test> -- --exact`.
- `cargo test -p rocketmq-broker --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- All 28 workspace members passed package-scoped `cargo fmt -p <package> -- --check`; the combined Windows invocation exceeded the operating system command-line length limit.
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` passed from `fuzz/`.
- `cargo test --workspace --all-features` could not complete locally because the RocksDB C++ rebuild exhausted the host disk before test execution; targeted all-features Broker coverage and workspace Clippy completed successfully before cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task shutdown handling so pending operations are cancelled and removed when their owning component shuts down.
  - Corrected task reporting to prevent scheduled tasks from being counted twice.
  - Improved shutdown health reporting and task hierarchy accuracy across broker services.

- **Tests**
  - Added coverage confirming clean cancellation, accurate task counts, and healthy shutdown reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->