### PR TITLE
[ISSUE #8942]🐛Restore rmcp 3.1 compatibility for MCP and SRE Connector

### DIFF
--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/capability.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/capability.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeSet;
 
 use chrono::DateTime;
 use chrono::Utc;
-use rmcp::model::TaskSupport;
 use rmcp::model::Tool;
 use serde::Deserialize;
 use serde::Serialize;
@@ -195,16 +194,10 @@ pub fn verify_manifest(
                 format!("tool `{}` does not publish read-only annotations", manifest_tool.name),
             )
         })?;
-        if annotations.read_only_hint != Some(true)
-            || annotations.destructive_hint == Some(true)
-            || live_tool.task_support() != TaskSupport::Forbidden
-        {
+        if annotations.read_only_hint != Some(true) || annotations.destructive_hint == Some(true) {
             return Err(ConnectorError::capability(
                 ConnectorErrorCode::CapabilityMismatch,
-                format!(
-                    "tool `{}` live annotations are not read-only and task-forbidden",
-                    manifest_tool.name
-                ),
+                format!("tool `{}` live annotations are not read-only", manifest_tool.name),
             ));
         }
         let schema_digest = digest_value(Value::Object(Map::from_iter([
@@ -309,7 +302,6 @@ mod tests {
     use std::sync::Arc;
 
     use rmcp::model::ToolAnnotations;
-    use rmcp::model::ToolExecution;
     use serde_json::json;
 
     use super::*;
@@ -337,7 +329,6 @@ mod tests {
             Some(true),
             Some(false),
         ))
-        .with_execution(ToolExecution::default())
     }
 
     fn fixture() -> (CapabilityManifest, Vec<Tool>, BTreeSet<String>) {
@@ -398,6 +389,16 @@ mod tests {
         assert_eq!(
             verify_manifest(mutation, "local", &tools, &resources, None)
                 .expect_err("mutation must fail")
+                .code,
+            ConnectorErrorCode::CapabilityMismatch
+        );
+
+        let (mut tasks, tools, resources) = fixture();
+        tasks.tools[0].task_support = "optional".to_owned();
+        tasks.tool_surface_digest = digest_value(serde_json::to_value(&tasks.tools).expect("tools serialize"));
+        assert_eq!(
+            verify_manifest(tasks, "local", &tools, &resources, None)
+                .expect_err("task support must fail")
                 .code,
             ConnectorErrorCode::CapabilityMismatch
         );

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use rmcp::model::CallToolRequestParams;
-use rmcp::model::CallToolResult;
+use rmcp::model::CallToolResponse;
 use rmcp::model::GetPromptRequestParams;
-use rmcp::model::GetPromptResult;
+use rmcp::model::GetPromptResponse;
 use rmcp::model::Implementation;
 use rmcp::model::InitializeRequestParams;
 use rmcp::model::InitializeResult;
@@ -26,6 +26,7 @@ use rmcp::model::ListToolsResult;
 use rmcp::model::PaginatedRequestParams;
 use rmcp::model::ProtocolVersion;
 use rmcp::model::ReadResourceRequestParams;
+use rmcp::model::ReadResourceResponse;
 use rmcp::model::ReadResourceResult;
 use rmcp::model::ServerCapabilities;
 use rmcp::model::ServerInfo;
@@ -169,7 +170,7 @@ impl ServerHandler for RocketmqMcpServer {
         &self,
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
+    ) -> Result<ReadResourceResponse, ErrorData> {
         let operation = crate::resources::uri::RocketmqResourceUri::parse(&request.uri)
             .map(|resource| resource.kind.metric_operation())
             .unwrap_or("invalid_resource_uri");
@@ -255,7 +256,7 @@ impl ServerHandler for RocketmqMcpServer {
         .instrument(span)
         .await;
         span_recorder.observe_call_result(&result);
-        result
+        result.map(Into::into)
     }
 
     async fn list_prompts(
@@ -273,11 +274,11 @@ impl ServerHandler for RocketmqMcpServer {
         &self,
         request: GetPromptRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, ErrorData> {
+    ) -> Result<GetPromptResponse, ErrorData> {
         if !self.app.guard().allows_resources(&self.access_context(&context)?) {
             return Err(ErrorData::invalid_params("prompt access is denied", None));
         }
-        prompts::renderer::get_prompt(request)
+        prompts::renderer::get_prompt(request).map(Into::into)
     }
 
     async fn list_tools(
@@ -297,7 +298,7 @@ impl ServerHandler for RocketmqMcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         let query = self.app.query().as_ref().clone().with_cancellation(context.ct.clone());
         let access = self.access_context(&context)?;
         let result = ToolExecutor::new(query, self.app.guard().clone())
@@ -305,7 +306,7 @@ impl ServerHandler for RocketmqMcpServer {
             .call_with_request_id(request, &request_id_string(&context.id))
             .await;
         self.app.trace_cache_metrics();
-        result
+        result.map(Into::into)
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -147,9 +147,6 @@ expression: surface
         "title": "RocketMQ cluster overview"
       },
       "description": "Summarize brokers, topic count, and consumer group count for one RocketMQ cluster.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -321,9 +318,6 @@ expression: surface
         "title": "RocketMQ topic list"
       },
       "description": "List a bounded page of topics visible from one RocketMQ cluster.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -500,9 +494,6 @@ expression: surface
         "title": "RocketMQ topic description"
       },
       "description": "Describe a topic with bounded queue route information.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -742,9 +733,6 @@ expression: surface
         "title": "RocketMQ topic route"
       },
       "description": "Get bounded topic route data without exposing internal addresses by default.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -977,9 +965,6 @@ expression: surface
         "title": "RocketMQ consumer groups"
       },
       "description": "List a bounded page of consumer groups and consumption summaries.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1172,9 +1157,6 @@ expression: surface
         "title": "RocketMQ consumer lag"
       },
       "description": "Get bounded per-queue lag for a topic and consumer group.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1402,9 +1384,6 @@ expression: surface
         "title": "RocketMQ broker description"
       },
       "description": "Describe broker state without exposing internal addresses by default.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1572,9 +1551,6 @@ expression: surface
         "title": "RocketMQ consumer lag diagnosis"
       },
       "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -147,9 +147,6 @@ expression: surface
         "title": "RocketMQ cluster overview"
       },
       "description": "Summarize brokers, topic count, and consumer group count for one RocketMQ cluster.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -321,9 +318,6 @@ expression: surface
         "title": "RocketMQ topic list"
       },
       "description": "List a bounded page of topics visible from one RocketMQ cluster.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -500,9 +494,6 @@ expression: surface
         "title": "RocketMQ topic description"
       },
       "description": "Describe a topic with bounded queue route information.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -742,9 +733,6 @@ expression: surface
         "title": "RocketMQ topic route"
       },
       "description": "Get bounded topic route data without exposing internal addresses by default.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -977,9 +965,6 @@ expression: surface
         "title": "RocketMQ consumer groups"
       },
       "description": "List a bounded page of consumer groups and consumption summaries.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1172,9 +1157,6 @@ expression: surface
         "title": "RocketMQ consumer lag"
       },
       "description": "Get bounded per-queue lag for a topic and consumer group.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1402,9 +1384,6 @@ expression: surface
         "title": "RocketMQ broker description"
       },
       "description": "Describe broker state without exposing internal addresses by default.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -1572,9 +1551,6 @@ expression: surface
         "title": "RocketMQ consumer lag diagnosis"
       },
       "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
@@ -2077,9 +2053,6 @@ expression: surface
         "title": "RocketMQ create topic plan"
       },
       "description": "Generate a non-mutating topic creation plan.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$defs": {
           "CreateTopicDesiredState": {
@@ -2301,9 +2274,6 @@ expression: surface
         "title": "RocketMQ topic configuration plan"
       },
       "description": "Generate a non-mutating topic configuration update plan.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$defs": {
           "UpdateTopicConfigDesiredState": {
@@ -2508,9 +2478,6 @@ expression: surface
         "title": "RocketMQ topic permission plan"
       },
       "description": "Generate a non-mutating topic permission update plan.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$defs": {
           "UpdateTopicPermissionsDesiredState": {
@@ -2711,9 +2678,6 @@ expression: surface
         "title": "RocketMQ broker configuration plan"
       },
       "description": "Generate a non-mutating broker configuration update plan.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$defs": {
           "UpdateBrokerConfigDesiredState": {
@@ -2918,9 +2882,6 @@ expression: surface
         "title": "RocketMQ consumer offset reset plan"
       },
       "description": "Generate a non-mutating consumer offset reset plan.",
-      "execution": {
-        "taskSupport": "forbidden"
-      },
       "inputSchema": {
         "$defs": {
           "ResetConsumerOffsetDesiredState": {

--- a/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/registry.rs
@@ -61,11 +61,9 @@ pub fn list_resources_for(
         );
     }
     let page = discovery_page(resources, request)?;
-    Ok(ListResourcesResult {
-        meta: None,
-        next_cursor: page.next_cursor,
-        resources: page.items,
-    })
+    let mut result = ListResourcesResult::with_all_items(page.items);
+    result.next_cursor = page.next_cursor;
+    Ok(result)
 }
 
 pub fn list_resource_templates(
@@ -104,11 +102,9 @@ pub fn list_resource_templates(
         ),
     ];
     let page = discovery_page(templates, request)?;
-    Ok(ListResourceTemplatesResult {
-        meta: None,
-        next_cursor: page.next_cursor,
-        resource_templates: page.items,
-    })
+    let mut result = ListResourceTemplatesResult::with_all_items(page.items);
+    result.next_cursor = page.next_cursor;
+    Ok(result)
 }
 
 fn resource_descriptor(uri: RocketmqResourceUri) -> Resource {

--- a/rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 use rmcp::model::ListToolsResult;
-use rmcp::model::TaskSupport;
 use rmcp::model::Tool;
 use rmcp::model::ToolAnnotations;
-use rmcp::model::ToolExecution;
 use schemars::JsonSchema;
 
 use crate::guard::RiskLevel;
@@ -277,7 +275,6 @@ impl ToolDescriptor {
                     .idempotent(self.annotations.idempotent)
                     .open_world(self.annotations.open_world),
             )
-            .with_execution(ToolExecution::new().with_task_support(TaskSupport::Forbidden))
     }
 }
 
@@ -320,6 +317,11 @@ mod tests {
             let tool = get_tool(descriptor.name).expect("catalog tool");
             assert_eq!(tool.name, descriptor.name);
             assert!(tool.output_schema.is_some());
+            let wire = serde_json::to_value(&tool).expect("tool serializes");
+            assert!(
+                wire.get("execution").is_none(),
+                "rmcp 3.1 tools must not expose a task-capable execution surface"
+            );
             assert!(matches!(
                 descriptor.risk_level,
                 RiskLevel::ReadOnly | RiskLevel::Diagnose | RiskLevel::Plan

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -1,6 +1,5 @@
 ---
-source: rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
-assertion_line: 361
+source: src/tools/catalog.rs
 expression: contracts
 ---
 [
@@ -13,9 +12,6 @@ expression: contracts
       "title": "RocketMQ cluster overview"
     },
     "description": "Summarize brokers, topic count, and consumer group count for one RocketMQ cluster.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -187,9 +183,6 @@ expression: contracts
       "title": "RocketMQ topic list"
     },
     "description": "List a bounded page of topics visible from one RocketMQ cluster.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -366,9 +359,6 @@ expression: contracts
       "title": "RocketMQ topic description"
     },
     "description": "Describe a topic with bounded queue route information.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -608,9 +598,6 @@ expression: contracts
       "title": "RocketMQ topic route"
     },
     "description": "Get bounded topic route data without exposing internal addresses by default.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -843,9 +830,6 @@ expression: contracts
       "title": "RocketMQ consumer groups"
     },
     "description": "List a bounded page of consumer groups and consumption summaries.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1038,9 +1022,6 @@ expression: contracts
       "title": "RocketMQ consumer lag"
     },
     "description": "Get bounded per-queue lag for a topic and consumer group.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1268,9 +1249,6 @@ expression: contracts
       "title": "RocketMQ broker description"
     },
     "description": "Describe broker state without exposing internal addresses by default.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1438,9 +1416,6 @@ expression: contracts
       "title": "RocketMQ consumer lag diagnosis"
     },
     "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,

--- a/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -1,6 +1,5 @@
 ---
-source: rocketmq-tools/rocketmq-mcp/src/tools/catalog.rs
-assertion_line: 364
+source: src/tools/catalog.rs
 expression: contracts
 ---
 [
@@ -13,9 +12,6 @@ expression: contracts
       "title": "RocketMQ cluster overview"
     },
     "description": "Summarize brokers, topic count, and consumer group count for one RocketMQ cluster.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -187,9 +183,6 @@ expression: contracts
       "title": "RocketMQ topic list"
     },
     "description": "List a bounded page of topics visible from one RocketMQ cluster.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -366,9 +359,6 @@ expression: contracts
       "title": "RocketMQ topic description"
     },
     "description": "Describe a topic with bounded queue route information.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -608,9 +598,6 @@ expression: contracts
       "title": "RocketMQ topic route"
     },
     "description": "Get bounded topic route data without exposing internal addresses by default.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -843,9 +830,6 @@ expression: contracts
       "title": "RocketMQ consumer groups"
     },
     "description": "List a bounded page of consumer groups and consumption summaries.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1038,9 +1022,6 @@ expression: contracts
       "title": "RocketMQ consumer lag"
     },
     "description": "Get bounded per-queue lag for a topic and consumer group.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1268,9 +1249,6 @@ expression: contracts
       "title": "RocketMQ broker description"
     },
     "description": "Describe broker state without exposing internal addresses by default.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1438,9 +1416,6 @@ expression: contracts
       "title": "RocketMQ consumer lag diagnosis"
     },
     "description": "Diagnose consumer lag from read-only lag, topic route, and broker evidence.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -1943,9 +1918,6 @@ expression: contracts
       "title": "RocketMQ create topic plan"
     },
     "description": "Generate a non-mutating topic creation plan.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$defs": {
         "CreateTopicDesiredState": {
@@ -2167,9 +2139,6 @@ expression: contracts
       "title": "RocketMQ topic configuration plan"
     },
     "description": "Generate a non-mutating topic configuration update plan.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$defs": {
         "UpdateTopicConfigDesiredState": {
@@ -2374,9 +2343,6 @@ expression: contracts
       "title": "RocketMQ topic permission plan"
     },
     "description": "Generate a non-mutating topic permission update plan.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$defs": {
         "UpdateTopicPermissionsDesiredState": {
@@ -2577,9 +2543,6 @@ expression: contracts
       "title": "RocketMQ broker configuration plan"
     },
     "description": "Generate a non-mutating broker configuration update plan.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$defs": {
         "UpdateBrokerConfigDesiredState": {
@@ -2784,9 +2747,6 @@ expression: contracts
       "title": "RocketMQ consumer offset reset plan"
     },
     "description": "Generate a non-mutating consumer offset reset plan.",
-    "execution": {
-      "taskSupport": "forbidden"
-    },
     "inputSchema": {
       "$defs": {
         "ResetConsumerOffsetDesiredState": {

--- a/rocketmq-tools/rocketmq-mcp/src/transport/streamable_http.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/transport/streamable_http.rs
@@ -220,7 +220,7 @@ fn streamable_server_config(
 ) -> StreamableHttpServerConfig {
     let mut server_config = StreamableHttpServerConfig::default()
         .with_allowed_hosts(allowed_hosts(&http_config))
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_cancellation_token(cancellation_token);
 
@@ -341,7 +341,7 @@ mod tests {
 
         assert!(server_config.allowed_origins.contains(&"https://localhost".to_string()));
         assert!(server_config.json_response);
-        assert!(!server_config.stateful_mode);
+        assert!(!server_config.legacy_session_mode);
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8942

### Brief Description

Updates the standalone RocketMQ MCP server and AI SRE Connector for the rmcp 3.1 API surface. The MCP handler now returns the response enums introduced by rmcp 3.1, resource discovery initializes the extended result metadata through the public constructors, and Streamable HTTP preserves stateless legacy-protocol behavior through the renamed configuration field.

The removed per-tool `execution` wire field is no longer emitted, while the signed MCP capability manifest and Connector verification continue to require `task_support=forbidden`, read-only annotations, non-destructive tools, matching schema digests, and `mutation_supported=false`. Default and change-planning protocol snapshots were refreshed to record only that rmcp wire-format change.

### How Did You Test This Change?

- `cargo fmt --all -- --check` in `rocketmq-tools/rocketmq-mcp`: passed.
- `cargo check --locked` in `rocketmq-tools/rocketmq-mcp`: passed.
- `python scripts/check_read_only_boundary.py` in `rocketmq-tools/rocketmq-mcp`: passed.
- `cargo test --locked` in `rocketmq-tools/rocketmq-mcp`: passed.
- `cargo test --locked --all-features` in `rocketmq-tools/rocketmq-mcp`: passed.
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` in `rocketmq-tools/rocketmq-mcp`: passed.
- `cargo doc --locked --no-deps` in `rocketmq-tools/rocketmq-mcp`: passed.
- The package-scoped `cargo fmt ... -- --check` command from `rocketmq-sre/AGENTS.md`: passed.
- `cargo check --locked --workspace` in `rocketmq-sre`: passed.
- `cargo test --locked --workspace --all-features` in `rocketmq-sre`: passed.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` in `rocketmq-sre`: passed.
- `cargo doc --locked --workspace --no-deps` in `rocketmq-sre`: passed.
- `python scripts/check_source_layout.py` in `rocketmq-sre`: passed.
- `python scripts/check_execution_dependency_boundary.py` in `rocketmq-sre`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MCP resource, prompt, and tool responses for improved protocol compatibility.
  * Preserved resource and template listings while refining pagination handling.
  * Removed unsupported task-execution metadata from generated tools and validation.
  * Added validation for manifests declaring prohibited task-support capabilities.
  * Disabled legacy session mode for streamable HTTP transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->