### PR TITLE
[ISSUE #8977]✨Generate direct binary codecs for typed headers

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen.rs
@@ -35,6 +35,11 @@ pub(super) fn generate(model: &HeaderModel) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let context_declarations = codegen_map::context_declarations(model);
+    let manual_fast_helpers = if model.fast && matches!(model.legacy_shim, LegacyShim::Manual) {
+        codegen_map::manual_fast_helpers(model, &codec_trait)
+    } else {
+        TokenStream::new()
+    };
     let map_items = codegen_map::codec_items(model, &codec_trait);
     let schema_items = codegen_schema::codec_items(model, &codec_trait);
     let shims = match model.legacy_shim {
@@ -45,6 +50,7 @@ pub(super) fn generate(model: &HeaderModel) -> TokenStream {
     quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             #context_declarations
+            #manual_fast_helpers
         }
 
         impl #impl_generics #codec_trait for #ident #ty_generics #where_clause {

--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -40,6 +40,29 @@ pub(super) fn context_declarations(model: &HeaderModel) -> TokenStream {
     quote!(#(#declarations)*)
 }
 
+pub(super) fn manual_fast_helpers(model: &HeaderModel, codec_trait: &TokenStream) -> TokenStream {
+    let protocol_path = &model.protocol_path;
+    let error_type = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
+    let sink_trait = quote!(#protocol_path::protocol::header_codec::EncodeSink);
+    let encode = local_encode_body(model, codec_trait, protocol_path);
+    let len_hint = local_len_hint_body(model, protocol_path);
+
+    quote! {
+        #[inline]
+        fn __request_header_codec_v3_encode_local<__RequestHeaderSink: #sink_trait>(
+            &self,
+            sink: &mut __RequestHeaderSink,
+        ) -> Result<(), #error_type> {
+            #encode
+        }
+
+        #[inline]
+        fn __request_header_codec_v3_local_encoded_len_hint(&self) -> usize {
+            #len_hint
+        }
+    }
+}
+
 pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> TokenStream {
     let protocol_path = &model.protocol_path;
     let error_type = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
@@ -111,7 +134,23 @@ fn validation_body(model: &HeaderModel, error_type: &TokenStream) -> TokenStream
 }
 
 fn encode_body(model: &HeaderModel, codec_trait: &TokenStream, protocol_path: &syn::Path) -> TokenStream {
-    let mut fields: Vec<_> = model.fields.iter().collect();
+    encode_selected_body(model.fields.iter(), codec_trait, protocol_path)
+}
+
+fn local_encode_body(model: &HeaderModel, codec_trait: &TokenStream, protocol_path: &syn::Path) -> TokenStream {
+    encode_selected_body(
+        model.fields.iter().filter(|field| !field.flattened),
+        codec_trait,
+        protocol_path,
+    )
+}
+
+fn encode_selected_body<'a>(
+    fields: impl Iterator<Item = &'a FieldModel>,
+    codec_trait: &TokenStream,
+    protocol_path: &syn::Path,
+) -> TokenStream {
+    let mut fields: Vec<_> = fields.collect();
     fields.sort_by_key(|field| field.stable_order());
     let writes = fields.into_iter().map(|field| {
         let ident = &field.ident;
@@ -149,6 +188,30 @@ fn encode_body(model: &HeaderModel, codec_trait: &TokenStream, protocol_path: &s
         <Self as #codec_trait>::validate_for_wire(self)?;
         #(#writes)*
         Ok(())
+    }
+}
+
+fn local_len_hint_body(model: &HeaderModel, protocol_path: &syn::Path) -> TokenStream {
+    let value_trait = quote!(#protocol_path::protocol::header_codec::HeaderValue);
+    let adds = model.fields.iter().filter(|field| !field.flattened).map(|field| {
+        let ident = &field.ident;
+        let overhead = 6_usize.saturating_add(field.key.value.len());
+        if field.option_inner.is_some() {
+            quote! {
+                if let Some(value) = &self.#ident {
+                    len = len.saturating_add(#overhead).saturating_add(#value_trait::encoded_len(value));
+                }
+            }
+        } else {
+            quote! {
+                len = len.saturating_add(#overhead).saturating_add(#value_trait::encoded_len(&self.#ident));
+            }
+        }
+    });
+    quote! {
+        let mut len = 0usize;
+        #(#adds)*
+        len
     }
 }
 

--- a/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
@@ -27,6 +27,31 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
     let codec_error = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
     let rocketmq_error = quote!(#protocol_path::__request_header_codec::RocketMQError);
     let map_sink = quote!(#protocol_path::protocol::header_codec::MapSink);
+    let fast_methods = if model.fast {
+        let binary_sink = quote!(#protocol_path::protocol::header_codec::BinarySink);
+        let encode_capability = quote!(#protocol_path::protocol::command_custom_header::HeaderEncodeCapability);
+        let bytes_mut = quote!(#protocol_path::__request_header_codec::BytesMut);
+        quote! {
+            fn encode_capability(&self) -> #encode_capability {
+                #encode_capability::DirectBinary
+            }
+
+            fn encode_direct_binary(&self, out: &mut #bytes_mut) -> Result<(), #codec_error> {
+                let checkpoint = out.len();
+                out.reserve(<Self as #codec_trait>::encoded_len_hint(self));
+                let result = {
+                    let mut sink = #binary_sink::new(out);
+                    <Self as #codec_trait>::encode_into(self, &mut sink)
+                };
+                if result.is_err() {
+                    out.truncate(checkpoint);
+                }
+                result
+            }
+        }
+    } else {
+        TokenStream::new()
+    };
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
@@ -70,6 +95,8 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
             fn encoded_len_hint(&self) -> usize {
                 <Self as #codec_trait>::encoded_len_hint(self)
             }
+
+            #fast_methods
         }
 
         impl #impl_generics #from_map_trait for #ident #ty_generics #where_clause {

--- a/rocketmq-protocol/src/lib.rs
+++ b/rocketmq-protocol/src/lib.rs
@@ -38,6 +38,7 @@ pub use rpc::topic_request_header::TopicRequestHeader;
 /// Stable implementation details used by RocketMQ derive macros.
 #[doc(hidden)]
 pub mod __request_header_codec {
+    pub use bytes::BytesMut;
     pub use cheetah_string::CheetahString;
     pub use rocketmq_error::RocketMQError;
 }

--- a/rocketmq-protocol/src/protocol/command_custom_header.rs
+++ b/rocketmq-protocol/src/protocol/command_custom_header.rs
@@ -176,10 +176,12 @@ pub trait CommandCustomHeader: AsAny {
     ///
     /// # Returns
     ///
-    /// This function returns `false` by default, indicating that the implementing type does not
-    /// support fast codec. This can be overridden by implementing types.
+    /// This legacy capability is limited to hand-written fast decoding. Direct
+    /// binary encoding is reported independently by [`Self::encode_capability`].
+    /// The default remains `false` so enabling generated direct encoding cannot
+    /// route decoding through an unimplemented legacy hook.
     fn support_fast_codec(&self) -> bool {
-        self.encode_capability() == HeaderEncodeCapability::DirectBinary
+        false
     }
 
     /// Retrieves the value associated with the specified field from the provided map.

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -26,6 +26,7 @@ use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
+use crate::protocol::header_codec::BinarySink;
 use crate::protocol::header_codec::HeaderCodec;
 use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_codec::MapSink;
@@ -134,62 +135,18 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
     }
 
     fn encode_direct_binary(&self, out: &mut BytesMut) -> Result<(), HeaderCodecError> {
-        self.write_if_not_null(out, FIELD_A, self.a.as_str());
-        self.write_if_not_null(out, FIELD_B, self.b.as_str());
-        self.write_if_not_null(out, FIELD_C, self.c.as_str());
-
-        // Reduce allocations by avoiding format! macro
-        let d_str = self.d.to_string();
-        self.write_if_not_null(out, FIELD_D, &d_str);
-        let e_str = self.e.to_string();
-        self.write_if_not_null(out, FIELD_E, &e_str);
-        let f_str = self.f.to_string();
-        self.write_if_not_null(out, FIELD_F, &f_str);
-        let g_str = self.g.to_string();
-        self.write_if_not_null(out, FIELD_G, &g_str);
-        let h_str = self.h.to_string();
-        self.write_if_not_null(out, FIELD_H, &h_str);
-
-        if let Some(ref value) = self.i {
-            self.write_if_not_null(out, FIELD_I, value.as_str());
+        let checkpoint = out.len();
+        // Java's V2 fast codec writes only the compact a..n fields. Inherited
+        // topic/RPC fields remain available through the compatibility map.
+        out.reserve(self.__request_header_codec_v3_local_encoded_len_hint());
+        let result = {
+            let mut sink = BinarySink::new(out);
+            self.__request_header_codec_v3_encode_local(&mut sink)
+        };
+        if result.is_err() {
+            out.truncate(checkpoint);
         }
-        if let Some(value) = self.j {
-            let j_str = value.to_string();
-            self.write_if_not_null(out, FIELD_J, &j_str);
-        }
-        if let Some(value) = self.k {
-            self.write_if_not_null(out, FIELD_K, if value { "true" } else { "false" });
-        }
-        if let Some(value) = self.l {
-            let l_str = value.to_string();
-            self.write_if_not_null(out, FIELD_L, &l_str);
-        }
-        if let Some(value) = self.m {
-            self.write_if_not_null(out, FIELD_M, if value { "true" } else { "false" });
-        }
-        if let Some(ref value) = self.n {
-            self.write_if_not_null(out, FIELD_N, value.as_str());
-        }
-        if let Some(ref header) = self.topic_request_header {
-            if let Some(ref rpc_header) = header.rpc_request_header {
-                if let Some(ref value) = rpc_header.broker_name {
-                    self.write_if_not_null(out, FIELD_BROKER_NAME, value.as_str());
-                }
-                if let Some(ref value) = rpc_header.namespace {
-                    self.write_if_not_null(out, FIELD_NAMESPACE, value.as_str());
-                }
-                if let Some(value) = rpc_header.namespaced {
-                    self.write_if_not_null(out, FIELD_NAMESPACED, if value { "true" } else { "false" });
-                }
-                if let Some(value) = rpc_header.oneway {
-                    self.write_if_not_null(out, FIELD_ONEWAY, if value { "true" } else { "false" });
-                }
-            }
-            if let Some(value) = header.lo {
-                self.write_if_not_null(out, FIELD_LO, if value { "true" } else { "false" });
-            }
-        }
-        Ok(())
+        result
     }
 
     fn decode_fast(&mut self, fields: &HashMap<CheetahString, CheetahString>) -> rocketmq_error::RocketMQResult<()> {
@@ -573,6 +530,23 @@ mod tests {
         ])
     }
 
+    fn decode_fast_fields(encoded: &[u8]) -> HashMap<CheetahString, CheetahString> {
+        let mut fields = HashMap::new();
+        let mut cursor = 0;
+        while cursor < encoded.len() {
+            let key_len = u16::from_be_bytes(encoded[cursor..cursor + 2].try_into().unwrap()) as usize;
+            cursor += 2;
+            let key = std::str::from_utf8(&encoded[cursor..cursor + key_len]).unwrap();
+            cursor += key_len;
+            let value_len = u32::from_be_bytes(encoded[cursor..cursor + 4].try_into().unwrap()) as usize;
+            cursor += 4;
+            let value = std::str::from_utf8(&encoded[cursor..cursor + value_len]).unwrap();
+            cursor += value_len;
+            fields.insert(key.into(), value.into());
+        }
+        fields
+    }
+
     #[test]
     fn send_message_request_header_v2_serializes_correctly() {
         let header = SendMessageRequestHeaderV2 {
@@ -622,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn topic_request_header_setters_initialize_missing_nested_headers_and_fast_codec_fields() {
+    fn topic_request_header_setters_preserve_map_fields_without_expanding_java_v2_fast_fields() {
         let mut header = minimal_header_v2();
 
         header.set_lo(Some(true));
@@ -647,15 +621,11 @@ mod tests {
 
         let mut encoded = BytesMut::new();
         header.encode_fast(&mut encoded);
-        let encoded = String::from_utf8_lossy(&encoded);
-        assert!(encoded.contains("n"));
-        assert!(encoded.contains("broker-a"));
-        assert!(encoded.contains("bname"));
-        assert!(encoded.contains("ns"));
-        assert!(encoded.contains("ns-a"));
-        assert!(encoded.contains("nsd"));
-        assert!(encoded.contains("oway"));
-        assert!(encoded.contains("lo"));
+        let fast_fields = decode_fast_fields(&encoded);
+        assert_eq!(fast_fields.get("n").map(CheetahString::as_str), Some("broker-a"));
+        for inherited in ["bname", "ns", "nsd", "oway", "lo"] {
+            assert!(!fast_fields.contains_key(inherited));
+        }
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/pull_message_request_header.rs
@@ -54,9 +54,11 @@ pub struct PullMessageRequestHeader {
     #[header(required, range = "i64")]
     pub suspend_timeout_millis: u64,
 
-    #[header(required)]
+    // The Java fast codec writes subscription before subVersion.
+    #[header(required, binary_order = 10)]
     pub sub_version: i64,
 
+    #[header(binary_order = 9)]
     pub subscription: Option<CheetahString>,
     pub expression_type: Option<CheetahString>,
     pub max_msg_bytes: Option<i32>,

--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -37,6 +37,7 @@ pub use schema::HeaderFieldSpec;
 pub use schema::HeaderFlattenSpec;
 pub use schema::HeaderPresence;
 pub use schema::ResolvedHeaderKey;
+pub use sink::BinarySink;
 pub use sink::EncodeSink;
 pub use sink::MapSink;
 pub use value::validate_unsigned_java_range;

--- a/rocketmq-protocol/src/protocol/header_codec/sink.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/sink.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::BufMut;
+use bytes::BytesMut;
 use cheetah_string::CheetahString;
 
 use super::private::Sealed;
@@ -78,6 +80,83 @@ impl EncodeSink for MapSink<'_> {
     }
 }
 
+/// An [`EncodeSink`] that writes canonical extension fields directly to a
+/// ROCKETMQ binary payload.
+///
+/// Each field uses a big-endian `u16` key length followed by a big-endian
+/// signed Java `int` value length. Scalar values are appended through
+/// [`HeaderValue::write_ascii`] without allocating an intermediate string.
+pub struct BinarySink<'a> {
+    out: &'a mut BytesMut,
+}
+
+impl<'a> BinarySink<'a> {
+    /// Creates a binary sink over an existing destination.
+    #[inline]
+    pub fn new(out: &'a mut BytesMut) -> Self {
+        Self { out }
+    }
+
+    /// Returns the borrowed destination after the sink is no longer needed.
+    #[inline]
+    pub fn into_inner(self) -> &'a mut BytesMut {
+        self.out
+    }
+}
+
+impl Sealed for BinarySink<'_> {}
+
+impl EncodeSink for BinarySink<'_> {
+    #[inline]
+    fn write<V: HeaderValue>(
+        &mut self,
+        key: &'static str,
+        value: &V,
+        context: HeaderFieldContext,
+    ) -> Result<(), HeaderCodecError> {
+        let key_len = u16::try_from(key.len()).map_err(|_| HeaderCodecError::KeyLengthOverflow {
+            header: context.header,
+            key: context.key,
+        })?;
+        let value_len_hint = value.encoded_len();
+        if value_len_hint > i32::MAX as usize {
+            return Err(HeaderCodecError::ValueLengthOverflow {
+                header: context.header,
+                key: context.key,
+            });
+        }
+
+        let pair_len = 2usize
+            .checked_add(key.len())
+            .and_then(|len| len.checked_add(4))
+            .and_then(|len| len.checked_add(value_len_hint))
+            .ok_or(HeaderCodecError::ValueLengthOverflow {
+                header: context.header,
+                key: context.key,
+            })?;
+        let pair_start = self.out.len();
+        self.out.reserve(pair_len);
+        self.out.put_u16(key_len);
+        self.out.extend_from_slice(key.as_bytes());
+
+        let value_len_offset = self.out.len();
+        self.out.put_i32(0);
+        let value_offset = self.out.len();
+        value.write_ascii(self.out);
+        let actual_value_len = self.out.len() - value_offset;
+        debug_assert_eq!(actual_value_len, value_len_hint);
+        let actual_value_len = i32::try_from(actual_value_len).map_err(|_| {
+            self.out.truncate(pair_start);
+            HeaderCodecError::ValueLengthOverflow {
+                header: context.header,
+                key: context.key,
+            }
+        })?;
+        self.out[value_len_offset..value_len_offset + 4].copy_from_slice(&actual_value_len.to_be_bytes());
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,5 +214,30 @@ mod tests {
             fields.get("queueOffset").map(CheetahString::as_str),
             Some("18446744073709551615")
         );
+    }
+
+    #[test]
+    fn binary_sink_appends_canonical_pairs_without_replacing_existing_bytes() {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let mut sink = BinarySink::new(&mut out);
+        sink.write("queueOffset", &-42_i64, CONTEXT).unwrap();
+        let out = sink.into_inner();
+
+        assert_eq!(out.len() - 6, 2 + 11 + 4 + 3);
+        assert_eq!(&out[..6], b"prefix");
+        assert_eq!(u16::from_be_bytes(out[6..8].try_into().unwrap()), 11);
+        assert_eq!(&out[8..19], b"queueOffset");
+        assert_eq!(i32::from_be_bytes(out[19..23].try_into().unwrap()), 3);
+        assert_eq!(&out[23..], b"-42");
+    }
+
+    #[test]
+    fn binary_sink_rejects_an_oversized_key_without_mutating_the_destination() {
+        let key = Box::leak("k".repeat(u16::MAX as usize + 1).into_boxed_str());
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let error = BinarySink::new(&mut out).write(key, &true, CONTEXT).unwrap_err();
+
+        assert!(matches!(error, HeaderCodecError::KeyLengthOverflow { .. }));
+        assert_eq!(out.as_ref(), b"prefix");
     }
 }

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -32,7 +32,7 @@ use rocketmq_protocol::protocol::header_codec::{
 use rocketmq_protocol::protocol::FastCodesHeader;
 use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader;
-use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderMap};
+use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderEncodeCapability, HeaderMap};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -94,7 +94,13 @@ struct RegisteredSchema {
     flattens: Vec<HeaderFlattenSpec>,
 }
 
-fn register<T: HeaderCodec>() -> RegisteredSchema {
+fn register<T: HeaderCodec + CommandCustomHeader + Default>() -> RegisteredSchema {
+    assert_eq!(
+        T::default().encode_capability() == HeaderEncodeCapability::DirectBinary,
+        T::FAST_ENABLED,
+        "{} encode capability must follow its fast schema flag",
+        T::TYPE_ID
+    );
     let mut fields = Vec::new();
     T::visit_field_specs(&mut |field| fields.push(*field));
     let mut flattens = Vec::new();
@@ -349,7 +355,11 @@ fn typed_validation_errors_remain_classified_and_redacted() {
 }
 
 fn decode_fast_fields(encoded: &[u8]) -> HeaderMap {
-    let mut fields = HeaderMap::new();
+    decode_fast_pairs(encoded).into_iter().collect()
+}
+
+fn decode_fast_pairs(encoded: &[u8]) -> Vec<(CheetahString, CheetahString)> {
+    let mut fields = Vec::new();
     let mut cursor = 0;
     while cursor < encoded.len() {
         let key_len = u16::from_be_bytes(encoded[cursor..cursor + 2].try_into().unwrap()) as usize;
@@ -360,20 +370,141 @@ fn decode_fast_fields(encoded: &[u8]) -> HeaderMap {
         cursor += 4;
         let value = std::str::from_utf8(&encoded[cursor..cursor + value_len]).unwrap();
         cursor += value_len;
-        fields.insert(key.into(), value.into());
+        fields.push((key.into(), value.into()));
     }
     fields
 }
 
+fn assert_direct_binary_matches_typed_map<T>(header: &T, expected_keys: &[&str])
+where
+    T: CommandCustomHeader,
+{
+    assert_eq!(header.encode_capability(), HeaderEncodeCapability::DirectBinary);
+    let expected = header.to_map().expect("typed compatibility map");
+    let mut encoded = BytesMut::from(&b"prefix"[..]);
+    header
+        .encode_direct_binary(&mut encoded)
+        .expect("typed direct binary encoding");
+    assert_eq!(&encoded[..6], b"prefix");
+    assert_eq!(encoded.len() - 6, header.encoded_len_hint());
+
+    let pairs = decode_fast_pairs(&encoded[6..]);
+    assert_eq!(
+        pairs.iter().map(|(key, _)| key.as_str()).collect::<Vec<_>>(),
+        expected_keys
+    );
+    assert_eq!(pairs.into_iter().collect::<HeaderMap>(), expected);
+}
+
 #[test]
-fn typed_maps_preserve_existing_send_fast_codecs() {
+fn generated_fast_headers_write_canonical_binary_pairs_in_schema_order() {
     let rpc = RpcRequestHeader {
         namespace: Some("namespace-a".into()),
         namespaced: Some(true),
         broker_name: Some("broker-a".into()),
         oneway: Some(false),
     };
-    let mut request = SendMessageRequestHeaderV2 {
+    let pull_request = PullMessageRequestHeader {
+        consumer_group: "group-a".into(),
+        topic: "topic-a".into(),
+        lite_topic: Some("lite-a".into()),
+        queue_id: -1,
+        queue_offset: -42,
+        max_msg_nums: 32,
+        sys_flag: 1,
+        commit_offset: 7,
+        suspend_timeout_millis: 15_000,
+        sub_version: 99,
+        subscription: Some("tag-a".into()),
+        expression_type: Some("TAG".into()),
+        max_msg_bytes: Some(1024),
+        request_source: Some(2),
+        proxy_forward_client_id: Some("client-a".into()),
+        topic_request: Some(NamesrvTopicRequestHeader {
+            lo: Some(true),
+            rpc: Some(rpc),
+        }),
+    };
+    assert_direct_binary_matches_typed_map(
+        &pull_request,
+        &[
+            "consumerGroup",
+            "topic",
+            "liteTopic",
+            "queueId",
+            "queueOffset",
+            "maxMsgNums",
+            "sysFlag",
+            "commitOffset",
+            "suspendTimeoutMillis",
+            "subscription",
+            "subVersion",
+            "expressionType",
+            "maxMsgBytes",
+            "requestSource",
+            "proxyFrowardClientId",
+            "lo",
+            "ns",
+            "nsd",
+            "bname",
+            "oway",
+        ],
+    );
+
+    let pull_response = PullMessageResponseHeader {
+        suggest_which_broker_id: 1,
+        next_begin_offset: -2,
+        min_offset: -3,
+        max_offset: 4,
+        offset_delta: Some(-5),
+        topic_sys_flag: Some(6),
+        group_sys_flag: Some(7),
+        forbidden_type: Some(8),
+    };
+    assert_direct_binary_matches_typed_map(
+        &pull_response,
+        &[
+            "suggestWhichBrokerId",
+            "nextBeginOffset",
+            "minOffset",
+            "maxOffset",
+            "offsetDelta",
+            "topicSysFlag",
+            "groupSysFlag",
+            "forbiddenType",
+        ],
+    );
+
+    let send_response = SendMessageResponseHeader::new(
+        "message-a".into(),
+        -1,
+        -42,
+        Some("transaction-a".into()),
+        Some("batch-a".into()),
+        Some("recall-a".into()),
+    );
+    assert_direct_binary_matches_typed_map(
+        &send_response,
+        &[
+            "msgId",
+            "queueId",
+            "queueOffset",
+            "transactionId",
+            "batchUniqId",
+            "recallHandle",
+        ],
+    );
+}
+
+#[test]
+fn typed_schemas_preserve_java_send_fast_contracts() {
+    let rpc = RpcRequestHeader {
+        namespace: Some("namespace-a".into()),
+        namespaced: Some(true),
+        broker_name: Some("broker-a".into()),
+        oneway: Some(false),
+    };
+    let request = SendMessageRequestHeaderV2 {
         a: "producer-a".into(),
         b: "topic-a".into(),
         c: "TBW102".into(),
@@ -395,8 +526,19 @@ fn typed_maps_preserve_existing_send_fast_codecs() {
     };
     let typed_request_map = request.to_map().unwrap();
     let mut request_bytes = BytesMut::new();
-    CommandCustomHeader::encode_fast(&mut request, &mut request_bytes);
-    assert_eq!(decode_fast_fields(&request_bytes), typed_request_map);
+    CommandCustomHeader::encode_direct_binary(&request, &mut request_bytes).unwrap();
+    let direct_request_map = decode_fast_fields(&request_bytes);
+    const JAVA_FAST_KEYS: [&str; 14] = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"];
+    let expected_direct_request_map = typed_request_map
+        .iter()
+        .filter(|(key, _)| JAVA_FAST_KEYS.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<HeaderMap>();
+    assert_eq!(direct_request_map, expected_direct_request_map);
+    for inherited in ["lo", "ns", "nsd", "bname", "oway"] {
+        assert!(typed_request_map.contains_key(inherited));
+        assert!(!direct_request_map.contains_key(inherited));
+    }
 
     let typed_request = <SendMessageRequestHeaderV2 as HeaderCodec>::decode_from_map(&typed_request_map).unwrap();
     let legacy_request = <SendMessageRequestHeaderV2 as FromMap>::from(&typed_request_map).unwrap();
@@ -415,9 +557,12 @@ fn typed_maps_preserve_existing_send_fast_codecs() {
         Some("recall-a".into()),
     );
     let typed_response_map = response.to_map().unwrap();
-    let mut response_bytes = BytesMut::new();
-    FastCodesHeader::encode_fast(&mut response, &mut response_bytes);
-    assert_eq!(decode_fast_fields(&response_bytes), typed_response_map);
+    let mut legacy_response_bytes = BytesMut::new();
+    FastCodesHeader::encode_fast(&mut response, &mut legacy_response_bytes);
+    let mut typed_response_bytes = BytesMut::new();
+    CommandCustomHeader::encode_direct_binary(&response, &mut typed_response_bytes).unwrap();
+    assert_eq!(typed_response_bytes, legacy_response_bytes);
+    assert_eq!(decode_fast_fields(&typed_response_bytes), typed_response_map);
 
     let mut fast_response = SendMessageResponseHeader::default();
     FastCodesHeader::decode_fast(&mut fast_response, &typed_response_map);
@@ -446,6 +591,15 @@ fn unsigned_fast_header_fields_enforce_inferred_java_ranges() {
             ..
         })
     ));
+    let mut bytes = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        request.encode_direct_binary(&mut bytes),
+        Err(HeaderCodecError::JavaRange {
+            key: "suspendTimeoutMillis",
+            ..
+        })
+    ));
+    assert_eq!(bytes.as_ref(), b"prefix");
 
     let response = PullMessageResponseHeader {
         suggest_which_broker_id: i64::MAX as u64 + 1,
@@ -459,4 +613,14 @@ fn unsigned_fast_header_fields_enforce_inferred_java_ranges() {
             ..
         })
     ));
+
+    let mut bytes = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        response.encode_direct_binary(&mut bytes),
+        Err(HeaderCodecError::JavaRange {
+            key: "suggestWhichBrokerId",
+            ..
+        })
+    ));
+    assert_eq!(bytes.as_ref(), b"prefix");
 }

--- a/rocketmq-protocol/tests/request_header_java_compatibility.rs
+++ b/rocketmq-protocol/tests/request_header_java_compatibility.rs
@@ -317,6 +317,15 @@ fn rust_production_frames_preserve_the_java_canonical_maps() {
             &expected,
         );
 
+        if fixture["actualPath"] == "fast" && serialize_type == SerializeType::ROCKETMQ {
+            assert_eq!(
+                frame,
+                decode_base64(fixture["frameBase64"].as_str().expect("Java fast frame")),
+                "{} Rust direct frame differs from Java fast encoding",
+                fixture_path.display()
+            );
+        }
+
         let mut input = BytesMut::from(frame.as_slice());
         let decoded = RemotingCommand::decode(&mut input)
             .expect("Rust frame decode")

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_header_value.stderr
@@ -10,6 +10,7 @@ help: the trait `header_codec::private::Sealed` is not implemented for `External
 7 | struct ExternalValue;
   | ^^^^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `header_codec::private::Sealed`:
+            BinarySink<'_>
             CheetahString
             MapSink<'_>
             bool
@@ -17,8 +18,7 @@ help: the trait `header_codec::private::Sealed` is not implemented for `External
             i64
             rocketmq_model::boundary_type::BoundaryType
             std::string::String
-            u32
-            u64
+          and $N others
 note: required by a bound in `HeaderValue`
  --> src/protocol/header_codec/value.rs
   |
@@ -27,11 +27,11 @@ note: required by a bound in `HeaderValue`
   = note: `HeaderValue` is a "sealed trait", because to implement it you also need to implement `rocketmq_protocol::protocol::header_codec::private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
             rocketmq_protocol::protocol::header_codec::MapSink<'_>
+            rocketmq_protocol::protocol::header_codec::BinarySink<'_>
             cheetah_string::CheetahString
             std::string::String
             bool
             i32
             i64
             u32
-            u64
-            rocketmq_model::boundary_type::BoundaryType
+          and $N others

--- a/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_runtime/fail/external_sink.stderr
@@ -10,6 +10,7 @@ help: the trait `header_codec::private::Sealed` is not implemented for `External
 5 | struct ExternalSink;
   | ^^^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `header_codec::private::Sealed`:
+            BinarySink<'_>
             MapSink<'_>
             bool
             i32
@@ -26,11 +27,11 @@ note: required by a bound in `EncodeSink`
   = note: `EncodeSink` is a "sealed trait", because to implement it you also need to implement `rocketmq_protocol::protocol::header_codec::private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
             rocketmq_protocol::protocol::header_codec::MapSink<'_>
+            rocketmq_protocol::protocol::header_codec::BinarySink<'_>
             rocketmq_protocol::__request_header_codec::CheetahString
             std::string::String
             bool
             i32
             i64
             u32
-            u64
-            rocketmq_model::boundary_type::BoundaryType
+          and $N others


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8977

### Brief Description

- Add a sealed, checked `BinarySink` that writes ROCKETMQ extension pairs directly to `BytesMut`, backpatches signed Java value lengths, and reuses allocation-free scalar ASCII writers.
- Generate immutable, fallible direct encoding only for `#[header(fast)]` V3 schemas while keeping map-only schemas unchanged and legacy fast decoding independent from encode capability.
- Preserve the Java fast wire contracts for pull and send headers, including Pull field order and the Send V2 `a` through `n` boundary, without populating production `java_type` attributes.
- Add transactional rollback, capability, field-order, typed-map, legacy-codec, and byte-exact Java golden coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-macros -p rocketmq-protocol -- --check`: passed.
- `cargo test -p rocketmq-macros`: passed, 13 tests.
- `cargo test -p rocketmq-protocol`: passed, including 1,422 library tests, integration tests, UI tests, Java golden tests, and doctests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo doc -p rocketmq-macros -p rocketmq-protocol --no-deps`: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed.
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`: passed.
- `cargo check --locked --offline` for `rocketmq-macros/tests/fixtures/renamed-consumer`: passed.
- `cargo fmt --all -- --check` at the workspace root and in `rocketmq-example/` could not start on Windows because the command line exceeds the OS limit (`os error 206`); the affected-package format check above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct binary encoding for supported request headers, improving encoding efficiency.
  * Added support for appending encoded header data to existing binary buffers.
* **Bug Fixes**
  * Corrected field ordering to match RocketMQ’s Java fast-encoding format.
  * Prevented partial output when encoding encounters invalid or oversized values.
  * Ensured inherited fields are excluded where required for compatible binary output.
* **Tests**
  * Expanded compatibility and validation coverage for binary encoding, legacy codecs, field ordering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->