### PR TITLE
[ISSUE #8920]✨Add bounded diagnostic evidence routes

### DIFF
--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -50,7 +50,11 @@ pub use mq_admin_mutation_ext::TopicConfigPatchOutcome;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::BrokerConfigAllowlisted;
 #[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::MQAdminMessageReadExt;
+#[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MQAdminReadExt;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::MessageMetadataRead;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::SubscriptionGroupConfigVersioned;
 #[cfg(feature = "admin-read")]

--- a/rocketmq-client/src/admin/mq_admin_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_read_ext.rs
@@ -22,6 +22,7 @@ use cheetah_string::CheetahString;
 use rand::seq::IndexedRandom;
 use rocketmq_model::common::config::TopicConfig;
 use rocketmq_model::common::mix_all;
+use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
 use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
@@ -33,6 +34,7 @@ use rocketmq_protocol::protocol::body::proxy_drain::ProxyDrainStateResponseBody;
 use rocketmq_protocol::protocol::body::topic::topic_list::TopicList;
 use rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
 use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
+use rocketmq_protocol::protocol::header::view_message_request_header::ViewMessageRequestHeader;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::route_facade::BrokerDataExt;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -63,6 +65,27 @@ pub struct TopicConfigVersioned {
 pub struct SubscriptionGroupConfigVersioned {
     pub version: u64,
     pub config: SubscriptionGroupConfig,
+}
+
+/// Fixed, body-free metadata returned by the read-only message lookup.
+///
+/// Network addresses, arbitrary properties, body bytes, and body digests are
+/// intentionally absent. Callers must pseudonymize identifier fields before
+/// exposing the value outside their trusted read boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageMetadataRead {
+    pub topic: String,
+    pub message_id: String,
+    pub unique_message_id: Option<String>,
+    pub born_timestamp: i64,
+    pub store_timestamp: i64,
+    pub queue_id: i32,
+    pub queue_offset: i64,
+    pub store_size: i32,
+    pub reconsume_times: i32,
+    pub sys_flag: i32,
+    pub flag: i32,
+    pub prepared_transaction_offset: i64,
 }
 
 #[allow(async_fn_in_trait)]
@@ -137,6 +160,18 @@ pub trait MQAdminReadExt: Send {
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo>;
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList>;
+}
+
+/// Additive read-only capability for fixed, body-free message metadata.
+#[allow(async_fn_in_trait)]
+pub trait MQAdminMessageReadExt: Send {
+    /// Looks up one message while returning only a fixed body-free metadata
+    /// projection.
+    async fn query_message_metadata(
+        &self,
+        topic: CheetahString,
+        message_id: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<MessageMetadataRead>;
 }
 
 impl MQAdminReadExt for DefaultMQAdminExt {
@@ -398,6 +433,51 @@ impl MQAdminReadExt for DefaultMQAdminExt {
             }
         }
         Ok(GroupList::default())
+    }
+}
+
+impl MQAdminMessageReadExt for DefaultMQAdminExt {
+    async fn query_message_metadata(
+        &self,
+        topic: CheetahString,
+        message_id: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<MessageMetadataRead> {
+        MessageDecoder::validate_message_id(message_id.as_str())
+            .map_err(|error| rocketmq_error::RocketMQError::IllegalArgument(format!("Invalid message ID: {error}")))?;
+        let decoded = MessageDecoder::decode_message_id(message_id.as_str()).map_err(|error| {
+            rocketmq_error::RocketMQError::IllegalArgument(format!("Failed to decode message ID: {error}"))
+        })?;
+        let broker_addr = CheetahString::from_string(format!("{}:{}", decoded.address.ip(), decoded.address.port()));
+        let message = self
+            .inner()
+            .mq_client_api()?
+            .view_message(
+                &broker_addr,
+                ViewMessageRequestHeader {
+                    topic: Some(topic.clone()),
+                    offset: decoded.offset,
+                },
+                self.inner().remoting_timeout_millis()?,
+            )
+            .await?;
+        Ok(MessageMetadataRead {
+            topic: topic.to_string(),
+            message_id: message.msg_id().to_string(),
+            unique_message_id: message
+                .properties()
+                .get(rocketmq_model::common::message::MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
+                .map(ToString::to_string)
+                .filter(|value| !value.is_empty()),
+            born_timestamp: message.born_timestamp(),
+            store_timestamp: message.store_timestamp(),
+            queue_id: message.queue_id(),
+            queue_offset: message.queue_offset(),
+            store_size: message.store_size(),
+            reconsume_times: message.reconsume_times(),
+            sys_flag: message.sys_flag(),
+            flag: message.flag(),
+            prepared_transaction_offset: message.prepared_transaction_offset(),
+        })
     }
 }
 

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -26,10 +26,14 @@ pub use crate::admin::BrokerConfigPatchOutcome;
 pub use crate::admin::ConsumerAdmin;
 pub use crate::admin::DefaultMQAdminExt;
 pub use crate::admin::DefaultMQAdminExtImpl;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::MQAdminMessageReadExt;
 #[cfg(feature = "admin-mutation")]
 pub use crate::admin::MQAdminMutationExt;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminReadExt;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::MessageMetadataRead;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::OffsetAdmin;
 #[cfg(feature = "admin-full")]

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -16,12 +16,12 @@
     "total": 69,
     "required": 32,
     "optional": 37,
-    "query": 18,
-    "not_production_verified": 51,
-    "required_query": 7,
-    "required_not_production_verified": 25,
-    "optional_query": 11,
-    "optional_not_production_verified": 26,
+    "query": 48,
+    "not_production_verified": 21,
+    "required_query": 32,
+    "required_not_production_verified": 0,
+    "optional_query": 16,
+    "optional_not_production_verified": 21,
     "source": "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs"
   },
   "capability_areas": [
@@ -66,6 +66,10 @@
           "path": "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs"
         },
         {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-connector/src/sources/diagnostic_projection.rs"
+        },
+        {
           "kind": "configuration",
           "path": "rocketmq-sre/config/evidence/required-source-profiles.v1.yaml"
         },
@@ -75,8 +79,8 @@
         }
       ],
       "limitations": [
-        "Only 18 of 69 declared Evidence requirements have a production query route.",
-        "Twenty-five required Evidence requirements remain not production verified."
+        "All 32 required Evidence requirements have fixed read-only query routes; live backend qualification remains environment-specific.",
+        "Twenty-one optional Evidence requirements retain explicit stable not-production-verified routes."
       ]
     },
     {
@@ -104,7 +108,7 @@
         }
       ],
       "limitations": [
-        "Pack registration and deterministic replay are contract tested, but required Evidence is not yet fully production queryable.",
+        "Pack registration and deterministic replay are contract tested, and required Evidence has complete fixed query routing.",
         "Pack-level live fault and missing-source qualification is incomplete."
       ]
     },

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
@@ -20,6 +20,7 @@ mod canonical;
 mod change_timeline;
 mod common;
 mod deployment_state;
+mod diagnostic_projection;
 mod inventory;
 mod kubernetes;
 mod kubernetes_events;
@@ -240,7 +241,7 @@ where
 
     pub(crate) async fn query(
         &self,
-        query: EvidenceQuery,
+        mut query: EvidenceQuery,
         external_cluster: &str,
         subject: &str,
         operation: Option<&EvidenceOperation>,
@@ -263,6 +264,7 @@ where
         let session = self.read_gateway.admit(&context, gateway_audit_target(source)).await?;
         let cache_key = cache_key(&query, external_cluster)?;
         if let Some(output) = self.cached(&cache_key).await {
+            pseudonymize_evidence_resource(&mut query.resource, self.config.pseudonymization_key());
             return capture(query, output);
         }
 
@@ -311,6 +313,7 @@ where
         );
         validate_query_completion(&context)?;
         self.insert_cache(cache_key, output.clone()).await;
+        pseudonymize_evidence_resource(&mut query.resource, self.config.pseudonymization_key());
         capture(query, output)
     }
 
@@ -959,6 +962,19 @@ fn cache_key(query: &EvidenceQuery, external_cluster: &str) -> Result<String, Co
     Ok(format!("sha256:{:x}", Sha256::digest(canonical)))
 }
 
+fn pseudonymize_evidence_resource(resource: &mut String, pseudonym_key: &[u8]) {
+    let Some(value) = resource.strip_prefix("message-metadata/") else {
+        return;
+    };
+    let (prefix, identifier) = value.rsplit_once('/').unwrap_or(("", value));
+    let identifier = self::common::pseudonymize_identifier(identifier, pseudonym_key);
+    *resource = if prefix.is_empty() {
+        format!("message-metadata/{identifier}")
+    } else {
+        format!("message-metadata/{prefix}/{identifier}")
+    };
+}
+
 fn capture(query: EvidenceQuery, output: SourceOutput) -> Result<EvidenceSnapshot, ConnectorError> {
     let correlation_id = query.correlation_id;
     let mut snapshot = EvidenceSnapshot::capture(
@@ -1149,6 +1165,18 @@ mod tests {
     }
 
     #[test]
+    fn evidence_resource_retains_topic_but_pseudonymizes_message_id() {
+        let mut resource = "message-metadata/orders/raw-message-id".to_owned();
+        pseudonymize_evidence_resource(&mut resource, b"tenant-key");
+
+        assert!(resource.starts_with("message-metadata/orders/sha256:"));
+        assert!(!resource.contains("raw-message-id"));
+        let first = resource.clone();
+        pseudonymize_evidence_resource(&mut resource, b"tenant-key");
+        assert_eq!(resource, first);
+    }
+
+    #[test]
     fn mcp_parser_accepts_only_fixed_read_operations() {
         assert!(matches!(
             mcp_operation("consumer-groups/billing/lag/orders"),
@@ -1158,7 +1186,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn manager_preserves_canonical_resource_for_unverified_body_free_metadata() {
+    async fn manager_pseudonymizes_message_metadata_resource_when_identifiers_are_incomplete() {
         let tenant_id = TenantId::new();
         let cluster_id = ClusterId::new();
         let config = Arc::new(ConnectorConfig {
@@ -1214,7 +1242,8 @@ mod tests {
             .await
             .expect("fail-closed evidence");
 
-        assert_eq!(snapshot.resource, resource);
+        assert!(snapshot.resource.starts_with("message-metadata/sha256:"));
+        assert!(!snapshot.resource.contains("id-hash-a"));
         assert_eq!(snapshot.coverage, CoverageStatus::NotProductionVerified);
         assert!(snapshot.partial);
         let EvidenceContent::Inline(content) = &snapshot.content else {

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/admin_query.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/admin_query.rs
@@ -26,9 +26,11 @@ use rocketmq_admin_core::core::client_connection::ListProducerConnectionsResult;
 use rocketmq_admin_core::core::client_connection::QueryConsumerConnectionsRequest;
 use rocketmq_admin_core::core::client_connection::QueryConsumerConnectionsResult;
 use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
+use rocketmq_admin_core::core::consumer::DashboardConsumerConfigRequest;
 use rocketmq_admin_core::core::consumer::ListConsumerGroupsRequest;
 use rocketmq_admin_core::core::consumer::QueryConsumerLagRequest;
 use rocketmq_admin_core::core::security::AdminCredentials;
+use rocketmq_admin_core::core::topic::GetTopicConfigRequest;
 use rocketmq_admin_core::core::topic::GetTopicRouteRequest;
 use rocketmq_admin_core::core::topic::ListTopicsRequest;
 use rocketmq_admin_core::core::topic::TopicQueryAdmin;
@@ -287,6 +289,97 @@ impl AdminQuerySource {
                 )
                 .await?,
             )?
+        } else if let Some(value) = resource.strip_prefix("topic-subscription-config/") {
+            let (consumer_group, topic) = exact_pair(value, "topic subscription config")?;
+            let topic_request = GetTopicConfigRequest::try_new(topic, None)
+                .map_err(|_| ConnectorError::source("read-only Topic configuration query is invalid"))?;
+            let topic_config = bounded_admin(
+                deadline,
+                cancel,
+                session.get_topic_config(&topic_request),
+                "read-only Topic configuration query failed",
+            )
+            .await?;
+            let group_request = DashboardConsumerConfigRequest {
+                consumer_group: consumer_group.to_owned(),
+                address: None,
+            };
+            let group_config = bounded_admin(
+                deadline,
+                cancel,
+                session.query_dashboard_consumer_config(&group_request),
+                "read-only Subscription Group configuration query failed",
+            )
+            .await;
+            let group = group_config.as_ref().ok().map(|config| {
+                serde_json::json!({
+                    "name": config.consumer_group,
+                    "consume_enable": config.consume_enable,
+                    "consume_from_min_enable": config.consume_from_min_enable,
+                    "consume_broadcast_enable": config.consume_broadcast_enable,
+                    "consume_message_orderly": config.consume_message_orderly,
+                    "retry_queue_nums": config.retry_queue_nums,
+                    "retry_max_times": config.retry_max_times,
+                    "broker_id": config.broker_id,
+                    "which_broker_when_consume_slowly": config.which_broker_when_consume_slowly,
+                    "notify_consumer_ids_changed_enable": config.notify_consumer_ids_changed_enable,
+                    "group_sys_flag": config.group_sys_flag,
+                    "consume_timeout_minute": config.consume_timeout_minute,
+                    "subscription_topics": config.subscription_topics
+                })
+            });
+            let mut output = SourceOutput::available(
+                serde_json::json!({
+                    "schema_version": "rocketmq.sre-topic-subscription-config.v1",
+                    "topic": {
+                        "name": topic_config.topic_name,
+                        "read_queue_nums": topic_config.read_queue_nums,
+                        "write_queue_nums": topic_config.write_queue_nums,
+                        "perm": topic_config.perm,
+                        "ordered": topic_config.order,
+                        "message_type": topic_config.message_type,
+                        "broker_count": topic_config.broker_name_list.len(),
+                        "inconsistent_fields": topic_config.inconsistent_fields
+                    },
+                    "consumer_group": group
+                }),
+                Utc::now(),
+            );
+            if group_config.is_err() {
+                output.partial = true;
+                output.coverage = rocketmq_sre_contracts::CoverageStatus::Partial;
+                output
+                    .warnings
+                    .push("subscription_group_configuration_unavailable".to_owned());
+            }
+            return Ok(output);
+        } else if let Some(value) = resource.strip_prefix("message-metadata/") {
+            let (topic, message_id) = exact_pair(value, "message metadata")?;
+            let metadata = bounded_admin(
+                deadline,
+                cancel,
+                session.query_message_metadata(topic, message_id),
+                "read-only body-free message metadata query failed",
+            )
+            .await?;
+            return Ok(SourceOutput::available(
+                serde_json::json!({
+                    "schema_version": "rocketmq.sre-message-metadata.v1",
+                    "topic": metadata.topic,
+                    "message_id": metadata.message_id,
+                    "unique_message_id": metadata.unique_message_id,
+                    "born_timestamp": metadata.born_timestamp,
+                    "store_timestamp": metadata.store_timestamp,
+                    "queue_id": metadata.queue_id,
+                    "queue_offset": metadata.queue_offset,
+                    "store_size": metadata.store_size,
+                    "reconsume_times": metadata.reconsume_times,
+                    "sys_flag": metadata.sys_flag,
+                    "flag": metadata.flag,
+                    "prepared_transaction_offset": metadata.prepared_transaction_offset
+                }),
+                Utc::now(),
+            ));
         } else if let Some(broker_name) = resource
             .strip_prefix("admin/broker-connections/")
             .or_else(|| resource.strip_prefix("broker-connections/"))
@@ -429,6 +522,22 @@ async fn query_client_connections(
 
 fn serialize(value: impl serde::Serialize) -> Result<Value, ConnectorError> {
     serde_json::to_value(value).map_err(|_| ConnectorError::source("read-only Admin result cannot be encoded"))
+}
+
+fn exact_pair<'a>(value: &'a str, resource: &str) -> Result<(&'a str, &'a str), ConnectorError> {
+    let Some((first, second)) = value.split_once('/') else {
+        return Err(ConnectorError::source(format!(
+            "read-only {resource} query requires exactly two identifiers"
+        )));
+    };
+    if second.contains('/') {
+        return Err(ConnectorError::source(format!(
+            "read-only {resource} query requires exactly two identifiers"
+        )));
+    }
+    validate_identifier(first, resource)?;
+    validate_identifier(second, resource)?;
+    Ok((first, second))
 }
 
 async fn bounded_admin<T>(

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/canonical.rs
@@ -14,6 +14,44 @@
 
 use crate::EvidenceOperation;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum BrokerDiagnosticProfile {
+    StorePressure,
+    StoreIntegrity,
+    RocksDbHealth,
+    TieredStore,
+    BrokerHa,
+    AuthFailure,
+    ColdDataFlow,
+    DrReadiness,
+    SecurityPosture,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MetricDiagnosticProfile {
+    CapacityRunway,
+    ControllerHa,
+    SendLatency,
+    ProxyConnectivity,
+    RetryDlq,
+    TransactionMessage,
+    PopRevive,
+    TimerBacklog,
+    QueueHotspot,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RouteDiagnosticProfile {
+    NameServer,
+    StaticTopic,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum KubernetesDiagnosticProfile {
+    UpgradeReadiness,
+    ChangeRegression,
+}
+
 /// Canonical projection applied after a source-owned wire response has passed
 /// its native contract validation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -32,6 +70,13 @@ pub(super) enum CanonicalProjection {
     CollectorWorkload,
     RuntimeObservability,
     ClusterTopology,
+    BrokerDiagnostics(BrokerDiagnosticProfile),
+    MetricDiagnostics(MetricDiagnosticProfile),
+    RouteDiagnostics(RouteDiagnosticProfile),
+    TopicSubscriptionConfig,
+    MessageMetadata,
+    RuntimeSaturation,
+    KubernetesDiagnostics(KubernetesDiagnosticProfile),
 }
 
 /// A fixed read-only query that can collect bounded source material for a
@@ -132,11 +177,13 @@ fn resolve_mcp(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         ));
     }
-    resolve_catalog_resource(
-        resource,
-        &["namesrv-route/", "static-topic-route/"],
-        "wave_b_mcp_projection_not_production_verified",
-    )
+    if let Some(topic) = resource.strip_prefix("namesrv-route/") {
+        return Some(topic_route_diagnostics(topic, RouteDiagnosticProfile::NameServer));
+    }
+    if let Some(topic) = resource.strip_prefix("static-topic-route/") {
+        return Some(topic_route_diagnostics(topic, RouteDiagnosticProfile::StaticTopic));
+    }
+    None
 }
 
 fn resolve_admin(resource: &str) -> Option<CanonicalResourceRoute> {
@@ -173,8 +220,14 @@ fn resolve_admin(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         ));
     }
-    if resource.starts_with("message-metadata/") {
-        return Some(not_verified("body_free_message_metadata_query_not_implemented"));
+    if let Some(value) = resource.strip_prefix("message-metadata/") {
+        return Some(match exact_pair(value) {
+            Some((topic, message_id)) => query(
+                CanonicalQuery::Admin(format!("message-metadata/{topic}/{message_id}")),
+                CanonicalProjection::MessageMetadata,
+            ),
+            None => not_verified("message_metadata_topic_and_id_required"),
+        });
     }
     if let Some(producer_group) = resource.strip_prefix("producer-connectivity/") {
         return Some(identifier(producer_group).map_or_else(
@@ -187,22 +240,62 @@ fn resolve_admin(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         ));
     }
-    resolve_catalog_resource(
-        resource,
-        &[
+    if let Some(value) = resource.strip_prefix("topic-subscription-config/") {
+        return Some(match exact_pair(value) {
+            Some((consumer_group, topic)) => query(
+                CanonicalQuery::Admin(format!("topic-subscription-config/{consumer_group}/{topic}")),
+                CanonicalProjection::TopicSubscriptionConfig,
+            ),
+            None => not_verified("topic_subscription_group_and_topic_required"),
+        });
+    }
+    for (prefix, query_resource, profile) in [
+        (
             "store-pressure/",
+            "store/health",
+            BrokerDiagnosticProfile::StorePressure,
+        ),
+        (
             "store-integrity/",
+            "store/recovery",
+            BrokerDiagnosticProfile::StoreIntegrity,
+        ),
+        (
             "rocksdb-health/",
-            "tiered-store/",
-            "broker-ha/",
-            "topic-subscription-config/",
+            "store/rocksdb",
+            BrokerDiagnosticProfile::RocksDbHealth,
+        ),
+        ("tiered-store/", "store/tiered", BrokerDiagnosticProfile::TieredStore),
+        ("broker-ha/", "broker/diagnostics", BrokerDiagnosticProfile::BrokerHa),
+        (
             "auth-failure/",
-            "cold-data-flow/",
+            "auth/diagnostics",
+            BrokerDiagnosticProfile::AuthFailure,
+        ),
+        ("cold-data-flow/", "store/tiered", BrokerDiagnosticProfile::ColdDataFlow),
+        (
             "dr-readiness/",
+            "broker/diagnostics",
+            BrokerDiagnosticProfile::DrReadiness,
+        ),
+        (
             "security-posture/",
-        ],
-        "wave_b_admin_projection_not_production_verified",
-    )
+            "auth/diagnostics",
+            BrokerDiagnosticProfile::SecurityPosture,
+        ),
+    ] {
+        if let Some(target) = resource.strip_prefix(prefix) {
+            return Some(if safe_resource_path(target) {
+                query(
+                    CanonicalQuery::Admin(query_resource.to_owned()),
+                    CanonicalProjection::BrokerDiagnostics(profile),
+                )
+            } else {
+                not_verified("canonical_resource_parameters_unavailable")
+            });
+        }
+    }
+    None
 }
 
 fn resolve_prometheus(resource: &str) -> Option<CanonicalResourceRoute> {
@@ -248,26 +341,78 @@ fn resolve_prometheus(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         ));
     }
+    for (prefix, query_resource, profile) in [
+        (
+            "capacity-runway/",
+            "trend/30d/rocketmq_store_disk_usage",
+            MetricDiagnosticProfile::CapacityRunway,
+        ),
+        (
+            "controller-ha/",
+            "metrics/rocketmq_controller_quorum_health_ratio",
+            MetricDiagnosticProfile::ControllerHa,
+        ),
+        (
+            "send-latency/",
+            "metrics/rocketmq_send_message_latency_milliseconds_bucket",
+            MetricDiagnosticProfile::SendLatency,
+        ),
+        (
+            "proxy-connectivity/",
+            "metrics/rocketmq_proxy_grpc_errors_total",
+            MetricDiagnosticProfile::ProxyConnectivity,
+        ),
+        (
+            "retry-dlq/",
+            "metrics/rocketmq_send_to_dlq_messages_total",
+            MetricDiagnosticProfile::RetryDlq,
+        ),
+        (
+            "transaction-message/",
+            "metrics/rocketmq_half_messages",
+            MetricDiagnosticProfile::TransactionMessage,
+        ),
+        (
+            "pop-revive/",
+            "metrics/rocketmq_pop_revive_lag",
+            MetricDiagnosticProfile::PopRevive,
+        ),
+        (
+            "timer-backlog/",
+            "metrics/rocketmq_timer_dequeue_lag",
+            MetricDiagnosticProfile::TimerBacklog,
+        ),
+        (
+            "queue-hotspot/",
+            "metrics/rocketmq_consumer_lag_messages",
+            MetricDiagnosticProfile::QueueHotspot,
+        ),
+    ] {
+        if let Some(target) = resource.strip_prefix(prefix) {
+            return Some(if safe_resource_path(target) {
+                query(
+                    CanonicalQuery::Prometheus {
+                        resource: query_resource.to_owned(),
+                        matchers: Vec::new(),
+                    },
+                    CanonicalProjection::MetricDiagnostics(profile),
+                )
+            } else {
+                not_verified("canonical_resource_parameters_unavailable")
+            });
+        }
+    }
     resolve_catalog_resource(
         resource,
         &[
             "store-trend/",
             "ha-network/",
-            "controller-ha/",
             "namesrv-network/",
-            "send-latency/",
-            "proxy-connectivity/",
-            "retry-dlq/",
-            "transaction-message/",
-            "pop-revive/",
-            "timer-backlog/",
-            "queue-hotspot/",
             "auth-telemetry/",
             "runtime-telemetry/",
-            "capacity-runway/",
             "prevention-trend/",
         ],
-        "wave_b_metric_projection_not_production_verified",
+        "optional_metric_projection_not_production_verified",
     )
 }
 
@@ -316,10 +461,30 @@ fn resolve_kubernetes(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         ));
     }
+    if let Some(namespace) = resource.strip_prefix("upgrade-readiness/") {
+        return Some(if safe_resource_path(namespace) {
+            query(
+                CanonicalQuery::Kubernetes("statefulsets".to_owned()),
+                CanonicalProjection::KubernetesDiagnostics(KubernetesDiagnosticProfile::UpgradeReadiness),
+            )
+        } else {
+            not_verified("canonical_resource_parameters_unavailable")
+        });
+    }
+    if let Some(namespace) = resource.strip_prefix("change-regression/") {
+        return Some(if safe_resource_path(namespace) {
+            query(
+                CanonicalQuery::Kubernetes("change-timeline".to_owned()),
+                CanonicalProjection::KubernetesDiagnostics(KubernetesDiagnosticProfile::ChangeRegression),
+            )
+        } else {
+            not_verified("canonical_resource_parameters_unavailable")
+        });
+    }
     resolve_catalog_resource(
         resource,
-        &["proxy-workload/", "upgrade-readiness/", "change-regression/"],
-        "wave_c_kubernetes_projection_not_production_verified",
+        &["proxy-workload/"],
+        "optional_kubernetes_projection_not_production_verified",
     )
 }
 
@@ -341,11 +506,17 @@ fn resolve_runtime(resource: &str) -> Option<CanonicalResourceRoute> {
             |_| not_verified("runtime_build_metadata_not_exposed"),
         ));
     }
-    resolve_catalog_resource(
-        resource,
-        &["runtime-saturation/"],
-        "wave_b_runtime_projection_not_production_verified",
-    )
+    resource.strip_prefix("runtime-saturation/").map(|component| {
+        identifier(component).map_or_else(
+            || not_verified("canonical_resource_parameters_unavailable"),
+            |component| {
+                query(
+                    CanonicalQuery::Runtime(format!("runtime/{component}")),
+                    CanonicalProjection::RuntimeSaturation,
+                )
+            },
+        )
+    })
 }
 
 fn resolve_topology(resource: &str) -> Option<CanonicalResourceRoute> {
@@ -360,6 +531,22 @@ fn resolve_topology(resource: &str) -> Option<CanonicalResourceRoute> {
             },
         )
     })
+}
+
+fn topic_route_diagnostics(topic: &str, profile: RouteDiagnosticProfile) -> CanonicalResourceRoute {
+    identifier(topic).map_or_else(
+        || not_verified("canonical_resource_parameters_unavailable"),
+        |topic| {
+            query(
+                CanonicalQuery::Mcp(EvidenceOperation::TopicDescribe {
+                    topic,
+                    limit: Some(200),
+                    cursor: None,
+                }),
+                CanonicalProjection::RouteDiagnostics(profile),
+            )
+        },
+    )
 }
 
 const fn query(query: CanonicalQuery, projection: CanonicalProjection) -> CanonicalResourceRoute {
@@ -482,12 +669,12 @@ mod tests {
         assert_eq!(requirement_count, 69);
         assert_eq!(required_count, 32);
         assert_eq!(optional_count, 37);
-        assert_eq!(query_count, 18);
-        assert_eq!(unsupported_count, 51);
-        assert_eq!(required_query_count, 7);
-        assert_eq!(required_unsupported_count, 25);
-        assert_eq!(optional_query_count, 11);
-        assert_eq!(optional_unsupported_count, 26);
+        assert_eq!(query_count, 48);
+        assert_eq!(unsupported_count, 21);
+        assert_eq!(required_query_count, 32);
+        assert_eq!(required_unsupported_count, 0);
+        assert_eq!(optional_query_count, 16);
+        assert_eq!(optional_unsupported_count, 21);
     }
 
     #[test]
@@ -540,6 +727,174 @@ mod tests {
     }
 
     #[test]
+    fn required_diagnostic_profiles_use_fixed_read_only_queries() {
+        for (resource, query_resource, profile) in [
+            (
+                "store-pressure/broker-a",
+                "store/health",
+                BrokerDiagnosticProfile::StorePressure,
+            ),
+            (
+                "store-integrity/broker-a",
+                "store/recovery",
+                BrokerDiagnosticProfile::StoreIntegrity,
+            ),
+            (
+                "rocksdb-health/broker-a",
+                "store/rocksdb",
+                BrokerDiagnosticProfile::RocksDbHealth,
+            ),
+            (
+                "tiered-store/broker-a",
+                "store/tiered",
+                BrokerDiagnosticProfile::TieredStore,
+            ),
+            (
+                "broker-ha/broker-a",
+                "broker/diagnostics",
+                BrokerDiagnosticProfile::BrokerHa,
+            ),
+            (
+                "auth-failure/broker-a",
+                "auth/diagnostics",
+                BrokerDiagnosticProfile::AuthFailure,
+            ),
+            (
+                "cold-data-flow/broker-a",
+                "store/tiered",
+                BrokerDiagnosticProfile::ColdDataFlow,
+            ),
+            (
+                "dr-readiness/broker-a",
+                "broker/diagnostics",
+                BrokerDiagnosticProfile::DrReadiness,
+            ),
+            (
+                "security-posture/broker-a",
+                "auth/diagnostics",
+                BrokerDiagnosticProfile::SecurityPosture,
+            ),
+        ] {
+            assert_eq!(
+                resolve("admin-query", resource),
+                Some(query(
+                    CanonicalQuery::Admin(query_resource.to_owned()),
+                    CanonicalProjection::BrokerDiagnostics(profile),
+                ))
+            );
+        }
+
+        for (resource, query_resource, profile) in [
+            (
+                "capacity-runway/cluster-a",
+                "trend/30d/rocketmq_store_disk_usage",
+                MetricDiagnosticProfile::CapacityRunway,
+            ),
+            (
+                "controller-ha/controller-a",
+                "metrics/rocketmq_controller_quorum_health_ratio",
+                MetricDiagnosticProfile::ControllerHa,
+            ),
+            (
+                "send-latency/topic-a",
+                "metrics/rocketmq_send_message_latency_milliseconds_bucket",
+                MetricDiagnosticProfile::SendLatency,
+            ),
+            (
+                "proxy-connectivity/proxy-a",
+                "metrics/rocketmq_proxy_grpc_errors_total",
+                MetricDiagnosticProfile::ProxyConnectivity,
+            ),
+            (
+                "retry-dlq/group-a",
+                "metrics/rocketmq_send_to_dlq_messages_total",
+                MetricDiagnosticProfile::RetryDlq,
+            ),
+            (
+                "transaction-message/topic-a",
+                "metrics/rocketmq_half_messages",
+                MetricDiagnosticProfile::TransactionMessage,
+            ),
+            (
+                "pop-revive/group-a",
+                "metrics/rocketmq_pop_revive_lag",
+                MetricDiagnosticProfile::PopRevive,
+            ),
+            (
+                "timer-backlog/topic-a",
+                "metrics/rocketmq_timer_dequeue_lag",
+                MetricDiagnosticProfile::TimerBacklog,
+            ),
+            (
+                "queue-hotspot/topic-a",
+                "metrics/rocketmq_consumer_lag_messages",
+                MetricDiagnosticProfile::QueueHotspot,
+            ),
+        ] {
+            assert_eq!(
+                resolve("prometheus", resource),
+                Some(query(
+                    CanonicalQuery::Prometheus {
+                        resource: query_resource.to_owned(),
+                        matchers: Vec::new(),
+                    },
+                    CanonicalProjection::MetricDiagnostics(profile),
+                ))
+            );
+        }
+
+        assert!(matches!(
+            resolve("admin-query", "message-metadata/topic-a/message-a"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Admin(_),
+                projection: CanonicalProjection::MessageMetadata,
+            })
+        ));
+        assert!(matches!(
+            resolve("admin-query", "topic-subscription-config/group-a/topic-a"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Admin(_),
+                projection: CanonicalProjection::TopicSubscriptionConfig,
+            })
+        ));
+        assert!(matches!(
+            resolve("rocketmq-mcp", "namesrv-route/topic-a"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Mcp(EvidenceOperation::TopicDescribe { .. }),
+                projection: CanonicalProjection::RouteDiagnostics(RouteDiagnosticProfile::NameServer),
+            })
+        ));
+        assert!(matches!(
+            resolve("rocketmq-mcp", "static-topic-route/topic-a"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Mcp(EvidenceOperation::TopicDescribe { .. }),
+                projection: CanonicalProjection::RouteDiagnostics(RouteDiagnosticProfile::StaticTopic),
+            })
+        ));
+        assert!(matches!(
+            resolve("runtime", "runtime-saturation/broker"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Runtime(_),
+                projection: CanonicalProjection::RuntimeSaturation,
+            })
+        ));
+        assert!(matches!(
+            resolve("kubernetes", "upgrade-readiness/rocketmq"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Kubernetes(_),
+                projection: CanonicalProjection::KubernetesDiagnostics(KubernetesDiagnosticProfile::UpgradeReadiness),
+            })
+        ));
+        assert!(matches!(
+            resolve("kubernetes", "change-regression/rocketmq"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Kubernetes(_),
+                projection: CanonicalProjection::KubernetesDiagnostics(KubernetesDiagnosticProfile::ChangeRegression),
+            })
+        ));
+    }
+
+    #[test]
     fn parameterized_routes_never_guess_missing_identifiers() {
         assert!(matches!(
             resolve("rocketmq-mcp", "consumer-lag/group-a"),
@@ -562,9 +917,16 @@ mod tests {
             })
         ));
         assert!(matches!(
-            resolve("admin-query", "message-metadata/id-hash-a"),
+            resolve("admin-query", "message-metadata/topic-a/message-a"),
+            Some(CanonicalResourceRoute::Query {
+                query: CanonicalQuery::Admin(_),
+                projection: CanonicalProjection::MessageMetadata
+            })
+        ));
+        assert!(matches!(
+            resolve("admin-query", "message-metadata/message-a"),
             Some(CanonicalResourceRoute::NotProductionVerified {
-                reason_code: "body_free_message_metadata_query_not_implemented"
+                reason_code: "message_metadata_topic_and_id_required"
             })
         ));
         assert!(resolve("rocketmq-mcp", "messages/raw-body").is_none());
@@ -582,11 +944,13 @@ mod tests {
             "consumer-runtime/" => "group-a",
             "deployment-drift/" => "broker-a",
             "build-info/" => "broker-a",
-            "message-metadata/" => "id-hash-a",
+            "message-metadata/" => "topic-a/message-a",
             "message-trace/" => "trace-hash-a",
             "topic-route/" => "topic-a",
+            "topic-subscription-config/" => "group-a/topic-a",
             "producer-connectivity/" => "producer-a",
             "observability/" => "mcp",
+            "runtime-saturation/" => "broker",
             "telemetry-pipeline/" => "collector-a",
             "otel-collector/" => "rocketmq",
             prefix if is_catalog_prefix(prefix) => "fixture",
@@ -612,7 +976,6 @@ mod tests {
             "proxy-workload/",
             "routing-trace/",
             "static-topic-route/",
-            "topic-subscription-config/",
             "retry-dlq/",
             "transaction-message/",
             "pop-revive/",
@@ -620,7 +983,6 @@ mod tests {
             "queue-hotspot/",
             "auth-failure/",
             "auth-telemetry/",
-            "runtime-saturation/",
             "runtime-telemetry/",
             "upgrade-readiness/",
             "capacity-runway/",

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/common.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/common.rs
@@ -404,7 +404,14 @@ fn is_forbidden_field(key: &str) -> bool {
 fn is_pseudonymized_field(key: &str) -> bool {
     matches!(
         normalized_key(key).as_str(),
-        "messageid" | "msgid" | "messagekey" | "messagekeys" | "keys" | "traceid"
+        "messageid"
+            | "uniquemessageid"
+            | "originmessageid"
+            | "msgid"
+            | "messagekey"
+            | "messagekeys"
+            | "keys"
+            | "traceid"
     )
 }
 
@@ -452,6 +459,7 @@ mod tests {
                 "access_token": "no",
                 "client_ip": "10.0.0.1",
                 "message_id": "message-a",
+                "unique_message_id": "unique-message-a",
                 "keys": ["order-1"],
                 "rows": [1, 2, 3]
             }),
@@ -465,6 +473,11 @@ mod tests {
         assert!(value.get("client_ip").is_none());
         assert!(
             value["message_id"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("sha256:"))
+        );
+        assert!(
+            value["unique_message_id"]
                 .as_str()
                 .is_some_and(|value| value.starts_with("sha256:"))
         );

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/diagnostic_projection.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/diagnostic_projection.rs
@@ -1,0 +1,612 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_sre_contracts::CoverageStatus;
+use serde_json::Map;
+use serde_json::Value;
+use serde_json::json;
+
+use super::canonical::BrokerDiagnosticProfile;
+use super::canonical::CanonicalProjection;
+use super::canonical::KubernetesDiagnosticProfile;
+use super::canonical::MetricDiagnosticProfile;
+use super::canonical::RouteDiagnosticProfile;
+use super::common::SourceOutput;
+use crate::ConnectorError;
+use crate::ConnectorErrorCode;
+
+const DIAGNOSTIC_SCHEMA: &str = "rocketmq.sre-diagnostic-source.v1";
+
+pub(super) fn apply(mut output: SourceOutput, projection: CanonicalProjection) -> Result<SourceOutput, ConnectorError> {
+    let projected = match projection {
+        CanonicalProjection::BrokerDiagnostics(profile) => broker_diagnostics(&output.content, profile)?,
+        CanonicalProjection::MetricDiagnostics(profile) => metric_diagnostics(&output.content, profile)?,
+        CanonicalProjection::RouteDiagnostics(profile) => route_diagnostics(&output.content, profile)?,
+        CanonicalProjection::TopicSubscriptionConfig => topic_subscription_config(&output.content)?,
+        CanonicalProjection::MessageMetadata => message_metadata(&output.content)?,
+        CanonicalProjection::RuntimeSaturation => runtime_saturation(&output.content)?,
+        CanonicalProjection::KubernetesDiagnostics(profile) => kubernetes_diagnostics(&output.content, profile)?,
+        _ => return Err(schema_mismatch()),
+    };
+    output.content = projected.content;
+    output.warnings.push(projected.warning.to_owned());
+    output.partial = true;
+    output.coverage = if projected.observed {
+        CoverageStatus::Partial
+    } else {
+        CoverageStatus::Missing
+    };
+    Ok(output)
+}
+
+struct Projected {
+    content: Value,
+    observed: bool,
+    warning: &'static str,
+}
+
+fn broker_diagnostics(raw: &Value, profile: BrokerDiagnosticProfile) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    let brokers = array(root, "brokers")?;
+    let mut rows = Vec::with_capacity(brokers.len());
+    for broker in brokers {
+        let broker = object(broker)?;
+        let mut row = Map::new();
+        copy_fields(broker, &mut row, &["broker_name", "broker_id", "coverage"]);
+        match profile {
+            BrokerDiagnosticProfile::StorePressure => {
+                copy_nested(broker, &mut row, "store_health")?;
+                copy_nested(broker, &mut row, "tiered")?;
+            }
+            BrokerDiagnosticProfile::StoreIntegrity => {
+                copy_nested(broker, &mut row, "recovery")?;
+                copy_nested(broker, &mut row, "background_index_rebuild")?;
+            }
+            BrokerDiagnosticProfile::RocksDbHealth => copy_nested(broker, &mut row, "rocksdb")?,
+            BrokerDiagnosticProfile::TieredStore | BrokerDiagnosticProfile::ColdDataFlow => {
+                copy_nested(broker, &mut row, "tiered")?;
+                copy_nested(broker, &mut row, "config")?;
+            }
+            BrokerDiagnosticProfile::BrokerHa | BrokerDiagnosticProfile::DrReadiness => {
+                copy_nested(broker, &mut row, "ha")?;
+                copy_nested(broker, &mut row, "readiness")?;
+                if profile == BrokerDiagnosticProfile::DrReadiness {
+                    copy_nested(broker, &mut row, "recovery")?;
+                }
+            }
+            BrokerDiagnosticProfile::AuthFailure | BrokerDiagnosticProfile::SecurityPosture => {
+                copy_auth_fields(broker, &mut row);
+            }
+        }
+        rows.push(Value::Object(row));
+    }
+    Ok(Projected {
+        content: json!({
+            "schema_version": DIAGNOSTIC_SCHEMA,
+            "profile": broker_profile_name(profile),
+            "observed_brokers": rows.len(),
+            "brokers": rows
+        }),
+        observed: !brokers.is_empty(),
+        warning: "diagnostic_profile_fields_incomplete",
+    })
+}
+
+fn copy_auth_fields(source: &Map<String, Value>, target: &mut Map<String, Value>) {
+    if let Some(auth) = source.get("auth") {
+        target.insert("auth".to_owned(), auth.clone());
+        return;
+    }
+    copy_fields(
+        source,
+        target,
+        &[
+            "authentication_enabled",
+            "authorization_enabled",
+            "acl_file_watch_enabled",
+            "acl_generation",
+            "reload",
+            "credential_rotation",
+        ],
+    );
+}
+
+fn metric_diagnostics(raw: &Value, profile: MetricDiagnosticProfile) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    if string(root, "schema_version")? != "rocketmq.prometheus-evidence.v1" {
+        return Err(schema_mismatch());
+    }
+    let metric = string(root, "metric")?;
+    let series = array(root, "series")?;
+    let mut first_values = Vec::new();
+    let mut latest_values = Vec::new();
+    let mut sample_count = 0_u64;
+    for series in series {
+        let series = object(series)?;
+        let samples = array(series, "samples")?;
+        sample_count = sample_count.saturating_add(samples.len() as u64);
+        if let Some(value) = samples.first().and_then(sample_number) {
+            first_values.push(value);
+        }
+        if let Some(value) = samples.last().and_then(sample_number) {
+            latest_values.push(value);
+        }
+    }
+    let mut summary = Map::new();
+    if let Some(value) = finite_sum(&latest_values) {
+        summary.insert("latest_sum".to_owned(), number(value)?);
+    }
+    if let Some(value) = latest_values.iter().copied().reduce(f64::max) {
+        summary.insert("latest_max".to_owned(), number(value)?);
+    }
+    if let Some(value) = latest_values.iter().copied().reduce(f64::min) {
+        summary.insert("latest_min".to_owned(), number(value)?);
+    }
+    if first_values.len() == latest_values.len()
+        && let (Some(first), Some(latest)) = (finite_sum(&first_values), finite_sum(&latest_values))
+    {
+        summary.insert("window_delta".to_owned(), number(latest - first)?);
+    }
+    Ok(Projected {
+        content: json!({
+            "schema_version": DIAGNOSTIC_SCHEMA,
+            "profile": metric_profile_name(profile),
+            "metric": metric,
+            "observed_series": latest_values.len(),
+            "sample_count": sample_count,
+            "summary": summary
+        }),
+        observed: !latest_values.is_empty(),
+        warning: "diagnostic_threshold_not_configured",
+    })
+}
+
+fn route_diagnostics(raw: &Value, profile: RouteDiagnosticProfile) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    let topic = string(root, "topic")?;
+    let read_queues = unsigned(root, "read_queue_count")?;
+    let write_queues = unsigned(root, "write_queue_count")?;
+    let brokers = root
+        .get("broker_names")
+        .or_else(|| root.get("brokers"))
+        .and_then(Value::as_array)
+        .ok_or_else(schema_mismatch)?;
+    Ok(Projected {
+        content: json!({
+            "schema_version": DIAGNOSTIC_SCHEMA,
+            "profile": route_profile_name(profile),
+            "topic": topic,
+            "route_available": !brokers.is_empty() && read_queues.max(write_queues) > 0,
+            "read_queue_count": read_queues,
+            "write_queue_count": write_queues,
+            "broker_count": brokers.len()
+        }),
+        observed: true,
+        warning: match profile {
+            RouteDiagnosticProfile::NameServer => "nameserver_cross_node_comparison_unavailable",
+            RouteDiagnosticProfile::StaticTopic => "static_mapping_detail_unavailable",
+        },
+    })
+}
+
+fn topic_subscription_config(raw: &Value) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    if string(root, "schema_version")? != "rocketmq.sre-topic-subscription-config.v1" {
+        return Err(schema_mismatch());
+    }
+    let topic = object(root.get("topic").ok_or_else(schema_mismatch)?)?;
+    let group = root.get("consumer_group").and_then(Value::as_object);
+    let mut content = Map::from_iter([
+        ("schema_version".to_owned(), Value::String(DIAGNOSTIC_SCHEMA.to_owned())),
+        (
+            "profile".to_owned(),
+            Value::String("topic_subscription_config".to_owned()),
+        ),
+        ("topic".to_owned(), Value::Object(topic.clone())),
+    ]);
+    if let Some(group) = group {
+        content.insert("consumer_group".to_owned(), Value::Object(group.clone()));
+        if let (Some(topic_name), Some(subscriptions)) = (
+            topic.get("name").and_then(Value::as_str),
+            group.get("subscription_topics").and_then(Value::as_array),
+        ) {
+            content.insert(
+                "filter_consistent".to_owned(),
+                Value::Bool(subscriptions.iter().any(|value| value.as_str() == Some(topic_name))),
+            );
+        }
+        if let (Some(topic_ordered), Some(group_ordered)) = (
+            topic.get("ordered").and_then(Value::as_bool),
+            group.get("consume_message_orderly").and_then(Value::as_bool),
+        ) {
+            content.insert(
+                "mode_consistent".to_owned(),
+                Value::Bool(topic_ordered == group_ordered),
+            );
+        }
+    }
+    Ok(Projected {
+        content: Value::Object(content),
+        observed: true,
+        warning: "topic_group_permission_semantics_unavailable",
+    })
+}
+
+fn message_metadata(raw: &Value) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    if string(root, "schema_version")? != "rocketmq.sre-message-metadata.v1" {
+        return Err(schema_mismatch());
+    }
+    let message_id = string(root, "message_id")?;
+    if !is_pseudonym(message_id) {
+        return Err(schema_mismatch());
+    }
+    let mut content = Map::from_iter([
+        ("schema_version".to_owned(), Value::String(DIAGNOSTIC_SCHEMA.to_owned())),
+        ("profile".to_owned(), Value::String("message_metadata".to_owned())),
+        ("message_id_hash".to_owned(), Value::String(message_id.to_owned())),
+    ]);
+    copy_fields(
+        root,
+        &mut content,
+        &[
+            "topic",
+            "born_timestamp",
+            "store_timestamp",
+            "queue_id",
+            "queue_offset",
+            "store_size",
+            "reconsume_times",
+            "sys_flag",
+            "flag",
+            "prepared_transaction_offset",
+        ],
+    );
+    content.insert("transaction_status".to_owned(), Value::String("unknown".to_owned()));
+    Ok(Projected {
+        content: Value::Object(content),
+        observed: true,
+        warning: "message_body_and_properties_excluded",
+    })
+}
+
+fn runtime_saturation(raw: &Value) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    if string(root, "schema_version")? != "rocketmq.sre-runtime-evidence.v1" {
+        return Err(schema_mismatch());
+    }
+    let diagnostics = object(root.get("diagnostics").ok_or_else(schema_mismatch)?)?;
+    let task_kinds = array(diagnostics, "task_kinds")?;
+    let blocking_lanes = array(diagnostics, "blocking_lanes")?;
+    let long_running = task_kinds
+        .iter()
+        .filter_map(|value| value.get("long_running"))
+        .filter_map(Value::as_u64)
+        .sum::<u64>();
+    let mut queued = 0_u64;
+    let mut running = 0_u64;
+    let mut timeouts = 0_u64;
+    let mut pressure = false;
+    for lane in blocking_lanes {
+        let lane = object(lane)?;
+        let lane_queued = lane.get("queued").and_then(Value::as_u64).ok_or_else(schema_mismatch)?;
+        let lane_running = lane
+            .get("running")
+            .and_then(Value::as_u64)
+            .ok_or_else(schema_mismatch)?;
+        let lane_timeouts = lane
+            .get("timed_out_still_running")
+            .and_then(Value::as_u64)
+            .ok_or_else(schema_mismatch)?;
+        queued = queued.saturating_add(lane_queued);
+        running = running.saturating_add(lane_running);
+        timeouts = timeouts.saturating_add(lane_timeouts);
+        pressure |= lane_timeouts > 0
+            || lane
+                .get("max_queue_depth")
+                .and_then(Value::as_u64)
+                .is_some_and(|limit| limit > 0 && lane_queued >= limit)
+            || lane
+                .get("max_concurrency")
+                .and_then(Value::as_u64)
+                .is_some_and(|limit| limit > 0 && lane_running >= limit);
+    }
+    let lifecycle = string(diagnostics, "lifecycle_state")?;
+    Ok(Projected {
+        content: json!({
+            "schema_version": DIAGNOSTIC_SCHEMA,
+            "profile": "runtime_saturation",
+            "component": diagnostics.get("component"),
+            "task_group_count": diagnostics.get("task_group_count"),
+            "task_count": diagnostics.get("task_count"),
+            "long_running_tasks": long_running,
+            "blocking_queued": queued,
+            "blocking_running": running,
+            "blocking_timeouts": timeouts,
+            "blocking_executor_saturated": pressure,
+            "lifecycle_state": lifecycle,
+            "truncated": diagnostics.get("truncated")
+        }),
+        observed: true,
+        warning: "runtime_capacity_and_lifecycle_progress_incomplete",
+    })
+}
+
+fn kubernetes_diagnostics(raw: &Value, profile: KubernetesDiagnosticProfile) -> Result<Projected, ConnectorError> {
+    let root = object(raw)?;
+    if string(root, "schema_version")? != "rocketmq.kubernetes-evidence.v1" {
+        return Err(schema_mismatch());
+    }
+    let items = array(root, "items")?;
+    let content = match profile {
+        KubernetesDiagnosticProfile::UpgradeReadiness => {
+            if string(root, "kind")? != "stateful_sets" {
+                return Err(schema_mismatch());
+            }
+            let ready = items
+                .iter()
+                .filter(|item| item.get("rollout_state").and_then(Value::as_str) == Some("ready"))
+                .count();
+            json!({
+                "schema_version": DIAGNOSTIC_SCHEMA,
+                "profile": "upgrade_readiness",
+                "observed_workloads": items.len(),
+                "ready_workloads": ready,
+                "rollout_ready": !items.is_empty() && ready == items.len()
+            })
+        }
+        KubernetesDiagnosticProfile::ChangeRegression => {
+            if string(root, "kind")? != "change_timeline" {
+                return Err(schema_mismatch());
+            }
+            let failures = items
+                .iter()
+                .filter(|item| {
+                    item.get("reason")
+                        .and_then(Value::as_str)
+                        .is_some_and(|reason| reason == "ProgressDeadlineExceeded" || reason.starts_with("Failed"))
+                })
+                .count();
+            json!({
+                "schema_version": DIAGNOSTIC_SCHEMA,
+                "profile": "change_regression",
+                "observed_changes": items.len(),
+                "failed_changes": failures
+            })
+        }
+    };
+    Ok(Projected {
+        content,
+        observed: !items.is_empty(),
+        warning: match profile {
+            KubernetesDiagnosticProfile::UpgradeReadiness => "upgrade_pdb_and_protocol_evidence_incomplete",
+            KubernetesDiagnosticProfile::ChangeRegression => "change_slo_comparison_unavailable",
+        },
+    })
+}
+
+fn object(value: &Value) -> Result<&Map<String, Value>, ConnectorError> {
+    value.as_object().ok_or_else(schema_mismatch)
+}
+
+fn array<'a>(object: &'a Map<String, Value>, field: &str) -> Result<&'a [Value], ConnectorError> {
+    object
+        .get(field)
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(schema_mismatch)
+}
+
+fn string<'a>(object: &'a Map<String, Value>, field: &str) -> Result<&'a str, ConnectorError> {
+    object.get(field).and_then(Value::as_str).ok_or_else(schema_mismatch)
+}
+
+fn unsigned(object: &Map<String, Value>, field: &str) -> Result<u64, ConnectorError> {
+    object.get(field).and_then(Value::as_u64).ok_or_else(schema_mismatch)
+}
+
+fn copy_fields(source: &Map<String, Value>, target: &mut Map<String, Value>, fields: &[&str]) {
+    for field in fields {
+        if let Some(value) = source.get(*field) {
+            target.insert((*field).to_owned(), value.clone());
+        }
+    }
+}
+
+fn copy_nested(
+    source: &Map<String, Value>,
+    target: &mut Map<String, Value>,
+    field: &str,
+) -> Result<(), ConnectorError> {
+    if let Some(value) = source.get(field) {
+        if !value.is_null() && !value.is_object() {
+            return Err(schema_mismatch());
+        }
+        target.insert(field.to_owned(), value.clone());
+    }
+    Ok(())
+}
+
+fn sample_number(value: &Value) -> Option<f64> {
+    value
+        .get("value")
+        .and_then(Value::as_f64)
+        .filter(|value| value.is_finite())
+}
+
+fn finite_sum(values: &[f64]) -> Option<f64> {
+    (!values.is_empty())
+        .then(|| values.iter().sum::<f64>())
+        .filter(|value| value.is_finite())
+}
+
+fn number(value: f64) -> Result<Value, ConnectorError> {
+    serde_json::Number::from_f64(value)
+        .map(Value::Number)
+        .ok_or_else(schema_mismatch)
+}
+
+fn is_pseudonym(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+const fn broker_profile_name(profile: BrokerDiagnosticProfile) -> &'static str {
+    match profile {
+        BrokerDiagnosticProfile::StorePressure => "store_pressure",
+        BrokerDiagnosticProfile::StoreIntegrity => "store_integrity",
+        BrokerDiagnosticProfile::RocksDbHealth => "rocksdb_health",
+        BrokerDiagnosticProfile::TieredStore => "tiered_store",
+        BrokerDiagnosticProfile::BrokerHa => "broker_ha",
+        BrokerDiagnosticProfile::AuthFailure => "auth_failure",
+        BrokerDiagnosticProfile::ColdDataFlow => "cold_data_flow",
+        BrokerDiagnosticProfile::DrReadiness => "dr_readiness",
+        BrokerDiagnosticProfile::SecurityPosture => "security_posture",
+    }
+}
+
+const fn metric_profile_name(profile: MetricDiagnosticProfile) -> &'static str {
+    match profile {
+        MetricDiagnosticProfile::CapacityRunway => "capacity_runway",
+        MetricDiagnosticProfile::ControllerHa => "controller_ha",
+        MetricDiagnosticProfile::SendLatency => "send_latency",
+        MetricDiagnosticProfile::ProxyConnectivity => "proxy_connectivity",
+        MetricDiagnosticProfile::RetryDlq => "retry_dlq",
+        MetricDiagnosticProfile::TransactionMessage => "transaction_message",
+        MetricDiagnosticProfile::PopRevive => "pop_revive",
+        MetricDiagnosticProfile::TimerBacklog => "timer_backlog",
+        MetricDiagnosticProfile::QueueHotspot => "queue_hotspot",
+    }
+}
+
+const fn route_profile_name(profile: RouteDiagnosticProfile) -> &'static str {
+    match profile {
+        RouteDiagnosticProfile::NameServer => "nameserver_route",
+        RouteDiagnosticProfile::StaticTopic => "static_topic_route",
+    }
+}
+
+fn schema_mismatch() -> ConnectorError {
+    ConnectorError::capability(
+        ConnectorErrorCode::CapabilityMismatch,
+        "diagnostic source response does not match the supported projection schema",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use chrono::Utc;
+    use rocketmq_sre_contracts::EvidenceExposure;
+    use rocketmq_sre_contracts::Sensitivity;
+
+    use super::*;
+
+    fn raw(content: Value) -> SourceOutput {
+        SourceOutput {
+            observed_at: Utc.with_ymd_and_hms(2026, 8, 3, 8, 0, 0).single().expect("time"),
+            freshness_seconds: 1,
+            partial: false,
+            warnings: Vec::new(),
+            sensitivity: Sensitivity::Internal,
+            coverage: CoverageStatus::Available,
+            exposure: EvidenceExposure::Unknown,
+            content,
+        }
+    }
+
+    #[test]
+    fn metric_profile_uses_only_observed_samples_and_never_invents_thresholds() {
+        let output = apply(
+            raw(json!({
+                "schema_version": "rocketmq.prometheus-evidence.v1",
+                "metric": "rocketmq_pop_revive_lag",
+                "series": [{"labels": {}, "samples": [
+                    {"observed_at": "2026-08-03T07:59:00Z", "value": 4.0},
+                    {"observed_at": "2026-08-03T08:00:00Z", "value": 9.0}
+                ]}]
+            })),
+            CanonicalProjection::MetricDiagnostics(MetricDiagnosticProfile::PopRevive),
+        )
+        .expect("metric projection");
+
+        assert_eq!(output.content["summary"]["latest_max"], 9.0);
+        assert_eq!(output.content["summary"]["window_delta"], 5.0);
+        assert!(output.content.get("revive_lag_high").is_none());
+        assert_eq!(output.coverage, CoverageStatus::Partial);
+    }
+
+    #[test]
+    fn message_profile_requires_a_gateway_pseudonym_and_has_no_body_surface() {
+        let output = apply(
+            raw(json!({
+                "schema_version": "rocketmq.sre-message-metadata.v1",
+                "topic": "orders",
+                "message_id": format!("sha256:{}", "a".repeat(64)),
+                "queue_id": 1,
+                "queue_offset": 8
+            })),
+            CanonicalProjection::MessageMetadata,
+        )
+        .expect("message projection");
+
+        assert_eq!(output.content["queue_offset"], 8);
+        assert!(output.content.get("body").is_none());
+        assert!(output.content.get("properties").is_none());
+        assert!(output.content.get("keys").is_none());
+        assert!(output.content.get("tags").is_none());
+    }
+
+    #[test]
+    fn open_runtime_does_not_invent_a_schedule_or_shutdown_stall() {
+        let output = apply(
+            raw(json!({
+                "schema_version": "rocketmq.sre-runtime-evidence.v1",
+                "diagnostics": {
+                    "component": "broker",
+                    "lifecycle_state": "open",
+                    "task_group_count": 2,
+                    "task_count": 1,
+                    "task_kinds": [{
+                        "kind": "worker",
+                        "active": 1,
+                        "long_running": 0,
+                        "max_elapsed_millis": 5
+                    }],
+                    "blocking_lanes": [{
+                        "lane": "short_io",
+                        "max_concurrency": 4,
+                        "max_queue_depth": 8,
+                        "queued": 0,
+                        "running": 1,
+                        "timed_out_still_running": 0,
+                        "blocking_still_running": 1,
+                        "task_kinds": []
+                    }],
+                    "truncated": false
+                }
+            })),
+            CanonicalProjection::RuntimeSaturation,
+        )
+        .expect("runtime projection");
+
+        assert_eq!(output.content["lifecycle_state"], "open");
+        assert_eq!(output.content["blocking_executor_saturated"], false);
+        assert!(output.content.get("schedule_or_shutdown_stalled").is_none());
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/projection.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/projection.rs
@@ -41,6 +41,18 @@ struct Projected {
 /// field names consumed by Wave A. A projection never supplies neutral
 /// defaults for unavailable fields.
 pub(super) fn apply(mut output: SourceOutput, projection: CanonicalProjection) -> Result<SourceOutput, ConnectorError> {
+    if matches!(
+        projection,
+        CanonicalProjection::BrokerDiagnostics(_)
+            | CanonicalProjection::MetricDiagnostics(_)
+            | CanonicalProjection::RouteDiagnostics(_)
+            | CanonicalProjection::TopicSubscriptionConfig
+            | CanonicalProjection::MessageMetadata
+            | CanonicalProjection::RuntimeSaturation
+            | CanonicalProjection::KubernetesDiagnostics(_)
+    ) {
+        return super::diagnostic_projection::apply(output, projection);
+    }
     let projected = match projection {
         CanonicalProjection::BrokerRuntime => broker_runtime(&output.content)?,
         CanonicalProjection::ConsumerLag => consumer_lag(&output.content)?,
@@ -56,6 +68,13 @@ pub(super) fn apply(mut output: SourceOutput, projection: CanonicalProjection) -
         CanonicalProjection::CollectorWorkload => kubernetes_workloads(&output.content, true)?,
         CanonicalProjection::RuntimeObservability => runtime_observability(&output.content)?,
         CanonicalProjection::ClusterTopology => cluster_topology(&output.content)?,
+        CanonicalProjection::BrokerDiagnostics(_)
+        | CanonicalProjection::MetricDiagnostics(_)
+        | CanonicalProjection::RouteDiagnostics(_)
+        | CanonicalProjection::TopicSubscriptionConfig
+        | CanonicalProjection::MessageMetadata
+        | CanonicalProjection::RuntimeSaturation
+        | CanonicalProjection::KubernetesDiagnostics(_) => unreachable!("diagnostic projection handled above"),
     };
 
     output.content = projected.content;

--- a/rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/client_message.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-core/src/diagnostics/packs/client_message.rs
@@ -33,8 +33,8 @@ const MESSAGE_FOLLOW_UP: &[FollowUpQuery] = &[
     },
     FollowUpQuery {
         source: "admin-query",
-        resource_template: "message-metadata/{message_hash}",
-        reason: "Collect body-free metadata only when an approved pseudonymous key exists",
+        resource_template: "message-metadata/{topic}/{message_id}",
+        reason: "Collect body-free metadata only when an exact Topic and Message ID are approved",
     },
 ];
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::AclClientRPCHook;
 use rocketmq_client_rust::DefaultMQAdminExt;
+use rocketmq_client_rust::MQAdminMessageReadExt;
 use rocketmq_client_rust::MQAdminReadExt;
 use rocketmq_client_rust::SessionCredentials;
 use rocketmq_client_rust::SigningAlgorithm;
@@ -251,6 +252,37 @@ impl ReadAdminSession {
         } else {
             Ok(())
         }
+    }
+
+    /// Reads one message through the compile-time read-only client and returns
+    /// only the fixed body-free metadata contract.
+    pub async fn query_message_metadata(
+        &self,
+        topic: &str,
+        message_id: &str,
+    ) -> AdminResult<crate::core::message::MessageMetadata> {
+        self.ensure_open()?;
+        let metadata = MQAdminMessageReadExt::query_message_metadata(
+            &self.inner,
+            CheetahString::from(topic),
+            CheetahString::from(message_id),
+        )
+        .await
+        .map_err(|error| backend_error("query_message_metadata", error))?;
+        Ok(crate::core::message::MessageMetadata {
+            topic: metadata.topic,
+            message_id: metadata.message_id,
+            unique_message_id: metadata.unique_message_id,
+            born_timestamp: metadata.born_timestamp,
+            store_timestamp: metadata.store_timestamp,
+            queue_id: metadata.queue_id,
+            queue_offset: metadata.queue_offset,
+            store_size: metadata.store_size,
+            reconsume_times: metadata.reconsume_times,
+            sys_flag: metadata.sys_flag,
+            flag: metadata.flag,
+            prepared_transaction_offset: metadata.prepared_transaction_offset,
+        })
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
@@ -47,6 +47,27 @@ pub struct MessageRecord {
     pub properties: BTreeMap<String, String>,
 }
 
+/// Body-free message metadata safe for diagnostic evidence collection.
+///
+/// Identifiers still require caller-owned pseudonymization before external
+/// exposure. The contract intentionally excludes network addresses, arbitrary
+/// properties, body bytes, and body digests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageMetadata {
+    pub topic: String,
+    pub message_id: String,
+    pub unique_message_id: Option<String>,
+    pub born_timestamp: i64,
+    pub store_timestamp: i64,
+    pub queue_id: i32,
+    pub queue_offset: i64,
+    pub store_size: i32,
+    pub reconsume_times: i32,
+    pub sys_flag: i32,
+    pub flag: i32,
+    pub prepared_transaction_offset: i64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueryMessagesByKeyRequest {
     pub topic: String,

--- a/scripts/public-api-intent.json
+++ b/scripts/public-api-intent.json
@@ -1525,6 +1525,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use crate::admin::MQAdminMessageReadExt",
+          "identity": "rocketmq-client/src/public_api.rs:pub use crate::admin::MQAdminMessageReadExt",
+          "owner": "client",
+          "path": "rocketmq-client/src/public_api.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use crate::admin::MQAdminMutationExt",
           "identity": "rocketmq-client/src/public_api.rs:pub use crate::admin::MQAdminMutationExt",
           "owner": "client",
@@ -1536,6 +1545,15 @@
           "category": "stable",
           "declaration": "pub use crate::admin::MQAdminReadExt",
           "identity": "rocketmq-client/src/public_api.rs:pub use crate::admin::MQAdminReadExt",
+          "owner": "client",
+          "path": "rocketmq-client/src/public_api.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
+          "declaration": "pub use crate::admin::MessageMetadataRead",
+          "identity": "rocketmq-client/src/public_api.rs:pub use crate::admin::MessageMetadataRead",
           "owner": "client",
           "path": "rocketmq-client/src/public_api.rs",
           "rationale": "deliberate root entry point",
@@ -1794,7 +1812,7 @@
           "removal_condition": "retain while the stable entry point remains supported"
         }
       ],
-      "maximum_exports": 199
+      "maximum_exports": 201
     },
     "rocketmq-model": {
       "entries": [


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8920

### Brief Description

- Adds fixed read-only query routes for all 32 required AI SRE Evidence requirements.
- Adds fail-closed diagnostic projections for Admin, Prometheus, MCP, Runtime, and Kubernetes sources without inventing missing thresholds or health.
- Adds a body-free message metadata extension and pseudonymizes message identifiers before Evidence capture.
- Preserves rules-only diagnosis and the MCP mutation-free dependency boundary.

### How Did You Test This Change?

- Ran the complete AI SRE workspace check, test, Clippy, documentation, source-layout, implementation-status, read-gateway, and execution-boundary validation.
- Ran the root workspace Clippy, Admin Core tests, architecture guards, telemetry guards, public API intent check, and the exact `admin-read` client check.
- Ran the complete RocketMQ MCP read-only boundary, check, test, all-features test, Clippy, and documentation validation.

### Special Notes

- Optional Evidence remains explicitly Query or not-production-verified; 21 optional requirements intentionally remain unavailable.
- The admin-read client test suite still reproduces the unrelated baseline concurrency failure `concurrent_detector_start_publishes_one_owned_task`; the required admin-read check, root Clippy, SRE workspace, and MCP workspace validations pass.
- No live model provider or API key is used in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only message metadata queries without exposing message bodies or sensitive properties.
  * Added topic subscription configuration diagnostics, including partial results when configuration is unavailable.
  * Expanded diagnostics for broker, metrics, routes, runtime saturation, and Kubernetes resources.
  * Added standardized diagnostic responses with validation and coverage indicators.

* **Privacy**
  * Resource identifiers and message identifiers are consistently pseudonymized in cached results and snapshots.

* **Bug Fixes**
  * Improved validation and handling of invalid or incomplete diagnostic requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->