### PR TITLE
[ISSUE #8983]✨Unify request header collision, empty value, and length handling

### DIFF
--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -39,6 +39,7 @@ pub mod forbidden_type;
 pub mod header;
 pub mod header_codec;
 pub mod header_facade;
+pub(crate) mod header_field_merge;
 pub mod headers;
 pub mod heartbeat;
 pub mod heartbeat_facade;

--- a/rocketmq-protocol/src/protocol/command_custom_header.rs
+++ b/rocketmq-protocol/src/protocol/command_custom_header.rs
@@ -55,8 +55,9 @@ pub trait CommandCustomHeader: AsAny {
     ///  
     /// Returns an `Option` that contains a `HashMap` of string keys and string values,  
     /// representing the implementing type's fields.  
-    /// If the conversion is successful, a non-empty map is returned.  
-    /// If the conversion fails, `None` is returned.  
+    /// If the conversion is successful, a map is returned; explicitly audited
+    /// fieldless headers return an empty map. If conversion fails, `None` is
+    /// returned.
     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>>;
 
     /// Appends this header's extension fields to an existing map.

--- a/rocketmq-protocol/src/protocol/header/empty_header.rs
+++ b/rocketmq-protocol/src/protocol/header/empty_header.rs
@@ -10,7 +10,7 @@ pub struct EmptyHeader {}
 
 impl CommandCustomHeader for EmptyHeader {
     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        None
+        Some(HashMap::new())
     }
 }
 
@@ -30,7 +30,7 @@ mod tests {
         assert_eq!(json, "{}");
         let de: EmptyHeader = serde_json::from_str(&json).unwrap();
         assert_eq!(header, de);
-        assert!(header.to_map().is_none());
+        assert_eq!(header.to_map(), Some(HashMap::new()));
 
         assert!(format!("{:?}", header).contains("EmptyHeader"));
     }

--- a/rocketmq-protocol/src/protocol/header_codec/error.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/error.rs
@@ -109,6 +109,18 @@ pub enum HeaderCodecError {
         key: &'static str,
     },
 
+    /// The complete extension-field payload exceeded its signed length field.
+    #[error("ROCKETMQ extension-field payload exceeds the signed 32-bit wire limit")]
+    ExtensionFieldsLengthOverflow,
+
+    /// A dynamic extension-field key exceeded its unsigned 16-bit length.
+    #[error("dynamic header key length exceeds the ROCKETMQ wire limit")]
+    DynamicKeyLengthOverflow,
+
+    /// A dynamic extension-field value exceeded its signed 32-bit length.
+    #[error("dynamic header value length exceeds the ROCKETMQ wire limit")]
+    DynamicValueLengthOverflow,
+
     /// Direct binary encoding was requested for a header without that capability.
     #[error("direct binary codec is unavailable for {header}")]
     FastCodecUnavailable {

--- a/rocketmq-protocol/src/protocol/header_field_merge.rs
+++ b/rocketmq-protocol/src/protocol/header_field_merge.rs
@@ -1,0 +1,211 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::HeaderMap;
+use crate::protocol::header_codec::AliasConflictPolicy;
+use crate::protocol::header_codec::DynamicCollisionPolicy;
+use crate::protocol::header_codec::HeaderCodecError;
+
+type FieldIdentity = (&'static str, &'static str);
+
+/// Returns whether a dynamic field names a canonical typed key or decode alias.
+#[inline]
+pub(crate) fn has_custom_ext_collision(header: &dyn CommandCustomHeader, dynamic: Option<&HeaderMap>) -> bool {
+    dynamic.is_some_and(|fields| fields.keys().any(|key| header.contains_wire_key(key.as_str())))
+}
+
+/// Merges typed and dynamic extension fields under the authoritative V3 policy.
+///
+/// The typed map is also the result map. Temporary selection metadata is only
+/// allocated after a typed/dynamic semantic overlap is found.
+pub(crate) fn merge_header_and_dynamic(
+    header: &dyn CommandCustomHeader,
+    dynamic: Option<&HeaderMap>,
+) -> Result<HeaderMap, HeaderCodecError> {
+    let mut merged = HeaderMap::with_capacity(dynamic.map_or(0, HeaderMap::len));
+    header.try_encode_into_map(&mut merged)?;
+
+    let Some(dynamic) = dynamic else {
+        return Ok(merged);
+    };
+
+    let mut selected_dynamic: Option<HashMap<FieldIdentity, u16>> = None;
+    for (raw_key, value) in dynamic {
+        let Some(resolved) = header.resolve_wire_key(raw_key.as_str()) else {
+            // Legacy codecs without a resolver retain their historical exact-key
+            // typed-wins behavior. Unknown dynamic fields remain untouched.
+            if !merged.contains_key(raw_key) {
+                merged.insert(raw_key.clone(), value.clone());
+            }
+            continue;
+        };
+
+        let identity = (resolved.owner_type_id, resolved.canonical);
+        if let Some(selected_precedence) = selected_dynamic
+            .as_mut()
+            .and_then(|selected| selected.get_mut(&identity))
+        {
+            let Some(selected_value) = merged.get(resolved.canonical) else {
+                merged.insert(resolved.canonical.into(), value.clone());
+                *selected_precedence = resolved.precedence;
+                continue;
+            };
+            if selected_value == value {
+                *selected_precedence = (*selected_precedence).min(resolved.precedence);
+                continue;
+            }
+
+            match resolved.alias_conflict {
+                AliasConflictPolicy::Error => {
+                    return Err(HeaderCodecError::Conflict {
+                        header: resolved.header,
+                        key: resolved.canonical,
+                    });
+                }
+                AliasConflictPolicy::PreferCanonical if resolved.precedence < *selected_precedence => {
+                    merged.insert(resolved.canonical.into(), value.clone());
+                    *selected_precedence = resolved.precedence;
+                }
+                AliasConflictPolicy::PreferCanonical => {}
+            }
+            continue;
+        }
+
+        if let Some(typed_value) = merged.get(resolved.canonical) {
+            if typed_value != value {
+                match resolved.dynamic_collision {
+                    DynamicCollisionPolicy::ErrorOnDifferentValue => {
+                        return Err(HeaderCodecError::DynamicFieldConflict {
+                            header: resolved.header,
+                            key: resolved.canonical,
+                        });
+                    }
+                }
+            }
+            continue;
+        }
+
+        merged.insert(resolved.canonical.into(), value.clone());
+        selected_dynamic
+            .get_or_insert_with(HashMap::new)
+            .insert(identity, resolved.precedence);
+    }
+
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use rocketmq_macros::RequestHeaderCodecV3;
+
+    use super::*;
+    use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+    #[derive(RequestHeaderCodecV3)]
+    #[header(type_id = "rocketmq_protocol::tests::StrictAliasHeader")]
+    struct StrictAliasHeader {
+        #[header(key = "canonical", alias = "legacy")]
+        value: Option<CheetahString>,
+    }
+
+    #[test]
+    fn identical_typed_alias_is_deduplicated_to_the_canonical_key() {
+        let header = RpcRequestHeader::new(Some("tenant".into()), None, None, None);
+        let dynamic = HeaderMap::from([("namespace".into(), "tenant".into()), ("trace".into(), "x".into())]);
+
+        let merged = merge_header_and_dynamic(&header, Some(&dynamic)).unwrap();
+
+        assert_eq!(merged.get("ns").map(CheetahString::as_str), Some("tenant"));
+        assert!(!merged.contains_key("namespace"));
+        assert_eq!(merged.get("trace").map(CheetahString::as_str), Some("x"));
+    }
+
+    #[test]
+    fn different_typed_alias_is_rejected_without_exposing_values() {
+        let header = RpcRequestHeader::new(Some("secret-alpha".into()), None, None, None);
+        let dynamic = HeaderMap::from([("namespace".into(), "secret-beta".into())]);
+
+        let error = merge_header_and_dynamic(&header, Some(&dynamic)).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HeaderCodecError::DynamicFieldConflict {
+                header: "RpcRequestHeader",
+                key: "ns"
+            }
+        ));
+        assert!(!error.to_string().contains("secret-alpha"));
+        assert!(!error.to_string().contains("secret-beta"));
+    }
+
+    #[test]
+    fn absent_typed_aliases_use_frozen_precedence_in_any_insertion_order() {
+        let header = RpcRequestHeader::default();
+        for entries in [
+            [("namespace", "legacy"), ("ns", "canonical")],
+            [("ns", "canonical"), ("namespace", "legacy")],
+        ] {
+            let dynamic = entries
+                .into_iter()
+                .map(|(key, value)| (key.into(), value.into()))
+                .collect();
+
+            let merged = merge_header_and_dynamic(&header, Some(&dynamic)).unwrap();
+
+            assert_eq!(merged.get("ns").map(CheetahString::as_str), Some("canonical"));
+            assert!(!merged.contains_key("namespace"));
+        }
+    }
+
+    #[test]
+    fn strict_absent_alias_conflict_is_rejected_in_any_insertion_order() {
+        let header = StrictAliasHeader { value: None };
+        for entries in [
+            [("legacy", "old"), ("canonical", "new")],
+            [("canonical", "new"), ("legacy", "old")],
+        ] {
+            let dynamic = entries
+                .into_iter()
+                .map(|(key, value)| (key.into(), value.into()))
+                .collect();
+
+            let error = merge_header_and_dynamic(&header, Some(&dynamic)).unwrap_err();
+
+            assert!(matches!(
+                error,
+                HeaderCodecError::Conflict {
+                    header: "StrictAliasHeader",
+                    key: "canonical"
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn collision_probe_uses_canonical_keys_and_aliases_only() {
+        let header = RpcRequestHeader::default();
+        assert!(has_custom_ext_collision(
+            &header,
+            Some(&HeaderMap::from([("namespace".into(), "tenant".into())]))
+        ));
+        assert!(!has_custom_ext_collision(
+            &header,
+            Some(&HeaderMap::from([("trace".into(), "value".into())]))
+        ));
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -36,6 +36,8 @@ use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_field_merge::merge_header_and_dynamic;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
@@ -96,15 +98,6 @@ pub struct RemotingCommand {
 
 impl Clone for RemotingCommand {
     fn clone(&self) -> Self {
-        let mut ext_fields = self.ext_fields.clone().unwrap_or_default();
-        if let Some(header) = self.command_custom_header.as_ref() {
-            if header.encode_capability() == HeaderEncodeCapability::MapOnly {
-                if let Some(header_fields) = header.to_map() {
-                    ext_fields.extend(header_fields);
-                }
-            }
-        }
-        let ext_fields = (!ext_fields.is_empty()).then_some(ext_fields);
         Self {
             code: self.code,
             language: self.language,
@@ -112,7 +105,7 @@ impl Clone for RemotingCommand {
             opaque: self.opaque,
             flag: self.flag,
             remark: self.remark.clone(),
-            ext_fields,
+            ext_fields: self.ext_fields.clone(),
             body: self.body.clone(),
             suspended: self.suspended,
             command_custom_header: self.command_custom_header.clone(),
@@ -244,6 +237,7 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
+        self.invalidate_materialized_custom_header();
         self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
         self.custom_header_to_net = false;
         self
@@ -253,6 +247,7 @@ impl RemotingCommand {
         mut self,
         command_custom_header: Box<dyn CommandCustomHeader + Send + Sync + 'static>,
     ) -> Self {
+        self.invalidate_materialized_custom_header();
         self.command_custom_header = Some(Arc::new(command_custom_header));
         self.custom_header_to_net = false;
         self
@@ -262,6 +257,7 @@ impl RemotingCommand {
     where
         T: std::ops::Deref<Target = Box<dyn CommandCustomHeader + Send + Sync + 'static>>,
     {
+        self.invalidate_materialized_custom_header();
         if let Some(header_fields) = command_custom_header.as_ref().and_then(|header| header.to_map()) {
             self.ext_fields.get_or_insert_with(HashMap::new).extend(header_fields);
         }
@@ -274,6 +270,7 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
+        self.invalidate_materialized_custom_header();
         self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
         self.custom_header_to_net = false;
     }
@@ -414,16 +411,14 @@ impl RemotingCommand {
     /// Encode header with optimized path selection
     #[inline]
     pub fn header_encode(&mut self) -> Option<Bytes> {
-        if self
-            .command_custom_header_ref()
-            .is_some_and(|header| header.check_fields().is_err())
-        {
-            return None;
-        }
-        self.make_custom_header_to_net();
         match self.serialize_type {
-            SerializeType::ROCKETMQ => Some(RocketMQSerializable::rocket_mq_protocol_encode_bytes(self)),
+            SerializeType::ROCKETMQ => {
+                let mut encoded = BytesMut::new();
+                RocketMQSerializable::try_rocketmq_protocol_encode(self, &mut encoded).ok()?;
+                Some(encoded.freeze())
+            }
             SerializeType::JSON => {
+                self.try_make_custom_header_to_net().ok()?;
                 #[cfg(feature = "simd")]
                 {
                     match simd_json::to_vec(self) {
@@ -455,19 +450,17 @@ impl RemotingCommand {
         // Encode header data
         let header_data = self.header_encode()?;
         let header_len = header_data.len();
-
-        // Calculate frame size: 4 (total_length) + 4 (serialize_type) + header_len
-        let frame_header_size = 8;
-        let total_length = 4 + header_len + body_length; // 4 is for serialize_type field
+        let (total_length, marked_header_length) =
+            Self::checked_frame_lengths(header_len, body_length, self.serialize_type).ok()?;
 
         // Allocate exact capacity
-        let mut result = BytesMut::with_capacity(frame_header_size + header_len);
+        let mut result = BytesMut::with_capacity(8 + header_len);
 
         // Write total length
-        result.put_i32(total_length as i32);
+        result.put_i32(total_length);
 
         // Write serialize type with embedded header length
-        result.put_i32(mark_protocol_type(header_len as i32, self.serialize_type));
+        result.put_i32(marked_header_length);
 
         // Write header data
         result.put(header_data);
@@ -478,31 +471,58 @@ impl RemotingCommand {
     /// Convert custom header to network format (merge into ext_fields)
     #[inline]
     pub fn make_custom_header_to_net(&mut self) {
+        let _ = self.try_make_custom_header_to_net();
+    }
+
+    /// Fallibly merges the custom header into dynamic extension fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation, conversion, alias, or dynamic-field
+    /// collision error without mutating this command.
+    pub fn try_make_custom_header_to_net(&mut self) -> Result<(), HeaderCodecError> {
         if self.custom_header_to_net {
-            return;
+            return Ok(());
         }
 
-        if let Some(header) = &self.command_custom_header {
-            if let Some(header_map) = header.to_map() {
-                match &mut self.ext_fields {
-                    None => {
-                        self.ext_fields = Some(header_map);
-                    }
-                    Some(ext) => {
-                        // Merge header map into existing ext_fields
-                        for (key, value) in header_map {
-                            ext.insert(key, value);
-                        }
-                    }
-                }
-            }
+        if let Some(header) = self.command_custom_header_ref() {
+            let merged = merge_header_and_dynamic(header, self.ext_fields.as_ref())?;
+            self.ext_fields = Some(merged);
         }
         self.custom_header_to_net = true;
+        Ok(())
     }
 
     #[inline]
     pub fn materialize_custom_header_to_ext_fields(&mut self) {
         self.make_custom_header_to_net();
+    }
+
+    fn invalidate_materialized_custom_header(&mut self) {
+        if !self.custom_header_to_net {
+            return;
+        }
+
+        let owned_keys = match (self.command_custom_header_ref(), self.ext_fields.as_ref()) {
+            (Some(header), Some(fields)) => {
+                let mut keys = fields
+                    .keys()
+                    .filter(|key| header.contains_wire_key(key.as_str()))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if let Some(legacy_fields) = header.to_map() {
+                    keys.extend(legacy_fields.into_keys());
+                }
+                keys
+            }
+            _ => Vec::new(),
+        };
+        if let Some(fields) = self.ext_fields.as_mut() {
+            for key in owned_keys {
+                fields.remove(&key);
+            }
+        }
+        self.custom_header_to_net = false;
     }
 
     #[inline]
@@ -531,18 +551,16 @@ impl RemotingCommand {
             header.check_fields()?;
         }
         match self.serialize_type {
-            SerializeType::JSON => {
-                self.fast_encode_json(dst);
-                Ok(())
-            }
+            SerializeType::JSON => self.fast_encode_json(dst),
             SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst),
         }
     }
 
     /// Optimized JSON encoding with pre-calculated capacity and zero-copy optimizations
     #[inline]
-    fn fast_encode_json(&mut self, dst: &mut BytesMut) {
-        self.make_custom_header_to_net();
+    fn fast_encode_json(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+        self.try_make_custom_header_to_net()
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
 
         // Pre-calculate approximate header size to reduce reallocations
         let estimated_header_size = self.estimate_json_header_size();
@@ -559,25 +577,16 @@ impl RemotingCommand {
         #[cfg(not(feature = "simd"))]
         let encode_result = serde_json::to_vec(self);
 
-        match encode_result {
-            Ok(header_bytes) => {
-                let header_length = header_bytes.len() as i32;
-                let body_length = body_length as i32;
-                let total_length = 4 + header_length + body_length;
+        let header_bytes = encode_result.map_err(|error| {
+            rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string())
+        })?;
+        let (total_length, marked_header_length) =
+            Self::checked_frame_lengths(header_bytes.len(), body_length, SerializeType::JSON)?;
 
-                // Write frame header
-                dst.put_i32(total_length);
-                dst.put_i32(RemotingCommand::mark_serialize_type(header_length, SerializeType::JSON));
-
-                // Write header bytes (zero-copy from Vec)
-                dst.put_slice(&header_bytes);
-            }
-            Err(_) => {
-                // Write minimal error frame
-                dst.put_i32(4); // total_length: just the serialize_type field
-                dst.put_i32(RemotingCommand::mark_serialize_type(0, SerializeType::JSON));
-            }
-        }
+        dst.put_i32(total_length);
+        dst.put_i32(marked_header_length);
+        dst.put_slice(&header_bytes);
+        Ok(())
     }
 
     /// Optimized ROCKETMQ binary encoding with minimal allocations
@@ -590,25 +599,55 @@ impl RemotingCommand {
         dst.put_i64(0); // Placeholder for total_length + serialize_type
 
         let capability = self.custom_header_encode_capability();
-        if capability == HeaderEncodeCapability::MapOnly {
-            self.make_custom_header_to_net();
-        }
 
         // Encode header directly to buffer
         let header_size = RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability)
             .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
-        let body_length = self.body.as_ref().map_or(0, |b| b.len()) as i32;
-
-        // Calculate serialize type with header length embedded
-        let serialize_type = RemotingCommand::mark_serialize_type(header_size as i32, SerializeType::ROCKETMQ);
+        let body_length = self.body.as_ref().map_or(0, |b| b.len());
+        let (total_length, serialize_type) =
+            Self::checked_frame_lengths(header_size, body_length, SerializeType::ROCKETMQ)?;
 
         // Write total_length and serialize_type at the beginning (in-place update)
-        let total_length = (4 + header_size as i32 + body_length).to_be_bytes();
+        let total_length = total_length.to_be_bytes();
         let serialize_type_bytes = serialize_type.to_be_bytes();
 
         dst[begin_index..begin_index + 4].copy_from_slice(&total_length);
         dst[begin_index + 4..begin_index + 8].copy_from_slice(&serialize_type_bytes);
         Ok(())
+    }
+
+    fn checked_frame_lengths(
+        header_length: usize,
+        body_length: usize,
+        serialize_type: SerializeType,
+    ) -> rocketmq_error::RocketMQResult<(i32, i32)> {
+        const MAX_HEADER_LENGTH: usize = 0x00ff_ffff;
+        if header_length > MAX_HEADER_LENGTH {
+            return Err(rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                format!("encoded header is {header_length} bytes, exceeding the 24-bit wire limit"),
+            )
+            .into());
+        }
+        let payload_length = 4usize
+            .checked_add(header_length)
+            .and_then(|length| length.checked_add(body_length))
+            .ok_or_else(|| {
+                rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded frame length overflow")
+            })?;
+        let total_length = i32::try_from(payload_length).map_err(|_| {
+            rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                format!("encoded payload is {payload_length} bytes, exceeding the signed 32-bit wire limit"),
+            )
+        })?;
+        let header_length = i32::try_from(header_length).map_err(|_| {
+            rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded header length overflow")
+        })?;
+        Ok((
+            total_length,
+            RemotingCommand::mark_serialize_type(header_length, serialize_type),
+        ))
     }
 
     /// Estimate JSON header size to reduce buffer reallocations
@@ -1017,11 +1056,15 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        self.custom_header_to_net = false;
-        match self.command_custom_header.as_mut() {
-            None => None,
-            Some(value) => Arc::get_mut(value)?.as_mut().as_any_mut().downcast_mut::<T>(),
+        let header = self.command_custom_header.as_ref()?;
+        if Arc::strong_count(header) != 1 || !header.as_ref().as_any().is::<T>() {
+            return None;
         }
+        self.invalidate_materialized_custom_header();
+        Arc::get_mut(self.command_custom_header.as_mut()?)?
+            .as_mut()
+            .as_any_mut()
+            .downcast_mut::<T>()
     }
 
     /// Compatibility name for the former shared-reference mutation escape.
@@ -1040,16 +1083,25 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        self.custom_header_to_net = false;
-        match self.command_custom_header.as_mut() {
-            None => Err(Self::custom_header_missing_error::<T>()),
-            Some(value) => Arc::get_mut(value)
-                .ok_or_else(Self::custom_header_shared_error)?
-                .as_mut()
-                .as_any_mut()
-                .downcast_mut::<T>()
-                .ok_or_else(Self::custom_header_type_mismatch_error::<T>),
+        match self.command_custom_header.as_ref() {
+            None => return Err(Self::custom_header_missing_error::<T>()),
+            Some(value) if Arc::strong_count(value) != 1 => return Err(Self::custom_header_shared_error()),
+            Some(value) if !value.as_ref().as_any().is::<T>() => {
+                return Err(Self::custom_header_type_mismatch_error::<T>());
+            }
+            Some(_) => {}
         }
+        self.invalidate_materialized_custom_header();
+        Arc::get_mut(
+            self.command_custom_header
+                .as_mut()
+                .ok_or_else(Self::custom_header_missing_error::<T>)?,
+        )
+        .ok_or_else(Self::custom_header_shared_error)?
+        .as_mut()
+        .as_any_mut()
+        .downcast_mut::<T>()
+        .ok_or_else(Self::custom_header_type_mismatch_error::<T>)
     }
 
     pub fn read_custom_header_mut_unchecked<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
@@ -1076,7 +1128,14 @@ impl RemotingCommand {
     }
 
     pub fn command_custom_header_mut(&mut self) -> Option<&mut dyn CommandCustomHeader> {
-        self.custom_header_to_net = false;
+        if self
+            .command_custom_header
+            .as_ref()
+            .is_none_or(|header| Arc::strong_count(header) != 1)
+        {
+            return None;
+        }
+        self.invalidate_materialized_custom_header();
         match self.command_custom_header.as_mut() {
             None => None,
             Some(value) => Arc::get_mut(value).map(|header| header.as_mut() as &mut dyn CommandCustomHeader),
@@ -1263,6 +1322,21 @@ mod tests {
     }
 
     #[test]
+    fn frame_length_checks_each_wire_boundary_and_limit_plus_one() {
+        const MAX_HEADER_LENGTH: usize = 0x00ff_ffff;
+        let (total, marked) =
+            RemotingCommand::checked_frame_lengths(MAX_HEADER_LENGTH, 0, SerializeType::ROCKETMQ).unwrap();
+        assert_eq!(total, 4 + MAX_HEADER_LENGTH as i32);
+        assert_eq!(parse_header_length(marked), MAX_HEADER_LENGTH);
+        assert!(RemotingCommand::checked_frame_lengths(MAX_HEADER_LENGTH + 1, 0, SerializeType::ROCKETMQ).is_err());
+
+        let max_body = i32::MAX as usize - 4;
+        let (total, _) = RemotingCommand::checked_frame_lengths(0, max_body, SerializeType::JSON).unwrap();
+        assert_eq!(total, i32::MAX);
+        assert!(RemotingCommand::checked_frame_lengths(0, max_body + 1, SerializeType::JSON).is_err());
+    }
+
+    #[test]
     fn try_read_custom_header_ref_reports_missing_header() {
         let command = RemotingCommand::create_remoting_command(1);
 
@@ -1294,12 +1368,12 @@ mod tests {
     }
 
     #[test]
-    fn clone_preserves_concrete_header_and_merges_all_extension_fields() {
+    fn clone_preserves_concrete_header_without_eagerly_hiding_dynamic_collisions() {
         let original =
             RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 }).set_ext_fields(HashMap::from([
                 (CheetahString::from("hook-field"), CheetahString::from("preserved")),
             ]));
-        let cloned = original.clone();
+        let mut cloned = original.clone();
 
         assert_eq!(
             cloned.try_read_custom_header_ref::<TestCustomHeader>().unwrap().value,
@@ -1312,6 +1386,8 @@ mod tests {
                 .map(CheetahString::as_str),
             Some("preserved")
         );
+        assert!(cloned.ext_fields().is_none_or(|fields| !fields.contains_key("value")));
+        cloned.try_make_custom_header_to_net().unwrap();
         assert_eq!(
             cloned
                 .ext_fields()
@@ -1319,6 +1395,58 @@ mod tests {
                 .map(CheetahString::as_str),
             Some("7")
         );
+    }
+
+    #[test]
+    fn typed_dynamic_conflict_fails_json_and_rocketmq_with_full_rollback() {
+        use crate::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let header = SendMessageResponseHeader::new("typed".into(), 1, 2, None, None, None);
+            let mut command = RemotingCommand::create_response_command_with_header(header)
+                .set_serialize_type(serialize_type)
+                .set_ext_fields(HashMap::from([("msgId".into(), "dynamic".into())]));
+            let mut destination = BytesMut::from(&b"prefix"[..]);
+
+            let error = command.try_fast_header_encode(&mut destination).unwrap_err();
+
+            assert_eq!(error.kind(), rocketmq_error::ErrorKind::RequestHeaderError);
+            assert_eq!(destination.as_ref(), b"prefix");
+            assert_eq!(
+                command
+                    .ext_fields()
+                    .and_then(|fields| fields.get("msgId"))
+                    .map(CheetahString::as_str),
+                Some("dynamic")
+            );
+        }
+    }
+
+    #[test]
+    fn present_empty_is_preserved_in_map_and_normalized_after_rocketmq_decode() {
+        use crate::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+
+        let header = SendMessageResponseHeader::new("msg".into(), 1, 2, Some(CheetahString::new()), None, None);
+        let mut materialized = RemotingCommand::create_response_command_with_header(header);
+        materialized.try_make_custom_header_to_net().unwrap();
+        assert_eq!(
+            materialized
+                .ext_fields()
+                .and_then(|fields| fields.get("transactionId"))
+                .map(CheetahString::as_str),
+            Some("")
+        );
+
+        let header = SendMessageResponseHeader::new("msg".into(), 1, 2, Some(CheetahString::new()), None, None);
+        let mut command =
+            RemotingCommand::create_response_command_with_header(header).set_serialize_type(SerializeType::ROCKETMQ);
+        let mut encoded = BytesMut::new();
+        command.try_fast_header_encode(&mut encoded).unwrap();
+        let decoded = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+
+        assert!(decoded
+            .ext_fields()
+            .is_some_and(|fields| !fields.contains_key("transactionId")));
     }
 
     #[test]
@@ -1416,6 +1544,24 @@ mod tests {
         );
         let decoded = command.decode_command_custom_header::<TestCustomHeader>().unwrap();
         assert_eq!(decoded.value, 9);
+    }
+
+    #[test]
+    fn failed_shared_header_mutation_keeps_materialized_fields_intact() {
+        let mut command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 });
+        command.try_make_custom_header_to_net().unwrap();
+        let _clone = command.clone();
+
+        assert!(command.try_read_custom_header_mut::<TestCustomHeader>().is_err());
+
+        assert!(command.custom_header_to_net);
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("value"))
+                .map(CheetahString::as_str),
+            Some("7")
+        );
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -23,6 +23,8 @@ use cheetah_string::CheetahString;
 
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_field_merge::has_custom_ext_collision;
+use crate::protocol::header_field_merge::merge_header_and_dynamic;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::protocol::LanguageCode;
 
@@ -34,10 +36,7 @@ fn decoding_error(required: usize, available: usize) -> rocketmq_error::RocketMQ
 }
 
 fn sorted_ext_fields(map: &HashMap<CheetahString, CheetahString>) -> Vec<(&CheetahString, &CheetahString)> {
-    let mut entries = map
-        .iter()
-        .filter(|(key, value)| !key.is_empty() && !value.is_empty())
-        .collect::<Vec<_>>();
+    let mut entries = map.iter().filter(|(key, _)| !key.is_empty()).collect::<Vec<_>>();
     entries.sort_unstable_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
     entries
 }
@@ -132,6 +131,19 @@ impl RocketMQSerializable {
         buf: &mut BytesMut,
         capability: HeaderEncodeCapability,
     ) -> Result<usize, HeaderCodecError> {
+        let checkpoint = buf.len();
+        let result = Self::try_rocketmq_protocol_encode_inner(cmd, buf, capability);
+        if result.is_err() {
+            buf.truncate(checkpoint);
+        }
+        result
+    }
+
+    fn try_rocketmq_protocol_encode_inner(
+        cmd: &RemotingCommand,
+        buf: &mut BytesMut,
+        capability: HeaderEncodeCapability,
+    ) -> Result<usize, HeaderCodecError> {
         let begin_index = buf.len();
 
         // Estimate required capacity and reserve upfront to reduce reallocations
@@ -156,34 +168,72 @@ impl RocketMQSerializable {
         let map_len_index = buf.len();
         buf.put_i32(0);
 
-        // Encode the custom header through shared access so cloned commands
-        // do not depend on Arc uniqueness.
-        if let Some(header) = cmd.command_custom_header_ref() {
-            if capability == HeaderEncodeCapability::DirectBinary {
+        // Keep the common direct path map-free. Semantic overlaps use the
+        // single authoritative typed/dynamic merge contract.
+        match cmd.command_custom_header_ref() {
+            Some(header)
+                if capability == HeaderEncodeCapability::DirectBinary
+                    && !has_custom_ext_collision(header, cmd.ext_fields()) =>
+            {
                 header.encode_direct_binary(buf)?;
+                if let Some(ext_fields) = cmd.ext_fields() {
+                    Self::write_ext_fields(buf, ext_fields)?;
+                }
             }
-        }
-
-        // Encode ext_fields map
-        if let Some(ext_fields) = cmd.ext_fields() {
-            for (key, value) in sorted_ext_fields(ext_fields) {
-                Self::write_str(buf, true, key.as_str());
-                Self::write_str(buf, false, value.as_str());
+            Some(header) => {
+                let merged = merge_header_and_dynamic(header, cmd.ext_fields())?;
+                Self::write_ext_fields(buf, &merged)?;
+            }
+            None => {
+                if let Some(ext_fields) = cmd.ext_fields() {
+                    Self::write_ext_fields(buf, ext_fields)?;
+                }
             }
         }
 
         // Update ext_fields length in-place
         let current_length = buf.len();
-        let ext_fields_length = (current_length - map_len_index - 4) as i32;
+        let ext_fields_length = Self::checked_ext_fields_length(current_length - map_len_index - 4)?;
         buf[map_len_index..map_len_index + 4].copy_from_slice(&ext_fields_length.to_be_bytes());
 
         Ok(buf.len() - begin_index)
     }
 
+    #[inline]
+    fn write_ext_fields(
+        buf: &mut BytesMut,
+        fields: &HashMap<CheetahString, CheetahString>,
+    ) -> Result<(), HeaderCodecError> {
+        for (key, value) in sorted_ext_fields(fields) {
+            let key_length = Self::checked_dynamic_key_length(key.len())?;
+            let value_length = Self::checked_dynamic_value_length(value.len())?;
+            buf.put_u16(key_length);
+            buf.put_slice(key.as_bytes());
+            buf.put_i32(value_length);
+            buf.put_slice(value.as_bytes());
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn checked_ext_fields_length(length: usize) -> Result<i32, HeaderCodecError> {
+        i32::try_from(length).map_err(|_| HeaderCodecError::ExtensionFieldsLengthOverflow)
+    }
+
+    #[inline]
+    fn checked_dynamic_key_length(length: usize) -> Result<u16, HeaderCodecError> {
+        u16::try_from(length).map_err(|_| HeaderCodecError::DynamicKeyLengthOverflow)
+    }
+
+    #[inline]
+    fn checked_dynamic_value_length(length: usize) -> Result<i32, HeaderCodecError> {
+        i32::try_from(length).map_err(|_| HeaderCodecError::DynamicValueLengthOverflow)
+    }
+
     /// Estimate the size needed for encoding to reduce reallocations
     #[inline]
     fn estimate_encode_size(cmd: &RemotingCommand) -> usize {
-        let mut size = 15; // Fixed header: code(2) + language(1) + version(2) + opaque(4) + flag(4) + map_len(4)
+        let mut size = 17; // Fixed header fields (13) plus the ext-map length (4).
 
         // Remark size
         if let Some(remark) = cmd.remark() {
@@ -195,10 +245,14 @@ impl RocketMQSerializable {
         // Ext fields size (approximate)
         if let Some(ext) = cmd.ext_fields() {
             for (k, v) in ext.iter() {
-                if !k.is_empty() && !v.is_empty() {
+                if !k.is_empty() {
                     size += 2 + k.len() + 4 + v.len();
                 }
             }
+        }
+
+        if let Some(header) = cmd.command_custom_header_ref() {
+            size = size.saturating_add(header.encoded_len_hint());
         }
 
         size
@@ -264,7 +318,7 @@ impl RocketMQSerializable {
         let mut valid_entries = 0;
 
         for (key, value) in map.iter() {
-            if !key.is_empty() && !value.is_empty() {
+            if !key.is_empty() {
                 total_length += 2 + key.len() + 4 + value.len();
                 valid_entries += 1;
             }
@@ -375,9 +429,9 @@ impl RocketMQSerializable {
             let key = Self::read_str(buffer, true, len)?.ok_or_else(|| decoding_error(0, 0))?;
 
             // Read value (long length prefix)
-            let value = Self::read_str(buffer, false, len)?.ok_or_else(|| decoding_error(0, 0))?;
-
-            map.insert(key, value);
+            if let Some(value) = Self::read_str(buffer, false, len)? {
+                map.insert(key, value);
+            }
         }
 
         Ok(map)
@@ -465,6 +519,15 @@ mod tests {
     }
 
     #[test]
+    fn map_serialize_preserves_present_empty_value() {
+        let map = HashMap::from([("key".into(), CheetahString::new())]);
+
+        let serialized = RocketMQSerializable::map_serialize(&map).unwrap();
+
+        assert_eq!(serialized, BytesMut::from(&[0, 3, 107, 101, 121, 0, 0, 0, 0][..]));
+    }
+
+    #[test]
     fn map_deserialize_empty() {
         let mut buf = BytesMut::new();
         let deserialized = RocketMQSerializable::map_deserialize(&mut buf, 0).unwrap();
@@ -476,6 +539,44 @@ mod tests {
         let mut buf = BytesMut::from(&[0, 3, 107, 101, 121, 0, 0, 0, 5, 118, 97, 108, 117, 101][..]);
         let deserialized = RocketMQSerializable::map_deserialize(&mut buf, 14).unwrap();
         assert_eq!(deserialized, [("key".into(), "value".into())].iter().cloned().collect());
+    }
+
+    #[test]
+    fn map_deserialize_normalizes_zero_length_value_to_absent() {
+        let mut buf = BytesMut::from(&[0, 3, 107, 101, 121, 0, 0, 0, 0][..]);
+
+        let deserialized = RocketMQSerializable::map_deserialize(&mut buf, 9).unwrap();
+
+        assert!(deserialized.is_empty());
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn extension_field_length_checks_limit_and_limit_plus_one() {
+        assert_eq!(
+            RocketMQSerializable::checked_ext_fields_length(i32::MAX as usize).unwrap(),
+            i32::MAX
+        );
+        assert!(matches!(
+            RocketMQSerializable::checked_ext_fields_length(i32::MAX as usize + 1),
+            Err(HeaderCodecError::ExtensionFieldsLengthOverflow)
+        ));
+        assert_eq!(
+            RocketMQSerializable::checked_dynamic_key_length(u16::MAX as usize).unwrap(),
+            u16::MAX
+        );
+        assert!(matches!(
+            RocketMQSerializable::checked_dynamic_key_length(u16::MAX as usize + 1),
+            Err(HeaderCodecError::DynamicKeyLengthOverflow)
+        ));
+        assert_eq!(
+            RocketMQSerializable::checked_dynamic_value_length(i32::MAX as usize).unwrap(),
+            i32::MAX
+        );
+        assert!(matches!(
+            RocketMQSerializable::checked_dynamic_value_length(i32::MAX as usize + 1),
+            Err(HeaderCodecError::DynamicValueLengthOverflow)
+        ));
     }
 
     #[test]

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/manifest.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/manifest.json
@@ -188,7 +188,7 @@
       "id": "empty-header",
       "rustTypeId": "rocketmq_protocol::protocol::header::empty_header::EmptyHeader",
       "file": "rust-only/empty-header.json",
-      "sha256": "dbc04184b62c3f4b49a47ce8a44547ab507291135334b1761d419df30fe2b05e"
+      "sha256": "4e27bfce2b6b35abd52c7ad6b1bed7b9be43d75cc8c254706049c18289831b65"
     }
   ],
   "wirePolicies": {

--- a/rocketmq-protocol/tests/fixtures/request_header_codec/rust-only/empty-header.json
+++ b/rocketmq-protocol/tests/fixtures/request_header_codec/rust-only/empty-header.json
@@ -3,7 +3,7 @@
   "id": "empty-header",
   "rustTypeId": "rocketmq_protocol::protocol::header::empty_header::EmptyHeader",
   "classification": "intentional-empty-header",
-  "logicalMap": null,
+  "logicalMap": {},
   "jsonObject": {},
   "owner": "rocketmq-rust maintainers",
   "reason": "The header intentionally has no wire fields"

--- a/rocketmq-protocol/tests/request_header_java_compatibility.rs
+++ b/rocketmq-protocol/tests/request_header_java_compatibility.rs
@@ -290,9 +290,9 @@ fn intentional_empty_headers_are_explicit_contract_entries() {
     )
     .expect("valid empty-header fixture JSON");
     assert_eq!(fixture["classification"], "intentional-empty-header");
-    assert!(fixture["logicalMap"].is_null());
+    assert_eq!(fixture["logicalMap"], serde_json::json!({}));
     assert_eq!(fixture["jsonObject"], serde_json::json!({}));
-    assert!(EmptyHeader::default().to_map().is_none());
+    assert_eq!(EmptyHeader::default().to_map(), Some(HashMap::new()));
 }
 
 #[test]

--- a/scripts/request-header-codec/generate_perf_corpus.py
+++ b/scripts/request-header-codec/generate_perf_corpus.py
@@ -37,6 +37,10 @@ def digest_map(fields: dict[str, str]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def digest_json_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true")
@@ -91,7 +95,7 @@ def main() -> None:
         "schemaVersion": 1,
         "corpusVersion": "request-header-codec-perf-v1",
         "javaCommit": inputs["javaCommit"],
-        "fixtureManifestSha256": hashlib.sha256((fixture_root / "manifest.json").read_bytes()).hexdigest(),
+        "fixtureManifestSha256": digest_json_file(fixture_root / "manifest.json"),
         "weightProfile": {
             "kind": "reviewed-equal-stratified",
             "productionTelemetry": False,

--- a/scripts/request-header-codec/perf-corpus-v1.json
+++ b/scripts/request-header-codec/perf-corpus-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "corpusVersion": "request-header-codec-perf-v1",
   "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
-  "fixtureManifestSha256": "58c0906471da30880049580162688f3ba963bc99a6377b0b9402668b1b7f4747",
+  "fixtureManifestSha256": "48fe766fbc557536cdace017fff244fafa93565ca0d4d7fb19e582183e695669",
   "weightProfile": {
     "kind": "reviewed-equal-stratified",
     "productionTelemetry": false,

--- a/scripts/request-header-codec/update_contract_fixtures.py
+++ b/scripts/request-header-codec/update_contract_fixtures.py
@@ -37,6 +37,10 @@ def canonical_json(document: object) -> bytes:
     return (json.dumps(document, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
 
 
+def normalized_newlines(payload: bytes) -> bytes:
+    return payload.replace(b"\r\n", b"\n")
+
+
 def build_fixture_tree(source: Path, destination: Path) -> dict[Path, bytes]:
     schema_path = source / "java-schema.json"
     index_path = source / "golden" / "index.json"
@@ -81,7 +85,7 @@ def build_fixture_tree(source: Path, destination: Path) -> dict[Path, bytes]:
             "id": header["golden"],
             "rustTypeId": header["rustTypeId"],
             "classification": "intentional-empty-header",
-            "logicalMap": None,
+            "logicalMap": {},
             "jsonObject": {},
             "owner": header["owner"],
             "reason": header["reason"],
@@ -149,7 +153,11 @@ def main() -> int:
         destination = args.output.resolve()
         expected = build_fixture_tree(source, destination)
         if args.check:
-            stale = [path for path, payload in expected.items() if not path.is_file() or path.read_bytes() != payload]
+            stale = [
+                path
+                for path, payload in expected.items()
+                if not path.is_file() or normalized_newlines(path.read_bytes()) != normalized_newlines(payload)
+            ]
             extra = []
             if destination.is_dir():
                 expected_paths = set(expected)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8983

### Brief Description

Unify typed custom headers and dynamic extension fields under one fallible merge contract. The common direct-binary path remains map-free, while semantic overlaps canonicalize aliases, deduplicate identical values, and reject conflicting values without exposing field contents.

Preserve present-empty values in maps and JSON, encode them as zero-length ROCKETMQ values, and normalize them to absent on binary decode. Check dynamic key/value sizes, the extension-map signed length, the serialized-header 24-bit length, and the total-frame signed length before backpatching. Encoding failures restore the caller's destination buffer.

The audited fieldless header now returns an explicit empty map. Contract fixtures and the 48-operation performance corpus use canonical newline hashing so their digests remain stable on Windows and Unix.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz`
- `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`
- `cargo check --locked --offline` in the renamed dependency fixture
- Replayed the pinned Java contract extractor and verified all 24 Rust frames with the Java production decoder
- Verified contract fixtures and the 48-operation performance corpus are current


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header serialization and merging, including support for empty values and fieldless headers.
  * Added collision detection and clearer handling of conflicting or oversized header fields.
  * Encoding now safely rolls back on failure and reports framing or serialization errors.
  * Improved compatibility with legacy header formats and newline differences in fixtures.

* **Tests**
  * Expanded coverage for header collisions, size limits, empty values, cloning, mutation safety, and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->