### PR TITLE
[ISSUE #8956]✨Qualify stale-epoch fencing under asymmetric Executor partitions

### DIFF
--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -180,6 +180,22 @@
           "path": "rocketmq-sre/config/qualification/execution-recovery.v1.json"
         },
         {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/asymmetric-executor-partition.v1.json"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/asymmetric_partition.rs"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_asymmetric_executor_partition_qualification.py"
+        },
+        {
           "kind": "test",
           "path": "rocketmq-sre/scripts/check_execution_recovery_qualification.py"
         },
@@ -371,7 +387,7 @@
         }
       ],
       "limitations": [
-        "Current/N-1 native binaries, two independent Kubernetes regions, the sixteen-scenario Kubernetes fault matrix, synchronous PostgreSQL failover, object recovery, and Control Plane backup/restore have passed disposable-environment qualification.",
+        "Current/N-1 native binaries, two independent Kubernetes regions, the sixteen-scenario Kubernetes fault matrix, synchronous PostgreSQL failover, object recovery, Control Plane backup/restore, and stale-epoch fencing under an asymmetric Executor partition have passed disposable-environment qualification.",
         "Deployment-specific production certification, sustained load, soak, and independent operator handoff evidence remain incomplete."
       ]
     },

--- a/rocketmq-sre/config/qualification/asymmetric-executor-partition.v1.json
+++ b/rocketmq-sre/config/qualification/asymmetric-executor-partition.v1.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "rocketmq-sre.asymmetric-executor-partition-qualification.v1",
+  "environment": "docker_postgresql_http_partition",
+  "operating_mode": "rules_only",
+  "production_certified": false,
+  "model_provider_network_calls": false,
+  "unattended_autonomous_execution": false,
+  "required_assertions": {
+    "old_executor_authority_reachable_after_partition": false,
+    "old_executor_agent_reachable_after_partition": true,
+    "agent_authority_reachable_during_takeover": true,
+    "new_epoch_greater_than_old_epoch": true,
+    "stale_dispatch_rejected": true,
+    "stale_effect_rows": 0,
+    "stale_target_writes": 0,
+    "fresh_target_writes": 1,
+    "minimum_fence_rejections": 1
+  },
+  "repository_evidence": {
+    "test_path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/asymmetric_partition.rs",
+    "test": "old_executor_cannot_write_after_asymmetric_authority_partition_and_epoch_takeover",
+    "runner": "rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_asymmetric_executor_partition_qualification.py"
+  },
+  "live_report": {
+    "schema_version": "rocketmq-sre.asymmetric-executor-partition-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/config/qualification/execution-recovery.v1.json
+++ b/rocketmq-sre/config/qualification/execution-recovery.v1.json
@@ -38,6 +38,18 @@
       "test": "rollback_failure_atomically_escalates_quarantines_and_notifies"
     }
   },
+  "asymmetric_partition_live_qualification": {
+    "manifest": "rocketmq-sre/config/qualification/asymmetric-executor-partition.v1.json",
+    "script": "rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_asymmetric_executor_partition_qualification.py",
+    "test_path": "rocketmq-sre/crates/rocketmq-sre-executor/tests/asymmetric_partition.rs",
+    "test": "old_executor_cannot_write_after_asymmetric_authority_partition_and_epoch_takeover",
+    "stale_effect_rows": 0,
+    "stale_target_writes": 0,
+    "fresh_target_writes": 1,
+    "model_provider_network_calls": false,
+    "production_certified": false
+  },
   "r1_live_qualification": {
     "manifest": "rocketmq-sre/config/qualification/r1-actions.v1.json",
     "script": "rocketmq-sre/scripts/r1-action-live-qualification.ps1",

--- a/rocketmq-sre/crates/rocketmq-sre-executor/tests/asymmetric_partition.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-executor/tests/asymmetric_partition.rs
@@ -1,0 +1,591 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "postgres_recovery/support.rs"]
+#[allow(
+    dead_code,
+    reason = "this focused integration target reuses only the PostgreSQL fixture helpers needed for fencing"
+)]
+mod support;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::http::StatusCode;
+use axum::routing::post;
+use chrono::TimeDelta;
+use chrono::Utc;
+use rocketmq_sre_contracts::AdvanceFenceRequest;
+use rocketmq_sre_contracts::AgentDispatchAuthorization;
+use rocketmq_sre_contracts::AgentDispatchRequest;
+use rocketmq_sre_contracts::AgentReadRequest;
+use rocketmq_sre_contracts::AgentReadResult;
+use rocketmq_sre_contracts::AgentStepRequest;
+use rocketmq_sre_contracts::EffectState;
+use rocketmq_sre_contracts::FenceAck;
+use rocketmq_sre_contracts::GrantVerification;
+use rocketmq_sre_contracts::IssueFenceGrantRequest;
+use rocketmq_sre_contracts::LEASE_AUTHORITY_SCHEMA_VERSION;
+use rocketmq_sre_contracts::LeaseFenceGrant;
+use rocketmq_sre_contracts::ReconcileEffectResponse;
+use rocketmq_sre_contracts::ReconcileEffectState;
+use rocketmq_sre_contracts::ReconcileGrant;
+use rocketmq_sre_contracts::VerifyFenceGrantRequest;
+use rocketmq_sre_contracts::VerifyReconcileGrantRequest;
+use rocketmq_sre_execution_agent::AgentActionHandler;
+use rocketmq_sre_execution_agent::AgentDriverRegistry;
+use rocketmq_sre_execution_agent::AgentEffectStore;
+use rocketmq_sre_execution_agent::DispatchBarrier;
+use rocketmq_sre_execution_agent::DriverDispatchOutcome;
+use rocketmq_sre_execution_agent::DriverFuture;
+use rocketmq_sre_execution_agent::ExecutionAgent;
+use rocketmq_sre_execution_agent::FenceAckSigner;
+use rocketmq_sre_execution_agent::HttpLeaseAuthorityClient;
+use rocketmq_sre_executor::ExecutionAgentClient;
+use rocketmq_sre_executor::ExecutionJournal;
+use rocketmq_sre_executor::ExecutorAuthorityClient;
+use rocketmq_sre_executor::ExecutorError;
+use rocketmq_sre_executor::HttpExecutionAgentClient;
+use rocketmq_sre_executor::HttpExecutorAuthorityClient;
+use rocketmq_sre_executor::LeaseCoordinator;
+use tokio::io::copy_bidirectional;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::task::JoinSet;
+use url::Url;
+use uuid::Uuid;
+
+use support::cleanup_schema;
+use support::isolated_pool;
+use support::seed_fixture;
+use support::step_intent;
+
+const AUTHORITY_TOKEN: &str = "partition-authority-fixture-token";
+const AGENT_TOKEN: &str = "partition-agent-fixture-token";
+const OLD_EXECUTOR_SUBJECT: &str = "executor-before-partition";
+const AGENT_SUBJECT: &str = "execution-agent-partition-fixture";
+
+#[derive(Clone)]
+struct AuthorityState {
+    tenant_id: rocketmq_sre_contracts::TenantId,
+    cluster_id: rocketmq_sre_contracts::ClusterId,
+    active_epoch: Arc<AtomicU64>,
+    pending_epoch: Arc<AtomicU64>,
+    old_grant: Arc<LeaseFenceGrant>,
+    agent_verifications: Arc<AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct CountingDriver {
+    writes: Arc<AtomicUsize>,
+}
+
+impl AgentActionHandler for CountingDriver {
+    fn read_state<'a>(&'a self, request: &'a AgentReadRequest) -> DriverFuture<'a, AgentReadResult> {
+        Box::pin(async move {
+            Ok(AgentReadResult {
+                schema_version: rocketmq_sre_contracts::EXECUTION_AGENT_SCHEMA_VERSION.to_owned(),
+                action: request.action,
+                target: request.target.clone(),
+                precondition_hash: format!("sha256:{}", "a".repeat(64)),
+                ready: true,
+                reason_codes: Vec::new(),
+                resource_conditions: Default::default(),
+                observed_at: Utc::now(),
+            })
+        })
+    }
+
+    fn dispatch<'a>(
+        &'a self,
+        _request: &'a AgentStepRequest,
+        operation_id: &'a str,
+    ) -> DriverFuture<'a, DriverDispatchOutcome> {
+        let writes = Arc::clone(&self.writes);
+        let operation_id = operation_id.to_owned();
+        Box::pin(async move {
+            writes.fetch_add(1, Ordering::SeqCst);
+            Ok(DriverDispatchOutcome {
+                operation_id,
+                outcome_code: "applied".to_owned(),
+                sanitized_summary: "one bounded partition qualification effect was applied".to_owned(),
+            })
+        })
+    }
+
+    fn reconcile<'a>(
+        &'a self,
+        _request: &'a AgentReadRequest,
+        _operation_id: Option<&str>,
+    ) -> DriverFuture<'a, ReconcileEffectResponse> {
+        Box::pin(async {
+            Ok(ReconcileEffectResponse {
+                schema_version: rocketmq_sre_contracts::EXECUTION_AGENT_SCHEMA_VERSION.to_owned(),
+                state: ReconcileEffectState::Applied,
+                outcome_code: "applied".to_owned(),
+                sanitized_summary: "bounded target state confirms the effect".to_owned(),
+                observed_at: Utc::now(),
+            })
+        })
+    }
+
+    fn compensate<'a>(
+        &'a self,
+        _request: &'a AgentStepRequest,
+        operation_id: &'a str,
+    ) -> DriverFuture<'a, DriverDispatchOutcome> {
+        let operation_id = operation_id.to_owned();
+        Box::pin(async move {
+            Ok(DriverDispatchOutcome {
+                operation_id,
+                outcome_code: "compensated".to_owned(),
+                sanitized_summary: "bounded partition qualification effect was compensated".to_owned(),
+            })
+        })
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires ROCKETMQ_SRE_TEST_DATABASE_URL pointing to disposable Docker PostgreSQL"]
+async fn old_executor_cannot_write_after_asymmetric_authority_partition_and_epoch_takeover() {
+    let database_url = std::env::var("ROCKETMQ_SRE_TEST_DATABASE_URL").expect("test database URL must be explicit");
+    let schema = format!("asymmetric_fence_{}", Uuid::new_v4().simple());
+    let pool = isolated_pool(&database_url, &schema).await;
+    sqlx::migrate!("../../migrations")
+        .run(&pool)
+        .await
+        .expect("empty-schema migrations");
+    let fixture = seed_fixture(&pool).await;
+    seed_execution(&pool, &fixture).await;
+    let leases = LeaseCoordinator::new(pool.clone());
+    let store = AgentEffectStore::new(pool.clone());
+    let now = Utc::now();
+    let old_lease = activate_initial_lease(&leases, &store, &fixture, now).await;
+    let old_intent = step_intent(
+        &fixture,
+        old_lease.id,
+        old_lease.epoch,
+        &old_lease.owner,
+        old_lease.expires_at,
+        "asymmetric-stale-dispatch",
+        now + TimeDelta::seconds(1),
+    );
+    let old_grant_request = issue_request(&fixture, &old_intent);
+    let authority_state = AuthorityState {
+        tenant_id: fixture.tenant_id,
+        cluster_id: fixture.cluster_id,
+        active_epoch: Arc::new(AtomicU64::new(old_lease.epoch.0)),
+        pending_epoch: Arc::new(AtomicU64::new(0)),
+        old_grant: Arc::new(old_intent.fence_grant.clone()),
+        agent_verifications: Arc::new(AtomicUsize::new(0)),
+    };
+    let authority_router = Router::new()
+        .route(
+            "/internal/v1/execution-authority/leases/fence-grant",
+            post(issue_old_grant),
+        )
+        .route(
+            "/internal/v1/execution-authority/verify/fence-grant",
+            post(verify_fence_grant),
+        )
+        .route(
+            "/internal/v1/execution-authority/verify/reconcile-grant",
+            post(verify_reconcile_grant),
+        )
+        .with_state(authority_state.clone());
+    let authority = start_http_server(authority_router).await;
+    let (old_authority_url, partition, partition_task) = start_partitionable_proxy(authority.address).await;
+    let old_authority = HttpExecutorAuthorityClient::new(
+        old_authority_url,
+        AUTHORITY_TOKEN,
+        OLD_EXECUTOR_SUBJECT,
+        Duration::from_secs(2),
+        true,
+    )
+    .expect("old Executor authority client");
+    let old_grant = old_authority
+        .issue_fence_grant(&old_grant_request)
+        .await
+        .expect("epoch-N grant before partition");
+    assert_eq!(old_grant, old_intent.fence_grant);
+
+    let writes = Arc::new(AtomicUsize::new(0));
+    let mut registry = AgentDriverRegistry::empty();
+    registry
+        .register_kubernetes(
+            fixture.plan.steps[0].action,
+            CountingDriver {
+                writes: Arc::clone(&writes),
+            },
+        )
+        .expect("closed qualification driver registration");
+    let agent_authority = Arc::new(
+        HttpLeaseAuthorityClient::new(
+            authority.url.clone(),
+            AUTHORITY_TOKEN,
+            AGENT_SUBJECT,
+            Duration::from_secs(2),
+            true,
+        )
+        .expect("Agent authority client"),
+    );
+    let agent = ExecutionAgent::new(
+        store.clone(),
+        DispatchBarrier::new(pool.clone()),
+        agent_authority,
+        registry,
+        FenceAckSigner::new("partition-agent-signing-key-at-least-32-bytes", AGENT_SUBJECT).expect("Agent signer"),
+        Duration::from_secs(5),
+    );
+    let agent_metrics = agent.clone();
+    let agent_server = start_http_server(rocketmq_sre_execution_agent::build_router(agent, AGENT_TOKEN, false)).await;
+    let old_agent = HttpExecutionAgentClient::new(agent_server.url.clone(), AGENT_TOKEN, Duration::from_secs(3), true)
+        .expect("old Executor Agent client");
+    old_agent
+        .capabilities()
+        .await
+        .expect("Agent reachable before partition");
+
+    partition.send(true).expect("partition control receiver");
+    partition_task.await.expect("partition proxy task");
+    assert!(matches!(
+        old_authority.issue_fence_grant(&old_grant_request).await,
+        Err(ExecutorError::Http(_) | ExecutorError::AuthorityUnavailable)
+    ));
+    old_agent
+        .capabilities()
+        .await
+        .expect("old Executor retains Agent reachability after authority partition");
+
+    let new_lease = leases
+        .begin_takeover(
+            fixture.tenant_id,
+            fixture.cluster_id,
+            "executor-after-partition",
+            "pending-after-partition",
+            now + TimeDelta::seconds(2),
+            now + TimeDelta::minutes(10),
+        )
+        .await
+        .expect("new pending epoch");
+    assert!(new_lease.epoch > old_lease.epoch);
+    authority_state.pending_epoch.store(new_lease.epoch.0, Ordering::SeqCst);
+    let reconcile_grant = ReconcileGrant {
+        lease_id: new_lease.id,
+        owner: new_lease.owner.clone(),
+        cluster_id: new_lease.cluster_id,
+        pending_epoch: new_lease.epoch,
+        audience: "rocketmq-sre-execution-agent-reconcile".to_owned(),
+        issued_at: new_lease.acquired_at,
+        expires_at: new_lease.expires_at,
+        nonce: new_lease.pending_nonce.clone(),
+        signature: "partition-reconcile-fixture-signature".to_owned(),
+    };
+    let fence_ack = old_agent
+        .advance_fence(&AdvanceFenceRequest {
+            schema_version: rocketmq_sre_contracts::EXECUTION_AGENT_SCHEMA_VERSION.to_owned(),
+            tenant_id: fixture.tenant_id,
+            reconcile_grant,
+        })
+        .await
+        .expect("Agent advances durable fence through its independent authority path")
+        .fence_ack;
+    leases
+        .activate(&new_lease, &fence_ack)
+        .await
+        .expect("new epoch activation");
+    authority_state.active_epoch.store(new_lease.epoch.0, Ordering::SeqCst);
+    authority_state.pending_epoch.store(0, Ordering::SeqCst);
+
+    let stale_request = dispatch_request(&fixture, old_intent);
+    assert!(matches!(
+        old_agent.dispatch(&stale_request).await,
+        Err(ExecutorError::AgentRejected)
+    ));
+    let stale_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM execution_agent_effects WHERE idempotency_key = $1")
+        .bind("asymmetric-stale-dispatch")
+        .fetch_one(&pool)
+        .await
+        .expect("stale effect count");
+    assert_eq!(stale_rows, 0);
+    assert_eq!(writes.load(Ordering::SeqCst), 0);
+
+    let fresh_intent = step_intent(
+        &fixture,
+        new_lease.id,
+        new_lease.epoch,
+        &new_lease.owner,
+        new_lease.expires_at,
+        "asymmetric-fresh-dispatch",
+        now + TimeDelta::seconds(3),
+    );
+    let fresh = old_agent
+        .dispatch(&dispatch_request(&fixture, fresh_intent))
+        .await
+        .expect("fresh epoch dispatch remains available");
+    assert_eq!(fresh.result.state, EffectState::Confirmed);
+    assert!(!fresh.replayed);
+    assert_eq!(writes.load(Ordering::SeqCst), 1);
+    let metrics = agent_metrics.metrics();
+    assert!(metrics.fence_rejections_total >= 1);
+    assert!(authority_state.agent_verifications.load(Ordering::SeqCst) >= 3);
+
+    println!(
+        "ASYMMETRIC_EXECUTOR_PARTITION_OK old_authority_reachable=false \
+         old_agent_reachable=true agent_authority_reachable=true old_epoch={} active_epoch={} \
+         stale_dispatch_rejected=true stale_effect_rows={} stale_target_writes=0 \
+         fresh_target_writes={} fence_rejections={}",
+        old_lease.epoch.0,
+        new_lease.epoch.0,
+        stale_rows,
+        writes.load(Ordering::SeqCst),
+        metrics.fence_rejections_total,
+    );
+
+    agent_server.stop().await;
+    authority.stop().await;
+    cleanup_schema(&pool, &schema).await;
+}
+
+async fn issue_old_grant(
+    State(state): State<AuthorityState>,
+    headers: HeaderMap,
+    Json(request): Json<IssueFenceGrantRequest>,
+) -> Result<Json<LeaseFenceGrant>, StatusCode> {
+    require_identity(&headers, OLD_EXECUTOR_SUBJECT)?;
+    let grant = state.old_grant.as_ref();
+    if request.tenant_id != state.tenant_id
+        || request.cluster_id != state.cluster_id
+        || request.lease_id != grant.lease_id
+        || request.epoch.0 != state.active_epoch.load(Ordering::SeqCst)
+        || request.execution_id != grant.execution_id
+        || request.step_id != grant.step_id
+        || request.plan_step_id != grant.plan_step_id
+        || request.compensation != grant.compensation
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    Ok(Json(grant.clone()))
+}
+
+async fn verify_fence_grant(
+    State(state): State<AuthorityState>,
+    headers: HeaderMap,
+    Json(request): Json<VerifyFenceGrantRequest>,
+) -> Result<Json<GrantVerification>, StatusCode> {
+    require_identity(&headers, AGENT_SUBJECT)?;
+    if request.tenant_id != state.tenant_id
+        || request.grant.cluster_id != state.cluster_id
+        || request.grant.epoch.0 != state.active_epoch.load(Ordering::SeqCst)
+        || request.grant.expires_at <= Utc::now()
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    state.agent_verifications.fetch_add(1, Ordering::SeqCst);
+    Ok(Json(GrantVerification {
+        schema_version: LEASE_AUTHORITY_SCHEMA_VERSION.to_owned(),
+        valid: true,
+        cluster_id: request.grant.cluster_id,
+        epoch: request.grant.epoch,
+        expires_at: request.grant.expires_at,
+    }))
+}
+
+async fn verify_reconcile_grant(
+    State(state): State<AuthorityState>,
+    headers: HeaderMap,
+    Json(request): Json<VerifyReconcileGrantRequest>,
+) -> Result<Json<GrantVerification>, StatusCode> {
+    require_identity(&headers, AGENT_SUBJECT)?;
+    if request.tenant_id != state.tenant_id
+        || request.grant.cluster_id != state.cluster_id
+        || request.grant.pending_epoch.0 != state.pending_epoch.load(Ordering::SeqCst)
+        || request.grant.expires_at <= Utc::now()
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    state.agent_verifications.fetch_add(1, Ordering::SeqCst);
+    Ok(Json(GrantVerification {
+        schema_version: LEASE_AUTHORITY_SCHEMA_VERSION.to_owned(),
+        valid: true,
+        cluster_id: request.grant.cluster_id,
+        epoch: request.grant.pending_epoch,
+        expires_at: request.grant.expires_at,
+    }))
+}
+
+fn require_identity(headers: &HeaderMap, expected_subject: &str) -> Result<(), StatusCode> {
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+    let subject = headers.get("x-rocketmq-subject").and_then(|value| value.to_str().ok());
+    if bearer != Some(&format!("Bearer {AUTHORITY_TOKEN}")) || subject != Some(expected_subject) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(())
+}
+
+fn issue_request(fixture: &support::Fixture, intent: &rocketmq_sre_contracts::StepIntent) -> IssueFenceGrantRequest {
+    IssueFenceGrantRequest {
+        schema_version: LEASE_AUTHORITY_SCHEMA_VERSION.to_owned(),
+        tenant_id: fixture.tenant_id,
+        cluster_id: fixture.cluster_id,
+        lease_id: intent.fence_grant.lease_id,
+        epoch: intent.fence_grant.epoch,
+        execution_id: intent.execution_id,
+        step_id: intent.step_id,
+        plan_step_id: intent.step.id,
+        compensation: false,
+    }
+}
+
+fn dispatch_request(fixture: &support::Fixture, intent: rocketmq_sre_contracts::StepIntent) -> AgentDispatchRequest {
+    AgentDispatchRequest {
+        schema_version: rocketmq_sre_contracts::EXECUTION_AGENT_SCHEMA_VERSION.to_owned(),
+        tenant_id: fixture.tenant_id,
+        plan_id: Some(fixture.plan.id),
+        authorization: AgentDispatchAuthorization::HumanApproved,
+        request: AgentStepRequest {
+            action: intent.step.action,
+            descriptor_version: intent.step.descriptor_version.clone(),
+            target: intent.step.resource.clone(),
+            parameters: intent.step.parameters.clone(),
+            intent,
+        },
+    }
+}
+
+async fn activate_initial_lease(
+    leases: &LeaseCoordinator,
+    store: &AgentEffectStore,
+    fixture: &support::Fixture,
+    now: chrono::DateTime<Utc>,
+) -> rocketmq_sre_executor::ExecutorLeaseRecord {
+    let pending = leases
+        .begin_takeover(
+            fixture.tenant_id,
+            fixture.cluster_id,
+            OLD_EXECUTOR_SUBJECT,
+            "pending-before-partition",
+            now,
+            now + TimeDelta::minutes(10),
+        )
+        .await
+        .expect("initial pending lease");
+    let ack = FenceAck {
+        cluster_id: fixture.cluster_id,
+        epoch: pending.epoch,
+        pending_nonce: pending.pending_nonce.clone(),
+        agent_subject: AGENT_SUBJECT.to_owned(),
+        acknowledged_at: now + TimeDelta::milliseconds(1),
+        signature: "initial-fence-fixture-signature".to_owned(),
+    };
+    store
+        .accept_fence(fixture.tenant_id, pending.id, &ack)
+        .await
+        .expect("initial durable Agent fence");
+    leases.activate(&pending, &ack).await.expect("initial active lease")
+}
+
+async fn seed_execution(pool: &sqlx::PgPool, fixture: &support::Fixture) {
+    ExecutionJournal::new(pool.clone(), "rocketmq-sre-executor")
+        .create_execution(
+            &fixture.request,
+            &fixture.plan.steps[0].resource,
+            fixture.plan.steps[0].action,
+            Utc::now(),
+        )
+        .await
+        .expect("durable execution before Agent effect");
+}
+
+struct RunningServer {
+    address: SocketAddr,
+    url: Url,
+    shutdown: oneshot::Sender<()>,
+    task: JoinHandle<()>,
+}
+
+impl RunningServer {
+    async fn stop(self) {
+        let _ = self.shutdown.send(());
+        self.task.await.expect("HTTP server task");
+    }
+}
+
+async fn start_http_server(router: Router) -> RunningServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("ephemeral HTTP listener");
+    let address = listener.local_addr().expect("HTTP listener address");
+    let url = Url::parse(&format!("http://{address}/")).expect("loopback URL");
+    let (shutdown, stopped) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = stopped.await;
+            })
+            .await
+            .expect("qualification HTTP server");
+    });
+    RunningServer {
+        address,
+        url,
+        shutdown,
+        task,
+    }
+}
+
+async fn start_partitionable_proxy(target: SocketAddr) -> (Url, watch::Sender<bool>, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("partition proxy listener");
+    let address = listener.local_addr().expect("partition proxy address");
+    let url = Url::parse(&format!("http://{address}/")).expect("partition proxy URL");
+    let (partition, mut partitioned) = watch::channel(false);
+    let task = tokio::spawn(async move {
+        let mut connections = JoinSet::new();
+        loop {
+            tokio::select! {
+                accept = listener.accept() => {
+                    let Ok((mut inbound, _)) = accept else {
+                        break;
+                    };
+                    connections.spawn(async move {
+                        if let Ok(mut outbound) = TcpStream::connect(target).await {
+                            let _ = copy_bidirectional(&mut inbound, &mut outbound).await;
+                        }
+                    });
+                }
+                changed = partitioned.changed() => {
+                    if changed.is_err() || *partitioned.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
+    });
+    (url, partition, task)
+}

--- a/rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1
+++ b/rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1
@@ -1,0 +1,215 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Check', 'Run')]
+    [string]$Mode = 'Run',
+
+    [string]$CargoTargetDir = 'D:\BuildCache\rocketmq-sre-asymmetric-executor-partition',
+
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+
+    [string]$PostgresImage = 'postgres:17-alpine'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$manifestPath = Join-Path $sreRoot 'config\qualification\asymmetric-executor-partition.v1.json'
+$checkerPath = Join-Path $scriptDirectory 'check_asymmetric_executor_partition_qualification.py'
+
+function Assert-DataPath([string]$Path, [string]$Description) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
+    }
+}
+
+function Invoke-Native([string]$Command, [string[]]$Arguments, [string]$Description) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+Assert-DataPath $CargoTargetDir 'Cargo target directory'
+Assert-DataPath $EvidenceRoot 'qualification Evidence root'
+$resolvedTarget = [IO.Path]::GetFullPath($CargoTargetDir)
+$resolvedEvidenceRoot = [IO.Path]::GetFullPath($EvidenceRoot).TrimEnd('\')
+$allowedEvidenceRoots = @(
+    [IO.Path]::GetFullPath('D:\rocketmq-sre-evidence').TrimEnd('\'),
+    [IO.Path]::GetFullPath('F:\rocketmq-sre-evidence').TrimEnd('\')
+)
+if (-not ($allowedEvidenceRoots -contains $resolvedEvidenceRoot)) {
+    throw 'Qualification reports must use D:\rocketmq-sre-evidence or F:\rocketmq-sre-evidence.'
+}
+
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath) `
+    'asymmetric Executor partition manifest validation'
+if ($Mode -eq 'Check') {
+    Write-Host 'ASYMMETRIC_EXECUTOR_PARTITION_CHECK_OK'
+    exit 0
+}
+
+$revision = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to determine the qualification source revision.'
+}
+$dirty = & git -C $repositoryRoot status --porcelain=v1
+if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($dirty -join ''))) {
+    throw 'Asymmetric Executor partition qualification requires a committed, clean source tree.'
+}
+
+$startedAt = [DateTimeOffset]::UtcNow
+$runName = 'asymmetric-executor-partition-{0}-{1}' -f `
+    $startedAt.ToString('yyyyMMdd-HHmmss'), ([Guid]::NewGuid().ToString('N'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $resolvedEvidenceRoot $runName))
+$expectedEvidencePrefix = $resolvedEvidenceRoot + '\'
+if (-not $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Qualification output escaped the configured Evidence root.'
+}
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+New-Item -ItemType Directory -Force -Path $runRoot, $resolvedTarget | Out-Null
+
+$containerName = 'rocketmq-sre-asymmetric-fence-' + [Guid]::NewGuid().ToString('N')
+$databasePassword = [Guid]::NewGuid().ToString('N')
+$containerCreated = $false
+$databaseUrlCleared = $false
+$testPassed = $false
+$marker = $null
+try {
+    $containerId = & docker run --detach --rm --name $containerName `
+        --publish '127.0.0.1::5432' `
+        --env "POSTGRES_PASSWORD=$databasePassword" `
+        $PostgresImage
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($containerId -join ''))) {
+        throw 'Unable to start the qualification-owned PostgreSQL container.'
+    }
+    $containerCreated = $true
+    $portMapping = (& docker port $containerName '5432/tcp').Trim()
+    if ($LASTEXITCODE -ne 0 -or $portMapping -notmatch ':(?<port>\d+)$') {
+        throw 'Unable to determine the qualification PostgreSQL port.'
+    }
+    $postgresPort = [int]$Matches.port
+
+    $ready = $false
+    for ($attempt = 0; $attempt -lt 60; $attempt++) {
+        & docker exec $containerName pg_isready --username postgres --dbname postgres *> $null
+        if ($LASTEXITCODE -eq 0) {
+            $ready = $true
+            break
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    if (-not $ready) {
+        throw 'Qualification PostgreSQL did not become ready.'
+    }
+
+    $env:ROCKETMQ_SRE_TEST_DATABASE_URL = `
+        "postgres://postgres:$databasePassword@127.0.0.1:$postgresPort/postgres"
+    $cargoArguments = @(
+        'test', '--locked',
+        '--manifest-path', (Join-Path $sreRoot 'Cargo.toml'),
+        '--target-dir', $resolvedTarget,
+        '-p', 'rocketmq-sre-executor',
+        '--test', 'asymmetric_partition',
+        '--', '--ignored', '--exact',
+        'old_executor_cannot_write_after_asymmetric_authority_partition_and_epoch_takeover',
+        '--nocapture'
+    )
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $testOutput = @(& cargo @cargoArguments 2>&1)
+        $cargoExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    $testOutput | ForEach-Object { Write-Host $_ }
+    if ($cargoExitCode -ne 0) {
+        throw "asymmetric Executor partition test failed with exit code $cargoExitCode."
+    }
+    $markerLine = @($testOutput | ForEach-Object { [string]$_ } | Where-Object {
+        $_ -match '^ASYMMETRIC_EXECUTOR_PARTITION_OK '
+    })
+    if ($markerLine.Count -ne 1) {
+        throw 'The qualification test did not emit exactly one result marker.'
+    }
+    $marker = [ordered]@{}
+    foreach ($match in [regex]::Matches($markerLine[0], '(?<key>[a-z_]+)=(?<value>[^\s]+)')) {
+        $marker[$match.Groups['key'].Value] = $match.Groups['value'].Value
+    }
+    $requiredMarkerKeys = @(
+        'old_authority_reachable', 'old_agent_reachable', 'agent_authority_reachable',
+        'old_epoch', 'active_epoch', 'stale_dispatch_rejected', 'stale_effect_rows',
+        'stale_target_writes', 'fresh_target_writes', 'fence_rejections'
+    )
+    if (@($requiredMarkerKeys | Where-Object { -not $marker.Contains($_) }).Count -ne 0) {
+        throw 'The qualification result marker is incomplete.'
+    }
+    $testPassed = $true
+}
+finally {
+    Remove-Item Env:\ROCKETMQ_SRE_TEST_DATABASE_URL -ErrorAction SilentlyContinue
+    $databaseUrlCleared = -not (Test-Path Env:\ROCKETMQ_SRE_TEST_DATABASE_URL)
+    if ($containerCreated) {
+        & docker rm --force --volumes $containerName *> $null
+        $containerCreated = $false
+    }
+    $databasePassword = $null
+}
+
+if (-not $testPassed -or $null -eq $marker) {
+    if ($runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+    throw 'Asymmetric Executor partition qualification did not pass.'
+}
+
+$report = [ordered]@{
+    schema_version = 'rocketmq-sre.asymmetric-executor-partition-qualification-report.v1'
+    candidate_commit = $revision
+    source_clean = $true
+    environment = 'docker_postgresql_http_partition'
+    started_at = $startedAt.ToString('o')
+    finished_at = [DateTimeOffset]::UtcNow.ToString('o')
+    status = 'passed'
+    connectivity = [ordered]@{
+        old_executor_authority_reachable_after_partition = $marker.old_authority_reachable -eq 'true'
+        old_executor_agent_reachable_after_partition = $marker.old_agent_reachable -eq 'true'
+        agent_authority_reachable_during_takeover = $marker.agent_authority_reachable -eq 'true'
+    }
+    fencing = [ordered]@{
+        old_epoch = [int]$marker.old_epoch
+        active_epoch = [int]$marker.active_epoch
+        stale_dispatch_rejected = $marker.stale_dispatch_rejected -eq 'true'
+        stale_effect_rows = [int]$marker.stale_effect_rows
+        stale_target_writes = [int]$marker.stale_target_writes
+        fresh_target_writes = [int]$marker.fresh_target_writes
+        fence_rejections = [int]$marker.fence_rejections
+    }
+    safety = [ordered]@{
+        model_provider_network_calls = 0
+        production_certified = $false
+        unattended_autonomous_execution = $false
+        secrets_recorded = $false
+        message_bodies_recorded = $false
+    }
+    cleanup = [ordered]@{
+        postgres_container_removed = -not $containerCreated
+        database_url_cleared = $databaseUrlCleared
+    }
+}
+$json = $report | ConvertTo-Json -Depth 8
+[IO.File]::WriteAllText($reportPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath, '--report', $reportPath) `
+    'asymmetric Executor partition report validation'
+Write-Host "ASYMMETRIC_EXECUTOR_PARTITION_LIVE_QUALIFICATION_OK report=$reportPath stale_target_writes=0 fresh_target_writes=1"

--- a/rocketmq-sre/scripts/check_asymmetric_executor_partition_qualification.py
+++ b/rocketmq-sre/scripts/check_asymmetric_executor_partition_qualification.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the asymmetric Executor partition qualification contract and report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "asymmetric-executor-partition.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.asymmetric-executor-partition-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.asymmetric-executor-partition-qualification-report.v1"
+ENVIRONMENT = "docker_postgresql_http_partition"
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+EXPECTED_ASSERTIONS: dict[str, bool | int] = {
+    "old_executor_authority_reachable_after_partition": False,
+    "old_executor_agent_reachable_after_partition": True,
+    "agent_authority_reachable_during_takeover": True,
+    "new_epoch_greater_than_old_epoch": True,
+    "stale_dispatch_rejected": True,
+    "stale_effect_rows": 0,
+    "stale_target_writes": 0,
+    "fresh_target_writes": 1,
+    "minimum_fence_rejections": 1,
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def repository_file(raw_path: Any, location: str, findings: list[str]) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location} must be a non-empty repository path")
+        return None
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location} must be repository implementation evidence")
+        return None
+    resolved = REPOSITORY_ROOT / Path(*path.parts)
+    if not resolved.is_file():
+        findings.append(f"{location} does not exist: {raw_path}")
+        return None
+    return resolved
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected = {
+        "schema_version": MANIFEST_SCHEMA,
+        "environment": ENVIRONMENT,
+        "operating_mode": "rules_only",
+        "production_certified": False,
+        "model_provider_network_calls": False,
+        "unattended_autonomous_execution": False,
+    }
+    for field, value in expected.items():
+        if manifest.get(field) != value:
+            findings.append(f"{field} must remain {value!r}")
+    if manifest.get("required_assertions") != EXPECTED_ASSERTIONS:
+        findings.append("required asymmetric-partition assertions drifted")
+
+    evidence = manifest.get("repository_evidence")
+    if not isinstance(evidence, dict):
+        findings.append("repository_evidence must be an object")
+    else:
+        test_path = repository_file(evidence.get("test_path"), "repository_evidence.test_path", findings)
+        for field in ("runner", "checker"):
+            repository_file(evidence.get(field), f"repository_evidence.{field}", findings)
+        test_name = evidence.get("test")
+        if test_path is not None and (
+            not isinstance(test_name, str) or test_name not in test_path.read_text(encoding="utf-8")
+        ):
+            findings.append("repository_evidence.test is absent from its test_path")
+
+    report = manifest.get("live_report")
+    if not isinstance(report, dict) or report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live_report contract is missing or unsupported")
+    else:
+        if report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if set(report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+        if report.get("secrets_recorded") is not False or report.get("message_bodies_recorded") is not False:
+            findings.append("live reports must exclude secrets and message bodies")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains a credential-like value")
+    return findings
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if report.get("schema_version") != REPORT_SCHEMA:
+        findings.append(f"report schema_version must be {REPORT_SCHEMA}")
+    if report.get("status") != "passed" or report.get("environment") != ENVIRONMENT:
+        findings.append("report must be a passed Docker PostgreSQL HTTP partition run")
+    revision = report.get("candidate_commit")
+    if not isinstance(revision, str) or not REVISION.fullmatch(revision):
+        findings.append("candidate_commit must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("qualification source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+
+    connectivity = report.get("connectivity")
+    expected_connectivity = {
+        "old_executor_authority_reachable_after_partition": False,
+        "old_executor_agent_reachable_after_partition": True,
+        "agent_authority_reachable_during_takeover": True,
+    }
+    if not isinstance(connectivity, dict) or connectivity != expected_connectivity:
+        findings.append("asymmetric connectivity proof is incomplete")
+
+    fencing = report.get("fencing")
+    if not isinstance(fencing, dict):
+        findings.append("fencing proof must be an object")
+    else:
+        old_epoch = fencing.get("old_epoch")
+        active_epoch = fencing.get("active_epoch")
+        if (
+            not isinstance(old_epoch, int)
+            or isinstance(old_epoch, bool)
+            or not isinstance(active_epoch, int)
+            or isinstance(active_epoch, bool)
+            or active_epoch <= old_epoch
+        ):
+            findings.append("active_epoch must be an integer greater than old_epoch")
+        expected_fencing = {
+            "stale_dispatch_rejected": True,
+            "stale_effect_rows": 0,
+            "stale_target_writes": 0,
+            "fresh_target_writes": 1,
+        }
+        for field, expected in expected_fencing.items():
+            if fencing.get(field) != expected:
+                findings.append(f"fencing.{field} must be {expected!r}")
+        rejections = fencing.get("fence_rejections")
+        if not isinstance(rejections, int) or isinstance(rejections, bool) or rejections < 1:
+            findings.append("fencing.fence_rejections must be at least one")
+
+    safety = report.get("safety")
+    expected_safety = {
+        "model_provider_network_calls": 0,
+        "production_certified": False,
+        "unattended_autonomous_execution": False,
+        "secrets_recorded": False,
+        "message_bodies_recorded": False,
+    }
+    if not isinstance(safety, dict) or safety != expected_safety:
+        findings.append("safety proof drifted from the rules-only non-production boundary")
+    cleanup = report.get("cleanup")
+    if not isinstance(cleanup, dict) or cleanup != {
+        "postgres_container_removed": True,
+        "database_url_cleared": True,
+    }:
+        findings.append("cleanup proof is incomplete")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains a credential-like value")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        findings = validate_manifest(load_json(args.manifest))
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report)))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"ASYMMETRIC_EXECUTOR_PARTITION_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"ASYMMETRIC_EXECUTOR_PARTITION_QUALIFICATION_FINDING {finding}")
+        print(f"ASYMMETRIC_EXECUTOR_PARTITION_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(
+        "ASYMMETRIC_EXECUTOR_PARTITION_QUALIFICATION_OK "
+        f"stale_effect_rows=0 stale_target_writes=0 fresh_target_writes=1{suffix}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/check_execution_recovery_qualification.py
+++ b/rocketmq-sre/scripts/check_execution_recovery_qualification.py
@@ -260,6 +260,29 @@ def validate(manifest: dict[str, Any]) -> list[str]:
             if path and (not isinstance(test_name, str) or test_name not in path.read_text(encoding="utf-8")):
                 findings.append(f"common evidence test is absent: {name}")
 
+    asymmetric = manifest.get("asymmetric_partition_live_qualification")
+    if not isinstance(asymmetric, dict):
+        findings.append("asymmetric Executor partition qualification is missing")
+    else:
+        expected_asymmetric = {
+            "stale_effect_rows": 0,
+            "stale_target_writes": 0,
+            "fresh_target_writes": 1,
+            "model_provider_network_calls": False,
+            "production_certified": False,
+        }
+        for field, expected in expected_asymmetric.items():
+            if asymmetric.get(field) != expected:
+                findings.append(f"asymmetric partition {field} must remain {expected!r}")
+        for field in ("manifest", "script", "checker"):
+            _repository_path(asymmetric.get(field), findings, f"asymmetric partition {field}")
+        test_path = _repository_path(asymmetric.get("test_path"), findings, "asymmetric partition test_path")
+        test_name = asymmetric.get("test")
+        if test_path and (
+            not isinstance(test_name, str) or test_name not in test_path.read_text(encoding="utf-8")
+        ):
+            findings.append("asymmetric partition test is absent from test_path")
+
     r2 = manifest.get("r2_authorization")
     if not isinstance(r2, dict) or any(
         r2.get(field) is not True
@@ -369,7 +392,7 @@ def main() -> int:
     print(
         "EXECUTION_RECOVERY_QUALIFICATION_OK "
         f"controlled_actions={len(EXPECTED_ACTIONS)} autonomous_actions={len(EXPECTED_AUTONOMY)} "
-        "regions=2 dr_exercises=6 model_network_calls=false"
+        "regions=2 dr_exercises=6 asymmetric_partition=true model_network_calls=false"
     )
     return 0
 

--- a/rocketmq-sre/scripts/tests/test_check_asymmetric_executor_partition_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_asymmetric_executor_partition_qualification.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the asymmetric Executor partition qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_asymmetric_executor_partition_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_asymmetric_executor_partition_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report() -> dict:
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "candidate_commit": "a" * 40,
+        "source_clean": True,
+        "environment": MODULE.ENVIRONMENT,
+        "started_at": "2026-08-06T00:00:00Z",
+        "finished_at": "2026-08-06T00:01:00Z",
+        "status": "passed",
+        "connectivity": {
+            "old_executor_authority_reachable_after_partition": False,
+            "old_executor_agent_reachable_after_partition": True,
+            "agent_authority_reachable_during_takeover": True,
+        },
+        "fencing": {
+            "old_epoch": 1,
+            "active_epoch": 2,
+            "stale_dispatch_rejected": True,
+            "stale_effect_rows": 0,
+            "stale_target_writes": 0,
+            "fresh_target_writes": 1,
+            "fence_rejections": 1,
+        },
+        "safety": {
+            "model_provider_network_calls": 0,
+            "production_certified": False,
+            "unattended_autonomous_execution": False,
+            "secrets_recorded": False,
+            "message_bodies_recorded": False,
+        },
+        "cleanup": {
+            "postgres_container_removed": True,
+            "database_url_cleared": True,
+        },
+    }
+
+
+class AsymmetricExecutorPartitionQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report()), [])
+
+    def test_rejects_stale_and_duplicate_writes(self) -> None:
+        report = valid_report()
+        report["fencing"]["stale_target_writes"] = 1
+        report["fencing"]["fresh_target_writes"] = 2
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("fencing.stale_target_writes must be 0", findings)
+        self.assertIn("fencing.fresh_target_writes must be 1", findings)
+
+    def test_rejects_symmetric_connectivity_or_weak_epoch_proof(self) -> None:
+        report = valid_report()
+        report["connectivity"]["old_executor_agent_reachable_after_partition"] = False
+        report["fencing"]["active_epoch"] = 1
+        report["fencing"]["fence_rejections"] = 0
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("asymmetric connectivity proof is incomplete", findings)
+        self.assertIn("active_epoch must be an integer greater than old_epoch", findings)
+        self.assertIn("fencing.fence_rejections must be at least one", findings)
+
+    def test_rejects_production_claim_and_sensitive_value(self) -> None:
+        report = valid_report()
+        report["safety"]["production_certified"] = True
+        report["unsafe"] = "Bearer qualification-token"
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("safety proof drifted from the rules-only non-production boundary", findings)
+        self.assertIn("report contains a credential-like value", findings)
+
+    def test_manifest_rejects_weakened_assertion(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["required_assertions"]["stale_effect_rows"] = 1
+
+        self.assertIn(
+            "required asymmetric-partition assertions drifted",
+            MODULE.validate_manifest(manifest),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8956

### Brief Description

Qualifies stale-epoch fencing across a real asymmetric Executor partition. The live test removes the old Executor's Lease Authority path while preserving its Execution Agent path, advances the Agent fence through an independent authority connection, and proves that the stale grant creates neither a durable effect row nor a target write. A fresh epoch then succeeds exactly once.

The change also adds a fail-closed qualification manifest, a sanitized machine-local report validator, and a PowerShell runner backed by a disposable Docker PostgreSQL instance. It remains rules-only, makes no model-provider calls, and does not claim production certification.

### How Did You Test This Change?

- `cargo check --locked --manifest-path rocketmq-sre/Cargo.toml --workspace`
- `cargo test --locked --manifest-path rocketmq-sre/Cargo.toml --workspace --all-features`
- `cargo clippy --locked --manifest-path rocketmq-sre/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --manifest-path rocketmq-sre/Cargo.toml --workspace --no-deps`
- `cargo fmt --manifest-path rocketmq-sre/Cargo.toml -p rocketmq-sre-executor -- --check`
- `python rocketmq-sre/scripts/check_source_layout.py`
- `python rocketmq-sre/scripts/check_execution_dependency_boundary.py`
- `python -m unittest rocketmq-sre/scripts/tests/test_check_asymmetric_executor_partition_qualification.py -v`
- `python rocketmq-sre/scripts/check_execution_recovery_qualification.py`
- `python rocketmq-sre/scripts/check_implementation_status.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -File rocketmq-sre/scripts/asymmetric-executor-partition-qualification.ps1 -Mode Run`

The full-workspace `cargo fmt --all -- --check` invocation could not start on Windows because the process exceeded the platform command/path length limit (OS error 206); the affected Executor package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added qualification coverage for asymmetric executor partitions and lease-epoch takeover behavior.
  - Added automated runners and validation for live qualification reports and evidence.
- **Bug Fixes**
  - Confirmed stale dispatches are rejected without side effects or target writes after authority changes.
  - Confirmed fresh-epoch dispatches continue successfully.
- **Tests**
  - Added integration and validation tests covering fencing, connectivity, cleanup, safety, and invalid qualification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->