### PR TITLE
[ISSUE #8918]🐛Make AI SRE deployment validation self-contained

### DIFF
--- a/.github/workflows/rocketmq-sre-ci.yml
+++ b/.github/workflows/rocketmq-sre-ci.yml
@@ -146,9 +146,9 @@ jobs:
             -p rocketmq-sre-executor --test fencing_interleavings \
             -- --ignored --test-threads=1
 
-      - name: Validate Compose and Kind deployment contracts
+      - name: Test and validate Compose and Kind deployment contracts
         shell: pwsh
-        run: ./rocketmq-sre/scripts/verify-mtls-deployment.ps1
+        run: ./rocketmq-sre/scripts/test-mtls-deployment-fixture-lifecycle.ps1
 
       - name: Clippy
         run: cargo clippy --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-targets --all-features -- -D warnings

--- a/rocketmq-sre/scripts/test-mtls-deployment-fixture-lifecycle.ps1
+++ b/rocketmq-sre/scripts/test-mtls-deployment-fixture-lifecycle.ps1
@@ -1,0 +1,103 @@
+# Copyright 2023 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$targetDirectory = [IO.Path]::GetFullPath((Join-Path $repositoryRoot 'target'))
+$fixtureDirectory = [IO.Path]::GetFullPath((Join-Path $targetDirectory 'phase00-certs'))
+$composeDirectory = Join-Path $sreRoot 'deploy/dev'
+$composeFile = Join-Path $composeDirectory 'compose.yaml'
+$validator = Join-Path $scriptDirectory 'verify-mtls-deployment.ps1'
+$preservedFixture = Join-Path $fixtureDirectory 'admin-read.env'
+$preservedContent = @(
+    'ROCKETMQ_SRE_ADMIN_ACCESS_KEY=preserved-validation-only-denied'
+    'ROCKETMQ_SRE_ADMIN_SECRET_KEY=preserved-validation-only-denied'
+    ''
+) -join "`n"
+$transientFixtures = @('agent-broker.env', 'probe.env', 'bootstrap.env')
+$fixtureDirectoryCreated = $false
+$preservedFixtureCreated = $false
+
+function Require-Command([string]$Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found."
+    }
+}
+
+function Assert-FixtureDirectoryBoundary {
+    $targetPrefix = $targetDirectory + [IO.Path]::DirectorySeparatorChar
+    if (-not $fixtureDirectory.StartsWith($targetPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Test fixture output escaped the repository target directory.'
+    }
+}
+
+Assert-FixtureDirectoryBoundary
+Require-Command docker
+
+if (Test-Path -LiteralPath $fixtureDirectory) {
+    throw "Fixture lifecycle test requires a clean directory: $fixtureDirectory"
+}
+
+try {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & docker @(
+            'compose',
+            '--project-directory', $composeDirectory,
+            '--file', $composeFile,
+            '--profile', 'observability',
+            'config', '--quiet'
+        ) *> $null
+        $bareComposeExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($bareComposeExitCode -eq 0) {
+        throw 'Bare Compose validation unexpectedly succeeded without required env fixtures.'
+    }
+
+    & $validator
+    if ($LASTEXITCODE -ne 0) {
+        throw "Self-contained deployment validation failed with exit code $LASTEXITCODE."
+    }
+    if (Test-Path -LiteralPath $fixtureDirectory) {
+        throw 'Self-contained deployment validation did not remove its temporary directory.'
+    }
+
+    New-Item -ItemType Directory -Path $fixtureDirectory | Out-Null
+    $fixtureDirectoryCreated = $true
+    [IO.File]::WriteAllText($preservedFixture, $preservedContent, [Text.UTF8Encoding]::new($false))
+    $preservedFixtureCreated = $true
+
+    & $validator
+    if ($LASTEXITCODE -ne 0) {
+        throw "Deployment validation with a preserved fixture failed with exit code $LASTEXITCODE."
+    }
+    if ([IO.File]::ReadAllText($preservedFixture) -cne $preservedContent) {
+        throw 'Deployment validation changed a pre-existing fixture.'
+    }
+    foreach ($fixture in $transientFixtures) {
+        if (Test-Path -LiteralPath (Join-Path $fixtureDirectory $fixture)) {
+            throw "Deployment validation retained a transient fixture: $fixture"
+        }
+    }
+}
+finally {
+    if ($preservedFixtureCreated -and (Test-Path -LiteralPath $preservedFixture -PathType Leaf)) {
+        Remove-Item -LiteralPath $preservedFixture -Force
+    }
+    if ($fixtureDirectoryCreated -and
+        (Test-Path -LiteralPath $fixtureDirectory -PathType Container) -and
+        -not (Get-ChildItem -LiteralPath $fixtureDirectory -Force | Select-Object -First 1)) {
+        Remove-Item -LiteralPath $fixtureDirectory -Force
+    }
+}
+
+Write-Host 'Deployment validation fixture lifecycle is correct.'

--- a/rocketmq-sre/scripts/verify-mtls-deployment.ps1
+++ b/rocketmq-sre/scripts/verify-mtls-deployment.ps1
@@ -13,8 +13,33 @@ $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
 $composeDirectory = Join-Path $sreRoot 'deploy/dev'
 $composeFile = Join-Path $composeDirectory 'compose.yaml'
 $kindDirectory = Join-Path $sreRoot 'deploy/kind'
-$certificateDirectory = Join-Path $repositoryRoot 'target/phase00-certs'
+$targetDirectory = [IO.Path]::GetFullPath((Join-Path $repositoryRoot 'target'))
+$certificateDirectory = [IO.Path]::GetFullPath((Join-Path $targetDirectory 'phase00-certs'))
 $opensslImage = 'alpine/openssl:3.5.2@sha256:ef8657028239a006f3de0bd04529e22c073bf0ab6655ece9f25c8dde9adec146'
+$validationEnvironmentFixtures = [ordered]@{
+    'admin-read.env' = @(
+        'ROCKETMQ_SRE_ADMIN_ACCESS_KEY=validation-only-denied'
+        'ROCKETMQ_SRE_ADMIN_SECRET_KEY=validation-only-denied'
+        ''
+    ) -join "`n"
+    'agent-broker.env' = @(
+        'ROCKETMQ_SRE_AGENT_BROKER_READ_ACCESS_KEY=validation-only-denied'
+        'ROCKETMQ_SRE_AGENT_BROKER_READ_SECRET_KEY=validation-only-denied'
+        'ROCKETMQ_SRE_AGENT_BROKER_MUTATION_ACCESS_KEY=validation-only-denied'
+        'ROCKETMQ_SRE_AGENT_BROKER_MUTATION_SECRET_KEY=validation-only-denied'
+        ''
+    ) -join "`n"
+    'probe.env' = @(
+        'ROCKETMQ_SRE_PROBE_ACCESS_KEY=validation-only-denied'
+        'ROCKETMQ_SRE_PROBE_SECRET_KEY_FILE=/validation-only/missing'
+        ''
+    ) -join "`n"
+    'bootstrap.env' = @(
+        'ROCKETMQ_ACL_ACCESS_KEY=validation-only-denied'
+        'ROCKETMQ_ACL_SECRET_KEY=validation-only-denied'
+        ''
+    ) -join "`n"
+}
 
 function Require-Command([string]$Name) {
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -45,6 +70,67 @@ function Assert-NotContains([string]$Path, [string]$Pattern, [string]$Descriptio
     $content = Get-Content -Raw -LiteralPath $Path
     if ($content -match $Pattern) {
         throw "$Description is forbidden in $Path."
+    }
+}
+
+function New-ValidationEnvironmentFixtureScope {
+    $targetPrefix = $targetDirectory + [IO.Path]::DirectorySeparatorChar
+    if (-not $certificateDirectory.StartsWith($targetPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Validation fixture output escaped the repository target directory.'
+    }
+
+    $directoryCreated = $false
+    if (-not (Test-Path -LiteralPath $certificateDirectory)) {
+        New-Item -ItemType Directory -Path $certificateDirectory | Out-Null
+        $directoryCreated = $true
+    }
+    elseif (-not (Test-Path -LiteralPath $certificateDirectory -PathType Container)) {
+        throw "Validation fixture directory is not a directory: $certificateDirectory"
+    }
+
+    $createdFiles = [Collections.Generic.List[string]]::new()
+    try {
+        foreach ($fixture in $validationEnvironmentFixtures.GetEnumerator()) {
+            $path = Join-Path $certificateDirectory $fixture.Key
+            if (Test-Path -LiteralPath $path) {
+                if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+                    throw "Validation fixture path is not a file: $path"
+                }
+                continue
+            }
+            [IO.File]::WriteAllText($path, $fixture.Value, [Text.UTF8Encoding]::new($false))
+            $createdFiles.Add($path)
+        }
+    }
+    catch {
+        foreach ($path in $createdFiles) {
+            if (Test-Path -LiteralPath $path -PathType Leaf) {
+                Remove-Item -LiteralPath $path -Force
+            }
+        }
+        if ($directoryCreated -and
+            -not (Get-ChildItem -LiteralPath $certificateDirectory -Force | Select-Object -First 1)) {
+            Remove-Item -LiteralPath $certificateDirectory -Force
+        }
+        throw
+    }
+
+    [pscustomobject]@{
+        CreatedFiles = $createdFiles
+        DirectoryCreated = $directoryCreated
+    }
+}
+
+function Remove-ValidationEnvironmentFixtureScope([pscustomobject]$Scope) {
+    foreach ($path in $Scope.CreatedFiles) {
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            Remove-Item -LiteralPath $path -Force
+        }
+    }
+    if ($Scope.DirectoryCreated -and
+        (Test-Path -LiteralPath $certificateDirectory -PathType Container) -and
+        -not (Get-ChildItem -LiteralPath $certificateDirectory -Force | Select-Object -First 1)) {
+        Remove-Item -LiteralPath $certificateDirectory -Force
     }
 }
 
@@ -145,92 +231,102 @@ if ($connectorContainer -match '(?m)^\s*-\s+\{?name:\s*runtime-secrets(?:,|\})')
     throw 'Kind Connector container must not mount the MCP runtime Secret.'
 }
 
-Require-Command docker
-Invoke-Native docker @(
-    'compose',
-    '--project-directory', $composeDirectory,
-    '--file', $composeFile,
-    '--profile', 'observability',
-    'config', '--quiet'
-)
+$validationFixtureScope = $null
+try {
+    $validationFixtureScope = New-ValidationEnvironmentFixtureScope
 
-Require-Command kubectl
-$renderedKind = & kubectl kustomize $kindDirectory
-if ($LASTEXITCODE -ne 0) {
-    throw "kubectl kustomize failed with exit code $LASTEXITCODE."
-}
-$renderedText = $renderedKind -join "`n"
-foreach ($requiredRender in @(
-    'name: sre-control-plane-mtls-proxy',
-    'name: connector-mtls-proxy',
-    'name: rocketmq-sre-control-plane-channel-server',
-    'name: rocketmq-sre-connector',
-    'name: rocketmq-sre-connector-read',
-    'name: rocketmq-sre-connector-node-read',
-    'name: sre-executor',
-    'name: sre-execution-agent',
-    'name: sre-executor-isolation',
-    'name: sre-execution-agent-isolation',
-    'port: 8444',
-    'kind: NetworkPolicy'
-)) {
-    if ($renderedText -notmatch [regex]::Escape($requiredRender)) {
-        throw "Rendered Kind assets do not contain '$requiredRender'."
+    Require-Command docker
+    Invoke-Native docker @(
+        'compose',
+        '--project-directory', $composeDirectory,
+        '--file', $composeFile,
+        '--profile', 'observability',
+        'config', '--quiet'
+    )
+
+    Require-Command kubectl
+    $renderedKind = & kubectl kustomize $kindDirectory
+    if ($LASTEXITCODE -ne 0) {
+        throw "kubectl kustomize failed with exit code $LASTEXITCODE."
     }
-}
-
-if ($CheckCertificates) {
-    $requiredCertificates = @(
-        'control-plane-server-ca-cert.pem',
-        'control-plane-server-cert.pem',
-        'connector-client-ca-cert.pem',
-        'connector-client-cert.pem',
-        'connector-client-identity.pem'
-    )
-    $missing = @(
-        $requiredCertificates |
-            Where-Object { -not (Test-Path -LiteralPath (Join-Path $certificateDirectory $_) -PathType Leaf) }
-    )
-    if ($missing.Count -gt 0) {
-        throw "Generated mTLS material is incomplete: $($missing -join ', '). Run dev.ps1 -Action Certs."
+    $renderedText = $renderedKind -join "`n"
+    foreach ($requiredRender in @(
+        'name: sre-control-plane-mtls-proxy',
+        'name: connector-mtls-proxy',
+        'name: rocketmq-sre-control-plane-channel-server',
+        'name: rocketmq-sre-connector',
+        'name: rocketmq-sre-connector-read',
+        'name: rocketmq-sre-connector-node-read',
+        'name: sre-executor',
+        'name: sre-execution-agent',
+        'name: sre-executor-isolation',
+        'name: sre-execution-agent-isolation',
+        'port: 8444',
+        'kind: NetworkPolicy'
+    )) {
+        if ($renderedText -notmatch [regex]::Escape($requiredRender)) {
+            throw "Rendered Kind assets do not contain '$requiredRender'."
+        }
     }
 
-    $mount = "${certificateDirectory}:/certs:ro"
-    Invoke-Native docker @(
-        'run', '--rm', '--volume', $mount, $opensslImage,
-        'verify', '-CAfile', '/certs/control-plane-server-ca-cert.pem',
-        '-purpose', 'sslserver', '/certs/control-plane-server-cert.pem'
-    )
-    Invoke-Native docker @(
-        'run', '--rm', '--volume', $mount, $opensslImage,
-        'verify', '-CAfile', '/certs/connector-client-ca-cert.pem',
-        '-purpose', 'sslclient', '/certs/connector-client-cert.pem'
-    )
-    Invoke-Native docker @(
-        'run', '--rm', '--volume', $mount, $opensslImage,
-        'x509', '-in', '/certs/control-plane-server-cert.pem',
-        '-noout', '-checkhost', 'sre-control-plane.rocketmq-sre.svc.cluster.local'
-    )
-    Invoke-Native docker @(
-        'run', '--rm', '--volume', $mount, $opensslImage,
-        'pkey', '-in', '/certs/connector-client-identity.pem', '-check', '-noout'
-    )
-    foreach ($proxyConfig in @($composeProxy, $kindProxy)) {
-        Invoke-Native docker @(
-            'run', '--rm',
-            '--user', '10001:10001',
-            '--read-only',
-            '--tmpfs', '/tmp:size=16m,mode=1777',
-            '--cap-drop', 'ALL',
-            '--security-opt', 'no-new-privileges:true',
-            '--volume', "${proxyConfig}:/etc/nginx/nginx.conf:ro",
-            '--volume', "$(Join-Path $certificateDirectory 'control-plane-server-cert.pem'):/etc/rocketmq/sre-channel/control-plane-server-cert.pem:ro",
-            '--volume', "$(Join-Path $certificateDirectory 'control-plane-server-key.pem'):/etc/rocketmq/sre-channel/control-plane-server-key.pem:ro",
-            '--volume', "$(Join-Path $certificateDirectory 'connector-client-ca-cert.pem'):/etc/rocketmq/sre-channel/connector-client-ca-cert.pem:ro",
-            '--entrypoint', 'nginx',
-            'nginx:1.29-alpine',
-            '-t', '-c', '/etc/nginx/nginx.conf'
+    if ($CheckCertificates) {
+        $requiredCertificates = @(
+            'control-plane-server-ca-cert.pem',
+            'control-plane-server-cert.pem',
+            'connector-client-ca-cert.pem',
+            'connector-client-cert.pem',
+            'connector-client-identity.pem'
         )
+        $missing = @(
+            $requiredCertificates |
+                Where-Object { -not (Test-Path -LiteralPath (Join-Path $certificateDirectory $_) -PathType Leaf) }
+        )
+        if ($missing.Count -gt 0) {
+            throw "Generated mTLS material is incomplete: $($missing -join ', '). Run dev.ps1 -Action Certs."
+        }
+
+        $mount = "${certificateDirectory}:/certs:ro"
+        Invoke-Native docker @(
+            'run', '--rm', '--volume', $mount, $opensslImage,
+            'verify', '-CAfile', '/certs/control-plane-server-ca-cert.pem',
+            '-purpose', 'sslserver', '/certs/control-plane-server-cert.pem'
+        )
+        Invoke-Native docker @(
+            'run', '--rm', '--volume', $mount, $opensslImage,
+            'verify', '-CAfile', '/certs/connector-client-ca-cert.pem',
+            '-purpose', 'sslclient', '/certs/connector-client-cert.pem'
+        )
+        Invoke-Native docker @(
+            'run', '--rm', '--volume', $mount, $opensslImage,
+            'x509', '-in', '/certs/control-plane-server-cert.pem',
+            '-noout', '-checkhost', 'sre-control-plane.rocketmq-sre.svc.cluster.local'
+        )
+        Invoke-Native docker @(
+            'run', '--rm', '--volume', $mount, $opensslImage,
+            'pkey', '-in', '/certs/connector-client-identity.pem', '-check', '-noout'
+        )
+        foreach ($proxyConfig in @($composeProxy, $kindProxy)) {
+            Invoke-Native docker @(
+                'run', '--rm',
+                '--user', '10001:10001',
+                '--read-only',
+                '--tmpfs', '/tmp:size=16m,mode=1777',
+                '--cap-drop', 'ALL',
+                '--security-opt', 'no-new-privileges:true',
+                '--volume', "${proxyConfig}:/etc/nginx/nginx.conf:ro",
+                '--volume', "$(Join-Path $certificateDirectory 'control-plane-server-cert.pem'):/etc/rocketmq/sre-channel/control-plane-server-cert.pem:ro",
+                '--volume', "$(Join-Path $certificateDirectory 'control-plane-server-key.pem'):/etc/rocketmq/sre-channel/control-plane-server-key.pem:ro",
+                '--volume', "$(Join-Path $certificateDirectory 'connector-client-ca-cert.pem'):/etc/rocketmq/sre-channel/connector-client-ca-cert.pem:ro",
+                '--entrypoint', 'nginx',
+                'nginx:1.29-alpine',
+                '-t', '-c', '/etc/nginx/nginx.conf'
+            )
+        }
+    }
+}
+finally {
+    if ($null -ne $validationFixtureScope) {
+        Remove-ValidationEnvironmentFixtureScope $validationFixtureScope
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8918

### Brief Description

Makes the AI SRE Compose and Kind deployment contract self-contained on clean runners. Static validation now creates bounded, validation-only versions of the four required Compose environment files under the ignored target directory, preserves every pre-existing fixture, and removes only files created by the current invocation in a `finally` block.

Adds a PowerShell lifecycle regression that proves bare Compose parsing fails without the fixtures, validates clean-runner recovery and cleanup, and verifies a pre-existing fixture remains byte-for-byte unchanged. The AI SRE workflow now runs this lifecycle test. Real certificate generation and `-CheckCertificates` behavior remain separate and unchanged.

### How Did You Test This Change?

- `./rocketmq-sre/scripts/test-mtls-deployment-fixture-lifecycle.ps1`
- `./rocketmq-sre/scripts/verify-mtls-deployment.ps1`
- Negative `./rocketmq-sre/scripts/verify-mtls-deployment.ps1 -CheckCertificates` cleanup check without generated certificates
- `./scripts/check-agents-routing.ps1`
- `python -B rocketmq-sre/scripts/check_implementation_status.py`
- `python -B rocketmq-sre/scripts/check_source_layout.py`
- `python -B rocketmq-sre/scripts/check_execution_dependency_boundary.py`
- `python -B rocketmq-sre/scripts/check_read_gateway_boundary.py`
- `cargo fmt --manifest-path rocketmq-sre/Cargo.toml -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace`
- `cargo test --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-features`
- `cargo clippy --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --no-deps`
- `npm --prefix rocketmq-sre/ui ci`
- `npm --prefix rocketmq-sre/ui run check:api`
- `npm --prefix rocketmq-sre/ui run lint`
- `npm --prefix rocketmq-sre/ui run test -- --run`
- `npm --prefix rocketmq-sre/ui run build`
- `git diff --check`

All listed validation completed successfully. Live certificate verification was not run because this change intentionally validates the clean static-contract path without generating private keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added lifecycle coverage for mTLS deployment fixtures across Docker Compose and Kind validation.
  * Verified expected failures, successful validation, fixture preservation, cleanup, and boundary enforcement.

* **Bug Fixes**
  * Improved validation cleanup to remove only temporary files and directories created during testing.
  * Added safer rollback behavior when deployment validation encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->