### PR TITLE
[ISSUE #8897]🐛Seed the SRE governance tenant fixture

### DIFF
--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service_tests.rs
@@ -595,6 +595,17 @@ pub(super) async fn seed_fixture(repository: &PostgresRepository) -> Fixture {
     let rules_only_diagnosis_id = DiagnosisRevisionId::new();
     let model_profile_id = Uuid::new_v4();
     let model_invocation_id = Uuid::new_v4();
+    let default_fleet_id = Uuid::parse_str("00000000-0000-4000-8000-000000000005").expect("default fleet id");
+    sqlx::query(
+        "INSERT INTO fleet_tenants (id, fleet_id, name, owner_name)
+         VALUES ($1, $2, $3, 'phase3-test')",
+    )
+    .bind(tenant_id.as_uuid())
+    .bind(default_fleet_id)
+    .bind(format!("phase3-test-{tenant_id}"))
+    .execute(&repository.pool)
+    .await
+    .expect("fleet tenant");
     sqlx::query(
         "INSERT INTO clusters (
             id, tenant_id, external_cluster_key, environment, region,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8897

### Brief Description

Seed the supervised-execution test tenant under the migration-owned default fleet before creating its cluster. This completes the PostgreSQL integration fixture required by `governance_admissions_tenant_id_fkey` while preserving the production foreign key and fail-closed governance behavior.

### How Did You Test This Change?

- Focused PostgreSQL 17 reproduction: 1 passed, 0 failed.
- `cargo test --locked -p rocketmq-sre-control-plane -- --include-ignored`: 270 passed, 0 failed.
- Standalone SRE package formatting: passed.
- `cargo check --locked --workspace`: passed.
- `cargo test --locked --workspace --all-features`: passed.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo doc --locked --workspace --no-deps`: passed.
- Source-layout, execution-dependency, and read-gateway boundary guards: passed.
- `cargo audit --file Cargo.lock`: passed with zero vulnerabilities.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to include tenant-to-fleet associations when creating test clusters.
  * Improved test coverage for fleet and tenant relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->