### PR TITLE
[ISSUE #8894]🐛Remove SRE dependency audit blockers

### DIFF
--- a/rocketmq-sre/Cargo.lock
+++ b/rocketmq-sre/Cargo.lock
@@ -279,12 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,12 +541,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -650,6 +638,16 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
 
 [[package]]
 name = "crc32fast"
@@ -838,17 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -939,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1057,13 +1043,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1132,17 +1117,6 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
-name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
@@ -1150,7 +1124,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1424,8 +1398,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1435,6 +1407,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1447,15 +1421,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1487,11 +1452,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1510,15 +1475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1854,6 +1810,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,33 +2086,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "plain",
- "redox_syscall 0.9.1",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2359,6 +2303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,22 +2370,6 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.7",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -2490,7 +2430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2562,28 +2501,33 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
- "md-5 0.10.6",
+ "itertools 0.15.0",
+ "md-5 0.11.0",
+ "nix",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.5",
- "reqwest 0.12.28",
- "ring",
+ "rand 0.10.2",
+ "reqwest",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2594,6 +2538,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2666,7 +2611,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2685,15 +2630,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2842,37 +2778,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polyval"
@@ -2916,15 +2825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,7 +2860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2981,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3082,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -3180,19 +3080,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3207,42 +3095,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rand_core"
@@ -3278,15 +3134,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -3359,48 +3206,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3439,7 +3244,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3468,7 +3273,7 @@ dependencies = [
  "futures",
  "http",
  "pin-project-lite",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sse-stream",
@@ -3525,7 +3330,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.11.0",
  "subtle",
  "thiserror",
@@ -3710,7 +3515,7 @@ name = "rocketmq-sre-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-sre-contracts",
  "serde",
  "serde_json",
@@ -3727,7 +3532,7 @@ dependencies = [
  "chrono",
  "http",
  "jsonschema",
- "reqwest 0.13.4",
+ "reqwest",
  "rmcp",
  "rocketmq-admin-core",
  "rocketmq-observability",
@@ -3775,7 +3580,7 @@ dependencies = [
  "hmac 0.12.1",
  "jsonwebtoken",
  "object_store",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-observability",
  "rocketmq-runtime",
  "rocketmq-sre-contracts",
@@ -3841,7 +3646,7 @@ dependencies = [
  "hmac 0.12.1",
  "k8s-openapi",
  "kube",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-admin-core",
  "rocketmq-runtime",
  "rocketmq-sre-contracts",
@@ -3868,7 +3673,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-runtime",
  "rocketmq-sre-contracts",
  "rocketmq-sre-core",
@@ -3898,7 +3703,7 @@ dependencies = [
  "prost",
  "protoc-bin-vendored",
  "rcgen",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-sre-contracts",
  "rustls",
  "schemars",
@@ -3942,7 +3747,7 @@ dependencies = [
  "cheetah-string",
  "dashmap",
  "flate2",
- "flume 0.12.0",
+ "flume",
  "form_urlencoded",
  "futures",
  "futures-util",
@@ -3951,7 +3756,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest",
  "rocketmq-error",
  "rocketmq-model",
  "rocketmq-protocol",
@@ -3980,26 +3785,6 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4411,17 +4196,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -4476,16 +4250,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4563,20 +4327,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
+name = "spin"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4587,12 +4347,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -4602,12 +4363,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -4620,14 +4380,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4638,15 +4398,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -4657,59 +4417,44 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.119",
+ "thiserror",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.7",
- "rsa",
  "serde",
- "sha1 0.10.7",
- "sha2 0.10.9",
- "smallvec",
+ "sha1",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -4724,17 +4469,15 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
- "home",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4746,13 +4489,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.11.1",
+ "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4762,7 +4506,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror",
  "tracing",
@@ -5551,12 +5294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5613,19 +5350,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5668,15 +5392,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
@@ -5686,13 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -5839,15 +5550,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5880,21 +5582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5941,12 +5628,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5959,12 +5640,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5974,12 +5649,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6007,12 +5676,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6022,12 +5685,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6043,12 +5700,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6058,12 +5709,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6152,7 +5797,7 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink 0.11.1",
+ "hashlink",
 ]
 
 [[package]]

--- a/rocketmq-sre/Cargo.toml
+++ b/rocketmq-sre/Cargo.toml
@@ -48,7 +48,7 @@ hmac = "0.12.1"
 jsonwebtoken = { version = "9.3.1", features = ["use_pem"] }
 k8s-openapi = { version = "0.28.0", features = ["v1_36"] }
 kube = { version = "4.2.0", default-features = false, features = ["client", "ring", "rustls-tls"] }
-object_store = { version = "0.12.4", features = ["aws", "fs"] }
+object_store = { version = "0.14.1", features = ["aws", "fs"] }
 prost = "0.14.4"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 rustls = { version = "0.23.42", default-features = false, features = ["ring", "std"] }
@@ -59,7 +59,7 @@ serde_jcs = "0.2.0"
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
-sqlx = { version = "0.8.6", default-features = false, features = ["chrono", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "uuid"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["chrono", "json", "macros", "migrate", "postgres", "runtime-tokio", "tls-rustls", "uuid"] }
 subtle = "2.6.1"
 thiserror = "2.0.12"
 tokio = { version = "1.52.0", features = ["macros", "net", "signal", "sync", "time"] }

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/assets/repository.rs
@@ -768,12 +768,15 @@ mod tests {
             "asset_snapshots",
             "asset_inventory_snapshots",
         ] {
-            sqlx::query(&format!("DELETE FROM {table} WHERE tenant_id = $1 AND cluster_id = $2"))
-                .bind(tenant.as_uuid())
-                .bind(cluster.as_uuid())
-                .execute(&repository.pool)
-                .await
-                .expect("test data cleanup");
+            // The table name comes from the closed test-only allowlist above; row values remain binds.
+            sqlx::query(sqlx::AssertSqlSafe(format!(
+                "DELETE FROM {table} WHERE tenant_id = $1 AND cluster_id = $2"
+            )))
+            .bind(tenant.as_uuid())
+            .bind(cluster.as_uuid())
+            .execute(&repository.pool)
+            .await
+            .expect("test data cleanup");
         }
         sqlx::query("DELETE FROM clusters WHERE id = $1")
             .bind(cluster.as_uuid())

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/blob.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/blob.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::PutPayload;
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/repository.rs
@@ -54,15 +54,15 @@ impl PostgresRepository {
                 "message journey cluster is outside the authenticated scope",
             ));
         }
-        let rows = sqlx::query(&format!(
-            "{EVIDENCE_COLUMNS}
+        let rows = sqlx::query(evidence_query(
+            "
              WHERE e.tenant_id = $1
                AND e.cluster_id = $2
                AND (e.expires_at IS NULL OR e.expires_at > NOW())
                AND e.resource LIKE ('%' || $3 || '%')
                AND e.source IN ('admin-query', 'tempo', 'mcp', 'rocketmq-mcp')
              ORDER BY e.observed_at ASC, e.id ASC
-             LIMIT 64"
+             LIMIT 64",
         ))
         .bind(auth.tenant_id.as_uuid())
         .bind(cluster_id.as_uuid())
@@ -83,12 +83,12 @@ impl PostgresRepository {
         enforce_evidence_scope(auth, snapshot)?;
         let query_hash = query_hash(snapshot);
         let mut transaction = self.pool.begin().await?;
-        let existing = sqlx::query(&format!(
-            "{EVIDENCE_COLUMNS}
+        let existing = sqlx::query(evidence_query(
+            "
              WHERE e.tenant_id = $1 AND e.cluster_id = $2 AND e.query_hash = $3
                AND e.time_range_start = $4 AND e.time_range_end = $5 AND e.content_hash = $6
                AND (e.expires_at IS NULL OR e.expires_at > NOW())
-             ORDER BY e.collected_at DESC LIMIT 1"
+             ORDER BY e.collected_at DESC LIMIT 1",
         ))
         .bind(auth.tenant_id.as_uuid())
         .bind(snapshot.cluster_id.as_uuid())
@@ -200,13 +200,13 @@ impl PostgresRepository {
                 "evidence cluster is outside the authenticated scope",
             ));
         }
-        let row = sqlx::query(&format!(
-            "{EVIDENCE_COLUMNS}
+        let row = sqlx::query(evidence_query(
+            "
              WHERE e.tenant_id = $1 AND e.cluster_id = $2
                AND e.source = $3 AND e.resource = $4
                AND (e.expires_at IS NULL OR e.expires_at > NOW())
              ORDER BY e.observed_at DESC, e.collected_at DESC, e.id DESC
-             LIMIT 1"
+             LIMIT 1",
         ))
         .bind(auth.tenant_id.as_uuid())
         .bind(cluster_id.as_uuid())
@@ -222,10 +222,10 @@ impl PostgresRepository {
         auth: &AuthContext,
         id: EvidenceId,
     ) -> Result<EvidenceSnapshot, ControlPlaneError> {
-        let row = sqlx::query(&format!(
-            "{EVIDENCE_COLUMNS}
+        let row = sqlx::query(evidence_query(
+            "
              WHERE e.id = $1 AND e.tenant_id = $2
-               AND (e.expires_at IS NULL OR e.expires_at > NOW())"
+               AND (e.expires_at IS NULL OR e.expires_at > NOW())",
         ))
         .bind(id.as_uuid())
         .bind(auth.tenant_id.as_uuid())
@@ -284,8 +284,8 @@ impl PostgresRepository {
                     .map_err(|_| ControlPlaneError::validation("invalid_request", "evidence cursor must be a UUID"))
             })
             .transpose()?;
-        let rows = sqlx::query(&format!(
-            "{EVIDENCE_COLUMNS}
+        let rows = sqlx::query(evidence_query(
+            "
              WHERE e.tenant_id = $1 AND e.cluster_id = $2
                AND (e.expires_at IS NULL OR e.expires_at > NOW())
                AND ($3::UUID IS NULL OR EXISTS (
@@ -294,7 +294,7 @@ impl PostgresRepository {
                ))
                AND ($4::TEXT IS NULL OR e.source = $4)
                AND ($5::UUID IS NULL OR e.id < $5)
-             ORDER BY e.id DESC LIMIT $6"
+             ORDER BY e.id DESC LIMIT $6",
         ))
         .bind(auth.tenant_id.as_uuid())
         .bind(query.cluster_id.as_uuid())
@@ -493,7 +493,12 @@ const EVIDENCE_COLUMNS: &str = "SELECT e.id, e.query_id, e.correlation_id, e.ten
     e.time_range_start, e.time_range_end, e.observed_at, e.freshness_seconds,
     e.coverage, e.sensitivity, e.exposure, e.partial, e.warnings, e.inline_content,
     e.content_uri, e.content_size_bytes, e.content_hash, e.content_digest
-    FROM evidence_snapshots e";
+                               FROM evidence_snapshots e";
+
+fn evidence_query(suffix: &'static str) -> sqlx::AssertSqlSafe<String> {
+    // Both fragments are compile-time constants; request data is supplied only through binds.
+    sqlx::AssertSqlSafe(format!("{EVIDENCE_COLUMNS}{suffix}"))
+}
 
 #[cfg(test)]
 mod tests {

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/forecast/repository.rs
@@ -228,7 +228,7 @@ impl PostgresRepository {
         &self,
         auth: &AuthContext,
         cluster_id: ClusterId,
-        statement: &str,
+        statement: &'static str,
     ) -> Result<Vec<T>, ControlPlaneError>
     where
         T: DeserializeOwned,

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/lifecycle_repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/lifecycle_repository.rs
@@ -87,7 +87,7 @@ impl PostgresRepository {
         tenant_id: TenantId,
     ) -> Result<Vec<ModelProfileLifecycleView>, ControlPlaneError> {
         self.ensure_model_profile_lifecycles(tenant_id).await?;
-        let rows = sqlx::query(&lifecycle_projection_query(None))
+        let rows = sqlx::query(lifecycle_projection_query(false))
             .bind(tenant_id.as_uuid())
             .fetch_all(&self.pool)
             .await?;
@@ -100,7 +100,7 @@ impl PostgresRepository {
         profile_id: ModelProfileId,
     ) -> Result<ModelProfileLifecycleView, ControlPlaneError> {
         self.ensure_model_profile_lifecycles(tenant_id).await?;
-        let row = sqlx::query(&lifecycle_projection_query(Some(2)))
+        let row = sqlx::query(lifecycle_projection_query(true))
             .bind(tenant_id.as_uuid())
             .bind(profile_id.as_uuid())
             .fetch_optional(&self.pool)
@@ -521,10 +521,10 @@ async fn append_lifecycle_event(
     Ok(())
 }
 
-fn lifecycle_projection_query(profile_parameter: Option<u8>) -> String {
-    let profile_filter =
-        profile_parameter.map_or_else(String::new, |parameter| format!(" AND profile.id = ${parameter}"));
-    format!(
+fn lifecycle_projection_query(filter_by_profile: bool) -> sqlx::AssertSqlSafe<String> {
+    let profile_filter = if filter_by_profile { " AND profile.id = $2" } else { "" };
+    // The optional clause is selected from static SQL; request values remain bind parameters.
+    sqlx::AssertSqlSafe(format!(
         "SELECT profile.id, profile.profile_name, profile.provider_family,
                 profile.model_family, profile.model_revision, profile.health,
                 lifecycle.state, lifecycle.revision, lifecycle.rollback_profile_id,
@@ -550,7 +550,7 @@ fn lifecycle_projection_query(profile_parameter: Option<u8>) -> String {
          ) smoke ON TRUE
          WHERE profile.tenant_id = $1{profile_filter}
          ORDER BY profile.priority, profile.profile_name"
-    )
+    ))
 }
 
 fn lifecycle_from_row(row: &PgRow) -> Result<ModelProfileLifecycleView, ControlPlaneError> {

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/repository.rs
@@ -182,14 +182,14 @@ impl ClusterRepository for PostgresRepository {
     }
 
     async fn list(&self) -> Result<Vec<Cluster>, ControlPlaneError> {
-        let rows = sqlx::query(&format!("{CLUSTER_COLUMNS} ORDER BY created_at ASC, id ASC"))
+        let rows = sqlx::query(cluster_query(" ORDER BY created_at ASC, id ASC"))
             .fetch_all(&self.pool)
             .await?;
         rows.iter().map(cluster_from_row).collect()
     }
 
     async fn get(&self, id: ClusterId) -> Result<Cluster, ControlPlaneError> {
-        let row = sqlx::query(&format!("{CLUSTER_COLUMNS} WHERE id = $1"))
+        let row = sqlx::query(cluster_query(" WHERE id = $1"))
             .bind(id.as_uuid())
             .fetch_optional(&self.pool)
             .await?
@@ -395,7 +395,12 @@ const CLUSTER_COLUMNS: &str = "SELECT
     id, tenant_id, external_cluster_key, environment, region,
     rocketmq_version, deployment_mode, owner_name, onboarding_state,
     created_at, updated_at, offboarded_at
-    FROM clusters";
+                              FROM clusters";
+
+fn cluster_query(suffix: &'static str) -> sqlx::AssertSqlSafe<String> {
+    // Both fragments are compile-time constants; request data is supplied only through binds.
+    sqlx::AssertSqlSafe(format!("{CLUSTER_COLUMNS}{suffix}"))
+}
 
 const CLUSTER_BY_EXTERNAL_KEY_FOR_UPDATE: &str = "SELECT
     id, tenant_id, external_cluster_key, environment, region,
@@ -461,7 +466,7 @@ async fn get_cluster_for_update(
     transaction: &mut Transaction<'_, Postgres>,
     id: ClusterId,
 ) -> Result<Cluster, ControlPlaneError> {
-    let row = sqlx::query(&format!("{CLUSTER_COLUMNS} WHERE id = $1 FOR UPDATE"))
+    let row = sqlx::query(cluster_query(" WHERE id = $1 FOR UPDATE"))
         .bind(id.as_uuid())
         .fetch_optional(&mut **transaction)
         .await?
@@ -473,7 +478,7 @@ async fn get_cluster_in_transaction(
     transaction: &mut Transaction<'_, Postgres>,
     id: ClusterId,
 ) -> Result<Cluster, ControlPlaneError> {
-    let row = sqlx::query(&format!("{CLUSTER_COLUMNS} WHERE id = $1"))
+    let row = sqlx::query(cluster_query(" WHERE id = $1"))
         .bind(id.as_uuid())
         .fetch_optional(&mut **transaction)
         .await?

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config/logger_level_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config/logger_level_tests.rs
@@ -242,6 +242,7 @@ fn test_credentials(identity: &str) -> Option<AdminCredentials> {
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -249,14 +250,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -264,9 +267,20 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::query(&format!("DROP SCHEMA \"{schema}\" CASCADE"))
+    assert_test_schema(schema);
+    sqlx::query(sqlx::AssertSqlSafe(format!("DROP SCHEMA \"{schema}\" CASCADE")))
         .execute(pool)
         .await
         .expect("drop isolated schema");
     pool.close().await;
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config_tests.rs
@@ -317,6 +317,7 @@ fn test_credentials(identity: &str) -> Option<AdminCredentials> {
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -324,14 +325,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -339,9 +342,22 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
     pool.close().await;
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_credential_rotation_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_credential_rotation_tests.rs
@@ -240,6 +240,7 @@ fn required_env(name: &str) -> String {
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -247,14 +248,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -262,9 +265,22 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
     pool.close().await;
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_image_canary_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_image_canary_tests.rs
@@ -174,6 +174,7 @@ async fn wait_for_canary(
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -181,14 +182,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -196,8 +199,21 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_subscription_group_e2e_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_subscription_group_e2e_tests.rs
@@ -332,6 +332,7 @@ fn test_credentials(identity: &str) -> Option<AdminCredentials> {
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -339,14 +340,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -354,8 +357,21 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_topic_config_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_topic_config_tests.rs
@@ -334,6 +334,7 @@ fn test_credentials(identity: &str) -> Option<AdminCredentials> {
 }
 
 async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(4)
@@ -341,14 +342,16 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -356,9 +359,22 @@ async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
     pool.close().await;
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }

--- a/rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery/support.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery/support.rs
@@ -62,6 +62,7 @@ pub(crate) struct Fixture {
 }
 
 pub(crate) async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
+    assert_test_schema(schema);
     let search_path: Arc<str> = Arc::from(format!("SET search_path TO \"{schema}\""));
     let pool = PgPoolOptions::new()
         .max_connections(8)
@@ -69,14 +70,16 @@ pub(crate) async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
         .after_connect(move |connection, _metadata| {
             let search_path = Arc::clone(&search_path);
             Box::pin(async move {
-                sqlx::query(search_path.as_ref()).execute(connection).await?;
+                sqlx::query(sqlx::AssertSqlSafe(search_path))
+                    .execute(connection)
+                    .await?;
                 Ok(())
             })
         })
         .connect(database_url)
         .await
         .expect("Docker PostgreSQL");
-    sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+    sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
         .execute(&pool)
         .await
         .expect("isolated schema");
@@ -84,11 +87,24 @@ pub(crate) async fn isolated_pool(database_url: &str, schema: &str) -> PgPool {
 }
 
 pub(crate) async fn cleanup_schema(pool: &PgPool, schema: &str) {
-    sqlx::raw_sql(&format!("SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"))
-        .execute(pool)
-        .await
-        .expect("drop isolated schema");
+    assert_test_schema(schema);
+    sqlx::raw_sql(sqlx::AssertSqlSafe(format!(
+        "SET search_path TO public; DROP SCHEMA \"{schema}\" CASCADE"
+    )))
+    .execute(pool)
+    .await
+    .expect("drop isolated schema");
     pool.close().await;
+}
+
+fn assert_test_schema(schema: &str) {
+    assert!(
+        !schema.is_empty()
+            && schema
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "test schema must be a generated lowercase ASCII identifier"
+    );
 }
 
 pub(crate) async fn assert_phase_three_tables(pool: &PgPool) {


### PR DESCRIPTION
## Summary

- upgrade SRE `object_store` to 0.14.1 / `quick-xml` 0.41.0 and SQLx to 0.9.0, removing the vulnerable/stale RSA dependency family from the lockfile;
- adopt SQLx 0.9 fail-closed SQL string contracts without accepting request-controlled SQL fragments;
- validate generated test schema identifiers before explicit `AssertSqlSafe` use;
- import the ObjectStore 0.14 extension API while preserving evidence storage behavior.

## Security result

- before: 3 RustSec vulnerabilities (2 High, 1 Medium)
- after: 0 vulnerabilities; no advisory ignores or lint suppressions

## Validation

From `rocketmq-sre/`:

- workspace package `cargo fmt ... -- --check`
- `cargo check --locked --workspace`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python scripts/check_read_gateway_boundary.py`
- `cargo audit --file Cargo.lock`

From the repository root:

- `./scripts/check-agents-routing.ps1`
- `git diff --check`

Closes #8894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query safety across repository operations and isolated database workflows.
  * Added validation for dynamically generated database schema names to prevent invalid or unsafe usage.
  * Preserved existing filtering, ordering, binding, cleanup, and expiration behavior.

* **Tests**
  * Strengthened database integration test setup and cleanup for more reliable schema isolation.
  * Improved handling of database connection search paths during test teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->