### PR TITLE
[ISSUE #8929]✨Qualify SRE diagnostic packs with persisted evidence

### DIFF
--- a/rocketmq-sre/Cargo.lock
+++ b/rocketmq-sre/Cargo.lock
@@ -279,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,7 +1601,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1996,7 +2002,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -2011,7 +2017,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "jiff",
  "serde",
  "serde_json",
@@ -2034,7 +2040,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e940a73033a7c5c7918b5ece7851d84571b58be25e937198da37fa13f116d3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "either",
  "futures",
@@ -2184,16 +2190,6 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -2507,7 +2503,7 @@ checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc-fast",
@@ -2520,7 +2516,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.15.0",
- "md-5 0.11.0",
+ "md-5",
  "nix",
  "parking_lot",
  "percent-encoding",
@@ -2628,7 +2624,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3210,7 +3206,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3312,13 +3308,13 @@ version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",
- "base64",
+ "base64 0.23.1",
  "cheetah-string",
  "chrono",
  "hex",
  "hmac 0.13.0",
  "ipnetwork",
- "md-5 0.11.0",
+ "md-5",
  "moka",
  "rocketmq-error",
  "rocketmq-model",
@@ -3389,7 +3385,7 @@ dependencies = [
 name = "rocketmq-model"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "byteorder",
  "bytes",
  "cheetah-string",
@@ -3399,7 +3395,7 @@ dependencies = [
  "flate2",
  "local-ip-address",
  "lz4_flex",
- "md-5 0.10.6",
+ "md-5",
  "rocketmq-error",
  "serde",
  "serde_json",
@@ -3573,7 +3569,7 @@ name = "rocketmq-sre-control-plane"
 version = "0.1.0"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -3619,9 +3615,10 @@ name = "rocketmq-sre-eval"
 version = "0.1.0"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "jsonwebtoken",
+ "reqwest",
  "rocketmq-runtime",
  "rocketmq-sre-contracts",
  "rocketmq-sre-core",
@@ -3630,6 +3627,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sqlx",
  "thiserror",
  "tokio",
  "tracing",
@@ -3641,7 +3639,7 @@ name = "rocketmq-sre-execution-agent"
 version = "0.1.0"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hmac 0.12.1",
  "k8s-openapi",
@@ -4051,7 +4049,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -4351,7 +4349,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -4457,7 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "chrono",
@@ -4472,7 +4470,7 @@ dependencies = [
  "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "memchr",
  "rand 0.10.2",
  "serde",
@@ -4883,7 +4881,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4969,7 +4967,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "bytes",
  "futures-util",

--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -216,6 +216,29 @@ npm --prefix rocketmq-sre/ui run build
 The Rust workspace uses the Rust 2024 module layout: `foo.rs` owns child modules
 under `foo/`. Legacy `foo/mod.rs` entry points are rejected.
 
+### Diagnostic qualification
+
+The versioned qualification manifest covers every built-in Diagnostic Pack with
+isolated normal, fault, and missing-Evidence scenarios. The live harness starts
+a disposable PostgreSQL 17 container, exercises the running Control Plane, and
+verifies persisted results, Evidence citations, schema rejection, and tenant and
+cluster boundaries. It remains rules-only: model network calls, target mutation,
+and execution records must all remain zero.
+
+Run the qualification from `rocketmq-sre/`; build output stays on `F:` and the
+redacted report is written outside the repository on `D:`:
+
+```powershell
+.\scripts\diagnostic-pack-live-qualification.ps1
+```
+
+PostgreSQL uses a bounded Docker `tmpfs` and is removed after the run. The
+committed contract is checked independently with:
+
+```powershell
+python scripts/check_diagnostic_pack_qualification.py
+```
+
 ## User interface
 
 The UI is designed as a full-screen desktop operations workspace using

--- a/rocketmq-sre/README.zh-CN.md
+++ b/rocketmq-sre/README.zh-CN.md
@@ -195,6 +195,25 @@ npm --prefix rocketmq-sre/ui run build
 Rust workspace 使用 Rust 2024 模块布局：`foo.rs` 负责声明放在 `foo/`
 目录下的子模块。项目拒绝旧式 `foo/mod.rs` 入口。
 
+### 诊断包资格验证
+
+版本化资格清单覆盖全部内置 Diagnostic Pack，并为每个包提供相互隔离的正常、故障和
+Evidence 缺失场景。实测工具会启动一次性 PostgreSQL 17 容器，通过运行中的 Control
+Plane 验证持久化结果、Evidence 引用、Schema 拒绝以及租户和集群边界。整个过程保持
+rules-only：模型网络调用、目标变更和执行记录必须全部为零。
+
+在 `rocketmq-sre/` 中运行下列命令；构建产物位于 `F:`，脱敏报告写入仓库外的 `D:`：
+
+```powershell
+.\scripts\diagnostic-pack-live-qualification.ps1
+```
+
+PostgreSQL 使用有界的 Docker `tmpfs`，运行结束后自动删除。可独立校验已提交的契约：
+
+```powershell
+python scripts/check_diagnostic_pack_qualification.py
+```
+
 ## 用户界面
 
 UI 按照 shadcn/ui 规范和可访问的 Radix UI primitive 设计为全屏桌面运维

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -85,12 +85,12 @@
     },
     {
       "id": "diagnostic-packs",
-      "status": "partial",
+      "status": "completed",
       "target_outcome": "evidence-coverage",
       "maturity": {
         "implemented": true,
         "contract_tested": true,
-        "live_smoke_passed": false,
+        "live_smoke_passed": true,
         "production_certified": false
       },
       "evidence": [
@@ -105,11 +105,27 @@
         {
           "kind": "test",
           "path": "rocketmq-sre/crates/rocketmq-sre-core/tests/diagnostic_replay.rs"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/diagnostic-packs.v1.json"
+        },
+        {
+          "kind": "source",
+          "path": "rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/live.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_diagnostic_pack_qualification.py"
+        },
+        {
+          "kind": "smoke",
+          "path": "rocketmq-sre/scripts/diagnostic-pack-live-qualification.ps1"
         }
       ],
       "limitations": [
-        "Pack registration and deterministic replay are contract tested, and required Evidence has complete fixed query routing.",
-        "Pack-level live fault and missing-source qualification is incomplete."
+        "All 32 built-in packs pass isolated normal, fault, and missing-Evidence qualification through the running Control Plane and disposable Docker PostgreSQL, covering 96 persisted results with citations and zero model, mutation, or execution calls.",
+        "Deployment-specific production certification remains required."
       ]
     },
     {

--- a/rocketmq-sre/config/qualification/diagnostic-packs.v1.json
+++ b/rocketmq-sre/config/qualification/diagnostic-packs.v1.json
@@ -1,0 +1,1295 @@
+{
+  "schema_version": "rocketmq-sre.diagnostic-pack-qualification.v1",
+  "operating_mode": "rules_only",
+  "model_provider_network_calls": false,
+  "target_mutation_calls": 0,
+  "execution_eligible": false,
+  "pack_count": 32,
+  "scenario_count": 3,
+  "pack_scenario_count": 96,
+  "inspection_templates": [
+    "cluster_health",
+    "consumer",
+    "broker",
+    "telemetry",
+    "producer_consumer"
+  ],
+  "fixture_assets": [
+    "tests/fixtures/diagnostics/cluster-topology.v1/normal.json",
+    "tests/fixtures/diagnostics/cluster-topology.v1/fault.json",
+    "tests/fixtures/diagnostics/cluster-topology.v1/missing.json",
+    "tests/fixtures/diagnostics/consumer-lag.v2/normal.json",
+    "tests/fixtures/diagnostics/consumer-lag.v2/fault.json",
+    "tests/fixtures/diagnostics/consumer-lag.v2/missing.json",
+    "tests/fixtures/diagnostics/consumer-runtime.v1/normal.json",
+    "tests/fixtures/diagnostics/consumer-runtime.v1/fault.json",
+    "tests/fixtures/diagnostics/consumer-runtime.v1/missing.json",
+    "tests/fixtures/diagnostics/producer-connectivity.v1/normal.json",
+    "tests/fixtures/diagnostics/producer-connectivity.v1/fault.json",
+    "tests/fixtures/diagnostics/producer-connectivity.v1/missing.json",
+    "tests/fixtures/diagnostics/broker-health.v1/normal.json",
+    "tests/fixtures/diagnostics/broker-health.v1/fault.json",
+    "tests/fixtures/diagnostics/broker-health.v1/missing.json",
+    "tests/fixtures/diagnostics/message-path.v1/normal.json",
+    "tests/fixtures/diagnostics/message-path.v1/fault.json",
+    "tests/fixtures/diagnostics/message-path.v1/missing.json",
+    "tests/fixtures/diagnostics/telemetry-pipeline.v1/normal.json",
+    "tests/fixtures/diagnostics/telemetry-pipeline.v1/fault.json",
+    "tests/fixtures/diagnostics/telemetry-pipeline.v1/missing.json",
+    "tests/fixtures/diagnostics/deployment-drift.v1/normal.json",
+    "tests/fixtures/diagnostics/deployment-drift.v1/fault.json",
+    "tests/fixtures/diagnostics/deployment-drift.v1/missing.json",
+    "tests/fixtures/diagnostics/wave-b/catalog.v1.json",
+    "tests/fixtures/diagnostics/wave-c/catalog.v1.json"
+  ],
+  "packs": [
+    {
+      "id": "cluster-topology.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "topology",
+          "source": "topology",
+          "resource_prefix": "asset-graph/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TOPOLOGY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TOPOLOGY_BROKEN_DEPENDENCY",
+            "TOPOLOGY_CHANGED",
+            "TOPOLOGY_CLIENT_DISCONNECTED",
+            "TOPOLOGY_ORPHAN_ASSET",
+            "TOPOLOGY_WORKLOAD_UNREADY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "consumer-lag.v2",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "consumer-lag",
+          "source": "rocketmq-mcp",
+          "resource_prefix": "consumer-lag/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "CONSUMER_LAG_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "CONSUMER_QUEUE_SKEW",
+            "CONSUMER_RUNTIME_UNAVAILABLE",
+            "CONSUMER_THROUGHPUT_DEFICIT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "consumer-runtime.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "runtime",
+          "source": "admin-query",
+          "resource_prefix": "consumer-runtime/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "CONSUMER_RUNTIME_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "CONSUMER_CLIENT_VERSION_UNSUPPORTED",
+            "CONSUMER_CONNECTION_LOST",
+            "CONSUMER_OFFSET_CONTROL_ANOMALY",
+            "CONSUMER_PROCESSING_SLOW",
+            "CONSUMER_REBALANCE_STALLED"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "producer-connectivity.v1",
+      "inspection_template": "producer_consumer",
+      "required_evidence": [
+        {
+          "key": "producer",
+          "source": "admin-query",
+          "resource_prefix": "producer-connectivity/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "PRODUCER_CONNECTIVITY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "PRODUCER_BACKPRESSURE",
+            "PRODUCER_CLIENT_VERSION_UNSUPPORTED",
+            "PRODUCER_CONNECTION_LOST",
+            "PRODUCER_QUEUE_SELECTION_FAILED",
+            "PRODUCER_ROUTE_STALE",
+            "PRODUCER_SEND_FAILURES"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "broker-health.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "broker-metrics",
+          "source": "prometheus",
+          "resource_prefix": "broker-health/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "BROKER_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "BROKER_DISK_PRESSURE",
+            "BROKER_FLUSH_DISPATCH_STALL",
+            "BROKER_HA_LAG",
+            "BROKER_NOT_READY",
+            "BROKER_REQUEST_ERRORS",
+            "BROKER_RESOURCE_PRESSURE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "message-path.v1",
+      "inspection_template": "producer_consumer",
+      "required_evidence": [
+        {
+          "key": "message-metadata",
+          "source": "admin-query",
+          "resource_prefix": "message-metadata/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "MESSAGE_PATH_COMPLETE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "MESSAGE_ACK_STAGE_MISSING",
+            "MESSAGE_DELIVERY_STAGE_MISSING",
+            "MESSAGE_TRANSACTION_STATUS_UNKNOWN"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "telemetry-pipeline.v1",
+      "inspection_template": "telemetry",
+      "required_evidence": [
+        {
+          "key": "runtime-observability",
+          "source": "runtime",
+          "resource_prefix": "observability/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TELEMETRY_PIPELINE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TELEMETRY_BACKEND_UNAVAILABLE",
+            "TELEMETRY_BUILD_FEATURE_DISABLED",
+            "TELEMETRY_COLLECTOR_UNAVAILABLE",
+            "TELEMETRY_EXPORTER_DISABLED",
+            "TELEMETRY_EXPORT_STALE",
+            "TELEMETRY_QUEUE_DROPPING"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "deployment-drift.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "deployment-diff",
+          "source": "kubernetes",
+          "resource_prefix": "deployment-drift/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "DEPLOYMENT_IN_SYNC"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "DEPLOYMENT_AVAILABILITY_DRIFT",
+            "DEPLOYMENT_CONFIG_DRIFT",
+            "DEPLOYMENT_IMAGE_FEATURE_DRIFT",
+            "DEPLOYMENT_SECURITY_DRIFT",
+            "DEPLOYMENT_STORAGE_DRIFT",
+            "DEPLOYMENT_TOPOLOGY_DRIFT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "store-pressure.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "store-pressure",
+          "source": "admin-query",
+          "resource_prefix": "store-pressure/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "STORE_PRESSURE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "STORE_DISK_PRESSURE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "store-integrity.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "store-integrity",
+          "source": "admin-query",
+          "resource_prefix": "store-integrity/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "STORE_INTEGRITY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "STORE_OFFSET_INCONSISTENT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "rocksdb-health.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "rocksdb-health",
+          "source": "admin-query",
+          "resource_prefix": "rocksdb-health/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "ROCKSDB_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "ROCKSDB_MAINTENANCE_STUCK"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "tiered-store.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "tiered-store",
+          "source": "admin-query",
+          "resource_prefix": "tiered-store/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TIERED_STORE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TIERED_PROVIDER_UNAVAILABLE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "broker-ha.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "broker-ha",
+          "source": "admin-query",
+          "resource_prefix": "broker-ha/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "BROKER_HA_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "BROKER_HA_REPLICA_LAG"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "controller-ha.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "controller-ha",
+          "source": "prometheus",
+          "resource_prefix": "controller-ha/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "CONTROLLER_HA_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "CONTROLLER_LEADER_UNKNOWN"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "namesrv-route.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "namesrv-route",
+          "source": "rocketmq-mcp",
+          "resource_prefix": "namesrv-route/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "NAMESRV_ROUTE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "NAMESRV_ROUTE_DIVERGENT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "send-latency.v1",
+      "inspection_template": "telemetry",
+      "required_evidence": [
+        {
+          "key": "send-latency",
+          "source": "prometheus",
+          "resource_prefix": "send-latency/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "SEND_LATENCY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "SEND_CLIENT_PROXY_LATENCY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "proxy-connectivity.v1",
+      "inspection_template": "telemetry",
+      "required_evidence": [
+        {
+          "key": "proxy-connectivity",
+          "source": "prometheus",
+          "resource_prefix": "proxy-connectivity/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "PROXY_CONNECTIVITY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "PROXY_GRPC_REMOTING_UNHEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "static-topic-route.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "static-topic-route",
+          "source": "rocketmq-mcp",
+          "resource_prefix": "static-topic-route/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "STATIC_TOPIC_ROUTE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "STATIC_ROUTE_EPOCH_DIVERGENT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "topic-subscription-config.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "topic-subscription-config",
+          "source": "admin-query",
+          "resource_prefix": "topic-subscription-config/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TOPIC_SUBSCRIPTION_CONFIG_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TOPIC_GROUP_PERMISSION_MISMATCH"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "retry-dlq.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "retry-dlq",
+          "source": "prometheus",
+          "resource_prefix": "retry-dlq/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "RETRY_DLQ_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "RETRY_DLQ_GROWTH"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "transaction-message.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "transaction-message",
+          "source": "prometheus",
+          "resource_prefix": "transaction-message/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TRANSACTION_MESSAGE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TRANSACTION_HALF_BACKLOG"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "pop-revive.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "pop-revive",
+          "source": "prometheus",
+          "resource_prefix": "pop-revive/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "POP_REVIVE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "POP_INFLIGHT_PRESSURE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "timer-backlog.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "timer-backlog",
+          "source": "prometheus",
+          "resource_prefix": "timer-backlog/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "TIMER_BACKLOG_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "TIMER_DEQUEUE_LAG"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "queue-hotspot.v1",
+      "inspection_template": "consumer",
+      "required_evidence": [
+        {
+          "key": "queue-hotspot",
+          "source": "prometheus",
+          "resource_prefix": "queue-hotspot/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "QUEUE_HOTSPOT_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "QUEUE_TRAFFIC_HOTSPOT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "auth-failure.v1",
+      "inspection_template": "telemetry",
+      "required_evidence": [
+        {
+          "key": "auth-failure",
+          "source": "admin-query",
+          "resource_prefix": "auth-failure/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "AUTH_FAILURE_NOT_OBSERVED"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "AUTH_SCOPE_DENIED"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "runtime-saturation.v1",
+      "inspection_template": "telemetry",
+      "required_evidence": [
+        {
+          "key": "runtime-saturation",
+          "source": "runtime",
+          "resource_prefix": "runtime-saturation/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "RUNTIME_SATURATION_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "RUNTIME_TASKGROUP_SATURATED"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "upgrade-readiness.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "upgrade-readiness",
+          "source": "kubernetes",
+          "resource_prefix": "upgrade-readiness/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "UPGRADE_READY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "UPGRADE_PROTOCOL_INCOMPATIBLE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "capacity-runway.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "capacity-runway",
+          "source": "prometheus",
+          "resource_prefix": "capacity-runway/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "CAPACITY_RUNWAY_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "CAPACITY_DISK_RUNWAY_LOW"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "cold-data-flow.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "cold-data-flow",
+          "source": "admin-query",
+          "resource_prefix": "cold-data-flow/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "COLD_DATA_FLOW_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "COLD_DATA_HIT_RATE_LOW"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "dr-readiness.v1",
+      "inspection_template": "broker",
+      "required_evidence": [
+        {
+          "key": "dr-readiness",
+          "source": "admin-query",
+          "resource_prefix": "dr-readiness/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "DR_READY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "DR_BACKUP_OR_SNAPSHOT_STALE"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "security-posture.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "security-posture",
+          "source": "admin-query",
+          "resource_prefix": "security-posture/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "SECURITY_POSTURE_HEALTHY"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "SECURITY_PRIVILEGE_DRIFT"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    },
+    {
+      "id": "change-regression.v1",
+      "inspection_template": "cluster_health",
+      "required_evidence": [
+        {
+          "key": "change-regression",
+          "source": "kubernetes",
+          "resource_prefix": "change-regression/"
+        }
+      ],
+      "scenarios": [
+        {
+          "scenario": "normal",
+          "expected_status": "healthy",
+          "expected_reason_codes": [
+            "CHANGE_NO_REGRESSION"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "fault",
+          "expected_status": "fault",
+          "expected_reason_codes": [
+            "CHANGE_SLO_REGRESSION"
+          ],
+          "partial": false,
+          "execution_eligible": false
+        },
+        {
+          "scenario": "missing",
+          "expected_status": "inconclusive",
+          "expected_reason_codes": [],
+          "partial": true,
+          "execution_eligible": false
+        }
+      ]
+    }
+  ]
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/model.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/evidence/model.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
+
 use rocketmq_sre_contracts::ClusterId;
+use rocketmq_sre_contracts::ContractError;
 use rocketmq_sre_contracts::EvidenceSnapshot;
 use rocketmq_sre_contracts::IncidentId;
 use rocketmq_sre_contracts::InvestigationId;
@@ -20,6 +23,30 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::ControlPlaneError;
+
+fn validate_schema(evidence: &EvidenceSnapshot) -> Result<(), ControlPlaneError> {
+    let supported = rocketmq_sre_contracts::current_evidence_schema();
+    evidence
+        .schema
+        .ensure_compatible(&supported.family, supported.major, &BTreeSet::new())
+        .map_err(|error| match error {
+            ContractError::UnsupportedSchemaFamily { .. } => {
+                ControlPlaneError::validation("unsupported_schema_family", "evidence schema family is unsupported")
+            }
+            ContractError::UnsupportedSchemaMajor { .. } => {
+                ControlPlaneError::validation("unsupported_schema_major", "evidence schema major is unsupported")
+            }
+            ContractError::MissingRequiredFeature { .. } => {
+                ControlPlaneError::validation("missing_required_feature", "evidence requires an unsupported feature")
+            }
+            ContractError::InvalidTimeRange
+            | ContractError::InvalidContentHash
+            | ContractError::InvalidStateTransition { .. }
+            | ContractError::InvalidDescriptor { .. } => {
+                ControlPlaneError::validation("invalid_request", "evidence schema is invalid")
+            }
+        })
+}
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct PersistEvidenceRequest {
@@ -36,9 +63,73 @@ impl PersistEvidenceRequest {
                 "evidence must be attached to an investigation or incident",
             ));
         }
+        validate_schema(&self.evidence)?;
         self.evidence
             .verify_content_hash()
             .map_err(|_| ControlPlaneError::validation("invalid_content_hash", "evidence content hash is invalid"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use rocketmq_sre_contracts::CorrelationId;
+    use rocketmq_sre_contracts::EvidenceContent;
+    use rocketmq_sre_contracts::EvidenceQuery;
+    use rocketmq_sre_contracts::QueryId;
+    use rocketmq_sre_contracts::SchemaVersion;
+    use rocketmq_sre_contracts::TenantId;
+    use rocketmq_sre_contracts::TimeRange;
+    use serde_json::json;
+
+    use super::*;
+
+    fn request_with_schema(schema: SchemaVersion) -> PersistEvidenceRequest {
+        let at = Utc::now();
+        let query = EvidenceQuery {
+            query_id: QueryId::new(),
+            correlation_id: CorrelationId::new(),
+            tenant_id: TenantId::new(),
+            cluster_id: ClusterId::new(),
+            source: "qualification".to_owned(),
+            resource: "diagnostic/fixture".to_owned(),
+            time_range: TimeRange::new(at, at).expect("valid time range"),
+        };
+        let evidence = EvidenceSnapshot::capture(query, schema, at, EvidenceContent::Inline(json!({"ok": true})))
+            .expect("fixture should seal");
+        PersistEvidenceRequest {
+            investigation_id: Some(InvestigationId::new()),
+            incident_id: None,
+            evidence,
+        }
+    }
+
+    #[test]
+    fn persistence_rejects_unknown_schema_major() {
+        let request = request_with_schema(SchemaVersion::new("rocketmq-sre.evidence", 99, 0));
+
+        assert!(matches!(
+            request.validate(),
+            Err(ControlPlaneError::Validation {
+                code: "unsupported_schema_major",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn persistence_rejects_unknown_required_feature() {
+        let request = request_with_schema(
+            rocketmq_sre_contracts::current_evidence_schema().requiring(["unknown-qualification-feature"]),
+        );
+
+        assert!(matches!(
+            request.validate(),
+            Err(ControlPlaneError::Validation {
+                code: "missing_required_feature",
+                ..
+            })
+        ));
     }
 }
 

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/inspection/service.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/inspection/service.rs
@@ -186,18 +186,19 @@ impl InspectionService {
                 )
             })?;
             let completed_at = Utc::now();
-            partial |= !report.missing_required_evidence.is_empty()
-                || matches!(
-                    report.status,
-                    DiagnosticStatus::Inconclusive | DiagnosticStatus::Unsupported
-                );
+            let pack_partial = diagnostic_pack_is_partial(
+                page.partial,
+                !report.missing_required_evidence.is_empty(),
+                report.status,
+            );
+            partial |= pack_partial;
             recommendations.extend(recommendations_from_report(&report));
             pack_runs.push(InspectionPackRun {
                 pack_id: report.pack_id.clone(),
                 pack_version: report.pack_version.to_string(),
                 input_evidence_ids: page.items.iter().map(|snapshot| snapshot.evidence_id).collect(),
                 output: report_json(&report),
-                partial,
+                partial: pack_partial,
                 started_at,
                 completed_at,
             });
@@ -233,6 +234,16 @@ impl InspectionService {
             )),
         }
     }
+}
+
+const fn diagnostic_pack_is_partial(
+    input_partial: bool,
+    missing_required_evidence: bool,
+    status: DiagnosticStatus,
+) -> bool {
+    input_partial
+        || missing_required_evidence
+        || matches!(status, DiagnosticStatus::Inconclusive | DiagnosticStatus::Unsupported)
 }
 
 fn template_packs(template: InspectionTemplate) -> &'static [&'static str] {
@@ -294,6 +305,8 @@ fn template_packs(template: InspectionTemplate) -> &'static [&'static str] {
             "change-regression.v1",
         ],
         InspectionTemplate::ProducerConsumer => &[
+            "producer-connectivity.v1",
+            "message-path.v1",
             "send-latency.v1",
             "consumer-lag.v2",
             "consumer-runtime.v1",
@@ -530,6 +543,38 @@ mod tests {
         ] {
             assert!(!template_packs(template).is_empty());
         }
+    }
+
+    #[test]
+    fn operational_templates_cover_the_complete_diagnostic_catalog() {
+        let covered = [
+            InspectionTemplate::ClusterHealth,
+            InspectionTemplate::Consumer,
+            InspectionTemplate::Broker,
+            InspectionTemplate::Telemetry,
+            InspectionTemplate::ProducerConsumer,
+        ]
+        .into_iter()
+        .flat_map(template_packs)
+        .copied()
+        .collect::<BTreeSet<_>>();
+        let expected = rocketmq_sre_core::diagnostics::full_pack_ids()
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            covered,
+            expected.iter().map(String::as_str).collect(),
+            "the bounded operational inspection surface must reach every built-in pack"
+        );
+    }
+
+    #[test]
+    fn pack_partial_status_is_scoped_to_the_current_pack() {
+        assert!(!diagnostic_pack_is_partial(false, false, DiagnosticStatus::Healthy));
+        assert!(!diagnostic_pack_is_partial(false, false, DiagnosticStatus::Fault));
+        assert!(diagnostic_pack_is_partial(false, true, DiagnosticStatus::Healthy));
+        assert!(diagnostic_pack_is_partial(false, false, DiagnosticStatus::Inconclusive));
     }
 
     #[test]

--- a/rocketmq-sre/crates/rocketmq-sre-eval/Cargo.toml
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/Cargo.toml
@@ -28,6 +28,7 @@ axum.workspace = true
 base64.workspace = true
 chrono.workspace = true
 jsonwebtoken.workspace = true
+reqwest.workspace = true
 rocketmq-sre-contracts.workspace = true
 rocketmq-sre-core.workspace = true
 rocketmq-sre-model-gateway.workspace = true
@@ -36,6 +37,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -63,3 +65,7 @@ path = "src/bin/phase01_shadow_eval.rs"
 [[bin]]
 name = "phase01-model-mock"
 path = "src/bin/phase01_model_mock.rs"
+
+[[bin]]
+name = "diagnostic-pack-qualification"
+path = "src/bin/diagnostic_pack_qualification.rs"

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/bin/diagnostic_pack_qualification.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/bin/diagnostic_pack_qualification.rs
@@ -1,0 +1,157 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use rocketmq_sre_eval::diagnostic_qualification::DiagnosticQualificationError;
+use rocketmq_sre_eval::diagnostic_qualification::LiveQualificationConfig;
+use rocketmq_sre_eval::diagnostic_qualification::run_live_qualification;
+use rocketmq_sre_eval::diagnostic_qualification::write_generated_manifest;
+
+const DEFAULT_TENANT: &str = "00000000-0000-4000-9000-000000008929";
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{}: {error}", error.code());
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<(), DiagnosticQualificationError> {
+    let mut arguments = env::args().skip(1);
+    match arguments.next().as_deref() {
+        Some("export-manifest") => {
+            let path = arguments.next().ok_or_else(|| {
+                DiagnosticQualificationError::InvalidManifest(
+                    "export-manifest requires an explicit output path".to_owned(),
+                )
+            })?;
+            if arguments.next().is_some() {
+                return Err(DiagnosticQualificationError::InvalidManifest(
+                    "export-manifest accepts only one output path".to_owned(),
+                ));
+            }
+            write_generated_manifest(Path::new(&path))?;
+            println!("DIAGNOSTIC_QUALIFICATION_MANIFEST_WRITTEN path={path}");
+            Ok(())
+        }
+        Some("run") => {
+            let output = required_output_path(arguments.next())?;
+            if arguments.next().is_some() {
+                return Err(DiagnosticQualificationError::InvalidManifest(
+                    "run accepts only one report output path".to_owned(),
+                ));
+            }
+            let config = config_from_env()?;
+            let report = run_live_qualification(&config).await?;
+            write_report(&output, &report)?;
+            println!(
+                "DIAGNOSTIC_PACK_QUALIFICATION_OK packs={} scenarios={} pack_scenarios={} \
+                 model_network_calls={} target_mutation_calls={} execution_records={} report={}",
+                report.pack_count,
+                report.scenario_count,
+                report.pack_scenario_count,
+                report.model_provider_network_calls,
+                report.target_mutation_calls,
+                report.execution_records,
+                output.display()
+            );
+            Ok(())
+        }
+        Some("--help" | "-h") | None => {
+            println!(
+                "diagnostic-pack-qualification export-manifest <PATH>\n\
+                 diagnostic-pack-qualification run <MACHINE_LOCAL_REPORT_PATH>"
+            );
+            Ok(())
+        }
+        Some(command) => Err(DiagnosticQualificationError::InvalidManifest(format!(
+            "unknown command `{command}`"
+        ))),
+    }
+}
+
+fn config_from_env() -> Result<LiveQualificationConfig, DiagnosticQualificationError> {
+    Ok(LiveQualificationConfig {
+        public_url: optional_env("ROCKETMQ_SRE_QUALIFICATION_PUBLIC_URL", "http://127.0.0.1:8090"),
+        connector_url: optional_env("ROCKETMQ_SRE_QUALIFICATION_CONNECTOR_URL", "http://127.0.0.1:8093"),
+        database_url: required_env("DATABASE_URL")?,
+        token: required_env("ROCKETMQ_SRE_QUALIFICATION_TOKEN")?,
+        tenant_id: parse_id("ROCKETMQ_SRE_QUALIFICATION_TENANT_ID", DEFAULT_TENANT)?,
+        revision: required_env("ROCKETMQ_SRE_QUALIFICATION_REVISION")?,
+        environment: optional_env("ROCKETMQ_SRE_QUALIFICATION_ENVIRONMENT", "docker-postgresql-local"),
+    })
+}
+
+fn required_env(name: &'static str) -> Result<String, DiagnosticQualificationError> {
+    env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| DiagnosticQualificationError::InvalidManifest(format!("{name} must be configured")))
+}
+
+fn optional_env(name: &'static str, fallback: &'static str) -> String {
+    env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn parse_id<T>(name: &'static str, fallback: &'static str) -> Result<T, DiagnosticQualificationError>
+where
+    T: std::str::FromStr,
+{
+    optional_env(name, fallback)
+        .parse()
+        .map_err(|_| DiagnosticQualificationError::InvalidManifest(format!("{name} must be a UUID")))
+}
+
+fn required_output_path(value: Option<String>) -> Result<PathBuf, DiagnosticQualificationError> {
+    let path = PathBuf::from(value.ok_or_else(|| {
+        DiagnosticQualificationError::InvalidManifest("run requires a machine-local report path".to_owned())
+    })?);
+    if !path.is_absolute() {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "qualification report path must be absolute and outside the repository".to_owned(),
+        ));
+    }
+    Ok(path)
+}
+
+fn write_report(
+    path: &Path,
+    report: &rocketmq_sre_eval::diagnostic_qualification::DiagnosticQualificationReport,
+) -> Result<(), DiagnosticQualificationError> {
+    let parent = path.parent().ok_or_else(|| {
+        DiagnosticQualificationError::InvalidManifest("qualification report path has no parent".to_owned())
+    })?;
+    fs::create_dir_all(parent).map_err(|source| DiagnosticQualificationError::Io {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+    let mut encoded = serde_json::to_vec_pretty(report)?;
+    encoded.push(b'\n');
+    fs::write(path, encoded).map_err(|source| DiagnosticQualificationError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Rules-only live qualification for the complete diagnostic-pack catalog.
+
+mod fixture;
+mod live;
+mod model;
+
+pub use fixture::generated_manifest;
+pub use fixture::load_committed_manifest;
+pub use fixture::write_generated_manifest;
+pub use live::run_live_qualification;
+pub use model::DiagnosticQualificationError;
+pub use model::DiagnosticQualificationManifest;
+pub use model::DiagnosticQualificationReport;
+pub use model::LiveQualificationConfig;
+pub use model::QualificationScenario;

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/fixture.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/fixture.rs
@@ -1,0 +1,615 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use chrono::DateTime;
+use chrono::Utc;
+use rocketmq_sre_contracts::ClusterId;
+use rocketmq_sre_contracts::CorrelationId;
+use rocketmq_sre_contracts::CoverageStatus;
+use rocketmq_sre_contracts::EvidenceContent;
+use rocketmq_sre_contracts::EvidenceQuery;
+use rocketmq_sre_contracts::EvidenceSnapshot;
+use rocketmq_sre_contracts::QueryId;
+use rocketmq_sre_contracts::TenantId;
+use rocketmq_sre_contracts::TimeRange;
+use rocketmq_sre_contracts::current_evidence_schema;
+use rocketmq_sre_core::diagnostics::full_pack_ids;
+use rocketmq_sre_core::diagnostics::full_registry;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::model::DiagnosticQualificationError;
+use super::model::DiagnosticQualificationManifest;
+use super::model::QUALIFICATION_PACK_COUNT;
+use super::model::QUALIFICATION_SCENARIO_COUNT;
+use super::model::QUALIFICATION_SCHEMA;
+use super::model::QualificationEvidenceRequirement;
+use super::model::QualificationExpectation;
+use super::model::QualificationScenario;
+use super::model::QualifiedDiagnosticPack;
+
+const WAVE_A_FIXTURES: &[(&str, &str)] = &[
+    (
+        "tests/fixtures/diagnostics/cluster-topology.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/cluster-topology.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/cluster-topology.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/cluster-topology.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/cluster-topology.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/cluster-topology.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-lag.v2/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-lag.v2/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-lag.v2/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-lag.v2/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-lag.v2/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-lag.v2/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-runtime.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-runtime.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-runtime.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-runtime.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/consumer-runtime.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/consumer-runtime.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/producer-connectivity.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/producer-connectivity.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/producer-connectivity.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/producer-connectivity.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/producer-connectivity.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/producer-connectivity.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/broker-health.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/broker-health.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/broker-health.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/broker-health.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/broker-health.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/broker-health.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/message-path.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/message-path.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/message-path.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/message-path.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/message-path.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/message-path.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/telemetry-pipeline.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/telemetry-pipeline.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/telemetry-pipeline.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/telemetry-pipeline.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/telemetry-pipeline.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/telemetry-pipeline.v1/missing.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/deployment-drift.v1/normal.json",
+        include_str!("../../../../tests/fixtures/diagnostics/deployment-drift.v1/normal.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/deployment-drift.v1/fault.json",
+        include_str!("../../../../tests/fixtures/diagnostics/deployment-drift.v1/fault.json"),
+    ),
+    (
+        "tests/fixtures/diagnostics/deployment-drift.v1/missing.json",
+        include_str!("../../../../tests/fixtures/diagnostics/deployment-drift.v1/missing.json"),
+    ),
+];
+const WAVE_B_CATALOG_PATH: &str = "tests/fixtures/diagnostics/wave-b/catalog.v1.json";
+const WAVE_C_CATALOG_PATH: &str = "tests/fixtures/diagnostics/wave-c/catalog.v1.json";
+const WAVE_B_CATALOG: &str = include_str!("../../../../tests/fixtures/diagnostics/wave-b/catalog.v1.json");
+const WAVE_C_CATALOG: &str = include_str!("../../../../tests/fixtures/diagnostics/wave-c/catalog.v1.json");
+const MAX_FIXTURE_CONTENT_BYTES: usize = 32 * 1024;
+
+#[derive(Clone, Debug, Deserialize)]
+struct RawFixture {
+    pack: String,
+    scenario: QualificationScenario,
+    expected_status: String,
+    #[serde(default)]
+    expected_reason_codes: Vec<String>,
+    evidence: Vec<RawEvidence>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct RawEvidence {
+    source: String,
+    resource: String,
+    #[serde(default = "available")]
+    coverage: CoverageStatus,
+    #[serde(default)]
+    partial: bool,
+    content: Value,
+}
+
+#[derive(Deserialize)]
+struct RawFixtureCatalog {
+    fixtures: Vec<RawFixture>,
+}
+
+pub(super) struct MaterializedPackScenario {
+    pub(super) expected: QualificationExpectation,
+    pub(super) evidence: Vec<EvidenceSnapshot>,
+}
+
+/// Builds the canonical manifest directly from the compiled registry and the
+/// checked-in fixture assets.
+pub fn generated_manifest() -> Result<DiagnosticQualificationManifest, DiagnosticQualificationError> {
+    let fixtures = raw_fixtures()?;
+    let expected = expected_by_pack(&fixtures)?;
+    let registry = full_registry().map_err(|error| {
+        DiagnosticQualificationError::InvalidManifest(format!("built-in diagnostic registry is invalid: {error}"))
+    })?;
+    let mut packs = Vec::new();
+    for id in full_pack_ids() {
+        let pack = registry.resolve(&id).ok_or_else(|| {
+            DiagnosticQualificationError::InvalidManifest(format!("registered pack `{id}` cannot be resolved"))
+        })?;
+        let scenarios = expected.get(&id).cloned().ok_or_else(|| {
+            DiagnosticQualificationError::InvalidManifest(format!("pack `{id}` has no qualification scenarios"))
+        })?;
+        packs.push(QualifiedDiagnosticPack {
+            inspection_template: inspection_template_for(&id)?.to_owned(),
+            id,
+            required_evidence: pack
+                .required_evidence()
+                .iter()
+                .map(|requirement| QualificationEvidenceRequirement {
+                    key: requirement.key.to_owned(),
+                    source: requirement.source.to_owned(),
+                    resource_prefix: requirement.resource_prefix.to_owned(),
+                })
+                .collect(),
+            scenarios,
+        });
+    }
+    let manifest = DiagnosticQualificationManifest {
+        schema_version: QUALIFICATION_SCHEMA.to_owned(),
+        operating_mode: "rules_only".to_owned(),
+        model_provider_network_calls: false,
+        target_mutation_calls: 0,
+        execution_eligible: false,
+        pack_count: QUALIFICATION_PACK_COUNT,
+        scenario_count: QUALIFICATION_SCENARIO_COUNT,
+        pack_scenario_count: QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT,
+        inspection_templates: vec![
+            "cluster_health".to_owned(),
+            "consumer".to_owned(),
+            "broker".to_owned(),
+            "telemetry".to_owned(),
+            "producer_consumer".to_owned(),
+        ],
+        fixture_assets: WAVE_A_FIXTURES
+            .iter()
+            .map(|(path, _)| (*path).to_owned())
+            .chain([WAVE_B_CATALOG_PATH.to_owned(), WAVE_C_CATALOG_PATH.to_owned()])
+            .collect(),
+        packs,
+    };
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+/// Loads the committed qualification manifest and rejects generator drift.
+pub fn load_committed_manifest(path: &Path) -> Result<DiagnosticQualificationManifest, DiagnosticQualificationError> {
+    let raw = fs::read_to_string(path).map_err(|source| DiagnosticQualificationError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let manifest: DiagnosticQualificationManifest = serde_json::from_str(&raw)?;
+    validate_manifest(&manifest)?;
+    if manifest != generated_manifest()? {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "committed manifest differs from the compiled registry or fixture assets".to_owned(),
+        ));
+    }
+    Ok(manifest)
+}
+
+/// Writes the stable generated manifest for deliberate artifact updates.
+pub fn write_generated_manifest(path: &Path) -> Result<(), DiagnosticQualificationError> {
+    let manifest = generated_manifest()?;
+    let mut encoded = serde_json::to_vec_pretty(&manifest)?;
+    encoded.push(b'\n');
+    fs::write(path, encoded).map_err(|source| DiagnosticQualificationError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub(super) fn materialize_pack_scenario(
+    pack_id: &str,
+    scenario: QualificationScenario,
+    tenant_id: TenantId,
+    cluster_id: ClusterId,
+    observed_at: DateTime<Utc>,
+) -> Result<MaterializedPackScenario, DiagnosticQualificationError> {
+    let fixture = raw_fixtures()?
+        .into_iter()
+        .find(|fixture| fixture.pack == pack_id && fixture.scenario == scenario)
+        .ok_or_else(|| {
+            DiagnosticQualificationError::InvalidFixture(format!(
+                "pack `{pack_id}` has no `{}` qualification fixture",
+                scenario.as_str()
+            ))
+        })?;
+    let expected = expectation(&fixture);
+    let mut evidence = Vec::new();
+    for item in fixture.evidence {
+        validate_evidence_fixture(&item)?;
+        let query = EvidenceQuery {
+            query_id: QueryId::new(),
+            correlation_id: CorrelationId::new(),
+            tenant_id,
+            cluster_id,
+            source: item.source,
+            resource: item.resource,
+            time_range: TimeRange::new(observed_at, observed_at)
+                .map_err(|error| DiagnosticQualificationError::InvalidFixture(error.to_string()))?,
+        };
+        let mut snapshot = EvidenceSnapshot::capture(
+            query,
+            current_evidence_schema(),
+            observed_at,
+            EvidenceContent::Inline(item.content),
+        )
+        .map_err(|error| DiagnosticQualificationError::InvalidFixture(error.to_string()))?;
+        snapshot.coverage = item.coverage;
+        snapshot.partial = item.partial;
+        snapshot.content_hash = snapshot
+            .compute_content_hash()
+            .map_err(|error| DiagnosticQualificationError::InvalidFixture(error.to_string()))?;
+        evidence.push(snapshot);
+    }
+    Ok(MaterializedPackScenario { expected, evidence })
+}
+
+fn inspection_template_for(pack_id: &str) -> Result<&'static str, DiagnosticQualificationError> {
+    match pack_id {
+        "cluster-topology.v1"
+        | "deployment-drift.v1"
+        | "namesrv-route.v1"
+        | "controller-ha.v1"
+        | "upgrade-readiness.v1"
+        | "capacity-runway.v1"
+        | "security-posture.v1"
+        | "change-regression.v1" => Ok("cluster_health"),
+        "consumer-lag.v2"
+        | "consumer-runtime.v1"
+        | "retry-dlq.v1"
+        | "transaction-message.v1"
+        | "pop-revive.v1"
+        | "timer-backlog.v1"
+        | "queue-hotspot.v1"
+        | "topic-subscription-config.v1" => Ok("consumer"),
+        "broker-health.v1"
+        | "store-pressure.v1"
+        | "store-integrity.v1"
+        | "rocksdb-health.v1"
+        | "tiered-store.v1"
+        | "broker-ha.v1"
+        | "static-topic-route.v1"
+        | "cold-data-flow.v1"
+        | "dr-readiness.v1" => Ok("broker"),
+        "telemetry-pipeline.v1"
+        | "runtime-saturation.v1"
+        | "send-latency.v1"
+        | "proxy-connectivity.v1"
+        | "auth-failure.v1" => Ok("telemetry"),
+        "producer-connectivity.v1" | "message-path.v1" => Ok("producer_consumer"),
+        _ => Err(DiagnosticQualificationError::InvalidManifest(format!(
+            "pack `{pack_id}` has no inspection template"
+        ))),
+    }
+}
+
+fn raw_fixtures() -> Result<Vec<RawFixture>, DiagnosticQualificationError> {
+    let mut fixtures = WAVE_A_FIXTURES
+        .iter()
+        .map(|(path, raw)| {
+            serde_json::from_str(raw)
+                .map_err(|error| DiagnosticQualificationError::InvalidFixture(format!("`{path}` is invalid: {error}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    for (path, raw) in [
+        (WAVE_B_CATALOG_PATH, WAVE_B_CATALOG),
+        (WAVE_C_CATALOG_PATH, WAVE_C_CATALOG),
+    ] {
+        let catalog: RawFixtureCatalog = serde_json::from_str(raw)
+            .map_err(|error| DiagnosticQualificationError::InvalidFixture(format!("`{path}` is invalid: {error}")))?;
+        fixtures.extend(catalog.fixtures);
+    }
+    for fixture in &fixtures {
+        for evidence in &fixture.evidence {
+            validate_evidence_fixture(evidence)?;
+        }
+    }
+    Ok(fixtures)
+}
+
+fn expected_by_pack(
+    fixtures: &[RawFixture],
+) -> Result<BTreeMap<String, Vec<QualificationExpectation>>, DiagnosticQualificationError> {
+    let known = full_pack_ids().into_iter().collect::<BTreeSet<_>>();
+    let mut result = BTreeMap::<String, Vec<QualificationExpectation>>::new();
+    for fixture in fixtures {
+        if !known.contains(&fixture.pack) {
+            return Err(DiagnosticQualificationError::InvalidFixture(format!(
+                "fixture references unknown pack `{}`",
+                fixture.pack
+            )));
+        }
+        result
+            .entry(fixture.pack.clone())
+            .or_default()
+            .push(expectation(fixture));
+    }
+    for (pack, scenarios) in &mut result {
+        scenarios.sort_by_key(|item| item.scenario);
+        let actual = scenarios.iter().map(|item| item.scenario).collect::<BTreeSet<_>>();
+        if actual != QualificationScenario::ALL.into_iter().collect() || scenarios.len() != QUALIFICATION_SCENARIO_COUNT
+        {
+            return Err(DiagnosticQualificationError::InvalidFixture(format!(
+                "pack `{pack}` must define exactly normal, fault, and missing scenarios"
+            )));
+        }
+    }
+    if result.len() != QUALIFICATION_PACK_COUNT || result.keys().cloned().collect::<BTreeSet<_>>() != known {
+        return Err(DiagnosticQualificationError::InvalidFixture(
+            "fixture catalog does not cover all 32 built-in packs".to_owned(),
+        ));
+    }
+    Ok(result)
+}
+
+fn expectation(fixture: &RawFixture) -> QualificationExpectation {
+    let mut reason_codes = fixture.expected_reason_codes.clone();
+    reason_codes.sort();
+    QualificationExpectation {
+        scenario: fixture.scenario,
+        expected_status: fixture.expected_status.clone(),
+        expected_reason_codes: reason_codes,
+        partial: fixture.scenario == QualificationScenario::Missing,
+        execution_eligible: false,
+    }
+}
+
+fn validate_manifest(manifest: &DiagnosticQualificationManifest) -> Result<(), DiagnosticQualificationError> {
+    if manifest.schema_version != QUALIFICATION_SCHEMA
+        || manifest.operating_mode != "rules_only"
+        || manifest.model_provider_network_calls
+        || manifest.target_mutation_calls != 0
+        || manifest.execution_eligible
+    {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "qualification must be rules-only, mutation-zero, and execution-ineligible".to_owned(),
+        ));
+    }
+    if manifest.pack_count != QUALIFICATION_PACK_COUNT
+        || manifest.scenario_count != QUALIFICATION_SCENARIO_COUNT
+        || manifest.pack_scenario_count != QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT
+        || manifest.packs.len() != QUALIFICATION_PACK_COUNT
+    {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "qualification cardinality must be 32 packs by 3 scenarios".to_owned(),
+        ));
+    }
+    let known = full_pack_ids().into_iter().collect::<BTreeSet<_>>();
+    let actual = manifest
+        .packs
+        .iter()
+        .map(|pack| pack.id.clone())
+        .collect::<BTreeSet<_>>();
+    if known != actual {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "qualification pack IDs differ from the compiled registry".to_owned(),
+        ));
+    }
+    for pack in &manifest.packs {
+        if !manifest.inspection_templates.contains(&pack.inspection_template) {
+            return Err(DiagnosticQualificationError::InvalidManifest(format!(
+                "pack `{}` references unknown inspection template `{}`",
+                pack.id, pack.inspection_template
+            )));
+        }
+        if pack.required_evidence.is_empty() {
+            return Err(DiagnosticQualificationError::InvalidManifest(format!(
+                "pack `{}` has no required Evidence contract",
+                pack.id
+            )));
+        }
+        let scenarios = pack.scenarios.iter().map(|item| item.scenario).collect::<BTreeSet<_>>();
+        if scenarios != QualificationScenario::ALL.into_iter().collect()
+            || pack.scenarios.len() != QUALIFICATION_SCENARIO_COUNT
+        {
+            return Err(DiagnosticQualificationError::InvalidManifest(format!(
+                "pack `{}` does not define exactly three scenarios",
+                pack.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_evidence_fixture(evidence: &RawEvidence) -> Result<(), DiagnosticQualificationError> {
+    let encoded = serde_json::to_vec(&evidence.content)?;
+    if encoded.len() > MAX_FIXTURE_CONTENT_BYTES {
+        return Err(DiagnosticQualificationError::InvalidFixture(format!(
+            "fixture `{}` exceeds the {MAX_FIXTURE_CONTENT_BYTES}-byte bound",
+            evidence.resource
+        )));
+    }
+    validate_safe_value(&evidence.content).map_err(|field| {
+        DiagnosticQualificationError::InvalidFixture(format!(
+            "fixture `{}` contains forbidden sensitive field or value `{field}`",
+            evidence.resource
+        ))
+    })
+}
+
+pub(super) fn validate_safe_value(value: &Value) -> Result<(), String> {
+    const FORBIDDEN_KEYS: &[&str] = &[
+        "access_token",
+        "authorization",
+        "body",
+        "client_ip",
+        "client_secret",
+        "message_body",
+        "payload",
+        "private_key",
+        "refresh_token",
+        "secret_key",
+        "tls_key",
+    ];
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object {
+                let normalized = key.to_ascii_lowercase();
+                if FORBIDDEN_KEYS.contains(&normalized.as_str()) {
+                    return Err(key.clone());
+                }
+                validate_safe_value(child)?;
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                validate_safe_value(child)?;
+            }
+        }
+        Value::String(text) => {
+            let normalized = text.to_ascii_lowercase();
+            if normalized.contains("-----begin private key-----")
+                || normalized.starts_with("bearer ")
+                || normalized.starts_with("sk-")
+            {
+                return Err("credential-like-value".to_owned());
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+    Ok(())
+}
+
+const fn available() -> CoverageStatus {
+    CoverageStatus::Available
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn committed_manifest_path() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../config/qualification/diagnostic-packs.v1.json")
+    }
+
+    #[test]
+    fn generated_manifest_covers_all_pack_scenarios() {
+        let manifest = generated_manifest().expect("qualification manifest");
+
+        assert_eq!(manifest.pack_count, 32);
+        assert_eq!(manifest.pack_scenario_count, 96);
+        assert_eq!(manifest.packs.len(), 32);
+        assert!(
+            manifest
+                .packs
+                .iter()
+                .all(|pack| manifest.inspection_templates.contains(&pack.inspection_template))
+        );
+    }
+
+    #[test]
+    fn materialized_pack_scenario_is_isolated() {
+        let materialized = materialize_pack_scenario(
+            "consumer-runtime.v1",
+            QualificationScenario::Missing,
+            TenantId::new(),
+            ClusterId::new(),
+            Utc::now(),
+        )
+        .expect("isolated fixture");
+
+        assert_eq!(materialized.expected.scenario, QualificationScenario::Missing);
+        assert!(materialized.expected.partial);
+        assert!(
+            materialized
+                .evidence
+                .iter()
+                .all(|evidence| evidence.resource.starts_with("consumer-runtime/"))
+        );
+    }
+
+    #[test]
+    fn committed_manifest_matches_registry_and_fixtures() {
+        load_committed_manifest(&committed_manifest_path()).expect("committed qualification manifest");
+    }
+
+    #[test]
+    fn manifest_rejects_unknown_pack_and_missing_scenario() {
+        let mut unknown = generated_manifest().expect("qualification manifest");
+        unknown.packs[0].id = "unknown-pack.v1".to_owned();
+        assert!(validate_manifest(&unknown).is_err());
+
+        let mut missing = generated_manifest().expect("qualification manifest");
+        missing.packs[0].scenarios.pop();
+        assert!(validate_manifest(&missing).is_err());
+    }
+
+    #[test]
+    fn fixtures_are_bounded_and_sensitive_field_free() {
+        let fixtures = raw_fixtures().expect("all fixtures");
+
+        assert_eq!(fixtures.len(), 96);
+        for fixture in fixtures {
+            for evidence in fixture.evidence {
+                validate_evidence_fixture(&evidence).expect("safe bounded fixture");
+            }
+        }
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/live.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/live.rs
@@ -1,0 +1,596 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use chrono::Utc;
+use reqwest::RequestBuilder;
+use reqwest::Response;
+use reqwest::StatusCode;
+use rocketmq_sre_contracts::ClusterId;
+use rocketmq_sre_contracts::EvidenceId;
+use rocketmq_sre_contracts::EvidenceSnapshot;
+use serde_json::Value;
+use serde_json::json;
+use sqlx::Row;
+use sqlx::postgres::PgPoolOptions;
+
+use super::fixture::MaterializedPackScenario;
+use super::fixture::generated_manifest;
+use super::fixture::materialize_pack_scenario;
+use super::fixture::validate_safe_value;
+use super::model::DiagnosticQualificationError;
+use super::model::DiagnosticQualificationReport;
+use super::model::LiveQualificationConfig;
+use super::model::QUALIFICATION_PACK_COUNT;
+use super::model::QUALIFICATION_REPORT_SCHEMA;
+use super::model::QUALIFICATION_SCENARIO_COUNT;
+use super::model::QualificationExpectation;
+use super::model::QualificationScenario;
+use super::model::QualifiedPackScenarioResult;
+
+const QUALIFICATION_SUBJECT: &str = "rocketmq-sre-diagnostic-qualification";
+const MAX_PERSISTED_EVIDENCE_BYTES: usize = 64 * 1024;
+const MAX_CITED_EVIDENCE: usize = 200;
+
+struct LiveClient<'a> {
+    http: reqwest::Client,
+    config: &'a LiveQualificationConfig,
+    cluster_scope: String,
+}
+
+struct PersistedPackRun {
+    pack_id: String,
+    output: Value,
+    partial: bool,
+}
+
+struct QualificationJob {
+    pack_id: String,
+    inspection_template: String,
+    scenario: QualificationScenario,
+    cluster_id: ClusterId,
+}
+
+fn qualification_jobs() -> Result<Vec<QualificationJob>, DiagnosticQualificationError> {
+    let manifest = generated_manifest()?;
+    let mut jobs = Vec::with_capacity(QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT);
+    for pack in manifest.packs {
+        for expectation in pack.scenarios {
+            jobs.push(QualificationJob {
+                pack_id: pack.id.clone(),
+                inspection_template: pack.inspection_template.clone(),
+                scenario: expectation.scenario,
+                cluster_id: ClusterId::new(),
+            });
+        }
+    }
+    if jobs.len() != QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "qualification job cardinality must be 32 packs by 3 isolated scenarios".to_owned(),
+        ));
+    }
+    Ok(jobs)
+}
+
+/// Exercises all built-in packs through the running Control Plane and verifies
+/// their persisted PostgreSQL results without enabling a model provider.
+pub async fn run_live_qualification(
+    config: &LiveQualificationConfig,
+) -> Result<DiagnosticQualificationReport, DiagnosticQualificationError> {
+    validate_config(config)?;
+    let started_at = Utc::now();
+    let jobs = qualification_jobs()?;
+    let client = LiveClient {
+        http: reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?,
+        config,
+        cluster_scope: jobs
+            .iter()
+            .map(|job| job.cluster_id.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&config.database_url)
+        .await?;
+    let mut results = Vec::with_capacity(QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT);
+    let mut first_evidence = None;
+    let mut schema_drift_rejected = false;
+
+    for job in &jobs {
+        client.onboard(&job.pack_id, job.scenario, job.cluster_id).await?;
+        let incident_id = client
+            .create_evidence_container(&job.pack_id, job.scenario, job.cluster_id)
+            .await?;
+        let materialized =
+            materialize_pack_scenario(&job.pack_id, job.scenario, config.tenant_id, job.cluster_id, Utc::now())?;
+        if !schema_drift_rejected && let Some(snapshot) = materialized.evidence.first() {
+            schema_drift_rejected = client
+                .assert_schema_drift_rejected(incident_id, snapshot.clone())
+                .await?;
+        }
+        for snapshot in &materialized.evidence {
+            let persisted = client.persist_evidence(incident_id, snapshot).await?;
+            first_evidence.get_or_insert((persisted.evidence_id, job.cluster_id));
+        }
+        client.run_inspection(job.cluster_id, &job.inspection_template).await?;
+        let pack_runs = load_pack_runs(&pool, config.tenant_id, job.cluster_id).await?;
+        results.push(
+            validate_pack_run_result(
+                &client,
+                &job.pack_id,
+                job.scenario,
+                job.cluster_id,
+                &materialized,
+                pack_runs,
+            )
+            .await?,
+        );
+    }
+
+    let (evidence_id, evidence_cluster) = first_evidence.ok_or_else(|| {
+        DiagnosticQualificationError::Assertion("normal and fault scenarios persisted no Evidence".to_owned())
+    })?;
+    let alternate_cluster = jobs
+        .iter()
+        .map(|job| job.cluster_id)
+        .find(|cluster_id| *cluster_id != evidence_cluster)
+        .ok_or_else(|| {
+            DiagnosticQualificationError::Assertion("cross-cluster test requires two clusters".to_owned())
+        })?;
+    let cross_cluster_access_rejected = client
+        .assert_cross_cluster_rejected(evidence_id, alternate_cluster)
+        .await?;
+    let model_provider_network_calls = count_for_tenant(&pool, "model_invocations", config.tenant_id).await?;
+    let execution_records = count_for_tenant(&pool, "executions", config.tenant_id).await?;
+    pool.close().await;
+
+    results.sort_by(|left, right| {
+        left.scenario
+            .cmp(&right.scenario)
+            .then_with(|| left.pack_id.cmp(&right.pack_id))
+    });
+    if results.len() != QUALIFICATION_PACK_COUNT * QUALIFICATION_SCENARIO_COUNT
+        || model_provider_network_calls != 0
+        || execution_records != 0
+        || !cross_cluster_access_rejected
+        || !schema_drift_rejected
+    {
+        return Err(DiagnosticQualificationError::Assertion(
+            "global mutation-zero, model-zero, scope, schema, or cardinality invariant failed".to_owned(),
+        ));
+    }
+
+    Ok(DiagnosticQualificationReport {
+        schema_version: QUALIFICATION_REPORT_SCHEMA.to_owned(),
+        revision: config.revision.clone(),
+        environment: config.environment.clone(),
+        database: "PostgreSQL 17 (Docker)".to_owned(),
+        started_at,
+        finished_at: Utc::now(),
+        status: "passed".to_owned(),
+        operating_mode: "rules_only".to_owned(),
+        pack_count: QUALIFICATION_PACK_COUNT,
+        scenario_count: QUALIFICATION_SCENARIO_COUNT,
+        pack_scenario_count: results.len(),
+        model_provider_network_calls,
+        target_mutation_calls: 0,
+        execution_records,
+        cross_cluster_access_rejected,
+        schema_drift_rejected,
+        results,
+    })
+}
+
+impl LiveClient<'_> {
+    async fn onboard(
+        &self,
+        pack_id: &str,
+        scenario: QualificationScenario,
+        cluster_id: ClusterId,
+    ) -> Result<(), DiagnosticQualificationError> {
+        let external_pack_id = pack_id.replace('.', "-");
+        let request = json!({
+            "cluster_id": cluster_id,
+            "tenant_id": self.config.tenant_id,
+            "external_cluster_key": format!(
+                "diagnostic-qualification-{external_pack_id}-{}",
+                scenario.as_str()
+            ),
+            "environment": "qualification",
+            "region": "docker-local",
+            "rocketmq_version": "read-only-fixture",
+            "deployment_mode": "qualification",
+            "owner": "rocketmq-sre",
+            "actor_subject": QUALIFICATION_SUBJECT,
+        });
+        let response = self
+            .authorized(self.http.post(self.public_endpoint("/v1/clusters/onboard")))
+            .json(&request)
+            .send()
+            .await?;
+        success_json(response, "cluster onboarding").await?;
+        Ok(())
+    }
+
+    async fn create_evidence_container(
+        &self,
+        pack_id: &str,
+        scenario: QualificationScenario,
+        cluster_id: ClusterId,
+    ) -> Result<rocketmq_sre_contracts::IncidentId, DiagnosticQualificationError> {
+        let response = self
+            .authorized(self.http.post(self.public_endpoint("/v1/incidents")))
+            .json(&json!({
+                "cluster_id": cluster_id,
+                "title": format!("Diagnostic qualification {pack_id} {} evidence", scenario.as_str()),
+                "resource": format!("qualification/{pack_id}/{}", scenario.as_str()),
+                "symptom_family": "diagnostic-qualification",
+            }))
+            .send()
+            .await?;
+        let value = success_json(response, "incident creation").await?;
+        serde_json::from_value(
+            value.pointer("/incident/id").cloned().ok_or_else(|| {
+                DiagnosticQualificationError::Assertion("incident response omitted its ID".to_owned())
+            })?,
+        )
+        .map_err(DiagnosticQualificationError::from)
+    }
+
+    async fn persist_evidence(
+        &self,
+        incident_id: rocketmq_sre_contracts::IncidentId,
+        snapshot: &EvidenceSnapshot,
+    ) -> Result<EvidenceSnapshot, DiagnosticQualificationError> {
+        let response = self
+            .authorized(self.http.post(self.connector_endpoint("/internal/v1/evidence")))
+            .json(&json!({
+                "investigation_id": null,
+                "incident_id": incident_id,
+                "evidence": snapshot,
+            }))
+            .send()
+            .await?;
+        let value = success_json(response, "Evidence persistence").await?;
+        let persisted: EvidenceSnapshot = serde_json::from_value(value)?;
+        persisted.verify_content_hash().map_err(|error| {
+            DiagnosticQualificationError::Assertion(format!("persisted Evidence hash failed: {error}"))
+        })?;
+        Ok(persisted)
+    }
+
+    async fn run_inspection(&self, cluster_id: ClusterId, template: &str) -> Result<(), DiagnosticQualificationError> {
+        let response = self
+            .authorized(self.http.post(self.public_endpoint("/v1/inspections")))
+            .json(&json!({
+                "cluster_id": cluster_id,
+                "template": template,
+                "schedule": null,
+            }))
+            .send()
+            .await?;
+        let value = success_json(response, "inspection execution").await?;
+        let status = value.pointer("/run/status").and_then(Value::as_str).unwrap_or_default();
+        if !matches!(status, "completed" | "needs_evidence") {
+            return Err(DiagnosticQualificationError::Assertion(format!(
+                "inspection `{template}` ended in unexpected status `{status}`"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn assert_schema_drift_rejected(
+        &self,
+        incident_id: rocketmq_sre_contracts::IncidentId,
+        mut snapshot: EvidenceSnapshot,
+    ) -> Result<bool, DiagnosticQualificationError> {
+        snapshot.schema.major = snapshot.schema.major.saturating_add(99);
+        snapshot.content_hash = snapshot
+            .compute_content_hash()
+            .map_err(|error| DiagnosticQualificationError::Assertion(error.to_string()))?;
+        let response = self
+            .authorized(self.http.post(self.connector_endpoint("/internal/v1/evidence")))
+            .json(&json!({
+                "investigation_id": null,
+                "incident_id": incident_id,
+                "evidence": snapshot,
+            }))
+            .send()
+            .await?;
+        error_code_is(response, StatusCode::BAD_REQUEST, "unsupported_schema_major").await
+    }
+
+    async fn assert_cross_cluster_rejected(
+        &self,
+        evidence_id: EvidenceId,
+        authorized_cluster: ClusterId,
+    ) -> Result<bool, DiagnosticQualificationError> {
+        let response = self
+            .authorized_for_clusters(
+                self.http
+                    .get(self.public_endpoint(&format!("/v1/evidence/{evidence_id}"))),
+                &authorized_cluster.to_string(),
+            )
+            .send()
+            .await?;
+        error_code_is(response, StatusCode::FORBIDDEN, "cluster_not_allowed").await
+    }
+
+    async fn read_evidence(
+        &self,
+        evidence_id: EvidenceId,
+        cluster_id: ClusterId,
+    ) -> Result<(), DiagnosticQualificationError> {
+        let response = self
+            .authorized(
+                self.http
+                    .get(self.public_endpoint(&format!("/v1/evidence/{evidence_id}"))),
+            )
+            .send()
+            .await?;
+        let value = success_json(response, "cited Evidence lookup").await?;
+        if serde_json::to_vec(&value)?.len() > MAX_PERSISTED_EVIDENCE_BYTES {
+            return Err(DiagnosticQualificationError::Assertion(format!(
+                "cited Evidence `{evidence_id}` exceeded the response bound"
+            )));
+        }
+        validate_safe_value(&value).map_err(|field| {
+            DiagnosticQualificationError::Assertion(format!(
+                "cited Evidence `{evidence_id}` exposed forbidden field or value `{field}`"
+            ))
+        })?;
+        let snapshot: EvidenceSnapshot = serde_json::from_value(value)?;
+        if snapshot.evidence_id != evidence_id
+            || snapshot.tenant_id != self.config.tenant_id
+            || snapshot.cluster_id != cluster_id
+        {
+            return Err(DiagnosticQualificationError::Assertion(format!(
+                "cited Evidence `{evidence_id}` crossed its persisted scope"
+            )));
+        }
+        snapshot.verify_content_hash().map_err(|error| {
+            DiagnosticQualificationError::Assertion(format!("cited Evidence `{evidence_id}` hash failed: {error}"))
+        })
+    }
+
+    fn authorized(&self, request: RequestBuilder) -> RequestBuilder {
+        self.authorized_for_clusters(request, &self.cluster_scope)
+    }
+
+    fn authorized_for_clusters(&self, request: RequestBuilder, clusters: &str) -> RequestBuilder {
+        request
+            .bearer_auth(&self.config.token)
+            .header("x-rocketmq-tenant", self.config.tenant_id.to_string())
+            .header("x-rocketmq-clusters", clusters)
+            .header("x-rocketmq-subject", QUALIFICATION_SUBJECT)
+    }
+
+    fn public_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.config.public_url.trim_end_matches('/'), path)
+    }
+
+    fn connector_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.config.connector_url.trim_end_matches('/'), path)
+    }
+}
+
+async fn load_pack_runs(
+    pool: &sqlx::PgPool,
+    tenant_id: rocketmq_sre_contracts::TenantId,
+    cluster_id: ClusterId,
+) -> Result<Vec<PersistedPackRun>, DiagnosticQualificationError> {
+    let rows = sqlx::query(
+        "SELECT pack_id, output, partial
+         FROM diagnostic_pack_runs
+         WHERE tenant_id = $1 AND cluster_id = $2 AND inspection_run_id IS NOT NULL
+         ORDER BY completed_at, id",
+    )
+    .bind(tenant_id.as_uuid())
+    .bind(cluster_id.as_uuid())
+    .fetch_all(pool)
+    .await?;
+    rows.iter()
+        .map(|row| {
+            Ok(PersistedPackRun {
+                pack_id: row.try_get("pack_id")?,
+                output: row.try_get("output")?,
+                partial: row.try_get("partial")?,
+            })
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()
+        .map_err(DiagnosticQualificationError::from)
+}
+
+async fn validate_pack_run_result(
+    client: &LiveClient<'_>,
+    pack_id: &str,
+    scenario: QualificationScenario,
+    cluster_id: ClusterId,
+    materialized: &MaterializedPackScenario,
+    pack_runs: Vec<PersistedPackRun>,
+) -> Result<QualifiedPackScenarioResult, DiagnosticQualificationError> {
+    let matching = pack_runs
+        .into_iter()
+        .filter(|run| run.pack_id == pack_id)
+        .collect::<Vec<_>>();
+    if matching.len() != 1 {
+        return Err(DiagnosticQualificationError::Assertion(format!(
+            "pack `{pack_id}` scenario `{}` persisted {} target results instead of one",
+            scenario.as_str(),
+            matching.len()
+        )));
+    }
+    let run = &matching[0];
+    validate_pack_run(pack_id, &materialized.expected, run)?;
+    let cited = cited_evidence_ids(&run.output)?;
+    if cited.len() > MAX_CITED_EVIDENCE {
+        return Err(DiagnosticQualificationError::Assertion(format!(
+            "pack `{pack_id}` exceeded the {MAX_CITED_EVIDENCE}-citation bound"
+        )));
+    }
+    for evidence_id in &cited {
+        client.read_evidence(*evidence_id, cluster_id).await?;
+    }
+    Ok(QualifiedPackScenarioResult {
+        pack_id: pack_id.to_owned(),
+        scenario,
+        status: materialized.expected.expected_status.clone(),
+        reason_codes: materialized.expected.expected_reason_codes.clone(),
+        cited_evidence_count: cited.len(),
+        persisted_run_count: matching.len(),
+        partial: materialized.expected.partial,
+        execution_eligible: false,
+    })
+}
+
+fn validate_pack_run(
+    pack_id: &str,
+    expectation: &QualificationExpectation,
+    run: &PersistedPackRun,
+) -> Result<(String, Vec<String>, bool), DiagnosticQualificationError> {
+    let status = run.output.get("status").and_then(Value::as_str).unwrap_or_default();
+    let execution_eligible = run
+        .output
+        .get("execution_eligible")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let mut reason_codes = run
+        .output
+        .get("findings")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|finding| finding.get("reason_code").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    reason_codes.sort();
+    if status != expectation.expected_status
+        || reason_codes != expectation.expected_reason_codes
+        || run.partial != expectation.partial
+        || execution_eligible != expectation.execution_eligible
+    {
+        return Err(DiagnosticQualificationError::Assertion(format!(
+            "pack `{pack_id}` result drifted: status `{status}` vs `{}`, reasons {:?} vs {:?}, partial `{}` vs `{}`, \
+             execution_eligible `{execution_eligible}` vs `{}`",
+            expectation.expected_status,
+            reason_codes,
+            expectation.expected_reason_codes,
+            run.partial,
+            expectation.partial,
+            expectation.execution_eligible
+        )));
+    }
+    Ok((status.to_owned(), reason_codes, execution_eligible))
+}
+
+fn cited_evidence_ids(output: &Value) -> Result<BTreeSet<EvidenceId>, DiagnosticQualificationError> {
+    let mut ids = BTreeSet::new();
+    for finding in output.get("findings").and_then(Value::as_array).into_iter().flatten() {
+        for field in ["supporting_evidence", "counter_evidence"] {
+            for citation in finding.get(field).and_then(Value::as_array).into_iter().flatten() {
+                let id = citation.get("evidence_id").cloned().ok_or_else(|| {
+                    DiagnosticQualificationError::Assertion("diagnostic citation omitted evidence_id".to_owned())
+                })?;
+                ids.insert(serde_json::from_value(id)?);
+            }
+        }
+    }
+    Ok(ids)
+}
+
+async fn count_for_tenant(
+    pool: &sqlx::PgPool,
+    table: &str,
+    tenant_id: rocketmq_sre_contracts::TenantId,
+) -> Result<u64, DiagnosticQualificationError> {
+    let query = match table {
+        "model_invocations" => "SELECT COUNT(*) AS count FROM model_invocations WHERE tenant_id = $1",
+        "executions" => "SELECT COUNT(*) AS count FROM executions WHERE tenant_id = $1",
+        _ => {
+            return Err(DiagnosticQualificationError::Assertion(
+                "qualification attempted an unbounded database query".to_owned(),
+            ));
+        }
+    };
+    let count: i64 = sqlx::query(query)
+        .bind(tenant_id.as_uuid())
+        .fetch_one(pool)
+        .await?
+        .try_get("count")?;
+    u64::try_from(count).map_err(|_| {
+        DiagnosticQualificationError::Assertion(format!("table `{table}` returned a negative record count"))
+    })
+}
+
+async fn success_json(response: Response, operation: &str) -> Result<Value, DiagnosticQualificationError> {
+    let status = response.status();
+    let value = response.json::<Value>().await?;
+    if !status.is_success() {
+        let code = value.get("code").and_then(Value::as_str).unwrap_or("unknown_error");
+        return Err(DiagnosticQualificationError::Assertion(format!(
+            "{operation} failed with HTTP {status} and code `{code}`"
+        )));
+    }
+    Ok(value)
+}
+
+async fn error_code_is(
+    response: Response,
+    expected_status: StatusCode,
+    expected_code: &str,
+) -> Result<bool, DiagnosticQualificationError> {
+    let status = response.status();
+    let value = response.json::<Value>().await?;
+    let code = value.get("code").and_then(Value::as_str);
+    Ok(status == expected_status && code == Some(expected_code))
+}
+
+fn validate_config(config: &LiveQualificationConfig) -> Result<(), DiagnosticQualificationError> {
+    if config.public_url.trim().is_empty()
+        || config.connector_url.trim().is_empty()
+        || config.database_url.trim().is_empty()
+        || config.token.trim().is_empty()
+        || config.revision.trim().is_empty()
+        || config.environment.trim().is_empty()
+    {
+        return Err(DiagnosticQualificationError::InvalidManifest(
+            "live qualification configuration contains an empty required value".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn citation_without_evidence_id_fails_closed() {
+        let output = json!({
+            "findings": [{
+                "supporting_evidence": [{}],
+                "counter_evidence": [],
+            }],
+        });
+
+        assert!(matches!(
+            cited_evidence_ids(&output),
+            Err(DiagnosticQualificationError::Assertion(message))
+                if message == "diagnostic citation omitted evidence_id"
+        ));
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/model.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/diagnostic_qualification/model.rs
@@ -1,0 +1,176 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use chrono::DateTime;
+use chrono::Utc;
+use rocketmq_sre_contracts::TenantId;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+pub const QUALIFICATION_SCHEMA: &str = "rocketmq-sre.diagnostic-pack-qualification.v1";
+pub const QUALIFICATION_REPORT_SCHEMA: &str = "rocketmq-sre.diagnostic-pack-qualification-report.v1";
+pub const QUALIFICATION_PACK_COUNT: usize = 32;
+pub const QUALIFICATION_SCENARIO_COUNT: usize = 3;
+
+/// Stable scenario names shared by fixtures, the manifest, and live reports.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QualificationScenario {
+    Normal,
+    Fault,
+    Missing,
+}
+
+impl QualificationScenario {
+    pub const ALL: [Self; QUALIFICATION_SCENARIO_COUNT] = [Self::Normal, Self::Fault, Self::Missing];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Fault => "fault",
+            Self::Missing => "missing",
+        }
+    }
+}
+
+/// One Evidence requirement recorded in the versioned qualification manifest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QualificationEvidenceRequirement {
+    pub key: String,
+    pub source: String,
+    pub resource_prefix: String,
+}
+
+/// Expected deterministic result for one pack and scenario.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QualificationExpectation {
+    pub scenario: QualificationScenario,
+    pub expected_status: String,
+    pub expected_reason_codes: Vec<String>,
+    pub partial: bool,
+    pub execution_eligible: bool,
+}
+
+/// Qualification definition for one built-in diagnostic pack.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QualifiedDiagnosticPack {
+    pub id: String,
+    pub inspection_template: String,
+    pub required_evidence: Vec<QualificationEvidenceRequirement>,
+    pub scenarios: Vec<QualificationExpectation>,
+}
+
+/// Committed, generated contract for all live diagnostic-pack scenarios.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DiagnosticQualificationManifest {
+    pub schema_version: String,
+    pub operating_mode: String,
+    pub model_provider_network_calls: bool,
+    pub target_mutation_calls: u32,
+    pub execution_eligible: bool,
+    pub pack_count: usize,
+    pub scenario_count: usize,
+    pub pack_scenario_count: usize,
+    pub inspection_templates: Vec<String>,
+    pub fixture_assets: Vec<String>,
+    pub packs: Vec<QualifiedDiagnosticPack>,
+}
+
+/// Secret-bearing configuration for a disposable live qualification run.
+///
+/// The type intentionally has no `Debug` implementation so a token or database
+/// URL cannot be logged through routine diagnostic formatting.
+pub struct LiveQualificationConfig {
+    pub public_url: String,
+    pub connector_url: String,
+    pub database_url: String,
+    pub token: String,
+    pub tenant_id: TenantId,
+    pub revision: String,
+    pub environment: String,
+}
+
+/// One successfully validated pack/scenario result.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QualifiedPackScenarioResult {
+    pub pack_id: String,
+    pub scenario: QualificationScenario,
+    pub status: String,
+    pub reason_codes: Vec<String>,
+    pub cited_evidence_count: usize,
+    pub persisted_run_count: usize,
+    pub partial: bool,
+    pub execution_eligible: bool,
+}
+
+/// Redacted machine-local evidence emitted by the live qualification harness.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DiagnosticQualificationReport {
+    pub schema_version: String,
+    pub revision: String,
+    pub environment: String,
+    pub database: String,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub status: String,
+    pub operating_mode: String,
+    pub pack_count: usize,
+    pub scenario_count: usize,
+    pub pack_scenario_count: usize,
+    pub model_provider_network_calls: u64,
+    pub target_mutation_calls: u64,
+    pub execution_records: u64,
+    pub cross_cluster_access_rejected: bool,
+    pub schema_drift_rejected: bool,
+    pub results: Vec<QualifiedPackScenarioResult>,
+}
+
+/// Stable failure categories for manifest and live qualification.
+#[derive(Debug, Error)]
+pub enum DiagnosticQualificationError {
+    #[error("failed to access `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("invalid qualification JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid diagnostic qualification manifest: {0}")]
+    InvalidManifest(String),
+    #[error("invalid diagnostic fixture: {0}")]
+    InvalidFixture(String),
+    #[error("live qualification HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("live qualification database query failed: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("diagnostic qualification assertion failed: {0}")]
+    Assertion(String),
+}
+
+impl DiagnosticQualificationError {
+    #[must_use]
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Io { .. } | Self::Http(_) | Self::Database(_) => "source_unavailable",
+            Self::Json(_) | Self::InvalidManifest(_) => "invalid_qualification_manifest",
+            Self::InvalidFixture(_) => "invalid_evidence_fixture",
+            Self::Assertion(_) => "diagnostic_qualification_failed",
+        }
+    }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/lib.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/lib.rs
@@ -15,6 +15,7 @@
 //! Deterministic schema export and signal-coverage manifest loading.
 
 pub mod assertions;
+pub mod diagnostic_qualification;
 pub mod phase1_shadow;
 pub mod phase2;
 pub mod replay;

--- a/rocketmq-sre/scripts/check_diagnostic_pack_qualification.py
+++ b/rocketmq-sre/scripts/check_diagnostic_pack_qualification.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the complete rules-only diagnostic-pack qualification contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "diagnostic-packs.v1.json"
+EXPECTED_SCHEMA = "rocketmq-sre.diagnostic-pack-qualification.v1"
+EXPECTED_REPORT_SCHEMA = "rocketmq-sre.diagnostic-pack-qualification-report.v1"
+EXPECTED_SCENARIOS = {"normal", "fault", "missing"}
+EXPECTED_TEMPLATES = {"cluster_health", "consumer", "broker", "telemetry", "producer_consumer"}
+PACK_COUNT = 32
+PACK_SCENARIO_COUNT = 96
+MAX_CITED_EVIDENCE = 200
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} root must be an object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if manifest.get("schema_version") != EXPECTED_SCHEMA:
+        findings.append(f"schema_version must be {EXPECTED_SCHEMA}")
+    if manifest.get("operating_mode") != "rules_only":
+        findings.append("operating_mode must be rules_only")
+    if manifest.get("model_provider_network_calls") is not False:
+        findings.append("model-provider network calls must be disabled")
+    if manifest.get("target_mutation_calls") != 0 or manifest.get("execution_eligible") is not False:
+        findings.append("qualification must remain mutation-zero and execution-ineligible")
+    if manifest.get("pack_count") != PACK_COUNT or manifest.get("scenario_count") != 3:
+        findings.append("manifest cardinality must be 32 packs by 3 scenarios")
+    if manifest.get("pack_scenario_count") != PACK_SCENARIO_COUNT:
+        findings.append("pack_scenario_count must be 96")
+    if set(manifest.get("inspection_templates", [])) != EXPECTED_TEMPLATES:
+        findings.append("inspection templates must expose the complete operational catalog")
+
+    packs = manifest.get("packs")
+    if not isinstance(packs, list) or len(packs) != PACK_COUNT:
+        findings.append("packs must contain exactly 32 entries")
+        packs = []
+    seen: set[str] = set()
+    combinations: set[tuple[str, str]] = set()
+    for index, pack in enumerate(packs):
+        location = f"packs[{index}]"
+        if not isinstance(pack, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        pack_id = pack.get("id")
+        if not isinstance(pack_id, str) or not re.fullmatch(r"[a-z0-9-]+\.v[1-9][0-9]*", pack_id):
+            findings.append(f"{location}.id must be a major-qualified pack ID")
+            continue
+        if pack_id in seen:
+            findings.append(f"duplicate pack ID: {pack_id}")
+        seen.add(pack_id)
+        if pack.get("inspection_template") not in EXPECTED_TEMPLATES:
+            findings.append(f"{pack_id} must select one declared inspection template")
+        requirements = pack.get("required_evidence")
+        if not isinstance(requirements, list) or not requirements:
+            findings.append(f"{pack_id} requires at least one Evidence contract")
+        else:
+            for requirement in requirements:
+                if not isinstance(requirement, dict) or any(
+                    not isinstance(requirement.get(field), str) or not requirement[field]
+                    for field in ("key", "source", "resource_prefix")
+                ):
+                    findings.append(f"{pack_id} contains an incomplete Evidence requirement")
+        scenarios = pack.get("scenarios")
+        if not isinstance(scenarios, list) or {item.get("scenario") for item in scenarios if isinstance(item, dict)} != EXPECTED_SCENARIOS:
+            findings.append(f"{pack_id} must contain normal, fault, and missing scenarios")
+            continue
+        for scenario in scenarios:
+            name = scenario.get("scenario")
+            combination = (pack_id, name)
+            if combination in combinations:
+                findings.append(f"duplicate pack/scenario: {pack_id}/{name}")
+            combinations.add(combination)
+            if scenario.get("execution_eligible") is not False:
+                findings.append(f"{pack_id}/{name} must be execution-ineligible")
+            if name == "missing" and (scenario.get("expected_status") != "inconclusive" or scenario.get("partial") is not True):
+                findings.append(f"{pack_id}/missing must be partial and inconclusive")
+    if len(combinations) != PACK_SCENARIO_COUNT:
+        findings.append("manifest does not contain 96 unique pack/scenario combinations")
+
+    assets = manifest.get("fixture_assets")
+    if not isinstance(assets, list) or not assets:
+        findings.append("fixture_assets must be a non-empty array")
+    else:
+        for value in assets:
+            if not isinstance(value, str):
+                findings.append("fixture asset path must be a string")
+                continue
+            path = PurePosixPath(value)
+            if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+                findings.append(f"fixture asset must be repository-relative implementation evidence: {value}")
+            elif not (SRE_ROOT / Path(*path.parts)).is_file():
+                findings.append(f"fixture asset does not exist: {value}")
+    for value in all_strings(manifest):
+        if SENSITIVE.search(value):
+            findings.append("manifest contains credential-like material")
+            break
+    return findings
+
+
+def validate_report(report: dict[str, Any], manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if report.get("schema_version") != EXPECTED_REPORT_SCHEMA or report.get("status") != "passed":
+        findings.append("live report schema or status is invalid")
+    for field in ("revision", "environment", "database", "started_at", "finished_at"):
+        if not isinstance(report.get(field), str) or not report[field]:
+            findings.append(f"live report requires {field}")
+    if report.get("operating_mode") != "rules_only":
+        findings.append("live report must remain rules_only")
+    for field in ("model_provider_network_calls", "target_mutation_calls", "execution_records"):
+        if report.get(field) != 0:
+            findings.append(f"live report {field} must be zero")
+    if report.get("cross_cluster_access_rejected") is not True or report.get("schema_drift_rejected") is not True:
+        findings.append("live report must prove cross-cluster and schema-drift rejection")
+    if report.get("pack_count") != PACK_COUNT or report.get("pack_scenario_count") != PACK_SCENARIO_COUNT:
+        findings.append("live report cardinality must be 32 packs and 96 pack/scenarios")
+
+    expected = {
+        (pack["id"], scenario["scenario"]): scenario
+        for pack in manifest["packs"]
+        for scenario in pack["scenarios"]
+    }
+    results = report.get("results")
+    if not isinstance(results, list) or len(results) != PACK_SCENARIO_COUNT:
+        findings.append("live report must contain exactly 96 results")
+        results = []
+    actual: set[tuple[str, str]] = set()
+    for result in results:
+        if not isinstance(result, dict):
+            findings.append("live report result must be an object")
+            continue
+        key = (result.get("pack_id"), result.get("scenario"))
+        if key in actual:
+            findings.append(f"live report duplicates {key}")
+        actual.add(key)
+        contract = expected.get(key)
+        if contract is None:
+            findings.append(f"live report contains unknown result {key}")
+            continue
+        if result.get("status") != contract["expected_status"]:
+            findings.append(f"live status drifted for {key}")
+        if result.get("reason_codes") != contract["expected_reason_codes"]:
+            findings.append(f"live reason codes drifted for {key}")
+        if result.get("partial") != contract["partial"] or result.get("execution_eligible") is not False:
+            findings.append(f"live safety result drifted for {key}")
+        if not isinstance(result.get("persisted_run_count"), int) or result["persisted_run_count"] < 1:
+            findings.append(f"live result was not persisted for {key}")
+        citation_count = result.get("cited_evidence_count")
+        if not isinstance(citation_count, int) or not 0 <= citation_count <= MAX_CITED_EVIDENCE:
+            findings.append(f"live citation count exceeded its bound for {key}")
+    if actual != set(expected):
+        findings.append("live report result surface differs from the manifest")
+    for value in all_strings(report):
+        if SENSITIVE.search(value):
+            findings.append("live report contains credential-like material")
+            break
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    arguments = parser.parse_args()
+    try:
+        manifest = load_object(arguments.manifest)
+        findings = validate_manifest(manifest)
+        if arguments.report is not None:
+            findings.extend(validate_report(load_object(arguments.report), manifest))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"DIAGNOSTIC_PACK_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"DIAGNOSTIC_PACK_QUALIFICATION_FINDING {finding}")
+        print(f"DIAGNOSTIC_PACK_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    print(
+        "DIAGNOSTIC_PACK_QUALIFICATION_OK "
+        f"packs={PACK_COUNT} pack_scenarios={PACK_SCENARIO_COUNT} "
+        f"live_report={str(arguments.report is not None).lower()} model_network_calls=false target_mutations=0"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/diagnostic-pack-live-qualification.ps1
+++ b/rocketmq-sre/scripts/diagnostic-pack-live-qualification.ps1
@@ -1,0 +1,193 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+    [string]$BuildRoot = 'F:\BuildCache\rocketmq-sre-diagnostic-pack-qualification',
+    [ValidateRange(1024, 65535)]
+    [int]$PostgresPort = 55432,
+    [switch]$KeepEnvironment,
+    [switch]$KeepBuildCache
+)
+
+$ErrorActionPreference = 'Stop'
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$manifestPath = Join-Path $sreRoot 'Cargo.toml'
+$buildRootPath = [IO.Path]::GetFullPath($BuildRoot)
+$evidenceRootPath = [IO.Path]::GetFullPath($EvidenceRoot)
+$containerName = 'rocketmq-sre-diagnostic-qualification-postgres'
+$token = "qualification-$([Guid]::NewGuid().ToString('N'))"
+$databasePassword = [Guid]::NewGuid().ToString('N')
+$databaseUrl = "postgres://rocketmq_sre:$databasePassword@127.0.0.1:$PostgresPort/rocketmq_sre"
+$timestamp = [DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss')
+$runRoot = Join-Path $evidenceRootPath "diagnostic-packs-$timestamp"
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+$controlPlaneStdout = Join-Path $runRoot 'control-plane.stdout.log'
+$controlPlaneStderr = Join-Path $runRoot 'control-plane.stderr.log'
+$controlPlaneProcess = $null
+
+function Assert-SafeLocalRoot([string]$Path, [string]$Name) {
+    $full = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($full)
+    if ($root -notin @('D:\', 'F:\')) {
+        throw "$Name must be located on D:\ or F:\."
+    }
+    if ($full -eq $root) {
+        throw "$Name cannot be a drive root."
+    }
+}
+
+function Invoke-Native([string]$File, [string[]]$Arguments) {
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$File failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Remove-QualificationContainer {
+    $existing = & docker container ls --all --quiet --filter "name=^/$containerName$"
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to inspect the qualification PostgreSQL container.'
+    }
+    if (-not [string]::IsNullOrWhiteSpace("$existing")) {
+        Invoke-Native docker @('container', 'rm', '--force', $containerName)
+    }
+}
+
+function Wait-Postgres {
+    $deadline = [DateTime]::UtcNow.AddMinutes(2)
+    do {
+        & docker exec $containerName pg_isready --username rocketmq_sre --dbname rocketmq_sre *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw 'Docker PostgreSQL did not become ready within two minutes.'
+}
+
+function Wait-ControlPlane {
+    $deadline = [DateTime]::UtcNow.AddMinutes(2)
+    do {
+        if ($controlPlaneProcess.HasExited) {
+            throw "Control Plane exited before readiness; inspect $controlPlaneStderr."
+        }
+        try {
+            $response = Invoke-WebRequest -UseBasicParsing -Uri 'http://127.0.0.1:8090/readyz' -TimeoutSec 3
+            if ($response.StatusCode -eq 200) {
+                return
+            }
+        }
+        catch {
+            # Startup includes PostgreSQL migrations and can take several probes.
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw 'Control Plane did not become ready within two minutes.'
+}
+
+Assert-SafeLocalRoot $buildRootPath 'BuildRoot'
+Assert-SafeLocalRoot $evidenceRootPath 'EvidenceRoot'
+if ($containerName -notmatch '^rocketmq-sre-diagnostic-qualification-[a-z0-9-]+$') {
+    throw 'Qualification container name is outside the fixed cleanup namespace.'
+}
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+try {
+    Invoke-Native docker @('version', '--format', '{{.Server.Version}}')
+    Remove-QualificationContainer
+    Invoke-Native docker @(
+        'run', '--detach', '--name', $containerName,
+        '--publish', "127.0.0.1:$PostgresPort`:5432",
+        '--env', 'POSTGRES_USER=rocketmq_sre',
+        '--env', "POSTGRES_PASSWORD=$databasePassword",
+        '--env', 'POSTGRES_DB=rocketmq_sre',
+        '--tmpfs', '/var/lib/postgresql/data:rw,nosuid,nodev,size=512m',
+        'postgres:17-alpine'
+    )
+    Wait-Postgres
+
+    $env:CARGO_TARGET_DIR = $buildRootPath
+    $env:CARGO_INCREMENTAL = '0'
+    $env:CARGO_PROFILE_DEV_DEBUG = '0'
+    Invoke-Native cargo @('build', '--manifest-path', $manifestPath, '--locked', '-p', 'rocketmq-sre-control-plane', '--bin', 'rocketmq-sre-control-plane')
+    Invoke-Native cargo @('build', '--manifest-path', $manifestPath, '--locked', '-p', 'rocketmq-sre-eval', '--bin', 'diagnostic-pack-qualification')
+
+    $env:DATABASE_URL = $databaseUrl
+    $env:ROCKETMQ_SRE_BIND_ADDR = '127.0.0.1:8090'
+    $env:ROCKETMQ_SRE_CONNECTOR_BIND_ADDR = '127.0.0.1:8093'
+    $env:ROCKETMQ_SRE_DATABASE_MAX_CONNECTIONS = '6'
+    $env:ROCKETMQ_SRE_SHUTDOWN_SECONDS = '5'
+    $env:ROCKETMQ_SRE_INTERNAL_TOKEN = $token
+    $env:ROCKETMQ_SRE_GRANT_SIGNING_KEY = $token
+    $env:ROCKETMQ_SRE_AGENT_ACK_KEY = $token
+    $env:ROCKETMQ_SRE_DEV_AUTH = 'true'
+    $env:ROCKETMQ_SRE_MODEL_ENABLED = 'false'
+    $env:ROCKETMQ_SRE_EXECUTOR_URL = ''
+    $env:ROCKETMQ_SRE_CONTROL_PLANE_EXECUTOR_TOKEN = ''
+    $env:ROCKETMQ_SRE_CONFIG_DIR = Join-Path $sreRoot 'config'
+    $env:ROCKETMQ_SRE_MIGRATIONS_DIR = Join-Path $sreRoot 'migrations'
+    $env:ROCKETMQ_SRE_OBJECT_STORE_LOCAL_PATH = Join-Path $runRoot 'objects'
+    $env:OTEL_SDK_DISABLED = 'true'
+    New-Item -ItemType Directory -Force -Path $env:ROCKETMQ_SRE_OBJECT_STORE_LOCAL_PATH | Out-Null
+
+    $controlPlaneBinary = Join-Path $buildRootPath 'debug\rocketmq-sre-control-plane.exe'
+    $qualificationBinary = Join-Path $buildRootPath 'debug\diagnostic-pack-qualification.exe'
+    $controlPlaneProcess = Start-Process `
+        -FilePath $controlPlaneBinary `
+        -WorkingDirectory $sreRoot `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $controlPlaneStdout `
+        -RedirectStandardError $controlPlaneStderr `
+        -PassThru
+    Wait-ControlPlane
+
+    $revision = (& git -C (Split-Path $sreRoot -Parent) rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+        throw 'Unable to determine the qualification source revision.'
+    }
+    $sourceChanges = & git -C $sreRoot status --porcelain --untracked-files=all
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to determine whether the qualification source is clean.'
+    }
+    if (-not [string]::IsNullOrWhiteSpace("$sourceChanges")) {
+        $revision = "$revision+worktree"
+    }
+    $env:ROCKETMQ_SRE_QUALIFICATION_TOKEN = $token
+    $env:ROCKETMQ_SRE_QUALIFICATION_PUBLIC_URL = 'http://127.0.0.1:8090'
+    $env:ROCKETMQ_SRE_QUALIFICATION_CONNECTOR_URL = 'http://127.0.0.1:8093'
+    $env:ROCKETMQ_SRE_QUALIFICATION_REVISION = $revision
+    $env:ROCKETMQ_SRE_QUALIFICATION_ENVIRONMENT = 'docker-postgresql-local'
+    Invoke-Native $qualificationBinary @('run', $reportPath)
+    Invoke-Native python @((Join-Path $PSScriptRoot 'check_diagnostic_pack_qualification.py'), '--report', $reportPath)
+
+    Write-Output "DIAGNOSTIC_PACK_LIVE_QUALIFICATION_OK report=$reportPath"
+}
+finally {
+    if ($null -ne $controlPlaneProcess -and -not $controlPlaneProcess.HasExited) {
+        Stop-Process -Id $controlPlaneProcess.Id -Force
+        $controlPlaneProcess.WaitForExit()
+    }
+    if (-not $KeepEnvironment) {
+        Remove-QualificationContainer
+    }
+    if (-not $KeepBuildCache -and (Test-Path -LiteralPath $buildRootPath)) {
+        $buildParent = [IO.Path]::GetFullPath((Join-Path $buildRootPath '..'))
+        if ($buildParent -ne 'F:\BuildCache' -and $buildParent -ne 'D:\BuildCache') {
+            throw 'Refusing to remove a build cache outside the fixed D:\BuildCache or F:\BuildCache boundary.'
+        }
+        Remove-Item -LiteralPath $buildRootPath -Recurse -Force
+    }
+}

--- a/rocketmq-sre/scripts/tests/test_check_diagnostic_pack_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_diagnostic_pack_qualification.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the complete diagnostic-pack qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_diagnostic_pack_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_diagnostic_pack_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class DiagnosticPackQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_object(MODULE.DEFAULT_MANIFEST)
+
+    def test_checked_in_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_rejects_unknown_inspection_template(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["packs"][0]["inspection_template"] = "unknown"
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertTrue(any("inspection template" in finding for finding in findings))
+
+    def test_rejects_missing_pack_scenario(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["packs"][0]["scenarios"].pop()
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertTrue(any("normal, fault, and missing" in finding for finding in findings))
+
+    def test_rejects_credential_like_material(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["packs"][0]["id"] = "Bearer unsafe-example-token"
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("manifest contains credential-like material", findings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8929

### Brief Description

Add a versioned rules-only qualification contract and disposable live harness for all 32 built-in SRE Diagnostic Packs. Each pack now runs in isolated normal, fault, and missing-Evidence clusters through the real Control Plane and PostgreSQL repository, producing 96 persisted target results with bounded, scope-checked Evidence citations.

The change also rejects unsupported Evidence schema majors and required features at persistence, exposes all built-in packs through bounded operational inspection templates, and fixes per-pack `partial` state so one pack cannot inherit another pack's incomplete status. The implementation status is promoted to `live_smoke_passed` only for Diagnostic Packs; deployment-specific Evidence source certification remains separate.

The harness uses a disposable Docker PostgreSQL 17 `tmpfs`, random local credentials, D/F machine-local paths, and automatic container cleanup. It asserts zero model-provider network calls, zero target mutations, and zero execution records. No DeepSeek credential or live model integration is included.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --locked --workspace`
- `cargo test --locked --workspace --all-features` with test debuginfo disabled after cleaning only the task-local F-drive Cargo targets: passed
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python scripts/check_diagnostic_pack_qualification.py --report <machine-local-report>`: 32 packs, 96 persisted scenarios, 70 cited Evidence records, zero model calls, zero mutations, and zero executions
- `python scripts/check_implementation_status.py`
- `python -m unittest scripts.tests.test_check_diagnostic_pack_qualification scripts.tests.test_check_implementation_status -v`
- `./scripts/check-error-hygiene.ps1` and `python scripts/error_architecture_guard.py`
- `git diff --check`

`./scripts/check-agents-routing.ps1` reached its standalone consumer check but failed because full `cargo metadata --locked` for the unchanged MCP workspace requires a lockfile update. The exact MCP metadata command fails on the clean `main` worktree as well; this PR does not modify MCP files or its lockfile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic-pack qualification covering 32 built-in packs across healthy, fault, and missing-evidence scenarios.
  * Added commands to run live qualification checks, export reports, and independently validate manifests and results.
  * Added pack-level partial-status reporting and producer-consumer connectivity diagnostics.
  * Added validation for evidence schema compatibility and required capabilities.

* **Documentation**
  * Documented qualification coverage, execution steps, cleanup behavior, validation checks, and deployment-specific certification limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->