### PR TITLE
[ISSUE #8960]✨Add typed request header derive diagnostics

### DIFF
--- a/rocketmq-macros/src/lib.rs
+++ b/rocketmq-macros/src/lib.rs
@@ -20,10 +20,12 @@ use syn::TypePath;
 
 use crate::remoting_serializable::remoting_serializable_inner;
 use crate::request_header_codec_v2::request_header_codec_inner_v2;
+use crate::request_header_codec_v3::request_header_codec_inner_v3;
 use crate::request_header_custom::request_header_codec_inner;
 
 mod remoting_serializable;
 mod request_header_codec_v2;
+mod request_header_codec_v3;
 mod request_header_custom;
 
 #[proc_macro_derive(RequestHeaderCodec, attributes(required))]
@@ -34,6 +36,15 @@ pub fn request_header_codec(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(RequestHeaderCodecV2, attributes(required, request_header, request_header_codec_v2))]
 pub fn request_header_codec_v2(input: TokenStream) -> TokenStream {
     request_header_codec_inner_v2(input)
+}
+
+/// Validates the explicit typed request-header wire model.
+///
+/// Map, schema, and compatibility implementations are added separately after
+/// the attribute grammar and diagnostics are frozen.
+#[proc_macro_derive(RequestHeaderCodecV3, attributes(header, required))]
+pub fn request_header_codec_v3(input: TokenStream) -> TokenStream {
+    request_header_codec_inner_v3(input)
 }
 
 #[proc_macro_derive(RemotingSerializable)]

--- a/rocketmq-macros/src/request_header_codec_v3.rs
+++ b/rocketmq-macros/src/request_header_codec_v3.rs
@@ -1,0 +1,173 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod attr;
+mod model;
+mod validate;
+
+use syn::DeriveInput;
+
+pub(super) fn request_header_codec_inner_v3(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand(input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+fn expand(input: proc_macro::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let input = syn::parse::<DeriveInput>(input)?;
+    let input_span = input.ident.span();
+    let (model, mut errors) = model::HeaderModel::parse_partial(input);
+    let Some(model) = model else {
+        return Err(errors.unwrap_or_else(|| {
+            syn::Error::new(input_span, "RequestHeaderCodecV3 could not construct a header model")
+        }));
+    };
+    if let Err(error) = validate::validate(&model) {
+        combine_error(&mut errors, error);
+    }
+    if let Some(error) = errors {
+        return Err(error);
+    }
+
+    // This change deliberately freezes parsing and validation before any
+    // production implementation is generated. Only migration diagnostics are
+    // emitted; map/schema/shim code generation consumes the validated model in
+    // the next isolated change.
+    Ok(migration_diagnostics(&model))
+}
+
+fn migration_diagnostics(model: &model::HeaderModel) -> proc_macro2::TokenStream {
+    use quote::{quote, quote_spanned};
+
+    let warnings = model.fields.iter().filter(|field| field.legacy_required).map(|field| {
+        let span = field.span;
+        quote_spanned! {span=>
+            const _: () = {
+                #[deprecated(note = "legacy #[required] is accepted temporarily; use #[header(required)]")]
+                const __REQUEST_HEADER_CODEC_V3_LEGACY_REQUIRED: () = ();
+                let _ = __REQUEST_HEADER_CODEC_V3_LEGACY_REQUIRED;
+            };
+        }
+    });
+    quote!(#(#warnings)*)
+}
+
+pub(super) fn combine_error(errors: &mut Option<syn::Error>, error: syn::Error) {
+    if let Some(errors) = errors {
+        errors.combine(error);
+    } else {
+        *errors = Some(error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::{quote, ToTokens};
+
+    use super::migration_diagnostics;
+    use super::model::{AliasConflict, FlattenPresence, HeaderModel, LookupPlan, MissingPolicy, ValueKind};
+    use super::validate;
+
+    #[test]
+    fn accepts_complete_container_and_field_models() {
+        let input = syn::parse_quote! {
+            #[header(
+                type_id = "fixtures::GenericHeader",
+                java_class = "org.apache.rocketmq.fixtures.GenericHeader",
+                validate = "Self::validate_header",
+                lookup = "get",
+                crate = "protocol_api",
+                fast
+            )]
+            struct GenericHeader<T> {
+                #[header(key = "value", alias = "legacyValue", alias_conflict = "error", required, binary_order = 1)]
+                value: T,
+                #[header(key = "offset", required, java_type = "long", range = "i64", binary_order = 2)]
+                offset: u64,
+                #[header(flatten, presence = "any", binary_order = 3)]
+                nested: Option<Nested<T>>,
+            }
+        };
+
+        let model = HeaderModel::parse(input).expect("model");
+        validate::validate(&model).expect("validation");
+
+        assert_eq!(model.lookup, LookupPlan::Get);
+        assert!(model.fast);
+        assert_eq!(
+            model.protocol_path.to_token_stream().to_string(),
+            quote!(protocol_api).to_string()
+        );
+        assert_eq!(model.fields[0].kind, ValueKind::Generic);
+        assert!(matches!(model.fields[0].missing, Some(MissingPolicy::Required)));
+        assert_eq!(model.fields[0].alias_conflict, AliasConflict::Error);
+        assert_eq!(model.fields[2].flatten_presence, Some(FlattenPresence::Any));
+    }
+
+    #[test]
+    fn serde_metadata_does_not_change_v3_wire_metadata() {
+        let input = syn::parse_quote! {
+            #[header(type_id = "fixtures::IndependentMetadata", crate = "protocol_api")]
+            #[serde(rename_all = "kebab-case")]
+            struct IndependentMetadata {
+                #[serde(rename = "serde-name", alias = "serde-alias", default)]
+                #[header(required)]
+                request_id: String,
+            }
+        };
+
+        let model = HeaderModel::parse(input).expect("model");
+        validate::validate(&model).expect("validation");
+
+        assert_eq!(model.fields[0].key.value, "requestId");
+        assert!(model.fields[0].aliases.is_empty());
+    }
+
+    #[test]
+    fn combines_errors_from_multiple_fields() {
+        let input = syn::parse_quote! {
+            #[header(type_id = "fixtures::Combined", crate = "protocol_api")]
+            struct Combined {
+                #[header(required)]
+                first: Option<String>,
+                second: bool,
+            }
+        };
+
+        let error = match HeaderModel::parse(input) {
+            Ok(_) => panic!("invalid fields must fail"),
+            Err(error) => error,
+        };
+        let rendered = error.into_compile_error().to_string();
+
+        assert!(rendered.contains("required cannot be used on Option<T>"));
+        assert!(rendered.contains("non-Option fields require required, default, or default_with"));
+    }
+
+    #[test]
+    fn legacy_required_emits_a_locatable_migration_diagnostic() {
+        let input = syn::parse_quote! {
+            #[header(type_id = "fixtures::LegacyRequired", crate = "protocol_api")]
+            struct LegacyRequired {
+                #[required]
+                value: String,
+            }
+        };
+
+        let model = HeaderModel::parse(input).expect("model");
+        validate::validate(&model).expect("validation");
+        let diagnostics = migration_diagnostics(&model).to_string();
+
+        assert!(diagnostics.contains("deprecated"));
+        assert!(diagnostics.contains("legacy #[required]"));
+    }
+}

--- a/rocketmq-macros/src/request_header_codec_v3/attr.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/attr.rs
@@ -1,0 +1,335 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::Span;
+use syn::meta::ParseNestedMeta;
+use syn::spanned::Spanned;
+use syn::{Attribute, LitInt, LitStr, Meta, Path, Token};
+
+use super::combine_error;
+
+#[derive(Default)]
+pub(super) struct ContainerAttrs {
+    pub(super) type_id: Option<LitStr>,
+    pub(super) java_class: Option<LitStr>,
+    pub(super) validate: Option<Path>,
+    pub(super) lookup: Option<LitStr>,
+    pub(super) protocol_path: Option<Path>,
+    pub(super) fast: Option<Span>,
+}
+
+#[derive(Default)]
+pub(super) struct FieldAttrs {
+    pub(super) key: Option<LitStr>,
+    pub(super) aliases: Vec<LitStr>,
+    pub(super) required: Option<Span>,
+    pub(super) legacy_required: Option<Span>,
+    pub(super) default: Option<Span>,
+    pub(super) default_with_declared: Option<Span>,
+    pub(super) default_with: Option<Path>,
+    pub(super) default_semantic: Option<LitStr>,
+    pub(super) alias_conflict: Option<LitStr>,
+    pub(super) flatten: Option<Span>,
+    pub(super) presence: Option<LitStr>,
+    pub(super) java_type: Option<LitStr>,
+    pub(super) range: Option<LitStr>,
+    pub(super) binary_order: Option<(u16, Span)>,
+}
+
+pub(super) fn parse_container_attrs(attrs: &[Attribute]) -> (ContainerAttrs, Option<syn::Error>) {
+    let mut parsed = ContainerAttrs::default();
+    let mut errors = None;
+
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("header")) {
+        let result = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("type_id") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.type_id,
+                    value,
+                    meta.path.span(),
+                    "duplicate type_id",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("java_class") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.java_class,
+                    value,
+                    meta.path.span(),
+                    "duplicate java_class",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("validate") {
+                if let Some(value) = parse_path(&meta, "validate", &mut errors)? {
+                    set_once(
+                        &mut parsed.validate,
+                        value,
+                        meta.path.span(),
+                        "duplicate validate",
+                        &mut errors,
+                    );
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("lookup") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.lookup,
+                    value,
+                    meta.path.span(),
+                    "duplicate lookup",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("crate") {
+                if let Some(value) = parse_path(&meta, "protocol crate", &mut errors)? {
+                    set_once(
+                        &mut parsed.protocol_path,
+                        value,
+                        meta.path.span(),
+                        "duplicate crate option",
+                        &mut errors,
+                    );
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("fast") {
+                set_once(
+                    &mut parsed.fast,
+                    meta.path.span(),
+                    meta.path.span(),
+                    "duplicate fast",
+                    &mut errors,
+                );
+                parse_flag(&meta, "fast")?;
+                return Ok(());
+            }
+            Err(meta.error("unsupported RequestHeaderCodecV3 container option"))
+        });
+        if let Err(error) = result {
+            combine_error(&mut errors, error);
+        }
+    }
+
+    (parsed, errors)
+}
+
+pub(super) fn parse_field_attrs(attrs: &[Attribute]) -> (FieldAttrs, Option<syn::Error>) {
+    let mut parsed = FieldAttrs::default();
+    let mut errors = None;
+
+    for attr in attrs {
+        if attr.path().is_ident("required") {
+            if !matches!(&attr.meta, Meta::Path(_)) {
+                combine_error(
+                    &mut errors,
+                    syn::Error::new(attr.span(), "legacy required must be a flag without arguments"),
+                );
+            }
+            set_once(
+                &mut parsed.legacy_required,
+                attr.span(),
+                attr.span(),
+                "duplicate legacy required attribute",
+                &mut errors,
+            );
+            continue;
+        }
+        if !attr.path().is_ident("header") {
+            continue;
+        }
+
+        let result = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("key") {
+                let value = parse_lit_str(&meta)?;
+                set_once(&mut parsed.key, value, meta.path.span(), "duplicate key", &mut errors);
+                return Ok(());
+            }
+            if meta.path.is_ident("alias") {
+                parsed.aliases.push(parse_lit_str(&meta)?);
+                return Ok(());
+            }
+            if meta.path.is_ident("required") {
+                set_once(
+                    &mut parsed.required,
+                    meta.path.span(),
+                    meta.path.span(),
+                    "duplicate required",
+                    &mut errors,
+                );
+                parse_flag(&meta, "required")?;
+                return Ok(());
+            }
+            if meta.path.is_ident("default") {
+                set_once(
+                    &mut parsed.default,
+                    meta.path.span(),
+                    meta.path.span(),
+                    "duplicate default",
+                    &mut errors,
+                );
+                parse_flag(&meta, "default")?;
+                return Ok(());
+            }
+            if meta.path.is_ident("default_with") {
+                set_once(
+                    &mut parsed.default_with_declared,
+                    meta.path.span(),
+                    meta.path.span(),
+                    "duplicate default_with",
+                    &mut errors,
+                );
+                if let Some(value) = parse_path(&meta, "default_with", &mut errors)? {
+                    if parsed.default_with.is_none() {
+                        parsed.default_with = Some(value);
+                    }
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("default_semantic") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.default_semantic,
+                    value,
+                    meta.path.span(),
+                    "duplicate default_semantic",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("alias_conflict") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.alias_conflict,
+                    value,
+                    meta.path.span(),
+                    "duplicate alias_conflict",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("flatten") {
+                set_once(
+                    &mut parsed.flatten,
+                    meta.path.span(),
+                    meta.path.span(),
+                    "duplicate flatten",
+                    &mut errors,
+                );
+                parse_flag(&meta, "flatten")?;
+                return Ok(());
+            }
+            if meta.path.is_ident("presence") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.presence,
+                    value,
+                    meta.path.span(),
+                    "duplicate presence",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("java_type") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.java_type,
+                    value,
+                    meta.path.span(),
+                    "duplicate java_type",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("range") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.range,
+                    value,
+                    meta.path.span(),
+                    "duplicate range",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("binary_order") {
+                let value: LitInt = meta.value()?.parse()?;
+                let order = value
+                    .base10_parse::<u16>()
+                    .map_err(|_| syn::Error::new(value.span(), "binary_order must fit in u16"))?;
+                set_once(
+                    &mut parsed.binary_order,
+                    (order, value.span()),
+                    meta.path.span(),
+                    "duplicate binary_order",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            Err(meta.error("unsupported RequestHeaderCodecV3 field option"))
+        });
+        if let Err(error) = result {
+            combine_error(&mut errors, error);
+        }
+    }
+
+    if let (Some(required), Some(_)) = (parsed.required, parsed.legacy_required) {
+        combine_error(
+            &mut errors,
+            syn::Error::new(required, "required is declared by both #[header] and #[required]"),
+        );
+    }
+
+    (parsed, errors)
+}
+
+fn parse_lit_str(meta: &ParseNestedMeta<'_>) -> syn::Result<LitStr> {
+    meta.value()?.parse()
+}
+
+fn parse_path(meta: &ParseNestedMeta<'_>, name: &str, errors: &mut Option<syn::Error>) -> syn::Result<Option<Path>> {
+    let value = parse_lit_str(meta)?;
+    match value.parse::<Path>() {
+        Ok(path) => Ok(Some(path)),
+        Err(error) => {
+            combine_error(
+                errors,
+                syn::Error::new(value.span(), format!("invalid {name} path: {error}")),
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn parse_flag(meta: &ParseNestedMeta<'_>, name: &str) -> syn::Result<()> {
+    if meta.input.peek(Token![=]) || meta.input.peek(syn::token::Paren) {
+        Err(meta.error(format!("{name} is a flag and does not accept a value")))
+    } else {
+        Ok(())
+    }
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, span: Span, message: &str, errors: &mut Option<syn::Error>) {
+    if slot.is_some() {
+        combine_error(errors, syn::Error::new(span, message));
+    } else {
+        *slot = Some(value);
+    }
+}

--- a/rocketmq-macros/src/request_header_codec_v3/model.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/model.rs
@@ -1,0 +1,573 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Fields, GenericArgument, Generics, Ident, LitStr, Path, PathArguments, Type};
+
+use super::attr::{parse_container_attrs, parse_field_attrs, FieldAttrs};
+use super::combine_error;
+use crate::snake_to_camel_case;
+
+pub(super) struct HeaderModel {
+    pub(super) ident: Ident,
+    pub(super) generics: Generics,
+    pub(super) type_id: LitStr,
+    pub(super) java_class: Option<LitStr>,
+    pub(super) validate_path: Option<Path>,
+    pub(super) lookup: LookupPlan,
+    pub(super) protocol_path: Path,
+    pub(super) fast: bool,
+    pub(super) fields: Vec<FieldModel>,
+}
+
+pub(super) struct FieldModel {
+    pub(super) ident: Ident,
+    pub(super) ty: Type,
+    pub(super) option_inner: Option<Type>,
+    pub(super) key: WireName,
+    pub(super) aliases: Vec<WireName>,
+    pub(super) alias_conflict: AliasConflict,
+    pub(super) missing: Option<MissingPolicy>,
+    pub(super) default_semantic: Option<SpannedString>,
+    pub(super) flattened: bool,
+    pub(super) flatten_presence: Option<FlattenPresence>,
+    pub(super) java_type: Option<SpannedString>,
+    pub(super) range: Option<HeaderRange>,
+    pub(super) binary_order: Option<(u16, Span)>,
+    pub(super) kind: ValueKind,
+    pub(super) legacy_required: bool,
+    pub(super) span: Span,
+}
+
+#[derive(Clone)]
+pub(super) struct WireName {
+    pub(super) value: String,
+    pub(super) span: Span,
+}
+
+#[derive(Clone)]
+pub(super) struct SpannedString {
+    pub(super) value: String,
+    pub(super) span: Span,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LookupPlan {
+    Auto,
+    Scan,
+    Get,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AliasConflict {
+    Error,
+    PreferCanonical,
+}
+
+#[derive(Clone)]
+pub(super) enum MissingPolicy {
+    Optional,
+    Required,
+    Default,
+    DefaultWith(Path),
+}
+
+impl PartialEq for MissingPolicy {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Optional, Self::Optional)
+                | (Self::Required, Self::Required)
+                | (Self::Default, Self::Default)
+                | (Self::DefaultWith(_), Self::DefaultWith(_))
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FlattenPresence {
+    Always,
+    Any,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum HeaderRange {
+    I32,
+    I64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ValueKind {
+    String,
+    Bool,
+    I32,
+    I64,
+    U32,
+    U64,
+    BoundaryType,
+    Generic,
+    Nested,
+    Unsupported,
+}
+
+impl HeaderModel {
+    #[cfg(test)]
+    pub(super) fn parse(input: DeriveInput) -> syn::Result<Self> {
+        let span = input.ident.span();
+        let (model, errors) = Self::parse_partial(input);
+        if let Some(error) = errors {
+            return Err(error);
+        }
+        model.ok_or_else(|| syn::Error::new(span, "RequestHeaderCodecV3 could not construct a header model"))
+    }
+
+    pub(super) fn parse_partial(input: DeriveInput) -> (Option<Self>, Option<syn::Error>) {
+        let mut errors = None;
+        let (attrs, attribute_errors) = parse_container_attrs(&input.attrs);
+        if let Some(error) = attribute_errors {
+            combine_error(&mut errors, error);
+        }
+
+        let type_id = attrs.type_id.unwrap_or_else(|| {
+            combine_error(
+                &mut errors,
+                syn::Error::new(
+                    input.ident.span(),
+                    "RequestHeaderCodecV3 requires header(type_id = \"...\")",
+                ),
+            );
+            LitStr::new("invalid::MissingTypeId", input.ident.span())
+        });
+        let lookup = parse_lookup(attrs.lookup, &mut errors);
+        let protocol_path = match attrs.protocol_path {
+            Some(path) => path,
+            None => match resolve_protocol_path(input.ident.span()) {
+                Ok(path) => path,
+                Err(error) => {
+                    combine_error(&mut errors, error);
+                    syn::parse_quote!(::rocketmq_protocol)
+                }
+            },
+        };
+
+        let generic_types: HashSet<String> = input
+            .generics
+            .type_params()
+            .map(|parameter| parameter.ident.to_string())
+            .collect();
+        let named = match input.data {
+            Data::Struct(data) => match data.fields {
+                Fields::Named(fields) => Some(fields.named),
+                Fields::Unnamed(fields) => {
+                    combine_error(
+                        &mut errors,
+                        syn::Error::new(fields.span(), "RequestHeaderCodecV3 requires a named struct"),
+                    );
+                    None
+                }
+                Fields::Unit => {
+                    combine_error(
+                        &mut errors,
+                        syn::Error::new(input.ident.span(), "RequestHeaderCodecV3 does not support unit structs"),
+                    );
+                    None
+                }
+            },
+            Data::Enum(data) => {
+                combine_error(
+                    &mut errors,
+                    syn::Error::new(data.enum_token.span(), "RequestHeaderCodecV3 does not support enums"),
+                );
+                None
+            }
+            Data::Union(data) => {
+                combine_error(
+                    &mut errors,
+                    syn::Error::new(data.union_token.span(), "RequestHeaderCodecV3 does not support unions"),
+                );
+                None
+            }
+        };
+
+        let valid_shape = named.is_some();
+        let mut fields = Vec::with_capacity(named.as_ref().map_or(0, syn::punctuated::Punctuated::len));
+        if let Some(named) = named {
+            for field in named {
+                match FieldModel::parse(field, &generic_types) {
+                    Ok(field) => fields.push(field),
+                    Err(error) => combine_error(&mut errors, error),
+                }
+            }
+        }
+
+        let model = valid_shape.then_some(Self {
+            ident: input.ident,
+            generics: input.generics,
+            type_id,
+            java_class: attrs.java_class,
+            validate_path: attrs.validate,
+            lookup,
+            protocol_path,
+            fast: attrs.fast.is_some(),
+            fields,
+        });
+        (model, errors)
+    }
+}
+
+impl FieldModel {
+    fn parse(field: syn::Field, generic_types: &HashSet<String>) -> syn::Result<Self> {
+        let span = field.span();
+        let ident = field
+            .ident
+            .clone()
+            .ok_or_else(|| syn::Error::new(span, "RequestHeaderCodecV3 requires named fields"))?;
+        let (attrs, mut errors) = parse_field_attrs(&field.attrs);
+        let option_inner = option_inner(&field.ty).cloned();
+        let base_type = option_inner.as_ref().unwrap_or(&field.ty);
+        let flattened = attrs.flatten.is_some();
+        let kind = classify_type(base_type, generic_types, flattened);
+        let key = attrs.key.as_ref().map_or_else(
+            || WireName {
+                value: snake_to_camel_case(&ident.to_string()),
+                span: ident.span(),
+            },
+            |key| WireName {
+                value: key.value(),
+                span: key.span(),
+            },
+        );
+        let aliases = attrs
+            .aliases
+            .iter()
+            .map(|alias| WireName {
+                value: alias.value(),
+                span: alias.span(),
+            })
+            .collect();
+
+        let alias_conflict = parse_alias_conflict(attrs.alias_conflict.as_ref(), &mut errors);
+        let flatten_presence = parse_flatten_presence(attrs.presence.as_ref(), &mut errors);
+        let range = parse_range(attrs.range.as_ref(), &mut errors);
+        let missing = normalize_missing(&attrs, option_inner.is_some(), flattened, span, &mut errors);
+        let default_semantic = attrs.default_semantic.as_ref().map(|semantic| SpannedString {
+            value: semantic.value(),
+            span: semantic.span(),
+        });
+        let java_type = attrs.java_type.as_ref().map(|java_type| SpannedString {
+            value: java_type.value(),
+            span: java_type.span(),
+        });
+
+        validate_field_attribute_shape(
+            &attrs,
+            flattened,
+            option_inner.is_some(),
+            kind,
+            flatten_presence,
+            attrs.presence.is_some(),
+            default_semantic.as_ref(),
+            span,
+            &mut errors,
+        );
+
+        if let Some(error) = errors {
+            return Err(error);
+        }
+
+        Ok(Self {
+            ident,
+            ty: field.ty,
+            option_inner,
+            key,
+            aliases,
+            alias_conflict,
+            missing,
+            default_semantic,
+            flattened,
+            flatten_presence,
+            java_type,
+            range,
+            binary_order: attrs.binary_order,
+            kind,
+            legacy_required: attrs.legacy_required.is_some(),
+            span,
+        })
+    }
+}
+
+fn parse_lookup(value: Option<LitStr>, errors: &mut Option<syn::Error>) -> LookupPlan {
+    let Some(value) = value else {
+        return LookupPlan::Auto;
+    };
+    match value.value().as_str() {
+        "auto" => LookupPlan::Auto,
+        "scan" => LookupPlan::Scan,
+        "get" => LookupPlan::Get,
+        _ => {
+            combine_error(
+                errors,
+                syn::Error::new(value.span(), "lookup must be one of: auto, scan, get"),
+            );
+            LookupPlan::Auto
+        }
+    }
+}
+
+fn parse_alias_conflict(value: Option<&LitStr>, errors: &mut Option<syn::Error>) -> AliasConflict {
+    let Some(value) = value else {
+        return AliasConflict::Error;
+    };
+    match value.value().as_str() {
+        "error" => AliasConflict::Error,
+        "prefer_canonical" => AliasConflict::PreferCanonical,
+        _ => {
+            combine_error(
+                errors,
+                syn::Error::new(value.span(), "alias_conflict must be error or prefer_canonical"),
+            );
+            AliasConflict::Error
+        }
+    }
+}
+
+fn parse_flatten_presence(value: Option<&LitStr>, errors: &mut Option<syn::Error>) -> Option<FlattenPresence> {
+    let value = value?;
+    match value.value().as_str() {
+        "always" => Some(FlattenPresence::Always),
+        "any" => Some(FlattenPresence::Any),
+        _ => {
+            combine_error(errors, syn::Error::new(value.span(), "presence must be always or any"));
+            None
+        }
+    }
+}
+
+fn parse_range(value: Option<&LitStr>, errors: &mut Option<syn::Error>) -> Option<HeaderRange> {
+    let value = value?;
+    match value.value().as_str() {
+        "i32" => Some(HeaderRange::I32),
+        "i64" => Some(HeaderRange::I64),
+        _ => {
+            combine_error(errors, syn::Error::new(value.span(), "range must be i32 or i64"));
+            None
+        }
+    }
+}
+
+fn normalize_missing(
+    attrs: &FieldAttrs,
+    optional: bool,
+    flattened: bool,
+    span: Span,
+    errors: &mut Option<syn::Error>,
+) -> Option<MissingPolicy> {
+    if flattened {
+        return None;
+    }
+
+    let required = attrs.required.is_some() || attrs.legacy_required.is_some();
+    let count = usize::from(required)
+        + usize::from(attrs.default.is_some())
+        + usize::from(attrs.default_with_declared.is_some());
+    if count > 1 {
+        combine_error(
+            errors,
+            syn::Error::new(span, "required, default, and default_with are mutually exclusive"),
+        );
+    }
+    if required && optional {
+        combine_error(errors, syn::Error::new(span, "required cannot be used on Option<T>"));
+    }
+
+    if required {
+        Some(MissingPolicy::Required)
+    } else if attrs.default.is_some() {
+        Some(MissingPolicy::Default)
+    } else if let Some(path) = &attrs.default_with {
+        Some(MissingPolicy::DefaultWith(path.clone()))
+    } else if attrs.default_with_declared.is_some() {
+        None
+    } else if optional {
+        Some(MissingPolicy::Optional)
+    } else {
+        combine_error(
+            errors,
+            syn::Error::new(span, "non-Option fields require required, default, or default_with"),
+        );
+        None
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "attribute groups are kept explicit for diagnostic spans"
+)]
+fn validate_field_attribute_shape(
+    attrs: &FieldAttrs,
+    flattened: bool,
+    optional: bool,
+    kind: ValueKind,
+    presence: Option<FlattenPresence>,
+    presence_declared: bool,
+    default_semantic: Option<&SpannedString>,
+    span: Span,
+    errors: &mut Option<syn::Error>,
+) {
+    let has_default = attrs.default.is_some() || attrs.default_with_declared.is_some();
+    if has_default && default_semantic.is_none() {
+        combine_error(
+            errors,
+            syn::Error::new(span, "default and default_with require default_semantic"),
+        );
+    }
+    if !has_default {
+        if let Some(semantic) = default_semantic {
+            combine_error(
+                errors,
+                syn::Error::new(semantic.span, "default_semantic requires default or default_with"),
+            );
+        }
+    }
+    if let Some(semantic) = default_semantic {
+        let valid = semantic.value.starts_with("literal:")
+            || semantic
+                .value
+                .strip_prefix("dynamic:")
+                .is_some_and(|identifier| !identifier.is_empty());
+        if !valid {
+            combine_error(
+                errors,
+                syn::Error::new(
+                    semantic.span,
+                    "default_semantic must be literal:<wire-text> or dynamic:<semantic-id>",
+                ),
+            );
+        }
+    }
+
+    if flattened {
+        if attrs.key.is_some()
+            || !attrs.aliases.is_empty()
+            || attrs.required.is_some()
+            || attrs.legacy_required.is_some()
+            || attrs.default.is_some()
+            || attrs.default_with_declared.is_some()
+            || attrs.default_semantic.is_some()
+            || attrs.alias_conflict.is_some()
+            || attrs.java_type.is_some()
+            || attrs.range.is_some()
+        {
+            combine_error(
+                errors,
+                syn::Error::new(
+                    span,
+                    "flatten cannot be combined with key, alias, missing policy, default, alias_conflict, java_type, or range",
+                ),
+            );
+        }
+        if optional && !presence_declared {
+            combine_error(
+                errors,
+                syn::Error::new(span, "Option<Flattened> requires presence = \"any\" or \"always\""),
+            );
+        }
+        if !optional && presence == Some(FlattenPresence::Any) {
+            combine_error(
+                errors,
+                syn::Error::new(span, "presence = \"any\" is valid only for Option<Flattened>"),
+            );
+        }
+        if !matches!(kind, ValueKind::Nested | ValueKind::Generic) {
+            combine_error(errors, syn::Error::new(span, "flatten requires a nested header type"));
+        }
+    } else if attrs.presence.is_some() {
+        combine_error(
+            errors,
+            syn::Error::new(span, "presence is valid only for flatten fields"),
+        );
+    }
+}
+
+fn option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return None;
+    };
+    if arguments.args.len() != 1 {
+        return None;
+    }
+    match arguments.args.first()? {
+        GenericArgument::Type(inner) => Some(inner),
+        _ => None,
+    }
+}
+
+fn classify_type(ty: &Type, generic_types: &HashSet<String>, flattened: bool) -> ValueKind {
+    let Type::Path(type_path) = ty else {
+        return ValueKind::Unsupported;
+    };
+    if type_path.qself.is_some() {
+        return ValueKind::Unsupported;
+    }
+    let Some(segment) = type_path.path.segments.last() else {
+        return ValueKind::Unsupported;
+    };
+    if generic_types.contains(&segment.ident.to_string()) && matches!(segment.arguments, PathArguments::None) {
+        return ValueKind::Generic;
+    }
+    if !matches!(segment.arguments, PathArguments::None) {
+        return if flattened {
+            ValueKind::Nested
+        } else {
+            ValueKind::Unsupported
+        };
+    }
+    match segment.ident.to_string().as_str() {
+        "String" | "CheetahString" => ValueKind::String,
+        "bool" => ValueKind::Bool,
+        "i32" => ValueKind::I32,
+        "i64" => ValueKind::I64,
+        "u32" => ValueKind::U32,
+        "u64" => ValueKind::U64,
+        "BoundaryType" => ValueKind::BoundaryType,
+        _ if flattened => ValueKind::Nested,
+        _ => ValueKind::Unsupported,
+    }
+}
+
+fn resolve_protocol_path(span: Span) -> syn::Result<Path> {
+    use proc_macro_crate::{crate_name, FoundCrate};
+
+    match crate_name("rocketmq-protocol") {
+        Ok(FoundCrate::Itself) => Ok(syn::parse_quote!(crate)),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name.replace('-', "_"), span);
+            Ok(syn::parse_quote!(::#ident))
+        }
+        Err(error) => Err(syn::Error::new(
+            span,
+            format!("unable to resolve rocketmq-protocol ({error}); use #[header(crate = \"path::to::protocol\")]"),
+        )),
+    }
+}

--- a/rocketmq-macros/src/request_header_codec_v3/validate.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/validate.rs
@@ -1,0 +1,253 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use quote::ToTokens;
+use syn::spanned::Spanned;
+use syn::PathArguments;
+
+use super::combine_error;
+use super::model::{
+    AliasConflict, FieldModel, HeaderModel, HeaderRange, LookupPlan, MissingPolicy, ValueKind, WireName,
+};
+
+pub(super) fn validate(model: &HeaderModel) -> syn::Result<()> {
+    let mut errors = None;
+    validate_container(model, &mut errors);
+    validate_fields(model, &mut errors);
+
+    match errors {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn validate_container(model: &HeaderModel, errors: &mut Option<syn::Error>) {
+    let type_id = model.type_id.value();
+    match syn::parse_str::<syn::Path>(&type_id) {
+        Ok(path)
+            if path.leading_colon.is_none()
+                && path.segments.len() >= 2
+                && path
+                    .segments
+                    .iter()
+                    .all(|segment| matches!(segment.arguments, PathArguments::None)) => {}
+        _ => combine_error(
+            errors,
+            syn::Error::new(
+                model.type_id.span(),
+                "type_id must be a stable, fully qualified Rust path with at least two segments",
+            ),
+        ),
+    }
+
+    if let Some(java_class) = &model.java_class {
+        let value = java_class.value();
+        let valid = value.split('.').count() >= 2 && value.split('.').all(is_java_identifier);
+        if !valid {
+            combine_error(
+                errors,
+                syn::Error::new(
+                    java_class.span(),
+                    "java_class must be a fully qualified Java class name",
+                ),
+            );
+        }
+    }
+
+    if model.protocol_path.segments.is_empty() {
+        combine_error(
+            errors,
+            syn::Error::new(model.ident.span(), "protocol crate path must not be empty"),
+        );
+    }
+    if model
+        .validate_path
+        .as_ref()
+        .is_some_and(|path| path.segments.is_empty())
+    {
+        combine_error(
+            errors,
+            syn::Error::new(model.ident.span(), "validate path must not be empty"),
+        );
+    }
+
+    // These values are code-generation decisions. Reading them here keeps the
+    // validated model complete without adding an intermediate partial impl.
+    let _ = model.generics.split_for_impl();
+    let _ = model.fast;
+    match model.lookup {
+        LookupPlan::Auto | LookupPlan::Scan | LookupPlan::Get => {}
+    }
+}
+
+fn validate_fields(model: &HeaderModel, errors: &mut Option<syn::Error>) {
+    let mut key_owners: HashMap<&str, &syn::Ident> = HashMap::new();
+    let mut order_owners: HashMap<u16, &syn::Ident> = HashMap::new();
+
+    for field in &model.fields {
+        validate_field(field, errors);
+
+        if !field.flattened {
+            for name in std::iter::once(&field.key).chain(field.aliases.iter()) {
+                validate_wire_name(name, errors);
+                if let Some(owner) = key_owners.insert(name.value.as_str(), &field.ident) {
+                    combine_error(
+                        errors,
+                        syn::Error::new(
+                            name.span,
+                            format!("wire key `{}` is already used by field `{owner}`", name.value),
+                        ),
+                    );
+                }
+            }
+        }
+
+        if let Some((order, span)) = field.binary_order {
+            if let Some(owner) = order_owners.insert(order, &field.ident) {
+                combine_error(
+                    errors,
+                    syn::Error::new(
+                        span,
+                        format!("binary_order `{order}` is already used by field `{owner}`"),
+                    ),
+                );
+            }
+        }
+    }
+}
+
+fn validate_field(field: &FieldModel, errors: &mut Option<syn::Error>) {
+    if field.kind == ValueKind::Unsupported {
+        combine_error(
+            errors,
+            syn::Error::new(
+                field.ty.span(),
+                format!(
+                    "unsupported RequestHeaderCodecV3 field type `{}`",
+                    field.ty.to_token_stream()
+                ),
+            ),
+        );
+    }
+
+    if !field.flattened && field.aliases.is_empty() && field.alias_conflict != AliasConflict::Error {
+        combine_error(
+            errors,
+            syn::Error::new(field.span, "alias_conflict requires at least one alias"),
+        );
+    }
+
+    if let Some(MissingPolicy::DefaultWith(path)) = &field.missing {
+        if path.segments.is_empty() {
+            combine_error(
+                errors,
+                syn::Error::new(field.span, "default_with path must not be empty"),
+            );
+        }
+    }
+    let _ = field.option_inner.as_ref();
+    let _ = field.default_semantic.as_ref();
+    let _ = field.flatten_presence;
+    validate_java_range(field, errors);
+}
+
+fn validate_wire_name(name: &WireName, errors: &mut Option<syn::Error>) {
+    if name.value.is_empty() {
+        combine_error(
+            errors,
+            syn::Error::new(name.span, "wire key and alias must not be empty"),
+        );
+    }
+    if name.value.bytes().any(|byte| byte == 0) {
+        combine_error(
+            errors,
+            syn::Error::new(name.span, "wire key and alias must not contain NUL"),
+        );
+    }
+    if name.value.len() > u16::MAX as usize {
+        combine_error(
+            errors,
+            syn::Error::new(name.span, "wire key and alias must fit the ROCKETMQ u16 key length"),
+        );
+    }
+}
+
+fn validate_java_range(field: &FieldModel, errors: &mut Option<syn::Error>) {
+    let java_type = field.java_type.as_ref().map(|value| value.value.as_str());
+    match (field.kind, field.range, java_type) {
+        (ValueKind::U32, Some(HeaderRange::I32), Some("int" | "Integer")) => {}
+        (ValueKind::U64, Some(HeaderRange::I64), Some("long" | "Long")) => {}
+        (ValueKind::U32, Some(_), _) => combine_error(
+            errors,
+            syn::Error::new(field.span, "u32 range requires java_type = \"int\" and range = \"i32\""),
+        ),
+        (ValueKind::U64, Some(_), _) => combine_error(
+            errors,
+            syn::Error::new(
+                field.span,
+                "u64 range requires java_type = \"long\" and range = \"i64\"",
+            ),
+        ),
+        (ValueKind::U32, None, Some("int" | "Integer")) => combine_error(
+            errors,
+            syn::Error::new(field.span, "unsigned Java int fields require range = \"i32\""),
+        ),
+        (ValueKind::U64, None, Some("long" | "Long")) => combine_error(
+            errors,
+            syn::Error::new(field.span, "unsigned Java long fields require range = \"i64\""),
+        ),
+        (ValueKind::I32, Some(_), _)
+        | (ValueKind::I64, Some(_), _)
+        | (ValueKind::Bool, Some(_), _)
+        | (ValueKind::String, Some(_), _)
+        | (ValueKind::BoundaryType, Some(_), _)
+        | (ValueKind::Generic, Some(_), _)
+        | (ValueKind::Nested, Some(_), _)
+        | (ValueKind::Unsupported, Some(_), _) => combine_error(
+            errors,
+            syn::Error::new(
+                field.span,
+                "range is supported only for unsigned Rust fields mapped to signed Java integers",
+            ),
+        ),
+        _ => {}
+    }
+
+    let valid_java_type = match field.kind {
+        ValueKind::String => matches!(java_type, None | Some("String")),
+        ValueKind::Bool => matches!(java_type, None | Some("boolean" | "Boolean")),
+        ValueKind::I32 | ValueKind::U32 => matches!(java_type, None | Some("int" | "Integer")),
+        ValueKind::I64 | ValueKind::U64 => matches!(java_type, None | Some("long" | "Long")),
+        ValueKind::BoundaryType => matches!(java_type, None | Some("BoundaryType")),
+        ValueKind::Generic | ValueKind::Nested | ValueKind::Unsupported => true,
+    };
+    if !valid_java_type {
+        let span = field.java_type.as_ref().map_or(field.span, |value| value.span);
+        combine_error(
+            errors,
+            syn::Error::new(span, "java_type is incompatible with the Rust header value type"),
+        );
+    }
+}
+
+fn is_java_identifier(component: &str) -> bool {
+    let mut chars = component.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || matches!(first, '_' | '$'))
+        && chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '$'))
+}

--- a/rocketmq-macros/tests/fixtures/renamed-consumer/src/main.rs
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/src/main.rs
@@ -13,10 +13,17 @@
 // limitations under the License.
 
 use protocol_api::CommandCustomHeader;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::{RequestHeaderCodecV2, RequestHeaderCodecV3};
 
 #[derive(RequestHeaderCodecV2)]
 struct RenamedConsumerHeader {
+    queue_id: i32,
+}
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::RenamedV3Header")]
+struct RenamedV3Header {
+    #[header(required)]
     queue_id: i32,
 }
 
@@ -24,4 +31,7 @@ fn main() {
     let header = RenamedConsumerHeader { queue_id: 7 };
     let fields = header.to_map().expect("header map");
     assert_eq!(fields.get("queueId").map(|value| value.as_str()), Some("7"));
+
+    let v3_header = RenamedV3Header { queue_id: 7 };
+    assert_eq!(v3_header.queue_id, 7);
 }

--- a/rocketmq-protocol/tests/request_header_codec_v3_ui.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_ui.rs
@@ -1,0 +1,20 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn request_header_codec_v3_validates_the_explicit_wire_model() {
+    let tests = trybuild::TestCases::new();
+    tests.pass("tests/ui/request_header_codec_v3/pass/*.rs");
+    tests.compile_fail("tests/ui/request_header_codec_v3/fail/*.rs");
+}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.rs
@@ -1,0 +1,24 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(crate = "rocketmq_protocol")]
+struct MissingTypeId {
+    #[header(required)]
+    value: String,
+}
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "Header", lookup = "indexed", crate = "rocketmq_protocol")]
+struct InvalidContainerValues {
+    #[header(required)]
+    value: String,
+}
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Unknown", unknown, crate = "rocketmq_protocol")]
+struct UnknownContainerOption {
+    #[header(required)]
+    value: String,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.stderr
@@ -1,0 +1,23 @@
+error: RequestHeaderCodecV3 requires header(type_id = "...")
+ --> tests/ui/request_header_codec_v3/fail/invalid_container.rs:5:8
+  |
+5 | struct MissingTypeId {
+  |        ^^^^^^^^^^^^^
+
+error: lookup must be one of: auto, scan, get
+  --> tests/ui/request_header_codec_v3/fail/invalid_container.rs:11:39
+   |
+11 | #[header(type_id = "Header", lookup = "indexed", crate = "rocketmq_protocol")]
+   |                                       ^^^^^^^^^
+
+error: type_id must be a stable, fully qualified Rust path with at least two segments
+  --> tests/ui/request_header_codec_v3/fail/invalid_container.rs:11:20
+   |
+11 | #[header(type_id = "Header", lookup = "indexed", crate = "rocketmq_protocol")]
+   |                    ^^^^^^^^
+
+error: unsupported RequestHeaderCodecV3 container option
+  --> tests/ui/request_header_codec_v3/fail/invalid_container.rs:18:41
+   |
+18 | #[header(type_id = "fixtures::Unknown", unknown, crate = "rocketmq_protocol")]
+   |                                         ^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_flatten.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_flatten.rs
@@ -1,0 +1,22 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+struct Nested;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Flatten", crate = "rocketmq_protocol")]
+struct InvalidFlatten {
+    #[header(flatten)]
+    optional_without_presence: Option<Nested>,
+    #[header(flatten, presence = "any")]
+    non_optional_any: Nested,
+    #[header(flatten, key = "nested", required, java_type = "Nested")]
+    conflicting_options: Nested,
+    #[header(presence = "always", required)]
+    presence_without_flatten: String,
+    #[header(flatten, presence = "sometimes")]
+    invalid_presence: Option<Nested>,
+    #[header(flatten)]
+    scalar: i32,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_flatten.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_flatten.stderr
@@ -1,0 +1,35 @@
+error: Option<Flattened> requires presence = "any" or "always"
+ --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:8:5
+  |
+8 |     #[header(flatten)]
+  |     ^
+
+error: presence = "any" is valid only for Option<Flattened>
+  --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:10:5
+   |
+10 |     #[header(flatten, presence = "any")]
+   |     ^
+
+error: flatten cannot be combined with key, alias, missing policy, default, alias_conflict, java_type, or range
+  --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:12:5
+   |
+12 |     #[header(flatten, key = "nested", required, java_type = "Nested")]
+   |     ^
+
+error: presence is valid only for flatten fields
+  --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:14:5
+   |
+14 |     #[header(presence = "always", required)]
+   |     ^
+
+error: presence must be always or any
+  --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:16:34
+   |
+16 |     #[header(flatten, presence = "sometimes")]
+   |                                  ^^^^^^^^^^^
+
+error: flatten requires a nested header type
+  --> tests/ui/request_header_codec_v3/fail/invalid_flatten.rs:18:5
+   |
+18 |     #[header(flatten)]
+   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs
@@ -1,0 +1,18 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Keys", crate = "rocketmq_protocol")]
+struct InvalidKeys {
+    #[header(key = "", required)]
+    empty: String,
+    #[header(key = "same", alias = "same", alias = "repeat", alias = "repeat", required)]
+    duplicate_aliases: String,
+    #[header(key = "same", required)]
+    duplicate_canonical: String,
+    #[header(key = "standalone", alias_conflict = "prefer_canonical", required)]
+    missing_alias: String,
+    #[header(key = "bad-policy", alias = "legacy", alias_conflict = "first", required)]
+    invalid_policy: String,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.stderr
@@ -1,0 +1,35 @@
+error: alias_conflict must be error or prefer_canonical
+  --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:14:69
+   |
+14 |     #[header(key = "bad-policy", alias = "legacy", alias_conflict = "first", required)]
+   |                                                                     ^^^^^^^
+
+error: wire key and alias must not be empty
+ --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:6:20
+  |
+6 |     #[header(key = "", required)]
+  |                    ^^
+
+error: wire key `same` is already used by field `duplicate_aliases`
+ --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:8:36
+  |
+8 |     #[header(key = "same", alias = "same", alias = "repeat", alias = "repeat", required)]
+  |                                    ^^^^^^
+
+error: wire key `repeat` is already used by field `duplicate_aliases`
+ --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:8:70
+  |
+8 |     #[header(key = "same", alias = "same", alias = "repeat", alias = "repeat", required)]
+  |                                                                      ^^^^^^^^
+
+error: wire key `same` is already used by field `duplicate_aliases`
+  --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:10:20
+   |
+10 |     #[header(key = "same", required)]
+   |                    ^^^^^^
+
+error: alias_conflict requires at least one alias
+  --> tests/ui/request_header_codec_v3/fail/invalid_keys_and_aliases.rs:12:5
+   |
+12 |     #[header(key = "standalone", alias_conflict = "prefer_canonical", required)]
+   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs
@@ -1,0 +1,19 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::MissingPolicies", crate = "rocketmq_protocol")]
+struct MissingPolicies {
+    #[header(required)]
+    required_option: Option<String>,
+    implicit_default: bool,
+    #[header(required, default, default_semantic = "literal:false")]
+    conflicting: bool,
+    #[header(default)]
+    missing_semantic: i32,
+    #[header(required, default_semantic = "literal:0")]
+    unexpected_semantic: i32,
+    #[header(default, default_semantic = "unstable")]
+    malformed_semantic: i32,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.stderr
@@ -1,0 +1,35 @@
+error: required cannot be used on Option<T>
+ --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:6:5
+  |
+6 |     #[header(required)]
+  |     ^
+
+error: non-Option fields require required, default, or default_with
+ --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:8:5
+  |
+8 |     implicit_default: bool,
+  |     ^^^^^^^^^^^^^^^^
+
+error: required, default, and default_with are mutually exclusive
+ --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:9:5
+  |
+9 |     #[header(required, default, default_semantic = "literal:false")]
+  |     ^
+
+error: default and default_with require default_semantic
+  --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:11:5
+   |
+11 |     #[header(default)]
+   |     ^
+
+error: default_semantic requires default or default_with
+  --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:13:43
+   |
+13 |     #[header(required, default_semantic = "literal:0")]
+   |                                           ^^^^^^^^^^^
+
+error: default_semantic must be literal:<wire-text> or dynamic:<semantic-id>
+  --> tests/ui/request_header_codec_v3/fail/invalid_missing_and_default.rs:15:42
+   |
+15 |     #[header(default, default_semantic = "unstable")]
+   |                                          ^^^^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs
@@ -1,0 +1,19 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Attributes", crate = "rocketmq_protocol")]
+struct InvalidAttributes {
+    #[header(required, binary_order = 7)]
+    first: String,
+    #[header(required, binary_order = 7)]
+    second: String,
+    #[header(required, mystery = "value")]
+    unknown: String,
+    #[header(required = true)]
+    valued_flag: String,
+    #[required]
+    #[header(required)]
+    duplicate_required_forms: String,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.stderr
@@ -1,0 +1,23 @@
+error: unsupported RequestHeaderCodecV3 field option
+  --> tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs:10:24
+   |
+10 |     #[header(required, mystery = "value")]
+   |                        ^^^^^^^
+
+error: required is a flag and does not accept a value
+  --> tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs:12:14
+   |
+12 |     #[header(required = true)]
+   |              ^^^^^^^^
+
+error: required is declared by both #[header] and #[required]
+  --> tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs:15:14
+   |
+15 |     #[header(required)]
+   |              ^^^^^^^^
+
+error: binary_order `7` is already used by field `first`
+ --> tests/ui/request_header_codec_v3/fail/invalid_order_and_attributes.rs:8:39
+  |
+8 |     #[header(required, binary_order = 7)]
+  |                                       ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs
@@ -1,0 +1,20 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Paths")]
+#[header(type_id = "fixtures::DuplicatePaths")]
+#[header(java_class = "not a java class")]
+#[header(validate = "not a path!")]
+#[header(crate = "not a path!")]
+#[header(fast)]
+#[header(fast)]
+struct InvalidPathsAndDuplicates<T> {
+    #[header(default_with = "not a path!", default_semantic = "dynamic:provider")]
+    invalid_default_path: i32,
+    #[header(required, binary_order = 65536)]
+    order_overflow: i32,
+    #[header(required)]
+    unsupported_generic_container: Vec<T>,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.stderr
@@ -1,0 +1,47 @@
+error: duplicate type_id
+ --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:5:10
+  |
+5 | #[header(type_id = "fixtures::DuplicatePaths")]
+  |          ^^^^^^^
+
+error: invalid validate path: unexpected token
+ --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:7:21
+  |
+7 | #[header(validate = "not a path!")]
+  |                     ^^^^^^^^^^^^^
+
+error: invalid protocol crate path: unexpected token
+ --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:8:18
+  |
+8 | #[header(crate = "not a path!")]
+  |                  ^^^^^^^^^^^^^
+
+error: duplicate fast
+  --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:10:10
+   |
+10 | #[header(fast)]
+   |          ^^^^
+
+error: invalid default_with path: unexpected token
+  --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:12:29
+   |
+12 |     #[header(default_with = "not a path!", default_semantic = "dynamic:provider")]
+   |                             ^^^^^^^^^^^^^
+
+error: binary_order must fit in u16
+  --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:14:39
+   |
+14 |     #[header(required, binary_order = 65536)]
+   |                                       ^^^^^
+
+error: java_class must be a fully qualified Java class name
+ --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:6:23
+  |
+6 | #[header(java_class = "not a java class")]
+  |                       ^^^^^^^^^^^^^^^^^^
+
+error: unsupported RequestHeaderCodecV3 field type `Vec < T >`
+  --> tests/ui/request_header_codec_v3/fail/invalid_paths_and_duplicates.rs:17:36
+   |
+17 |     unsupported_generic_container: Vec<T>,
+   |                                    ^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs
@@ -1,0 +1,20 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Ranges", crate = "rocketmq_protocol")]
+struct InvalidRanges {
+    #[header(required, java_type = "long", range = "i32")]
+    wrong_u32_range: u32,
+    #[header(required, java_type = "long")]
+    missing_u64_range: u64,
+    #[header(required, java_type = "long", range = "i64")]
+    signed_with_range: i64,
+    #[header(required, java_type = "boolean")]
+    incompatible_java_type: i32,
+    #[header(required)]
+    unsupported: usize,
+    #[header(required, range = "u64")]
+    invalid_range_name: u64,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.stderr
@@ -1,0 +1,41 @@
+error: range must be i32 or i64
+  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:16:32
+   |
+16 |     #[header(required, range = "u64")]
+   |                                ^^^^^
+
+error: u32 range requires java_type = "int" and range = "i32"
+ --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:6:5
+  |
+6 |     #[header(required, java_type = "long", range = "i32")]
+  |     ^
+
+error: java_type is incompatible with the Rust header value type
+ --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:6:36
+  |
+6 |     #[header(required, java_type = "long", range = "i32")]
+  |                                    ^^^^^^
+
+error: unsigned Java long fields require range = "i64"
+ --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:8:5
+  |
+8 |     #[header(required, java_type = "long")]
+  |     ^
+
+error: range is supported only for unsigned Rust fields mapped to signed Java integers
+  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:10:5
+   |
+10 |     #[header(required, java_type = "long", range = "i64")]
+   |     ^
+
+error: java_type is incompatible with the Rust header value type
+  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:12:36
+   |
+12 |     #[header(required, java_type = "boolean")]
+   |                                    ^^^^^^^^^
+
+error: unsupported RequestHeaderCodecV3 field type `usize`
+  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:15:18
+   |
+15 |     unsupported: usize,
+   |                  ^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_shapes.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_shapes.rs
@@ -1,0 +1,23 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Tuple", crate = "rocketmq_protocol")]
+struct Tuple(#[header(required)] String);
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Unit", crate = "rocketmq_protocol")]
+struct Unit;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Enum", crate = "rocketmq_protocol")]
+enum HeaderEnum {
+    Value,
+}
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::Union", crate = "rocketmq_protocol")]
+union HeaderUnion {
+    value: i32,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_shapes.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_shapes.stderr
@@ -1,0 +1,23 @@
+error: RequestHeaderCodecV3 requires a named struct
+ --> tests/ui/request_header_codec_v3/fail/invalid_shapes.rs:5:13
+  |
+5 | struct Tuple(#[header(required)] String);
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: RequestHeaderCodecV3 does not support unit structs
+ --> tests/ui/request_header_codec_v3/fail/invalid_shapes.rs:9:8
+  |
+9 | struct Unit;
+  |        ^^^^
+
+error: RequestHeaderCodecV3 does not support enums
+  --> tests/ui/request_header_codec_v3/fail/invalid_shapes.rs:13:1
+   |
+13 | enum HeaderEnum {
+   | ^^^^
+
+error: RequestHeaderCodecV3 does not support unions
+  --> tests/ui/request_header_codec_v3/fail/invalid_shapes.rs:19:1
+   |
+19 | union HeaderUnion {
+   | ^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/complete_model.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/complete_model.rs
@@ -1,0 +1,45 @@
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV3;
+use rocketmq_model::boundary_type::BoundaryType;
+
+fn default_flag() -> bool {
+    false
+}
+
+struct Nested<T> {
+    value: T,
+}
+
+#[derive(RequestHeaderCodecV3)]
+#[header(
+    type_id = "fixtures::CompleteHeader",
+    java_class = "org.apache.rocketmq.fixtures.CompleteHeader",
+    validate = "Self::validate_header",
+    lookup = "get",
+    crate = "rocketmq_protocol",
+    fast
+)]
+struct CompleteHeader<T> {
+    #[header(key = "name", alias = "legacyName", alias_conflict = "prefer_canonical", required)]
+    name: CheetahString,
+    #[header(key = "description")]
+    description: Option<String>,
+    #[header(default_with = "default_flag", default_semantic = "literal:false")]
+    enabled: bool,
+    #[header(default, default_semantic = "literal:0")]
+    attempts: i32,
+    #[header(required)]
+    timestamp: i64,
+    #[header(required, java_type = "int", range = "i32")]
+    queue_id: u32,
+    #[header(required, java_type = "long", range = "i64")]
+    offset: u64,
+    #[header(default, default_semantic = "literal:LOWER")]
+    boundary: BoundaryType,
+    #[header(required)]
+    generic: T,
+    #[header(flatten, presence = "any")]
+    nested: Option<Nested<T>>,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/legacy_required_migration.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/legacy_required_migration.rs
@@ -1,0 +1,10 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "fixtures::LegacyRequired", crate = "rocketmq_protocol")]
+struct LegacyRequired {
+    #[required]
+    value: String,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/serde_metadata_is_independent.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/serde_metadata_is_independent.rs
@@ -1,0 +1,12 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(RequestHeaderCodecV3, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[header(type_id = "fixtures::SerdeIndependent", crate = "rocketmq_protocol")]
+struct SerdeIndependent {
+    #[serde(rename = "json-name")]
+    #[header(key = "wireName", required)]
+    name: String,
+}
+
+fn main() {}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8960

### Brief Description

Register `RequestHeaderCodecV3` and introduce its explicit `#[header(...)]` parser, normalized model, and compile-time validator. The derive now validates stable type identities, container paths and lookup plans, missing/default semantics, aliases and collisions, flatten presence, Java signed ranges, binary order, supported value types, generics, and renamed protocol dependencies.

Diagnostics preserve successfully parsed fields after an error so parser and validator findings are reported together with precise spans. Legacy `#[required]` remains temporarily accepted and emits a targeted deprecation warning. This change intentionally does not generate production map, schema, or compatibility implementations and does not migrate production headers.

### How Did You Test This Change?

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-macros`
- `cargo test -p rocketmq-protocol`
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_ui`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `cargo doc -p rocketmq-macros --no-deps`
- `scripts/check-agents-routing.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `RequestHeaderCodecV3` derive macro for defining RocketMQ request headers.
  * Supports header metadata, aliases, required and optional fields, defaults, flattened fields, Java type mappings, and numeric ranges.
  * Added comprehensive validation for header definitions with clear compile-time diagnostics.
  * Legacy `required` declarations now provide migration guidance.

* **Tests**
  * Added coverage for valid configurations, metadata compatibility, migration diagnostics, and invalid declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->