### PR TITLE
[ISSUE #8967]✨Migrate representative request headers to the typed codec

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -22,26 +22,39 @@ fn default_max_count() -> i32 {
 }
 
 #[doc = "REQUEST_HEADER_CODEC_INCREMENTAL_PROBE: 0"]
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
-#[request_header(validate = "validate")]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetLiteClientInfoRequestHeader",
+    validate = "Self::validate"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetLiteClientInfoRequestHeader {
+    #[header(java_type = "String")]
     pub parent_topic: Option<CheetahString>,
+    #[header(java_type = "String")]
     pub group: Option<CheetahString>,
+    #[header(java_type = "String")]
     pub client_id: Option<CheetahString>,
 
     #[serde(default = "default_max_count")]
+    #[header(
+        default_with = "default_max_count",
+        default_semantic = "literal:1000",
+        java_type = "int"
+    )]
     pub max_count: i32,
 }
 
 impl GetLiteClientInfoRequestHeader {
-    fn validate(&self) -> rocketmq_error::RocketMQResult<()> {
+    fn validate(&self) -> Result<(), crate::protocol::header_codec::HeaderCodecError> {
         if self.max_count > 0 {
             return Ok(());
         }
-        Err(rocketmq_error::RocketMQError::request_header_error(
-            "GetLiteClientInfoRequestHeader.maxCount: must be greater than zero",
-        ))
+        Err(crate::protocol::header_codec::HeaderCodecError::Validation {
+            header: "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+            rule: "max_count_positive",
+        })
     }
 }
 

--- a/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
 use serde::Deserialize;
 use serde::Serialize;
@@ -21,23 +21,30 @@ use serde::Serialize;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Default, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Default, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SearchOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchOffsetRequestHeader {
-    #[required]
+    #[header(required, java_type = "String")]
     pub topic: CheetahString,
 
+    #[header(java_type = "String")]
     pub lite_topic: Option<CheetahString>,
 
-    #[required]
+    #[header(required, java_type = "Integer")]
     pub queue_id: i32,
 
-    #[required]
+    #[header(required, java_type = "Long")]
     pub timestamp: i64,
 
+    #[header(default, default_semantic = "literal:LOWER", java_type = "BoundaryType")]
     pub boundary_type: BoundaryType,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "any")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/search_offset_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/search_offset_response_header.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SearchOffsetResponseHeader"
+)]
 pub struct SearchOffsetResponseHeader {
-    #[required]
+    #[header(required, java_type = "Long")]
     pub offset: i64,
 }
 

--- a/rocketmq-protocol/src/rpc/rpc_request_header.rs
+++ b/rocketmq-protocol/src/rpc/rpc_request_header.rs
@@ -13,23 +13,51 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.rpc.RpcRequestHeader"
+)]
 pub struct RpcRequestHeader {
     // the namespace name
     #[serde(rename = "ns", alias = "namespace")]
+    #[header(
+        key = "ns",
+        alias = "namespace",
+        alias_conflict = "prefer_canonical",
+        java_type = "String"
+    )]
     pub namespace: Option<CheetahString>,
     // if the data has been namespaced
     #[serde(rename = "nsd", alias = "namespaced")]
+    #[header(
+        key = "nsd",
+        alias = "namespaced",
+        alias_conflict = "prefer_canonical",
+        java_type = "Boolean"
+    )]
     pub namespaced: Option<bool>,
     // the abstract remote addr name, usually the physical broker name
     #[serde(rename = "bname", alias = "brokerName")]
+    #[header(
+        key = "bname",
+        alias = "brokerName",
+        alias_conflict = "prefer_canonical",
+        java_type = "String"
+    )]
     pub broker_name: Option<CheetahString>,
     // oneway
     #[serde(rename = "oway", alias = "oneway")]
+    #[header(
+        key = "oway",
+        alias = "oneway",
+        alias_conflict = "prefer_canonical",
+        java_type = "Boolean"
+    )]
     pub oneway: Option<bool>,
 }
 

--- a/rocketmq-protocol/src/rpc/topic_request_header.rs
+++ b/rocketmq-protocol/src/rpc/topic_request_header.rs
@@ -13,16 +13,22 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.rpc.TopicRequestHeader"
+)]
 pub struct TopicRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "any")]
     pub rpc_request_header: Option<RpcRequestHeader>,
+    #[header(java_type = "Boolean")]
     pub lo: Option<bool>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -1,0 +1,327 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+
+use cheetah_string::CheetahString;
+use rocketmq_model::boundary_type::BoundaryType;
+use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
+use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+use rocketmq_protocol::protocol::header_codec::{
+    AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
+    HeaderValueKind,
+};
+use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
+use rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader;
+use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderMap};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JavaSchema {
+    headers: Vec<JavaHeader>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JavaHeader {
+    rust_type_id: String,
+    rust_type: String,
+    java_class: String,
+    java_fast: bool,
+    fields: Vec<JavaField>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JavaField {
+    key: String,
+    java_type: String,
+    presence: String,
+    default_semantic: String,
+    declared_in: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SchemaOverrides {
+    defaults: Vec<DefaultOverride>,
+    alias_conflict_policies: Vec<AliasOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DefaultOverride {
+    rust_type: String,
+    field: String,
+    semantic: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AliasOverride {
+    rust_type: String,
+    canonical: String,
+    aliases: Vec<String>,
+    policy: String,
+}
+
+struct RegisteredSchema {
+    type_id: &'static str,
+    java_class: &'static str,
+    fast: bool,
+    local_fields: &'static [HeaderFieldSpec],
+    fields: Vec<HeaderFieldSpec>,
+    flattens: Vec<HeaderFlattenSpec>,
+}
+
+fn register<T: HeaderCodec>() -> RegisteredSchema {
+    let mut fields = Vec::new();
+    T::visit_field_specs(&mut |field| fields.push(*field));
+    let mut flattens = Vec::new();
+    T::visit_flatten_specs(&mut |flatten| flattens.push(*flatten));
+    RegisteredSchema {
+        type_id: T::TYPE_ID,
+        java_class: T::JAVA_CLASS.expect("registered production headers declare a Java peer"),
+        fast: T::FAST_ENABLED,
+        local_fields: T::LOCAL_FIELD_SPECS,
+        fields,
+        flattens,
+    }
+}
+
+fn registry() -> Vec<RegisteredSchema> {
+    vec![
+        register::<RpcRequestHeader>(),
+        register::<TopicRequestHeader>(),
+        register::<GetLiteClientInfoRequestHeader>(),
+        register::<SearchOffsetRequestHeader>(),
+        register::<SearchOffsetResponseHeader>(),
+    ]
+}
+
+fn rust_kind(kind: HeaderValueKind) -> &'static str {
+    match kind {
+        HeaderValueKind::String => "string",
+        HeaderValueKind::Bool => "bool",
+        HeaderValueKind::I32 | HeaderValueKind::U32 => "i32",
+        HeaderValueKind::I64 | HeaderValueKind::U64 => "i64",
+        HeaderValueKind::BoundaryType => "boundary",
+    }
+}
+
+fn java_kind(java_type: &str) -> &'static str {
+    match java_type {
+        "java.lang.String" | "String" => "string",
+        "boolean" | "java.lang.Boolean" | "Boolean" => "bool",
+        "int" | "java.lang.Integer" | "Integer" => "i32",
+        "long" | "java.lang.Long" | "Long" => "i64",
+        value if value.ends_with(".BoundaryType") || value == "BoundaryType" => "boundary",
+        value => panic!("unsupported registered Java field type {value}"),
+    }
+}
+
+#[test]
+fn registered_typed_schemas_match_the_pinned_java_contract() {
+    let java: JavaSchema = serde_json::from_str(include_str!("fixtures/request_header_codec/java-schema.json"))
+        .expect("pinned Java schema");
+    let overrides: SchemaOverrides =
+        serde_json::from_str(include_str!("../../scripts/request-header-codec/schema-overrides.json"))
+            .expect("schema overrides");
+    let registered = registry();
+
+    let mut type_ids = HashSet::new();
+    for schema in &registered {
+        assert!(
+            type_ids.insert(schema.type_id),
+            "duplicate typed schema ID {}",
+            schema.type_id
+        );
+    }
+    let by_type_id: HashMap<_, _> = registered.iter().map(|schema| (schema.type_id, schema)).collect();
+
+    for schema in &registered {
+        let java_header = java
+            .headers
+            .iter()
+            .find(|header| header.rust_type_id == schema.type_id)
+            .unwrap_or_else(|| panic!("missing pinned Java schema for {}", schema.type_id));
+        assert_eq!(schema.java_class, java_header.java_class);
+        assert_eq!(schema.fast, java_header.java_fast);
+        assert_eq!(
+            schema.fields.len(),
+            java_header.fields.len(),
+            "{} field count",
+            schema.type_id
+        );
+
+        for field in &schema.fields {
+            let java_field = java_header
+                .fields
+                .iter()
+                .find(|candidate| candidate.key == field.key)
+                .unwrap_or_else(|| panic!("missing Java field {}.{}", schema.type_id, field.key));
+            assert_eq!(rust_kind(field.kind), java_kind(&java_field.java_type));
+
+            let owner = by_type_id
+                .get(field.declared_in)
+                .unwrap_or_else(|| panic!("unregistered field owner {}", field.declared_in));
+            assert_eq!(owner.java_class, java_field.declared_in);
+
+            match field.presence {
+                HeaderPresence::Required => assert_eq!(java_field.presence, "required"),
+                HeaderPresence::Optional => assert_eq!(java_field.presence, "optional"),
+                HeaderPresence::Default | HeaderPresence::DefaultWith(_) => {
+                    let expected = field.default_semantic.expect("default fields declare stable semantics");
+                    let reviewed = overrides
+                        .defaults
+                        .iter()
+                        .find(|entry| entry.rust_type == java_header.rust_type && entry.field == field.key)
+                        .map(|entry| entry.semantic.as_str())
+                        .or_else(|| {
+                            java_field
+                                .default_semantic
+                                .starts_with("literal:")
+                                .then_some(java_field.default_semantic.as_str())
+                        });
+                    assert_eq!(reviewed, Some(expected), "{}.{} default", schema.type_id, field.key);
+                }
+            }
+        }
+
+        for flatten in &schema.flattens {
+            assert!(
+                by_type_id.contains_key(flatten.nested_type_id),
+                "{} flattens unregistered {}",
+                schema.type_id,
+                flatten.nested_type_id
+            );
+        }
+
+        for field in schema
+            .local_fields
+            .iter()
+            .filter(|field| field.alias_conflict == AliasConflictPolicy::PreferCanonical)
+        {
+            let reviewed = overrides.alias_conflict_policies.iter().any(|entry| {
+                entry.rust_type == java_header.rust_type
+                    && entry.canonical == field.key
+                    && entry
+                        .aliases
+                        .iter()
+                        .map(String::as_str)
+                        .eq(field.aliases.iter().copied())
+                    && entry.policy == "prefer_canonical"
+            });
+            assert!(
+                reviewed,
+                "unreviewed prefer_canonical policy for {}.{}",
+                schema.type_id, field.key
+            );
+        }
+    }
+}
+
+#[test]
+fn representative_headers_preserve_defaults_aliases_flattening_and_validation() {
+    let empty = HeaderMap::new();
+    let typed_default = <GetLiteClientInfoRequestHeader as HeaderCodec>::decode_from_map(&empty).unwrap();
+    let legacy_default = <GetLiteClientInfoRequestHeader as FromMap>::from(&empty).unwrap();
+    assert_eq!(typed_default.max_count, 1000);
+    assert_eq!(legacy_default.max_count, 1000);
+
+    for value in ["invalid", "0", "-1"] {
+        let map = HeaderMap::from([("maxCount".into(), value.into())]);
+        assert!(<GetLiteClientInfoRequestHeader as HeaderCodec>::decode_from_map(&map).is_err());
+        assert!(<GetLiteClientInfoRequestHeader as FromMap>::from(&map).is_err());
+    }
+
+    let rpc_map = HeaderMap::from([
+        ("ns".into(), "canonical".into()),
+        ("namespace".into(), "legacy".into()),
+        ("nsd".into(), "true".into()),
+        ("bname".into(), "broker-a".into()),
+        ("oway".into(), "false".into()),
+    ]);
+    let rpc = <RpcRequestHeader as HeaderCodec>::decode_from_map(&rpc_map).unwrap();
+    assert_eq!(rpc.namespace.as_deref(), Some("canonical"));
+    assert_eq!(rpc.namespaced, Some(true));
+
+    let header = SearchOffsetRequestHeader {
+        topic: CheetahString::from_static_str("topic-a"),
+        lite_topic: Some(CheetahString::from_static_str("lite-a")),
+        queue_id: 3,
+        timestamp: 42,
+        boundary_type: BoundaryType::Upper,
+        topic_request_header: Some(TopicRequestHeader {
+            rpc_request_header: Some(rpc),
+            lo: Some(true),
+        }),
+    };
+    let map = header.to_map().expect("typed compatibility map");
+    for key in [
+        "topic",
+        "liteTopic",
+        "queueId",
+        "timestamp",
+        "boundaryType",
+        "lo",
+        "ns",
+        "nsd",
+        "bname",
+        "oway",
+    ] {
+        assert!(map.contains_key(key), "missing flattened key {key}");
+    }
+    for legacy in ["namespace", "namespaced", "brokerName", "oneway"] {
+        assert!(!map.contains_key(legacy));
+    }
+    let decoded = <SearchOffsetRequestHeader as HeaderCodec>::decode_from_map(&map).unwrap();
+    assert_eq!(decoded.topic, "topic-a");
+    assert_eq!(decoded.boundary_type, BoundaryType::Upper);
+    assert_eq!(decoded.topic_request_header.unwrap().get_lo(), Some(&true));
+
+    let mut lower_map = map;
+    lower_map.remove("boundaryType");
+    let lower = <SearchOffsetRequestHeader as HeaderCodec>::decode_from_map(&lower_map).unwrap();
+    assert_eq!(lower.boundary_type, BoundaryType::Lower);
+
+    let response = SearchOffsetResponseHeader { offset: 99 };
+    let response_map = response.to_map().unwrap();
+    assert_eq!(response_map.get("offset").map(CheetahString::as_str), Some("99"));
+    assert_eq!(
+        <SearchOffsetResponseHeader as HeaderCodec>::decode_from_map(&response_map)
+            .unwrap()
+            .offset,
+        99
+    );
+}
+
+#[test]
+fn typed_validation_errors_remain_classified_and_redacted() {
+    let invalid = GetLiteClientInfoRequestHeader {
+        max_count: 0,
+        ..Default::default()
+    };
+    let mut map = HeaderMap::new();
+    assert!(matches!(
+        invalid.try_encode_into_map(&mut map),
+        Err(HeaderCodecError::Validation {
+            rule: "max_count_positive",
+            ..
+        })
+    ));
+    assert!(map.is_empty());
+}

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -13,6 +13,17 @@
       }
     },
     {
+      "rustType": "SearchOffsetRequestHeader",
+      "field": "boundaryType",
+      "semantic": "literal:LOWER",
+      "owner": "rocketmq-rust maintainers",
+      "reason": "Matches SearchOffsetRequestHeader.getBoundaryType(), which returns LOWER when the Java field is null",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/search_offset_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SearchOffsetRequestHeader.java"
+      }
+    },
+    {
       "rustType": "AlterSyncStateSetRequestHeader",
       "field": "invokeTime",
       "semantic": "dynamic:current_time_millis",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8967

### Brief Description

Migrate `RpcRequestHeader`, `TopicRequestHeader`, `GetLiteClientInfoRequestHeader`, `SearchOffsetRequestHeader`, and `SearchOffsetResponseHeader` to `RequestHeaderCodecV3` with explicit Java type, presence, alias, flattening, default, and validation metadata.

Add an explicit typed schema registry test that compares the migrated headers with the pinned Java schema and reviewed overrides. The behavioral coverage verifies canonical alias precedence, nested flattening, Java-compatible defaults, required fields, validation failures, and compatibility map round trips.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-protocol -- --check`
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_registry -- --nocapture`
- `cargo test -p rocketmq-protocol`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-protocol --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `git diff --check`

The root workspace and standalone example `cargo fmt --all -- --check` commands are blocked on Windows by command-line length error 206; the affected `rocketmq-protocol` package format check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved request-header compatibility with Java-based protocol metadata.
  * Added support for canonical and legacy header aliases, defaults, required fields, and flattened header structures.
  * Added a default `LOWER` boundary behavior for offset searches.
  * Improved validation errors with clearer, classified reporting.

* **Tests**
  * Added comprehensive coverage for header encoding, decoding, aliases, defaults, mappings, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->