### PR TITLE
[ISSUE #8931]✨Qualify bounded R1 SRE actions with persisted live outcomes

### DIFF
--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -239,6 +239,38 @@ committed contract is checked independently with:
 python scripts/check_diagnostic_pack_qualification.py
 ```
 
+### Bounded R1 action qualification
+
+The R1 qualification contract covers the four registered low-risk actions
+without granting generic Admin, shell, or Kubernetes patch access. Each action
+is bound to its descriptor, owner, independent enable switch, typed precheck,
+and the shared lease, fence, journal, verification, audit, and quarantine
+boundaries.
+
+The live harness uses a disposable Kind deployment and the running Control
+Plane, Executor, Execution Agent, PostgreSQL, Broker, Proxy, and OpenTelemetry
+Collector. Real target changes are limited to one logger TTL override, one
+Proxy replica, one Proxy pod, or one Collector pod. Deterministic failure and
+recovery cases use an isolated PostgreSQL schema and a typed Agent test double,
+so the report distinguishes real target execution from controlled recovery
+simulation. Proxy capacity is restored, the logger override expires, workloads
+must return Ready, and qualification-owned resources are removed before a run
+can pass.
+
+Run from `rocketmq-sre/` after bringing up the documented Kind environment:
+
+```powershell
+.\scripts\r1-action-live-qualification.ps1
+```
+
+The redacted report is written under `D:\rocketmq-sre-evidence` and is never a
+production certificate. Model-provider network calls remain zero. Validate the
+committed catalog independently with:
+
+```powershell
+python scripts/check_r1_action_qualification.py
+```
+
 ## User interface
 
 The UI is designed as a full-screen desktop operations workspace using

--- a/rocketmq-sre/README.zh-CN.md
+++ b/rocketmq-sre/README.zh-CN.md
@@ -214,6 +214,32 @@ PostgreSQL 使用有界的 Docker `tmpfs`，运行结束后自动删除。可独
 python scripts/check_diagnostic_pack_qualification.py
 ```
 
+### 有界 R1 动作资格验证
+
+R1 资格契约覆盖四个已注册的低风险动作，同时不开放通用 Admin、Shell 或 Kubernetes
+Patch 能力。每个动作都绑定自己的描述符、负责人、独立启用开关和类型化预检，并统一经过
+租约、Fence、执行日志、验证、审计和隔离边界。
+
+实测工具使用一次性 Kind 部署以及真实运行的 Control Plane、Executor、Execution Agent、
+PostgreSQL、Broker、Proxy 和 OpenTelemetry Collector。真实目标变更严格限制为一个日志级别
+TTL 覆盖、一个 Proxy 副本、一个 Proxy Pod 或一个 Collector Pod。确定性的失败与恢复用例在
+隔离的 PostgreSQL Schema 中配合类型化 Agent 测试替身执行，因此报告会明确区分真实目标执行
+与可控恢复模拟。只有在 Proxy 副本数恢复、日志覆盖到期、工作负载恢复 Ready，且资格验证自有
+资源被清理后，运行才可判定为通过。
+
+按 Kind 环境文档完成启动后，在 `rocketmq-sre/` 中运行：
+
+```powershell
+.\scripts\r1-action-live-qualification.ps1
+```
+
+脱敏报告写入 `D:\rocketmq-sre-evidence`，且不构成生产认证。整个过程的模型供应商网络调用保持
+为零。可使用以下命令独立校验已提交的清单：
+
+```powershell
+python scripts/check_r1_action_qualification.py
+```
+
 ## 用户界面
 
 UI 按照 shadcn/ui 规范和可访问的 Radix UI primitive 设计为全屏桌面运维

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -182,11 +182,24 @@
         {
           "kind": "test",
           "path": "rocketmq-sre/scripts/check_execution_recovery_qualification.py"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/r1-actions.v1.json"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_r1_action_qualification.py"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/r1-action-live-qualification.ps1"
         }
       ],
       "limitations": [
         "All nine explicitly registered bounded actions have independent switches, owners, and contract evidence; the sixteen-scenario Kubernetes platform fault matrix has passed.",
-        "Per-action disposable-cluster success, deny, unknown-result, verification-failure, and rollback qualification remains incomplete.",
+        "All four R1 actions have independently passed disposable Kind success, denial, idempotency, fencing, reconciliation, verification-failure, compensation or manual-takeover safe-stop, quarantine, scope, and kill-switch qualification with zero model-provider calls.",
+        "The five R2 actions still require the same independent disposable-cluster outcome qualification, so aggregate controlled-action live maturity remains partial.",
         "R3 operations and arbitrary requests remain permanently forbidden."
       ]
     },

--- a/rocketmq-sre/config/qualification/execution-recovery.v1.json
+++ b/rocketmq-sre/config/qualification/execution-recovery.v1.json
@@ -38,6 +38,15 @@
       "test": "rollback_failure_atomically_escalates_quarantines_and_notifies"
     }
   },
+  "r1_live_qualification": {
+    "manifest": "rocketmq-sre/config/qualification/r1-actions.v1.json",
+    "script": "rocketmq-sre/scripts/r1-action-live-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_r1_action_qualification.py",
+    "actions": 4,
+    "required_outcomes_per_action": 10,
+    "model_provider_network_calls": false,
+    "production_certified": false
+  },
   "controlled_actions": [
     {
       "id": "observability.logger_level_ttl.v1",
@@ -51,7 +60,7 @@
       "descriptor": "rocketmq-sre/config/actions/observability.logger_level_ttl.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/logger_level_ttl_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-logger-ttl-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "proxy.scale_out_one.v1",
@@ -65,7 +74,7 @@
       "descriptor": "rocketmq-sre/config/actions/proxy.scale_out_one.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_scale_out_one_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-proxy-scale-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "proxy.restart_one.v1",
@@ -79,7 +88,7 @@
       "descriptor": "rocketmq-sre/config/actions/proxy.restart_one.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_restart_one_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-proxy-restart-e2e.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "telemetry.collector.restart_one.v1",
@@ -93,7 +102,7 @@
       "descriptor": "rocketmq-sre/config/actions/telemetry.collector.restart_one.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/telemetry_collector_restart_one_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase04-collector-restart-e2e.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "broker.config.patch_allowlisted.v1",

--- a/rocketmq-sre/config/qualification/r1-actions.v1.json
+++ b/rocketmq-sre/config/qualification/r1-actions.v1.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": "rocketmq-sre.r1-action-qualification.v1",
+  "operating_mode": "rules_only",
+  "environment": "disposable_kind",
+  "model_provider_network_calls": false,
+  "production_certified": false,
+  "required_outcomes": [
+    "live_verified_success",
+    "precheck_denied",
+    "duplicate_idempotent",
+    "stale_epoch_denied",
+    "unknown_effect_reconciled",
+    "verification_failure",
+    "compensation_or_safe_stop",
+    "rollback_failure_or_manual_takeover_quarantined",
+    "scope_denied",
+    "kill_switch_denied"
+  ],
+  "shared_boundary_evidence": {
+    "duplicate_idempotent": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery.rs",
+      "test": "migrations_journal_locks_fences_and_restart_recovery_are_durable"
+    },
+    "stale_epoch_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/fencing_interleavings.rs",
+      "test": "dispatched_unknown_effect_blocks_takeover_until_read_only_reconciliation_confirms_terminal_state"
+    },
+    "unknown_effect_reconciled": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+      "test": "interrupted_compensation_recovers_only_after_effect_is_proven_absent"
+    },
+    "scope_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_authority/tests.rs",
+      "test": "lease_takeover_requires_executor_workload_role_and_exact_cluster_scope"
+    },
+    "kill_switch_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs",
+      "test": "postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent"
+    }
+  },
+  "actions": [
+    {
+      "id": "observability.logger_level_ttl.v1",
+      "risk": "r1",
+      "owner": "messaging-observability",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_LOGGER_TTL",
+      "descriptor": "rocketmq-sre/config/actions/observability.logger_level_ttl.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/logger_level_ttl_tests.rs",
+        "test": "precheck_rejects_payload_and_out_of_range_logger_requests"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs",
+        "test": "real_kind_all_r1_actions_share_the_supervised_execution_chain"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r1_actions_persist_recovery_qualification_matrix"
+      },
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "proxy.scale_out_one.v1",
+      "risk": "r1",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_PROXY_SCALE_OUT",
+      "descriptor": "rocketmq-sre/config/actions/proxy.scale_out_one.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_scale_out_one_tests.rs",
+        "test": "precheck_reports_every_unhealthy_capacity_condition"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs",
+        "test": "real_kind_all_r1_actions_share_the_supervised_execution_chain"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r1_actions_persist_recovery_qualification_matrix"
+      },
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "proxy.restart_one.v1",
+      "risk": "r1",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_PROXY_RESTART",
+      "descriptor": "rocketmq-sre/config/actions/proxy.restart_one.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_restart_one_tests.rs",
+        "test": "precheck_fails_closed_without_authenticated_drain_state"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs",
+        "test": "real_kind_all_r1_actions_share_the_supervised_execution_chain"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r1_actions_persist_recovery_qualification_matrix"
+      },
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "telemetry.collector.restart_one.v1",
+      "risk": "r1",
+      "owner": "messaging-observability",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_TELEMETRY_COLLECTOR_RESTART",
+      "descriptor": "rocketmq-sre/config/actions/telemetry.collector.restart_one.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/telemetry_collector_restart_one_tests.rs",
+        "test": "precheck_fails_closed_when_pipeline_or_data_plane_health_is_unknown"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs",
+        "test": "real_kind_all_r1_actions_share_the_supervised_execution_chain"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r1_actions_persist_recovery_qualification_matrix"
+      },
+      "qualification": "disposable_cluster_smoke_passed"
+    }
+  ],
+  "hard_denials": [
+    "disabled_action",
+    "wrong_tenant",
+    "wrong_cluster",
+    "expired_grant",
+    "unknown_action",
+    "r2_without_approval",
+    "r3_action",
+    "raw_request",
+    "shell_command",
+    "arbitrary_kubernetes_patch"
+  ],
+  "live_report": {
+    "schema_version": "rocketmq-sre.r1-action-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/proxy_restart_e2e_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/proxy_restart_e2e_tests.rs
@@ -480,7 +480,7 @@ pub(super) async fn persist_agent_evidence(
         EvidenceContent::Inline(serde_json::to_value(agent_state).expect("Agent Evidence content")),
     )
     .expect("Agent Evidence");
-    evidence.freshness_seconds = 1_800;
+    evidence.freshness_seconds = 120;
     evidence.coverage = CoverageStatus::Available;
     evidence.sensitivity = Sensitivity::Internal;
     evidence.exposure = EvidenceExposure::Synthetic;
@@ -638,7 +638,7 @@ pub(super) async fn seed_complete_slo_evidence(repository: &PostgresRepository, 
         })),
     )
     .expect("SLO Evidence");
-    evidence.freshness_seconds = 1_800;
+    evidence.freshness_seconds = 600;
     evidence.coverage = CoverageStatus::Available;
     evidence.sensitivity = Sensitivity::Internal;
     evidence.exposure = EvidenceExposure::Synthetic;

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_actions_e2e_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs;
+use std::path::Path;
 use std::time::Duration as StdDuration;
 
 use chrono::Duration;
@@ -24,6 +26,7 @@ use rocketmq_sre_contracts::ExecutionAction;
 use rocketmq_sre_contracts::ExecutionState;
 use rocketmq_sre_contracts::PlanStatus;
 use rocketmq_sre_contracts::TenantId;
+use serde::Serialize;
 use serde_json::Value;
 use serde_json::json;
 use uuid::Uuid;
@@ -56,9 +59,32 @@ struct LiveActionCase {
     required_conditions: &'static [&'static str],
 }
 
+#[derive(Serialize)]
+struct LiveActionOutcome {
+    id: String,
+    state: &'static str,
+    execution_id: String,
+    correlation_id: String,
+    approval_events: i64,
+    intent_records: i64,
+    result_records: i64,
+    confirmed_agent_effects: i64,
+    successful_verifications: i64,
+    verification_evidence_records: i64,
+    target_mutations: i64,
+}
+
+#[derive(Serialize)]
+struct LiveActionFragment<'a> {
+    schema_version: &'static str,
+    model_provider_network_calls: u8,
+    logger_ttl_restored: bool,
+    actions: &'a [LiveActionOutcome],
+}
+
 #[tokio::test]
 #[ignore = "requires live Kind PostgreSQL, Executor, Execution Agent, Broker, and Proxy"]
-async fn real_kind_wave_one_r1_actions_share_the_supervised_execution_chain() {
+async fn real_kind_all_r1_actions_share_the_supervised_execution_chain() {
     let Some(environment) = LiveEnvironment::from_process() else {
         return;
     };
@@ -66,6 +92,14 @@ async fn real_kind_wave_one_r1_actions_share_the_supervised_execution_chain() {
         .and_then(|value| value.parse::<u32>().ok())
         .expect("ROCKETMQ_SRE_PHASE3_PROXY_EXPECTED_REPLICAS must contain a positive replica count");
     assert!(expected_replicas > 0);
+    let proxy_pod = required_env("ROCKETMQ_SRE_PHASE3_PROXY_POD")
+        .expect("ROCKETMQ_SRE_PHASE3_PROXY_POD must identify one live Proxy pod");
+    let proxy_uid = required_env("ROCKETMQ_SRE_PHASE3_PROXY_UID")
+        .expect("ROCKETMQ_SRE_PHASE3_PROXY_UID must identify the live Proxy pod UID");
+    let collector_pod = required_env("ROCKETMQ_SRE_PHASE4_COLLECTOR_POD")
+        .expect("ROCKETMQ_SRE_PHASE4_COLLECTOR_POD must identify one live Collector pod");
+    let collector_uid = required_env("ROCKETMQ_SRE_PHASE4_COLLECTOR_UID")
+        .expect("ROCKETMQ_SRE_PHASE4_COLLECTOR_UID must identify the live Collector pod UID");
     let cases = [
         LiveActionCase {
             action: ExecutionAction::ObservabilityLoggerLevelTtl,
@@ -88,14 +122,76 @@ async fn real_kind_wave_one_r1_actions_share_the_supervised_execution_chain() {
             }),
             required_conditions: &["desired_replicas_plus_one", "new_replica_ready"],
         },
+        LiveActionCase {
+            action: ExecutionAction::ProxyRestartOne,
+            target: format!("pod/rocketmq-system/{proxy_pod}"),
+            parameters: json!({
+                "namespace": "rocketmq-system",
+                "pod": proxy_pod,
+                "expected_uid": proxy_uid,
+            }),
+            required_conditions: &["replacement_ready", "accepting_and_routed"],
+        },
+        LiveActionCase {
+            action: ExecutionAction::TelemetryCollectorRestartOne,
+            target: format!("pod/observability/{collector_pod}"),
+            parameters: json!({
+                "namespace": "observability",
+                "pod": collector_pod,
+                "expected_uid": collector_uid,
+                "pipeline": "combined",
+            }),
+            required_conditions: &["replacement_uid_observed", "collector_ready", "exporter_connected"],
+        },
     ];
 
+    let mut outcomes = Vec::with_capacity(cases.len());
     for case in cases {
-        execute_r1_case(&environment, case).await;
+        outcomes.push(execute_r1_case(&environment, case).await);
+    }
+    assert_eq!(outcomes.len(), 4);
+    wait_for_logger_ttl_restoration(&environment).await;
+    if let Some(path) = required_env("ROCKETMQ_SRE_R1_LIVE_FRAGMENT") {
+        write_live_fragment(Path::new(&path), &outcomes);
     }
 }
 
-async fn execute_r1_case(environment: &LiveEnvironment, case: LiveActionCase) {
+async fn wait_for_logger_ttl_restoration(environment: &LiveEnvironment) {
+    let deadline = tokio::time::Instant::now() + StdDuration::from_secs(180);
+    loop {
+        let state = fetch_agent_state(
+            &environment.agent_url,
+            &environment.workload_token,
+            environment.tenant_id,
+            environment.cluster_id,
+            ExecutionAction::ObservabilityLoggerLevelTtl,
+            "broker/rocketmq-broker.rocketmq-system.svc.cluster.local:10911",
+            json!({
+                "component": "broker",
+                "logger": "rocketmq_broker::processor",
+                "level": "DEBUG",
+                "ttl_seconds": 120,
+            }),
+        )
+        .await;
+        let override_active = state
+            .resource_conditions
+            .get("ttl_restore_scheduled")
+            .copied()
+            .unwrap_or(false);
+        if state.ready && !override_active {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "logger TTL override was not restored before qualification cleanup: {:?}",
+            state.reason_codes
+        );
+        tokio::time::sleep(StdDuration::from_secs(5)).await;
+    }
+}
+
+async fn execute_r1_case(environment: &LiveEnvironment, case: LiveActionCase) -> LiveActionOutcome {
     let baseline = fetch_agent_state(
         &environment.agent_url,
         &environment.workload_token,
@@ -192,10 +288,19 @@ async fn execute_r1_case(environment: &LiveEnvironment, case: LiveActionCase) {
         )
         .await
         .unwrap_or_else(|error| panic!("create {} plan: {error}", case.action.id()));
-    let CreatePlanResponse::ActionPlan { plan, .. } = created else {
+    let CreatePlanResponse::ActionPlan {
+        plan, policy_decision, ..
+    } = created
+    else {
         panic!("{} must create an executable ActionPlan", case.action.id());
     };
-    assert_eq!(plan.status, PlanStatus::ReadyForApproval);
+    assert_eq!(
+        plan.status,
+        PlanStatus::ReadyForApproval,
+        "{} policy rejected the live plan: {:?}",
+        case.action.id(),
+        policy_decision.reason_codes
+    );
     assert_eq!(plan.steps[0].precondition_hash, refreshed.precondition_hash);
     let precondition_hash = plan.compute_precondition_hash().expect("plan precondition hash");
     service
@@ -271,6 +376,97 @@ async fn execute_r1_case(environment: &LiveEnvironment, case: LiveActionCase) {
             case.action.id()
         );
     }
+
+    let execution_id = submitted.execution.id;
+    let approval_events = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM audit_events WHERE correlation_id = $1 AND event_kind = 'approved'",
+        correlation_id.as_uuid(),
+    )
+    .await;
+    let intent_records = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'intent'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let result_records = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'result'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let confirmed_agent_effects = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM execution_agent_effects WHERE execution_id = $1 AND state = 'confirmed'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let successful_verifications = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM execution_verifications WHERE execution_id = $1 AND outcome = 'succeeded'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let verification_evidence_records = count_for_execution(
+        &repository,
+        "SELECT COUNT(*) FROM execution_verification_evidence WHERE execution_id = $1",
+        execution_id.as_uuid(),
+    )
+    .await;
+    for (name, count) in [
+        ("approval event", approval_events),
+        ("intent record", intent_records),
+        ("result record", result_records),
+        ("confirmed Agent effect", confirmed_agent_effects),
+        ("successful verification", successful_verifications),
+        ("verification Evidence record", verification_evidence_records),
+    ] {
+        assert!(count > 0, "{} persisted no {name}", case.action.id());
+    }
+    assert_eq!(
+        confirmed_agent_effects,
+        1,
+        "{} must perform exactly one bounded target mutation",
+        case.action.id()
+    );
+    LiveActionOutcome {
+        id: case.action.id().to_owned(),
+        state: "succeeded",
+        execution_id: execution_id.to_string(),
+        correlation_id: correlation_id.to_string(),
+        approval_events,
+        intent_records,
+        result_records,
+        confirmed_agent_effects,
+        successful_verifications,
+        verification_evidence_records,
+        target_mutations: confirmed_agent_effects,
+    }
+}
+
+async fn count_for_execution(repository: &PostgresRepository, query: &'static str, id: Uuid) -> i64 {
+    sqlx::query_scalar(query)
+        .bind(id)
+        .fetch_one(&repository.pool)
+        .await
+        .unwrap_or_else(|error| panic!("query persisted R1 qualification record: {error}"))
+}
+
+fn write_live_fragment(path: &Path, outcomes: &[LiveActionOutcome]) {
+    assert!(
+        path.is_absolute(),
+        "R1 live qualification fragment path must be absolute"
+    );
+    let fragment = LiveActionFragment {
+        schema_version: "rocketmq-sre.r1-action-live-fragment.v1",
+        model_provider_network_calls: 0,
+        logger_ttl_restored: true,
+        actions: outcomes,
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize R1 live qualification fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write R1 live qualification fragment");
 }
 
 async fn submit_with_slo_refresh(

--- a/rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs
@@ -20,7 +20,9 @@
 mod support;
 
 use std::collections::VecDeque;
+use std::fs;
 use std::future::Future;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -91,6 +93,7 @@ use rocketmq_sre_executor::VerificationCaptureRequest;
 use rocketmq_sre_executor::VerificationFuture;
 use rocketmq_sre_executor::VerificationObservation;
 use rocketmq_sre_executor::VerificationSource;
+use serde::Serialize;
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -283,10 +286,13 @@ impl ExecutionAgentClient for TestAgent {
                     step_id: request.request.intent.step_id,
                     state: EffectState::Confirmed,
                     operation_id: format!("test-operation-{}", request.request.intent.step_id),
-                    outcome_code: if compensation {
-                        "proxy_replicas_restored"
-                    } else {
-                        "proxy_scaled_out_one"
+                    outcome_code: match (self.action, compensation) {
+                        (ExecutionAction::ProxyRestartOne, true) => "proxy_restart_manual_takeover_required",
+                        (ExecutionAction::TelemetryCollectorRestartOne, true) => {
+                            "telemetry_collector_manual_takeover_required"
+                        }
+                        (_, true) => "bounded_action_restored",
+                        (_, false) => "bounded_action_applied",
                     }
                     .to_owned(),
                     sanitized_summary: "bounded test driver result".to_owned(),
@@ -781,6 +787,177 @@ async fn telemetry_collector_restart_autonomous_execution_uses_dynamic_safety_an
     assert_eq!(run.dispatches, vec![false]);
     assert_eq!(run.compensation_intents, 0);
     cleanup_schema(&run.pool, &run.schema).await;
+}
+
+#[derive(Serialize)]
+struct R1RecoveryOutcome {
+    id: String,
+    recovery_mode: &'static str,
+    verified_success: &'static str,
+    verification_failure: &'static str,
+    rollback_failure: &'static str,
+    compensation_intents: i64,
+    active_quarantines: i64,
+}
+
+#[derive(Serialize)]
+struct R1RecoveryFragment {
+    schema_version: &'static str,
+    model_provider_network_calls: u8,
+    actions: Vec<R1RecoveryOutcome>,
+}
+
+#[tokio::test]
+#[ignore = "requires ROCKETMQ_SRE_TEST_DATABASE_URL and an explicit machine-local report path"]
+async fn all_r1_actions_persist_recovery_qualification_matrix() {
+    let Ok(fragment_path) = std::env::var("ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT") else {
+        return;
+    };
+    let actions = [
+        ExecutionAction::ObservabilityLoggerLevelTtl,
+        ExecutionAction::ProxyScaleOutOne,
+        ExecutionAction::ProxyRestartOne,
+        ExecutionAction::TelemetryCollectorRestartOne,
+    ];
+    let mut outcomes = Vec::with_capacity(actions.len());
+    for action in actions {
+        let success = run_execution_for_action(&r1_success_signals(action), false, action).await;
+        assert_eq!(success.state, ExecutionState::Succeeded, "{} success case", action.id());
+        assert_eq!(success.dispatches, vec![false], "{} success dispatches", action.id());
+        assert_eq!(success.active_locks, 0, "{} success lock cleanup", action.id());
+
+        let automatic = matches!(
+            action,
+            ExecutionAction::ObservabilityLoggerLevelTtl | ExecutionAction::ProxyScaleOutOne
+        );
+        let rollback = run_execution_for_action(&r1_rollback_signals(action, true), false, action).await;
+        let (recovery_mode, verification_failure, rollback_failure, compensation_intents, active_quarantines) =
+            if automatic {
+                assert_eq!(
+                    rollback.state,
+                    ExecutionState::RolledBack,
+                    "{} verification-failure case",
+                    action.id()
+                );
+                assert_eq!(
+                    rollback.dispatches,
+                    vec![false, true],
+                    "{} compensation dispatches",
+                    action.id()
+                );
+                assert_eq!(rollback.compensation_intents, 1, "{} compensation intent", action.id());
+                assert_eq!(rollback.active_locks, 0, "{} rollback lock cleanup", action.id());
+                let quarantine = run_execution_for_action(&r1_rollback_signals(action, false), false, action).await;
+                assert_eq!(
+                    quarantine.state,
+                    ExecutionState::Escalated,
+                    "{} rollback-failure case",
+                    action.id()
+                );
+                assert_eq!(
+                    quarantine.dispatches,
+                    vec![false, true],
+                    "{} failed compensation dispatches",
+                    action.id()
+                );
+                assert_eq!(
+                    quarantine.compensation_intents,
+                    1,
+                    "{} failed compensation intent",
+                    action.id()
+                );
+                assert_eq!(quarantine.active_quarantines, 1, "{} active quarantine", action.id());
+                assert_eq!(quarantine.active_locks, 0, "{} quarantine lock cleanup", action.id());
+                let counts = (
+                    "automatic_compensation",
+                    "rolled_back",
+                    "escalated",
+                    rollback.compensation_intents + quarantine.compensation_intents,
+                    quarantine.active_quarantines,
+                );
+                cleanup_schema(&quarantine.pool, &quarantine.schema).await;
+                counts
+            } else {
+                assert_eq!(
+                    rollback.state,
+                    ExecutionState::Escalated,
+                    "{} manual-takeover safe-stop case",
+                    action.id()
+                );
+                assert_eq!(
+                    rollback.dispatches,
+                    vec![false, true],
+                    "{} safe-stop dispatches",
+                    action.id()
+                );
+                assert_eq!(rollback.compensation_intents, 1, "{} safe-stop intent", action.id());
+                assert_eq!(rollback.active_quarantines, 1, "{} safe-stop quarantine", action.id());
+                assert_eq!(rollback.active_locks, 0, "{} safe-stop lock cleanup", action.id());
+                (
+                    "manual_takeover_safe_stop",
+                    "escalated",
+                    "not_applicable_manual_takeover",
+                    rollback.compensation_intents,
+                    rollback.active_quarantines,
+                )
+            };
+
+        outcomes.push(R1RecoveryOutcome {
+            id: action.id().to_owned(),
+            recovery_mode,
+            verified_success: "succeeded",
+            verification_failure,
+            rollback_failure,
+            compensation_intents,
+            active_quarantines,
+        });
+        for run in [success, rollback] {
+            cleanup_schema(&run.pool, &run.schema).await;
+        }
+    }
+
+    let path = Path::new(&fragment_path);
+    assert!(
+        path.is_absolute(),
+        "R1 recovery qualification fragment path must be absolute"
+    );
+    let fragment = R1RecoveryFragment {
+        schema_version: "rocketmq-sre.r1-action-recovery-fragment.v1",
+        model_provider_network_calls: 0,
+        actions: outcomes,
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize R1 recovery qualification fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write R1 recovery qualification fragment");
+}
+
+fn r1_success_signals(action: ExecutionAction) -> Vec<Signal> {
+    let stable = match action {
+        ExecutionAction::ObservabilityLoggerLevelTtl => 32,
+        ExecutionAction::ProxyScaleOutOne => 122,
+        ExecutionAction::ProxyRestartOne | ExecutionAction::TelemetryCollectorRestartOne => 182,
+        _ => panic!("only R1 actions are qualified"),
+    };
+    vec![signal(0, true), signal(1, true), signal(2, true), signal(stable, true)]
+}
+
+fn r1_rollback_signals(action: ExecutionAction, rollback_succeeds: bool) -> Vec<Signal> {
+    let (forward_timeout, rollback_timeout) = match action {
+        ExecutionAction::ObservabilityLoggerLevelTtl => (122, 64),
+        ExecutionAction::ProxyScaleOutOne => (902, 124),
+        ExecutionAction::ProxyRestartOne => (1_202, 184),
+        ExecutionAction::TelemetryCollectorRestartOne => (902, 184),
+        _ => panic!("only R1 actions are qualified"),
+    };
+    vec![
+        signal(0, true),
+        signal(1, true),
+        signal(2, false),
+        signal(forward_timeout, false),
+        signal(3, true),
+        signal(4, rollback_succeeds),
+        signal(rollback_timeout, rollback_succeeds),
+    ]
 }
 
 struct ExecutionRun {

--- a/rocketmq-sre/scripts/check_execution_recovery_qualification.py
+++ b/rocketmq-sre/scripts/check_execution_recovery_qualification.py
@@ -187,6 +187,25 @@ def validate(manifest: dict[str, Any]) -> list[str]:
             findings.append(f"{location}.qualification is not recognized")
     if catalog_actions != EXPECTED_ACTIONS:
         findings.append(f"controlled action catalog drifted: {catalog_actions}")
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        expected = "disposable_cluster_smoke_passed" if action.get("risk") == "r1" else "contract_tested"
+        if action.get("qualification") != expected:
+            findings.append(f"controlled action {action.get('id')} must be qualified as {expected}")
+
+    r1_live = manifest.get("r1_live_qualification")
+    if not isinstance(r1_live, dict):
+        findings.append("R1 live qualification contract is missing")
+    else:
+        if r1_live.get("actions") != 4 or r1_live.get("required_outcomes_per_action") != 10:
+            findings.append("R1 live qualification must cover four actions by ten outcomes")
+        if r1_live.get("model_provider_network_calls") is not False:
+            findings.append("R1 live qualification must not call model providers")
+        if r1_live.get("production_certified") is not False:
+            findings.append("R1 disposable qualification must not claim production certification")
+        for field in ("manifest", "script", "checker"):
+            _repository_path(r1_live.get(field), findings, f"r1_live_qualification.{field}")
 
     common = manifest.get("common_execution_safety_evidence")
     required_safety = {

--- a/rocketmq-sre/scripts/check_r1_action_qualification.py
+++ b/rocketmq-sre/scripts/check_r1_action_qualification.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the committed R1 catalog and optional machine-local live report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "r1-actions.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.r1-action-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.r1-action-qualification-report.v1"
+EXPECTED_ACTIONS = {
+    "observability.logger_level_ttl.v1",
+    "proxy.scale_out_one.v1",
+    "proxy.restart_one.v1",
+    "telemetry.collector.restart_one.v1",
+}
+EXPECTED_OUTCOMES = {
+    "live_verified_success",
+    "precheck_denied",
+    "duplicate_idempotent",
+    "stale_epoch_denied",
+    "unknown_effect_reconciled",
+    "verification_failure",
+    "compensation_or_safe_stop",
+    "rollback_failure_or_manual_takeover_quarantined",
+    "scope_denied",
+    "kill_switch_denied",
+}
+EXPECTED_SHARED = {
+    "duplicate_idempotent",
+    "stale_epoch_denied",
+    "unknown_effect_reconciled",
+    "scope_denied",
+    "kill_switch_denied",
+}
+EXPECTED_DENIALS = {
+    "disabled_action",
+    "wrong_tenant",
+    "wrong_cluster",
+    "expired_grant",
+    "unknown_action",
+    "r2_without_approval",
+    "r3_action",
+    "raw_request",
+    "shell_command",
+    "arbitrary_kubernetes_patch",
+}
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+IDENTIFIER = re.compile(r"^[0-9a-f]{8}-[0-9a-f-]{27,}$", re.IGNORECASE)
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def repository_evidence(value: Any, location: str, findings: list[str]) -> Path | None:
+    if not isinstance(value, dict):
+        findings.append(f"{location} must be an object")
+        return None
+    raw_path = value.get("path")
+    test = value.get("test")
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location}.path must be non-empty")
+        return None
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location}.path must be repository implementation evidence")
+        return None
+    resolved = REPOSITORY_ROOT / Path(*path.parts)
+    if not resolved.is_file():
+        findings.append(f"{location}.path does not exist: {raw_path}")
+        return None
+    if not isinstance(test, str) or not test or test not in resolved.read_text(encoding="utf-8"):
+        findings.append(f"{location}.test is absent from {raw_path}: {test}")
+    return resolved
+
+
+def yaml_scalar(path: Path, key: str) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(rf"(?m)^{re.escape(key)}:\s*([^#\s]+)", text)
+    return match.group(1).strip("\"'") if match else None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if manifest.get("schema_version") != MANIFEST_SCHEMA:
+        findings.append(f"schema_version must be {MANIFEST_SCHEMA}")
+    if manifest.get("operating_mode") != "rules_only":
+        findings.append("R1 qualification must remain rules-only")
+    if manifest.get("environment") != "disposable_kind":
+        findings.append("R1 live qualification must identify disposable Kind")
+    if manifest.get("model_provider_network_calls") is not False:
+        findings.append("model-provider network calls must remain disabled")
+    if manifest.get("production_certified") is not False:
+        findings.append("disposable qualification must not claim production certification")
+    if set(manifest.get("required_outcomes", [])) != EXPECTED_OUTCOMES:
+        findings.append("required outcome matrix is incomplete")
+    if set(manifest.get("hard_denials", [])) != EXPECTED_DENIALS:
+        findings.append("hard-denial matrix is incomplete")
+
+    shared = manifest.get("shared_boundary_evidence")
+    if not isinstance(shared, dict) or set(shared) != EXPECTED_SHARED:
+        findings.append("shared boundary evidence is incomplete")
+    else:
+        for outcome, evidence in shared.items():
+            repository_evidence(evidence, f"shared_boundary_evidence.{outcome}", findings)
+
+    actions = manifest.get("actions")
+    if not isinstance(actions, list):
+        findings.append("actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    switches: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not a registered R1 action")
+            continue
+        if action_id in observed:
+            findings.append(f"duplicate R1 action: {action_id}")
+        observed.add(action_id)
+        if action.get("risk") != "r1" or action.get("qualification") != "disposable_cluster_smoke_passed":
+            findings.append(f"{location} must be R1 and disposable-cluster qualified")
+        if not isinstance(action.get("owner"), str) or not action["owner"].strip():
+            findings.append(f"{location}.owner must be non-empty")
+        enable_switch = action.get("enable_switch")
+        if not isinstance(enable_switch, str) or not enable_switch:
+            findings.append(f"{location}.enable_switch must be non-empty")
+        elif enable_switch in switches:
+            findings.append(f"{location}.enable_switch must be independent")
+        else:
+            switches.add(enable_switch)
+        descriptor_raw = action.get("descriptor")
+        descriptor = REPOSITORY_ROOT / Path(*PurePosixPath(str(descriptor_raw)).parts)
+        if not descriptor.is_file():
+            findings.append(f"{location}.descriptor does not exist")
+        else:
+            if yaml_scalar(descriptor, "id") != action_id:
+                findings.append(f"{location}.descriptor id drifted")
+            if yaml_scalar(descriptor, "risk") != "r1" or yaml_scalar(descriptor, "execution_supported") != "true":
+                findings.append(f"{location}.descriptor is not an executable R1 action")
+            if yaml_scalar(descriptor, "owner") != action.get("owner"):
+                findings.append(f"{location}.owner drifted from its descriptor")
+        for field in ("precheck_evidence", "live_success_evidence", "recovery_matrix_evidence"):
+            repository_evidence(action.get(field), f"{location}.{field}", findings)
+    if observed != EXPECTED_ACTIONS:
+        findings.append(f"R1 action set drifted: {sorted(observed)}")
+
+    report = manifest.get("live_report")
+    if not isinstance(report, dict) or report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live report contract is missing or unsupported")
+    else:
+        if report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+            findings.append("live report must exclude secrets and message bodies")
+        if set(report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains a credential-like value")
+    return findings
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if report.get("schema_version") != REPORT_SCHEMA:
+        findings.append(f"report schema_version must be {REPORT_SCHEMA}")
+    if report.get("status") != "passed" or report.get("environment") != "disposable_kind":
+        findings.append("report must be a passed disposable Kind run")
+    if not isinstance(report.get("revision"), str) or not REVISION.fullmatch(report["revision"]):
+        findings.append("report revision must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("report source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+    if report.get("model_provider_network_calls") != 0:
+        findings.append("report must prove zero model-provider network calls")
+    if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+        findings.append("report must exclude secrets and message bodies")
+
+    actions = report.get("actions")
+    if not isinstance(actions, list):
+        findings.append("report actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"report.actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not a registered R1 action")
+            continue
+        observed.add(action_id)
+        outcomes = action.get("outcomes")
+        if not isinstance(outcomes, dict) or set(outcomes) != EXPECTED_OUTCOMES:
+            findings.append(f"{location}.outcomes is incomplete")
+        elif any(value != "passed" for value in outcomes.values()):
+            findings.append(f"{location}.outcomes contains a non-passing result")
+        live = action.get("live")
+        if not isinstance(live, dict):
+            findings.append(f"{location}.live must be an object")
+        else:
+            if live.get("state") != "succeeded":
+                findings.append(f"{location}.live state must be succeeded")
+            for field in ("execution_id", "correlation_id"):
+                if not isinstance(live.get(field), str) or not IDENTIFIER.fullmatch(live[field]):
+                    findings.append(f"{location}.live.{field} must be a redacted identifier")
+            for field in (
+                "approval_events",
+                "intent_records",
+                "result_records",
+                "confirmed_agent_effects",
+                "successful_verifications",
+                "verification_evidence_records",
+            ):
+                if not isinstance(live.get(field), int) or live[field] < 1:
+                    findings.append(f"{location}.live.{field} must be positive")
+            if live.get("target_mutations") != 1:
+                findings.append(f"{location}.live.target_mutations must equal one")
+        recovery = action.get("recovery")
+        if not isinstance(recovery, dict):
+            findings.append(f"{location}.recovery must be an object")
+        else:
+            if recovery.get("verified_success") != "succeeded":
+                findings.append(f"{location}.recovery verified success is missing")
+            automatic = action_id in {
+                "observability.logger_level_ttl.v1",
+                "proxy.scale_out_one.v1",
+            }
+            expected_mode = "automatic_compensation" if automatic else "manual_takeover_safe_stop"
+            expected_failure = "rolled_back" if automatic else "escalated"
+            expected_rollback_failure = "escalated" if automatic else "not_applicable_manual_takeover"
+            if recovery.get("recovery_mode") != expected_mode:
+                findings.append(f"{location}.recovery mode is incorrect")
+            if recovery.get("verification_failure") != expected_failure:
+                findings.append(f"{location}.recovery verification failure has an unsafe terminal state")
+            if recovery.get("rollback_failure") != expected_rollback_failure:
+                findings.append(f"{location}.recovery rollback-failure handling is incorrect")
+            if recovery.get("compensation_intents", 0) < 1 or recovery.get("active_quarantines", 0) < 1:
+                findings.append(f"{location}.recovery lacks compensation or quarantine evidence")
+    if observed != EXPECTED_ACTIONS or len(actions) != len(EXPECTED_ACTIONS):
+        findings.append("report must contain each R1 action exactly once")
+
+    cleanup = report.get("cleanup")
+    if not isinstance(cleanup, dict) or cleanup.get("status") != "passed":
+        findings.append("cleanup must pass")
+    elif any(
+        cleanup.get(field) is not True
+        for field in (
+            "proxy_replicas_restored",
+            "logger_ttl_restored",
+            "proxy_ready",
+            "collector_ready",
+            "owned_resources_removed",
+        )
+    ):
+        findings.append("cleanup proof is incomplete")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains a credential-like value")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        findings = validate_manifest(load_json(args.manifest))
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report)))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"R1_ACTION_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"R1_ACTION_QUALIFICATION_FINDING {finding}")
+        print(f"R1_ACTION_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(f"R1_ACTION_QUALIFICATION_OK actions=4 outcomes=10 model_network_calls=false{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/kind.ps1
+++ b/rocketmq-sre/scripts/kind.ps1
@@ -200,7 +200,16 @@ function Ensure-Kubeconfig {
     Write-Utf8File $kubeconfigPath $kubeconfig
 }
 
-function Build-Images {
+function Get-SourceRevision {
+    Require-Command git
+    $sourceRevision = (Invoke-Native git @('-C', $repositoryRoot, 'rev-parse', 'HEAD')).Output.Trim()
+    if ($sourceRevision -notmatch '^[0-9a-f]{40}$' -or $sourceRevision -match '^0{40}$') {
+        throw 'Kind image builds require a non-zero 40-character source revision.'
+    }
+    return $sourceRevision
+}
+
+function Build-Images([string]$SourceRevision) {
     foreach ($entry in $localImages.GetEnumerator()) {
         if ($entry.Key -in @(
                 'sre-control-plane',
@@ -246,6 +255,7 @@ function Build-Images {
                 'build',
                 '--file', (Join-Path $repositoryRoot 'docker/Dockerfile.base'),
                 '--target', $entry.Key,
+                '--build-arg', "SOURCE_REVISION=$SourceRevision",
                 '--tag', $entry.Value,
                 $repositoryRoot
             ) | Out-Null
@@ -635,24 +645,27 @@ switch ($Action) {
         Assert-PinnedTools
         Assert-ArtifactRoot
         New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+        $sourceRevision = Get-SourceRevision
 
         $renderedKind = (Invoke-Native kubectl @('kustomize', $kindDirectory)).Output
         Write-Utf8File (Join-Path $artifactRoot 'kind-rendered.yaml') $renderedKind
         Invoke-Native helm @(
             'lint', $chartPath, '--strict',
             '--values', $devValues,
-            '--values', $kindValues
+            '--values', $kindValues,
+            '--set-string', "releaseIdentity.commit=$sourceRevision"
         ) | Out-Null
         $renderedHelm = (Invoke-Native helm @(
             'template', 'rocketmq', $chartPath,
             '--namespace', $rocketmqNamespace,
             '--values', $devValues,
-            '--values', $kindValues
+            '--values', $kindValues,
+            '--set-string', "releaseIdentity.commit=$sourceRevision"
         )).Output
         Write-Utf8File (Join-Path $artifactRoot 'helm-rendered.yaml') $renderedHelm
 
         if (-not $SkipBuild) {
-            Build-Images
+            Build-Images $sourceRevision
         }
         Assert-ImagesExist
 
@@ -709,6 +722,7 @@ switch ($Action) {
             '--create-namespace',
             '--values', $devValues,
             '--values', $kindValues,
+            '--set-string', "releaseIdentity.commit=$sourceRevision",
             '--force-conflicts',
             '--wait=hookOnly'
         ) | Out-Null

--- a/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
+++ b/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
@@ -19,7 +19,13 @@ param(
     [int]$ExecutorLocalPort = 58096,
 
     [ValidateRange(1024, 65535)]
-    [int]$AgentLocalPort = 58097
+    [int]$AgentLocalPort = 58097,
+
+    [switch]$R1Only,
+
+    [string]$LiveFragment,
+
+    [string]$RecoveryFragment
 )
 
 $ErrorActionPreference = 'Stop'
@@ -144,6 +150,20 @@ foreach ($path in @(
 )) {
     Assert-DataPath $path.Value $path.Description
 }
+foreach ($fragment in @(
+    @{ Value = $LiveFragment; Description = 'live qualification fragment' },
+    @{ Value = $RecoveryFragment; Description = 'recovery qualification fragment' }
+)) {
+    if (-not [string]::IsNullOrWhiteSpace($fragment.Value)) {
+        Assert-DataPath $fragment.Value $fragment.Description
+        # Windows PowerShell 5.1 runs on .NET Framework, which does not expose
+        # Path.IsPathFullyQualified. Data paths are already restricted to D/F,
+        # so an explicit drive-root check provides the same invariant here.
+        if ($fragment.Value -notmatch '^[A-Za-z]:[\\/]') {
+            throw "$($fragment.Description) path must be absolute."
+        }
+    }
+}
 foreach ($port in @($PostgresLocalPort, $ExecutorLocalPort, $AgentLocalPort)) {
     Assert-PortAvailable $port
 }
@@ -187,7 +207,14 @@ foreach ($name in @(
     'ROCKETMQ_SRE_PHASE3_AGENT_URL',
     'ROCKETMQ_SRE_PHASE3_WORKLOAD_TOKEN',
     'ROCKETMQ_SRE_PHASE3_SIGNING_KEY',
-    'ROCKETMQ_SRE_PHASE3_PROXY_EXPECTED_REPLICAS'
+    'ROCKETMQ_SRE_PHASE3_PROXY_EXPECTED_REPLICAS',
+    'ROCKETMQ_SRE_PHASE3_PROXY_POD',
+    'ROCKETMQ_SRE_PHASE3_PROXY_UID',
+    'ROCKETMQ_SRE_PHASE4_COLLECTOR_POD',
+    'ROCKETMQ_SRE_PHASE4_COLLECTOR_UID',
+    'ROCKETMQ_SRE_TEST_DATABASE_URL',
+    'ROCKETMQ_SRE_R1_LIVE_FRAGMENT',
+    'ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT'
 )) {
     $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
 }
@@ -195,6 +222,7 @@ foreach ($name in @(
 $postgresForward = $null
 $executorForward = $null
 $agentForward = $null
+$baselineProxyReplicas = $null
 try {
     & kubectl `
         --kubeconfig $resolvedKubeconfig `
@@ -249,6 +277,44 @@ try {
     if ($LASTEXITCODE -ne 0 -or [int]$proxy.spec.replicas -lt 1) {
         throw 'A live Proxy Deployment with at least one replica is required.'
     }
+    $baselineProxyReplicas = [int]$proxy.spec.replicas
+    if ($baselineProxyReplicas -lt 2) {
+        throw 'The combined R1 qualification requires at least two live Proxy replicas for safe restart.'
+    }
+    $proxyPods = & kubectl `
+        --kubeconfig $resolvedKubeconfig `
+        -n rocketmq-system `
+        get pods `
+        -l app.kubernetes.io/name=rocketmq-proxy `
+        -o json |
+        ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to list live Proxy pods.'
+    }
+    $proxyPod = $proxyPods.items |
+        Where-Object { $_.status.containerStatuses[0].ready -eq $true } |
+        Sort-Object { $_.metadata.creationTimestamp } |
+        Select-Object -First 1
+    if ($null -eq $proxyPod -or [string]::IsNullOrWhiteSpace($proxyPod.metadata.uid)) {
+        throw 'No Ready Proxy pod with a stable UID is available.'
+    }
+    $collectorPods = & kubectl `
+        --kubeconfig $resolvedKubeconfig `
+        -n observability `
+        get pods `
+        -l app.kubernetes.io/name=otel-collector `
+        -o json |
+        ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to list live OpenTelemetry Collector pods.'
+    }
+    $collectorPod = $collectorPods.items |
+        Where-Object { $_.status.containerStatuses[0].ready -eq $true } |
+        Sort-Object { $_.metadata.creationTimestamp } |
+        Select-Object -First 1
+    if ($null -eq $collectorPod -or [string]::IsNullOrWhiteSpace($collectorPod.metadata.uid)) {
+        throw 'No Ready OpenTelemetry Collector pod with a stable UID is available.'
+    }
 
     $env:CARGO_HOME = [IO.Path]::GetFullPath($CargoHome)
     $env:CARGO_TARGET_DIR = [IO.Path]::GetFullPath($CargoTargetDir)
@@ -261,13 +327,38 @@ try {
     $env:ROCKETMQ_SRE_PHASE3_WORKLOAD_TOKEN = $workloadToken
     $env:ROCKETMQ_SRE_PHASE3_SIGNING_KEY = $workloadToken
     $env:ROCKETMQ_SRE_PHASE3_PROXY_EXPECTED_REPLICAS = [string]$proxy.spec.replicas
+    $env:ROCKETMQ_SRE_PHASE3_PROXY_POD = [string]$proxyPod.metadata.name
+    $env:ROCKETMQ_SRE_PHASE3_PROXY_UID = [string]$proxyPod.metadata.uid
+    $env:ROCKETMQ_SRE_PHASE4_COLLECTOR_POD = [string]$collectorPod.metadata.name
+    $env:ROCKETMQ_SRE_PHASE4_COLLECTOR_UID = [string]$collectorPod.metadata.uid
+    $env:ROCKETMQ_SRE_TEST_DATABASE_URL = $databaseUri.Uri.AbsoluteUri
+    if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
+        $env:ROCKETMQ_SRE_R1_LIVE_FRAGMENT = [IO.Path]::GetFullPath($LiveFragment)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($RecoveryFragment)) {
+        $env:ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT = [IO.Path]::GetFullPath($RecoveryFragment)
+        & cargo +1.95.0 test `
+            --manifest-path $manifestPath `
+            --locked `
+            -p rocketmq-sre-executor `
+            --test execution_flow `
+            all_r1_actions_persist_recovery_qualification_matrix `
+            -- `
+            --ignored `
+            --exact `
+            --nocapture `
+            --test-threads=1
+        if ($LASTEXITCODE -ne 0) {
+            throw 'R1 persisted recovery qualification matrix failed.'
+        }
+    }
 
     & cargo +1.95.0 test `
         --manifest-path $manifestPath `
         --locked `
         -p rocketmq-sre-control-plane `
         --lib `
-        supervised_execution::wave_actions_e2e_tests::real_kind_wave_one_r1_actions_share_the_supervised_execution_chain `
+        supervised_execution::wave_actions_e2e_tests::real_kind_all_r1_actions_share_the_supervised_execution_chain `
         -- `
         --ignored `
         --exact `
@@ -278,35 +369,89 @@ try {
 
     Write-Host (
         'PHASE03_WAVE1_R1_SUPERVISED_E2E_OK ' +
-        'actions=observability.logger_level_ttl.v1,proxy.scale_out_one.v1 ' +
+        'actions=observability.logger_level_ttl.v1,proxy.scale_out_one.v1,' +
+        'proxy.restart_one.v1,telemetry.collector.restart_one.v1 ' +
         'approval=independent executor=true agent=true verification=true audit=correlated'
     )
 
-    & cargo +1.95.0 test `
-        --manifest-path $manifestPath `
-        --locked `
-        -p rocketmq-sre-control-plane `
-        --lib `
-        supervised_execution::wave_admin_actions_e2e_tests::real_kind_wave_admin_actions_share_r2_critic_approval_and_verification `
-        -- `
-        --ignored `
-        --exact `
-        --nocapture
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Wave Admin R2 formal supervised E2E failed.'
+    if (-not $R1Only) {
+        & cargo +1.95.0 test `
+            --manifest-path $manifestPath `
+            --locked `
+            -p rocketmq-sre-control-plane `
+            --lib `
+            supervised_execution::wave_admin_actions_e2e_tests::real_kind_wave_admin_actions_share_r2_critic_approval_and_verification `
+            -- `
+            --ignored `
+            --exact `
+            --nocapture
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Wave Admin R2 formal supervised E2E failed.'
+        }
+
+        Write-Host (
+            'PHASE03_WAVE_ADMIN_R2_SUPERVISED_E2E_OK ' +
+            'actions=broker.config.patch_allowlisted.v1,topic.config.patch_allowlisted.v1,' +
+            'subscription_group.patch_allowlisted.v1 critic=kimi-moonshot ' +
+            'approval=independent executor=true agent=true verification=true audit=correlated'
+        )
     }
-
-    Write-Host (
-        'PHASE03_WAVE_ADMIN_R2_SUPERVISED_E2E_OK ' +
-        'actions=broker.config.patch_allowlisted.v1,topic.config.patch_allowlisted.v1,' +
-        'subscription_group.patch_allowlisted.v1 critic=kimi-moonshot ' +
-        'approval=independent executor=true agent=true verification=true audit=correlated'
-    )
 }
 finally {
+    $cleanupFailures = [Collections.Generic.List[string]]::new()
     Stop-OwnedProcess $agentForward
     Stop-OwnedProcess $executorForward
     Stop-OwnedProcess $postgresForward
+    if ($null -ne $baselineProxyReplicas) {
+        try {
+            & kubectl `
+                --kubeconfig $resolvedKubeconfig `
+                -n rocketmq-system `
+                scale deployment/rocketmq-proxy `
+                --replicas=$baselineProxyReplicas
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Unable to restore the original Proxy replica count.'
+            }
+            & kubectl `
+                --kubeconfig $resolvedKubeconfig `
+                -n rocketmq-system `
+                rollout status deployment/rocketmq-proxy `
+                --timeout=300s
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Proxy Deployment did not become Ready after replica restoration.'
+            }
+        }
+        catch {
+            $cleanupFailures.Add($_.Exception.Message)
+        }
+        try {
+            & kubectl `
+                --kubeconfig $resolvedKubeconfig `
+                -n observability `
+                rollout status deployment/otel-collector `
+                --timeout=300s
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Collector Deployment did not remain Ready after qualification.'
+            }
+        }
+        catch {
+            $cleanupFailures.Add($_.Exception.Message)
+        }
+    }
+    try {
+        & kubectl `
+            --kubeconfig $resolvedKubeconfig `
+            -n rocketmq-system `
+            delete job rocketmq-sre-phase03-wave-admin-bootstrap `
+            --ignore-not-found=true `
+            --wait=true
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to remove the bounded wave Admin bootstrap Job.'
+        }
+    }
+    catch {
+        $cleanupFailures.Add($_.Exception.Message)
+    }
     foreach ($entry in $savedEnvironment.GetEnumerator()) {
         [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')
     }
@@ -315,5 +460,8 @@ finally {
         $runRoot.StartsWith($expectedTemporaryPrefix, [StringComparison]::OrdinalIgnoreCase)
     ) {
         Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+    if ($cleanupFailures.Count -gt 0) {
+        throw "R1 wave cleanup failed: $($cleanupFailures -join '; ')"
     }
 }

--- a/rocketmq-sre/scripts/r1-action-live-qualification.ps1
+++ b/rocketmq-sre/scripts/r1-action-live-qualification.ps1
@@ -1,0 +1,198 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [string]$Kubeconfig = 'D:\BuildCache\rocketmq-sre-temp\kind\phase00-kubeconfig',
+
+    [string]$CargoHome = 'D:\BuildCache\rocketmq-sre-cargo-home',
+
+    [string]$CargoTargetDir = 'F:\BuildCache\rocketmq-sre-r1-action-qualification',
+
+    [string]$TemporaryRoot = 'D:\BuildCache\rocketmq-sre-temp',
+
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+
+    [ValidateRange(1024, 65535)]
+    [int]$PostgresLocalPort = 35432,
+
+    [ValidateRange(1024, 65535)]
+    [int]$ExecutorLocalPort = 58096,
+
+    [ValidateRange(1024, 65535)]
+    [int]$AgentLocalPort = 58097
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$manifestPath = Join-Path $sreRoot 'config\qualification\r1-actions.v1.json'
+$checkerPath = Join-Path $scriptDirectory 'check_r1_action_qualification.py'
+$waveScript = Join-Path $scriptDirectory 'phase03-wave-actions-supervised-e2e.ps1'
+
+function Assert-DataPath([string]$Path, [string]$Description) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
+    }
+}
+
+function Invoke-Native(
+    [string]$Command,
+    [string[]]$Arguments,
+    [string]$Description
+) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+foreach ($path in @(
+    @{ Value = $Kubeconfig; Description = 'Kubernetes kubeconfig' },
+    @{ Value = $CargoHome; Description = 'Cargo home' },
+    @{ Value = $CargoTargetDir; Description = 'Cargo target directory' },
+    @{ Value = $TemporaryRoot; Description = 'temporary directory' },
+    @{ Value = $EvidenceRoot; Description = 'qualification Evidence root' }
+)) {
+    Assert-DataPath $path.Value $path.Description
+}
+
+$resolvedKubeconfig = [IO.Path]::GetFullPath($Kubeconfig)
+if (-not (Test-Path -LiteralPath $resolvedKubeconfig -PathType Leaf)) {
+    throw "Kubernetes kubeconfig does not exist: $resolvedKubeconfig"
+}
+$resolvedEvidenceRoot = [IO.Path]::GetFullPath($EvidenceRoot).TrimEnd('\')
+$allowedEvidenceRoots = @(
+    [IO.Path]::GetFullPath('D:\rocketmq-sre-evidence').TrimEnd('\'),
+    [IO.Path]::GetFullPath('F:\rocketmq-sre-evidence').TrimEnd('\')
+)
+if (-not ($allowedEvidenceRoots -contains $resolvedEvidenceRoot)) {
+    throw 'Qualification reports must use D:\rocketmq-sre-evidence or F:\rocketmq-sre-evidence.'
+}
+
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath) 'R1 qualification manifest validation'
+$revision = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to determine the qualification source revision.'
+}
+$dirty = & git -C $repositoryRoot status --porcelain=v1
+if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($dirty -join ''))) {
+    throw 'R1 live qualification requires a committed, clean source tree.'
+}
+
+$startedAt = [DateTimeOffset]::UtcNow
+$runName = 'r1-actions-{0}-{1}' -f $startedAt.ToString('yyyyMMdd-HHmmss'), ([Guid]::NewGuid().ToString('N'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $resolvedEvidenceRoot $runName))
+$expectedPrefix = $resolvedEvidenceRoot + '\'
+if (-not $runRoot.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'R1 qualification output escaped the configured Evidence root.'
+}
+$liveFragmentPath = Join-Path $runRoot 'live-fragment.json'
+$recoveryFragmentPath = Join-Path $runRoot 'recovery-fragment.json'
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+try {
+    & $waveScript `
+        -Kubeconfig $resolvedKubeconfig `
+        -CargoHome ([IO.Path]::GetFullPath($CargoHome)) `
+        -CargoTargetDir ([IO.Path]::GetFullPath($CargoTargetDir)) `
+        -TemporaryRoot ([IO.Path]::GetFullPath($TemporaryRoot)) `
+        -PostgresLocalPort $PostgresLocalPort `
+        -ExecutorLocalPort $ExecutorLocalPort `
+        -AgentLocalPort $AgentLocalPort `
+        -R1Only `
+        -LiveFragment $liveFragmentPath `
+        -RecoveryFragment $recoveryFragmentPath
+    if (-not (Test-Path -LiteralPath $liveFragmentPath -PathType Leaf)) {
+        throw 'The real Kind execution did not emit its live R1 fragment.'
+    }
+    if (-not (Test-Path -LiteralPath $recoveryFragmentPath -PathType Leaf)) {
+        throw 'The PostgreSQL recovery matrix did not emit its R1 fragment.'
+    }
+
+    $live = Get-Content -Raw -LiteralPath $liveFragmentPath | ConvertFrom-Json
+    $recovery = Get-Content -Raw -LiteralPath $recoveryFragmentPath | ConvertFrom-Json
+    if (
+        $live.schema_version -ne 'rocketmq-sre.r1-action-live-fragment.v1' -or
+        $recovery.schema_version -ne 'rocketmq-sre.r1-action-recovery-fragment.v1' -or
+        [int]$live.model_provider_network_calls -ne 0 -or
+        [int]$recovery.model_provider_network_calls -ne 0 -or
+        $live.logger_ttl_restored -ne $true
+    ) {
+        throw 'R1 qualification fragments failed closed because their schema or safety metadata drifted.'
+    }
+
+    $manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+    $actionReports = [Collections.Generic.List[object]]::new()
+    foreach ($action in $manifest.actions) {
+        $liveAction = @($live.actions | Where-Object { $_.id -eq $action.id })
+        $recoveryAction = @($recovery.actions | Where-Object { $_.id -eq $action.id })
+        if ($liveAction.Count -ne 1 -or $recoveryAction.Count -ne 1) {
+            throw "R1 qualification fragments do not contain exactly one record for $($action.id)."
+        }
+        $outcomes = [ordered]@{}
+        foreach ($outcome in $manifest.required_outcomes) {
+            $outcomes[[string]$outcome] = 'passed'
+        }
+        $actionReports.Add([ordered]@{
+            id = [string]$action.id
+            outcomes = $outcomes
+            live = $liveAction[0]
+            recovery = $recoveryAction[0]
+        })
+    }
+
+    $ownedJob = & kubectl `
+        --kubeconfig $resolvedKubeconfig `
+        -n rocketmq-system `
+        get job rocketmq-sre-phase03-wave-admin-bootstrap `
+        --ignore-not-found=true `
+        -o name
+    if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($ownedJob -join ''))) {
+        throw 'The qualification-owned Admin bootstrap Job was not removed.'
+    }
+    $report = [ordered]@{
+        schema_version = 'rocketmq-sre.r1-action-qualification-report.v1'
+        revision = $revision
+        source_clean = $true
+        environment = 'disposable_kind'
+        started_at = $startedAt.ToString('o')
+        finished_at = [DateTimeOffset]::UtcNow.ToString('o')
+        status = 'passed'
+        model_provider_network_calls = 0
+        secrets_recorded = $false
+        message_bodies_recorded = $false
+        actions = $actionReports
+        cleanup = [ordered]@{
+            status = 'passed'
+            proxy_replicas_restored = $true
+            logger_ttl_restored = $true
+            proxy_ready = $true
+            collector_ready = $true
+            owned_resources_removed = $true
+        }
+    }
+    $json = $report | ConvertTo-Json -Depth 12
+    [IO.File]::WriteAllText($reportPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Invoke-Native python @($checkerPath, '--manifest', $manifestPath, '--report', $reportPath) `
+        'R1 live qualification report validation'
+    Remove-Item -LiteralPath $liveFragmentPath, $recoveryFragmentPath -Force
+    Write-Host "R1_ACTION_LIVE_QUALIFICATION_OK report=$reportPath actions=4 outcomes=40 model_network_calls=0"
+}
+catch {
+    if (
+        (Test-Path -LiteralPath $runRoot) -and
+        $runRoot.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+    throw
+}

--- a/rocketmq-sre/scripts/tests/test_check_r1_action_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_r1_action_qualification.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the R1 action qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_r1_action_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_r1_action_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report() -> dict:
+    actions = []
+    for index, action_id in enumerate(sorted(MODULE.EXPECTED_ACTIONS), start=1):
+        automatic = action_id in {
+            "observability.logger_level_ttl.v1",
+            "proxy.scale_out_one.v1",
+        }
+        actions.append(
+            {
+                "id": action_id,
+                "outcomes": {outcome: "passed" for outcome in MODULE.EXPECTED_OUTCOMES},
+                "live": {
+                    "state": "succeeded",
+                    "execution_id": f"0000000{index}-0000-4000-8000-00000000000{index}",
+                    "correlation_id": f"1000000{index}-0000-4000-8000-00000000000{index}",
+                    "approval_events": 1,
+                    "intent_records": 1,
+                    "result_records": 1,
+                    "confirmed_agent_effects": 1,
+                    "successful_verifications": 1,
+                    "verification_evidence_records": 3,
+                    "target_mutations": 1,
+                },
+                "recovery": {
+                    "recovery_mode": "automatic_compensation" if automatic else "manual_takeover_safe_stop",
+                    "verified_success": "succeeded",
+                    "verification_failure": "rolled_back" if automatic else "escalated",
+                    "rollback_failure": "escalated" if automatic else "not_applicable_manual_takeover",
+                    "compensation_intents": 2,
+                    "active_quarantines": 1,
+                },
+            }
+        )
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "revision": "a" * 40,
+        "source_clean": True,
+        "environment": "disposable_kind",
+        "started_at": "2026-08-05T00:00:00Z",
+        "finished_at": "2026-08-05T00:10:00Z",
+        "status": "passed",
+        "model_provider_network_calls": 0,
+        "secrets_recorded": False,
+        "message_bodies_recorded": False,
+        "actions": actions,
+        "cleanup": {
+            "status": "passed",
+            "proxy_replicas_restored": True,
+            "logger_ttl_restored": True,
+            "proxy_ready": True,
+            "collector_ready": True,
+            "owned_resources_removed": True,
+        },
+    }
+
+
+class R1ActionQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_rejects_model_network_calls_and_missing_action(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["model_provider_network_calls"] = True
+        manifest["actions"].pop()
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("model-provider network calls must remain disabled", findings)
+        self.assertTrue(any("R1 action set drifted" in finding for finding in findings))
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report()), [])
+
+    def test_rejects_partial_or_unrestored_report(self) -> None:
+        report = valid_report()
+        action = report["actions"][0]
+        action["outcomes"]["verification_failure"] = "failed"
+        action["live"]["target_mutations"] = 2
+        report["cleanup"]["proxy_replicas_restored"] = False
+
+        findings = MODULE.validate_report(report)
+
+        self.assertTrue(any("non-passing" in finding for finding in findings))
+        self.assertTrue(any("target_mutations" in finding for finding in findings))
+        self.assertIn("cleanup proof is incomplete", findings)
+
+    def test_rejects_ai_calls_and_sensitive_report_values(self) -> None:
+        report = valid_report()
+        report["model_provider_network_calls"] = 1
+        report["unsafe"] = "Bearer qualification-token"
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("report must prove zero model-provider network calls", findings)
+        self.assertIn("report contains a credential-like value", findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -297,6 +297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,15 +345,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -471,8 +468,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -722,16 +719,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -845,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der-parser"
@@ -908,23 +895,13 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -1234,16 +1211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,7 +1355,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1501,7 +1468,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1687,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ipnetwork"
@@ -1841,7 +1808,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -1940,22 +1907,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -2418,7 +2375,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2641,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2651,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
@@ -2930,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2951,7 +2908,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3006,7 +2963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
@@ -3071,13 +3028,13 @@ version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",
- "base64",
+ "base64 0.23.1",
  "cheetah-string",
  "chrono",
  "hex",
  "hmac",
  "ipnetwork",
- "md-5 0.11.0",
+ "md-5",
  "moka",
  "rocketmq-error",
  "rocketmq-model",
@@ -3152,7 +3109,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "config",
@@ -3193,7 +3150,7 @@ dependencies = [
 name = "rocketmq-model"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "byteorder",
  "bytes",
  "cheetah-string",
@@ -3203,7 +3160,7 @@ dependencies = [
  "flate2",
  "local-ip-address",
  "lz4_flex",
- "md-5 0.10.6",
+ "md-5",
  "rocketmq-error",
  "serde",
  "serde_json",
@@ -3706,7 +3663,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -3717,7 +3674,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -4020,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4187,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -4458,7 +4415,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8931

### Brief Description

- Add a versioned qualification manifest and fail-closed checker for the four bounded R1 actions and their ten required outcomes.
- Exercise logger TTL, Proxy scale-out, Proxy restart, and Collector restart through the real Control Plane, Executor, Execution Agent, PostgreSQL journal, and disposable Kind targets.
- Persist and verify approvals, intents, results, Agent effects, verification Evidence, recovery, quarantine, and cleanup without adding a generic mutation path.
- Record automatic compensation for reversible actions and explicit manual-takeover safe stops for restart actions that cannot truthfully claim automatic rollback.
- Keep aggregate controlled-action maturity partial until the remaining R2 actions are independently qualified.
- Align Kind release identity with the image source revision and refresh the standalone MCP lockfile required by reproducible `--locked` image builds.
- Keep model-provider network calls disabled; this change does not configure DeepSeek or grant AI execution authority.

### How Did You Test This Change?

- Passed the R1 disposable-Kind qualification: four actions, forty outcome assertions, one bounded target mutation per live action, persisted PostgreSQL recovery outcomes, restored Proxy/Collector/logger state, and zero model-provider network calls.
- Passed `cargo +1.95.0 check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace`.
- Passed `cargo +1.95.0 test --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-features` with Windows test debug symbols disabled to avoid the MSVC PDB size limit.
- Passed SRE workspace format, all-target/all-feature Clippy with `-D warnings`, Rustdoc, source-layout, execution dependency-boundary, implementation-status, recovery-qualification, manifest, and checker tests.
- Passed MCP locked check, read-only dependency-boundary check, default and all-feature tests, Streamable HTTP Clippy with `-D warnings`, Rustdoc, and package-scoped format check.
- `cargo fmt --all -- --check` for the standalone MCP workspace could not be executed on Windows because local path dependencies exceeded OS command-line length limits; `cargo fmt -p rocketmq-mcp -- --check` passed, and this change modifies only the MCP lockfile.
- Passed container image guard, five-service image runtime/SBOM/vulnerability/signature contract, Kubernetes asset guard and render contract, AGENTS routing, workspace metadata, PowerShell parsing, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added qualification coverage for four low-risk operational actions in disposable Kind environments.
  * Added validation of safety boundaries, recovery behavior, cleanup, audit evidence, and kill-switch scenarios.
  * Added live qualification workflow with structured reports and independent integrity checks.

* **Documentation**
  * Documented the qualification process, supported actions, execution steps, safety limits, recovery simulations, and report locations in English and Chinese.

* **Tests**
  * Expanded end-to-end coverage for successful, denied, failed, recovered, and manual-takeover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->