### PR TITLE
[ISSUE #8973]✨Migrate Java fast headers to typed map schemas

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3.rs
+++ b/rocketmq-macros/src/request_header_codec_v3.rs
@@ -76,7 +76,7 @@ mod tests {
     use quote::{quote, ToTokens};
 
     use super::migration_diagnostics;
-    use super::model::{AliasConflict, FlattenPresence, HeaderModel, LookupPlan, MissingPolicy, ValueKind};
+    use super::model::{AliasConflict, FlattenPresence, HeaderModel, LegacyShim, LookupPlan, MissingPolicy, ValueKind};
     use super::validate;
 
     #[test]
@@ -87,6 +87,7 @@ mod tests {
                 java_class = "org.apache.rocketmq.fixtures.GenericHeader",
                 validate = "Self::validate_header",
                 lookup = "get",
+                legacy_shim = "manual",
                 crate = "protocol_api",
                 fast
             )]
@@ -104,6 +105,7 @@ mod tests {
         validate::validate(&model).expect("validation");
 
         assert_eq!(model.lookup, LookupPlan::Get);
+        assert_eq!(model.legacy_shim, LegacyShim::Manual);
         assert!(model.fast);
         assert_eq!(
             model.protocol_path.to_token_stream().to_string(),

--- a/rocketmq-macros/src/request_header_codec_v3/attr.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/attr.rs
@@ -25,6 +25,7 @@ pub(super) struct ContainerAttrs {
     pub(super) java_class: Option<LitStr>,
     pub(super) validate: Option<Path>,
     pub(super) lookup: Option<LitStr>,
+    pub(super) legacy_shim: Option<LitStr>,
     pub(super) protocol_path: Option<Path>,
     pub(super) fast: Option<Span>,
 }
@@ -94,6 +95,17 @@ pub(super) fn parse_container_attrs(attrs: &[Attribute]) -> (ContainerAttrs, Opt
                     value,
                     meta.path.span(),
                     "duplicate lookup",
+                    &mut errors,
+                );
+                return Ok(());
+            }
+            if meta.path.is_ident("legacy_shim") {
+                let value = parse_lit_str(&meta)?;
+                set_once(
+                    &mut parsed.legacy_shim,
+                    value,
+                    meta.path.span(),
+                    "duplicate legacy_shim",
                     &mut errors,
                 );
                 return Ok(());

--- a/rocketmq-macros/src/request_header_codec_v3/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen.rs
@@ -20,7 +20,7 @@ use syn::Generics;
 use super::codegen_map;
 use super::codegen_schema;
 use super::codegen_shim;
-use super::model::{HeaderModel, MissingPolicy};
+use super::model::{HeaderModel, LegacyShim, MissingPolicy};
 
 pub(super) fn generate(model: &HeaderModel) -> TokenStream {
     let ident = &model.ident;
@@ -37,7 +37,10 @@ pub(super) fn generate(model: &HeaderModel) -> TokenStream {
     let context_declarations = codegen_map::context_declarations(model);
     let map_items = codegen_map::codec_items(model, &codec_trait);
     let schema_items = codegen_schema::codec_items(model, &codec_trait);
-    let shims = codegen_shim::generate(model, &generics, &codec_trait);
+    let shims = match model.legacy_shim {
+        LegacyShim::Generated => codegen_shim::generate(model, &generics, &codec_trait),
+        LegacyShim::Manual => TokenStream::new(),
+    };
 
     quote! {
         impl #impl_generics #ident #ty_generics #where_clause {

--- a/rocketmq-macros/src/request_header_codec_v3/model.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/model.rs
@@ -29,6 +29,7 @@ pub(super) struct HeaderModel {
     pub(super) java_class: Option<LitStr>,
     pub(super) validate_path: Option<Path>,
     pub(super) lookup: LookupPlan,
+    pub(super) legacy_shim: LegacyShim,
     pub(super) protocol_path: Path,
     pub(super) fast: bool,
     pub(super) fields: Vec<FieldModel>,
@@ -71,6 +72,12 @@ pub(super) enum LookupPlan {
     Auto,
     Scan,
     Get,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LegacyShim {
+    Generated,
+    Manual,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -154,6 +161,7 @@ impl HeaderModel {
             LitStr::new("invalid::MissingTypeId", input.ident.span())
         });
         let lookup = parse_lookup(attrs.lookup, &mut errors);
+        let legacy_shim = parse_legacy_shim(attrs.legacy_shim, &mut errors);
         let protocol_path = match attrs.protocol_path {
             Some(path) => path,
             None => match resolve_protocol_path(input.ident.span()) {
@@ -229,6 +237,7 @@ impl HeaderModel {
             java_class: attrs.java_class,
             validate_path: attrs.validate,
             lookup,
+            legacy_shim,
             protocol_path,
             fast: attrs.fast.is_some(),
             fields,
@@ -337,6 +346,23 @@ fn parse_lookup(value: Option<LitStr>, errors: &mut Option<syn::Error>) -> Looku
                 syn::Error::new(value.span(), "lookup must be one of: auto, scan, get"),
             );
             LookupPlan::Auto
+        }
+    }
+}
+
+fn parse_legacy_shim(value: Option<LitStr>, errors: &mut Option<syn::Error>) -> LegacyShim {
+    let Some(value) = value else {
+        return LegacyShim::Generated;
+    };
+    match value.value().as_str() {
+        "generated" => LegacyShim::Generated,
+        "manual" => LegacyShim::Manual,
+        _ => {
+            combine_error(
+                errors,
+                syn::Error::new(value.span(), "legacy_shim must be generated or manual"),
+            );
+            LegacyShim::Generated
         }
     }
 }

--- a/rocketmq-macros/src/request_header_codec_v3/validate.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/validate.rs
@@ -194,26 +194,29 @@ fn validate_wire_name(name: &WireName, errors: &mut Option<syn::Error>) {
 fn validate_java_range(field: &FieldModel, errors: &mut Option<syn::Error>) {
     let java_type = field.java_type.as_ref().map(|value| value.value.as_str());
     match (field.kind, field.range, java_type) {
-        (ValueKind::U32, Some(HeaderRange::I32), Some("int" | "Integer")) => {}
-        (ValueKind::U64, Some(HeaderRange::I64), Some("long" | "Long")) => {}
+        (ValueKind::U32, Some(HeaderRange::I32), None | Some("int" | "Integer")) => {}
+        (ValueKind::U64, Some(HeaderRange::I64), None | Some("long" | "Long")) => {}
         (ValueKind::U32, Some(_), _) => combine_error(
             errors,
-            syn::Error::new(field.span, "u32 range requires java_type = \"int\" and range = \"i32\""),
+            syn::Error::new(
+                field.span,
+                "u32 fields require range = \"i32\"; java_type, when present, must be int or Integer",
+            ),
         ),
         (ValueKind::U64, Some(_), _) => combine_error(
             errors,
             syn::Error::new(
                 field.span,
-                "u64 range requires java_type = \"long\" and range = \"i64\"",
+                "u64 fields require range = \"i64\"; java_type, when present, must be long or Long",
             ),
         ),
-        (ValueKind::U32, None, Some("int" | "Integer")) => combine_error(
+        (ValueKind::U32, None, _) => combine_error(
             errors,
-            syn::Error::new(field.span, "unsigned Java int fields require range = \"i32\""),
+            syn::Error::new(field.span, "unsigned u32 fields require range = \"i32\""),
         ),
-        (ValueKind::U64, None, Some("long" | "Long")) => combine_error(
+        (ValueKind::U64, None, _) => combine_error(
             errors,
-            syn::Error::new(field.span, "unsigned Java long fields require range = \"i64\""),
+            syn::Error::new(field.span, "unsigned u64 fields require range = \"i64\""),
         ),
         (ValueKind::I32, Some(_), _)
         | (ValueKind::I64, Some(_), _)

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,6 +25,10 @@ use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
+use crate::protocol::header_codec::HeaderCodec;
+use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_codec::MapSink;
+use crate::protocol::header_codec::ResolvedHeaderKey;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
@@ -48,32 +53,31 @@ const FIELD_NAMESPACED: &str = "nsd";
 const FIELD_ONEWAY: &str = "oway";
 const FIELD_LO: &str = "lo";
 
-const KEY_A: CheetahString = CheetahString::from_static_str(FIELD_A);
-const KEY_B: CheetahString = CheetahString::from_static_str(FIELD_B);
-const KEY_C: CheetahString = CheetahString::from_static_str(FIELD_C);
-const KEY_D: CheetahString = CheetahString::from_static_str(FIELD_D);
-const KEY_E: CheetahString = CheetahString::from_static_str(FIELD_E);
-const KEY_F: CheetahString = CheetahString::from_static_str(FIELD_F);
-const KEY_G: CheetahString = CheetahString::from_static_str(FIELD_G);
-const KEY_H: CheetahString = CheetahString::from_static_str(FIELD_H);
-const KEY_I: CheetahString = CheetahString::from_static_str(FIELD_I);
-const KEY_J: CheetahString = CheetahString::from_static_str(FIELD_J);
-const KEY_K: CheetahString = CheetahString::from_static_str(FIELD_K);
-const KEY_L: CheetahString = CheetahString::from_static_str(FIELD_L);
-const KEY_M: CheetahString = CheetahString::from_static_str(FIELD_M);
-const KEY_N: CheetahString = CheetahString::from_static_str(FIELD_N);
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeaderV2",
+    legacy_shim = "manual",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageRequestHeaderV2 {
-    pub a: CheetahString,         // producerGroup
-    pub b: CheetahString,         // topic
-    pub c: CheetahString,         // defaultTopic
-    pub d: i32,                   // defaultTopicQueueNums
-    pub e: i32,                   // queueId
-    pub f: i32,                   // sysFlag
-    pub g: i64,                   // bornTimestamp
-    pub h: i32,                   // flag
+    #[header(required)]
+    pub a: CheetahString, // producerGroup
+    #[header(required)]
+    pub b: CheetahString, // topic
+    #[header(required)]
+    pub c: CheetahString, // defaultTopic
+    #[header(required)]
+    pub d: i32, // defaultTopicQueueNums
+    #[header(required)]
+    pub e: i32, // queueId
+    #[header(required)]
+    pub f: i32, // sysFlag
+    #[header(required)]
+    pub g: i64, // bornTimestamp
+    #[header(required)]
+    pub h: i32, // flag
     pub i: Option<CheetahString>, // properties
     pub j: Option<i32>,           // reconsumeTimes
     pub k: Option<bool>,          // unitMode
@@ -82,44 +86,46 @@ pub struct SendMessageRequestHeaderV2 {
     pub n: Option<CheetahString>, // brokerName
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 
 impl CommandCustomHeader for SendMessageRequestHeaderV2 {
+    fn check_fields(&self) -> rocketmq_error::RocketMQResult<()> {
+        <Self as HeaderCodec>::validate_for_wire(self)
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))
+    }
+
     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::with_capacity(14);
-        map.insert(KEY_A.clone(), self.a.clone());
-        map.insert(KEY_B.clone(), self.b.clone());
-        map.insert(KEY_C.clone(), self.c.clone());
-        map.insert(KEY_D.clone(), CheetahString::from_string_owned(self.d.to_string()));
-        map.insert(KEY_E.clone(), CheetahString::from_string_owned(self.e.to_string()));
-        map.insert(KEY_F.clone(), CheetahString::from_string_owned(self.f.to_string()));
-        map.insert(KEY_G.clone(), CheetahString::from_string_owned(self.g.to_string()));
-        map.insert(KEY_H.clone(), CheetahString::from_string_owned(self.h.to_string()));
-        if let Some(ref value) = self.i {
-            map.insert(KEY_I.clone(), value.clone());
-        }
-        if let Some(value) = self.j {
-            map.insert(KEY_J.clone(), CheetahString::from_string_owned(value.to_string()));
-        }
-        if let Some(value) = self.k {
-            map.insert(KEY_K.clone(), CheetahString::from_string_owned(value.to_string()));
-        }
-        if let Some(value) = self.l {
-            map.insert(KEY_L.clone(), CheetahString::from_string_owned(value.to_string()));
-        }
-        if let Some(value) = self.m {
-            map.insert(KEY_M.clone(), CheetahString::from_string_owned(value.to_string()));
-        }
-        if let Some(ref value) = self.n {
-            map.insert(KEY_N.clone(), value.clone());
-        }
-        if let Some(ref value) = self.topic_request_header {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
+        let mut map = HashMap::with_capacity(<Self as HeaderCodec>::FIELD_COUNT_HINT);
+        self.try_encode_into_map(&mut map).ok()?;
         Some(map)
+    }
+
+    fn encode_into_map(&self, out: &mut HashMap<CheetahString, CheetahString>) {
+        let _ = self.try_encode_into_map(out);
+    }
+
+    fn try_encode_into_map(&self, out: &mut HashMap<CheetahString, CheetahString>) -> Result<(), HeaderCodecError> {
+        out.reserve(<Self as HeaderCodec>::FIELD_COUNT_HINT);
+        let mut sink = MapSink::new(out);
+        <Self as HeaderCodec>::encode_into(self, &mut sink)
+    }
+
+    fn resolve_wire_key(&self, key: &str) -> Option<ResolvedHeaderKey> {
+        <Self as HeaderCodec>::resolve_wire_key(key)
+    }
+
+    fn canonical_wire_key(&self, key: &str) -> Option<&'static str> {
+        <Self as HeaderCodec>::canonical_wire_key(key)
+    }
+
+    fn contains_wire_key(&self, key: &str) -> bool {
+        <Self as HeaderCodec>::contains_wire_key(key)
+    }
+
+    fn encoded_len_hint(&self) -> usize {
+        <Self as HeaderCodec>::encoded_len_hint(self)
     }
 
     fn encode_fast(&mut self, out: &mut BytesMut) {
@@ -323,70 +329,8 @@ impl FromMap for SendMessageRequestHeaderV2 {
     type Target = Self;
 
     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        #[inline(always)]
-        fn get_required<'a>(
-            map: &'a HashMap<CheetahString, CheetahString>,
-            key: &CheetahString,
-            field: &'static str,
-        ) -> Result<&'a CheetahString, rocketmq_error::RocketMQError> {
-            map.get(key).ok_or_else(|| {
-                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                    format: "header",
-                    message: format!("Missing field: {}", field),
-                })
-            })
-        }
-
-        #[inline(always)]
-        fn parse_required<T: FromStr>(
-            map: &HashMap<CheetahString, CheetahString>,
-            key: &CheetahString,
-            field: &'static str,
-        ) -> Result<T, rocketmq_error::RocketMQError> {
-            get_required(map, key, field)?.as_str().parse::<T>().map_err(|_| {
-                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                    format: "header",
-                    message: format!("Parse {} field error", field),
-                })
-            })
-        }
-
-        #[inline(always)]
-        fn optional_parse<T: FromStr>(
-            map: &HashMap<CheetahString, CheetahString>,
-            key: &CheetahString,
-            field: &'static str,
-        ) -> Result<Option<T>, rocketmq_error::RocketMQError> {
-            match map.get(key) {
-                Some(value) => value.as_str().parse::<T>().map(Some).map_err(|_| {
-                    rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                        format: "header",
-                        message: format!("Parse {} field error", field),
-                    })
-                }),
-                None => Ok(None),
-            }
-        }
-
-        Ok(SendMessageRequestHeaderV2 {
-            a: get_required(map, &KEY_A, FIELD_A)?.clone(),
-            b: get_required(map, &KEY_B, FIELD_B)?.clone(),
-            c: get_required(map, &KEY_C, FIELD_C)?.clone(),
-
-            d: parse_required::<i32>(map, &KEY_D, FIELD_D)?,
-            e: parse_required::<i32>(map, &KEY_E, FIELD_E)?,
-            f: parse_required::<i32>(map, &KEY_F, FIELD_F)?,
-            g: parse_required::<i64>(map, &KEY_G, FIELD_G)?,
-            h: parse_required::<i32>(map, &KEY_H, FIELD_H)?,
-
-            i: map.get(&KEY_I).cloned(),
-            j: optional_parse::<i32>(map, &KEY_J, FIELD_J)?,
-            k: optional_parse::<bool>(map, &KEY_K, FIELD_K)?,
-            l: optional_parse::<i32>(map, &KEY_L, FIELD_L)?,
-            m: optional_parse::<bool>(map, &KEY_M, FIELD_M)?,
-            n: map.get(&KEY_N).cloned(),
-            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
+        <Self as HeaderCodec>::decode_from_map(map)
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))
     }
 }
 

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -15,20 +15,25 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::FastCodesHeader;
 
-#[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageResponseHeader",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageResponseHeader {
-    #[required]
+    #[header(required)]
     msg_id: CheetahString,
-    #[required]
+    #[header(required)]
     queue_id: i32,
-    #[required]
+    #[header(required)]
     queue_offset: i64,
     transaction_id: Option<CheetahString>,
     batch_uniq_id: Option<CheetahString>,

--- a/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
@@ -14,6 +14,7 @@
 
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -71,11 +72,16 @@ impl GetTopicsByClusterRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.rpc.TopicRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct TopicRequestHeader {
     pub lo: Option<bool>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/pull_message_request_header.rs
@@ -13,43 +13,48 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PullMessageRequestHeader",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PullMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     pub lite_topic: Option<CheetahString>,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
-    #[required]
+    #[header(required)]
     pub queue_offset: i64,
 
-    #[required]
+    #[header(required)]
     pub max_msg_nums: i32,
 
-    #[required]
+    #[header(required)]
     pub sys_flag: i32,
 
-    #[required]
+    #[header(required)]
     pub commit_offset: i64,
 
-    #[required]
+    #[header(required, range = "i64")]
     pub suspend_timeout_millis: u64,
 
-    #[required]
+    #[header(required)]
     pub sub_version: i64,
 
     pub subscription: Option<CheetahString>,
@@ -57,8 +62,14 @@ pub struct PullMessageRequestHeader {
     pub max_msg_bytes: Option<i32>,
     pub request_source: Option<i32>,
     #[serde(rename = "proxyFrowardClientId", alias = "proxyForwardClientId")]
+    #[header(
+        key = "proxyFrowardClientId",
+        alias = "proxyForwardClientId",
+        alias_conflict = "prefer_canonical"
+    )]
     pub proxy_forward_client_id: Option<CheetahString>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/pull_message_response_header.rs
@@ -12,23 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PullMessageResponseHeader",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PullMessageResponseHeader {
-    #[required]
+    #[header(required, range = "i64")]
     pub suggest_which_broker_id: u64,
 
-    #[required]
+    #[header(required)]
     pub next_begin_offset: i64,
 
-    #[required]
+    #[header(required)]
     pub min_offset: i64,
 
-    #[required]
+    #[header(required)]
     pub max_offset: i64,
 
     pub offset_delta: Option<i64>,

--- a/rocketmq-protocol/src/rpc/topic_request_header.rs
+++ b/rocketmq-protocol/src/rpc/topic_request_header.rs
@@ -26,7 +26,7 @@ use crate::rpc::rpc_request_header::RpcRequestHeader;
 )]
 pub struct TopicRequestHeader {
     #[serde(flatten)]
-    #[header(flatten, presence = "any")]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
     pub lo: Option<bool>,
 }

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -14,15 +14,22 @@
 
 use std::collections::{HashMap, HashSet};
 
+use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as NamesrvTopicRequestHeader;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
-    HeaderValueKind,
+    HeaderRange, HeaderValueKind,
 };
+use rocketmq_protocol::protocol::FastCodesHeader;
 use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader;
 use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderMap};
@@ -106,9 +113,14 @@ fn registry() -> Vec<RegisteredSchema> {
     vec![
         register::<RpcRequestHeader>(),
         register::<TopicRequestHeader>(),
+        register::<NamesrvTopicRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
         register::<SearchOffsetRequestHeader>(),
         register::<SearchOffsetResponseHeader>(),
+        register::<PullMessageRequestHeader>(),
+        register::<PullMessageResponseHeader>(),
+        register::<SendMessageRequestHeaderV2>(),
+        register::<SendMessageResponseHeader>(),
     ]
 }
 
@@ -179,6 +191,11 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
                 .find(|candidate| candidate.key == field.key)
                 .unwrap_or_else(|| panic!("missing Java field {}.{}", schema.type_id, field.key));
             assert_eq!(rust_kind(field.kind), java_kind(&java_field.java_type));
+            match field.kind {
+                HeaderValueKind::U32 => assert_eq!(field.java_range, Some(HeaderRange::I32)),
+                HeaderValueKind::U64 => assert_eq!(field.java_range, Some(HeaderRange::I64)),
+                _ => assert_eq!(field.java_range, None),
+            }
 
             let owner = by_type_id
                 .get(field.declared_in)
@@ -329,4 +346,117 @@ fn typed_validation_errors_remain_classified_and_redacted() {
         })
     ));
     assert!(map.is_empty());
+}
+
+fn decode_fast_fields(encoded: &[u8]) -> HeaderMap {
+    let mut fields = HeaderMap::new();
+    let mut cursor = 0;
+    while cursor < encoded.len() {
+        let key_len = u16::from_be_bytes(encoded[cursor..cursor + 2].try_into().unwrap()) as usize;
+        cursor += 2;
+        let key = std::str::from_utf8(&encoded[cursor..cursor + key_len]).unwrap();
+        cursor += key_len;
+        let value_len = u32::from_be_bytes(encoded[cursor..cursor + 4].try_into().unwrap()) as usize;
+        cursor += 4;
+        let value = std::str::from_utf8(&encoded[cursor..cursor + value_len]).unwrap();
+        cursor += value_len;
+        fields.insert(key.into(), value.into());
+    }
+    fields
+}
+
+#[test]
+fn typed_maps_preserve_existing_send_fast_codecs() {
+    let rpc = RpcRequestHeader {
+        namespace: Some("namespace-a".into()),
+        namespaced: Some(true),
+        broker_name: Some("broker-a".into()),
+        oneway: Some(false),
+    };
+    let mut request = SendMessageRequestHeaderV2 {
+        a: "producer-a".into(),
+        b: "topic-a".into(),
+        c: "TBW102".into(),
+        d: 4,
+        e: 2,
+        f: 0,
+        g: 42,
+        h: 1,
+        i: Some("properties".into()),
+        j: Some(3),
+        k: Some(true),
+        l: Some(5),
+        m: Some(false),
+        n: Some("broker-a".into()),
+        topic_request_header: Some(TopicRequestHeader {
+            rpc_request_header: Some(rpc),
+            lo: Some(true),
+        }),
+    };
+    let typed_request_map = request.to_map().unwrap();
+    let mut request_bytes = BytesMut::new();
+    CommandCustomHeader::encode_fast(&mut request, &mut request_bytes);
+    assert_eq!(decode_fast_fields(&request_bytes), typed_request_map);
+
+    let typed_request = <SendMessageRequestHeaderV2 as HeaderCodec>::decode_from_map(&typed_request_map).unwrap();
+    let legacy_request = <SendMessageRequestHeaderV2 as FromMap>::from(&typed_request_map).unwrap();
+    let mut fast_request = SendMessageRequestHeaderV2::default();
+    CommandCustomHeader::decode_fast(&mut fast_request, &typed_request_map).unwrap();
+    assert_eq!(typed_request.to_map(), Some(typed_request_map.clone()));
+    assert_eq!(legacy_request.to_map(), Some(typed_request_map.clone()));
+    assert_eq!(fast_request.to_map(), Some(typed_request_map));
+
+    let mut response = SendMessageResponseHeader::new(
+        "message-a".into(),
+        -1,
+        -42,
+        Some("transaction-a".into()),
+        Some("batch-a".into()),
+        Some("recall-a".into()),
+    );
+    let typed_response_map = response.to_map().unwrap();
+    let mut response_bytes = BytesMut::new();
+    FastCodesHeader::encode_fast(&mut response, &mut response_bytes);
+    assert_eq!(decode_fast_fields(&response_bytes), typed_response_map);
+
+    let mut fast_response = SendMessageResponseHeader::default();
+    FastCodesHeader::decode_fast(&mut fast_response, &typed_response_map);
+    assert_eq!(fast_response.to_map(), Some(typed_response_map));
+}
+
+#[test]
+fn unsigned_fast_header_fields_enforce_inferred_java_ranges() {
+    let request = PullMessageRequestHeader {
+        consumer_group: "group-a".into(),
+        topic: "topic-a".into(),
+        queue_id: 0,
+        queue_offset: 0,
+        max_msg_nums: 32,
+        sys_flag: 0,
+        commit_offset: 0,
+        suspend_timeout_millis: i64::MAX as u64 + 1,
+        sub_version: 1,
+        ..Default::default()
+    };
+    let mut map = HeaderMap::new();
+    assert!(matches!(
+        request.try_encode_into_map(&mut map),
+        Err(HeaderCodecError::JavaRange {
+            key: "suspendTimeoutMillis",
+            ..
+        })
+    ));
+
+    let response = PullMessageResponseHeader {
+        suggest_which_broker_id: i64::MAX as u64 + 1,
+        ..Default::default()
+    };
+    let mut map = HeaderMap::new();
+    assert!(matches!(
+        response.try_encode_into_map(&mut map),
+        Err(HeaderCodecError::JavaRange {
+            key: "suggestWhichBrokerId",
+            ..
+        })
+    ));
 }

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.rs
@@ -21,4 +21,15 @@ struct UnknownContainerOption {
     value: String,
 }
 
+#[derive(RequestHeaderCodecV3)]
+#[header(
+    type_id = "fixtures::InvalidLegacyShim",
+    legacy_shim = "disabled",
+    crate = "rocketmq_protocol"
+)]
+struct InvalidLegacyShim {
+    #[header(required)]
+    value: String,
+}
+
 fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_container.stderr
@@ -21,3 +21,9 @@ error: unsupported RequestHeaderCodecV3 container option
    |
 18 | #[header(type_id = "fixtures::Unknown", unknown, crate = "rocketmq_protocol")]
    |                                         ^^^^^^^
+
+error: legacy_shim must be generated or manual
+  --> tests/ui/request_header_codec_v3/fail/invalid_container.rs:27:19
+   |
+27 |     legacy_shim = "disabled",
+   |                   ^^^^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs
@@ -5,7 +5,7 @@ use rocketmq_macros::RequestHeaderCodecV3;
 struct InvalidRanges {
     #[header(required, java_type = "long", range = "i32")]
     wrong_u32_range: u32,
-    #[header(required, java_type = "long")]
+    #[header(required)]
     missing_u64_range: u64,
     #[header(required, java_type = "long", range = "i64")]
     signed_with_range: i64,

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.stderr
@@ -4,7 +4,7 @@ error: range must be i32 or i64
 16 |     #[header(required, range = "u64")]
    |                                ^^^^^
 
-error: u32 range requires java_type = "int" and range = "i32"
+error: u32 fields require range = "i32"; java_type, when present, must be int or Integer
  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:6:5
   |
 6 |     #[header(required, java_type = "long", range = "i32")]
@@ -16,10 +16,10 @@ error: java_type is incompatible with the Rust header value type
 6 |     #[header(required, java_type = "long", range = "i32")]
   |                                    ^^^^^^
 
-error: unsigned Java long fields require range = "i64"
+error: unsigned u64 fields require range = "i64"
  --> tests/ui/request_header_codec_v3/fail/invalid_ranges_and_types.rs:8:5
   |
-8 |     #[header(required, java_type = "long")]
+8 |     #[header(required)]
   |     ^
 
 error: range is supported only for unsigned Rust fields mapped to signed Java integers

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/complete_model.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/complete_model.rs
@@ -30,9 +30,9 @@ struct CompleteHeader<T> {
     attempts: i32,
     #[header(required)]
     timestamp: i64,
-    #[header(required, java_type = "int", range = "i32")]
+    #[header(required, range = "i32")]
     queue_id: u32,
-    #[header(required, java_type = "long", range = "i64")]
+    #[header(required, range = "i64")]
     offset: u64,
     #[header(default, default_semantic = "literal:LOWER")]
     boundary: BoundaryType,

--- a/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/manual_legacy_shim.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v3/pass/manual_legacy_shim.rs
@@ -1,0 +1,43 @@
+use rocketmq_macros::RequestHeaderCodecV3;
+use rocketmq_protocol::protocol::header_codec::HeaderCodec;
+use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderMap};
+
+#[derive(RequestHeaderCodecV3)]
+#[header(
+    type_id = "fixtures::ManualLegacyShim",
+    legacy_shim = "manual",
+    crate = "rocketmq_protocol"
+)]
+struct ManualLegacyShim {
+    #[header(required)]
+    value: i32,
+}
+
+impl CommandCustomHeader for ManualLegacyShim {
+    fn to_map(&self) -> Option<HeaderMap> {
+        let mut map = HeaderMap::new();
+        self.try_encode_into_map(&mut map).ok()?;
+        Some(map)
+    }
+
+    fn try_encode_into_map(
+        &self,
+        out: &mut HeaderMap,
+    ) -> Result<(), rocketmq_protocol::protocol::header_codec::HeaderCodecError> {
+        let mut sink = rocketmq_protocol::protocol::header_codec::MapSink::new(out);
+        <Self as HeaderCodec>::encode_into(self, &mut sink)
+    }
+}
+
+impl FromMap for ManualLegacyShim {
+    type Error = rocketmq_protocol::__request_header_codec::RocketMQError;
+    type Target = Self;
+
+    fn from(map: &HeaderMap) -> Result<Self::Target, Self::Error> {
+        <Self as HeaderCodec>::decode_from_map(map).map_err(|error| {
+            rocketmq_protocol::__request_header_codec::RocketMQError::request_header_error(error.to_string())
+        })
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8973

### Brief Description

Add a `legacy_shim = "manual"` RequestHeaderCodecV3 option so headers with existing hand-optimized legacy trait implementations can reuse the typed map codec and schema without generating conflicting implementations. Infer Java signed integer compatibility for unsigned Rust fields from `range = "i32"` or `range = "i64"`, leaving `java_type` optional.

Migrate the Java fast-header counterparts for pull and send requests and responses to typed schemas. Preserve the existing send fast binary codecs, delegate the legacy SendMessageRequestHeaderV2 map adapters to HeaderCodec, and extend the pinned Java registry, compile-fail coverage, range checks, and typed/legacy/fast parity tests.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-macros --package rocketmq-protocol -- --check`
- `cargo test -p rocketmq-macros`
- `cargo test -p rocketmq-protocol`
- `cargo clippy -p rocketmq-macros --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-macros --no-deps`
- `cargo doc -p rocketmq-protocol --no-deps`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`
- `cargo check --locked --offline` from `rocketmq-macros/tests/fixtures/renamed-consumer/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable legacy compatibility handling, supporting either generated or manually implemented shims.
  - Improved protocol header encoding and decoding for messaging, pull, topic, and NameServer operations.
  - Added fast header processing and more complete required-field, alias, flattening, and type metadata support.

- **Bug Fixes**
  - Improved validation of numeric ranges and Java-compatible types.
  - Ensured flattened RPC fields are preserved during encoding, including when absent.
  - Improved diagnostic messages for invalid header configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->