### PR TITLE
[ISSUE #8899]🐛Normalize Broker source contract line endings

### DIFF
--- a/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
+++ b/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
@@ -16,7 +16,7 @@
 fn admin_dispatch_is_shared_without_a_request_wide_mutex() {
     let processor = include_str!("../src/processor.rs");
     let request_pipeline = include_str!("../src/broker_runtime/request_pipeline.rs");
-    let admin = include_str!("../src/processor/admin_broker_processor.rs");
+    let admin = include_str!("../src/processor/admin_broker_processor.rs").replace("\r\n", "\n");
 
     assert!(processor.contains("AdminBroker(Arc<AdminBrokerProcessor<MS>>)"));
     assert!(processor.contains("processor.process_request_shared(channel, ctx, request).await"));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8899

### Brief Description

Normalize the Broker admin processor source snapshot from CRLF to LF before evaluating its multiline architectural contract. This keeps the existing shared-dispatch assertions unchanged while making the integration test independent of the checkout line-ending convention.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --all-features --test admin_processor_concurrency_tests -- --nocapture`
- `cargo test -p rocketmq-broker --all-features`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability across different line-ending formats when validating admin processor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->