### PR TITLE
[ISSUE #8933]✨Qualify approved R2 SRE actions with persisted live outcomes

### DIFF
--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -271,6 +271,38 @@ committed catalog independently with:
 python scripts/check_r1_action_qualification.py
 ```
 
+### Controlled R2 action qualification
+
+The R2 qualification contract covers the five approved moderate-risk actions:
+allowlisted Broker, Topic, and Subscription Group configuration patches; a
+single digest-pinned Proxy image canary; and overlap-first credential rotation.
+Every plan must pass an offline heterogeneous Critic, independent human
+approval, hash-bound authorization, generation or version fencing, typed Agent
+precheck, durable execution journaling, stable-window verification, and
+automatic compensation. Unattended execution remains disabled.
+
+The qualification entry point creates a new disposable Kind cluster from a
+clean committed revision, registers an immutable local canary image, runs all
+five actions through the Control Plane, Executor, and Execution Agent, and
+validates deterministic recovery cases in isolated PostgreSQL schemas. It then
+removes the canary, credential fixtures, bootstrap job, cluster, and generated
+runtime artifacts before writing a passing report. The scripted Critic uses a
+different model family but performs no provider network call.
+
+Run from `rocketmq-sre/`; build output stays on `D:` and `F:`, and the redacted
+report is written outside the repository on `D:`:
+
+```powershell
+.\scripts\r2-action-live-qualification.ps1
+```
+
+The report is implementation qualification rather than production
+certification. Validate the committed catalog independently with:
+
+```powershell
+python scripts/check_r2_action_qualification.py
+```
+
 ## User interface
 
 The UI is designed as a full-screen desktop operations workspace using

--- a/rocketmq-sre/README.zh-CN.md
+++ b/rocketmq-sre/README.zh-CN.md
@@ -240,6 +240,30 @@ TTL 覆盖、一个 Proxy 副本、一个 Proxy Pod 或一个 Collector Pod。�
 python scripts/check_r1_action_qualification.py
 ```
 
+### 受控 R2 动作资格验证
+
+R2 资格契约覆盖五个已批准的中等风险动作：Broker、Topic 和订阅组的白名单配置补丁，
+单副本且使用镜像摘要固定的 Proxy 金丝雀，以及先重叠后切换的凭据轮换。每个计划都必须经过
+离线异构 Critic、独立人工审批、绑定哈希的授权、Generation 或版本 Fence、类型化 Agent
+预检、持久化执行日志、稳定窗口验证和自动补偿。无人值守执行保持关闭。
+
+资格验证入口从干净且已提交的源码版本创建全新的一次性 Kind 集群，注册不可变的本地金丝雀
+镜像，并让五个动作全部经过 Control Plane、Executor 和 Execution Agent。确定性恢复用例在
+隔离的 PostgreSQL Schema 中执行。通过前，工具会删除金丝雀、凭据夹具、Bootstrap Job、
+Kind 集群和生成的运行时文件。脚本化 Critic 使用不同的模型系列，但不会发起模型供应商网络调用。
+
+在 `rocketmq-sre/` 中运行；构建产物保留在 `D:` 和 `F:`，脱敏报告写入仓库外的 `D:`：
+
+```powershell
+.\scripts\r2-action-live-qualification.ps1
+```
+
+该报告用于证明实现资格，不构成生产认证。可独立校验已提交的清单：
+
+```powershell
+python scripts/check_r2_action_qualification.py
+```
+
 ## 用户界面
 
 UI 按照 shadcn/ui 规范和可访问的 Radix UI primitive 设计为全屏桌面运维

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -154,12 +154,12 @@
     },
     {
       "id": "controlled-actions",
-      "status": "partial",
+      "status": "completed",
       "target_outcome": "execution-qualification",
       "maturity": {
         "implemented": true,
         "contract_tested": true,
-        "live_smoke_passed": false,
+        "live_smoke_passed": true,
         "production_certified": false
       },
       "evidence": [
@@ -194,12 +194,25 @@
         {
           "kind": "test",
           "path": "rocketmq-sre/scripts/r1-action-live-qualification.ps1"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/r2-actions.v1.json"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_r2_action_qualification.py"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/r2-action-live-qualification.ps1"
         }
       ],
       "limitations": [
         "All nine explicitly registered bounded actions have independent switches, owners, and contract evidence; the sixteen-scenario Kubernetes platform fault matrix has passed.",
         "All four R1 actions have independently passed disposable Kind success, denial, idempotency, fencing, reconciliation, verification-failure, compensation or manual-takeover safe-stop, quarantine, scope, and kill-switch qualification with zero model-provider calls.",
-        "The five R2 actions still require the same independent disposable-cluster outcome qualification, so aggregate controlled-action live maturity remains partial.",
+        "All five R2 actions have independently passed disposable Kind Critic, actor-separation, approval, live success, idempotency, generation or epoch fencing, reconciliation, verification-failure, automatic compensation, rollback-failure quarantine, scope, and kill-switch qualification with zero model-provider calls.",
+        "Disposable qualification proves implementation behavior but does not certify a deployment-specific production cluster.",
         "R3 operations and arbitrary requests remain permanently forbidden."
       ]
     },

--- a/rocketmq-sre/config/qualification/r2-actions.v1.json
+++ b/rocketmq-sre/config/qualification/r2-actions.v1.json
@@ -1,0 +1,210 @@
+{
+  "schema_version": "rocketmq-sre.r2-action-qualification.v1",
+  "operating_mode": "rules_only",
+  "environment": "disposable_kind",
+  "critic_transport": "offline_scripted",
+  "model_provider_network_calls": false,
+  "unattended_execution": false,
+  "production_certified": false,
+  "required_outcomes": [
+    "live_verified_success",
+    "critic_required_and_heterogeneous",
+    "same_family_critic_denied",
+    "self_approval_denied",
+    "duplicate_idempotent",
+    "stale_generation_or_epoch_denied",
+    "unknown_effect_reconciled",
+    "verification_failure",
+    "automatic_compensation",
+    "rollback_failure_quarantined",
+    "scope_denied",
+    "kill_switch_denied"
+  ],
+  "shared_boundary_evidence": {
+    "critic_required_and_heterogeneous": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/critic_tests.rs",
+      "test": "postgres_r2_critic_is_heterogeneous_durable_and_required_for_approval"
+    },
+    "same_family_critic_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/critic_tests.rs",
+      "test": "postgres_same_family_alias_and_endpoint_degrade_without_unlocking_r2"
+    },
+    "self_approval_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/service_tests.rs",
+      "test": "postgres_plan_policy_approval_audit_and_quarantine_are_fail_closed"
+    },
+    "duplicate_idempotent": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery.rs",
+      "test": "migrations_journal_locks_fences_and_restart_recovery_are_durable"
+    },
+    "stale_generation_or_epoch_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/fencing_interleavings.rs",
+      "test": "fence_ack_waits_for_inflight_dispatch_and_old_epoch_cannot_write_after_ack"
+    },
+    "unknown_effect_reconciled": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/fencing_interleavings.rs",
+      "test": "dispatched_unknown_effect_blocks_takeover_until_read_only_reconciliation_confirms_terminal_state"
+    },
+    "scope_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/execution_authority/tests.rs",
+      "test": "lease_takeover_requires_executor_workload_role_and_exact_cluster_scope"
+    },
+    "kill_switch_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs",
+      "test": "postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent"
+    }
+  },
+  "actions": [
+    {
+      "id": "broker.config.patch_allowlisted.v1",
+      "risk": "r2",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_BROKER_CONFIG",
+      "descriptor": "rocketmq-sre/config/actions/broker.config.patch_allowlisted.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/broker_config_patch_tests.rs",
+        "test": "precheck_rejects_generation_drift_and_restart_required_fields"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs",
+        "test": "real_kind_wave_admin_actions_share_r2_critic_approval_and_verification"
+      },
+      "generation_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_broker_config_tests.rs",
+        "test": "real_broker_generation_cas_rejects_stale_write_and_rolls_back"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r2_actions_persist_recovery_qualification_matrix"
+      },
+      "required_live_invariants": ["generation_incremented", "patch_visible"],
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "topic.config.patch_allowlisted.v1",
+      "risk": "r2",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_TOPIC_CONFIG",
+      "descriptor": "rocketmq-sre/config/actions/topic.config.patch_allowlisted.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/topic_config_patch_tests.rs",
+        "test": "precheck_rejects_version_drift_and_inconsistent_config"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs",
+        "test": "real_kind_wave_admin_actions_share_r2_critic_approval_and_verification"
+      },
+      "generation_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_topic_config_tests.rs",
+        "test": "real_topic_version_cas_rejects_stale_write_and_rolls_back"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r2_actions_persist_recovery_qualification_matrix"
+      },
+      "required_live_invariants": ["topic_version_incremented", "patch_visible"],
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "subscription_group.patch_allowlisted.v1",
+      "risk": "r2",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_SUBSCRIPTION_GROUP_CONFIG",
+      "descriptor": "rocketmq-sre/config/actions/subscription_group.patch_allowlisted.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/subscription_group_patch_tests.rs",
+        "test": "precheck_rejects_unknown_retry_semantics_and_permission_drift"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs",
+        "test": "real_kind_wave_admin_actions_share_r2_critic_approval_and_verification"
+      },
+      "generation_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_subscription_group_e2e_tests.rs",
+        "test": "real_subscription_group_version_cas_rejects_stale_write_and_rolls_back"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r2_actions_persist_recovery_qualification_matrix"
+      },
+      "required_live_invariants": ["subscription_group_version_incremented", "patch_visible"],
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "proxy.rollout_image_canary.v1",
+      "risk": "r2",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_PROXY_IMAGE_CANARY",
+      "descriptor": "rocketmq-sre/config/actions/proxy.rollout_image_canary.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_image_canary_tests.rs",
+        "test": "precheck_requires_pdb_slo_and_idle_generation"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs",
+        "test": "real_kind_wave_admin_actions_share_r2_critic_approval_and_verification"
+      },
+      "generation_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_proxy_image_canary_tests.rs",
+        "test": "real_kind_proxy_image_canary_is_one_replica_and_reversible"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r2_actions_persist_recovery_qualification_matrix"
+      },
+      "required_live_invariants": ["canary_generation_observed", "canary_ready", "old_replicas_unchanged"],
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "security.credential_rotate_overlap.v1",
+      "risk": "r2",
+      "owner": "messaging-security",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_CREDENTIAL_ROTATION",
+      "descriptor": "rocketmq-sre/config/actions/security.credential_rotate_overlap.v1.yaml",
+      "precheck_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/credential_rotation_tests.rs",
+        "test": "precheck_rejects_active_version_drift_and_unhealthy_credentials"
+      },
+      "live_success_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/credential_rotation_e2e_tests.rs",
+        "test": "real_kind_supervised_credential_overlap_passes_critic_and_verification"
+      },
+      "generation_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/production_credential_rotation_tests.rs",
+        "test": "real_credential_overlap_rejects_bad_candidate_and_restores_previous_selector"
+      },
+      "recovery_matrix_evidence": {
+        "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs",
+        "test": "all_r2_actions_persist_recovery_qualification_matrix"
+      },
+      "required_live_invariants": ["candidate_active", "previous_retiring", "overlap_deadline_recorded"],
+      "qualification": "disposable_cluster_smoke_passed"
+    }
+  ],
+  "hard_denials": [
+    "disabled_action",
+    "wrong_tenant",
+    "wrong_cluster",
+    "expired_grant",
+    "unknown_action",
+    "critic_missing",
+    "critic_same_family",
+    "self_approval",
+    "stale_plan_hash",
+    "stale_precondition",
+    "r3_action",
+    "raw_request",
+    "shell_command",
+    "arbitrary_kubernetes_patch"
+  ],
+  "live_report": {
+    "schema_version": "rocketmq-sre.r2-action-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/credential_rotation_e2e_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/credential_rotation_e2e_tests.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::VecDeque;
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration as StdDuration;
@@ -31,6 +34,7 @@ use rocketmq_sre_model_gateway::ProviderError;
 use rocketmq_sre_model_gateway::TransportFuture;
 use rocketmq_sre_model_gateway::TransportRequest;
 use rocketmq_sre_model_gateway::TransportResponse;
+use serde::Serialize;
 use serde_json::json;
 use uuid::Uuid;
 
@@ -55,6 +59,35 @@ use crate::workflow::WorkflowService;
 
 const DEFAULT_TENANT_ID: &str = "00000000-0000-4000-8000-000000000002";
 const DEFAULT_CLUSTER_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+#[derive(Serialize)]
+struct CredentialLiveOutcome {
+    id: &'static str,
+    state: &'static str,
+    execution_id: String,
+    correlation_id: String,
+    critic_reviews: i64,
+    approval_events: i64,
+    intent_records: i64,
+    result_records: i64,
+    confirmed_agent_effects: i64,
+    successful_verifications: i64,
+    verification_evidence_records: i64,
+    target_mutations: i64,
+    actor_separation: bool,
+    critic_transport: &'static str,
+    primary_model_family: String,
+    critic_model_family: String,
+    safety_invariants: BTreeMap<String, bool>,
+}
+
+#[derive(Serialize)]
+struct CredentialLiveFragment<'a> {
+    schema_version: &'static str,
+    model_provider_network_calls: u8,
+    critic_transport: &'static str,
+    actions: [&'a CredentialLiveOutcome; 1],
+}
 
 #[tokio::test]
 #[ignore = "requires live Kind PostgreSQL, Executor, Agent, credential fixtures, and authenticated Broker"]
@@ -155,6 +188,7 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
     .expect("supervised execution service");
     let operator = auth(tenant_id, cluster_id, "phase3-credential-operator", &["operator"]);
     let approver = auth(tenant_id, cluster_id, "phase3-credential-approver", &["approver"]);
+    let correlation_id = CorrelationId::new();
     let created = service
         .create_plan(
             &operator,
@@ -171,7 +205,7 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
                     evidence_ids: vec![fixture.agent_evidence_id],
                 }],
             },
-            CorrelationId::new(),
+            correlation_id,
         )
         .await
         .expect("create credential rotation plan");
@@ -188,7 +222,7 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
             &CriticReviewRequest {
                 plan_hash: plan.plan_hash.clone(),
             },
-            CorrelationId::new(),
+            correlation_id,
         )
         .await
         .expect("heterogeneous credential rotation Critic");
@@ -198,6 +232,11 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
     assert_eq!(
         reviewed.review.critic_model_family.as_deref(),
         Some(critic_family.as_str())
+    );
+    assert_ne!(
+        reviewed.review.primary_model_family.trim().to_ascii_lowercase(),
+        critic_family.trim().to_ascii_lowercase(),
+        "credential Critic must use a different model family"
     );
     let precondition_hash = reviewed
         .plan
@@ -213,17 +252,18 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
                 reason: "Independent review accepted the bounded credential overlap and rollback".to_owned(),
                 validity_seconds: Some(1_500),
             },
-            CorrelationId::new(),
+            correlation_id,
         )
         .await
         .expect("independent human approval");
+    let plan_id = reviewed.plan.id;
     let execution_request = SubmitExecutionRequest {
         plan_id: reviewed.plan.id,
         plan_hash: reviewed.plan.plan_hash,
         precondition_hash,
         idempotency_key: format!("phase3-credential-overlap-{}", Uuid::new_v4()),
     };
-    let submission = service.submit_execution(&operator, &execution_request, CorrelationId::new());
+    let submission = service.submit_execution(&operator, &execution_request, correlation_id);
     tokio::pin!(submission);
     let submitted = loop {
         tokio::select! {
@@ -255,6 +295,10 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
     assert_eq!(applied.resource_conditions.get("candidate_active"), Some(&true));
     assert_eq!(applied.resource_conditions.get("previous_retiring"), Some(&true));
     assert_eq!(
+        applied.resource_conditions.get("overlap_deadline_recorded"),
+        Some(&true)
+    );
+    assert_eq!(
         sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*)
              FROM execution_agent_credential_rotation_before_states
@@ -266,6 +310,127 @@ async fn real_kind_supervised_credential_overlap_passes_critic_and_verification(
         .expect("credential rotation before-state count"),
         1
     );
+
+    if let Some(path) = required_env("ROCKETMQ_SRE_R2_CREDENTIAL_LIVE_FRAGMENT") {
+        let execution_id = submitted.execution.id;
+        let critic_reviews = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM critic_reviews WHERE plan_id = $1 AND status = 'valid'",
+            plan_id.as_uuid(),
+        )
+        .await;
+        let approval_events = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM audit_events WHERE correlation_id = $1 AND event_kind = 'approved'",
+            correlation_id.as_uuid(),
+        )
+        .await;
+        let actor_subjects = count_for_id(
+            &repository,
+            "SELECT COUNT(DISTINCT actor_subject) FROM audit_events WHERE correlation_id = $1 AND event_kind IN ('plan_created', 'approved')",
+            correlation_id.as_uuid(),
+        )
+        .await;
+        let intent_records = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'intent'",
+            execution_id.as_uuid(),
+        )
+        .await;
+        let result_records = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'result'",
+            execution_id.as_uuid(),
+        )
+        .await;
+        let confirmed_agent_effects = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM execution_agent_effects WHERE execution_id = $1 AND state = 'confirmed'",
+            execution_id.as_uuid(),
+        )
+        .await;
+        let successful_verifications = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM execution_verifications WHERE execution_id = $1 AND outcome = 'succeeded'",
+            execution_id.as_uuid(),
+        )
+        .await;
+        let verification_evidence_records = count_for_id(
+            &repository,
+            "SELECT COUNT(*) FROM execution_verification_evidence WHERE execution_id = $1",
+            execution_id.as_uuid(),
+        )
+        .await;
+        for (name, count) in [
+            ("Critic review", critic_reviews),
+            ("approval event", approval_events),
+            ("intent record", intent_records),
+            ("result record", result_records),
+            ("confirmed Agent effect", confirmed_agent_effects),
+            ("successful verification", successful_verifications),
+            ("verification Evidence record", verification_evidence_records),
+        ] {
+            assert!(count > 0, "credential qualification persisted no {name}");
+        }
+        assert!(
+            actor_subjects >= 2,
+            "credential qualification did not preserve actor separation"
+        );
+        assert_eq!(
+            confirmed_agent_effects, 1,
+            "credential qualification must perform exactly one bounded target mutation"
+        );
+        let outcome = CredentialLiveOutcome {
+            id: ExecutionAction::SecurityCredentialRotateOverlap.id(),
+            state: "succeeded",
+            execution_id: execution_id.to_string(),
+            correlation_id: correlation_id.to_string(),
+            critic_reviews,
+            approval_events,
+            intent_records,
+            result_records,
+            confirmed_agent_effects,
+            successful_verifications,
+            verification_evidence_records,
+            target_mutations: confirmed_agent_effects,
+            actor_separation: true,
+            critic_transport: "offline_scripted",
+            primary_model_family: reviewed.review.primary_model_family,
+            critic_model_family: critic_family,
+            safety_invariants: [
+                ("candidate_active".to_owned(), true),
+                ("previous_retiring".to_owned(), true),
+                ("overlap_deadline_recorded".to_owned(), true),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        write_live_fragment(Path::new(&path), &outcome);
+    }
+}
+
+async fn count_for_id(repository: &PostgresRepository, query: &'static str, id: Uuid) -> i64 {
+    sqlx::query_scalar(query)
+        .bind(id)
+        .fetch_one(&repository.pool)
+        .await
+        .unwrap_or_else(|error| panic!("query persisted credential qualification record: {error}"))
+}
+
+fn write_live_fragment(path: &Path, outcome: &CredentialLiveOutcome) {
+    assert!(
+        path.is_absolute(),
+        "credential qualification fragment path must be absolute"
+    );
+    let fragment = CredentialLiveFragment {
+        schema_version: "rocketmq-sre.r2-action-live-fragment.v1",
+        model_provider_network_calls: 0,
+        critic_transport: "offline_scripted",
+        actions: [outcome],
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize credential qualification fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write credential qualification fragment");
 }
 
 async fn ensure_kind_cluster(

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/supervised_execution/wave_admin_actions_e2e_tests.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
@@ -28,6 +31,7 @@ use rocketmq_sre_contracts::ExecutionAction;
 use rocketmq_sre_contracts::ExecutionState;
 use rocketmq_sre_contracts::PlanStatus;
 use rocketmq_sre_contracts::TenantId;
+use serde::Serialize;
 use serde_json::Map;
 use serde_json::Value;
 use serde_json::json;
@@ -69,13 +73,42 @@ struct DiscoveredActionCase {
     required_conditions: &'static [&'static str],
 }
 
+#[derive(Serialize)]
+struct LiveR2ActionOutcome {
+    id: String,
+    state: &'static str,
+    execution_id: String,
+    correlation_id: String,
+    critic_reviews: i64,
+    approval_events: i64,
+    intent_records: i64,
+    result_records: i64,
+    confirmed_agent_effects: i64,
+    successful_verifications: i64,
+    verification_evidence_records: i64,
+    target_mutations: i64,
+    actor_separation: bool,
+    critic_transport: &'static str,
+    primary_model_family: String,
+    critic_model_family: String,
+    safety_invariants: BTreeMap<String, bool>,
+}
+
+#[derive(Serialize)]
+struct LiveR2ActionFragment<'a> {
+    schema_version: &'static str,
+    model_provider_network_calls: u8,
+    critic_transport: &'static str,
+    actions: &'a [LiveR2ActionOutcome],
+}
+
 #[tokio::test]
 #[ignore = "requires live Kind PostgreSQL, Executor, Agent, authenticated Broker, and wave Admin fixtures"]
 async fn real_kind_wave_admin_actions_share_r2_critic_approval_and_verification() {
     let Some(environment) = LiveEnvironment::from_process() else {
         return;
     };
-    let cases = [
+    let mut cases = vec![
         discover_case(
             &environment,
             ExecutionAction::BrokerConfigPatchAllowlisted,
@@ -119,10 +152,57 @@ async fn real_kind_wave_admin_actions_share_r2_critic_approval_and_verification(
         )
         .await,
     ];
-
-    for case in cases {
-        execute_r2_case(&environment, case).await;
+    if let Some(case) = discover_proxy_canary_case(&environment).await {
+        cases.push(case);
     }
+
+    let mut outcomes = Vec::with_capacity(cases.len());
+    for case in cases {
+        outcomes.push(execute_r2_case(&environment, case).await);
+    }
+    if let Some(path) = required_env("ROCKETMQ_SRE_R2_ADMIN_LIVE_FRAGMENT") {
+        assert_eq!(
+            outcomes.len(),
+            4,
+            "R2 qualification must include all three Admin CAS actions and the Proxy image canary"
+        );
+        write_live_fragment(Path::new(&path), &outcomes);
+    }
+}
+
+async fn discover_proxy_canary_case(environment: &LiveEnvironment) -> Option<DiscoveredActionCase> {
+    let image_digest = required_env("ROCKETMQ_SRE_PHASE3_PROXY_IMAGE_DIGEST")?;
+    for generation in 1..=512 {
+        let target = "deployment/rocketmq-system/rocketmq-proxy".to_owned();
+        let parameters = json!({
+            "namespace": "rocketmq-system",
+            "workload": "rocketmq-proxy",
+            "container": "proxy",
+            "expected_generation": generation,
+            "image_digest": image_digest,
+            "canary_replicas": 1,
+        });
+        let baseline = fetch_agent_state(
+            &environment.agent_url,
+            &environment.workload_token,
+            environment.tenant_id,
+            environment.cluster_id,
+            ExecutionAction::ProxyRolloutImageCanary,
+            &target,
+            parameters.clone(),
+        )
+        .await;
+        if baseline.ready {
+            return Some(DiscoveredActionCase {
+                action: ExecutionAction::ProxyRolloutImageCanary,
+                target,
+                parameters,
+                baseline,
+                required_conditions: &["canary_generation_observed", "canary_ready", "old_replicas_unchanged"],
+            });
+        }
+    }
+    panic!("Proxy image canary did not expose a ready generation in the bounded live fixture");
 }
 
 #[allow(
@@ -174,7 +254,7 @@ async fn discover_case(
     );
 }
 
-async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCase) {
+async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCase) -> LiveR2ActionOutcome {
     let repository = PostgresRepository::connect(&environment.database_url, 5)
         .await
         .expect("Kind PostgreSQL repository");
@@ -229,7 +309,7 @@ async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCa
     let executor = ExecutorSubmissionClient::http(
         environment.executor_url.parse::<Url>().expect("Executor URL"),
         environment.workload_token.clone(),
-        StdDuration::from_secs(900),
+        StdDuration::from_secs(1_920),
         true,
     )
     .expect("Executor client");
@@ -298,6 +378,11 @@ async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCa
         reviewed.review.critic_model_family.as_deref(),
         Some(critic_family.as_str())
     );
+    assert_ne!(
+        reviewed.review.primary_model_family.trim().to_ascii_lowercase(),
+        critic_family.trim().to_ascii_lowercase(),
+        "R2 Critic must use a different model family"
+    );
     let precondition_hash = reviewed
         .plan
         .compute_precondition_hash()
@@ -319,6 +404,14 @@ async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCa
         )
         .await
         .unwrap_or_else(|error| panic!("approve {} plan: {error}", case.action.id()));
+    let plan_id = reviewed.plan.id;
+    let execution_deadline = StdDuration::from_secs(
+        reviewed.plan.steps[0]
+            .verification
+            .max_wait_seconds
+            .checked_add(60)
+            .expect("bounded verification deadline"),
+    );
     let execution_request = SubmitExecutionRequest {
         plan_id: reviewed.plan.id,
         plan_hash: reviewed.plan.plan_hash,
@@ -332,6 +425,7 @@ async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCa
         correlation_id,
         &repository,
         &fixture,
+        execution_deadline,
     )
     .await;
     assert_eq!(
@@ -376,6 +470,131 @@ async fn execute_r2_case(environment: &LiveEnvironment, case: DiscoveredActionCa
             case.action.id()
         );
     }
+
+    let execution_id = submitted.execution.id;
+    let critic_reviews = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM critic_reviews WHERE plan_id = $1 AND status = 'valid'",
+        plan_id.as_uuid(),
+    )
+    .await;
+    let approval_events = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM audit_events WHERE correlation_id = $1 AND event_kind = 'approved'",
+        correlation_id.as_uuid(),
+    )
+    .await;
+    let actor_subjects = count_for_id(
+        &repository,
+        "SELECT COUNT(DISTINCT actor_subject) FROM audit_events WHERE correlation_id = $1 AND event_kind IN ('plan_created', 'approved')",
+        correlation_id.as_uuid(),
+    )
+    .await;
+    let intent_records = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'intent'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let result_records = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM execution_steps WHERE execution_id = $1 AND record_kind = 'result'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let confirmed_agent_effects = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM execution_agent_effects WHERE execution_id = $1 AND state = 'confirmed'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let successful_verifications = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM execution_verifications WHERE execution_id = $1 AND outcome = 'succeeded'",
+        execution_id.as_uuid(),
+    )
+    .await;
+    let verification_evidence_records = count_for_id(
+        &repository,
+        "SELECT COUNT(*) FROM execution_verification_evidence WHERE execution_id = $1",
+        execution_id.as_uuid(),
+    )
+    .await;
+    for (name, count) in [
+        ("Critic review", critic_reviews),
+        ("approval event", approval_events),
+        ("intent record", intent_records),
+        ("result record", result_records),
+        ("confirmed Agent effect", confirmed_agent_effects),
+        ("successful verification", successful_verifications),
+        ("verification Evidence record", verification_evidence_records),
+    ] {
+        assert!(count > 0, "{} persisted no {name}", case.action.id());
+    }
+    assert!(
+        actor_subjects >= 2,
+        "{} did not preserve actor separation",
+        case.action.id()
+    );
+    assert_eq!(
+        confirmed_agent_effects,
+        1,
+        "{} must perform exactly one bounded target mutation",
+        case.action.id()
+    );
+    let safety_invariants = case
+        .required_conditions
+        .iter()
+        .map(|condition| {
+            (
+                (*condition).to_owned(),
+                applied.resource_conditions.get(*condition).copied().unwrap_or(false),
+            )
+        })
+        .collect();
+    LiveR2ActionOutcome {
+        id: case.action.id().to_owned(),
+        state: "succeeded",
+        execution_id: execution_id.to_string(),
+        correlation_id: correlation_id.to_string(),
+        critic_reviews,
+        approval_events,
+        intent_records,
+        result_records,
+        confirmed_agent_effects,
+        successful_verifications,
+        verification_evidence_records,
+        target_mutations: confirmed_agent_effects,
+        actor_separation: true,
+        critic_transport: "offline_scripted",
+        primary_model_family: reviewed.review.primary_model_family,
+        critic_model_family: critic_family,
+        safety_invariants,
+    }
+}
+
+async fn count_for_id(repository: &PostgresRepository, query: &'static str, id: Uuid) -> i64 {
+    sqlx::query_scalar(query)
+        .bind(id)
+        .fetch_one(&repository.pool)
+        .await
+        .unwrap_or_else(|error| panic!("query persisted R2 qualification record: {error}"))
+}
+
+fn write_live_fragment(path: &Path, outcomes: &[LiveR2ActionOutcome]) {
+    assert!(
+        path.is_absolute(),
+        "R2 live qualification fragment path must be absolute"
+    );
+    let fragment = LiveR2ActionFragment {
+        schema_version: "rocketmq-sre.r2-action-live-fragment.v1",
+        model_provider_network_calls: 0,
+        critic_transport: "offline_scripted",
+        actions: outcomes,
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize R2 live qualification fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write R2 live qualification fragment");
 }
 
 async fn submit_with_slo_refresh(
@@ -385,13 +604,21 @@ async fn submit_with_slo_refresh(
     correlation_id: CorrelationId,
     repository: &PostgresRepository,
     fixture: &ExecutionFixture,
+    absolute_deadline: StdDuration,
 ) -> super::model::ExecutionSubmissionView {
     let submission = service.submit_execution(operator, request, correlation_id);
     tokio::pin!(submission);
+    let deadline = tokio::time::Instant::now() + absolute_deadline;
     loop {
         tokio::select! {
             result = &mut submission => {
                 return result.expect("execute supervised wave Admin action");
+            }
+            () = tokio::time::sleep_until(deadline) => {
+                panic!(
+                    "supervised wave Admin action exceeded its absolute {}-second deadline",
+                    absolute_deadline.as_secs()
+                );
             }
             () = tokio::time::sleep(StdDuration::from_secs(60)) => {
                 seed_complete_slo_evidence(repository, fixture).await;

--- a/rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-executor/tests/execution_flow.rs
@@ -102,9 +102,7 @@ use support::audit;
 use support::cleanup_schema;
 use support::isolated_pool;
 use support::seed_fixture;
-use support::seed_logger_fixture;
-use support::seed_proxy_restart_fixture;
-use support::seed_telemetry_collector_restart_fixture;
+use support::seed_fixture_for_action;
 use support::step_intent;
 
 type TestFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ExecutorError>> + Send + 'a>>;
@@ -931,6 +929,111 @@ async fn all_r1_actions_persist_recovery_qualification_matrix() {
     fs::write(path, bytes).expect("write R1 recovery qualification fragment");
 }
 
+#[derive(Serialize)]
+struct R2RecoveryOutcome {
+    id: String,
+    recovery_mode: &'static str,
+    verified_success: &'static str,
+    verification_failure: &'static str,
+    rollback_failure: &'static str,
+    compensation_intents: i64,
+    active_quarantines: i64,
+}
+
+#[derive(Serialize)]
+struct R2RecoveryFragment {
+    schema_version: &'static str,
+    model_provider_network_calls: u8,
+    actions: Vec<R2RecoveryOutcome>,
+}
+
+#[tokio::test]
+#[ignore = "requires ROCKETMQ_SRE_TEST_DATABASE_URL and an explicit machine-local report path"]
+async fn all_r2_actions_persist_recovery_qualification_matrix() {
+    let Ok(fragment_path) = std::env::var("ROCKETMQ_SRE_R2_RECOVERY_FRAGMENT") else {
+        return;
+    };
+    let actions = [
+        ExecutionAction::BrokerConfigPatchAllowlisted,
+        ExecutionAction::TopicConfigPatchAllowlisted,
+        ExecutionAction::SubscriptionGroupPatchAllowlisted,
+        ExecutionAction::ProxyRolloutImageCanary,
+        ExecutionAction::SecurityCredentialRotateOverlap,
+    ];
+    let mut outcomes = Vec::with_capacity(actions.len());
+    for action in actions {
+        let success = run_execution_for_action(&r2_success_signals(action), false, action).await;
+        assert_eq!(success.state, ExecutionState::Succeeded, "{} success case", action.id());
+        assert_eq!(success.dispatches, vec![false], "{} success dispatches", action.id());
+        assert_eq!(success.active_locks, 0, "{} success lock cleanup", action.id());
+
+        let rollback = run_execution_for_action(&r2_rollback_signals(action, true), false, action).await;
+        assert_eq!(
+            rollback.state,
+            ExecutionState::RolledBack,
+            "{} verification-failure case",
+            action.id()
+        );
+        assert_eq!(
+            rollback.dispatches,
+            vec![false, true],
+            "{} compensation dispatches",
+            action.id()
+        );
+        assert_eq!(rollback.compensation_intents, 1, "{} compensation intent", action.id());
+        assert_eq!(rollback.active_locks, 0, "{} rollback lock cleanup", action.id());
+
+        let quarantine = run_execution_for_action(&r2_rollback_signals(action, false), false, action).await;
+        assert_eq!(
+            quarantine.state,
+            ExecutionState::Escalated,
+            "{} rollback-failure case",
+            action.id()
+        );
+        assert_eq!(
+            quarantine.dispatches,
+            vec![false, true],
+            "{} failed compensation dispatches",
+            action.id()
+        );
+        assert_eq!(
+            quarantine.compensation_intents,
+            1,
+            "{} failed compensation intent",
+            action.id()
+        );
+        assert_eq!(quarantine.active_quarantines, 1, "{} active quarantine", action.id());
+        assert_eq!(quarantine.active_locks, 0, "{} quarantine lock cleanup", action.id());
+
+        outcomes.push(R2RecoveryOutcome {
+            id: action.id().to_owned(),
+            recovery_mode: "automatic_compensation",
+            verified_success: "succeeded",
+            verification_failure: "rolled_back",
+            rollback_failure: "escalated",
+            compensation_intents: rollback.compensation_intents + quarantine.compensation_intents,
+            active_quarantines: quarantine.active_quarantines,
+        });
+        for run in [success, rollback, quarantine] {
+            cleanup_schema(&run.pool, &run.schema).await;
+        }
+    }
+
+    let path = Path::new(&fragment_path);
+    assert!(
+        path.is_absolute(),
+        "R2 recovery qualification fragment path must be absolute"
+    );
+    let fragment = R2RecoveryFragment {
+        schema_version: "rocketmq-sre.r2-action-recovery-fragment.v1",
+        model_provider_network_calls: 0,
+        actions: outcomes,
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize R2 recovery qualification fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write R2 recovery qualification fragment");
+}
+
 fn r1_success_signals(action: ExecutionAction) -> Vec<Signal> {
     let stable = match action {
         ExecutionAction::ObservabilityLoggerLevelTtl => 32,
@@ -957,6 +1060,38 @@ fn r1_rollback_signals(action: ExecutionAction, rollback_succeeds: bool) -> Vec<
         signal(3, true),
         signal(4, rollback_succeeds),
         signal(rollback_timeout, rollback_succeeds),
+    ]
+}
+
+fn r2_success_signals(action: ExecutionAction) -> Vec<Signal> {
+    let stable = match action {
+        ExecutionAction::BrokerConfigPatchAllowlisted
+        | ExecutionAction::TopicConfigPatchAllowlisted
+        | ExecutionAction::SubscriptionGroupPatchAllowlisted => 182,
+        ExecutionAction::ProxyRolloutImageCanary => 602,
+        ExecutionAction::SecurityCredentialRotateOverlap => 302,
+        _ => panic!("only R2 actions are qualified"),
+    };
+    vec![signal(0, true), signal(1, true), signal(2, true), signal(stable, true)]
+}
+
+fn r2_rollback_signals(action: ExecutionAction, rollback_succeeds: bool) -> Vec<Signal> {
+    let (forward_timeout, rollback_stable) = match action {
+        ExecutionAction::BrokerConfigPatchAllowlisted
+        | ExecutionAction::TopicConfigPatchAllowlisted
+        | ExecutionAction::SubscriptionGroupPatchAllowlisted => (902, 184),
+        ExecutionAction::ProxyRolloutImageCanary => (1_802, 604),
+        ExecutionAction::SecurityCredentialRotateOverlap => (1_802, 304),
+        _ => panic!("only R2 actions are qualified"),
+    };
+    vec![
+        signal(0, true),
+        signal(1, true),
+        signal(2, false),
+        signal(forward_timeout, false),
+        signal(3, true),
+        signal(4, rollback_succeeds),
+        signal(rollback_stable, rollback_succeeds),
     ]
 }
 
@@ -992,13 +1127,7 @@ async fn run_execution_for_action(signals: &[Signal], autonomous: bool, action: 
         .run(&pool)
         .await
         .expect("empty-schema migrations");
-    let mut fixture = match action {
-        ExecutionAction::ProxyScaleOutOne => seed_fixture(&pool).await,
-        ExecutionAction::ObservabilityLoggerLevelTtl => seed_logger_fixture(&pool).await,
-        ExecutionAction::ProxyRestartOne => seed_proxy_restart_fixture(&pool).await,
-        ExecutionAction::TelemetryCollectorRestartOne => seed_telemetry_collector_restart_fixture(&pool).await,
-        _ => panic!("the executor integration flow supports only the qualified R1 scenarios under test"),
-    };
+    let mut fixture = seed_fixture_for_action(&pool, action).await;
     if autonomous {
         fixture.request.approvals.clear();
         fixture.request.autonomy_grant = Some(autonomy_grant(&fixture));
@@ -1013,10 +1142,25 @@ async fn run_execution_for_action(signals: &[Signal], autonomous: bool, action: 
         ExecutionAction::TelemetryCollectorRestartOne => {
             include_str!("../../../config/actions/telemetry.collector.restart_one.v1.yaml")
         }
-        _ => panic!("the executor integration flow supports only the qualified R1 descriptors under test"),
+        ExecutionAction::BrokerConfigPatchAllowlisted => {
+            include_str!("../../../config/actions/broker.config.patch_allowlisted.v1.yaml")
+        }
+        ExecutionAction::TopicConfigPatchAllowlisted => {
+            include_str!("../../../config/actions/topic.config.patch_allowlisted.v1.yaml")
+        }
+        ExecutionAction::SubscriptionGroupPatchAllowlisted => {
+            include_str!("../../../config/actions/subscription_group.patch_allowlisted.v1.yaml")
+        }
+        ExecutionAction::ProxyRolloutImageCanary => {
+            include_str!("../../../config/actions/proxy.rollout_image_canary.v1.yaml")
+        }
+        ExecutionAction::SecurityCredentialRotateOverlap => {
+            include_str!("../../../config/actions/security.credential_rotate_overlap.v1.yaml")
+        }
+        _ => panic!("the executor integration flow does not support this qualification descriptor"),
     };
     let mut descriptor: rocketmq_sre_contracts::ActionDescriptor =
-        serde_yaml::from_str(descriptor_yaml).expect("R1 action descriptor");
+        serde_yaml::from_str(descriptor_yaml).expect("qualification action descriptor");
     descriptor.execution_supported = true;
     let registry = Arc::new(ExecutorActionRegistry::from_descriptors([descriptor]).expect("test registry"));
     let dispatches = Arc::new(Mutex::new(Vec::new()));

--- a/rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery/support.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-executor/tests/postgres_recovery/support.rs
@@ -162,7 +162,7 @@ pub(crate) async fn seed_telemetry_collector_restart_fixture(pool: &PgPool) -> F
     seed_fixture_for_action(pool, ExecutionAction::TelemetryCollectorRestartOne).await
 }
 
-async fn seed_fixture_for_action(pool: &PgPool, action: ExecutionAction) -> Fixture {
+pub(crate) async fn seed_fixture_for_action(pool: &PgPool, action: ExecutionAction) -> Fixture {
     sqlx::raw_sql(include_str!("../../../../deploy/dev/postgres/phase3-seed.sql"))
         .execute(pool)
         .await
@@ -181,6 +181,18 @@ async fn seed_fixture_for_action(pool: &PgPool, action: ExecutionAction) -> Fixt
         primary_invocation_id,
         action,
     );
+    let risk = if matches!(
+        action,
+        ExecutionAction::BrokerConfigPatchAllowlisted
+            | ExecutionAction::TopicConfigPatchAllowlisted
+            | ExecutionAction::SubscriptionGroupPatchAllowlisted
+            | ExecutionAction::ProxyRolloutImageCanary
+            | ExecutionAction::SecurityCredentialRotateOverlap
+    ) {
+        "r2"
+    } else {
+        "r1"
+    };
     sqlx::query(
         "INSERT INTO action_plans (
             id, tenant_id, cluster_id, incident_id, diagnosis_revision_id,
@@ -190,8 +202,8 @@ async fn seed_fixture_for_action(pool: &PgPool, action: ExecutionAction) -> Fixt
          ) VALUES (
             $1, $2, $3, $4, $5,
             $6, $7, $8, $9,
-            'r1', 'approved', $10, $11, $12,
-            $13, $14
+            $10, 'approved', $11, $12, $13,
+            $14, $15
          )",
     )
     .bind(plan.id.as_uuid())
@@ -203,6 +215,7 @@ async fn seed_fixture_for_action(pool: &PgPool, action: ExecutionAction) -> Fixt
     .bind(i32::try_from(plan.version).expect("plan version"))
     .bind(&plan.plan_hash)
     .bind(&plan.evidence_hash)
+    .bind(risk)
     .bind(serde_json::to_value(&plan).expect("plan snapshot"))
     .bind(&plan.created_by)
     .bind(plan.created_at)
@@ -325,7 +338,131 @@ fn action_plan(
                 timeout_seconds: 300,
             },
         ),
-        _ => panic!("the executor integration fixture supports only the qualified R1 scenarios under test"),
+        ExecutionAction::BrokerConfigPatchAllowlisted => (
+            "broker/rocketmq-broker:10911".to_owned(),
+            json!({
+                "broker": "rocketmq-broker:10911",
+                "expected_generation": 1,
+                "patch": {"max_client_event_count": 9_999}
+            }),
+            ImpactScope::AllowlistedFields,
+            VerificationSpec {
+                resource_conditions: vec!["generation_incremented".to_owned(), "patch_visible".to_owned()],
+                technical_slis: vec!["broker_error_ratio".to_owned(), "store_dispatch_latency".to_owned()],
+                stable_window_seconds: 180,
+                max_wait_seconds: 900,
+            },
+            CompensationSpec {
+                mode: CompensationMode::Automatic,
+                required_before_fields: vec!["before_config".to_owned(), "latest_generation".to_owned()],
+                timeout_seconds: 600,
+            },
+        ),
+        ExecutionAction::TopicConfigPatchAllowlisted => (
+            "topic/SRE_R2_QUALIFICATION".to_owned(),
+            json!({
+                "topic": "SRE_R2_QUALIFICATION",
+                "expected_version": 1,
+                "patch": {"read_queue_nums": 5, "write_queue_nums": 5}
+            }),
+            ImpactScope::AllowlistedFields,
+            VerificationSpec {
+                resource_conditions: vec!["topic_version_incremented".to_owned(), "patch_visible".to_owned()],
+                technical_slis: vec!["send_success_ratio".to_owned(), "consume_success_ratio".to_owned()],
+                stable_window_seconds: 180,
+                max_wait_seconds: 900,
+            },
+            CompensationSpec {
+                mode: CompensationMode::Automatic,
+                required_before_fields: vec!["before_config".to_owned(), "latest_version".to_owned()],
+                timeout_seconds: 600,
+            },
+        ),
+        ExecutionAction::SubscriptionGroupPatchAllowlisted => (
+            "subscription-group/SRE_R2_QUALIFICATION".to_owned(),
+            json!({
+                "group": "SRE_R2_QUALIFICATION",
+                "expected_version": 1,
+                "patch": {"retry_max_times": 15}
+            }),
+            ImpactScope::AllowlistedFields,
+            VerificationSpec {
+                resource_conditions: vec![
+                    "subscription_group_version_incremented".to_owned(),
+                    "patch_visible".to_owned(),
+                ],
+                technical_slis: vec!["consume_success_ratio".to_owned(), "retry_backlog_growth".to_owned()],
+                stable_window_seconds: 180,
+                max_wait_seconds: 900,
+            },
+            CompensationSpec {
+                mode: CompensationMode::Automatic,
+                required_before_fields: vec!["before_config".to_owned(), "latest_version".to_owned()],
+                timeout_seconds: 600,
+            },
+        ),
+        ExecutionAction::ProxyRolloutImageCanary => (
+            "deployment/rocketmq-system/rocketmq-proxy".to_owned(),
+            json!({
+                "namespace": "rocketmq-system",
+                "workload": "rocketmq-proxy",
+                "container": "proxy",
+                "expected_generation": 1,
+                "image_digest": format!("sha256:{}", "c".repeat(64)),
+                "canary_replicas": 1
+            }),
+            ImpactScope::OneReplica,
+            VerificationSpec {
+                resource_conditions: vec![
+                    "canary_generation_observed".to_owned(),
+                    "canary_ready".to_owned(),
+                    "old_replicas_unchanged".to_owned(),
+                ],
+                technical_slis: vec![
+                    "proxy_error_ratio".to_owned(),
+                    "proxy_p99_latency".to_owned(),
+                    "synthetic_message_path".to_owned(),
+                ],
+                stable_window_seconds: 600,
+                max_wait_seconds: 1_800,
+            },
+            CompensationSpec {
+                mode: CompensationMode::Automatic,
+                required_before_fields: vec!["previous_image_digest".to_owned(), "expected_generation".to_owned()],
+                timeout_seconds: 900,
+            },
+        ),
+        ExecutionAction::SecurityCredentialRotateOverlap => (
+            "credential-set/broker-admin".to_owned(),
+            json!({
+                "credential_set": "broker-admin",
+                "active_version": "v1",
+                "candidate_version": "v2",
+                "candidate_secret_ref": "kubernetes://rocketmq-sre/broker-admin-credential-v2",
+                "overlap_seconds": 300,
+                "validation_probe_topic": "SRE_PROBE_CREDENTIAL_ROTATION"
+            }),
+            ImpactScope::SingleResource,
+            VerificationSpec {
+                resource_conditions: vec![
+                    "candidate_active".to_owned(),
+                    "previous_retiring".to_owned(),
+                    "overlap_deadline_recorded".to_owned(),
+                ],
+                technical_slis: vec![
+                    "credential_probe_success_ratio".to_owned(),
+                    "authentication_error_ratio".to_owned(),
+                ],
+                stable_window_seconds: 300,
+                max_wait_seconds: 1_800,
+            },
+            CompensationSpec {
+                mode: CompensationMode::Automatic,
+                required_before_fields: vec!["active_version".to_owned(), "candidate_version".to_owned()],
+                timeout_seconds: 600,
+            },
+        ),
+        _ => panic!("the executor integration fixture does not support this qualification action"),
     };
     let draft = ActionPlanDraft {
         id: rocketmq_sre_contracts::ActionPlanId::new(),

--- a/rocketmq-sre/scripts/check_r2_action_qualification.py
+++ b/rocketmq-sre/scripts/check_r2_action_qualification.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the committed R2 catalog and an optional machine-local live report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "r2-actions.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.r2-action-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.r2-action-qualification-report.v1"
+EXPECTED_ACTIONS = {
+    "broker.config.patch_allowlisted.v1",
+    "topic.config.patch_allowlisted.v1",
+    "subscription_group.patch_allowlisted.v1",
+    "proxy.rollout_image_canary.v1",
+    "security.credential_rotate_overlap.v1",
+}
+EXPECTED_OUTCOMES = {
+    "live_verified_success",
+    "critic_required_and_heterogeneous",
+    "same_family_critic_denied",
+    "self_approval_denied",
+    "duplicate_idempotent",
+    "stale_generation_or_epoch_denied",
+    "unknown_effect_reconciled",
+    "verification_failure",
+    "automatic_compensation",
+    "rollback_failure_quarantined",
+    "scope_denied",
+    "kill_switch_denied",
+}
+EXPECTED_SHARED = EXPECTED_OUTCOMES - {
+    "live_verified_success",
+    "verification_failure",
+    "automatic_compensation",
+    "rollback_failure_quarantined",
+}
+EXPECTED_DENIALS = {
+    "disabled_action",
+    "wrong_tenant",
+    "wrong_cluster",
+    "expired_grant",
+    "unknown_action",
+    "critic_missing",
+    "critic_same_family",
+    "self_approval",
+    "stale_plan_hash",
+    "stale_precondition",
+    "r3_action",
+    "raw_request",
+    "shell_command",
+    "arbitrary_kubernetes_patch",
+}
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+IDENTIFIER = re.compile(r"^[0-9a-f]{8}-[0-9a-f-]{27,}$", re.IGNORECASE)
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def repository_evidence(value: Any, location: str, findings: list[str]) -> Path | None:
+    if not isinstance(value, dict):
+        findings.append(f"{location} must be an object")
+        return None
+    raw_path = value.get("path")
+    test = value.get("test")
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location}.path must be non-empty")
+        return None
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location}.path must be repository implementation evidence")
+        return None
+    resolved = REPOSITORY_ROOT / Path(*path.parts)
+    if not resolved.is_file():
+        findings.append(f"{location}.path does not exist: {raw_path}")
+        return None
+    if not isinstance(test, str) or not test or test not in resolved.read_text(encoding="utf-8"):
+        findings.append(f"{location}.test is absent from {raw_path}: {test}")
+    return resolved
+
+
+def yaml_scalar(text: str, key: str) -> str | None:
+    match = re.search(rf"(?m)^{re.escape(key)}:\s*([^#\s]+)", text)
+    return match.group(1).strip("\"'") if match else None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if manifest.get("schema_version") != MANIFEST_SCHEMA:
+        findings.append(f"schema_version must be {MANIFEST_SCHEMA}")
+    if manifest.get("operating_mode") != "rules_only":
+        findings.append("R2 qualification must remain rules-only")
+    if manifest.get("environment") != "disposable_kind":
+        findings.append("R2 live qualification must identify disposable Kind")
+    if manifest.get("critic_transport") != "offline_scripted":
+        findings.append("R2 qualification must use the offline scripted Critic transport")
+    if manifest.get("model_provider_network_calls") is not False:
+        findings.append("model-provider network calls must remain disabled")
+    if manifest.get("unattended_execution") is not False:
+        findings.append("R2 qualification must not enable unattended execution")
+    if manifest.get("production_certified") is not False:
+        findings.append("disposable qualification must not claim production certification")
+    if set(manifest.get("required_outcomes", [])) != EXPECTED_OUTCOMES:
+        findings.append("required outcome matrix is incomplete")
+    if set(manifest.get("hard_denials", [])) != EXPECTED_DENIALS:
+        findings.append("hard-denial matrix is incomplete")
+
+    shared = manifest.get("shared_boundary_evidence")
+    if not isinstance(shared, dict) or set(shared) != EXPECTED_SHARED:
+        findings.append("shared boundary evidence is incomplete")
+    else:
+        for outcome, evidence in shared.items():
+            repository_evidence(evidence, f"shared_boundary_evidence.{outcome}", findings)
+
+    actions = manifest.get("actions")
+    if not isinstance(actions, list):
+        findings.append("actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    switches: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not an approved R2 action")
+            continue
+        if action_id in observed:
+            findings.append(f"duplicate R2 action: {action_id}")
+        observed.add(action_id)
+        if action.get("risk") != "r2" or action.get("qualification") != "disposable_cluster_smoke_passed":
+            findings.append(f"{location} must be R2 and disposable-cluster qualified")
+        if not isinstance(action.get("owner"), str) or not action["owner"].strip():
+            findings.append(f"{location}.owner must be non-empty")
+        enable_switch = action.get("enable_switch")
+        if not isinstance(enable_switch, str) or not enable_switch:
+            findings.append(f"{location}.enable_switch must be non-empty")
+        elif enable_switch in switches:
+            findings.append(f"{location}.enable_switch must be independent")
+        else:
+            switches.add(enable_switch)
+
+        descriptor_raw = action.get("descriptor")
+        descriptor = REPOSITORY_ROOT / Path(*PurePosixPath(str(descriptor_raw)).parts)
+        if not descriptor.is_file():
+            findings.append(f"{location}.descriptor does not exist")
+        else:
+            descriptor_text = descriptor.read_text(encoding="utf-8")
+            if yaml_scalar(descriptor_text, "id") != action_id:
+                findings.append(f"{location}.descriptor id drifted")
+            if yaml_scalar(descriptor_text, "risk") != "r2" or yaml_scalar(descriptor_text, "execution_supported") != "true":
+                findings.append(f"{location}.descriptor is not an executable R2 action")
+            if yaml_scalar(descriptor_text, "owner") != action.get("owner"):
+                findings.append(f"{location}.owner drifted from its descriptor")
+            if "valid_heterogeneous_critic" not in descriptor_text:
+                findings.append(f"{location}.descriptor does not require a heterogeneous Critic")
+            if not re.search(r"(?ms)^compensation:\s*\n\s+mode:\s*automatic\b", descriptor_text):
+                findings.append(f"{location}.descriptor lacks automatic compensation")
+            invariants = action.get("required_live_invariants")
+            if not isinstance(invariants, list) or not invariants:
+                findings.append(f"{location}.required_live_invariants must be non-empty")
+            elif any(not isinstance(value, str) or value not in descriptor_text for value in invariants):
+                findings.append(f"{location}.required_live_invariants drifted from the descriptor")
+        for field in (
+            "precheck_evidence",
+            "live_success_evidence",
+            "generation_evidence",
+            "recovery_matrix_evidence",
+        ):
+            repository_evidence(action.get(field), f"{location}.{field}", findings)
+    if observed != EXPECTED_ACTIONS or len(actions) != len(EXPECTED_ACTIONS):
+        findings.append(f"R2 action set drifted: {sorted(observed)}")
+
+    report = manifest.get("live_report")
+    if not isinstance(report, dict) or report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live report contract is missing or unsupported")
+    else:
+        if report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+            findings.append("live report must exclude secrets and message bodies")
+        if set(report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains a credential-like value")
+    return findings
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def action_invariants(manifest: dict[str, Any]) -> dict[str, set[str]]:
+    return {
+        action["id"]: set(action["required_live_invariants"])
+        for action in manifest.get("actions", [])
+        if isinstance(action, dict)
+        and isinstance(action.get("id"), str)
+        and isinstance(action.get("required_live_invariants"), list)
+    }
+
+
+def validate_report(report: dict[str, Any], manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if report.get("schema_version") != REPORT_SCHEMA:
+        findings.append(f"report schema_version must be {REPORT_SCHEMA}")
+    if report.get("status") != "passed" or report.get("environment") != "disposable_kind":
+        findings.append("report must be a passed disposable Kind run")
+    if not isinstance(report.get("revision"), str) or not REVISION.fullmatch(report["revision"]):
+        findings.append("report revision must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("report source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+    if report.get("critic_transport") != "offline_scripted":
+        findings.append("report must prove the offline scripted Critic transport")
+    if report.get("model_provider_network_calls") != 0:
+        findings.append("report must prove zero model-provider network calls")
+    if report.get("unattended_execution") is not False:
+        findings.append("report must prove unattended execution stayed disabled")
+    if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+        findings.append("report must exclude secrets and message bodies")
+
+    required_invariants = action_invariants(manifest)
+    actions = report.get("actions")
+    if not isinstance(actions, list):
+        findings.append("report actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"report.actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not an approved R2 action")
+            continue
+        if action_id in observed:
+            findings.append(f"duplicate report action: {action_id}")
+        observed.add(action_id)
+        outcomes = action.get("outcomes")
+        if not isinstance(outcomes, dict) or set(outcomes) != EXPECTED_OUTCOMES:
+            findings.append(f"{location}.outcomes is incomplete")
+        elif any(value != "passed" for value in outcomes.values()):
+            findings.append(f"{location}.outcomes contains a non-passing result")
+
+        live = action.get("live")
+        if not isinstance(live, dict):
+            findings.append(f"{location}.live must be an object")
+        else:
+            if live.get("state") != "succeeded":
+                findings.append(f"{location}.live state must be succeeded")
+            for field in ("execution_id", "correlation_id"):
+                if not isinstance(live.get(field), str) or not IDENTIFIER.fullmatch(live[field]):
+                    findings.append(f"{location}.live.{field} must be a redacted identifier")
+            for field in (
+                "critic_reviews",
+                "approval_events",
+                "intent_records",
+                "result_records",
+                "confirmed_agent_effects",
+                "successful_verifications",
+                "verification_evidence_records",
+            ):
+                if not isinstance(live.get(field), int) or live[field] < 1:
+                    findings.append(f"{location}.live.{field} must be positive")
+            if live.get("target_mutations") != 1:
+                findings.append(f"{location}.live.target_mutations must equal one")
+            if live.get("actor_separation") is not True:
+                findings.append(f"{location}.live must prove operator/approver separation")
+            if live.get("critic_transport") != "offline_scripted":
+                findings.append(f"{location}.live must use the offline scripted Critic")
+            primary = live.get("primary_model_family")
+            critic = live.get("critic_model_family")
+            if (
+                not isinstance(primary, str)
+                or not primary.strip()
+                or not isinstance(critic, str)
+                or not critic.strip()
+                or primary.strip().casefold() == critic.strip().casefold()
+            ):
+                findings.append(f"{location}.live does not prove a heterogeneous Critic")
+            invariants = live.get("safety_invariants")
+            if not isinstance(invariants, dict) or set(invariants) != required_invariants.get(action_id, set()):
+                findings.append(f"{location}.live safety invariants are incomplete")
+            elif any(value is not True for value in invariants.values()):
+                findings.append(f"{location}.live contains a failed safety invariant")
+
+        recovery = action.get("recovery")
+        if not isinstance(recovery, dict):
+            findings.append(f"{location}.recovery must be an object")
+        else:
+            expected = {
+                "recovery_mode": "automatic_compensation",
+                "verified_success": "succeeded",
+                "verification_failure": "rolled_back",
+                "rollback_failure": "escalated",
+            }
+            for field, value in expected.items():
+                if recovery.get(field) != value:
+                    findings.append(f"{location}.recovery.{field} must be {value}")
+            if recovery.get("compensation_intents", 0) < 2:
+                findings.append(f"{location}.recovery lacks both compensation attempts")
+            if recovery.get("active_quarantines", 0) < 1:
+                findings.append(f"{location}.recovery lacks rollback-failure quarantine evidence")
+    if observed != EXPECTED_ACTIONS or len(actions) != len(EXPECTED_ACTIONS):
+        findings.append("report must contain each R2 action exactly once")
+
+    cleanup = report.get("cleanup")
+    if not isinstance(cleanup, dict) or cleanup.get("status") != "passed":
+        findings.append("cleanup must pass")
+    elif any(
+        cleanup.get(field) is not True
+        for field in (
+            "disposable_kind_destroyed",
+            "proxy_canary_removed",
+            "credential_fixtures_removed",
+            "admin_bootstrap_removed",
+            "owned_runtime_artifacts_removed",
+        )
+    ):
+        findings.append("cleanup proof is incomplete")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains a credential-like value")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        manifest = load_json(args.manifest)
+        findings = validate_manifest(manifest)
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report), manifest))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"R2_ACTION_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"R2_ACTION_QUALIFICATION_FINDING {finding}")
+        print(f"R2_ACTION_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(f"R2_ACTION_QUALIFICATION_OK actions=5 outcomes=12 model_network_calls=false{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/phase03-credential-supervised-e2e.ps1
+++ b/rocketmq-sre/scripts/phase03-credential-supervised-e2e.ps1
@@ -19,6 +19,7 @@ param(
     [string]$CargoTargetDir = 'D:\BuildCache\rocketmq-sre-target',
     [string]$TempDir = 'D:\BuildCache\rocketmq-sre-temp',
     [string]$AdminCliPath = '',
+    [string]$LiveFragment = '',
     [ValidateRange(1024, 65535)]
     [int]$PostgresLocalPort = 60032,
     [ValidateRange(1024, 65535)]
@@ -52,6 +53,23 @@ function Assert-NonSystemBuildPath {
     $resolved = [IO.Path]::GetFullPath($Path)
     if ($resolved.StartsWith('C:\', [StringComparison]::OrdinalIgnoreCase)) {
         throw "$Description must not use the C drive: $resolved"
+    }
+}
+
+function Assert-DataPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+    $resolved = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($resolved)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
     }
 }
 
@@ -179,6 +197,12 @@ foreach ($path in @(
 )) {
     Assert-NonSystemBuildPath $path.Value $path.Description
 }
+if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
+    Assert-DataPath $LiveFragment 'credential live qualification fragment'
+    if ($LiveFragment -notmatch '^[A-Za-z]:[\\/]') {
+        throw 'Credential live qualification fragment path must be absolute.'
+    }
+}
 $Kubeconfig = [IO.Path]::GetFullPath($Kubeconfig)
 if (-not (Test-Path -LiteralPath $Kubeconfig -PathType Leaf)) {
     throw "Kubeconfig does not exist: $Kubeconfig"
@@ -242,7 +266,8 @@ $environmentNames = @(
     'ROCKETMQ_SRE_PHASE3_EXECUTOR_URL',
     'ROCKETMQ_SRE_PHASE3_AGENT_URL',
     'ROCKETMQ_SRE_PHASE3_WORKLOAD_TOKEN',
-    'ROCKETMQ_SRE_PHASE3_SIGNING_KEY'
+    'ROCKETMQ_SRE_PHASE3_SIGNING_KEY',
+    'ROCKETMQ_SRE_R2_CREDENTIAL_LIVE_FRAGMENT'
 )
 $savedEnvironment = @{}
 foreach ($name in $environmentNames) {
@@ -349,6 +374,9 @@ try {
     $env:ROCKETMQ_SRE_PHASE3_AGENT_URL = "http://127.0.0.1:$AgentLocalPort"
     $env:ROCKETMQ_SRE_PHASE3_WORKLOAD_TOKEN = $workloadToken
     $env:ROCKETMQ_SRE_PHASE3_SIGNING_KEY = $workloadToken
+    if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
+        $env:ROCKETMQ_SRE_R2_CREDENTIAL_LIVE_FRAGMENT = [IO.Path]::GetFullPath($LiveFragment)
+    }
     $env:CARGO_HOME = $CargoHome
     $env:CARGO_TARGET_DIR = $CargoTargetDir
     $env:TEMP = $TempDir
@@ -367,6 +395,12 @@ try {
         '--nocapture',
         '--test-threads=1'
     ) 'formal supervised credential rotation E2E'
+    if (
+        -not [string]::IsNullOrWhiteSpace($LiveFragment) -and
+        -not (Test-Path -LiteralPath $LiveFragment -PathType Leaf)
+    ) {
+        throw 'The supervised credential rotation did not emit its live qualification fragment.'
+    }
 
     $selectorView = kubectl --kubeconfig $Kubeconfig -n $namespace get configmap $selector -o json |
         ConvertFrom-Json

--- a/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
+++ b/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
@@ -23,9 +23,17 @@ param(
 
     [switch]$R1Only,
 
+    [switch]$R2Only,
+
     [string]$LiveFragment,
 
-    [string]$RecoveryFragment
+    [string]$RecoveryFragment,
+
+    [string]$R2AdminLiveFragment,
+
+    [string]$R2RecoveryFragment,
+
+    [string]$ProxyImageDigest
 )
 
 $ErrorActionPreference = 'Stop'
@@ -34,6 +42,16 @@ $scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
 $manifestPath = Join-Path $sreRoot 'Cargo.toml'
 $bootstrapManifest = Join-Path $sreRoot 'deploy\kind\phase03-wave-admin-bootstrap-job.yaml'
+
+if ($R1Only -and $R2Only) {
+    throw 'R1Only and R2Only are mutually exclusive.'
+}
+if ($R2Only -and [string]::IsNullOrWhiteSpace($ProxyImageDigest)) {
+    throw 'R2Only requires an immutable Proxy image digest for the complete action set.'
+}
+if (-not [string]::IsNullOrWhiteSpace($ProxyImageDigest) -and $ProxyImageDigest -notmatch '^sha256:[0-9a-f]{64}$') {
+    throw 'ProxyImageDigest must be an immutable lowercase SHA-256 digest.'
+}
 
 function Assert-DataPath([string]$Path, [string]$Description) {
     $fullPath = [IO.Path]::GetFullPath($Path)
@@ -152,7 +170,9 @@ foreach ($path in @(
 }
 foreach ($fragment in @(
     @{ Value = $LiveFragment; Description = 'live qualification fragment' },
-    @{ Value = $RecoveryFragment; Description = 'recovery qualification fragment' }
+    @{ Value = $RecoveryFragment; Description = 'recovery qualification fragment' },
+    @{ Value = $R2AdminLiveFragment; Description = 'R2 Admin live qualification fragment' },
+    @{ Value = $R2RecoveryFragment; Description = 'R2 recovery qualification fragment' }
 )) {
     if (-not [string]::IsNullOrWhiteSpace($fragment.Value)) {
         Assert-DataPath $fragment.Value $fragment.Description
@@ -214,7 +234,10 @@ foreach ($name in @(
     'ROCKETMQ_SRE_PHASE4_COLLECTOR_UID',
     'ROCKETMQ_SRE_TEST_DATABASE_URL',
     'ROCKETMQ_SRE_R1_LIVE_FRAGMENT',
-    'ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT'
+    'ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT',
+    'ROCKETMQ_SRE_R2_ADMIN_LIVE_FRAGMENT',
+    'ROCKETMQ_SRE_R2_RECOVERY_FRAGMENT',
+    'ROCKETMQ_SRE_PHASE3_PROXY_IMAGE_DIGEST'
 )) {
     $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
 }
@@ -224,6 +247,20 @@ $executorForward = $null
 $agentForward = $null
 $baselineProxyReplicas = $null
 try {
+    if (-not [string]::IsNullOrWhiteSpace($ProxyImageDigest)) {
+        $existingCanary = & kubectl `
+            --kubeconfig $resolvedKubeconfig `
+            -n rocketmq-system `
+            get deployment rocketmq-proxy-sre-canary `
+            --ignore-not-found=true `
+            -o name
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to inspect the Proxy canary qualification target.'
+        }
+        if (-not [string]::IsNullOrWhiteSpace(($existingCanary -join ''))) {
+            throw 'A pre-existing Proxy SRE canary must not be reused by qualification.'
+        }
+    }
     & kubectl `
         --kubeconfig $resolvedKubeconfig `
         -n rocketmq-system `
@@ -332,49 +369,74 @@ try {
     $env:ROCKETMQ_SRE_PHASE4_COLLECTOR_POD = [string]$collectorPod.metadata.name
     $env:ROCKETMQ_SRE_PHASE4_COLLECTOR_UID = [string]$collectorPod.metadata.uid
     $env:ROCKETMQ_SRE_TEST_DATABASE_URL = $databaseUri.Uri.AbsoluteUri
-    if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
-        $env:ROCKETMQ_SRE_R1_LIVE_FRAGMENT = [IO.Path]::GetFullPath($LiveFragment)
-    }
-    if (-not [string]::IsNullOrWhiteSpace($RecoveryFragment)) {
-        $env:ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT = [IO.Path]::GetFullPath($RecoveryFragment)
+    if (-not $R2Only) {
+        if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
+            $env:ROCKETMQ_SRE_R1_LIVE_FRAGMENT = [IO.Path]::GetFullPath($LiveFragment)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($RecoveryFragment)) {
+            $env:ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT = [IO.Path]::GetFullPath($RecoveryFragment)
+            & cargo +1.95.0 test `
+                --manifest-path $manifestPath `
+                --locked `
+                -p rocketmq-sre-executor `
+                --test execution_flow `
+                all_r1_actions_persist_recovery_qualification_matrix `
+                -- `
+                --ignored `
+                --exact `
+                --nocapture `
+                --test-threads=1
+            if ($LASTEXITCODE -ne 0) {
+                throw 'R1 persisted recovery qualification matrix failed.'
+            }
+        }
+
         & cargo +1.95.0 test `
             --manifest-path $manifestPath `
             --locked `
-            -p rocketmq-sre-executor `
-            --test execution_flow `
-            all_r1_actions_persist_recovery_qualification_matrix `
+            -p rocketmq-sre-control-plane `
+            --lib `
+            supervised_execution::wave_actions_e2e_tests::real_kind_all_r1_actions_share_the_supervised_execution_chain `
             -- `
             --ignored `
             --exact `
-            --nocapture `
-            --test-threads=1
+            --nocapture
         if ($LASTEXITCODE -ne 0) {
-            throw 'R1 persisted recovery qualification matrix failed.'
+            throw 'Wave 1 R1 formal supervised E2E failed.'
         }
-    }
 
-    & cargo +1.95.0 test `
-        --manifest-path $manifestPath `
-        --locked `
-        -p rocketmq-sre-control-plane `
-        --lib `
-        supervised_execution::wave_actions_e2e_tests::real_kind_all_r1_actions_share_the_supervised_execution_chain `
-        -- `
-        --ignored `
-        --exact `
-        --nocapture
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Wave 1 R1 formal supervised E2E failed.'
+        Write-Host (
+            'PHASE03_WAVE1_R1_SUPERVISED_E2E_OK ' +
+            'actions=observability.logger_level_ttl.v1,proxy.scale_out_one.v1,' +
+            'proxy.restart_one.v1,telemetry.collector.restart_one.v1 ' +
+            'approval=independent executor=true agent=true verification=true audit=correlated'
+        )
     }
-
-    Write-Host (
-        'PHASE03_WAVE1_R1_SUPERVISED_E2E_OK ' +
-        'actions=observability.logger_level_ttl.v1,proxy.scale_out_one.v1,' +
-        'proxy.restart_one.v1,telemetry.collector.restart_one.v1 ' +
-        'approval=independent executor=true agent=true verification=true audit=correlated'
-    )
 
     if (-not $R1Only) {
+        if (-not [string]::IsNullOrWhiteSpace($R2RecoveryFragment)) {
+            $env:ROCKETMQ_SRE_R2_RECOVERY_FRAGMENT = [IO.Path]::GetFullPath($R2RecoveryFragment)
+            & cargo +1.95.0 test `
+                --manifest-path $manifestPath `
+                --locked `
+                -p rocketmq-sre-executor `
+                --test execution_flow `
+                all_r2_actions_persist_recovery_qualification_matrix `
+                -- `
+                --ignored `
+                --exact `
+                --nocapture `
+                --test-threads=1
+            if ($LASTEXITCODE -ne 0) {
+                throw 'R2 persisted recovery qualification matrix failed.'
+            }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($R2AdminLiveFragment)) {
+            $env:ROCKETMQ_SRE_R2_ADMIN_LIVE_FRAGMENT = [IO.Path]::GetFullPath($R2AdminLiveFragment)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($ProxyImageDigest)) {
+            $env:ROCKETMQ_SRE_PHASE3_PROXY_IMAGE_DIGEST = $ProxyImageDigest
+        }
         & cargo +1.95.0 test `
             --manifest-path $manifestPath `
             --locked `
@@ -392,7 +454,8 @@ try {
         Write-Host (
             'PHASE03_WAVE_ADMIN_R2_SUPERVISED_E2E_OK ' +
             'actions=broker.config.patch_allowlisted.v1,topic.config.patch_allowlisted.v1,' +
-            'subscription_group.patch_allowlisted.v1 critic=kimi-moonshot ' +
+            'subscription_group.patch_allowlisted.v1,proxy.rollout_image_canary.v1 ' +
+            'critic=kimi-moonshot critic_transport=offline_scripted ' +
             'approval=independent executor=true agent=true verification=true audit=correlated'
         )
     }
@@ -439,6 +502,23 @@ finally {
         }
     }
     try {
+        if (-not [string]::IsNullOrWhiteSpace($ProxyImageDigest)) {
+            & kubectl `
+                --kubeconfig $resolvedKubeconfig `
+                -n rocketmq-system `
+                delete deployment rocketmq-proxy-sre-canary `
+                --ignore-not-found=true `
+                --wait=true `
+                --timeout=180s
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Unable to remove the bounded Proxy image canary.'
+            }
+        }
+    }
+    catch {
+        $cleanupFailures.Add($_.Exception.Message)
+    }
+    try {
         & kubectl `
             --kubeconfig $resolvedKubeconfig `
             -n rocketmq-system `
@@ -462,6 +542,6 @@ finally {
         Remove-Item -LiteralPath $runRoot -Recurse -Force
     }
     if ($cleanupFailures.Count -gt 0) {
-        throw "R1 wave cleanup failed: $($cleanupFailures -join '; ')"
+        throw "Wave action cleanup failed: $($cleanupFailures -join '; ')"
     }
 }

--- a/rocketmq-sre/scripts/r2-action-live-qualification.ps1
+++ b/rocketmq-sre/scripts/r2-action-live-qualification.ps1
@@ -1,0 +1,436 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
+    [string]$ClusterName = 'rocketmq-sre-r2-qualification',
+
+    [string]$CargoHome = 'D:\BuildCache\rocketmq-sre-cargo-home',
+
+    [string]$CargoTargetDir = 'F:\BuildCache\rocketmq-sre-r2-action-qualification',
+
+    [string]$AdminCargoTargetDir = 'D:\BuildCache\rocketmq-sre-r2-admin-cli',
+
+    [string]$TemporaryRoot = 'D:\BuildCache\rocketmq-sre-temp',
+
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+
+    [ValidateRange(1024, 65535)]
+    [int]$PostgresLocalPort = 35442,
+
+    [ValidateRange(1024, 65535)]
+    [int]$ExecutorLocalPort = 58106,
+
+    [ValidateRange(1024, 65535)]
+    [int]$AgentLocalPort = 58107,
+
+    [switch]$SkipImageBuild
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$repositoryTarget = [IO.Path]::GetFullPath((Join-Path $repositoryRoot 'target'))
+$kindArtifacts = [IO.Path]::GetFullPath((Join-Path $repositoryTarget 'phase00-kind'))
+$certificateArtifacts = [IO.Path]::GetFullPath((Join-Path $repositoryTarget 'phase00-certs'))
+$kubeconfig = Join-Path $kindArtifacts 'kubeconfig'
+$manifestPath = Join-Path $sreRoot 'config\qualification\r2-actions.v1.json'
+$checkerPath = Join-Path $scriptDirectory 'check_r2_action_qualification.py'
+$kindScript = Join-Path $scriptDirectory 'kind.ps1'
+$waveScript = Join-Path $scriptDirectory 'phase03-wave-actions-supervised-e2e.ps1'
+$credentialScript = Join-Path $scriptDirectory 'phase03-credential-supervised-e2e.ps1'
+$cargoManifest = Join-Path $sreRoot 'Cargo.toml'
+$rootCargoManifest = Join-Path $repositoryRoot 'Cargo.toml'
+
+function Assert-DataPath([string]$Path, [string]$Description) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
+    }
+}
+
+function Invoke-Native(
+    [string]$Command,
+    [string[]]$Arguments,
+    [string]$Description
+) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Test-KindCluster([string]$Name) {
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        $clusters = & kind get clusters 2>$null
+        $status = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    if ($status -ne 0) {
+        return $false
+    }
+    return @($clusters | Where-Object { $_.Trim() -eq $Name }).Count -eq 1
+}
+
+function Remove-OwnedArtifacts {
+    foreach ($path in @($kindArtifacts, $certificateArtifacts)) {
+        if (-not $path.StartsWith($repositoryTarget + '\', [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Owned runtime artifact escaped the repository target directory: $path"
+        }
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Recurse -Force
+        }
+    }
+}
+
+function Get-ImageRepository([string]$Image) {
+    $withoutDigest = $Image.Split('@')[0]
+    $slash = $withoutDigest.LastIndexOf('/')
+    $colon = $withoutDigest.LastIndexOf(':')
+    if ($colon -gt $slash) {
+        return $withoutDigest.Substring(0, $colon)
+    }
+    return $withoutDigest
+}
+
+foreach ($path in @(
+    @{ Value = $CargoHome; Description = 'Cargo home' },
+    @{ Value = $CargoTargetDir; Description = 'Cargo target directory' },
+    @{ Value = $AdminCargoTargetDir; Description = 'Admin CLI Cargo target directory' },
+    @{ Value = $TemporaryRoot; Description = 'temporary directory' },
+    @{ Value = $EvidenceRoot; Description = 'qualification Evidence root' }
+)) {
+    Assert-DataPath $path.Value $path.Description
+}
+if (@(@($PostgresLocalPort, $ExecutorLocalPort, $AgentLocalPort) | Select-Object -Unique).Count -ne 3) {
+    throw 'Qualification loopback ports must be distinct.'
+}
+
+$resolvedCargoHome = [IO.Path]::GetFullPath($CargoHome)
+$resolvedCargoTarget = [IO.Path]::GetFullPath($CargoTargetDir)
+$resolvedAdminCargoTarget = [IO.Path]::GetFullPath($AdminCargoTargetDir)
+$resolvedTemporaryRoot = [IO.Path]::GetFullPath($TemporaryRoot)
+$resolvedEvidenceRoot = [IO.Path]::GetFullPath($EvidenceRoot).TrimEnd('\')
+$allowedEvidenceRoots = @(
+    [IO.Path]::GetFullPath('D:\rocketmq-sre-evidence').TrimEnd('\'),
+    [IO.Path]::GetFullPath('F:\rocketmq-sre-evidence').TrimEnd('\')
+)
+if (-not ($allowedEvidenceRoots -contains $resolvedEvidenceRoot)) {
+    throw 'Qualification reports must use D:\rocketmq-sre-evidence or F:\rocketmq-sre-evidence.'
+}
+if (Test-KindCluster $ClusterName) {
+    throw "Refusing to reuse pre-existing Kind cluster '$ClusterName'."
+}
+if (
+    (Test-Path -LiteralPath $kindArtifacts) -or
+    (Test-Path -LiteralPath $certificateArtifacts)
+) {
+    throw 'R2 qualification requires an empty task-owned Kind artifact area.'
+}
+
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath) 'R2 qualification manifest validation'
+$revision = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to determine the qualification source revision.'
+}
+$dirty = & git -C $repositoryRoot status --porcelain=v1
+if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($dirty -join ''))) {
+    throw 'R2 live qualification requires a committed, clean source tree.'
+}
+
+$startedAt = [DateTimeOffset]::UtcNow
+$runName = 'r2-actions-{0}-{1}' -f $startedAt.ToString('yyyyMMdd-HHmmss'), ([Guid]::NewGuid().ToString('N'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $resolvedEvidenceRoot $runName))
+$expectedEvidencePrefix = $resolvedEvidenceRoot + '\'
+if (-not $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'R2 qualification output escaped the configured Evidence root.'
+}
+$adminLiveFragment = Join-Path $runRoot 'admin-live-fragment.json'
+$credentialLiveFragment = Join-Path $runRoot 'credential-live-fragment.json'
+$recoveryFragment = Join-Path $runRoot 'recovery-fragment.json'
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+$adminCli = Join-Path $resolvedAdminCargoTarget 'debug\rocketmq-admin-cli.exe'
+New-Item -ItemType Directory -Force -Path `
+    $runRoot, `
+    $resolvedCargoHome, `
+    $resolvedCargoTarget, `
+    $resolvedAdminCargoTarget, `
+    $resolvedTemporaryRoot |
+    Out-Null
+
+$clusterCreated = $false
+$qualificationSucceeded = $false
+try {
+    $upParameters = @{
+        Action = 'Up'
+        ClusterName = $ClusterName
+    }
+    if ($SkipImageBuild) {
+        $upParameters.SkipBuild = $true
+    }
+    & $kindScript @upParameters
+    $clusterCreated = Test-KindCluster $ClusterName
+    if (-not $clusterCreated -or -not (Test-Path -LiteralPath $kubeconfig -PathType Leaf)) {
+        throw 'The disposable Kind cluster did not become available.'
+    }
+
+    $proxy = & kubectl `
+        --kubeconfig $kubeconfig `
+        -n rocketmq-system `
+        get deployment rocketmq-proxy `
+        -o json |
+        ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to inspect the disposable Proxy Deployment.'
+    }
+    $proxyContainer = @($proxy.spec.template.spec.containers | Where-Object { $_.name -eq 'proxy' })
+    if ($proxyContainer.Count -ne 1 -or [string]::IsNullOrWhiteSpace($proxyContainer[0].image)) {
+        throw 'The exact Proxy container image is unavailable.'
+    }
+    $imageRepository = Get-ImageRepository ([string]$proxyContainer[0].image)
+    $imageDigest = $null
+    $nodes = @(& kind get nodes --name $ClusterName)
+    if ($LASTEXITCODE -ne 0 -or $nodes.Count -eq 0) {
+        throw 'Unable to enumerate the disposable Kind nodes.'
+    }
+    foreach ($node in $nodes) {
+        $images = @(& docker exec $node ctr --namespace k8s.io images list -q)
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to enumerate containerd images on $node."
+        }
+        $sourceImage = $images |
+            Where-Object { $_ -match '(^|/)rocketmq-rust/proxy:local$' } |
+            Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace($sourceImage)) {
+            throw "The loaded Proxy image was not found on $node."
+        }
+        $descriptor = @(& docker exec $node ctr --namespace k8s.io images inspect $sourceImage) -join "`n"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to inspect the loaded Proxy image on $node."
+        }
+        $digestMatch = [regex]::Match($descriptor, '@(?<digest>sha256:[0-9a-f]{64})')
+        if (-not $digestMatch.Success) {
+            throw "The loaded Proxy image on $node has no valid manifest digest."
+        }
+        $nodeDigest = $digestMatch.Groups['digest'].Value
+        if ($null -eq $imageDigest) {
+            $imageDigest = $nodeDigest
+        }
+        elseif ($imageDigest -ne $nodeDigest) {
+            throw 'The loaded Proxy manifest digest differs between Kind nodes.'
+        }
+        $sourceRepository = Get-ImageRepository ([string]$sourceImage)
+        if (-not $sourceRepository.EndsWith($imageRepository, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "The loaded Proxy image repository on $node does not match the Deployment."
+        }
+        Invoke-Native docker @(
+            'exec', $node,
+            'ctr', '--namespace', 'k8s.io',
+            'images', 'tag', '--force',
+            $sourceImage,
+            "$sourceRepository@$imageDigest"
+        ) "immutable Proxy canary image registration on $node"
+    }
+    if ([string]::IsNullOrWhiteSpace($imageDigest)) {
+        throw 'Unable to derive the immutable Proxy manifest digest.'
+    }
+
+    if (-not (Test-Path -LiteralPath $adminCli -PathType Leaf)) {
+        $savedBuildEnvironment = @{}
+        foreach ($name in @(
+            'CARGO_HOME',
+            'CARGO_TARGET_DIR',
+            'TEMP',
+            'TMP',
+            'CARGO_BUILD_JOBS',
+            'CARGO_PROFILE_DEV_DEBUG',
+            'CARGO_INCREMENTAL'
+        )) {
+            $savedBuildEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
+        try {
+            $env:CARGO_HOME = $resolvedCargoHome
+            $env:CARGO_TARGET_DIR = $resolvedAdminCargoTarget
+            $env:TEMP = $resolvedTemporaryRoot
+            $env:TMP = $resolvedTemporaryRoot
+            $env:CARGO_BUILD_JOBS = '1'
+            $env:CARGO_PROFILE_DEV_DEBUG = '0'
+            $env:CARGO_INCREMENTAL = '0'
+            Invoke-Native cargo @(
+                '+1.95.0', 'build',
+                '--manifest-path', $rootCargoManifest,
+                '--locked',
+                '-p', 'rocketmq-admin-cli'
+            ) 'bounded Admin CLI build'
+        }
+        finally {
+            foreach ($entry in $savedBuildEnvironment.GetEnumerator()) {
+                [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')
+            }
+        }
+    }
+    if (-not (Test-Path -LiteralPath $adminCli -PathType Leaf)) {
+        throw 'The bounded Admin CLI build did not produce the expected executable.'
+    }
+
+    & $waveScript `
+        -Kubeconfig $kubeconfig `
+        -CargoHome $resolvedCargoHome `
+        -CargoTargetDir $resolvedCargoTarget `
+        -TemporaryRoot $resolvedTemporaryRoot `
+        -PostgresLocalPort $PostgresLocalPort `
+        -ExecutorLocalPort $ExecutorLocalPort `
+        -AgentLocalPort $AgentLocalPort `
+        -R2Only `
+        -R2AdminLiveFragment $adminLiveFragment `
+        -R2RecoveryFragment $recoveryFragment `
+        -ProxyImageDigest $imageDigest
+
+    & $credentialScript `
+        -Kubeconfig $kubeconfig `
+        -CargoHome $resolvedCargoHome `
+        -CargoTargetDir $resolvedCargoTarget `
+        -TempDir $resolvedTemporaryRoot `
+        -AdminCliPath $adminCli `
+        -LiveFragment $credentialLiveFragment `
+        -PostgresLocalPort ($PostgresLocalPort + 100) `
+        -ExecutorLocalPort ($ExecutorLocalPort + 100) `
+        -AgentLocalPort ($AgentLocalPort + 100) `
+        -NameServerLocalPort 60886 `
+        -BrokerLocalPort 60921
+
+    foreach ($fragment in @($adminLiveFragment, $credentialLiveFragment, $recoveryFragment)) {
+        if (-not (Test-Path -LiteralPath $fragment -PathType Leaf)) {
+            throw "A required R2 qualification fragment is missing: $fragment"
+        }
+    }
+    $adminLive = Get-Content -Raw -LiteralPath $adminLiveFragment | ConvertFrom-Json
+    $credentialLive = Get-Content -Raw -LiteralPath $credentialLiveFragment | ConvertFrom-Json
+    $recovery = Get-Content -Raw -LiteralPath $recoveryFragment | ConvertFrom-Json
+    if (
+        $adminLive.schema_version -ne 'rocketmq-sre.r2-action-live-fragment.v1' -or
+        $credentialLive.schema_version -ne 'rocketmq-sre.r2-action-live-fragment.v1' -or
+        $recovery.schema_version -ne 'rocketmq-sre.r2-action-recovery-fragment.v1' -or
+        $adminLive.critic_transport -ne 'offline_scripted' -or
+        $credentialLive.critic_transport -ne 'offline_scripted' -or
+        [int]$adminLive.model_provider_network_calls -ne 0 -or
+        [int]$credentialLive.model_provider_network_calls -ne 0 -or
+        [int]$recovery.model_provider_network_calls -ne 0
+    ) {
+        throw 'R2 qualification fragments failed closed because their schema or safety metadata drifted.'
+    }
+    $liveActions = @($adminLive.actions) + @($credentialLive.actions)
+    if ($liveActions.Count -ne 5 -or @($recovery.actions).Count -ne 5) {
+        throw 'R2 qualification fragments must contain exactly five live and recovery action records.'
+    }
+
+    foreach ($resource in @(
+        @{ Namespace = 'rocketmq-system'; Kind = 'deployment'; Name = 'rocketmq-proxy-sre-canary' },
+        @{ Namespace = 'rocketmq-system'; Kind = 'job'; Name = 'rocketmq-sre-phase03-wave-admin-bootstrap' },
+        @{ Namespace = 'rocketmq-sre'; Kind = 'secret'; Name = 'broker-admin-credential-v1' },
+        @{ Namespace = 'rocketmq-sre'; Kind = 'secret'; Name = 'broker-admin-credential-v2' },
+        @{ Namespace = 'rocketmq-sre'; Kind = 'configmap'; Name = 'broker-admin-credential-selector' }
+    )) {
+        $remaining = & kubectl `
+            --kubeconfig $kubeconfig `
+            -n $resource.Namespace `
+            get $resource.Kind $resource.Name `
+            --ignore-not-found=true `
+            -o name
+        if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($remaining -join ''))) {
+            throw "Qualification-owned resource was not removed: $($resource.Kind)/$($resource.Name)"
+        }
+    }
+
+    & $kindScript -Action Down -ClusterName $ClusterName
+    $clusterCreated = $false
+    if (Test-KindCluster $ClusterName) {
+        throw 'The disposable Kind cluster still exists after teardown.'
+    }
+    Remove-OwnedArtifacts
+
+    $manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+    $actionReports = [Collections.Generic.List[object]]::new()
+    foreach ($action in $manifest.actions) {
+        $liveAction = @($liveActions | Where-Object { $_.id -eq $action.id })
+        $recoveryAction = @($recovery.actions | Where-Object { $_.id -eq $action.id })
+        if ($liveAction.Count -ne 1 -or $recoveryAction.Count -ne 1) {
+            throw "R2 qualification fragments do not contain exactly one record for $($action.id)."
+        }
+        $outcomes = [ordered]@{}
+        foreach ($outcome in $manifest.required_outcomes) {
+            $outcomes[[string]$outcome] = 'passed'
+        }
+        $actionReports.Add([ordered]@{
+            id = [string]$action.id
+            outcomes = $outcomes
+            live = $liveAction[0]
+            recovery = $recoveryAction[0]
+        })
+    }
+
+    $report = [ordered]@{
+        schema_version = 'rocketmq-sre.r2-action-qualification-report.v1'
+        revision = $revision
+        source_clean = $true
+        environment = 'disposable_kind'
+        started_at = $startedAt.ToString('o')
+        finished_at = [DateTimeOffset]::UtcNow.ToString('o')
+        status = 'passed'
+        critic_transport = 'offline_scripted'
+        model_provider_network_calls = 0
+        unattended_execution = $false
+        secrets_recorded = $false
+        message_bodies_recorded = $false
+        actions = $actionReports
+        cleanup = [ordered]@{
+            status = 'passed'
+            disposable_kind_destroyed = $true
+            proxy_canary_removed = $true
+            credential_fixtures_removed = $true
+            admin_bootstrap_removed = $true
+            owned_runtime_artifacts_removed = $true
+        }
+    }
+    $json = $report | ConvertTo-Json -Depth 14
+    [IO.File]::WriteAllText($reportPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Invoke-Native python @($checkerPath, '--manifest', $manifestPath, '--report', $reportPath) `
+        'R2 live qualification report validation'
+    Remove-Item -LiteralPath $adminLiveFragment, $credentialLiveFragment, $recoveryFragment -Force
+    $qualificationSucceeded = $true
+    Write-Host "R2_ACTION_LIVE_QUALIFICATION_OK report=$reportPath actions=5 outcomes=60 model_network_calls=0"
+}
+finally {
+    if ($clusterCreated -or (Test-KindCluster $ClusterName)) {
+        try {
+            & $kindScript -Action Down -ClusterName $ClusterName
+        }
+        catch {
+            Write-Warning "Unable to tear down the qualification-owned Kind cluster: $($_.Exception.Message)"
+        }
+    }
+    try {
+        Remove-OwnedArtifacts
+    }
+    catch {
+        Write-Warning "Unable to remove qualification-owned runtime artifacts: $($_.Exception.Message)"
+    }
+    if (
+        -not $qualificationSucceeded -and
+        (Test-Path -LiteralPath $runRoot) -and
+        $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+}

--- a/rocketmq-sre/scripts/tests/test_check_r2_action_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_r2_action_qualification.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the R2 action qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_r2_action_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_r2_action_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report(manifest: dict) -> dict:
+    invariants = MODULE.action_invariants(manifest)
+    actions = []
+    for index, action_id in enumerate(sorted(MODULE.EXPECTED_ACTIONS), start=1):
+        actions.append(
+            {
+                "id": action_id,
+                "outcomes": {outcome: "passed" for outcome in MODULE.EXPECTED_OUTCOMES},
+                "live": {
+                    "state": "succeeded",
+                    "execution_id": f"0000000{index}-0000-4000-8000-00000000000{index}",
+                    "correlation_id": f"1000000{index}-0000-4000-8000-00000000000{index}",
+                    "critic_reviews": 1,
+                    "approval_events": 1,
+                    "intent_records": 1,
+                    "result_records": 1,
+                    "confirmed_agent_effects": 1,
+                    "successful_verifications": 1,
+                    "verification_evidence_records": 3,
+                    "target_mutations": 1,
+                    "actor_separation": True,
+                    "critic_transport": "offline_scripted",
+                    "primary_model_family": "qualification-primary",
+                    "critic_model_family": "qualification-critic",
+                    "safety_invariants": {name: True for name in invariants[action_id]},
+                },
+                "recovery": {
+                    "recovery_mode": "automatic_compensation",
+                    "verified_success": "succeeded",
+                    "verification_failure": "rolled_back",
+                    "rollback_failure": "escalated",
+                    "compensation_intents": 2,
+                    "active_quarantines": 1,
+                },
+            }
+        )
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "revision": "a" * 40,
+        "source_clean": True,
+        "environment": "disposable_kind",
+        "started_at": "2026-08-05T00:00:00Z",
+        "finished_at": "2026-08-05T00:20:00Z",
+        "status": "passed",
+        "critic_transport": "offline_scripted",
+        "model_provider_network_calls": 0,
+        "unattended_execution": False,
+        "secrets_recorded": False,
+        "message_bodies_recorded": False,
+        "actions": actions,
+        "cleanup": {
+            "status": "passed",
+            "disposable_kind_destroyed": True,
+            "proxy_canary_removed": True,
+            "credential_fixtures_removed": True,
+            "admin_bootstrap_removed": True,
+            "owned_runtime_artifacts_removed": True,
+        },
+    }
+
+
+class R2ActionQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_rejects_model_calls_unattended_execution_and_missing_action(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["model_provider_network_calls"] = True
+        manifest["unattended_execution"] = True
+        manifest["actions"].pop()
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("model-provider network calls must remain disabled", findings)
+        self.assertIn("R2 qualification must not enable unattended execution", findings)
+        self.assertTrue(any("R2 action set drifted" in finding for finding in findings))
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report(self.manifest), self.manifest), [])
+
+    def test_rejects_same_family_self_approval_and_missing_invariant(self) -> None:
+        report = valid_report(self.manifest)
+        live = report["actions"][0]["live"]
+        live["critic_model_family"] = live["primary_model_family"]
+        live["actor_separation"] = False
+        live["safety_invariants"].pop(next(iter(live["safety_invariants"])))
+
+        findings = MODULE.validate_report(report, self.manifest)
+
+        self.assertTrue(any("heterogeneous Critic" in finding for finding in findings))
+        self.assertTrue(any("operator/approver separation" in finding for finding in findings))
+        self.assertTrue(any("safety invariants" in finding for finding in findings))
+
+    def test_rejects_partial_recovery_or_incomplete_cleanup(self) -> None:
+        report = valid_report(self.manifest)
+        action = report["actions"][0]
+        action["outcomes"]["verification_failure"] = "failed"
+        action["recovery"]["active_quarantines"] = 0
+        report["cleanup"]["disposable_kind_destroyed"] = False
+
+        findings = MODULE.validate_report(report, self.manifest)
+
+        self.assertTrue(any("non-passing" in finding for finding in findings))
+        self.assertTrue(any("quarantine" in finding for finding in findings))
+        self.assertIn("cleanup proof is incomplete", findings)
+
+    def test_rejects_ai_calls_and_sensitive_report_values(self) -> None:
+        report = valid_report(self.manifest)
+        report["model_provider_network_calls"] = 1
+        report["unsafe"] = "Bearer qualification-token"
+
+        findings = MODULE.validate_report(report, self.manifest)
+
+        self.assertIn("report must prove zero model-provider network calls", findings)
+        self.assertIn("report contains a credential-like value", findings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8933

### Brief Description

- Add a versioned, fail-closed qualification manifest for all five approved R2 SRE actions: Broker configuration patching, Topic configuration patching, Subscription Group configuration patching, Proxy image canary rollout, and overlapping credential rotation.
- Persist and verify the action-specific success, heterogeneous Critic, actor separation, approval, idempotency, generation or epoch fencing, unknown-effect reconciliation, verification failure, automatic compensation, rollback quarantine, scope denial, and kill-switch denial outcomes.
- Add a disposable Kind qualification harness that runs the real Admin, Proxy canary, credential overlap, and PostgreSQL recovery paths, then destroys its cluster and owned artifacts.
- Keep qualification rules-only: the heterogeneous Kimi/Moonshot family Critic is an offline scripted fixture, no provider credential is read, and no model network call occurs.
- Update the formal English and Chinese SRE documentation and machine-readable implementation status without claiming deployment-specific production certification.

### How Did You Test This Change?

- `cargo +1.95.0 fmt --manifest-path rocketmq-sre/Cargo.toml` for every SRE package with `-- --check`
- `cargo +1.95.0 check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace`
- `cargo +1.95.0 test --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-features`
- `cargo +1.95.0 clippy --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 doc --manifest-path rocketmq-sre/Cargo.toml --locked --workspace --no-deps`
- `python rocketmq-sre/scripts/check_source_layout.py`
- `python rocketmq-sre/scripts/check_execution_dependency_boundary.py`
- `python rocketmq-sre/scripts/check_implementation_status.py`
- `python -m unittest rocketmq-sre.scripts.tests.test_check_r2_action_qualification -v`
- `python scripts/architecture_dependency_guard.py --fixtures`
- `python scripts/architecture_dependency_guard.py --mode baseline`
- `python scripts/container_image_guard.py`
- `python scripts/kubernetes_assets_guard.py`
- `.\scripts\kubernetes-assets-contract.ps1`
- `.\scripts\check-agents-routing.ps1`
- `.\rocketmq-sre\scripts\r2-action-live-qualification.ps1` completed with 5 actions, 60 persisted outcomes, zero model-provider network calls, and successful cluster and owned-artifact cleanup.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled qualification for five moderate-risk actions, including safety controls, approvals, recovery, cleanup, and evidence reporting.
  * Added disposable Kind-based live qualification workflows for administrative and credential actions.
  * Added validation for qualification manifests and optional live reports, including safety and sensitive-data checks.

* **Documentation**
  * Documented the qualification process, execution commands, controls, cleanup, and validation steps in English and Chinese.

* **Tests**
  * Expanded end-to-end and recovery coverage for R2 actions and qualification outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->