### PR TITLE
[ISSUE #8916]✨Track evidence-backed AI SRE implementation status

### DIFF
--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -1,0 +1,279 @@
+{
+  "schema_version": "rocketmq-sre.implementation-status.v1",
+  "status_definitions": [
+    "completed",
+    "partial",
+    "deferred",
+    "not_started"
+  ],
+  "maturity_definitions": [
+    "implemented",
+    "contract_tested",
+    "live_smoke_passed",
+    "production_certified"
+  ],
+  "evidence_requirement_baseline": {
+    "total": 69,
+    "required": 32,
+    "optional": 37,
+    "query": 18,
+    "not_production_verified": 51,
+    "required_query": 7,
+    "required_not_production_verified": 25,
+    "optional_query": 11,
+    "optional_not_production_verified": 26,
+    "source": "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs"
+  },
+  "capability_areas": [
+    {
+      "id": "workspace-foundation",
+      "status": "completed",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/Cargo.toml"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_source_layout.py"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_execution_dependency_boundary.py"
+        }
+      ],
+      "limitations": []
+    },
+    {
+      "id": "evidence-sources",
+      "status": "partial",
+      "target_outcome": "evidence-coverage",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/evidence/required-source-profiles.v1.yaml"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-connector/tests/read_gateway_contract.rs"
+        }
+      ],
+      "limitations": [
+        "Only 18 of 69 declared Evidence requirements have a production query route.",
+        "Twenty-five required Evidence requirements remain not production verified."
+      ]
+    },
+    {
+      "id": "diagnostic-packs",
+      "status": "partial",
+      "target_outcome": "evidence-coverage",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/catalog.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-core/tests/full_diagnostic_catalog.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-core/tests/diagnostic_replay.rs"
+        }
+      ],
+      "limitations": [
+        "Pack registration and deterministic replay are contract tested, but required Evidence is not yet fully production queryable.",
+        "Pack-level live fault and missing-source qualification is incomplete."
+      ]
+    },
+    {
+      "id": "operator-workspace",
+      "status": "partial",
+      "target_outcome": "production-readiness",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/ui/src/pages/EvidenceWorkbenchPage.tsx"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/ui/src/api/openapiContract.test.ts"
+        }
+      ],
+      "limitations": [
+        "Desktop operator flows are implemented, while production identity, scale, and handoff qualification remain incomplete."
+      ]
+    },
+    {
+      "id": "controlled-actions",
+      "status": "partial",
+      "target_outcome": "execution-qualification",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/action-implementation/implementation-plan.v1.yaml"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs"
+        },
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/dispatch_barrier.rs"
+        }
+      ],
+      "limitations": [
+        "Only explicitly registered bounded actions have implementations; production qualification is incomplete.",
+        "R3 operations and arbitrary requests remain permanently forbidden."
+      ]
+    },
+    {
+      "id": "bounded-autonomy",
+      "status": "partial",
+      "target_outcome": "execution-qualification",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/autonomy/defaults.yaml"
+        },
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/service.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs"
+        }
+      ],
+      "limitations": [
+        "Autonomy remains disabled by default and has not completed disposable-cluster production qualification.",
+        "Per-organization and per-cluster operational evidence is incomplete."
+      ]
+    },
+    {
+      "id": "enterprise-integrations",
+      "status": "partial",
+      "target_outcome": "enterprise-integrations",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/secret.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/vault_agent_file_secret.rs"
+        },
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/blob.rs"
+        }
+      ],
+      "limitations": [
+        "Adapters exist, but a representative enterprise identity, credential provider, object store, and observability backend are not live qualified."
+      ]
+    },
+    {
+      "id": "model-providers",
+      "status": "partial",
+      "target_outcome": "model-diagnosis",
+      "maturity": {
+        "implemented": true,
+        "contract_tested": true,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/http_transport.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/provider_contracts.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/live_provider_smoke.rs"
+        }
+      ],
+      "limitations": [
+        "Protocol adapters are contract tested without a real provider credential.",
+        "DeepSeek live qualification is intentionally deferred until all non-model readiness work is complete."
+      ]
+    },
+    {
+      "id": "production-qualification",
+      "status": "not_started",
+      "target_outcome": "production-readiness",
+      "maturity": {
+        "implemented": false,
+        "contract_tested": false,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [],
+      "reason": "Current and previous-version binaries, multi-region recovery, sustained load, soak, and independent handoff evidence have not been completed.",
+      "limitations": []
+    },
+    {
+      "id": "ai-assisted-diagnosis",
+      "status": "deferred",
+      "target_outcome": "model-diagnosis",
+      "maturity": {
+        "implemented": false,
+        "contract_tested": false,
+        "live_smoke_passed": false,
+        "production_certified": false
+      },
+      "evidence": [],
+      "reason": "DeepSeek credential intake and AI-assisted diagnosis are intentionally last, after Evidence, enterprise integration, execution-boundary, and production-readiness qualification.",
+      "limitations": []
+    }
+  ]
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs
@@ -425,13 +425,29 @@ mod tests {
         let registry = full_registry().expect("complete built-in registry");
         let mut pack_ids = BTreeSet::new();
         let mut requirement_count = 0;
+        let mut required_count = 0;
+        let mut optional_count = 0;
         let mut query_count = 0;
         let mut unsupported_count = 0;
+        let mut required_query_count = 0;
+        let mut required_unsupported_count = 0;
+        let mut optional_query_count = 0;
+        let mut optional_unsupported_count = 0;
 
         for pack in registry.active_packs() {
             pack_ids.insert(pack.qualified_id());
-            for requirement in pack.required_evidence().iter().chain(pack.optional_evidence()) {
+            for (requirement, required) in pack
+                .required_evidence()
+                .iter()
+                .map(|requirement| (requirement, true))
+                .chain(pack.optional_evidence().iter().map(|requirement| (requirement, false)))
+            {
                 requirement_count += 1;
+                if required {
+                    required_count += 1;
+                } else {
+                    optional_count += 1;
+                }
                 let resource = example_resource(requirement);
                 let source = normalize_source(requirement.source).expect("registered pack source");
                 let route = resolve(source, &resource).unwrap_or_else(|| {
@@ -441,10 +457,22 @@ mod tests {
                     )
                 });
                 match route {
-                    CanonicalResourceRoute::Query { .. } => query_count += 1,
+                    CanonicalResourceRoute::Query { .. } => {
+                        query_count += 1;
+                        if required {
+                            required_query_count += 1;
+                        } else {
+                            optional_query_count += 1;
+                        }
+                    }
                     CanonicalResourceRoute::NotProductionVerified { reason_code } => {
                         assert!(!reason_code.is_empty());
                         unsupported_count += 1;
+                        if required {
+                            required_unsupported_count += 1;
+                        } else {
+                            optional_unsupported_count += 1;
+                        }
                     }
                 }
             }
@@ -452,8 +480,14 @@ mod tests {
 
         assert_eq!(pack_ids, full_pack_ids().into_iter().collect());
         assert_eq!(requirement_count, 69);
+        assert_eq!(required_count, 32);
+        assert_eq!(optional_count, 37);
         assert_eq!(query_count, 18);
         assert_eq!(unsupported_count, 51);
+        assert_eq!(required_query_count, 7);
+        assert_eq!(required_unsupported_count, 25);
+        assert_eq!(optional_query_count, 11);
+        assert_eq!(optional_unsupported_count, 26);
     }
 
     #[test]

--- a/rocketmq-sre/scripts/check_implementation_status.py
+++ b/rocketmq-sre/scripts/check_implementation_status.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the evidence-backed AI SRE implementation status baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = (
+    REPOSITORY_ROOT
+    / "rocketmq-sre"
+    / "config"
+    / "implementation"
+    / "implementation-status.v1.json"
+)
+EXPECTED_SCHEMA = "rocketmq-sre.implementation-status.v1"
+EXPECTED_STATUSES = ("completed", "partial", "deferred", "not_started")
+EXPECTED_MATURITY = (
+    "implemented",
+    "contract_tested",
+    "live_smoke_passed",
+    "production_certified",
+)
+EXPECTED_EVIDENCE_KINDS = {"configuration", "source", "test", "smoke"}
+BASELINE_ASSERTIONS = {
+    "total": "requirement_count",
+    "required": "required_count",
+    "optional": "optional_count",
+    "query": "query_count",
+    "not_production_verified": "unsupported_count",
+    "required_query": "required_query_count",
+    "required_not_production_verified": "required_unsupported_count",
+    "optional_query": "optional_query_count",
+    "optional_not_production_verified": "optional_unsupported_count",
+}
+LOCAL_PATH = re.compile(r"(?:^[A-Za-z]:[\\/]|^/(?:home|Users|tmp)/)")
+SENSITIVE_VALUE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError("manifest root must be an object")
+    return value
+
+
+def _all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for key, child in value.items():
+            strings.extend(_all_strings(key))
+            strings.extend(_all_strings(child))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for child in value:
+            strings.extend(_all_strings(child))
+        return strings
+    return []
+
+
+def _validate_evidence_path(path_value: Any, repository_root: Path) -> list[str]:
+    if not isinstance(path_value, str) or not path_value:
+        return ["evidence path must be a non-empty string"]
+    path = PurePosixPath(path_value)
+    findings: list[str] = []
+    if path.is_absolute() or ".." in path.parts or LOCAL_PATH.search(path_value):
+        findings.append(f"evidence path must be repository-relative: {path_value}")
+        return findings
+    if "docs" in path.parts:
+        findings.append(f"documentation is not accepted as implementation evidence: {path_value}")
+    if not (repository_root / Path(*path.parts)).exists():
+        findings.append(f"evidence path does not exist: {path_value}")
+    return findings
+
+
+def _source_assertions(path: Path) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8")
+    return {
+        name: int(value)
+        for name, value in re.findall(r"assert_eq!\((\w+),\s*(\d+)\);", text)
+    }
+
+
+def validate_manifest(manifest: dict[str, Any], repository_root: Path) -> list[str]:
+    findings: list[str] = []
+    if manifest.get("schema_version") != EXPECTED_SCHEMA:
+        findings.append(f"schema_version must be {EXPECTED_SCHEMA}")
+    if manifest.get("status_definitions") != list(EXPECTED_STATUSES):
+        findings.append("status_definitions must use the canonical ordered vocabulary")
+    if manifest.get("maturity_definitions") != list(EXPECTED_MATURITY):
+        findings.append("maturity_definitions must use the canonical ordered vocabulary")
+
+    for value in _all_strings(manifest):
+        if SENSITIVE_VALUE.search(value):
+            findings.append("manifest contains a credential-like value")
+        if LOCAL_PATH.search(value):
+            findings.append("manifest contains a machine-local filesystem path")
+
+    baseline = manifest.get("evidence_requirement_baseline")
+    if not isinstance(baseline, dict):
+        findings.append("evidence_requirement_baseline must be an object")
+    else:
+        numeric_values = {key: baseline.get(key) for key in BASELINE_ASSERTIONS}
+        if not all(isinstance(value, int) and value >= 0 for value in numeric_values.values()):
+            findings.append("all Evidence baseline counts must be non-negative integers")
+        else:
+            if baseline["total"] != baseline["required"] + baseline["optional"]:
+                findings.append("Evidence total must equal required plus optional")
+            if baseline["total"] != baseline["query"] + baseline["not_production_verified"]:
+                findings.append("Evidence total must equal query plus not_production_verified")
+            if baseline["required"] != (
+                baseline["required_query"] + baseline["required_not_production_verified"]
+            ):
+                findings.append("required Evidence counts are inconsistent")
+            if baseline["optional"] != (
+                baseline["optional_query"] + baseline["optional_not_production_verified"]
+            ):
+                findings.append("optional Evidence counts are inconsistent")
+
+        source = baseline.get("source")
+        source_findings = _validate_evidence_path(source, repository_root)
+        findings.extend(source_findings)
+        if not source_findings:
+            assertions = _source_assertions(repository_root / Path(*PurePosixPath(source).parts))
+            for field, assertion in BASELINE_ASSERTIONS.items():
+                if assertions.get(assertion) != baseline.get(field):
+                    findings.append(
+                        f"Evidence baseline {field} does not match {assertion} in {source}"
+                    )
+
+    areas = manifest.get("capability_areas")
+    if not isinstance(areas, list) or not areas:
+        findings.append("capability_areas must be a non-empty array")
+        return findings
+
+    seen_ids: set[str] = set()
+    for index, area in enumerate(areas):
+        location = f"capability_areas[{index}]"
+        if not isinstance(area, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        area_id = area.get("id")
+        if not isinstance(area_id, str) or not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", area_id):
+            findings.append(f"{location}.id must be a stable kebab-case identifier")
+        elif area_id in seen_ids:
+            findings.append(f"duplicate capability id: {area_id}")
+        else:
+            seen_ids.add(area_id)
+
+        status = area.get("status")
+        if status not in EXPECTED_STATUSES:
+            findings.append(f"{location}.status is not recognized")
+
+        maturity = area.get("maturity")
+        if not isinstance(maturity, dict) or tuple(maturity) != EXPECTED_MATURITY:
+            findings.append(f"{location}.maturity must contain the ordered canonical levels")
+        elif not all(isinstance(maturity[level], bool) for level in EXPECTED_MATURITY):
+            findings.append(f"{location}.maturity values must be booleans")
+        else:
+            reached_false = False
+            for level in EXPECTED_MATURITY:
+                reached_false = reached_false or not maturity[level]
+                if reached_false and maturity[level]:
+                    findings.append(f"{location}.maturity cannot skip a lower level")
+                    break
+
+        evidence = area.get("evidence")
+        if not isinstance(evidence, list):
+            findings.append(f"{location}.evidence must be an array")
+            evidence = []
+        for evidence_index, item in enumerate(evidence):
+            evidence_location = f"{location}.evidence[{evidence_index}]"
+            if not isinstance(item, dict):
+                findings.append(f"{evidence_location} must be an object")
+                continue
+            if item.get("kind") not in EXPECTED_EVIDENCE_KINDS:
+                findings.append(f"{evidence_location}.kind is not recognized")
+            findings.extend(_validate_evidence_path(item.get("path"), repository_root))
+
+        if status in {"completed", "partial"} and not evidence:
+            findings.append(f"{location} requires implementation evidence")
+        if status == "partial" and not area.get("limitations"):
+            findings.append(f"{location} requires explicit limitations")
+        if status in {"deferred", "not_started"} and not area.get("reason"):
+            findings.append(f"{location} requires an explicit reason")
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", nargs="?", type=Path, default=DEFAULT_MANIFEST)
+    args = parser.parse_args()
+
+    try:
+        manifest = load_manifest(args.manifest)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"IMPLEMENTATION_STATUS_FAILED unable_to_load={error}")
+        return 1
+
+    findings = validate_manifest(manifest, REPOSITORY_ROOT)
+    if findings:
+        for finding in findings:
+            print(f"IMPLEMENTATION_STATUS_FINDING {finding}")
+        print(f"IMPLEMENTATION_STATUS_FAILED findings={len(findings)}")
+        return 1
+
+    print(
+        "IMPLEMENTATION_STATUS_OK "
+        f"capability_areas={len(manifest['capability_areas'])} "
+        f"evidence_requirements={manifest['evidence_requirement_baseline']['total']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/tests/test_check_implementation_status.py
+++ b/rocketmq-sre/scripts/tests/test_check_implementation_status.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the AI SRE implementation status validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_implementation_status.py"
+SPEC = importlib.util.spec_from_file_location("check_implementation_status", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ImplementationStatusTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_manifest(MODULE.DEFAULT_MANIFEST)
+
+    def test_checked_in_manifest_is_valid(self) -> None:
+        self.assertEqual(
+            MODULE.validate_manifest(self.manifest, MODULE.REPOSITORY_ROOT),
+            [],
+        )
+
+    def test_rejects_completed_area_without_evidence(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["capability_areas"][0]["evidence"] = []
+
+        findings = MODULE.validate_manifest(manifest, MODULE.REPOSITORY_ROOT)
+
+        self.assertIn("capability_areas[0] requires implementation evidence", findings)
+
+    def test_rejects_skipped_maturity_level(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        maturity = manifest["capability_areas"][0]["maturity"]
+        maturity["contract_tested"] = False
+        maturity["live_smoke_passed"] = True
+
+        findings = MODULE.validate_manifest(manifest, MODULE.REPOSITORY_ROOT)
+
+        self.assertIn("capability_areas[0].maturity cannot skip a lower level", findings)
+
+    def test_rejects_credential_like_value(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["capability_areas"][0]["limitations"] = ["Bearer unsafe-example-token"]
+
+        findings = MODULE.validate_manifest(manifest, MODULE.REPOSITORY_ROOT)
+
+        self.assertIn("manifest contains a credential-like value", findings)
+
+    def test_rejects_local_or_documentation_evidence(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["capability_areas"][0]["evidence"] = [
+            {"kind": "test", "path": "C:/workspace/result.txt"},
+            {"kind": "test", "path": "rocketmq-sre/docs/compatibility.md"},
+        ]
+
+        findings = MODULE.validate_manifest(manifest, MODULE.REPOSITORY_ROOT)
+
+        self.assertTrue(any("repository-relative" in finding for finding in findings))
+        self.assertTrue(any("not accepted" in finding for finding in findings))
+
+    def test_rejects_evidence_baseline_drift(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["evidence_requirement_baseline"]["query"] = 17
+        manifest["evidence_requirement_baseline"]["not_production_verified"] = 52
+
+        findings = MODULE.validate_manifest(manifest, MODULE.REPOSITORY_ROOT)
+
+        self.assertTrue(any("query does not match query_count" in finding for finding in findings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8916

### Brief Description

Adds a machine-readable AI SRE implementation status baseline covering ten capability areas and the current Evidence requirement coverage. The new standard-library validator rejects unknown status or maturity values, missing implementation evidence, baseline drift, documentation-only evidence, local filesystem paths, and credential-like values.

The canonical Connector registry test now distinguishes required and optional Evidence query coverage. The checked-in baseline records 69 requirements: 32 required and 37 optional, with 18 queryable and 51 explicitly not production verified. DeepSeek live qualification and AI-assisted diagnosis remain deferred, and this change does not add model calls or mutation authority.

### How Did You Test This Change?

- `python -B rocketmq-sre/scripts/check_implementation_status.py`
- `python -B -m unittest discover -s rocketmq-sre/scripts/tests -p 'test_check_implementation_status.py' -v`
- `python -B rocketmq-sre/scripts/check_source_layout.py`
- `python -B rocketmq-sre/scripts/check_execution_dependency_boundary.py`
- `python -B rocketmq-sre/scripts/check_read_gateway_boundary.py`
- `cargo fmt --manifest-path rocketmq-sre/Cargo.toml -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace`
- `cargo test --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-features`
- `cargo clippy --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --no-deps`
- `git diff --check`

All commands completed successfully. Tests requiring an explicitly configured PostgreSQL database or live model-provider credential remained ignored by their existing opt-in design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an implementation status manifest covering maturity levels, evidence coverage, limitations, and readiness across nine capability areas.
  * Added validation that checks status records, evidence references, maturity progression, sensitive values, and baseline counts.

* **Tests**
  * Added coverage for valid manifests, missing or invalid evidence, skipped maturity levels, credential-like values, and baseline drift.
  * Strengthened evidence contract checks with separate required and optional evidence counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->