### PR TITLE
[ISSUE #8938]✨Qualify bounded autonomy cohorts for approved R1 SRE actions

### DIFF
--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -303,6 +303,40 @@ certification. Validate the committed catalog independently with:
 python scripts/check_r2_action_qualification.py
 ```
 
+### Bounded-autonomy qualification
+
+The autonomy qualification contract covers the same four approved R1 actions
+without enabling unattended target execution. A clean committed revision is
+deployed to a new disposable Kind cluster with PostgreSQL running inside the
+cluster. For each action, the harness persists 20 Shadow outcomes, enforces a
+seven-day observation window, persists five human-approved Supervised
+successes, verifies an offline heterogeneous Critic binding, and exercises
+fail-closed safety controls, ExpectedDeny handling, failure pause, owner
+recovery, real Supervised execution, and cleanup.
+
+Live target execution is capped at `Supervised`. Qualification may calculate
+that Autonomous promotion prerequisites are satisfied, but it never performs
+that live transition and never dispatches an unattended target mutation. The
+scripted primary and Critic identities are contract fixtures only; provider
+credentials and model network calls are forbidden. DeepSeek-backed diagnosis
+is intentionally integrated last, after the remaining non-model readiness
+work, when an API key is supplied.
+
+Run from `rocketmq-sre/`; the harness creates and destroys its own cluster,
+keeps build output on `D:` and `F:`, and writes the redacted report outside the
+repository:
+
+```powershell
+.\scripts\autonomy-action-live-qualification.ps1
+```
+
+The report is implementation qualification, not production certification. The
+committed contract can be checked without a cluster:
+
+```powershell
+python scripts/check_autonomy_action_qualification.py
+```
+
 ## User interface
 
 The UI is designed as a full-screen desktop operations workspace using

--- a/rocketmq-sre/README.zh-CN.md
+++ b/rocketmq-sre/README.zh-CN.md
@@ -264,6 +264,32 @@ Kind 集群和生成的运行时文件。脚本化 Critic 使用不同的模型�
 python scripts/check_r2_action_qualification.py
 ```
 
+### 有界自治资格验证
+
+自治资格契约覆盖同一组四个已批准 R1 动作，但不会启用无人值守的目标执行。验证工具会把干净且
+已提交的源码版本部署到全新的一次性 Kind 集群，PostgreSQL 在集群内以容器运行。对于每个动作，
+工具会持久化 20 个 Shadow 结果，执行七天观察窗口约束，持久化 5 个经人工批准的 Supervised
+成功样本，验证离线异构 Critic 绑定，并覆盖 fail-closed 安全控制、ExpectedDeny 处理、失败暂停、
+负责人恢复、真实 Supervised 执行和清理。
+
+真实目标执行的上限固定为 `Supervised`。资格验证可以计算 Autonomous 晋级条件是否满足，但不会
+执行该实时状态转换，也不会下发无人值守的目标变更。脚本化的主模型与 Critic 身份仅用于契约夹具；
+模型凭据和模型网络调用均被禁止。使用 DeepSeek 的真实 AI 诊断会在其余非模型就绪工作完成后最后
+接入，届时再提供 API key。
+
+在 `rocketmq-sre/` 中运行；工具会自行创建并销毁集群，构建产物保留在 `D:` 和 `F:`，脱敏报告
+写入仓库外：
+
+```powershell
+.\scripts\autonomy-action-live-qualification.ps1
+```
+
+该报告用于证明实现资格，不构成生产认证。无需集群即可校验已提交的契约：
+
+```powershell
+python scripts/check_autonomy_action_qualification.py
+```
+
 ## 用户界面
 
 UI 按照 shadcn/ui 规范和可访问的 Radix UI primitive 设计为全屏桌面运维

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -223,7 +223,7 @@
       "maturity": {
         "implemented": true,
         "contract_tested": true,
-        "live_smoke_passed": false,
+        "live_smoke_passed": true,
         "production_certified": false
       },
       "evidence": [
@@ -246,11 +246,23 @@
         {
           "kind": "test",
           "path": "rocketmq-sre/scripts/check_execution_recovery_qualification.py"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/autonomy-actions.v1.json"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_autonomy_action_qualification.py"
+        },
+        {
+          "kind": "smoke",
+          "path": "rocketmq-sre/scripts/autonomy-action-live-qualification.ps1"
         }
       ],
       "limitations": [
-        "Autonomy remains disabled by default; the Kubernetes platform fault matrix has passed, while per-action shadow and supervised qualification remains incomplete.",
-        "Per-organization and per-cluster operational evidence is incomplete."
+        "Autonomy remains disabled by default; all four approved R1 actions have disposable Kind and PostgreSQL Shadow-to-Supervised qualification with persisted cohorts, samples, denials, pause recovery, real supervised target verification, and zero model-provider calls.",
+        "The live qualification ceiling is Supervised: unattended Autonomous target execution, per-organization evidence, deployment-specific production certification, and production owner acceptance remain incomplete."
       ]
     },
     {

--- a/rocketmq-sre/config/qualification/autonomy-actions.v1.json
+++ b/rocketmq-sre/config/qualification/autonomy-actions.v1.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "rocketmq-sre.autonomy-action-qualification.v1",
+  "operating_mode": "rules_only",
+  "environment": "disposable_kind",
+  "live_mode_ceiling": "supervised",
+  "unattended_autonomous_execution": false,
+  "model_provider_network_calls": false,
+  "production_certified": false,
+  "required_outcomes": [
+    "disabled_by_default",
+    "shadow_cohort_persisted",
+    "insufficient_shadow_denied",
+    "shadow_window_qualified",
+    "supervised_transition_persisted",
+    "heterogeneous_critic_bound",
+    "same_family_critic_denied",
+    "insufficient_supervised_denied",
+    "supervised_successes_persisted",
+    "stale_or_partial_evidence_denied",
+    "freeze_or_budget_denied",
+    "kill_switch_denied",
+    "execution_failure_paused",
+    "expected_deny_not_paused",
+    "live_supervised_action_verified",
+    "recovery_and_cleanup"
+  ],
+  "shared_boundary_evidence": {
+    "lifecycle_matrix": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs",
+      "test": "all_r1_actions_persist_shadow_and_supervised_qualification_matrix"
+    },
+    "same_family_critic_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs",
+      "test": "all_r1_actions_persist_shadow_and_supervised_qualification_matrix"
+    },
+    "stale_or_partial_evidence_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-core/src/eligibility.rs",
+      "test": "base_eligibility_fails_closed_for_stale_or_partial_evidence"
+    },
+    "freeze_or_budget_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-core/src/eligibility.rs",
+      "test": "dynamic_safety_fails_closed_for_each_authoritative_control"
+    },
+    "kill_switch_denied": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs",
+      "test": "postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent"
+    },
+    "failure_pause_reconciled": {
+      "path": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs",
+      "test": "postgres_pause_reconciler_repairs_a_dropped_failure_event_once"
+    }
+  },
+  "actions": [
+    {
+      "id": "observability.logger_level_ttl.v1",
+      "risk": "r1",
+      "owner": "messaging-observability",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_LOGGER_TTL",
+      "descriptor": "rocketmq-sre/config/actions/observability.logger_level_ttl.v1.yaml",
+      "policy": "rocketmq-sre/config/autonomy/actions/observability.logger_level_ttl.v1.yaml",
+      "shadow_samples": 20,
+      "supervised_successes": 5,
+      "observation_window_days": 7,
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "proxy.scale_out_one.v1",
+      "risk": "r1",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_PROXY_SCALE_OUT",
+      "descriptor": "rocketmq-sre/config/actions/proxy.scale_out_one.v1.yaml",
+      "policy": "rocketmq-sre/config/autonomy/actions/proxy.scale_out_one.v1.yaml",
+      "shadow_samples": 20,
+      "supervised_successes": 5,
+      "observation_window_days": 7,
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "proxy.restart_one.v1",
+      "risk": "r1",
+      "owner": "messaging-platform",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_PROXY_RESTART",
+      "descriptor": "rocketmq-sre/config/actions/proxy.restart_one.v1.yaml",
+      "policy": "rocketmq-sre/config/autonomy/actions/proxy.restart_one.v1.yaml",
+      "shadow_samples": 20,
+      "supervised_successes": 5,
+      "observation_window_days": 7,
+      "qualification": "disposable_cluster_smoke_passed"
+    },
+    {
+      "id": "telemetry.collector.restart_one.v1",
+      "risk": "r1",
+      "owner": "messaging-observability",
+      "enable_switch": "ROCKETMQ_SRE_AGENT_ENABLE_TELEMETRY_COLLECTOR_RESTART",
+      "descriptor": "rocketmq-sre/config/actions/telemetry.collector.restart_one.v1.yaml",
+      "policy": "rocketmq-sre/config/autonomy/actions/telemetry.collector.restart_one.v1.yaml",
+      "shadow_samples": 20,
+      "supervised_successes": 5,
+      "observation_window_days": 7,
+      "qualification": "disposable_cluster_smoke_passed"
+    }
+  ],
+  "offline_critic_fixture": {
+    "transport": "offline_scripted",
+    "primary_model_family": "qualification-primary",
+    "critic_model_family": "qualification-critic",
+    "heterogeneous_required": true
+  },
+  "live_report": {
+    "schema_version": "rocketmq-sre.autonomy-action-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/config/qualification/execution-recovery.v1.json
+++ b/rocketmq-sre/config/qualification/execution-recovery.v1.json
@@ -47,6 +47,27 @@
     "model_provider_network_calls": false,
     "production_certified": false
   },
+  "r2_live_qualification": {
+    "manifest": "rocketmq-sre/config/qualification/r2-actions.v1.json",
+    "script": "rocketmq-sre/scripts/r2-action-live-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_r2_action_qualification.py",
+    "actions": 5,
+    "required_outcomes_per_action": 12,
+    "model_provider_network_calls": false,
+    "unattended_execution": false,
+    "production_certified": false
+  },
+  "autonomy_live_qualification": {
+    "manifest": "rocketmq-sre/config/qualification/autonomy-actions.v1.json",
+    "script": "rocketmq-sre/scripts/autonomy-action-live-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_autonomy_action_qualification.py",
+    "actions": 4,
+    "required_outcomes_per_action": 16,
+    "live_mode_ceiling": "supervised",
+    "unattended_autonomous_execution": false,
+    "model_provider_network_calls": false,
+    "production_certified": false
+  },
   "controlled_actions": [
     {
       "id": "observability.logger_level_ttl.v1",
@@ -116,7 +137,7 @@
       "descriptor": "rocketmq-sre/config/actions/broker.config.patch_allowlisted.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/broker_config_patch_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-broker-cas-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "topic.config.patch_allowlisted.v1",
@@ -130,7 +151,7 @@
       "descriptor": "rocketmq-sre/config/actions/topic.config.patch_allowlisted.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/topic_config_patch_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-topic-cas-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "subscription_group.patch_allowlisted.v1",
@@ -144,7 +165,7 @@
       "descriptor": "rocketmq-sre/config/actions/subscription_group.patch_allowlisted.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/subscription_group_patch_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-subscription-group-cas-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "proxy.rollout_image_canary.v1",
@@ -158,7 +179,7 @@
       "descriptor": "rocketmq-sre/config/actions/proxy.rollout_image_canary.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/proxy_image_canary_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-proxy-image-canary-smoke.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     },
     {
       "id": "security.credential_rotate_overlap.v1",
@@ -172,7 +193,7 @@
       "descriptor": "rocketmq-sre/config/actions/security.credential_rotate_overlap.v1.yaml",
       "precheck_test": "rocketmq-sre/crates/rocketmq-sre-execution-agent/src/drivers/credential_rotation_tests.rs",
       "disposable_cluster_smoke": "rocketmq-sre/scripts/phase03-credential-supervised-e2e.ps1",
-      "qualification": "contract_tested"
+      "qualification": "disposable_cluster_smoke_passed"
     }
   ],
   "r2_authorization": {

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -24,7 +26,6 @@ use super::model::CreateShadowCohortRequest;
 use super::model::PrepareAutonomousCohortRequest;
 use super::model::RecordQualificationSampleRequest;
 use super::repository_tests::Fixture;
-use super::repository_tests::seed_critic_review;
 use super::repository_tests::seed_fixture;
 use super::repository_tests::seed_successful_supervised_execution_for_action_at;
 use super::repository_tests::unique_digest;
@@ -46,7 +47,11 @@ use rocketmq_sre_contracts::ActionDescriptor;
 use rocketmq_sre_contracts::ActionPlan;
 use rocketmq_sre_contracts::ActionPlanDraft;
 use rocketmq_sre_contracts::ActionRisk;
+use rocketmq_sre_contracts::AutonomousExecutionFailure;
 use rocketmq_sre_contracts::AutonomyMode;
+use rocketmq_sre_contracts::AutonomyOutcome;
+use rocketmq_sre_contracts::AutonomyOutcomeClass;
+use rocketmq_sre_contracts::AutonomyOutcomeId;
 use rocketmq_sre_contracts::AutonomySampleKind;
 use rocketmq_sre_contracts::CompensationMode;
 use rocketmq_sre_contracts::CompensationSpec;
@@ -59,11 +64,16 @@ use rocketmq_sre_contracts::PlanStepId;
 use rocketmq_sre_contracts::VerificationSpec;
 use rocketmq_sre_contracts::canonical_sha256;
 use rocketmq_sre_core::EMBEDDED_ACTION_DESCRIPTOR_YAMLS;
+use serde::Serialize;
 use uuid::Uuid;
 
 const SHADOW_SAMPLES: usize = 20;
 const SUPERVISED_SUCCESSES: usize = 5;
 const OBSERVATION_DAYS: i64 = 7;
+const PRIMARY_MODEL_FAMILY: &str = "qualification-primary";
+const PRIMARY_MODEL_REVISION: &str = "fixture-r1";
+const CRITIC_MODEL_FAMILY: &str = "qualification-critic";
+const CRITIC_MODEL_REVISION: &str = "fixture-r1";
 
 #[derive(Clone, Copy)]
 enum R1ActionScenario {
@@ -152,10 +162,86 @@ async fn telemetry_collector_restart_qualifies_through_shadow_supervised_and_aut
     qualify_r1_action_through_autonomy(R1ActionScenario::TelemetryCollectorRestartOne).await;
 }
 
-async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
-    let Some(database_url) = std::env::var("ROCKETMQ_SRE_TEST_DATABASE_URL").ok() else {
+#[derive(Serialize)]
+struct AutonomyLifecycleOutcome {
+    id: String,
+    initial_mode: &'static str,
+    final_mode: &'static str,
+    shadow_samples: u32,
+    supervised_successes: u32,
+    observation_window_days: i64,
+    shadow_cohorts: u8,
+    supervised_cohorts: u8,
+    same_family_critic_denied: bool,
+    autonomous_transition_executed: bool,
+    expected_deny_paused: bool,
+    execution_failure_paused: bool,
+    critic_transport: &'static str,
+    primary_model_family: &'static str,
+    critic_model_family: &'static str,
+}
+
+#[derive(Serialize)]
+struct AutonomyLifecycleFragment {
+    schema_version: &'static str,
+    live_mode_ceiling: &'static str,
+    unattended_autonomous_execution: bool,
+    model_provider_network_calls: u8,
+    actions: Vec<AutonomyLifecycleOutcome>,
+}
+
+#[tokio::test]
+#[ignore = "requires ROCKETMQ_SRE_TEST_DATABASE_URL and an explicit machine-local fragment path"]
+async fn all_r1_actions_persist_shadow_and_supervised_qualification_matrix() {
+    let Ok(fragment_path) = std::env::var("ROCKETMQ_SRE_AUTONOMY_QUALIFICATION_FRAGMENT") else {
         return;
     };
+    let path = Path::new(&fragment_path);
+    let rendered = path.to_string_lossy();
+    assert!(
+        path.is_absolute(),
+        "autonomy qualification fragment path must be absolute"
+    );
+    assert!(
+        rendered.starts_with("D:\\") || rendered.starts_with("F:\\"),
+        "autonomy qualification fragment must use the D or F drive"
+    );
+
+    let scenarios = [
+        R1ActionScenario::LoggerTtl,
+        R1ActionScenario::ProxyScaleOut,
+        R1ActionScenario::ProxyRestartOne,
+        R1ActionScenario::TelemetryCollectorRestartOne,
+    ];
+    let mut outcomes = Vec::with_capacity(scenarios.len());
+    for scenario in scenarios {
+        outcomes.push(
+            qualify_r1_action(scenario, false)
+                .await
+                .expect("qualification database must be configured"),
+        );
+    }
+    let fragment = AutonomyLifecycleFragment {
+        schema_version: "rocketmq-sre.autonomy-action-lifecycle-fragment.v1",
+        live_mode_ceiling: "supervised",
+        unattended_autonomous_execution: false,
+        model_provider_network_calls: 0,
+        actions: outcomes,
+    };
+    let mut bytes = serde_json::to_vec_pretty(&fragment).expect("serialize autonomy lifecycle fragment");
+    bytes.push(b'\n');
+    fs::write(path, bytes).expect("write autonomy lifecycle fragment");
+}
+
+async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
+    let _ = qualify_r1_action(scenario, true).await;
+}
+
+async fn qualify_r1_action(
+    scenario: R1ActionScenario,
+    promote_to_autonomous: bool,
+) -> Option<AutonomyLifecycleOutcome> {
+    let database_url = std::env::var("ROCKETMQ_SRE_TEST_DATABASE_URL").ok()?;
     let repository = PostgresRepository::connect(&database_url, 8)
         .await
         .expect("repository with migrations");
@@ -217,8 +303,8 @@ async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
                 action: scenario.action(),
                 action_version: "1.0.0".to_owned(),
                 primary_profile: fixture.primary_profile.clone(),
-                primary_model_family: "deepseek".to_owned(),
-                primary_model_revision: "v3.2".to_owned(),
+                primary_model_family: PRIMARY_MODEL_FAMILY.to_owned(),
+                primary_model_revision: PRIMARY_MODEL_REVISION.to_owned(),
             },
         )
         .await
@@ -280,13 +366,41 @@ async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
     assert_eq!(supervised.lifecycle.mode, AutonomyMode::Supervised);
     assert_eq!(supervised.qualification.qualified_shadow_samples, SHADOW_SAMPLES as u32);
     assert!(supervised.qualification.shadow_observation_window_met);
+    let qualified_shadow_samples = supervised.qualification.qualified_shadow_samples;
 
     let primary_plan = &plans[0];
-    let (base_review_id, critic_invocation_id, critic_profile) = seed_critic_review(&repository, primary_plan).await;
+    let (base_review_id, critic_invocation_id, critic_profile) =
+        seed_qualification_critic_review(&repository, primary_plan).await;
     let mut critic_reviews = vec![base_review_id];
     for plan in plans.iter().take(SUPERVISED_SUCCESSES).skip(1) {
         critic_reviews.push(seed_shared_critic_review(&repository, plan, critic_invocation_id, &critic_profile).await);
     }
+    assert!(
+        service
+            .prepare_autonomous_cohort(
+                &auth,
+                &PrepareAutonomousCohortRequest {
+                    cluster_id: fixture.cluster_id,
+                    action: scenario.action(),
+                    action_version: "1.0.0".to_owned(),
+                    diagnosis_revision_id: primary_plan.diagnosis_revision_id,
+                    plan_id: primary_plan.plan_id,
+                    plan_hash: primary_plan.plan_hash.clone(),
+                    critic_review_id: critic_reviews[0],
+                    primary_model_invocation_id: primary_plan.primary_invocation_id,
+                    critic_model_invocation_id: critic_invocation_id,
+                    primary_profile: primary_plan.primary_profile.clone(),
+                    primary_model_family: PRIMARY_MODEL_FAMILY.to_owned(),
+                    primary_model_revision: PRIMARY_MODEL_REVISION.to_owned(),
+                    critic_profile: critic_profile.clone(),
+                    critic_model_family: PRIMARY_MODEL_FAMILY.to_owned(),
+                    critic_model_revision: PRIMARY_MODEL_REVISION.to_owned(),
+                },
+            )
+            .await
+            .is_err(),
+        "same-family Critic must fail closed"
+    );
     let autonomous_cohort = service
         .prepare_autonomous_cohort(
             &auth,
@@ -301,11 +415,11 @@ async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
                 primary_model_invocation_id: primary_plan.primary_invocation_id,
                 critic_model_invocation_id: critic_invocation_id,
                 primary_profile: primary_plan.primary_profile.clone(),
-                primary_model_family: "deepseek".to_owned(),
-                primary_model_revision: "v3.2".to_owned(),
+                primary_model_family: PRIMARY_MODEL_FAMILY.to_owned(),
+                primary_model_revision: PRIMARY_MODEL_REVISION.to_owned(),
                 critic_profile,
-                critic_model_family: "glm".to_owned(),
-                critic_model_revision: "glm-5".to_owned(),
+                critic_model_family: CRITIC_MODEL_FAMILY.to_owned(),
+                critic_model_revision: CRITIC_MODEL_REVISION.to_owned(),
             },
         )
         .await
@@ -357,6 +471,107 @@ async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
         &clock_value,
         autonomous_cohort.created_at + Duration::days(OBSERVATION_DAYS) + Duration::seconds(30),
     );
+    if !promote_to_autonomous {
+        let qualified = service.scope(&auth, &query).await.expect("qualified Supervised scope");
+        assert_eq!(qualified.lifecycle.mode, AutonomyMode::Supervised);
+        assert_eq!(
+            qualified.qualification.qualified_supervised_successes,
+            SUPERVISED_SUCCESSES as u32
+        );
+        assert!(qualified.qualification.autonomous_observation_window_met);
+
+        let deny_plan = &plans[SUPERVISED_SUCCESSES];
+        let denied_at = autonomous_cohort.created_at + Duration::days(OBSERVATION_DAYS) + Duration::seconds(31);
+        repository
+            .record_autonomy_outcome(
+                &AutonomyOutcome {
+                    id: AutonomyOutcomeId::new(),
+                    tenant_id: fixture.tenant_id,
+                    cluster_id: fixture.cluster_id,
+                    action: scenario.action(),
+                    action_version: "1.0.0".to_owned(),
+                    incident_id: deny_plan.incident_id,
+                    plan_id: deny_plan.plan_id,
+                    plan_hash: deny_plan.plan_hash.clone(),
+                    execution_id: None,
+                    cohort_id: Some(autonomous_cohort.id),
+                    class: AutonomyOutcomeClass::ExpectedDeny,
+                    failure: None,
+                    reason_codes: vec!["freeze_active".to_owned()],
+                    first_positive_intent_persisted: false,
+                    occurred_at: denied_at,
+                    reconciled_at: denied_at,
+                },
+                "autonomy-qualification-reconciler",
+            )
+            .await
+            .expect("persist ExpectedDeny outcome");
+        let after_deny = service.scope(&auth, &query).await.expect("scope after ExpectedDeny");
+        assert_eq!(after_deny.lifecycle.mode, AutonomyMode::Supervised);
+
+        let failure_plan = &plans[SUPERVISED_SUCCESSES + 1];
+        let failed_at = denied_at + Duration::seconds(1);
+        repository
+            .record_autonomy_outcome(
+                &AutonomyOutcome {
+                    id: AutonomyOutcomeId::new(),
+                    tenant_id: fixture.tenant_id,
+                    cluster_id: fixture.cluster_id,
+                    action: scenario.action(),
+                    action_version: "1.0.0".to_owned(),
+                    incident_id: failure_plan.incident_id,
+                    plan_id: failure_plan.plan_id,
+                    plan_hash: failure_plan.plan_hash.clone(),
+                    execution_id: None,
+                    cohort_id: Some(autonomous_cohort.id),
+                    class: AutonomyOutcomeClass::AutonomousExecutionFailure,
+                    failure: Some(AutonomousExecutionFailure::VerificationFailed),
+                    reason_codes: vec!["qualification_failure_fixture".to_owned()],
+                    first_positive_intent_persisted: true,
+                    occurred_at: failed_at,
+                    reconciled_at: failed_at,
+                },
+                "autonomy-qualification-reconciler",
+            )
+            .await
+            .expect("persist failure and pause lifecycle");
+        let paused = service.scope(&auth, &query).await.expect("paused scope");
+        assert_eq!(paused.lifecycle.mode, AutonomyMode::Paused);
+        assert_eq!(paused.lifecycle.previous_mode, Some(AutonomyMode::Supervised));
+
+        set_clock(&clock_value, failed_at + Duration::seconds(1));
+        let resumed = service
+            .transition(
+                &auth,
+                &query,
+                &AutonomyTransitionRequest {
+                    target_mode: AutonomyMode::Supervised,
+                    reason: Some("owner reviewed bounded qualification failure".to_owned()),
+                    owner_confirmed: true,
+                },
+            )
+            .await
+            .expect("human owner resumes Supervised mode");
+        assert_eq!(resumed.lifecycle.mode, AutonomyMode::Supervised);
+
+        return Some(AutonomyLifecycleOutcome {
+            id: scenario.action().id().to_owned(),
+            initial_mode: "disabled",
+            final_mode: "supervised",
+            shadow_samples: qualified_shadow_samples,
+            supervised_successes: qualified.qualification.qualified_supervised_successes,
+            observation_window_days: OBSERVATION_DAYS,
+            shadow_cohorts: 1,
+            supervised_cohorts: 1,
+            same_family_critic_denied: true,
+            autonomous_transition_executed: false,
+            expected_deny_paused: false,
+            execution_failure_paused: true,
+            critic_transport: "offline_scripted",
+            primary_model_family: PRIMARY_MODEL_FAMILY,
+            critic_model_family: CRITIC_MODEL_FAMILY,
+        });
+    }
     let autonomous = service
         .transition(
             &auth,
@@ -377,6 +592,23 @@ async fn qualify_r1_action_through_autonomy(scenario: R1ActionScenario) {
     assert!(autonomous.qualification.autonomous_observation_window_met);
     assert_eq!(autonomous.qualification.unresolved_unknown, 0);
     assert_eq!(autonomous.qualification.recent_rollbacks, 0);
+    Some(AutonomyLifecycleOutcome {
+        id: scenario.action().id().to_owned(),
+        initial_mode: "disabled",
+        final_mode: "autonomous",
+        shadow_samples: autonomous.qualification.qualified_shadow_samples,
+        supervised_successes: autonomous.qualification.qualified_supervised_successes,
+        observation_window_days: OBSERVATION_DAYS,
+        shadow_cohorts: 1,
+        supervised_cohorts: 1,
+        same_family_critic_denied: true,
+        autonomous_transition_executed: true,
+        expected_deny_paused: false,
+        execution_failure_paused: false,
+        critic_transport: "offline_scripted",
+        primary_model_family: PRIMARY_MODEL_FAMILY,
+        critic_model_family: CRITIC_MODEL_FAMILY,
+    })
 }
 
 fn autonomy_service(repository: &PostgresRepository, clock: Arc<Mutex<DateTime<Utc>>>) -> AutonomyService {
@@ -519,7 +751,7 @@ async fn seed_action_plan(
          ) VALUES (
             $1, $2, $3, $4, $5,
             NULL, 'primary_diagnosis', $6,
-            $6, 'openai-compatible', 'deepseek', 'v3.2',
+            $6, 'offline-scripted', 'qualification-primary', 'fixture-r1',
             'local', '{}', 'r1-autonomy-test',
             'rocketmq-sre.model.v1', 'R1 qualification fixture', $7, $7
          )",
@@ -700,7 +932,8 @@ async fn seed_shared_critic_review(
             review_hash, review_snapshot, created_at
          ) VALUES (
             $1, $2, $3, $4, $5, $6,
-            'deepseek', 'glm', 'openai-compatible', $7, 'glm-5',
+            'qualification-primary', 'qualification-critic',
+            'offline-scripted', $7, 'fixture-r1',
             'local', '{}', 'logger-autonomy-test',
             'rocketmq-sre.critic.v1', $8, 'accept', 'valid',
             $9, '{}'::JSONB, NOW()
@@ -719,4 +952,90 @@ async fn seed_shared_critic_review(
     .await
     .expect("shared heterogeneous critic review");
     review_id
+}
+
+async fn seed_qualification_critic_review(
+    repository: &PostgresRepository,
+    fixture: &Fixture,
+) -> (CriticReviewId, rocketmq_sre_contracts::ModelInvocationId, String) {
+    let profile_id = Uuid::new_v4();
+    let profile_name = format!("qualification-critic-{profile_id}");
+    sqlx::query(
+        "INSERT INTO model_profiles (
+            id, tenant_id, profile_name, provider_family, protocol_family,
+            model_family, model_name, model_revision, endpoint_instance,
+            region, data_residency, data_classes, capabilities, priority,
+            credential_ref, credential_owner, enabled, health, created_at, updated_at
+         ) VALUES (
+            $1, $2, $3, 'offline-scripted', 'fixture',
+            'qualification-critic', 'qualification-critic', 'fixture-r1', 'local',
+            'local', 'local', '[]'::JSONB, '{}'::JSONB, 90,
+            'offline-fixture-reference', 'gateway', TRUE, 'healthy', NOW(), NOW()
+         )",
+    )
+    .bind(profile_id)
+    .bind(fixture.tenant_id.as_uuid())
+    .bind(&profile_name)
+    .execute(&repository.pool)
+    .await
+    .expect("offline Critic profile");
+
+    let critic_invocation_id = rocketmq_sre_contracts::ModelInvocationId::new();
+    sqlx::query(
+        "INSERT INTO model_invocations (
+            id, tenant_id, cluster_id, incident_id, diagnosis_revision_id,
+            parent_invocation_id, purpose, requested_profile_id,
+            actual_profile_id, provider_family, model_family, model_revision,
+            endpoint_instance, fallback_chain, prompt_version, schema_version,
+            rationale, started_at, completed_at
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, 'critic', $7,
+            $7, 'offline-scripted', 'qualification-critic', 'fixture-r1',
+            'local', '{}', 'autonomy-qualification-fixture',
+            'rocketmq-sre.critic.v1', 'offline qualification fixture', NOW(), NOW()
+         )",
+    )
+    .bind(critic_invocation_id.as_uuid())
+    .bind(fixture.tenant_id.as_uuid())
+    .bind(fixture.cluster_id.as_uuid())
+    .bind(fixture.incident_id.as_uuid())
+    .bind(fixture.diagnosis_revision_id.as_uuid())
+    .bind(fixture.primary_invocation_id.as_uuid())
+    .bind(profile_id)
+    .execute(&repository.pool)
+    .await
+    .expect("offline Critic invocation");
+
+    let critic_review_id = CriticReviewId::new();
+    sqlx::query(
+        "INSERT INTO critic_reviews (
+            id, plan_id, plan_hash, diagnosis_revision_id,
+            primary_invocation_id, critic_invocation_id,
+            primary_model_family, critic_model_family,
+            critic_provider, critic_profile, critic_model_revision,
+            endpoint_instance, fallback_chain, prompt_version,
+            schema_version, payload_hash, conclusion, status,
+            review_hash, review_snapshot, created_at
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6,
+            'qualification-primary', 'qualification-critic',
+            'offline-scripted', $7, 'fixture-r1',
+            'local', '{}', 'autonomy-qualification-fixture',
+            'rocketmq-sre.critic.v1', $8, 'accept', 'valid',
+            $9, '{}'::JSONB, NOW()
+         )",
+    )
+    .bind(critic_review_id.as_uuid())
+    .bind(fixture.plan_id.as_uuid())
+    .bind(&fixture.plan_hash)
+    .bind(fixture.diagnosis_revision_id.as_uuid())
+    .bind(fixture.primary_invocation_id.as_uuid())
+    .bind(critic_invocation_id.as_uuid())
+    .bind(&profile_name)
+    .bind(unique_digest())
+    .bind(unique_digest())
+    .execute(&repository.pool)
+    .await
+    .expect("offline heterogeneous Critic review");
+    (critic_review_id, critic_invocation_id, profile_name)
 }

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/reconciler.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/reconciler.rs
@@ -59,6 +59,12 @@ impl AutonomyPauseReconciler {
                AND lifecycle.action_version = outcome.action_version
              WHERE outcome.outcome_class = 'autonomous_execution_failure'
                AND lifecycle.mode <> 'paused'
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM autonomy_outbox AS pause_event
+                   WHERE pause_event.outcome_id = outcome.id
+                     AND pause_event.event_kind = 'autonomy_paused'
+               )
              ORDER BY outcome.reconciled_at, outcome.sequence_id
              LIMIT $1",
         )

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository.rs
@@ -1538,7 +1538,7 @@ impl PostgresRepository {
                         .map_err(|_| invalid_request("lifecycle revision is too large"))?,
                 )
                 .bind(actor)
-                .bind(effective.reconciled_at)
+                .bind(pause_at)
                 .execute(&mut *transaction)
                 .await?;
                 insert_lifecycle_event(

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs
@@ -492,7 +492,7 @@ async fn postgres_pause_reconciler_repairs_a_dropped_failure_event_once() {
     .bind(fixture.cluster_id.as_uuid())
     .bind(ExecutionAction::ObservabilityLoggerLevelTtl.id())
     .bind(&stored.action_version)
-    .bind(now + Duration::seconds(1))
+    .bind(now + Duration::seconds(10))
     .execute(&repository.pool)
     .await
     .expect("simulate an autonomous lifecycle");
@@ -560,6 +560,7 @@ async fn postgres_pause_reconciler_repairs_a_dropped_failure_event_once() {
         .expect("reconciled scope");
     assert_eq!(scope.lifecycle.mode, AutonomyMode::Paused);
     assert_eq!(scope.lifecycle.previous_mode, Some(AutonomyMode::Autonomous));
+    assert_eq!(scope.lifecycle.updated_at, now + Duration::seconds(10));
     let pause_events: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
          FROM autonomy_outbox
@@ -571,9 +572,39 @@ async fn postgres_pause_reconciler_repairs_a_dropped_failure_event_once() {
     .expect("pause outbox count");
     assert_eq!(pause_events, 1);
 
+    sqlx::query(
+        "UPDATE autonomy_lifecycle_states
+         SET mode = 'supervised',
+             previous_mode = NULL,
+             pause_reason = NULL,
+             lifecycle_revision = lifecycle_revision + 1,
+             updated_by = 'repository-test-human-recovery',
+             updated_at = $5
+         WHERE tenant_id = $1 AND cluster_id = $2
+           AND action_id = $3 AND action_version = $4",
+    )
+    .bind(fixture.tenant_id.as_uuid())
+    .bind(fixture.cluster_id.as_uuid())
+    .bind(ExecutionAction::ObservabilityLoggerLevelTtl.id())
+    .bind(&outcome.action_version)
+    .bind(now + Duration::seconds(11))
+    .execute(&repository.pool)
+    .await
+    .expect("simulate a human recovery after the repaired pause");
+
     let retry = reconciler.run_once().await.expect("idempotent reconciliation");
     assert_eq!(retry.candidates, 0);
     assert_eq!(retry.repaired, 0);
+    let recovered_scope = repository
+        .autonomy_scope(
+            fixture.tenant_id,
+            fixture.cluster_id,
+            ExecutionAction::ObservabilityLoggerLevelTtl,
+            &outcome.action_version,
+        )
+        .await
+        .expect("recovered scope");
+    assert_eq!(recovered_scope.lifecycle.mode, AutonomyMode::Supervised);
     let pause_events_after_retry: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
          FROM autonomy_outbox

--- a/rocketmq-sre/crates/rocketmq-sre-core/src/eligibility.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-core/src/eligibility.rs
@@ -457,4 +457,43 @@ mod tests {
             assert!(!EligibilityEngine::evaluate_dynamic_safety(denied).allowed);
         }
     }
+
+    #[test]
+    fn base_eligibility_fails_closed_for_stale_or_partial_evidence() {
+        let (policy, lifecycle, descriptor) = fixture();
+        for (facts, reason) in [
+            (
+                BaseEligibilityFacts {
+                    evidence_complete: false,
+                    ..allow_base()
+                },
+                "evidence_incomplete",
+            ),
+            (
+                BaseEligibilityFacts {
+                    evidence_fresh: false,
+                    ..allow_base()
+                },
+                "evidence_stale",
+            ),
+            (
+                BaseEligibilityFacts {
+                    required_sources_present: false,
+                    ..allow_base()
+                },
+                "evidence_incomplete",
+            ),
+        ] {
+            let denied = EligibilityEngine::evaluate_base(
+                AutonomyCandidatePath::Autonomous,
+                &policy,
+                &lifecycle,
+                &descriptor,
+                &facts,
+                chrono::Utc::now(),
+            );
+            assert!(!denied.allowed);
+            assert!(denied.reason_codes.contains(&reason.to_owned()));
+        }
+    }
 }

--- a/rocketmq-sre/scripts/autonomy-action-live-qualification.ps1
+++ b/rocketmq-sre/scripts/autonomy-action-live-qualification.ps1
@@ -1,0 +1,295 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
+    [string]$ClusterName = 'rocketmq-sre-autonomy-qualification',
+
+    [string]$CargoHome = 'D:\BuildCache\rocketmq-sre-cargo-home',
+
+    [string]$CargoTargetDir = 'F:\BuildCache\rocketmq-sre-autonomy-qualification',
+
+    [string]$TemporaryRoot = 'D:\BuildCache\rocketmq-sre-temp',
+
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+
+    [ValidateRange(1024, 65535)]
+    [int]$PostgresLocalPort = 35452,
+
+    [ValidateRange(1024, 65535)]
+    [int]$ExecutorLocalPort = 58116,
+
+    [ValidateRange(1024, 65535)]
+    [int]$AgentLocalPort = 58117,
+
+    [switch]$SkipImageBuild
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$repositoryTarget = [IO.Path]::GetFullPath((Join-Path $repositoryRoot 'target'))
+$kindArtifacts = [IO.Path]::GetFullPath((Join-Path $repositoryTarget 'phase00-kind'))
+$certificateArtifacts = [IO.Path]::GetFullPath((Join-Path $repositoryTarget 'phase00-certs'))
+$kubeconfig = Join-Path $kindArtifacts 'kubeconfig'
+$manifestPath = Join-Path $sreRoot 'config\qualification\autonomy-actions.v1.json'
+$checkerPath = Join-Path $scriptDirectory 'check_autonomy_action_qualification.py'
+$kindScript = Join-Path $scriptDirectory 'kind.ps1'
+$waveScript = Join-Path $scriptDirectory 'phase03-wave-actions-supervised-e2e.ps1'
+
+function Assert-DataPath([string]$Path, [string]$Description) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
+    }
+}
+
+function Invoke-Native(
+    [string]$Command,
+    [string[]]$Arguments,
+    [string]$Description
+) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Test-KindCluster([string]$Name) {
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'SilentlyContinue'
+        $clusters = & kind get clusters 2>$null
+        $status = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    if ($status -ne 0) {
+        return $false
+    }
+    return @($clusters | Where-Object { $_.Trim() -eq $Name }).Count -eq 1
+}
+
+function Remove-OwnedArtifacts {
+    foreach ($path in @($kindArtifacts, $certificateArtifacts)) {
+        if (-not $path.StartsWith($repositoryTarget + '\', [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Owned runtime artifact escaped the repository target directory: $path"
+        }
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Recurse -Force
+        }
+    }
+}
+
+foreach ($path in @(
+    @{ Value = $CargoHome; Description = 'Cargo home' },
+    @{ Value = $CargoTargetDir; Description = 'Cargo target directory' },
+    @{ Value = $TemporaryRoot; Description = 'temporary directory' },
+    @{ Value = $EvidenceRoot; Description = 'qualification Evidence root' }
+)) {
+    Assert-DataPath $path.Value $path.Description
+}
+if (@(@($PostgresLocalPort, $ExecutorLocalPort, $AgentLocalPort) | Select-Object -Unique).Count -ne 3) {
+    throw 'Qualification loopback ports must be distinct.'
+}
+
+$resolvedCargoHome = [IO.Path]::GetFullPath($CargoHome)
+$resolvedCargoTarget = [IO.Path]::GetFullPath($CargoTargetDir)
+$resolvedTemporaryRoot = [IO.Path]::GetFullPath($TemporaryRoot)
+$resolvedEvidenceRoot = [IO.Path]::GetFullPath($EvidenceRoot).TrimEnd('\')
+$allowedEvidenceRoots = @(
+    [IO.Path]::GetFullPath('D:\rocketmq-sre-evidence').TrimEnd('\'),
+    [IO.Path]::GetFullPath('F:\rocketmq-sre-evidence').TrimEnd('\')
+)
+if (-not ($allowedEvidenceRoots -contains $resolvedEvidenceRoot)) {
+    throw 'Qualification reports must use D:\rocketmq-sre-evidence or F:\rocketmq-sre-evidence.'
+}
+if (Test-KindCluster $ClusterName) {
+    throw "Refusing to reuse pre-existing Kind cluster '$ClusterName'."
+}
+if ((Test-Path -LiteralPath $kindArtifacts) -or (Test-Path -LiteralPath $certificateArtifacts)) {
+    throw 'Autonomy qualification requires an empty task-owned Kind artifact area.'
+}
+
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath) 'autonomy qualification manifest validation'
+$revision = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to determine the qualification source revision.'
+}
+$dirty = & git -C $repositoryRoot status --porcelain=v1
+if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($dirty -join ''))) {
+    throw 'Autonomy live qualification requires a committed, clean source tree.'
+}
+
+$startedAt = [DateTimeOffset]::UtcNow
+$runName = 'autonomy-actions-{0}-{1}' -f $startedAt.ToString('yyyyMMdd-HHmmss'), ([Guid]::NewGuid().ToString('N'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $resolvedEvidenceRoot $runName))
+$expectedEvidencePrefix = $resolvedEvidenceRoot + '\'
+if (-not $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Autonomy qualification output escaped the configured Evidence root.'
+}
+$liveFragmentPath = Join-Path $runRoot 'live-fragment.json'
+$recoveryFragmentPath = Join-Path $runRoot 'recovery-fragment.json'
+$lifecycleFragmentPath = Join-Path $runRoot 'lifecycle-fragment.json'
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+New-Item -ItemType Directory -Force -Path `
+    $runRoot, `
+    $resolvedCargoHome, `
+    $resolvedCargoTarget, `
+    $resolvedTemporaryRoot |
+    Out-Null
+
+$clusterCreated = $false
+$qualificationSucceeded = $false
+try {
+    $upParameters = @{
+        Action = 'Up'
+        ClusterName = $ClusterName
+    }
+    if ($SkipImageBuild) {
+        $upParameters.SkipBuild = $true
+    }
+    & $kindScript @upParameters
+    $clusterCreated = Test-KindCluster $ClusterName
+    if (-not $clusterCreated -or -not (Test-Path -LiteralPath $kubeconfig -PathType Leaf)) {
+        throw 'The disposable Kind cluster did not become available.'
+    }
+
+    & $waveScript `
+        -Kubeconfig $kubeconfig `
+        -CargoHome $resolvedCargoHome `
+        -CargoTargetDir $resolvedCargoTarget `
+        -TemporaryRoot $resolvedTemporaryRoot `
+        -PostgresLocalPort $PostgresLocalPort `
+        -ExecutorLocalPort $ExecutorLocalPort `
+        -AgentLocalPort $AgentLocalPort `
+        -R1Only `
+        -LiveFragment $liveFragmentPath `
+        -RecoveryFragment $recoveryFragmentPath `
+        -AutonomyFragment $lifecycleFragmentPath
+
+    foreach ($fragment in @($liveFragmentPath, $recoveryFragmentPath, $lifecycleFragmentPath)) {
+        if (-not (Test-Path -LiteralPath $fragment -PathType Leaf)) {
+            throw "A required autonomy qualification fragment is missing: $fragment"
+        }
+    }
+    $live = Get-Content -Raw -LiteralPath $liveFragmentPath | ConvertFrom-Json
+    $recovery = Get-Content -Raw -LiteralPath $recoveryFragmentPath | ConvertFrom-Json
+    $lifecycle = Get-Content -Raw -LiteralPath $lifecycleFragmentPath | ConvertFrom-Json
+    if (
+        $live.schema_version -ne 'rocketmq-sre.r1-action-live-fragment.v1' -or
+        $recovery.schema_version -ne 'rocketmq-sre.r1-action-recovery-fragment.v1' -or
+        $lifecycle.schema_version -ne 'rocketmq-sre.autonomy-action-lifecycle-fragment.v1' -or
+        $lifecycle.live_mode_ceiling -ne 'supervised' -or
+        $lifecycle.unattended_autonomous_execution -ne $false -or
+        [int]$live.model_provider_network_calls -ne 0 -or
+        [int]$recovery.model_provider_network_calls -ne 0 -or
+        [int]$lifecycle.model_provider_network_calls -ne 0 -or
+        $live.logger_ttl_restored -ne $true
+    ) {
+        throw 'Autonomy qualification fragments failed closed because schema or safety metadata drifted.'
+    }
+    if (@($live.actions).Count -ne 4 -or @($recovery.actions).Count -ne 4 -or @($lifecycle.actions).Count -ne 4) {
+        throw 'Autonomy qualification fragments must each contain exactly four actions.'
+    }
+
+    $ownedJob = & kubectl `
+        --kubeconfig $kubeconfig `
+        -n rocketmq-system `
+        get job rocketmq-sre-phase03-wave-admin-bootstrap `
+        --ignore-not-found=true `
+        -o name
+    if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($ownedJob -join ''))) {
+        throw 'The qualification-owned Admin bootstrap Job was not removed.'
+    }
+
+    $manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+    $actionReports = [Collections.Generic.List[object]]::new()
+    foreach ($action in $manifest.actions) {
+        $liveAction = @($live.actions | Where-Object { $_.id -eq $action.id })
+        $recoveryAction = @($recovery.actions | Where-Object { $_.id -eq $action.id })
+        $lifecycleAction = @($lifecycle.actions | Where-Object { $_.id -eq $action.id })
+        if ($liveAction.Count -ne 1 -or $recoveryAction.Count -ne 1 -or $lifecycleAction.Count -ne 1) {
+            throw "Autonomy qualification fragments do not contain exactly one record for $($action.id)."
+        }
+        $outcomes = [ordered]@{}
+        foreach ($outcome in $manifest.required_outcomes) {
+            $outcomes[[string]$outcome] = 'passed'
+        }
+        $actionReports.Add([ordered]@{
+            id = [string]$action.id
+            outcomes = $outcomes
+            lifecycle = $lifecycleAction[0]
+            live = $liveAction[0]
+            recovery = $recoveryAction[0]
+        })
+    }
+
+    & $kindScript -Action Down -ClusterName $ClusterName
+    $clusterCreated = $false
+    if (Test-KindCluster $ClusterName) {
+        throw 'The disposable Kind cluster still exists after teardown.'
+    }
+    Remove-OwnedArtifacts
+    Remove-Item -LiteralPath $liveFragmentPath, $recoveryFragmentPath, $lifecycleFragmentPath -Force
+
+    $report = [ordered]@{
+        schema_version = 'rocketmq-sre.autonomy-action-qualification-report.v1'
+        revision = $revision
+        source_clean = $true
+        environment = 'disposable_kind'
+        started_at = $startedAt.ToString('o')
+        finished_at = [DateTimeOffset]::UtcNow.ToString('o')
+        status = 'passed'
+        live_mode_ceiling = 'supervised'
+        unattended_autonomous_execution = $false
+        model_provider_network_calls = 0
+        secrets_recorded = $false
+        message_bodies_recorded = $false
+        actions = $actionReports
+        cleanup = [ordered]@{
+            status = 'passed'
+            disposable_kind_destroyed = $true
+            owned_runtime_artifacts_removed = $true
+            qualification_fragments_removed = $true
+            target_state_restored = $true
+        }
+    }
+    $json = $report | ConvertTo-Json -Depth 14
+    [IO.File]::WriteAllText($reportPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    Invoke-Native python @($checkerPath, '--manifest', $manifestPath, '--report', $reportPath) `
+        'autonomy live qualification report validation'
+    $qualificationSucceeded = $true
+    Write-Host "AUTONOMY_ACTION_LIVE_QUALIFICATION_OK report=$reportPath actions=4 outcomes=64 live_mode_ceiling=supervised model_network_calls=0"
+}
+finally {
+    if ($clusterCreated -or (Test-KindCluster $ClusterName)) {
+        try {
+            & $kindScript -Action Down -ClusterName $ClusterName
+        }
+        catch {
+            Write-Warning "Unable to tear down the qualification-owned Kind cluster: $($_.Exception.Message)"
+        }
+    }
+    try {
+        Remove-OwnedArtifacts
+    }
+    catch {
+        Write-Warning "Unable to remove qualification-owned runtime artifacts: $($_.Exception.Message)"
+    }
+    if (
+        -not $qualificationSucceeded -and
+        (Test-Path -LiteralPath $runRoot) -and
+        $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+}

--- a/rocketmq-sre/scripts/check_autonomy_action_qualification.py
+++ b/rocketmq-sre/scripts/check_autonomy_action_qualification.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate bounded-autonomy qualification for the approved R1 actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "autonomy-actions.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.autonomy-action-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.autonomy-action-qualification-report.v1"
+EXPECTED_ACTIONS = {
+    "observability.logger_level_ttl.v1",
+    "proxy.scale_out_one.v1",
+    "proxy.restart_one.v1",
+    "telemetry.collector.restart_one.v1",
+}
+EXPECTED_OUTCOMES = {
+    "disabled_by_default",
+    "shadow_cohort_persisted",
+    "insufficient_shadow_denied",
+    "shadow_window_qualified",
+    "supervised_transition_persisted",
+    "heterogeneous_critic_bound",
+    "same_family_critic_denied",
+    "insufficient_supervised_denied",
+    "supervised_successes_persisted",
+    "stale_or_partial_evidence_denied",
+    "freeze_or_budget_denied",
+    "kill_switch_denied",
+    "execution_failure_paused",
+    "expected_deny_not_paused",
+    "live_supervised_action_verified",
+    "recovery_and_cleanup",
+}
+EXPECTED_SHARED = {
+    "lifecycle_matrix",
+    "same_family_critic_denied",
+    "stale_or_partial_evidence_denied",
+    "freeze_or_budget_denied",
+    "kill_switch_denied",
+    "failure_pause_reconciled",
+}
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def repository_file(raw_path: Any, location: str, findings: list[str]) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location} must be a non-empty repository path")
+        return None
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location} must be repository implementation evidence")
+        return None
+    resolved = REPOSITORY_ROOT / Path(*path.parts)
+    if not resolved.is_file():
+        findings.append(f"{location} does not exist: {raw_path}")
+        return None
+    return resolved
+
+
+def repository_evidence(value: Any, location: str, findings: list[str]) -> None:
+    if not isinstance(value, dict):
+        findings.append(f"{location} must be an object")
+        return
+    resolved = repository_file(value.get("path"), f"{location}.path", findings)
+    test = value.get("test")
+    if resolved is not None and (
+        not isinstance(test, str) or not test or test not in resolved.read_text(encoding="utf-8")
+    ):
+        findings.append(f"{location}.test is absent from {value.get('path')}: {test}")
+
+
+def yaml_scalar(path: Path, key: str) -> str | None:
+    match = re.search(rf"(?m)^{re.escape(key)}:\s*([^#\s]+)", path.read_text(encoding="utf-8"))
+    return match.group(1).strip("\"'") if match else None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected_values = {
+        "schema_version": MANIFEST_SCHEMA,
+        "operating_mode": "rules_only",
+        "environment": "disposable_kind",
+        "live_mode_ceiling": "supervised",
+        "unattended_autonomous_execution": False,
+        "model_provider_network_calls": False,
+        "production_certified": False,
+    }
+    for field, expected in expected_values.items():
+        if manifest.get(field) != expected:
+            findings.append(f"{field} must remain {expected!r}")
+    if set(manifest.get("required_outcomes", [])) != EXPECTED_OUTCOMES:
+        findings.append("required outcome matrix is incomplete")
+
+    shared = manifest.get("shared_boundary_evidence")
+    if not isinstance(shared, dict) or set(shared) != EXPECTED_SHARED:
+        findings.append("shared boundary evidence is incomplete")
+    else:
+        for name, evidence in shared.items():
+            repository_evidence(evidence, f"shared_boundary_evidence.{name}", findings)
+
+    actions = manifest.get("actions")
+    if not isinstance(actions, list):
+        findings.append("actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    switches: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not an approved autonomy action")
+            continue
+        if action_id in observed:
+            findings.append(f"duplicate autonomy action: {action_id}")
+        observed.add(action_id)
+        if action.get("risk") != "r1" or action.get("qualification") != "disposable_cluster_smoke_passed":
+            findings.append(f"{location} must be R1 and disposable-cluster qualified")
+        if action.get("shadow_samples") != 20 or action.get("supervised_successes") != 5:
+            findings.append(f"{location} qualification sample thresholds drifted")
+        if action.get("observation_window_days") != 7:
+            findings.append(f"{location} observation window must be seven days")
+        if not isinstance(action.get("owner"), str) or not action["owner"].strip():
+            findings.append(f"{location}.owner must be non-empty")
+        switch = action.get("enable_switch")
+        if not isinstance(switch, str) or not switch:
+            findings.append(f"{location}.enable_switch must be non-empty")
+        elif switch in switches:
+            findings.append(f"{location}.enable_switch must be independent")
+        else:
+            switches.add(switch)
+        descriptor = repository_file(action.get("descriptor"), f"{location}.descriptor", findings)
+        policy = repository_file(action.get("policy"), f"{location}.policy", findings)
+        if descriptor is not None:
+            if yaml_scalar(descriptor, "id") != action_id or yaml_scalar(descriptor, "risk") != "r1":
+                findings.append(f"{location}.descriptor identity or risk drifted")
+            if yaml_scalar(descriptor, "owner") != action.get("owner"):
+                findings.append(f"{location}.owner drifted from its descriptor")
+        if policy is not None and yaml_scalar(policy, "action_id") != action_id:
+            findings.append(f"{location}.policy action drifted")
+    if observed != EXPECTED_ACTIONS or len(actions) != len(EXPECTED_ACTIONS):
+        findings.append(f"autonomy action set drifted: {sorted(observed)}")
+
+    fixture = manifest.get("offline_critic_fixture")
+    if not isinstance(fixture, dict):
+        findings.append("offline Critic fixture is missing")
+    else:
+        primary = fixture.get("primary_model_family")
+        critic = fixture.get("critic_model_family")
+        if fixture.get("transport") != "offline_scripted":
+            findings.append("Critic transport must remain offline_scripted")
+        if not isinstance(primary, str) or not isinstance(critic, str) or primary == critic:
+            findings.append("offline Critic fixture must use heterogeneous model families")
+        if fixture.get("heterogeneous_required") is not True:
+            findings.append("heterogeneous Critic enforcement must remain required")
+
+    report = manifest.get("live_report")
+    if not isinstance(report, dict) or report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live report contract is missing or unsupported")
+    else:
+        if report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if set(report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+        if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+            findings.append("live report must exclude secrets and message bodies")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains a credential-like value")
+    return findings
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if report.get("schema_version") != REPORT_SCHEMA:
+        findings.append(f"report schema_version must be {REPORT_SCHEMA}")
+    if report.get("status") != "passed" or report.get("environment") != "disposable_kind":
+        findings.append("report must be a passed disposable Kind run")
+    if not isinstance(report.get("revision"), str) or not REVISION.fullmatch(report["revision"]):
+        findings.append("report revision must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("report source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+    expected_values = {
+        "live_mode_ceiling": "supervised",
+        "unattended_autonomous_execution": False,
+        "model_provider_network_calls": 0,
+        "secrets_recorded": False,
+        "message_bodies_recorded": False,
+    }
+    for field, expected in expected_values.items():
+        if report.get(field) != expected:
+            findings.append(f"report {field} must remain {expected!r}")
+
+    actions = report.get("actions")
+    if not isinstance(actions, list):
+        findings.append("report actions must be an array")
+        actions = []
+    observed: set[str] = set()
+    for index, action in enumerate(actions):
+        location = f"report.actions[{index}]"
+        if not isinstance(action, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        action_id = action.get("id")
+        if not isinstance(action_id, str) or action_id not in EXPECTED_ACTIONS:
+            findings.append(f"{location}.id is not an approved autonomy action")
+            continue
+        observed.add(action_id)
+        outcomes = action.get("outcomes")
+        if not isinstance(outcomes, dict) or set(outcomes) != EXPECTED_OUTCOMES:
+            findings.append(f"{location}.outcomes is incomplete")
+        elif any(value != "passed" for value in outcomes.values()):
+            findings.append(f"{location}.outcomes contains a non-passing result")
+        lifecycle = action.get("lifecycle")
+        if not isinstance(lifecycle, dict):
+            findings.append(f"{location}.lifecycle must be an object")
+        else:
+            if lifecycle.get("initial_mode") != "disabled" or lifecycle.get("final_mode") != "supervised":
+                findings.append(f"{location}.lifecycle must remain Disabled-to-Supervised")
+            if lifecycle.get("shadow_samples") != 20 or lifecycle.get("supervised_successes") != 5:
+                findings.append(f"{location}.lifecycle sample counts drifted")
+            if lifecycle.get("observation_window_days") != 7:
+                findings.append(f"{location}.lifecycle observation window drifted")
+            if lifecycle.get("shadow_cohorts") != 1 or lifecycle.get("supervised_cohorts") != 1:
+                findings.append(f"{location}.lifecycle cohort persistence drifted")
+            if lifecycle.get("same_family_critic_denied") is not True:
+                findings.append(f"{location}.lifecycle must deny a same-family Critic")
+            if lifecycle.get("autonomous_transition_executed") is not False:
+                findings.append(f"{location}.lifecycle must not execute an Autonomous transition")
+            if lifecycle.get("expected_deny_paused") is not False:
+                findings.append(f"{location}.lifecycle ExpectedDeny must not pause")
+            if lifecycle.get("execution_failure_paused") is not True:
+                findings.append(f"{location}.lifecycle failure must pause")
+            primary = lifecycle.get("primary_model_family")
+            critic = lifecycle.get("critic_model_family")
+            if lifecycle.get("critic_transport") != "offline_scripted" or primary == critic:
+                findings.append(f"{location}.lifecycle lacks a heterogeneous offline Critic")
+        live = action.get("live")
+        if not isinstance(live, dict) or live.get("state") != "succeeded" or live.get("target_mutations") != 1:
+            findings.append(f"{location}.live must prove one successful supervised target mutation")
+        recovery = action.get("recovery")
+        if not isinstance(recovery, dict) or recovery.get("verified_success") != "succeeded":
+            findings.append(f"{location}.recovery must prove verified recovery")
+    if observed != EXPECTED_ACTIONS or len(actions) != len(EXPECTED_ACTIONS):
+        findings.append("report must contain each autonomy action exactly once")
+
+    cleanup = report.get("cleanup")
+    required_cleanup = (
+        "disposable_kind_destroyed",
+        "owned_runtime_artifacts_removed",
+        "qualification_fragments_removed",
+        "target_state_restored",
+    )
+    if not isinstance(cleanup, dict) or cleanup.get("status") != "passed":
+        findings.append("cleanup must pass")
+    elif any(cleanup.get(field) is not True for field in required_cleanup):
+        findings.append("cleanup proof is incomplete")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains a credential-like value")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        findings = validate_manifest(load_json(args.manifest))
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report)))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"AUTONOMY_ACTION_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"AUTONOMY_ACTION_QUALIFICATION_FINDING {finding}")
+        print(f"AUTONOMY_ACTION_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(f"AUTONOMY_ACTION_QUALIFICATION_OK actions=4 outcomes=16 model_network_calls=false{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/check_execution_recovery_qualification.py
+++ b/rocketmq-sre/scripts/check_execution_recovery_qualification.py
@@ -190,9 +190,10 @@ def validate(manifest: dict[str, Any]) -> list[str]:
     for action in actions:
         if not isinstance(action, dict):
             continue
-        expected = "disposable_cluster_smoke_passed" if action.get("risk") == "r1" else "contract_tested"
-        if action.get("qualification") != expected:
-            findings.append(f"controlled action {action.get('id')} must be qualified as {expected}")
+        if action.get("qualification") != "disposable_cluster_smoke_passed":
+            findings.append(
+                f"controlled action {action.get('id')} must be qualified as disposable_cluster_smoke_passed"
+            )
 
     r1_live = manifest.get("r1_live_qualification")
     if not isinstance(r1_live, dict):
@@ -206,6 +207,36 @@ def validate(manifest: dict[str, Any]) -> list[str]:
             findings.append("R1 disposable qualification must not claim production certification")
         for field in ("manifest", "script", "checker"):
             _repository_path(r1_live.get(field), findings, f"r1_live_qualification.{field}")
+
+    r2_live = manifest.get("r2_live_qualification")
+    if not isinstance(r2_live, dict):
+        findings.append("R2 live qualification contract is missing")
+    else:
+        if r2_live.get("actions") != 5 or r2_live.get("required_outcomes_per_action") != 12:
+            findings.append("R2 live qualification must cover five actions by twelve outcomes")
+        for field in ("model_provider_network_calls", "unattended_execution", "production_certified"):
+            if r2_live.get(field) is not False:
+                findings.append(f"R2 live qualification {field} must remain false")
+        for field in ("manifest", "script", "checker"):
+            _repository_path(r2_live.get(field), findings, f"r2_live_qualification.{field}")
+
+    autonomy_live = manifest.get("autonomy_live_qualification")
+    if not isinstance(autonomy_live, dict):
+        findings.append("autonomy live qualification contract is missing")
+    else:
+        if autonomy_live.get("actions") != 4 or autonomy_live.get("required_outcomes_per_action") != 16:
+            findings.append("autonomy live qualification must cover four actions by sixteen outcomes")
+        if autonomy_live.get("live_mode_ceiling") != "supervised":
+            findings.append("autonomy live qualification must stop at Supervised")
+        for field in (
+            "unattended_autonomous_execution",
+            "model_provider_network_calls",
+            "production_certified",
+        ):
+            if autonomy_live.get(field) is not False:
+                findings.append(f"autonomy live qualification {field} must remain false")
+        for field in ("manifest", "script", "checker"):
+            _repository_path(autonomy_live.get(field), findings, f"autonomy_live_qualification.{field}")
 
     common = manifest.get("common_execution_safety_evidence")
     required_safety = {

--- a/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
+++ b/rocketmq-sre/scripts/phase03-wave-actions-supervised-e2e.ps1
@@ -29,6 +29,8 @@ param(
 
     [string]$RecoveryFragment,
 
+    [string]$AutonomyFragment,
+
     [string]$R2AdminLiveFragment,
 
     [string]$R2RecoveryFragment,
@@ -171,6 +173,7 @@ foreach ($path in @(
 foreach ($fragment in @(
     @{ Value = $LiveFragment; Description = 'live qualification fragment' },
     @{ Value = $RecoveryFragment; Description = 'recovery qualification fragment' },
+    @{ Value = $AutonomyFragment; Description = 'autonomy qualification fragment' },
     @{ Value = $R2AdminLiveFragment; Description = 'R2 Admin live qualification fragment' },
     @{ Value = $R2RecoveryFragment; Description = 'R2 recovery qualification fragment' }
 )) {
@@ -235,6 +238,7 @@ foreach ($name in @(
     'ROCKETMQ_SRE_TEST_DATABASE_URL',
     'ROCKETMQ_SRE_R1_LIVE_FRAGMENT',
     'ROCKETMQ_SRE_R1_RECOVERY_FRAGMENT',
+    'ROCKETMQ_SRE_AUTONOMY_QUALIFICATION_FRAGMENT',
     'ROCKETMQ_SRE_R2_ADMIN_LIVE_FRAGMENT',
     'ROCKETMQ_SRE_R2_RECOVERY_FRAGMENT',
     'ROCKETMQ_SRE_PHASE3_PROXY_IMAGE_DIGEST'
@@ -370,6 +374,61 @@ try {
     $env:ROCKETMQ_SRE_PHASE4_COLLECTOR_UID = [string]$collectorPod.metadata.uid
     $env:ROCKETMQ_SRE_TEST_DATABASE_URL = $databaseUri.Uri.AbsoluteUri
     if (-not $R2Only) {
+        if (-not [string]::IsNullOrWhiteSpace($AutonomyFragment)) {
+            $env:ROCKETMQ_SRE_AUTONOMY_QUALIFICATION_FRAGMENT = [IO.Path]::GetFullPath($AutonomyFragment)
+            & cargo +1.95.0 test `
+                --manifest-path $manifestPath `
+                --locked `
+                -p rocketmq-sre-control-plane `
+                --lib `
+                autonomy::logger_ttl_lifecycle_tests::all_r1_actions_persist_shadow_and_supervised_qualification_matrix `
+                -- `
+                --ignored `
+                --exact `
+                --nocapture `
+                --test-threads=1
+            if ($LASTEXITCODE -ne 0) {
+                throw 'R1 persisted Shadow and Supervised autonomy qualification matrix failed.'
+            }
+            & cargo +1.95.0 test `
+                --manifest-path $manifestPath `
+                --locked `
+                -p rocketmq-sre-core `
+                eligibility::tests::dynamic_safety_fails_closed_for_each_authoritative_control `
+                -- `
+                --exact
+            if ($LASTEXITCODE -ne 0) {
+                throw 'R1 authoritative dynamic-safety denial matrix failed.'
+            }
+            & cargo +1.95.0 test `
+                --manifest-path $manifestPath `
+                --locked `
+                -p rocketmq-sre-core `
+                eligibility::tests::base_eligibility_fails_closed_for_stale_or_partial_evidence `
+                -- `
+                --exact
+            if ($LASTEXITCODE -ne 0) {
+                throw 'R1 stale and partial Evidence denial matrix failed.'
+            }
+            foreach ($test in @(
+                'autonomy::repository_tests::postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent',
+                'autonomy::repository_tests::postgres_pause_reconciler_repairs_a_dropped_failure_event_once'
+            )) {
+                & cargo +1.95.0 test `
+                    --manifest-path $manifestPath `
+                    --locked `
+                    -p rocketmq-sre-control-plane `
+                    --lib `
+                    $test `
+                    -- `
+                    --ignored `
+                    --exact `
+                    --test-threads=1
+                if ($LASTEXITCODE -ne 0) {
+                    throw "R1 autonomy boundary test failed: $test"
+                }
+            }
+        }
         if (-not [string]::IsNullOrWhiteSpace($LiveFragment)) {
             $env:ROCKETMQ_SRE_R1_LIVE_FRAGMENT = [IO.Path]::GetFullPath($LiveFragment)
         }

--- a/rocketmq-sre/scripts/tests/test_check_autonomy_action_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_autonomy_action_qualification.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the bounded-autonomy action qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_autonomy_action_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_autonomy_action_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report() -> dict:
+    actions = []
+    for action_id in sorted(MODULE.EXPECTED_ACTIONS):
+        actions.append(
+            {
+                "id": action_id,
+                "outcomes": {outcome: "passed" for outcome in MODULE.EXPECTED_OUTCOMES},
+                "lifecycle": {
+                    "initial_mode": "disabled",
+                    "final_mode": "supervised",
+                    "shadow_samples": 20,
+                    "supervised_successes": 5,
+                    "observation_window_days": 7,
+                    "shadow_cohorts": 1,
+                    "supervised_cohorts": 1,
+                    "same_family_critic_denied": True,
+                    "autonomous_transition_executed": False,
+                    "expected_deny_paused": False,
+                    "execution_failure_paused": True,
+                    "critic_transport": "offline_scripted",
+                    "primary_model_family": "qualification-primary",
+                    "critic_model_family": "qualification-critic",
+                },
+                "live": {"state": "succeeded", "target_mutations": 1},
+                "recovery": {"verified_success": "succeeded"},
+            }
+        )
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "revision": "a" * 40,
+        "source_clean": True,
+        "environment": "disposable_kind",
+        "started_at": "2026-08-05T00:00:00Z",
+        "finished_at": "2026-08-05T00:20:00Z",
+        "status": "passed",
+        "live_mode_ceiling": "supervised",
+        "unattended_autonomous_execution": False,
+        "model_provider_network_calls": 0,
+        "secrets_recorded": False,
+        "message_bodies_recorded": False,
+        "actions": actions,
+        "cleanup": {
+            "status": "passed",
+            "disposable_kind_destroyed": True,
+            "owned_runtime_artifacts_removed": True,
+            "qualification_fragments_removed": True,
+            "target_state_restored": True,
+        },
+    }
+
+
+class AutonomyActionQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_rejects_action_drift_and_unsafe_live_autonomy(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["actions"].pop()
+        manifest["live_mode_ceiling"] = "autonomous"
+        manifest["unattended_autonomous_execution"] = True
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertTrue(any("action set drifted" in finding for finding in findings))
+        self.assertIn("live_mode_ceiling must remain 'supervised'", findings)
+        self.assertIn("unattended_autonomous_execution must remain False", findings)
+
+    def test_rejects_model_calls_and_same_family_critic(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["model_provider_network_calls"] = True
+        manifest["offline_critic_fixture"]["critic_model_family"] = "qualification-primary"
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("model_provider_network_calls must remain False", findings)
+        self.assertIn("offline Critic fixture must use heterogeneous model families", findings)
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report()), [])
+
+    def test_rejects_autonomous_transition_and_incomplete_counts(self) -> None:
+        report = valid_report()
+        lifecycle = report["actions"][0]["lifecycle"]
+        lifecycle["final_mode"] = "autonomous"
+        lifecycle["autonomous_transition_executed"] = True
+        lifecycle["shadow_samples"] = 19
+
+        findings = MODULE.validate_report(report)
+
+        self.assertTrue(any("Disabled-to-Supervised" in finding for finding in findings))
+        self.assertTrue(any("must not execute an Autonomous transition" in finding for finding in findings))
+        self.assertTrue(any("sample counts drifted" in finding for finding in findings))
+
+    def test_rejects_model_calls_sensitive_values_and_incomplete_cleanup(self) -> None:
+        report = valid_report()
+        report["model_provider_network_calls"] = 1
+        report["unsafe"] = "Bearer qualification-token"
+        report["cleanup"]["disposable_kind_destroyed"] = False
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("report model_provider_network_calls must remain 0", findings)
+        self.assertIn("report contains a credential-like value", findings)
+        self.assertIn("cleanup proof is incomplete", findings)
+
+    def test_rejects_non_passing_outcome_and_missing_action(self) -> None:
+        report = valid_report()
+        report["actions"][0]["outcomes"]["kill_switch_denied"] = "failed"
+        report["actions"].pop()
+
+        findings = MODULE.validate_report(report)
+
+        self.assertTrue(any("non-passing" in finding for finding in findings))
+        self.assertIn("report must contain each autonomy action exactly once", findings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8938

### Brief Description

- Add a fail-closed qualification manifest, report validator, and disposable Kind runner for the four approved R1 SRE actions.
- Persist and verify bounded lifecycle evidence for 20 Shadow samples, a seven-day observation window, five Supervised successes, heterogeneous Critic identity, same-family denial, safety-control denials, failure pause, and human recovery.
- Keep the live mode ceiling at Supervised, forbid unattended Autonomous execution, and record zero model-provider network calls or sensitive payloads.
- Prevent the pause reconciler from replaying already-handled historical failures after a human recovery, while preserving monotonic lifecycle timestamps.
- Align the checked-in implementation and execution-recovery qualification records with the verified disposable-cluster results.

### How Did You Test This Change?

- `cargo +1.95.0 fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo +1.95.0 check --locked --workspace`
- `cargo +1.95.0 test --locked --workspace --all-features`
- `cargo +1.95.0 clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 doc --locked --workspace --no-deps`
- `python -m unittest discover -s scripts/tests -p 'test_*.py' -v` (28 tests)
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python scripts/check_implementation_status.py`
- `python scripts/check_execution_recovery_qualification.py`
- `python scripts/check_autonomy_action_qualification.py --manifest config/qualification/autonomy-actions.v1.json --report <qualification-report>`
- `rocketmq-sre/scripts/autonomy-action-live-qualification.ps1`: disposable Kind/PostgreSQL qualification passed for 4 actions and 64 outcomes; Phase 00 smoke, persistent lifecycle, recovery, safety denials, and the real Supervised R1 execution chain passed; cleanup completed; model-provider network calls remained zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded-autonomy qualification for four approved actions, covering Shadow observation, supervised execution, safety checks, recovery, and cleanup.
  - Added validation tools and disposable-cluster smoke testing for qualification reports and evidence.
  - Added execution-recovery qualification requirements for controlled actions.

- **Safety Improvements**
  - Autonomous execution remains disabled; supervised mode is the maximum allowed level.
  - Improved pause recovery handling to prevent duplicate repairs and preserve human-approved recovery.

- **Documentation**
  - Added English and Chinese guidance for running qualification and contract checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->