### PR TITLE
[ISSUE #8896]📝Record accepted architecture candidate evidence

### DIFF
--- a/rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json
+++ b/rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": 1,
+  "commit": "d88a973131ce4f57d01a65def8ecb7944a45ba21",
+  "environment": {
+    "os": "Microsoft Windows 11 Professional 10.0.26200 build 26200",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)"
+  },
+  "checks": [
+    {
+      "name": "pr_static",
+      "command": "python scripts/run_architecture_tests.py --tier pr_static",
+      "status": "passed"
+    },
+    {
+      "name": "root_format_package_loop",
+      "command": "cargo fmt -p <each of 28 root workspace packages> -- --check",
+      "status": "passed"
+    },
+    {
+      "name": "root_clippy",
+      "command": "cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings",
+      "status": "passed"
+    },
+    {
+      "name": "runtime_ownership",
+      "command": ".\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline",
+      "status": "passed"
+    },
+    {
+      "name": "error_hygiene",
+      "command": ".\\scripts\\check-error-hygiene.ps1",
+      "status": "passed"
+    },
+    {
+      "name": "architecture_contracts",
+      "command": "python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture",
+      "status": "passed"
+    },
+    {
+      "name": "protocol_all_features",
+      "command": "cargo test -p rocketmq-protocol --all-features",
+      "status": "passed"
+    },
+    {
+      "name": "broker_all_features",
+      "command": "cargo test -p rocketmq-broker --all-features",
+      "status": "passed"
+    },
+    {
+      "name": "broker_component_contract",
+      "command": "cargo test -p rocketmq-broker --all-features --test broker_runtime_component_contract",
+      "status": "passed"
+    },
+    {
+      "name": "tieredstore_full",
+      "command": "cargo test -p rocketmq-tieredstore --all-features",
+      "status": "passed"
+    },
+    {
+      "name": "broker_epoch_fault_smoke",
+      "command": "cargo test -p rocketmq-broker --test controller_epoch_fault_smoke",
+      "status": "passed"
+    },
+    {
+      "name": "store_ha_fault_smoke",
+      "command": "cargo test -p rocketmq-store --test ha_fault_smoke",
+      "status": "passed"
+    },
+    {
+      "name": "controller_snapshot_restore",
+      "command": "cargo test -p rocketmq-controller --test controller_snapshot_restore",
+      "status": "passed"
+    },
+    {
+      "name": "controller_storage_faults",
+      "command": "cargo test -p rocketmq-controller --test controller_storage_faults",
+      "status": "passed"
+    },
+    {
+      "name": "sre_format",
+      "command": "cd rocketmq-sre; cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check",
+      "status": "passed"
+    },
+    {
+      "name": "sre_check",
+      "command": "cd rocketmq-sre; cargo check --locked --workspace",
+      "status": "passed"
+    },
+    {
+      "name": "sre_test_all_features",
+      "command": "cd rocketmq-sre; cargo test --locked --workspace --all-features",
+      "status": "passed"
+    },
+    {
+      "name": "sre_clippy_all_features",
+      "command": "cd rocketmq-sre; cargo clippy --locked --workspace --all-targets --all-features -- -D warnings",
+      "status": "passed"
+    },
+    {
+      "name": "sre_doc",
+      "command": "cd rocketmq-sre; cargo doc --locked --workspace --no-deps",
+      "status": "passed"
+    },
+    {
+      "name": "sre_source_layout",
+      "command": "cd rocketmq-sre; python scripts/check_source_layout.py",
+      "status": "passed"
+    },
+    {
+      "name": "sre_execution_boundary",
+      "command": "cd rocketmq-sre; python scripts/check_execution_dependency_boundary.py",
+      "status": "passed"
+    },
+    {
+      "name": "sre_read_gateway_boundary",
+      "command": "cd rocketmq-sre; python scripts/check_read_gateway_boundary.py",
+      "status": "passed"
+    },
+    {
+      "name": "sre_postgresql_repositories",
+      "command": "cargo test --manifest-path rocketmq-sre/Cargo.toml --locked -p rocketmq-sre-control-plane -- --include-ignored",
+      "status": "passed"
+    },
+    {
+      "name": "root_dependency_audit",
+      "command": "cargo audit --file Cargo.lock",
+      "status": "passed"
+    },
+    {
+      "name": "sre_dependency_audit",
+      "command": "cd rocketmq-sre; cargo audit --file Cargo.lock",
+      "status": "passed"
+    },
+    {
+      "name": "transport_short_stability",
+      "command": "target/release/examples/architecture_network_performance_collector.exe --sample connection-soak mixed-tls-churn (two back-to-back cycles)",
+      "status": "passed"
+    }
+  ],
+  "known_failures": []
+}

--- a/rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.md
+++ b/rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.md
@@ -1,0 +1,248 @@
+<!--
+  Copyright 2023 The RocketMQ Rust Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Architecture Candidate Verification — d88a973131ce4f57d01a65def8ecb7944a45ba21
+
+## Decision
+
+- Code/system score: **93.5 / 100**.
+- Status: **passed for the code/system phase**.
+- Production-certified: **no**.
+- Critical or High correctness/security blockers: **0**.
+
+This candidate completes the current code and system architecture phase. It does
+not claim 95+ production readiness because target-hardware performance evidence,
+the six-hour soak, complete disaster recovery, Docker images, and real external
+adapters remain later V1 validation.
+
+## Candidate and environment
+
+| Field | Recorded value |
+|---|---|
+| Git commit | `d88a973131ce4f57d01a65def8ecb7944a45ba21` |
+| Worktree | Clean source tree; ignored build artifacts only |
+| Recorded on | `2026-08-01` UTC |
+| OS | Microsoft Windows 11 Professional 10.0.26200, build 26200 |
+| Rust | `rustc 1.95.0 (59807616e 2026-04-14)` |
+| Cargo | `cargo 1.95.0 (f2d3ce0bd 2026-03-21)` |
+| Target | `x86_64-pc-windows-msvc` |
+| CPU | Intel Core i7-11700K, 16 logical processors |
+| Memory | 34,219,397,120 bytes |
+| Filesystem | NTFS |
+
+The final SRE verification, PostgreSQL repository suite, and dependency audits ran
+against the exact source tree merged as this commit. Root-workspace results
+collected at `e542c3d25945892ada81f98611606813e77b57cd` remain applicable because
+the intervening production changes are confined to the standalone SRE workspace;
+the final delta adds only the PostgreSQL test fixture and a line-ending
+normalization in a Broker source-contract test.
+
+## Source changes covered
+
+The candidate closes the PR-01 through PR-17 architecture implementation chain
+and its validation repairs:
+
+- explicit `TaskGroup` ownership, cancellation, deadlines, joins, and service
+  lifecycle convergence;
+- fallible protocol decoding, malformed-header rejection, exhaustive HA authority,
+  checked mmap access, and replicated acknowledgement contracts;
+- count-and-byte bounded queues, producer egress completion, overload admission,
+  and in-process embedded Proxy dispatch;
+- capability-based Store, Admin, Consumer, and Client boundaries plus canonical
+  public APIs and hotspot ownership decisions;
+- one fail-closed SRE `ReadGateway`, typed SQL construction, dependency audit
+  remediation, and cross-platform architecture/feature CI gates.
+
+## Static validation
+
+| Validation | Result | Evidence |
+|---|---:|---|
+| PR-static architecture inventory | 22/22 modules passed | Final candidate run |
+| Milestone contracts | 26/26 modules passed | Non-SRE-equivalent parent tree |
+| Phase contracts | 4/4 modules passed | Non-SRE-equivalent parent tree |
+| Active dynamic fixtures | 7/7 modules passed | Non-SRE-equivalent parent tree |
+| Root workspace Clippy, all targets/features | Passed with `-D warnings` | Non-SRE-equivalent parent tree |
+| Root workspace formatting | All 28 packages passed individually | Windows command-line fallback |
+| Runtime ownership audit | Passed with boundary enforcement | Non-SRE-equivalent parent tree |
+| Typed error hygiene | Passed | Non-SRE-equivalent parent tree |
+| AGENTS routing and documentation guards | Passed | Non-SRE-equivalent parent tree |
+
+`cargo fmt --all -- --check` exceeded the Windows process command-line limit
+(`OS error 206`). Running `cargo fmt -p <package> -- --check` for every one of the
+28 root members passed. This is an execution-platform limitation with a complete,
+non-mutating equivalent check, not a source finding.
+
+## Focused correctness and contracts
+
+| Area | Actual result |
+|---|---|
+| Protocol | `cargo test -p rocketmq-protocol --all-features` passed; 1,394 unit tests plus wire/integration/doc coverage passed |
+| Broker full all-features suite | 810 tests passed across test binaries; 0 failed; 6 intentionally ignored |
+| Broker component lifecycle | 4/4 `component_service_contract` tests passed |
+| TieredStore lifecycle/drain | 66 library, 1 auxiliary, and 7 integration tests passed (74 total) |
+| Budget, egress, Proxy, capability, canonical API, hotspot guards | Covered by the 22 PR-static, 26 milestone, 4 phase, and 7 active dynamic modules; all passed |
+| RocksDB | 82 foundation and 9 semantics tests passed; Broker RocksDB and POP focused suites passed |
+| Loom | Runtime and Store concurrency suites passed |
+| Fuzz build | All configured nightly fuzz targets passed compilation |
+
+The earlier 11 Broker TaskGroup lifecycle failures are not accepted exceptions:
+the owner-cancellation repair is in this candidate, the complete all-features
+Broker suite passes with zero failures, and the Windows source-contract test now
+normalizes line endings before evaluating its multiline invariant.
+
+## Performance comparison
+
+The performance policy, sidecar schema, workload collector, environment binding,
+noise checks, zero-baseline classification, and comparison guard tests passed.
+The connection-soak sample below also records actual throughput, p99 latency, peak
+RSS, allocations, I/O amplification, and post-cooldown convergence.
+
+No completed baseline/candidate report from the dedicated target-hardware runner
+was available for this commit. Therefore this record makes no production
+throughput, latency, RSS, allocation, syscall, or I/O-regression claim. The full
+5-sample plus 2-priming-sample comparison remains deferred; its absence is not a
+code/system blocker and cannot be silently interpreted as a pass.
+
+## Key fault smoke
+
+| Scenario | Actual result | Invariant |
+|---|---:|---|
+| Broker HA epoch/ACK faults | 2/2 passed | Stale authority cannot acknowledge or publish state |
+| Store HA faults | 7/7 passed | Recovery preserves acknowledged offsets and rejects invalid state |
+| Controller snapshot restore | 5/5 passed | Snapshot/reopen restores committed state |
+| Controller storage faults | 7/7 passed | Failed persistence does not publish candidate memory state |
+| TieredStore shutdown race | 74-test suite passed | Accepted requests drain before operation cancellation |
+
+Each smoke owns its temporary state and cleanup. These deterministic fault tests
+exercise the production transition paths, but are not a substitute for complete
+node/cluster recreation or regional DR.
+
+## 30–60 minute stability
+
+Two back-to-back isolated production-parameter samples ran from
+`2026-08-01T19:53:04Z` through `2026-08-01T20:25:05Z`: 1,920.821 seconds,
+or 32.01 minutes. Each sample executed 50,000 mixed TLS connection operations,
+a 900-second workload window, and a 60-second cooldown, followed by healthy
+server/runtime shutdown.
+
+| Cycle | Elapsed | Throughput/s | p99 latency | Peak RSS | Allocations/op | I/O amplification | Post-cooldown state |
+|---|---:|---:|---:|---:|---:|---:|---|
+| 1 | 960.765 s | 55.555331 | 5,638.5 us | 62,234,624 B | 345.020280 | 1.266168 | tasks 0; pending 0; child groups 0; converged |
+| 2 | 960.056 s | 55.555368 | 12,828.5 us | 55,021,568 B | 345.022240 | 1.266168 | tasks 0; pending 0; child groups 0; converged |
+
+Both cycles reported zero data/server rejections, no panic or timeout, no
+retained per-operation child group, and complete resource convergence. The
+transport source tree is byte-equivalent between the sampled commit
+`77de8cb3549349671842722b61771f8778eb8460` and this candidate. The intervening
+changes are the SRE PostgreSQL test fixture fixed by PR #8898 and the Broker-only
+test normalization fixed by PR #8900. This 32-minute result is short
+stability evidence, not the deferred six-hour soak or a target-hardware
+baseline/candidate performance certification.
+
+## Basic restore smoke
+
+- Controller snapshot restore: 5/5 passed.
+- Store HA restart/recovery: 7/7 passed.
+- RocksDB reopen and persistence semantics: 82 foundation plus 9 semantics tests
+  passed.
+- TieredStore accepted-request drain, shutdown, and clean restart contracts: 74
+  tests passed.
+
+These results cover empty/local fixture startup, reopen/restore, read/write/query
+continuity, shutdown, cleanup, and restart. Cluster recreation, external backup or
+object-store restore, and regional disaster recovery remain deferred.
+
+## SRE/security contracts
+
+At the final candidate commit, the standalone SRE profile completed in 513.4
+seconds before the final test-fixture repair and then completed again against the
+final source tree in 353.0 seconds, both with exit code 0:
+
+- package-scoped `cargo fmt -- --check`;
+- `cargo check --locked --workspace`;
+- `cargo test --locked --workspace --all-features`;
+- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`;
+- `cargo doc --locked --workspace --no-deps`;
+- source-layout, execution-dependency, and read-gateway boundary guards;
+- `cargo audit --file Cargo.lock`.
+
+The CI-equivalent PostgreSQL 17 command also passed 270/270 tests after the
+supervised-execution fixture was bound to its required fleet tenant. The foreign
+key and production fail-closed behavior were not relaxed.
+
+The SRE audit reports zero vulnerabilities after upgrading `object_store`/`quick-xml`
+and SQLx and preserving fail-closed static SQL construction. The root audit also
+reports zero vulnerabilities; its only advisory is the already allowed unmaintained
+`proc-macro-error2` warning. Real commercial model providers, organization IdP, and
+production object storage were not exercised.
+
+## Known failures
+
+None in the accepted code/system scope. `known_failures` is therefore empty in the
+machine-readable record. Platform constraints and deferred production evidence are
+listed explicitly in their own sections rather than hidden as passes or failures.
+
+## Deferred V1 validation
+
+- dedicated target-hardware baseline/candidate performance comparison;
+- at least six hours of soak/chaos evidence;
+- complete node/cluster recreation, backup/restore, and disaster recovery;
+- Docker image build, scan, registry, digest, and deployment evidence;
+- real model Provider, organization IdP, and production object-store adapters;
+- formal upgrade and N-1 validation where it becomes release-relevant.
+
+No SHA-256 inventory, signature, image digest, promotion state, or complex rollback
+matrix is required by this code/system candidate.
+
+## Score evidence
+
+| Scoring evidence | Effect on assessment |
+|---|---|
+| Runtime/task ownership and bounded resource contracts are enforced in code and guards | Removes the principal Tokio lifecycle and unbounded-concurrency deductions |
+| Protocol, Store, Broker, Controller, TieredStore, Loom, and fuzz-focused evidence is green | Removes current code-correctness blockers |
+| Canonical APIs, capability ports, module/hotspot policy, and SRE gateway boundaries are enforced | Raises maintainability and extension readiness |
+| Root and SRE security audits report zero vulnerabilities | Removes the dependency-security blocker |
+| Production performance, six-hour soak, complete DR, images, and real adapters are deferred | Retains the gap from 93.5 to 95+ production readiness |
+
+Accordingly, this candidate is assessed at **93.5 / 100 for code and system
+architecture**, with no additional score awarded by this evidence-only PR. It is
+not a 95+ production-ready certification.
+
+## Command log
+
+| Scope | Command | Result |
+|---|---|---:|
+| Candidate identity | `git rev-parse HEAD`; `git status --porcelain` | Exact SHA; clean source |
+| Static architecture | `python scripts/run_architecture_tests.py --tier pr_static` | Exit 0, 22/22 |
+| Architecture contracts | `python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture` | Exit 0, 37/37 |
+| Root formatting fallback | `cargo fmt -p <each root member> -- --check` | Exit 0, 28/28 packages |
+| Root lint | `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` | Exit 0 |
+| Runtime | `.\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` | Exit 0 |
+| Errors | `.\\scripts\\check-error-hygiene.ps1` | Exit 0 |
+| Protocol | `cargo test -p rocketmq-protocol --all-features` | Exit 0 |
+| Broker | `cargo test -p rocketmq-broker --all-features` and focused component/HA suites | Exit 0; 810 passed, 0 failed, 6 ignored across the full suite |
+| Persistence faults | Focused Store, Controller, RocksDB, and TieredStore commands listed above | Exit 0 |
+| SRE full profile | Commands listed in SRE/security contracts | Exit 0, final SHA |
+| Dependency security | Root and SRE `cargo audit --file Cargo.lock` | Exit 0, zero vulnerabilities |
+| Short stability | Two isolated production-parameter `connection-soak/mixed-tls-churn` samples | See stability section |
+| PostgreSQL repositories | `cargo test --manifest-path rocketmq-sre/Cargo.toml --locked -p rocketmq-sre-control-plane -- --include-ignored` | Exit 0, 270/270 |
+| Candidate schema | `python scripts/architecture_candidate_guard.py --record rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json` | Exit 0 |
+
+Raw timed stability JSON is intentionally not committed and is retained under
+`target/architecture-candidate/33c35fae9/`; only an SRE test fixture and a
+Broker-only test normalization changed between that transport run and the final
+commit. The lightweight companion record is
+[2026-08-01-d88a97313.json](2026-08-01-d88a97313.json).

--- a/rocketmq-doc/en/architecture-production-readiness-runbook.md
+++ b/rocketmq-doc/en/architecture-production-readiness-runbook.md
@@ -210,6 +210,13 @@ known-failure list. It deliberately rejects SHA-256 inventories, image digests,
 signatures, and promotion state because those fields are meaningful only after
 real artifacts and a production-like environment exist.
 
+The latest accepted code/system record is
+[d88a973131ce4f57d01a65def8ecb7944a45ba21](architecture-candidates/2026-08-01-d88a97313.md),
+with its [machine-readable companion](architecture-candidates/2026-08-01-d88a97313.json).
+It records a `93.5 / 100` code/system assessment and is not production certification;
+the six-hour soak, target-hardware comparison, complete disaster recovery, Docker
+images, and real external adapters remain deferred V1 evidence.
+
 ```powershell
 python scripts/architecture_candidate_guard.py `
   --record scripts/tests/fixtures/architecture-candidate/pass.json

--- a/rocketmq-doc/en/architecture-release-evidence-index.md
+++ b/rocketmq-doc/en/architecture-release-evidence-index.md
@@ -44,6 +44,17 @@ commit SHA; this document does not claim that a scheduled or release run succeed
 | `rocketmq-tieredstore` | `rocketmq-tieredstore` |
 | `rocketmq-transport` | `rocketmq-transport` |
 
+## Accepted code/system candidate
+
+- Commit: `d88a973131ce4f57d01a65def8ecb7944a45ba21`.
+- Human-readable verification: [2026-08-01-d88a97313.md](architecture-candidates/2026-08-01-d88a97313.md).
+- Machine-readable verification: [2026-08-01-d88a97313.json](architecture-candidates/2026-08-01-d88a97313.json).
+- Code/system score: `93.5 / 100`.
+- Production certified: no.
+
+This acceptance covers the code/system phase. Target-hardware performance comparison, the six-hour
+soak, complete disaster recovery, Docker images, and real external adapters remain later V1 evidence.
+
 ## Current implementation baseline
 
 - Baseline ID: `architecture-implementation-2026-07-29-v1`.

--- a/scripts/architecture-validation-inventory.json
+++ b/scripts/architecture-validation-inventory.json
@@ -30,6 +30,13 @@
       "target/architecture-storage-matrix.json"
     ]
   },
+  "candidate_record": {
+    "commit": "d88a973131ce4f57d01a65def8ecb7944a45ba21",
+    "markdown": "rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.md",
+    "json": "rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json",
+    "code_system_score": "93.5 / 100",
+    "production_certified": false
+  },
   "root": {
     "owner": "RocketMQ Rust maintainers",
     "manifest": "Cargo.toml",

--- a/scripts/architecture_documentation_guard.py
+++ b/scripts/architecture_documentation_guard.py
@@ -266,6 +266,7 @@ def validate_schema(policy: dict[str, Any]) -> list[Finding]:
         "schema_version",
         "toolchains",
         "implementation_baseline",
+        "candidate_record",
         "root",
         "standalone",
         "node_projects",
@@ -284,6 +285,59 @@ def validate_schema(policy: dict[str, Any]) -> list[Finding]:
     standalone = policy.get("standalone", [])
     if not isinstance(standalone, list) or len(standalone) != 7:
         findings.append(Finding("standalone-count", normalized(POLICY_RELATIVE), "exactly seven Cargo roots required"))
+    return findings
+
+
+def validate_candidate_record(root: Path, policy: dict[str, Any]) -> list[Finding]:
+    record = policy.get("candidate_record")
+    expected_fields = {
+        "commit",
+        "markdown",
+        "json",
+        "code_system_score",
+        "production_certified",
+    }
+    if not isinstance(record, dict) or set(record) != expected_fields:
+        return [
+            Finding(
+                "candidate-record-schema",
+                normalized(POLICY_RELATIVE),
+                "unexpected candidate_record schema",
+            )
+        ]
+
+    findings: list[Finding] = []
+    if (
+        not isinstance(record["commit"], str)
+        or re.fullmatch(r"[0-9a-f]{40}", record["commit"]) is None
+    ):
+        findings.append(
+            Finding("candidate-record-commit", normalized(POLICY_RELATIVE), str(record["commit"]))
+        )
+    score = record["code_system_score"]
+    if (
+        not isinstance(score, str)
+        or re.fullmatch(r"(?:100(?:\.0)?|[0-9]{1,2}(?:\.[0-9])?) / 100", score) is None
+    ):
+        findings.append(
+            Finding("candidate-record-score", normalized(POLICY_RELATIVE), str(score))
+        )
+    if not isinstance(record["production_certified"], bool):
+        findings.append(
+            Finding(
+                "candidate-record-production",
+                normalized(POLICY_RELATIVE),
+                "production_certified must be a boolean",
+            )
+        )
+
+    for field in ("markdown", "json"):
+        if not isinstance(record[field], str) or not record[field]:
+            findings.append(Finding("candidate-record-path", normalized(POLICY_RELATIVE), field))
+            continue
+        path = Path(record[field])
+        if path.is_absolute() or ".." in path.parts or not (root / path).is_file():
+            findings.append(Finding("candidate-record-path", normalized(POLICY_RELATIVE), field))
     return findings
 
 
@@ -760,6 +814,23 @@ def render_document(policy: dict[str, Any], facts: Facts) -> str:
         "|---|---|",
     ]
     lines.extend(f"| `{package.name}` | `{package.path}` |" for package in facts.root_packages)
+    candidate = policy["candidate_record"]
+    production_status = "yes" if candidate["production_certified"] else "no"
+    lines.extend(
+        [
+            "",
+            "## Accepted code/system candidate",
+            "",
+            f"- Commit: `{candidate['commit']}`.",
+            f"- Human-readable verification: [{Path(candidate['markdown']).name}]({candidate['markdown'].removeprefix('rocketmq-doc/en/')}).",
+            f"- Machine-readable verification: [{Path(candidate['json']).name}]({candidate['json'].removeprefix('rocketmq-doc/en/')}).",
+            f"- Code/system score: `{candidate['code_system_score']}`.",
+            f"- Production certified: {production_status}.",
+            "",
+            "This acceptance covers the code/system phase. Target-hardware performance comparison, the six-hour",
+            "soak, complete disaster recovery, Docker images, and real external adapters remain later V1 evidence.",
+        ]
+    )
     baseline = policy["implementation_baseline"]
     lines.extend(
         [
@@ -906,6 +977,7 @@ def render_document(policy: dict[str, Any], facts: Facts) -> str:
 
 def validate(root: Path, policy: dict[str, Any], facts: Facts) -> list[Finding]:
     findings = validate_schema(policy)
+    findings.extend(validate_candidate_record(root, policy))
     findings.extend(validate_implementation_baseline(root, policy))
     findings.extend(validate_python_tests(root, policy))
     findings.extend(validate_toolchains(root, policy, facts))

--- a/scripts/tests/test_architecture_candidate_guard.py
+++ b/scripts/tests/test_architecture_candidate_guard.py
@@ -25,6 +25,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
 FIXTURE = SCRIPTS / "tests" / "fixtures" / "architecture-candidate" / "pass.json"
+ACCEPTED_RECORD = (
+    ROOT / "rocketmq-doc" / "en" / "architecture-candidates" / "2026-08-01-d88a97313.json"
+)
 sys.path.insert(0, str(SCRIPTS))
 
 import architecture_candidate_guard as guard  # noqa: E402
@@ -36,6 +39,12 @@ class ArchitectureCandidateGuardTests(unittest.TestCase):
 
     def test_lightweight_candidate_record_passes(self) -> None:
         self.assertEqual([], guard.validate(self.record))
+
+    def test_accepted_code_system_candidate_passes(self) -> None:
+        record = json.loads(ACCEPTED_RECORD.read_text(encoding="utf-8"))
+
+        self.assertEqual([], guard.validate(record))
+        self.assertEqual("d88a973131ce4f57d01a65def8ecb7944a45ba21", record["commit"])
 
     def test_required_candidate_fields_fail_closed(self) -> None:
         for field in ("commit", "environment", "checks", "known_failures"):

--- a/scripts/tests/test_architecture_documentation_guard.py
+++ b/scripts/tests/test_architecture_documentation_guard.py
@@ -146,6 +146,13 @@ tokio = { workspace = true, features = ["sync"] }
                 "commands": ["cargo metadata --format-version 1 --no-deps"],
                 "required_evidence": ["target/baseline.json"],
             },
+            "candidate_record": {
+                "commit": "d88a973131ce4f57d01a65def8ecb7944a45ba21",
+                "markdown": "rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.md",
+                "json": "rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json",
+                "code_system_score": "93.5 / 100",
+                "production_certified": False,
+            },
             "python_tests": {
                 "ci": {"guards": "guards", "contracts": "contracts"},
                 "entries": [],
@@ -181,6 +188,8 @@ tokio = { workspace = true, features = ["sync"] }
         self.assertEqual(first, second)
         self.assertIn("rocketmq-runtime", first)
         self.assertIn("architecture-implementation-2026-07-29-v1", first)
+        self.assertIn("d88a973131ce4f57d01a65def8ecb7944a45ba21", first)
+        self.assertIn("Production certified: no", first)
 
     def test_implementation_baseline_rejects_unversioned_id_and_unsafe_paths(self) -> None:
         policy = {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8896

### Brief Description

Publish the accepted architecture candidate record for code commit `d88a973131ce4f57d01a65def8ecb7944a45ba21` in paired Markdown and machine-readable JSON. Link that record from the generated evidence index and production-readiness runbook, and extend the documentation guard so the recorded commit, paths, score, and production-certification boundary are validated and rendered deterministically.

The record captures the final green code/system evidence, including the full Broker all-features suite with zero failures and two back-to-back 32.01-minute transport stability cycles. It explicitly leaves target-hardware performance comparison, the six-hour soak, complete disaster recovery, Docker images, and real external adapters as deferred V1 validation, so the accepted score remains `93.5 / 100` rather than claiming 95+ production readiness.

### How Did You Test This Change?

- `python scripts/architecture_candidate_guard.py --record rocketmq-doc/en/architecture-candidates/2026-08-01-d88a97313.json`
- `python -m unittest scripts.tests.test_architecture_candidate_guard scripts.tests.test_architecture_documentation_guard -v`
- `python scripts/architecture_documentation_guard.py --check`
- `python scripts/run_architecture_tests.py --tier pr_static`
- `.\scripts\check-agents-routing.ps1`
- `python -m py_compile scripts/architecture_documentation_guard.py`
- `git diff --check`

The candidate record also cites the complete validation evidence collected on the bound code candidate, including Protocol all-features, Broker all-features, error hygiene, runtime ownership, SRE PostgreSQL repositories, security audits, focused HA/restore suites, and short stability samples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the latest architecture candidate verification record, including a 93.5/100 assessment and evidence of passed validation checks.
  * Updated readiness guidance and release evidence to clearly identify the candidate as not production-certified.
  * Documented remaining validation requirements, including performance, soak, disaster recovery, container, and adapter testing.

* **Tests**
  * Added automated checks to ensure candidate records are complete, valid, and accurately represented in generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->