### PR TITLE
[ISSUE #8980]✨Retire duplicate fast header logic and complete Java goldens

### DIFF
--- a/rocketmq-protocol/benches/request_header_codec.rs
+++ b/rocketmq-protocol/benches/request_header_codec.rs
@@ -41,6 +41,7 @@ use rocketmq_protocol::protocol::header::message_operation_header::send_message_
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::SerializeType;
@@ -270,6 +271,9 @@ fn benchmark_request_headers(criterion: &mut Criterion) {
         match case.header.as_str() {
             "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader" => {
                 register::<PullMessageRequestHeader, _>(criterion, case, &mut allocations, decode_fast)
+            }
+            "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader" => {
+                register::<PullMessageResponseHeader, _>(criterion, case, &mut allocations, decode_fast)
             }
             "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader" => {
                 register::<SendMessageRequestHeader, _>(criterion, case, &mut allocations, decode_fast)

--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -244,6 +244,12 @@ impl<T: serde::de::DeserializeOwned> RemotingDeserializable for T {
     }
 }
 
+/// Legacy handwritten fast-header codec surface.
+///
+/// Production encoding uses
+/// [`command_custom_header::CommandCustomHeader::encode_capability`] and
+/// [`command_custom_header::CommandCustomHeader::encode_direct_binary`].
+#[deprecated(note = "use CommandCustomHeader typed map/direct-binary APIs")]
 pub trait FastCodesHeader {
     fn write_if_not_null(out: &mut BytesMut, key: &str, value: &str) {
         if !value.is_empty() {

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::protocol::command_custom_header::HeaderMap;
+#[allow(
+    deprecated,
+    reason = "imports the legacy trait only to provide its compatibility adapter"
+)]
 use crate::protocol::FastCodesHeader;
 
 #[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
@@ -107,70 +112,17 @@ impl SendMessageResponseHeader {
     pub fn set_recall_handle(&mut self, recall_handle: Option<CheetahString>) {
         self.recall_handle = recall_handle;
     }
-
-    fn write_i64(out: &mut bytes::BytesMut, key: &str, value: i64) {
-        let mut buffer = [0_u8; 20];
-        let mut cursor = buffer.len();
-        let mut number = value.unsigned_abs();
-
-        loop {
-            cursor -= 1;
-            buffer[cursor] = b'0' + (number % 10) as u8;
-            number /= 10;
-            if number == 0 {
-                break;
-            }
-        }
-
-        if value.is_negative() {
-            cursor -= 1;
-            buffer[cursor] = b'-';
-        }
-
-        let value = std::str::from_utf8(&buffer[cursor..]).expect("decimal integer bytes are valid UTF-8");
-        Self::write_if_not_null(out, key, value);
-    }
 }
 
+#[allow(deprecated, reason = "source-compatible adapter for the legacy public trait")]
 impl FastCodesHeader for SendMessageResponseHeader {
     fn encode_fast(&mut self, out: &mut bytes::BytesMut) {
-        Self::write_if_not_null(out, "msgId", self.msg_id.as_str());
-        Self::write_i64(out, "queueId", i64::from(self.queue_id));
-        Self::write_i64(out, "queueOffset", self.queue_offset);
-        if let Some(ref transaction_id) = self.transaction_id {
-            Self::write_if_not_null(out, "transactionId", transaction_id.as_str());
-        }
-        if let Some(ref batch_uniq_id) = self.batch_uniq_id {
-            Self::write_if_not_null(out, "batchUniqId", batch_uniq_id.as_str());
-        }
-        if let Some(ref recall_handle) = self.recall_handle {
-            Self::write_if_not_null(out, "recallHandle", recall_handle.as_str());
-        }
+        let _ = CommandCustomHeader::encode_direct_binary(self, out);
     }
 
-    fn decode_fast(&mut self, fields: &HashMap<CheetahString, CheetahString>) {
-        if let Some(str) = fields.get(&CheetahString::from_slice("msgId")) {
-            self.msg_id = str.clone();
-        }
-
-        if let Some(str) = fields.get(&CheetahString::from_slice("queueId")) {
-            self.queue_id = str.parse::<i32>().unwrap_or_default();
-        }
-
-        if let Some(str) = fields.get(&CheetahString::from_slice("queueOffset")) {
-            self.queue_offset = str.parse::<i64>().unwrap_or_default();
-        }
-
-        if let Some(str) = fields.get(&CheetahString::from_slice("transactionId")) {
-            self.transaction_id = Some(str.clone());
-        }
-
-        if let Some(str) = fields.get(&CheetahString::from_slice("batchUniqId")) {
-            self.batch_uniq_id = Some(str.clone());
-        }
-
-        if let Some(str) = fields.get(&CheetahString::from_slice("recallHandle")) {
-            self.recall_handle = Some(str.clone());
+    fn decode_fast(&mut self, fields: &HeaderMap) {
+        if let Ok(decoded) = <Self as FromMap>::from(fields) {
+            *self = decoded;
         }
     }
 }
@@ -252,6 +204,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated, reason = "verifies the source-compatible legacy adapter delegates to V3")]
     fn send_message_response_header_encode_decode_fast() {
         let mut header = SendMessageResponseHeader::new(
             CheetahString::from("msg123"),
@@ -263,7 +216,7 @@ mod tests {
         );
 
         let mut out = bytes::BytesMut::new();
-        header.encode_fast(&mut out);
+        FastCodesHeader::encode_fast(&mut header, &mut out);
         assert!(!out.is_empty());
 
         let mut fields = std::collections::HashMap::new();
@@ -278,7 +231,7 @@ mod tests {
         );
 
         let mut header = SendMessageResponseHeader::default();
-        header.decode_fast(&fields);
+        FastCodesHeader::decode_fast(&mut header, &fields);
 
         assert_eq!(header.msg_id(), "msg123");
         assert_eq!(header.queue_id(), 1);
@@ -289,11 +242,12 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated, reason = "verifies the source-compatible legacy adapter delegates to V3")]
     fn send_message_response_header_fast_encode_writes_signed_numeric_fields() {
         let mut header = SendMessageResponseHeader::new(CheetahString::from("msg123"), -1, -42, None, None, None);
         let mut out = bytes::BytesMut::new();
 
-        header.encode_fast(&mut out);
+        FastCodesHeader::encode_fast(&mut header, &mut out);
 
         let encoded = String::from_utf8(out.to_vec()).unwrap();
         assert!(encoded.contains("queueId"));

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/golden/index.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/golden/index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
-  "fixtureCount": 22,
+  "fixtureCount": 24,
   "fixtures": [
     {
       "id": "clean-controller-canonical-json",
@@ -114,6 +114,22 @@
       "serializeType": "ROCKETMQ",
       "frameLength": 423,
       "fnv1a64": "8cd6d4885da4e11e"
+    },
+    {
+      "id": "pull-response-fast-json",
+      "file": "pull-response-fast-json.json",
+      "rustTypeId": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "serializeType": "JSON",
+      "frameLength": 279,
+      "fnv1a64": "68d2e82d5aa34e01"
+    },
+    {
+      "id": "pull-response-fast-rocketmq",
+      "file": "pull-response-fast-rocketmq.json",
+      "rustTypeId": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "serializeType": "ROCKETMQ",
+      "frameLength": 190,
+      "fnv1a64": "087ad30b64622877"
     },
     {
       "id": "query-consume-queue-sparse-json",

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/golden/pull-response-fast-json.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/golden/pull-response-fast-json.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "id": "pull-response-fast-json",
+  "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
+  "rustTypeId": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+  "javaClass": "org.apache.rocketmq.remoting.protocol.header.PullMessageResponseHeader",
+  "requestCode": "PULL_MESSAGE",
+  "requestCodeValue": 11,
+  "wireCodeValue": 11,
+  "direction": "response",
+  "serializeType": "JSON",
+  "actualPath": "normal",
+  "inputFields": {
+    "suggestWhichBrokerId": 1,
+    "nextBeginOffset": -2,
+    "minOffset": -3,
+    "maxOffset": 99,
+    "offsetDelta": -5,
+    "topicSysFlag": 6,
+    "groupSysFlag": 7,
+    "forbiddenType": 8
+  },
+  "declaredLogicalFields": {
+    "forbiddenType": "8",
+    "groupSysFlag": "7",
+    "maxOffset": "99",
+    "minOffset": "-3",
+    "nextBeginOffset": "-2",
+    "offsetDelta": "-5",
+    "suggestWhichBrokerId": "1",
+    "topicSysFlag": "6"
+  },
+  "canonicalExtFields": {
+    "forbiddenType": "8",
+    "groupSysFlag": "7",
+    "maxOffset": "99",
+    "minOffset": "-3",
+    "nextBeginOffset": "-2",
+    "offsetDelta": "-5",
+    "suggestWhichBrokerId": "1",
+    "topicSysFlag": "6"
+  },
+  "frameBase64": "AAABEwAAAQ97ImNvZGUiOjExLCJleHRGaWVsZHMiOnsic3VnZ2VzdFdoaWNoQnJva2VySWQiOiIxIiwiZ3JvdXBTeXNGbGFnIjoiNyIsIm5leHRCZWdpbk9mZnNldCI6Ii0yIiwiZm9yYmlkZGVuVHlwZSI6IjgiLCJvZmZzZXREZWx0YSI6Ii01IiwibWF4T2Zmc2V0IjoiOTkiLCJtaW5PZmZzZXQiOiItMyIsInRvcGljU3lzRmxhZyI6IjYifSwiZmxhZyI6MCwibGFuZ3VhZ2UiOiJSVVNUIiwib3BhcXVlIjo3LCJzZXJpYWxpemVUeXBlQ3VycmVudFJQQyI6IkpTT04iLCJ2ZXJzaW9uIjo1MDF9",
+  "frameLength": 279,
+  "fnv1a64": "68d2e82d5aa34e01",
+  "opaque": 7,
+  "version": 501,
+  "language": "RUST"
+}

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/golden/pull-response-fast-rocketmq.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/golden/pull-response-fast-rocketmq.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "id": "pull-response-fast-rocketmq",
+  "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
+  "rustTypeId": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+  "javaClass": "org.apache.rocketmq.remoting.protocol.header.PullMessageResponseHeader",
+  "requestCode": "PULL_MESSAGE",
+  "requestCodeValue": 11,
+  "wireCodeValue": 11,
+  "direction": "response",
+  "serializeType": "ROCKETMQ",
+  "actualPath": "fast",
+  "inputFields": {
+    "suggestWhichBrokerId": 1,
+    "nextBeginOffset": -2,
+    "minOffset": -3,
+    "maxOffset": 99,
+    "offsetDelta": -5,
+    "topicSysFlag": 6,
+    "groupSysFlag": 7,
+    "forbiddenType": 8
+  },
+  "declaredLogicalFields": {
+    "forbiddenType": "8",
+    "groupSysFlag": "7",
+    "maxOffset": "99",
+    "minOffset": "-3",
+    "nextBeginOffset": "-2",
+    "offsetDelta": "-5",
+    "suggestWhichBrokerId": "1",
+    "topicSysFlag": "6"
+  },
+  "canonicalExtFields": {
+    "forbiddenType": "8",
+    "groupSysFlag": "7",
+    "maxOffset": "99",
+    "minOffset": "-3",
+    "nextBeginOffset": "-2",
+    "offsetDelta": "-5",
+    "suggestWhichBrokerId": "1",
+    "topicSysFlag": "6"
+  },
+  "frameBase64": "AAAAugEAALYACwwB9QAAAAcAAAAAAAAAAAAAAKEAFHN1Z2dlc3RXaGljaEJyb2tlcklkAAAAATEAD25leHRCZWdpbk9mZnNldAAAAAItMgAJbWluT2Zmc2V0AAAAAi0zAAltYXhPZmZzZXQAAAACOTkAC29mZnNldERlbHRhAAAAAi01AAx0b3BpY1N5c0ZsYWcAAAABNgAMZ3JvdXBTeXNGbGFnAAAAATcADWZvcmJpZGRlblR5cGUAAAABOA==",
+  "frameLength": 190,
+  "fnv1a64": "087ad30b64622877",
+  "opaque": 7,
+  "version": 501,
+  "language": "RUST"
+}

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/java-schema.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/java-schema.json
@@ -7162,7 +7162,7 @@
           "key": "boundaryType",
           "javaType": "org.apache.rocketmq.common.BoundaryType",
           "presence": "optional",
-          "defaultSemantic": "null",
+          "defaultSemantic": "literal:LOWER",
           "declaredIn": "org.apache.rocketmq.remoting.protocol.header.SearchOffsetRequestHeader",
           "inheritanceDepth": 0
         },

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/manifest.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/manifest.json
@@ -5,13 +5,13 @@
   "rustHistoricalCommit": "0c4722568a74987f7be51df12ec87dbfdc05fbba",
   "schema": {
     "file": "java-schema.json",
-    "sha256": "9f045244eed3ed6096cc87fae61c818cdb797d2a07fdc9fff097c5757b06322b",
+    "sha256": "670154f7418b944bc31ff930866cb810cfa2e8ffcbede8dce7492161e976754c",
     "mappedHeaderCount": 143
   },
   "goldenIndex": {
     "file": "golden/index.json",
-    "sha256": "08fbab786092d227fa6f4b4a6068578ea72416b7c97af2bff20275ea35e529fd",
-    "fixtureCount": 22
+    "sha256": "3d31a495dc9c99de3e5556a9f002d1a9c6a618f1855b2fb0dfd2dc97fc2bc27f",
+    "fixtureCount": 24
   },
   "goldenFiles": [
     {
@@ -111,6 +111,20 @@
       "sha256": "6e889b3506d6add4f55796cd8cd330f14a85a17019e22c567d9e5556a3f44986",
       "frameLength": 423,
       "fnv1a64": "8cd6d4885da4e11e"
+    },
+    {
+      "id": "pull-response-fast-json",
+      "file": "golden/pull-response-fast-json.json",
+      "sha256": "09e67491eec9ed1672a6aa604bede5b505e3809a8c21780fe577458104530c74",
+      "frameLength": 279,
+      "fnv1a64": "68d2e82d5aa34e01"
+    },
+    {
+      "id": "pull-response-fast-rocketmq",
+      "file": "golden/pull-response-fast-rocketmq.json",
+      "sha256": "c7990781ef078d960a79bf2f3881171068bed0def676a2140f821fde029fba4a",
+      "frameLength": 190,
+      "fnv1a64": "087ad30b64622877"
     },
     {
       "id": "query-consume-queue-sparse-json",

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -29,6 +29,7 @@ use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
     HeaderRange, HeaderValueKind,
 };
+#[allow(deprecated, reason = "verifies the source-compatible legacy adapter delegates to V3")]
 use rocketmq_protocol::protocol::FastCodesHeader;
 use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader;
@@ -497,6 +498,7 @@ fn generated_fast_headers_write_canonical_binary_pairs_in_schema_order() {
 }
 
 #[test]
+#[allow(deprecated, reason = "verifies the source-compatible legacy adapter delegates to V3")]
 fn typed_schemas_preserve_java_send_fast_contracts() {
     let rpc = RpcRequestHeader {
         namespace: Some("namespace-a".into()),

--- a/rocketmq-protocol/tests/request_header_java_compatibility.rs
+++ b/rocketmq-protocol/tests/request_header_java_compatibility.rs
@@ -31,6 +31,7 @@ use rocketmq_protocol::protocol::header::message_operation_header::send_message_
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::SerializeType;
@@ -144,6 +145,9 @@ fn encode_registered_header(
         "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader" => {
             encode_rust_header::<PullMessageRequestHeader>(code, serialize_type, expected)
         }
+        "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader" => {
+            encode_rust_header::<PullMessageResponseHeader>(code, serialize_type, expected)
+        }
         "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader" => {
             encode_rust_header::<SendMessageRequestHeader>(code, serialize_type, expected)
         }
@@ -212,6 +216,10 @@ fn pinned_java_frames_decode_and_reencode_to_the_canonical_logical_map() {
                 assert_header_map::<PullMessageRequestHeader>(&command, &expected);
                 assert_fast_header_map::<PullMessageRequestHeader>(&command, &expected);
             }
+            "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader" => {
+                assert_header_map::<PullMessageResponseHeader>(&command, &expected);
+                assert_fast_header_map::<PullMessageResponseHeader>(&command, &expected);
+            }
             "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader" => {
                 assert_header_map::<SendMessageRequestHeader>(&command, &expected);
                 assert_fast_header_map::<SendMessageRequestHeader>(&command, &expected);
@@ -258,7 +266,7 @@ fn fixture_manifest_pins_schema_and_empty_value_policy() {
     .expect("valid fixture manifest JSON");
 
     assert_eq!(manifest["schema"]["mappedHeaderCount"], 143);
-    assert_eq!(manifest["goldenIndex"]["fixtureCount"], 22);
+    assert_eq!(manifest["goldenIndex"]["fixtureCount"], 24);
     assert_eq!(manifest["legacyEmptyHeaders"].as_array().unwrap().len(), 1);
     assert_eq!(manifest["wirePolicies"]["logicalMapEmpty"], "preserve");
     assert_eq!(manifest["wirePolicies"]["jsonEmpty"], "preserve");

--- a/scripts/request-header-codec/generate_perf_corpus.py
+++ b/scripts/request-header-codec/generate_perf_corpus.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 FAST_HEADERS = {
     "pull-fast-inherited",
-    "send-v1-fast",
+    "pull-response-fast",
     "send-v2-fast",
     "send-response-fast",
 }

--- a/scripts/request-header-codec/golden-inputs-v1.json
+++ b/scripts/request-header-codec/golden-inputs-v1.json
@@ -31,6 +31,23 @@
       }
     },
     {
+      "id": "pull-response-fast",
+      "rustTypeId": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "direction": "response",
+      "requestCode": "PULL_MESSAGE",
+      "serializeTypes": ["ROCKETMQ", "JSON"],
+      "fields": {
+        "suggestWhichBrokerId": 1,
+        "nextBeginOffset": -2,
+        "minOffset": -3,
+        "maxOffset": 99,
+        "offsetDelta": -5,
+        "topicSysFlag": 6,
+        "groupSysFlag": 7,
+        "forbiddenType": 8
+      }
+    },
+    {
       "id": "send-v1-fast",
       "rustTypeId": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "direction": "request",

--- a/scripts/request-header-codec/java-harness/src/main/java/org/apache/rocketmq/headercodec/HeaderCodecBenchmark.java
+++ b/scripts/request-header-codec/java-harness/src/main/java/org/apache/rocketmq/headercodec/HeaderCodecBenchmark.java
@@ -59,6 +59,8 @@ public class HeaderCodecBenchmark {
         "notification-defaults-rocketmq",
         "pull-fast-inherited-json",
         "pull-fast-inherited-rocketmq",
+        "pull-response-fast-json",
+        "pull-response-fast-rocketmq",
         "query-consume-queue-sparse-json",
         "query-consume-queue-sparse-rocketmq",
         "send-response-fast-json",

--- a/scripts/request-header-codec/perf-corpus-v1.json
+++ b/scripts/request-header-codec/perf-corpus-v1.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "corpusVersion": "request-header-codec-perf-v1",
   "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
-  "fixtureManifestSha256": "a10703c65c49754e81ee8f0c262a96bc3ed64a4288c03b089081dff0c269f24f",
+  "fixtureManifestSha256": "58c0906471da30880049580162688f3ba963bc99a6377b0b9402668b1b7f4747",
   "weightProfile": {
     "kind": "reviewed-equal-stratified",
     "productionTelemetry": false,
-    "operationCount": 44,
+    "operationCount": 48,
     "weightSum": 1.0,
     "fastSubsetWeightSum": 1.0
   },
@@ -14,7 +14,7 @@
     {
       "id": "clean-controller-canonical-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
@@ -38,7 +38,7 @@
     {
       "id": "clean-controller-canonical-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
@@ -62,7 +62,7 @@
     {
       "id": "clean-controller-canonical-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
@@ -86,7 +86,7 @@
     {
       "id": "clean-controller-canonical-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
@@ -110,7 +110,7 @@
     {
       "id": "consume-direct-collision-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
@@ -141,7 +141,7 @@
     {
       "id": "consume-direct-collision-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
@@ -172,7 +172,7 @@
     {
       "id": "consume-direct-collision-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
@@ -203,7 +203,7 @@
     {
       "id": "consume-direct-collision-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
@@ -234,7 +234,7 @@
     {
       "id": "consumer-status-inherited-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
@@ -261,7 +261,7 @@
     {
       "id": "consumer-status-inherited-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
@@ -288,7 +288,7 @@
     {
       "id": "consumer-status-inherited-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
@@ -315,7 +315,7 @@
     {
       "id": "consumer-status-inherited-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
@@ -342,7 +342,7 @@
     {
       "id": "delete-topic-inherited-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
@@ -368,7 +368,7 @@
     {
       "id": "delete-topic-inherited-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
@@ -394,7 +394,7 @@
     {
       "id": "delete-topic-inherited-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
@@ -420,7 +420,7 @@
     {
       "id": "delete-topic-inherited-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
@@ -446,7 +446,7 @@
     {
       "id": "get-lite-explicit-default-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
@@ -469,7 +469,7 @@
     {
       "id": "get-lite-explicit-default-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
@@ -492,7 +492,7 @@
     {
       "id": "get-lite-explicit-default-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
@@ -515,7 +515,7 @@
     {
       "id": "get-lite-explicit-default-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
@@ -538,7 +538,7 @@
     {
       "id": "notification-defaults-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
@@ -573,7 +573,7 @@
     {
       "id": "notification-defaults-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
@@ -608,7 +608,7 @@
     {
       "id": "notification-defaults-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
@@ -643,7 +643,7 @@
     {
       "id": "notification-defaults-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
@@ -678,7 +678,7 @@
     {
       "id": "pull-fast-inherited-rocketmq-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
@@ -716,7 +716,7 @@
     {
       "id": "pull-fast-inherited-rocketmq-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
@@ -754,7 +754,7 @@
     {
       "id": "pull-fast-inherited-json-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
@@ -792,7 +792,7 @@
     {
       "id": "pull-fast-inherited-json-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
@@ -828,9 +828,117 @@
       "weightSource": "reviewed-equal-stratified-no-production-telemetry"
     },
     {
+      "id": "pull-response-fast-rocketmq-encode",
+      "tier": 1,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.08333333333333333,
+      "operation": "encode",
+      "header": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "fixtureId": "pull-response-fast-rocketmq",
+      "requestCode": 11,
+      "fields": {
+        "forbiddenType": "8",
+        "groupSysFlag": "7",
+        "maxOffset": "99",
+        "minOffset": "-3",
+        "nextBeginOffset": "-2",
+        "offsetDelta": "-5",
+        "suggestWhichBrokerId": "1",
+        "topicSysFlag": "6"
+      },
+      "unknownCount": 0,
+      "flattenDepth": 0,
+      "optionDensity": 0.0,
+      "serializeType": "ROCKETMQ",
+      "expectedSemanticSha256": "75ad15d11ce36c9db13aafee40a279eba8ea60c10170d2ed91cdcfb18047a00a",
+      "expectedFrameFnv1a64": "087ad30b64622877",
+      "weightSource": "reviewed-equal-stratified-no-production-telemetry"
+    },
+    {
+      "id": "pull-response-fast-rocketmq-decode",
+      "tier": 1,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.08333333333333333,
+      "operation": "decode",
+      "header": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "fixtureId": "pull-response-fast-rocketmq",
+      "requestCode": 11,
+      "fields": {
+        "forbiddenType": "8",
+        "groupSysFlag": "7",
+        "maxOffset": "99",
+        "minOffset": "-3",
+        "nextBeginOffset": "-2",
+        "offsetDelta": "-5",
+        "suggestWhichBrokerId": "1",
+        "topicSysFlag": "6"
+      },
+      "unknownCount": 0,
+      "flattenDepth": 0,
+      "optionDensity": 0.0,
+      "serializeType": "ROCKETMQ",
+      "expectedSemanticSha256": "75ad15d11ce36c9db13aafee40a279eba8ea60c10170d2ed91cdcfb18047a00a",
+      "expectedFrameFnv1a64": "087ad30b64622877",
+      "weightSource": "reviewed-equal-stratified-no-production-telemetry"
+    },
+    {
+      "id": "pull-response-fast-json-encode",
+      "tier": 1,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.0,
+      "operation": "encode",
+      "header": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "fixtureId": "pull-response-fast-json",
+      "requestCode": 11,
+      "fields": {
+        "forbiddenType": "8",
+        "groupSysFlag": "7",
+        "maxOffset": "99",
+        "minOffset": "-3",
+        "nextBeginOffset": "-2",
+        "offsetDelta": "-5",
+        "suggestWhichBrokerId": "1",
+        "topicSysFlag": "6"
+      },
+      "unknownCount": 0,
+      "flattenDepth": 0,
+      "optionDensity": 0.0,
+      "serializeType": "JSON",
+      "expectedSemanticSha256": "75ad15d11ce36c9db13aafee40a279eba8ea60c10170d2ed91cdcfb18047a00a",
+      "expectedFrameFnv1a64": "68d2e82d5aa34e01",
+      "weightSource": "reviewed-equal-stratified-no-production-telemetry"
+    },
+    {
+      "id": "pull-response-fast-json-decode",
+      "tier": 1,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.08333333333333333,
+      "operation": "decode",
+      "header": "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
+      "fixtureId": "pull-response-fast-json",
+      "requestCode": 11,
+      "fields": {
+        "forbiddenType": "8",
+        "groupSysFlag": "7",
+        "maxOffset": "99",
+        "minOffset": "-3",
+        "nextBeginOffset": "-2",
+        "offsetDelta": "-5",
+        "suggestWhichBrokerId": "1",
+        "topicSysFlag": "6"
+      },
+      "unknownCount": 0,
+      "flattenDepth": 0,
+      "optionDensity": 0.0,
+      "serializeType": "JSON",
+      "expectedSemanticSha256": "75ad15d11ce36c9db13aafee40a279eba8ea60c10170d2ed91cdcfb18047a00a",
+      "expectedFrameFnv1a64": "68d2e82d5aa34e01",
+      "weightSource": "reviewed-equal-stratified-no-production-telemetry"
+    },
+    {
       "id": "query-consume-queue-sparse-rocketmq-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -859,7 +967,7 @@
     {
       "id": "query-consume-queue-sparse-rocketmq-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -888,7 +996,7 @@
     {
       "id": "query-consume-queue-sparse-json-encode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -917,7 +1025,7 @@
     {
       "id": "query-consume-queue-sparse-json-decode",
       "tier": 2,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -946,7 +1054,7 @@
     {
       "id": "send-response-fast-rocketmq-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
@@ -971,7 +1079,7 @@
     {
       "id": "send-response-fast-rocketmq-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
@@ -996,7 +1104,7 @@
     {
       "id": "send-response-fast-json-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
@@ -1021,7 +1129,7 @@
     {
       "id": "send-response-fast-json-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
@@ -1045,9 +1153,9 @@
     },
     {
       "id": "send-v1-fast-rocketmq-encode",
-      "tier": 1,
-      "gateWeight": 0.022727272727272728,
-      "fastGateWeight": 0.08333333333333333,
+      "tier": 2,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "fixtureId": "send-v1-fast-rocketmq",
@@ -1082,9 +1190,9 @@
     },
     {
       "id": "send-v1-fast-rocketmq-decode",
-      "tier": 1,
-      "gateWeight": 0.022727272727272728,
-      "fastGateWeight": 0.08333333333333333,
+      "tier": 2,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "fixtureId": "send-v1-fast-rocketmq",
@@ -1119,8 +1227,8 @@
     },
     {
       "id": "send-v1-fast-json-encode",
-      "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "tier": 2,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
@@ -1156,9 +1264,9 @@
     },
     {
       "id": "send-v1-fast-json-decode",
-      "tier": 1,
-      "gateWeight": 0.022727272727272728,
-      "fastGateWeight": 0.08333333333333333,
+      "tier": 2,
+      "gateWeight": 0.020833333333333332,
+      "fastGateWeight": 0.0,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "fixtureId": "send-v1-fast-json",
@@ -1194,7 +1302,7 @@
     {
       "id": "send-v2-fast-rocketmq-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
@@ -1227,7 +1335,7 @@
     {
       "id": "send-v2-fast-rocketmq-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
@@ -1260,7 +1368,7 @@
     {
       "id": "send-v2-fast-json-encode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.0,
       "operation": "encode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
@@ -1298,7 +1406,7 @@
     {
       "id": "send-v2-fast-json-decode",
       "tier": 1,
-      "gateWeight": 0.022727272727272728,
+      "gateWeight": 0.020833333333333332,
       "fastGateWeight": 0.08333333333333333,
       "operation": "decode",
       "header": "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8980

### Brief Description

- Deprecates the duplicate public `FastCodesHeader` surface while keeping it source-compatible, and replaces the only production implementation's handwritten field list with adapters over generated `CommandCustomHeader` direct encoding and typed `FromMap` decoding.
- Adds pinned Java JSON and ROCKETMQ fixtures for `PullMessageResponseHeader`, then verifies Rust direct encoding is byte-for-byte identical to the Java fast frame and that Java decodes all 24 Rust production frames.
- Adds the pull response to both benchmark harnesses and fixes the fast-subset weighting to include the four actual Java `FastCodesHeader` implementations instead of the normal-path Send V1 header.
- Keeps production header fields free of handwritten `java_type` metadata and preserves the existing module layout without adding `mod.rs`.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check`: passed.
- `cargo test -p rocketmq-protocol`: passed, including 1,422 library tests, integration/UI tests, cross-language fixtures, and doctests.
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo doc -p rocketmq-protocol --no-deps`: passed.
- `scripts/request-header-codec/extract-java-contract.ps1` against the clean pinned Java commit: passed and generated 24 fixtures.
- `scripts/request-header-codec/verify-cross-language.ps1`: passed; Java verified all 24 Rust frames.
- `python scripts/request-header-codec/update_contract_fixtures.py --input <extractor-output> --check`: passed.
- `python scripts/request-header-codec/generate_perf_corpus.py --check`: passed with 48 production operations and a normalized fast-subset weight of 1.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz/`: passed with one Windows linker stdout warning.
- `cargo clippy --all-targets -- -D warnings` in `rocketmq-example/`: passed; its generated lockfile changes were removed.
- `cargo check --locked --offline` in the renamed-consumer fixture: passed.
- `cargo fmt --all -- --check` at the workspace root and in `rocketmq-example/` could not start on Windows because the generated rustfmt command line exceeds OS error 206; the affected package format check above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pull-message response headers across RocketMQ and JSON encoding and decoding.
  * Expanded Java/Rust compatibility coverage for pull-message responses.

* **Bug Fixes**
  * Corrected the default semantic value for search offset boundary types.

* **Deprecations**
  * Marked the legacy fast-header codec as deprecated and directed users toward newer codec APIs.

* **Performance**
  * Added pull-message response scenarios to benchmark and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->