### PR TITLE
[ISSUE #8975]✨Make fast request-header encoding clone-safe

### DIFF
--- a/rocketmq-protocol/src/lib.rs
+++ b/rocketmq-protocol/src/lib.rs
@@ -26,6 +26,7 @@ pub use code::request_code::RequestCode;
 pub use code::response_code::RemotingSysResponseCode;
 pub use protocol::command_custom_header::CommandCustomHeader;
 pub use protocol::command_custom_header::FromMap;
+pub use protocol::command_custom_header::HeaderEncodeCapability;
 pub use protocol::command_custom_header::HeaderMap;
 pub use protocol::encoded_frame::EncodedFrame;
 pub use protocol::header_codec::HeaderCodec;

--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -57,6 +57,7 @@ pub mod topic;
 
 pub use command_custom_header::CommandCustomHeader;
 pub use command_custom_header::FromMap;
+pub use command_custom_header::HeaderEncodeCapability;
 pub use data_version_compat as data_version_facade;
 pub use encoded_frame::EncodedFrame;
 pub use remoting_command::RemotingCommand;

--- a/rocketmq-protocol/src/protocol/command_custom_header.rs
+++ b/rocketmq-protocol/src/protocol/command_custom_header.rs
@@ -24,6 +24,21 @@ use crate::rocketmq_serializable::RocketMQSerializable;
 /// Wire-format extension fields carried by a RocketMQ remoting command.
 pub type HeaderMap = HashMap<CheetahString, CheetahString>;
 
+/// Encoding paths available for a custom header.
+///
+/// This capability is intentionally limited to encoding. Legacy fast decode
+/// remains a separate compatibility concern until all handwritten decoders
+/// have migrated to the typed [`crate::HeaderCodec`] path.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum HeaderEncodeCapability {
+    /// Materialize the header into extension fields before serialization.
+    #[default]
+    MapOnly,
+    /// Encode the header directly into the ROCKETMQ extension-field payload.
+    DirectBinary,
+}
+
 pub trait CommandCustomHeader: AsAny {
     /// Checks the fields of the implementing type.  
     ///  
@@ -96,6 +111,28 @@ pub trait CommandCustomHeader: AsAny {
         0
     }
 
+    /// Returns the authoritative encoding path for this header.
+    fn encode_capability(&self) -> HeaderEncodeCapability {
+        HeaderEncodeCapability::MapOnly
+    }
+
+    /// Appends this header directly to a ROCKETMQ extension-field payload.
+    ///
+    /// Implementations must require only shared access so cloned remoting
+    /// commands can encode the same immutable header. Callers must check
+    /// [`Self::encode_capability`] before invoking this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified header codec error when validation or binary
+    /// representation fails. The default reports that direct encoding is
+    /// unavailable.
+    fn encode_direct_binary(&self, _out: &mut bytes::BytesMut) -> Result<(), HeaderCodecError> {
+        Err(HeaderCodecError::FastCodecUnavailable {
+            header: std::any::type_name::<Self>(),
+        })
+    }
+
     /// Writes the provided `key` to the `out` buffer if the `value` is not empty.
     ///
     /// # Arguments
@@ -115,10 +152,14 @@ pub trait CommandCustomHeader: AsAny {
         }
     }
 
-    /// A placeholder function for fast encoding.
+    /// Compatibility adapter for the legacy mutable fast-encoding API.
     ///
-    /// This function currently does nothing and can be overridden by implementing types.
-    fn encode_fast(&mut self, _out: &mut bytes::BytesMut) {}
+    /// Production serialization uses [`Self::encode_capability`] and
+    /// [`Self::encode_direct_binary`] directly. This adapter cannot propagate
+    /// errors and remains only for existing callers during migration.
+    fn encode_fast(&mut self, out: &mut bytes::BytesMut) {
+        let _ = self.encode_direct_binary(out);
+    }
 
     /// A placeholder function for fast decoding.
     ///
@@ -138,7 +179,7 @@ pub trait CommandCustomHeader: AsAny {
     /// This function returns `false` by default, indicating that the implementing type does not
     /// support fast codec. This can be overridden by implementing types.
     fn support_fast_codec(&self) -> bool {
-        false
+        self.encode_capability() == HeaderEncodeCapability::DirectBinary
     }
 
     /// Retrieves the value associated with the specified field from the provided map.

--- a/rocketmq-protocol/src/protocol/encoded_frame.rs
+++ b/rocketmq-protocol/src/protocol/encoded_frame.rs
@@ -46,7 +46,7 @@ impl EncodedFrame {
     /// length field.
     pub fn from_command(mut command: RemotingCommand) -> RocketMQResult<Self> {
         let mut encoded_header = BytesMut::new();
-        command.fast_header_encode(&mut encoded_header);
+        command.try_fast_header_encode(&mut encoded_header)?;
         let body = command.take_body().unwrap_or_default();
         if encoded_header.len() < FRAME_PREFIX_BYTES {
             return Err(SerializationError::encode_failed(
@@ -138,9 +138,31 @@ mod tests {
     use cheetah_string::CheetahString;
 
     use super::EncodedFrame;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::HeaderEncodeCapability;
     use crate::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+    use crate::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
+    use crate::protocol::header_codec::HeaderCodecError;
     use crate::protocol::remoting_command::RemotingCommand;
     use crate::protocol::SerializeType;
+
+    struct FailingDirectHeader;
+
+    impl CommandCustomHeader for FailingDirectHeader {
+        fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+            Some(HashMap::new())
+        }
+
+        fn encode_capability(&self) -> HeaderEncodeCapability {
+            HeaderEncodeCapability::DirectBinary
+        }
+
+        fn encode_direct_binary(&self, _out: &mut BytesMut) -> Result<(), HeaderCodecError> {
+            Err(HeaderCodecError::FastCodecUnavailable {
+                header: "FailingDirectHeader",
+            })
+        }
+    }
 
     fn legacy_contiguous(mut command: RemotingCommand) -> Bytes {
         let mut bytes = BytesMut::new();
@@ -232,5 +254,81 @@ mod tests {
 
             assert_eq!(encode(first), encode(second));
         }
+    }
+
+    #[test]
+    fn direct_header_encoding_is_identical_after_multiple_command_clones() {
+        let header = SendMessageRequestHeaderV2 {
+            a: "producer-a".into(),
+            b: "topic-a".into(),
+            c: "TBW102".into(),
+            d: 4,
+            e: 2,
+            f: 0,
+            g: 42,
+            h: 1,
+            ..Default::default()
+        };
+        let original = RemotingCommand::create_remoting_command(310)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_command_custom_header(header);
+        let first_clone = original.clone();
+        let second_clone = first_clone.clone();
+
+        let frames = [original, first_clone, second_clone].map(|command| {
+            EncodedFrame::from_command(command)
+                .expect("shared direct header should encode")
+                .into_bytes()
+        });
+        assert_eq!(frames[0], frames[1]);
+        assert_eq!(frames[1], frames[2]);
+
+        for frame in frames {
+            let mut input = BytesMut::from(frame.as_ref());
+            let decoded = RemotingCommand::decode(&mut input)
+                .expect("frame should decode")
+                .expect("frame should be complete");
+            let decoded_header = decoded
+                .decode_command_custom_header::<SendMessageRequestHeaderV2>()
+                .expect("direct fields should remain present");
+            assert_eq!(decoded_header.a.as_str(), "producer-a");
+            assert_eq!(decoded_header.b.as_str(), "topic-a");
+            assert_eq!(decoded_header.g, 42);
+        }
+    }
+
+    #[test]
+    fn fallible_direct_header_encoding_rolls_back_the_destination() {
+        let mut command = RemotingCommand::create_remoting_command(311)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_command_custom_header(FailingDirectHeader);
+        let mut destination = BytesMut::from(&b"existing"[..]);
+
+        assert!(command.try_fast_header_encode(&mut destination).is_err());
+        assert_eq!(destination.as_ref(), b"existing");
+    }
+
+    #[test]
+    fn materialized_direct_header_is_not_encoded_twice_after_clone() {
+        let header = SendMessageRequestHeaderV2 {
+            a: "producer-b".into(),
+            b: "topic-b".into(),
+            c: "TBW102".into(),
+            d: 4,
+            e: 3,
+            f: 0,
+            g: 43,
+            h: 1,
+            ..Default::default()
+        };
+        let mut original = RemotingCommand::create_remoting_command(312)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_command_custom_header(header);
+        original.materialize_custom_header_to_ext_fields();
+        let cloned = original.clone();
+
+        let original_frame = EncodedFrame::from_command(original).unwrap().into_bytes();
+        let cloned_frame = EncodedFrame::from_command(cloned).unwrap().into_bytes();
+        assert_eq!(original_frame, cloned_frame);
     }
 }

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
+use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header_codec::HeaderCodec;
@@ -128,7 +129,11 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
         <Self as HeaderCodec>::encoded_len_hint(self)
     }
 
-    fn encode_fast(&mut self, out: &mut BytesMut) {
+    fn encode_capability(&self) -> HeaderEncodeCapability {
+        HeaderEncodeCapability::DirectBinary
+    }
+
+    fn encode_direct_binary(&self, out: &mut BytesMut) -> Result<(), HeaderCodecError> {
         self.write_if_not_null(out, FIELD_A, self.a.as_str());
         self.write_if_not_null(out, FIELD_B, self.b.as_str());
         self.write_if_not_null(out, FIELD_C, self.c.as_str());
@@ -184,6 +189,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
                 self.write_if_not_null(out, FIELD_LO, if value { "true" } else { "false" });
             }
         }
+        Ok(())
     }
 
     fn decode_fast(&mut self, fields: &HashMap<CheetahString, CheetahString>) -> rocketmq_error::RocketMQResult<()> {

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -35,6 +35,7 @@ use crate::code::request_code::RequestCode;
 use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
+use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
@@ -96,8 +97,12 @@ pub struct RemotingCommand {
 impl Clone for RemotingCommand {
     fn clone(&self) -> Self {
         let mut ext_fields = self.ext_fields.clone().unwrap_or_default();
-        if let Some(header_fields) = self.command_custom_header.as_ref().and_then(|header| header.to_map()) {
-            ext_fields.extend(header_fields);
+        if let Some(header) = self.command_custom_header.as_ref() {
+            if header.encode_capability() == HeaderEncodeCapability::MapOnly {
+                if let Some(header_fields) = header.to_map() {
+                    ext_fields.extend(header_fields);
+                }
+            }
         }
         let ext_fields = (!ext_fields.is_empty()).then_some(ext_fields);
         Self {
@@ -502,19 +507,35 @@ impl RemotingCommand {
 
     #[inline]
     pub fn fast_header_encode(&mut self, dst: &mut BytesMut) {
-        if self
-            .command_custom_header_ref()
-            .is_some_and(|header| header.check_fields().is_err())
-        {
-            return;
+        let _ = self.try_fast_header_encode(dst);
+    }
+
+    /// Encodes the frame header and rolls the destination back on failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns the custom-header validation or direct-binary encoding failure.
+    #[inline]
+    pub fn try_fast_header_encode(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+        let checkpoint = dst.len();
+        let result = self.try_fast_header_encode_inner(dst);
+        if result.is_err() {
+            dst.truncate(checkpoint);
+        }
+        result
+    }
+
+    #[inline]
+    fn try_fast_header_encode_inner(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+        if let Some(header) = self.command_custom_header_ref() {
+            header.check_fields()?;
         }
         match self.serialize_type {
             SerializeType::JSON => {
                 self.fast_encode_json(dst);
+                Ok(())
             }
-            SerializeType::ROCKETMQ => {
-                self.fast_encode_rocketmq(dst);
-            }
+            SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst),
         }
     }
 
@@ -561,22 +582,21 @@ impl RemotingCommand {
 
     /// Optimized ROCKETMQ binary encoding with minimal allocations
     #[inline]
-    fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut) {
+    fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
         let begin_index = dst.len();
 
         // Reserve space for total_length (4 bytes) and serialize_type (4 bytes)
         dst.reserve(8);
         dst.put_i64(0); // Placeholder for total_length + serialize_type
 
-        // Check if custom header supports fast codec
-        if let Some(header) = self.command_custom_header_ref() {
-            if !header.support_fast_codec() {
-                self.make_custom_header_to_net();
-            }
+        let capability = self.custom_header_encode_capability();
+        if capability == HeaderEncodeCapability::MapOnly {
+            self.make_custom_header_to_net();
         }
 
         // Encode header directly to buffer
-        let header_size = RocketMQSerializable::rocketmq_protocol_encode(self, dst);
+        let header_size = RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability)
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
         let body_length = self.body.as_ref().map_or(0, |b| b.len()) as i32;
 
         // Calculate serialize type with header length embedded
@@ -588,6 +608,7 @@ impl RemotingCommand {
 
         dst[begin_index..begin_index + 4].copy_from_slice(&total_length);
         dst[begin_index + 4..begin_index + 8].copy_from_slice(&serialize_type_bytes);
+        Ok(())
     }
 
     /// Estimate JSON header size to reduce buffer reallocations
@@ -1042,6 +1063,15 @@ impl RemotingCommand {
         match self.command_custom_header.as_ref() {
             None => None,
             Some(value) => Some(value.as_ref().as_ref()),
+        }
+    }
+
+    pub(crate) fn custom_header_encode_capability(&self) -> HeaderEncodeCapability {
+        if self.custom_header_to_net {
+            HeaderEncodeCapability::MapOnly
+        } else {
+            self.command_custom_header_ref()
+                .map_or(HeaderEncodeCapability::MapOnly, CommandCustomHeader::encode_capability)
         }
     }
 

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -21,6 +21,8 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
 
+use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::protocol::LanguageCode;
 
@@ -104,6 +106,32 @@ impl RocketMQSerializable {
     /// Optimized ROCKETMQ protocol encoding with reduced allocations
     #[inline]
     pub fn rocketmq_protocol_encode(cmd: &mut RemotingCommand, buf: &mut BytesMut) -> usize {
+        let checkpoint = buf.len();
+        match Self::try_rocketmq_protocol_encode(cmd, buf) {
+            Ok(encoded) => encoded,
+            Err(_) => {
+                buf.truncate(checkpoint);
+                0
+            }
+        }
+    }
+
+    /// Fallible ROCKETMQ protocol encoding with reduced allocations.
+    ///
+    /// # Errors
+    ///
+    /// Returns the direct custom-header encoding failure when the selected
+    /// header cannot be represented in the ROCKETMQ extension-field payload.
+    #[inline]
+    pub fn try_rocketmq_protocol_encode(cmd: &RemotingCommand, buf: &mut BytesMut) -> Result<usize, HeaderCodecError> {
+        Self::try_rocketmq_protocol_encode_with_capability(cmd, buf, cmd.custom_header_encode_capability())
+    }
+
+    pub(crate) fn try_rocketmq_protocol_encode_with_capability(
+        cmd: &RemotingCommand,
+        buf: &mut BytesMut,
+        capability: HeaderEncodeCapability,
+    ) -> Result<usize, HeaderCodecError> {
         let begin_index = buf.len();
 
         // Estimate required capacity and reserve upfront to reduce reallocations
@@ -128,10 +156,11 @@ impl RocketMQSerializable {
         let map_len_index = buf.len();
         buf.put_i32(0);
 
-        // Encode custom header if it supports fast codec
-        if let Some(header) = cmd.command_custom_header_mut() {
-            if header.support_fast_codec() {
-                header.encode_fast(buf);
+        // Encode the custom header through shared access so cloned commands
+        // do not depend on Arc uniqueness.
+        if let Some(header) = cmd.command_custom_header_ref() {
+            if capability == HeaderEncodeCapability::DirectBinary {
+                header.encode_direct_binary(buf)?;
             }
         }
 
@@ -148,7 +177,7 @@ impl RocketMQSerializable {
         let ext_fields_length = (current_length - map_len_index - 4) as i32;
         buf[map_len_index..map_len_index + 4].copy_from_slice(&ext_fields_length.to_be_bytes());
 
-        buf.len() - begin_index
+        Ok(buf.len() - begin_index)
     }
 
     /// Estimate the size needed for encoding to reduce reallocations


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8975

### Brief Description

Add an explicit `HeaderEncodeCapability` and fallible `encode_direct_binary(&self)` contract for custom request headers. ROCKETMQ serialization now selects the encode path once and invokes direct encoding through an immutable header reference, while map-only headers retain the existing materialization path.

Move `SendMessageRequestHeaderV2` to the immutable direct-binary contract without changing its field order or wire values. Preserve the legacy public encode facade, add destination rollback on fallible failures, and prevent cloned or previously materialized direct headers from being omitted or encoded twice. Full-frame tests cover original, cloned, multiply cloned, materialized, and failing direct headers.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-protocol -- --check`
- `cargo test -p rocketmq-protocol`
- `cargo test -p rocketmq-protocol protocol::encoded_frame::tests -- --nocapture`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-protocol --no-deps`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`
- `cargo check --locked --offline` from `rocketmq-macros/tests/fixtures/renamed-consumer/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for direct binary encoding of compatible custom headers.
  - Exposed header encoding capabilities and fallible encoding APIs for improved integration control.

- **Bug Fixes**
  - Encoding failures are now reported instead of being silently ignored.
  - Buffer changes are rolled back when header encoding fails.
  - Improved handling of cloned and materialized command headers to prevent duplicate encoding.

- **Compatibility**
  - Existing encoding methods remain available while using the updated encoding behavior internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->