### PR TITLE
[ISSUE #8953]✨Introduce typed request header codec runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 |---|---|---|
 | `rocketmq-dashboard/rocketmq-dashboard-common/` | Root workspace member and shared dashboard crate | This file |
 | `rocketmq-example/` | Standalone Cargo project | `rocketmq-example/AGENTS.md` |
+| `rocketmq-macros/tests/fixtures/renamed-consumer/` | Standalone compile fixture for renamed codec dependencies | Its local `AGENTS.md` |
 | `rocketmq-tools/rocketmq-mcp/` | Standalone Rust MCP server | Its local `AGENTS.md` |
 | `rocketmq-sre/` | Standalone AI SRE Rust workspace and UI | Its local `AGENTS.md` |
 | `rocketmq-sre/ui/` | Standalone React/TypeScript/Vite AI SRE frontend | Its local `AGENTS.md` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,6 +4497,7 @@ dependencies = [
  "chrono",
  "criterion",
  "flate2",
+ "itoa",
  "lz4_flex",
  "memchr",
  "rand 0.10.2",
@@ -4507,6 +4508,7 @@ dependencies = [
  "serde_json",
  "serde_json_any_key",
  "simd-json",
+ "thiserror 2.0.19",
  "trybuild",
  "zstd",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -292,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,15 +316,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -511,8 +508,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -780,16 +777,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -929,23 +916,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -1258,16 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,7 +1389,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1535,7 +1502,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1935,22 +1902,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -2933,7 +2890,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3016,13 +2973,13 @@ version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",
- "base64",
+ "base64 0.23.1",
  "cheetah-string",
  "chrono",
  "hex",
  "hmac",
  "ipnetwork",
- "md-5 0.11.0",
+ "md-5",
  "moka",
  "rocketmq-error",
  "rocketmq-model",
@@ -3149,6 +3106,7 @@ dependencies = [
 name = "rocketmq-macros"
 version = "1.0.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3158,7 +3116,7 @@ dependencies = [
 name = "rocketmq-model"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "byteorder",
  "bytes",
  "cheetah-string",
@@ -3168,7 +3126,7 @@ dependencies = [
  "flate2",
  "local-ip-address",
  "lz4_flex",
- "md-5 0.10.6",
+ "md-5",
  "rocketmq-error",
  "serde",
  "serde_json",
@@ -3218,6 +3176,7 @@ dependencies = [
  "cheetah-string",
  "chrono",
  "flate2",
+ "itoa",
  "lz4_flex",
  "memchr",
  "rand 0.10.2",
@@ -3227,6 +3186,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "zstd",
 ]
 
@@ -3722,7 +3682,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -3733,7 +3693,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -4189,7 +4149,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4451,7 +4411,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 

--- a/rocketmq-macros/tests/fixtures/renamed-consumer/AGENTS.md
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/AGENTS.md
@@ -1,0 +1,20 @@
+# Renamed dependency fixture working agreement
+
+## Scope
+
+- This file applies to the standalone Cargo project in this directory.
+- The root repository instructions also apply unless this file is more specific.
+
+## Purpose and boundaries
+
+- Keep `rocketmq-protocol` renamed to `protocol_api`; the fixture proves derive output does not assume the dependency name.
+- Keep this project outside the root workspace and suitable for locked, offline validation.
+- Do not add production behavior, publishable APIs, or unrelated dependencies here.
+
+## Validation
+
+Run from the repository root:
+
+```bash
+cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml
+```

--- a/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "cheetah-string",
  "chrono",
  "flate2",
+ "itoa",
  "lz4_flex",
  "memchr",
  "rand",
@@ -763,6 +764,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "zstd",
 ]
 

--- a/rocketmq-protocol/Cargo.toml
+++ b/rocketmq-protocol/Cargo.toml
@@ -35,6 +35,7 @@ bitvec = "1.0.1"
 cheetah-string.workspace = true
 flate2 = { version = "1.1.9", features = ["zlib"], default-features = false }
 lz4_flex = { version = "0.13", default-features = false }
+itoa = "1.0.18"
 memchr = "2.8.0"
 rocketmq-error = { workspace = true, features = ["with_serde"] }
 bytemuck = "1.25.0"
@@ -46,6 +47,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_json_any_key.workspace = true
 simd-json = { version = "0.17", optional = true }
+thiserror.workspace = true
 zstd = "0.13"
 
 [dev-dependencies]

--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -37,6 +37,7 @@ pub mod encoded_frame;
 pub mod filter;
 pub mod forbidden_type;
 pub mod header;
+pub mod header_codec;
 pub mod header_facade;
 pub mod headers;
 pub mod heartbeat;

--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -1,0 +1,44 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Typed runtime primitives shared by request-header codec implementations.
+//!
+//! This module deliberately exposes only protocol-reviewed wire value types and
+//! protocol-owned sinks. Both extension traits are sealed so adding a Rust type
+//! or sink cannot silently expand RocketMQ wire semantics in another crate.
+
+mod error;
+mod schema;
+mod sink;
+mod value;
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub use error::HeaderCodecError;
+pub use schema::AliasConflictPolicy;
+pub use schema::DynamicCollisionPolicy;
+pub use schema::FlattenPresenceSpec;
+pub use schema::HeaderFieldSpec;
+pub use schema::HeaderFlattenSpec;
+pub use schema::HeaderPresence;
+pub use schema::ResolvedHeaderKey;
+pub use sink::EncodeSink;
+pub use sink::MapSink;
+pub use value::validate_unsigned_java_range;
+pub use value::HeaderFieldContext;
+pub use value::HeaderRange;
+pub use value::HeaderValue;
+pub use value::HeaderValueKind;

--- a/rocketmq-protocol/src/protocol/header_codec/error.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/error.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::HeaderValueKind;
+
+/// A classified request-header encoding, decoding, or validation failure.
+///
+/// Variants intentionally carry only static schema metadata. In particular,
+/// malformed wire values are never retained or rendered by this error type.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum HeaderCodecError {
+    /// A field declared as required was absent.
+    #[error("missing required header field {header}.{key}")]
+    Missing {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// A present field could not be decoded as its declared wire type.
+    #[error("invalid header field {header}.{key}: expected {expected:?}")]
+    InvalidValue {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+        /// Expected protocol value category.
+        expected: HeaderValueKind,
+    },
+
+    /// Canonical and alias keys carried different values.
+    #[error("conflicting canonical and alias values for {header}.{key}")]
+    Conflict {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// A typed value and dynamic extension field disagreed.
+    #[error("typed header and dynamic field conflict for {header}.{key}")]
+    DynamicFieldConflict {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// A legacy [`crate::CommandCustomHeader`] validation hook failed.
+    #[error("legacy header validation failed for {header}")]
+    LegacyValidation {
+        /// Static Rust type name for the legacy header.
+        header: &'static str,
+    },
+
+    /// A legacy header could not provide its compatibility map.
+    #[error("legacy header map conversion failed for {header}")]
+    LegacyMapConversionFailed {
+        /// Static Rust type name for the legacy header.
+        header: &'static str,
+    },
+
+    /// A header-specific validation rule failed.
+    #[error("header validation failed for {header}: {rule}")]
+    Validation {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Static, non-sensitive validation rule identifier.
+        rule: &'static str,
+    },
+
+    /// An unsigned Rust value exceeded its declared signed Java range.
+    #[error("header value is outside Java range for {header}.{key}")]
+    JavaRange {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// A wire key cannot be represented by the ROCKETMQ binary format.
+    #[error("header key length exceeds the ROCKETMQ limit for {header}.{key}")]
+    KeyLengthOverflow {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// A wire value cannot be represented by the ROCKETMQ binary format.
+    #[error("header value length exceeds the ROCKETMQ limit for {header}.{key}")]
+    ValueLengthOverflow {
+        /// Stable header type identifier.
+        header: &'static str,
+        /// Canonical wire key.
+        key: &'static str,
+    },
+
+    /// Direct binary encoding was requested for a header without that capability.
+    #[error("direct binary codec is unavailable for {header}")]
+    FastCodecUnavailable {
+        /// Stable header type identifier.
+        header: &'static str,
+    },
+}

--- a/rocketmq-protocol/src/protocol/header_codec/schema.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/schema.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::HeaderRange;
+use super::HeaderValueKind;
+
+/// Decode behavior when canonical and legacy alias keys coexist.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AliasConflictPolicy {
+    /// Reject different canonical and alias values.
+    Error,
+    /// Use the canonical value when an audited compatibility rule permits it.
+    PreferCanonical,
+}
+
+/// Merge behavior between typed fields and dynamic extension fields.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DynamicCollisionPolicy {
+    /// Accept an identical value but reject a different value.
+    ErrorOnDifferentValue,
+}
+
+/// Missing-field semantics recorded in generated header schemas.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HeaderPresence {
+    /// The key must be present.
+    Required,
+    /// Absence decodes as `None`.
+    Optional,
+    /// Absence uses `Default::default`.
+    Default,
+    /// Absence calls the named, reviewed default provider.
+    DefaultWith(&'static str),
+}
+
+/// Presence semantics for a flattened nested header.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FlattenPresenceSpec {
+    /// Always construct and validate the nested header.
+    Always,
+    /// Construct the nested header when any of its canonical keys or aliases exists.
+    Any,
+}
+
+/// Static schema metadata for one non-flattened header field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HeaderFieldSpec {
+    /// Rust source field name.
+    pub rust_field: &'static str,
+    /// Canonical wire key used by encoders.
+    pub key: &'static str,
+    /// Ordered decode-only aliases.
+    pub aliases: &'static [&'static str],
+    /// Canonical/alias conflict behavior.
+    pub alias_conflict: AliasConflictPolicy,
+    /// Protocol value category.
+    pub kind: HeaderValueKind,
+    /// Missing-field behavior.
+    pub presence: HeaderPresence,
+    /// Stable literal or dynamic default semantic identifier.
+    pub default_semantic: Option<&'static str>,
+    /// Java field type used by compatibility tooling.
+    pub java_type: Option<&'static str>,
+    /// Signed Java range imposed on an unsigned Rust value.
+    pub java_range: Option<HeaderRange>,
+    /// Stable field order within the declaring header.
+    pub binary_order: u16,
+    /// Stable type identifier of the declaring header.
+    pub declared_in: &'static str,
+}
+
+/// Static schema metadata for one flattened nested header.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HeaderFlattenSpec {
+    /// Rust source field name.
+    pub rust_field: &'static str,
+    /// Stable typed-codec identifier of the nested header.
+    pub nested_type_id: &'static str,
+    /// Nested construction policy.
+    pub presence: FlattenPresenceSpec,
+    /// Stable group order within the declaring header.
+    pub binary_order: u16,
+    /// Stable type identifier of the declaring header.
+    pub declared_in: &'static str,
+}
+
+/// Canonical resolution result for a canonical key or decode alias.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolvedHeaderKey {
+    /// Stable header name used in diagnostics.
+    pub header: &'static str,
+    /// Stable type identifier of the field owner, including nested owners.
+    pub owner_type_id: &'static str,
+    /// Canonical wire key.
+    pub canonical: &'static str,
+    /// Resolution precedence: canonical is zero and alias `n` is `n + 1`.
+    pub precedence: u16,
+    /// Canonical/alias conflict behavior.
+    pub alias_conflict: AliasConflictPolicy,
+    /// Typed/dynamic collision behavior.
+    pub dynamic_collision: DynamicCollisionPolicy,
+}

--- a/rocketmq-protocol/src/protocol/header_codec/sink.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/sink.rs
@@ -1,0 +1,139 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+
+use super::private::Sealed;
+use super::HeaderCodecError;
+use super::HeaderFieldContext;
+use super::HeaderValue;
+use crate::protocol::command_custom_header::HeaderMap;
+
+/// A statically dispatched destination for typed header fields.
+///
+/// This trait is sealed. Protocol-owned implementations preserve identical
+/// field semantics while allowing LLVM to specialize map and future binary
+/// writes without a trait object in the per-field path.
+pub trait EncodeSink: Sealed {
+    /// Writes one canonical field.
+    ///
+    /// The caller is responsible for header validation and Java range checks
+    /// before this method. Sinks must not duplicate those policy decisions.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified codec error when the destination wire format cannot
+    /// represent the key or value. Map writes are currently infallible.
+    fn write<V: HeaderValue>(
+        &mut self,
+        key: &'static str,
+        value: &V,
+        context: HeaderFieldContext,
+    ) -> Result<(), HeaderCodecError>;
+}
+
+/// An [`EncodeSink`] that appends typed fields directly to a [`HeaderMap`].
+pub struct MapSink<'a> {
+    out: &'a mut HeaderMap,
+}
+
+impl<'a> MapSink<'a> {
+    /// Creates a map sink over an existing destination.
+    #[inline]
+    pub const fn new(out: &'a mut HeaderMap) -> Self {
+        Self { out }
+    }
+
+    /// Returns the borrowed destination after the sink is no longer needed.
+    #[inline]
+    pub fn into_inner(self) -> &'a mut HeaderMap {
+        self.out
+    }
+}
+
+impl Sealed for MapSink<'_> {}
+
+impl EncodeSink for MapSink<'_> {
+    #[inline]
+    fn write<V: HeaderValue>(
+        &mut self,
+        key: &'static str,
+        value: &V,
+        _context: HeaderFieldContext,
+    ) -> Result<(), HeaderCodecError> {
+        self.out
+            .insert(CheetahString::from_static_str(key), value.to_map_value());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::header_codec::HeaderValueKind;
+
+    const CONTEXT: HeaderFieldContext =
+        HeaderFieldContext::new("ExampleHeader", "topic", HeaderValueKind::String, None);
+
+    #[test]
+    fn writes_into_existing_map_without_an_intermediate_map() {
+        let mut fields = HeaderMap::with_capacity(2);
+        fields.insert(
+            CheetahString::from_static_str("existing"),
+            CheetahString::from_static_str("value"),
+        );
+
+        let mut sink = MapSink::new(&mut fields);
+        sink.write("topic", &CheetahString::from("测试-topic"), CONTEXT)
+            .unwrap();
+        let fields = sink.into_inner();
+
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields.get("topic").map(CheetahString::as_str), Some("测试-topic"));
+        assert_eq!(fields.get("existing").map(CheetahString::as_str), Some("value"));
+    }
+
+    #[test]
+    fn canonical_write_replaces_an_existing_value() {
+        let mut fields = HeaderMap::new();
+        fields.insert(
+            CheetahString::from_static_str("topic"),
+            CheetahString::from_static_str("old"),
+        );
+
+        MapSink::new(&mut fields)
+            .write("topic", &String::from("new"), CONTEXT)
+            .unwrap();
+
+        assert_eq!(fields.get("topic").map(CheetahString::as_str), Some("new"));
+    }
+
+    #[test]
+    fn scalar_write_uses_the_header_value_canonical_form() {
+        let mut fields = HeaderMap::new();
+        let mut sink = MapSink::new(&mut fields);
+
+        sink.write(
+            "queueOffset",
+            &u64::MAX,
+            HeaderFieldContext::new("ExampleHeader", "queueOffset", HeaderValueKind::U64, None),
+        )
+        .unwrap();
+
+        assert_eq!(
+            fields.get("queueOffset").map(CheetahString::as_str),
+            Some("18446744073709551615")
+        );
+    }
+}

--- a/rocketmq-protocol/src/protocol/header_codec/value.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/value.rs
@@ -1,0 +1,529 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_model::boundary_type::BoundaryType;
+
+use super::private::Sealed;
+use super::HeaderCodecError;
+
+/// Protocol-reviewed value categories supported by typed request headers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HeaderValueKind {
+    /// UTF-8 text.
+    String,
+    /// Canonical ASCII `true` or `false`.
+    Bool,
+    /// Signed 32-bit decimal integer.
+    I32,
+    /// Signed 64-bit decimal integer.
+    I64,
+    /// Unsigned 32-bit decimal integer.
+    U32,
+    /// Unsigned 64-bit decimal integer.
+    U64,
+    /// RocketMQ offset boundary selector.
+    BoundaryType,
+}
+
+/// A signed Java numeric range applied to an unsigned Rust field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HeaderRange {
+    /// Java `int`/`Integer`: `0..=i32::MAX` for an unsigned Rust field.
+    I32,
+    /// Java `long`/`Long`: `0..=i64::MAX` for an unsigned Rust field.
+    I64,
+}
+
+/// Static field metadata used for typed conversion and diagnostics.
+///
+/// Derive output creates one constant context per field, so successful codec
+/// paths never allocate diagnostic metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HeaderFieldContext {
+    /// Stable header type identifier.
+    pub header: &'static str,
+    /// Canonical wire key.
+    pub key: &'static str,
+    /// Expected value category.
+    pub kind: HeaderValueKind,
+    /// Optional Java signed-range constraint.
+    pub range: Option<HeaderRange>,
+}
+
+impl HeaderFieldContext {
+    /// Creates static metadata for one header field.
+    pub const fn new(
+        header: &'static str,
+        key: &'static str,
+        kind: HeaderValueKind,
+        range: Option<HeaderRange>,
+    ) -> Self {
+        Self {
+            header,
+            key,
+            kind,
+            range,
+        }
+    }
+}
+
+/// A protocol-approved request-header wire value.
+///
+/// Implementations must keep `encoded_len` and `write_ascii` byte-for-byte
+/// consistent. This trait is sealed: new wire types require an explicit
+/// implementation and compatibility review in `rocketmq-protocol`.
+pub trait HeaderValue: Sealed + Sized {
+    /// Static value category used by generated schemas and diagnostics.
+    const KIND: HeaderValueKind;
+
+    /// Produces the owned value required by a [`crate::HeaderMap`].
+    fn to_map_value(&self) -> CheetahString;
+
+    /// Returns the exact number of bytes written by [`Self::write_ascii`].
+    fn encoded_len(&self) -> usize;
+
+    /// Appends the canonical UTF-8/ASCII wire representation without a
+    /// temporary `String` for scalar values.
+    fn write_ascii(&self, out: &mut BytesMut);
+
+    /// Decodes a complete map value according to the field context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeaderCodecError::InvalidValue`] for malformed or overflowing
+    /// scalar values, or [`HeaderCodecError::JavaRange`] when an unsigned value
+    /// exceeds its field's declared signed Java range. Errors never retain
+    /// `raw`.
+    fn decode(raw: &str, context: HeaderFieldContext) -> Result<Self, HeaderCodecError>;
+}
+
+/// Validates an unsigned value against its field-level signed Java range.
+///
+/// A context without a range is a Rust extension and remains unrestricted.
+/// Derive output calls this helper once before sink dispatch; unsigned decoders
+/// call it once after successful parsing.
+///
+/// # Errors
+///
+/// Returns [`HeaderCodecError::JavaRange`] when `value` exceeds the declared
+/// range. The error contains only static field metadata.
+#[inline]
+pub fn validate_unsigned_java_range(value: u64, context: HeaderFieldContext) -> Result<(), HeaderCodecError> {
+    let in_range = match context.range {
+        None => true,
+        Some(HeaderRange::I32) => value <= i32::MAX as u64,
+        Some(HeaderRange::I64) => value <= i64::MAX as u64,
+    };
+    if in_range {
+        Ok(())
+    } else {
+        Err(HeaderCodecError::JavaRange {
+            header: context.header,
+            key: context.key,
+        })
+    }
+}
+
+#[inline]
+const fn invalid_value(context: HeaderFieldContext) -> HeaderCodecError {
+    HeaderCodecError::InvalidValue {
+        header: context.header,
+        key: context.key,
+        expected: context.kind,
+    }
+}
+
+#[inline]
+fn signed_decimal_len(value: i64) -> usize {
+    unsigned_decimal_len(value.unsigned_abs()) + usize::from(value < 0)
+}
+
+#[inline]
+fn unsigned_decimal_len(value: u64) -> usize {
+    if value == 0 {
+        1
+    } else {
+        value.ilog10() as usize + 1
+    }
+}
+
+impl Sealed for CheetahString {}
+
+impl HeaderValue for CheetahString {
+    const KIND: HeaderValueKind = HeaderValueKind::String;
+
+    #[inline]
+    fn to_map_value(&self) -> CheetahString {
+        self.clone()
+    }
+
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn write_ascii(&self, out: &mut BytesMut) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    #[inline]
+    fn decode(raw: &str, _context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+        Ok(CheetahString::from_slice(raw))
+    }
+}
+
+impl Sealed for String {}
+
+impl HeaderValue for String {
+    const KIND: HeaderValueKind = HeaderValueKind::String;
+
+    #[inline]
+    fn to_map_value(&self) -> CheetahString {
+        CheetahString::from_slice(self)
+    }
+
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn write_ascii(&self, out: &mut BytesMut) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    #[inline]
+    fn decode(raw: &str, _context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+        Ok(raw.to_owned())
+    }
+}
+
+impl Sealed for bool {}
+
+impl HeaderValue for bool {
+    const KIND: HeaderValueKind = HeaderValueKind::Bool;
+
+    #[inline]
+    fn to_map_value(&self) -> CheetahString {
+        CheetahString::from_static_str(if *self { "true" } else { "false" })
+    }
+
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        if *self {
+            4
+        } else {
+            5
+        }
+    }
+
+    #[inline]
+    fn write_ascii(&self, out: &mut BytesMut) {
+        out.extend_from_slice(if *self { b"true" } else { b"false" });
+    }
+
+    #[inline]
+    fn decode(raw: &str, context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+        if raw.eq_ignore_ascii_case("true") {
+            Ok(true)
+        } else if raw.eq_ignore_ascii_case("false") {
+            Ok(false)
+        } else {
+            Err(invalid_value(context))
+        }
+    }
+}
+
+macro_rules! impl_signed_header_value {
+    ($ty:ty, $kind:ident) => {
+        impl Sealed for $ty {}
+
+        impl HeaderValue for $ty {
+            const KIND: HeaderValueKind = HeaderValueKind::$kind;
+
+            #[inline]
+            fn to_map_value(&self) -> CheetahString {
+                let mut buffer = itoa::Buffer::new();
+                CheetahString::from_slice(buffer.format(*self))
+            }
+
+            #[inline]
+            fn encoded_len(&self) -> usize {
+                signed_decimal_len(*self as i64)
+            }
+
+            #[inline]
+            fn write_ascii(&self, out: &mut BytesMut) {
+                let mut buffer = itoa::Buffer::new();
+                out.extend_from_slice(buffer.format(*self).as_bytes());
+            }
+
+            #[inline]
+            fn decode(raw: &str, context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+                raw.parse::<$ty>().map_err(|_| invalid_value(context))
+            }
+        }
+    };
+}
+
+macro_rules! impl_unsigned_header_value {
+    ($ty:ty, $kind:ident) => {
+        impl Sealed for $ty {}
+
+        impl HeaderValue for $ty {
+            const KIND: HeaderValueKind = HeaderValueKind::$kind;
+
+            #[inline]
+            fn to_map_value(&self) -> CheetahString {
+                let mut buffer = itoa::Buffer::new();
+                CheetahString::from_slice(buffer.format(*self))
+            }
+
+            #[inline]
+            fn encoded_len(&self) -> usize {
+                unsigned_decimal_len(*self as u64)
+            }
+
+            #[inline]
+            fn write_ascii(&self, out: &mut BytesMut) {
+                let mut buffer = itoa::Buffer::new();
+                out.extend_from_slice(buffer.format(*self).as_bytes());
+            }
+
+            #[inline]
+            fn decode(raw: &str, context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+                let value = raw.parse::<$ty>().map_err(|_| invalid_value(context))?;
+                validate_unsigned_java_range(value as u64, context)?;
+                Ok(value)
+            }
+        }
+    };
+}
+
+impl_signed_header_value!(i32, I32);
+impl_signed_header_value!(i64, I64);
+impl_unsigned_header_value!(u32, U32);
+impl_unsigned_header_value!(u64, U64);
+
+impl Sealed for BoundaryType {}
+
+impl HeaderValue for BoundaryType {
+    const KIND: HeaderValueKind = HeaderValueKind::BoundaryType;
+
+    #[inline]
+    fn to_map_value(&self) -> CheetahString {
+        CheetahString::from_static_str(match self {
+            BoundaryType::Lower => "LOWER",
+            BoundaryType::Upper => "UPPER",
+        })
+    }
+
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        match self {
+            BoundaryType::Lower => 5,
+            BoundaryType::Upper => 5,
+        }
+    }
+
+    #[inline]
+    fn write_ascii(&self, out: &mut BytesMut) {
+        out.extend_from_slice(match self {
+            BoundaryType::Lower => b"LOWER",
+            BoundaryType::Upper => b"UPPER",
+        });
+    }
+
+    #[inline]
+    fn decode(raw: &str, _context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+        Ok(BoundaryType::get_type(raw))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const fn context(kind: HeaderValueKind, range: Option<HeaderRange>) -> HeaderFieldContext {
+        HeaderFieldContext::new("ExampleHeader", "value", kind, range)
+    }
+
+    fn assert_encoding<T>(value: T, expected: &str)
+    where
+        T: HeaderValue,
+    {
+        let mut out = BytesMut::new();
+        value.write_ascii(&mut out);
+        assert_eq!(value.encoded_len(), expected.len());
+        assert_eq!(out.as_ref(), expected.as_bytes());
+        assert_eq!(value.to_map_value().as_str(), expected);
+    }
+
+    #[test]
+    fn strings_preserve_empty_unicode_and_exact_lengths() {
+        for raw in ["", "topic", "主题-🚀"] {
+            let cheetah = CheetahString::decode(raw, context(HeaderValueKind::String, None)).unwrap();
+            assert_encoding(cheetah, raw);
+
+            let owned = String::decode(raw, context(HeaderValueKind::String, None)).unwrap();
+            assert_encoding(owned, raw);
+        }
+    }
+
+    #[test]
+    fn signed_integers_cover_extrema_zero_and_overflow() {
+        for value in [i32::MIN, -1, 0, 1, i32::MAX] {
+            let text = value.to_string();
+            assert_eq!(i32::decode(&text, context(HeaderValueKind::I32, None)).unwrap(), value);
+            assert_encoding(value, &text);
+        }
+        for value in [i64::MIN, -1, 0, 1, i64::MAX] {
+            let text = value.to_string();
+            assert_eq!(i64::decode(&text, context(HeaderValueKind::I64, None)).unwrap(), value);
+            assert_encoding(value, &text);
+        }
+
+        assert_eq!(i32::decode("+1", context(HeaderValueKind::I32, None)).unwrap(), 1);
+        for raw in ["2147483648", "-2147483649", " 1", "1 "] {
+            assert!(matches!(
+                i32::decode(raw, context(HeaderValueKind::I32, None)),
+                Err(HeaderCodecError::InvalidValue { .. })
+            ));
+        }
+        for raw in ["9223372036854775808", "-9223372036854775809"] {
+            assert!(matches!(
+                i64::decode(raw, context(HeaderValueKind::I64, None)),
+                Err(HeaderCodecError::InvalidValue { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn unsigned_integers_cover_extrema_overflow_and_java_ranges() {
+        for value in [0, 1, u32::MAX] {
+            let text = value.to_string();
+            assert_eq!(u32::decode(&text, context(HeaderValueKind::U32, None)).unwrap(), value);
+            assert_encoding(value, &text);
+        }
+        for value in [0, 1, u64::MAX] {
+            let text = value.to_string();
+            assert_eq!(u64::decode(&text, context(HeaderValueKind::U64, None)).unwrap(), value);
+            assert_encoding(value, &text);
+        }
+
+        assert!(matches!(
+            u32::decode("4294967296", context(HeaderValueKind::U32, None)),
+            Err(HeaderCodecError::InvalidValue { .. })
+        ));
+        assert!(matches!(
+            u64::decode("18446744073709551616", context(HeaderValueKind::U64, None)),
+            Err(HeaderCodecError::InvalidValue { .. })
+        ));
+        assert!(matches!(
+            u64::decode("-1", context(HeaderValueKind::U64, None)),
+            Err(HeaderCodecError::InvalidValue { .. })
+        ));
+
+        assert_eq!(
+            u32::decode(
+                &i32::MAX.to_string(),
+                context(HeaderValueKind::U32, Some(HeaderRange::I32)),
+            )
+            .unwrap(),
+            i32::MAX as u32
+        );
+        assert!(matches!(
+            u32::decode(
+                &(i32::MAX as u32 + 1).to_string(),
+                context(HeaderValueKind::U32, Some(HeaderRange::I32)),
+            ),
+            Err(HeaderCodecError::JavaRange { .. })
+        ));
+        assert_eq!(
+            u64::decode(
+                &i64::MAX.to_string(),
+                context(HeaderValueKind::U64, Some(HeaderRange::I64)),
+            )
+            .unwrap(),
+            i64::MAX as u64
+        );
+        assert!(matches!(
+            u64::decode(
+                &(i64::MAX as u64 + 1).to_string(),
+                context(HeaderValueKind::U64, Some(HeaderRange::I64)),
+            ),
+            Err(HeaderCodecError::JavaRange { .. })
+        ));
+    }
+
+    #[test]
+    fn encode_range_helper_keeps_rust_extensions_unrestricted() {
+        let unrestricted = context(HeaderValueKind::U64, None);
+        assert!(validate_unsigned_java_range(u64::MAX, unrestricted).is_ok());
+
+        let java_long = context(HeaderValueKind::U32, Some(HeaderRange::I64));
+        assert!(validate_unsigned_java_range(u32::MAX as u64, java_long).is_ok());
+
+        let java_int = context(HeaderValueKind::U32, Some(HeaderRange::I32));
+        let error = validate_unsigned_java_range(i32::MAX as u64 + 1, java_int).unwrap_err();
+        assert!(matches!(error, HeaderCodecError::JavaRange { .. }));
+    }
+
+    #[test]
+    fn booleans_decode_case_insensitively_but_encode_canonically() {
+        for raw in ["true", "TRUE", "TrUe"] {
+            assert!(bool::decode(raw, context(HeaderValueKind::Bool, None)).unwrap());
+        }
+        for raw in ["false", "FALSE", "FaLsE"] {
+            assert!(!bool::decode(raw, context(HeaderValueKind::Bool, None)).unwrap());
+        }
+        for raw in ["", "1", "yes", " true"] {
+            assert!(matches!(
+                bool::decode(raw, context(HeaderValueKind::Bool, None)),
+                Err(HeaderCodecError::InvalidValue { .. })
+            ));
+        }
+        assert_encoding(true, "true");
+        assert_encoding(false, "false");
+    }
+
+    #[test]
+    fn boundary_type_preserves_java_fallback_and_canonical_encoding() {
+        assert_eq!(
+            BoundaryType::decode("upper", context(HeaderValueKind::BoundaryType, None)).unwrap(),
+            BoundaryType::Upper
+        );
+        for raw in ["lower", "unknown", "", "上界"] {
+            assert_eq!(
+                BoundaryType::decode(raw, context(HeaderValueKind::BoundaryType, None)).unwrap(),
+                BoundaryType::Lower
+            );
+        }
+        assert_encoding(BoundaryType::Lower, "LOWER");
+        assert_encoding(BoundaryType::Upper, "UPPER");
+    }
+
+    #[test]
+    fn errors_do_not_echo_malformed_values() {
+        let raw = "secret-invalid-value";
+        let error = bool::decode(raw, context(HeaderValueKind::Bool, None)).unwrap_err();
+        let rendered = error.to_string();
+
+        assert!(!rendered.contains(raw));
+        assert_eq!(rendered, "invalid header field ExampleHeader.value: expected Bool");
+    }
+}

--- a/rocketmq-protocol/tests/request_header_codec_runtime_ui.rs
+++ b/rocketmq-protocol/tests/request_header_codec_runtime_ui.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn runtime_extension_traits_are_sealed() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/request_header_codec_runtime/fail/*.rs");
+}

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.rs
@@ -1,0 +1,27 @@
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header_codec::{
+    HeaderCodecError, HeaderFieldContext, HeaderValue, HeaderValueKind,
+};
+
+struct ExternalValue;
+
+impl HeaderValue for ExternalValue {
+    const KIND: HeaderValueKind = HeaderValueKind::String;
+
+    fn to_map_value(&self) -> CheetahString {
+        CheetahString::new()
+    }
+
+    fn encoded_len(&self) -> usize {
+        0
+    }
+
+    fn write_ascii(&self, _out: &mut BytesMut) {}
+
+    fn decode(_raw: &str, _context: HeaderFieldContext) -> Result<Self, HeaderCodecError> {
+        Ok(Self)
+    }
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.stderr
@@ -1,0 +1,37 @@
+error[E0277]: the trait bound `ExternalValue: header_codec::private::Sealed` is not satisfied
+ --> tests/ui/request_header_codec_runtime/fail/external_header_value.rs:9:22
+  |
+9 | impl HeaderValue for ExternalValue {
+  |                      ^^^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `header_codec::private::Sealed` is not implemented for `ExternalValue`
+ --> tests/ui/request_header_codec_runtime/fail/external_header_value.rs:7:1
+  |
+7 | struct ExternalValue;
+  | ^^^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `header_codec::private::Sealed`:
+            CheetahString
+            MapSink<'_>
+            bool
+            i32
+            i64
+            rocketmq_model::boundary_type::BoundaryType
+            std::string::String
+            u32
+            u64
+note: required by a bound in `HeaderValue`
+ --> src/protocol/header_codec/value.rs
+  |
+  | pub trait HeaderValue: Sealed + Sized {
+  |                        ^^^^^^ required by this bound in `HeaderValue`
+  = note: `HeaderValue` is a "sealed trait", because to implement it you also need to implement `rocketmq_protocol::protocol::header_codec::private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            rocketmq_protocol::protocol::header_codec::MapSink<'_>
+            cheetah_string::CheetahString
+            std::string::String
+            bool
+            i32
+            i64
+            u32
+            u64
+            rocketmq_model::boundary_type::BoundaryType

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.rs
@@ -1,0 +1,18 @@
+use rocketmq_protocol::protocol::header_codec::{
+    EncodeSink, HeaderCodecError, HeaderFieldContext, HeaderValue,
+};
+
+struct ExternalSink;
+
+impl EncodeSink for ExternalSink {
+    fn write<V: HeaderValue>(
+        &mut self,
+        _key: &'static str,
+        _value: &V,
+        _context: HeaderFieldContext,
+    ) -> Result<(), HeaderCodecError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.stderr
@@ -1,0 +1,36 @@
+error[E0277]: the trait bound `ExternalSink: header_codec::private::Sealed` is not satisfied
+ --> tests/ui/request_header_codec_runtime/fail/external_sink.rs:7:21
+  |
+7 | impl EncodeSink for ExternalSink {
+  |                     ^^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `header_codec::private::Sealed` is not implemented for `ExternalSink`
+ --> tests/ui/request_header_codec_runtime/fail/external_sink.rs:5:1
+  |
+5 | struct ExternalSink;
+  | ^^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `header_codec::private::Sealed`:
+            MapSink<'_>
+            bool
+            i32
+            i64
+            rocketmq_model::boundary_type::BoundaryType
+            std::string::String
+            u32
+            u64
+note: required by a bound in `EncodeSink`
+ --> src/protocol/header_codec/sink.rs
+  |
+  | pub trait EncodeSink: Sealed {
+  |                       ^^^^^^ required by this bound in `EncodeSink`
+  = note: `EncodeSink` is a "sealed trait", because to implement it you also need to implement `rocketmq_protocol::protocol::header_codec::private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            rocketmq_protocol::protocol::header_codec::MapSink<'_>
+            rocketmq_protocol::__request_header_codec::CheetahString
+            std::string::String
+            bool
+            i32
+            i64
+            u32
+            u64
+            rocketmq_model::boundary_type::BoundaryType

--- a/rocketmq-sre/Cargo.lock
+++ b/rocketmq-sre/Cargo.lock
@@ -2831,6 +2831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,6 +3387,7 @@ dependencies = [
 name = "rocketmq-macros"
 version = "1.0.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3447,6 +3457,7 @@ dependencies = [
  "cheetah-string",
  "chrono",
  "flate2",
+ "itoa",
  "lz4_flex",
  "memchr",
  "rand 0.10.2",
@@ -3456,6 +3467,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "zstd",
 ]
 
@@ -4864,6 +4876,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -2597,6 +2597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr3"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3105,7 @@ dependencies = [
 name = "rocketmq-macros"
 version = "1.0.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3217,6 +3227,7 @@ dependencies = [
  "cheetah-string",
  "chrono",
  "flate2",
+ "itoa",
  "lz4_flex",
  "memchr",
  "rand 0.10.2",
@@ -3226,6 +3237,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "thiserror",
  "zstd",
 ]
 
@@ -4126,6 +4138,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8953
- Fixes #8955

### Brief Description

Introduce the protocol-owned typed request-header codec runtime used by the next codec implementation. The runtime seals supported values and sinks, provides allocation-conscious canonical scalar encoding, classifies non-sensitive errors, records field and flatten schema metadata, and enforces Java signed-range compatibility for unsigned Rust fields.

Restore the standalone renamed-consumer fixture route and refresh affected lockfiles so the linked CI routing and locked-metadata checks recognize and validate every standalone consumer.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-protocol`
- `cargo test -p rocketmq-macros`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- The full validation profiles for `rocketmq-example/`, `rocketmq-sre/`, and `rocketmq-tools/rocketmq-mcp/`
- `scripts/check-agents-routing.ps1`
- `scripts/check-error-hygiene.ps1`
- `git diff --check`

`cargo audit --file fuzz/Cargo.lock` still reports the existing RUSTSEC-2026-0235 advisory for `rkyv 0.7.46`; the same finding is present in the base lockfile and is unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed RocketMQ header encoding and decoding for strings, booleans, integers, and boundary values.
  * Added canonical formatting, validation, Java-compatible numeric range checks, and structured codec errors.
  * Added support for header schemas, aliases, flattened fields, collision handling, and presence rules.
  * Added safe writing of encoded headers into existing header maps.
* **Tests**
  * Added coverage for value conversion, validation, overflow handling, compatibility behavior, and protected extension points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->