### PR TITLE
[ISSUE #8969]✨Infer Java field types for typed request headers

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
@@ -30,19 +30,12 @@ fn default_max_count() -> i32 {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct GetLiteClientInfoRequestHeader {
-    #[header(java_type = "String")]
     pub parent_topic: Option<CheetahString>,
-    #[header(java_type = "String")]
     pub group: Option<CheetahString>,
-    #[header(java_type = "String")]
     pub client_id: Option<CheetahString>,
 
     #[serde(default = "default_max_count")]
-    #[header(
-        default_with = "default_max_count",
-        default_semantic = "literal:1000",
-        java_type = "int"
-    )]
+    #[header(default_with = "default_max_count", default_semantic = "literal:1000")]
     pub max_count: i32,
 }
 

--- a/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
@@ -28,19 +28,18 @@ use crate::rpc::topic_request_header::TopicRequestHeader;
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SearchOffsetRequestHeader {
-    #[header(required, java_type = "String")]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[header(java_type = "String")]
     pub lite_topic: Option<CheetahString>,
 
-    #[header(required, java_type = "Integer")]
+    #[header(required)]
     pub queue_id: i32,
 
-    #[header(required, java_type = "Long")]
+    #[header(required)]
     pub timestamp: i64,
 
-    #[header(default, default_semantic = "literal:LOWER", java_type = "BoundaryType")]
+    #[header(default, default_semantic = "literal:LOWER")]
     pub boundary_type: BoundaryType,
 
     #[serde(flatten)]

--- a/rocketmq-protocol/src/protocol/header/search_offset_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/search_offset_response_header.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
     java_class = "org.apache.rocketmq.remoting.protocol.header.SearchOffsetResponseHeader"
 )]
 pub struct SearchOffsetResponseHeader {
-    #[header(required, java_type = "Long")]
+    #[header(required)]
     pub offset: i64,
 }
 

--- a/rocketmq-protocol/src/protocol/header_codec/schema.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/schema.rs
@@ -70,7 +70,11 @@ pub struct HeaderFieldSpec {
     pub presence: HeaderPresence,
     /// Stable literal or dynamic default semantic identifier.
     pub default_semantic: Option<&'static str>,
-    /// Java field type used by compatibility tooling.
+    /// Optional Java type override for compatibility tooling.
+    ///
+    /// Tooling should infer the normal wire category from [`Self::kind`] when
+    /// this is `None`. Production headers only set this for exceptional
+    /// mappings that cannot be inferred from the Rust value type.
     pub java_type: Option<&'static str>,
     /// Signed Java range imposed on an unsigned Rust value.
     pub java_range: Option<HeaderRange>,

--- a/rocketmq-protocol/src/rpc/rpc_request_header.rs
+++ b/rocketmq-protocol/src/rpc/rpc_request_header.rs
@@ -25,39 +25,19 @@ use serde::Serialize;
 pub struct RpcRequestHeader {
     // the namespace name
     #[serde(rename = "ns", alias = "namespace")]
-    #[header(
-        key = "ns",
-        alias = "namespace",
-        alias_conflict = "prefer_canonical",
-        java_type = "String"
-    )]
+    #[header(key = "ns", alias = "namespace", alias_conflict = "prefer_canonical")]
     pub namespace: Option<CheetahString>,
     // if the data has been namespaced
     #[serde(rename = "nsd", alias = "namespaced")]
-    #[header(
-        key = "nsd",
-        alias = "namespaced",
-        alias_conflict = "prefer_canonical",
-        java_type = "Boolean"
-    )]
+    #[header(key = "nsd", alias = "namespaced", alias_conflict = "prefer_canonical")]
     pub namespaced: Option<bool>,
     // the abstract remote addr name, usually the physical broker name
     #[serde(rename = "bname", alias = "brokerName")]
-    #[header(
-        key = "bname",
-        alias = "brokerName",
-        alias_conflict = "prefer_canonical",
-        java_type = "String"
-    )]
+    #[header(key = "bname", alias = "brokerName", alias_conflict = "prefer_canonical")]
     pub broker_name: Option<CheetahString>,
     // oneway
     #[serde(rename = "oway", alias = "oneway")]
-    #[header(
-        key = "oway",
-        alias = "oneway",
-        alias_conflict = "prefer_canonical",
-        java_type = "Boolean"
-    )]
+    #[header(key = "oway", alias = "oneway", alias_conflict = "prefer_canonical")]
     pub oneway: Option<bool>,
 }
 

--- a/rocketmq-protocol/src/rpc/topic_request_header.rs
+++ b/rocketmq-protocol/src/rpc/topic_request_header.rs
@@ -28,7 +28,6 @@ pub struct TopicRequestHeader {
     #[serde(flatten)]
     #[header(flatten, presence = "any")]
     pub rpc_request_header: Option<RpcRequestHeader>,
-    #[header(java_type = "Boolean")]
     pub lo: Option<bool>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -153,6 +153,11 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
     let by_type_id: HashMap<_, _> = registered.iter().map(|schema| (schema.type_id, schema)).collect();
 
     for schema in &registered {
+        assert!(
+            schema.local_fields.iter().all(|field| field.java_type.is_none()),
+            "{} must infer Java-compatible value kinds instead of repeating java_type metadata",
+            schema.type_id
+        );
         let java_header = java
             .headers
             .iter()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8969

### Brief Description

Remove redundant `java_type` annotations from the representative production headers migrated to `RequestHeaderCodecV3`. Their Java-compatible wire categories are inferred from `HeaderValue::KIND` and checked against the pinned Java schema.

Keep `java_type` as an optional schema override for exceptional mappings that cannot be inferred from the Rust value type. Clarify that contract in `HeaderFieldSpec` documentation and extend the typed registry test to reject handwritten Java type metadata on the registered production fields.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-protocol -- --check`
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_registry -- --nocapture`
- `cargo test -p rocketmq-protocol`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-protocol --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `git diff --check`

The root workspace and standalone example `cargo fmt --all -- --check` commands are blocked on Windows by command-line length error 206; the affected `rocketmq-protocol` package format check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Java type information is inferred for protocol headers and when explicit overrides are needed.

* **Tests**
  * Added validation ensuring registered schemas rely on inferred Java-compatible value types where applicable.

* **Refactor**
  * Simplified internal header metadata across request and response protocols without changing field types, defaults, validation, serialization, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->