### PR TITLE
[ISSUE #8987]✨Make hardened V2 replay cover the current performance corpus

### DIFF
--- a/scripts/request-header-codec/README.md
+++ b/scripts/request-header-codec/README.md
@@ -33,7 +33,7 @@ Do not edit generated schema or golden files by hand. Do not commit raw JMH, Cri
 
 ## Performance workflow
 
-`perf-corpus-v1.json` defines the production-weighted set of 44 encode and decode operations. Regenerate it after the fixture manifest changes, or use `--check` in verification jobs:
+`perf-corpus-v1.json` defines the production-weighted set of 48 encode and decode operations. Regenerate it after the fixture manifest changes, or use `--check` in verification jobs:
 
 ```powershell
 python scripts/request-header-codec/generate_perf_corpus.py --check
@@ -69,6 +69,8 @@ $common = @{
 ```
 
 Interrupted runs can continue with `-Resume` and the same output directory. Never use `-Resume` after changing the corpus, fixtures, source commit, runner, or benchmark configuration.
+
+Release replay temporarily overlays the bundled current Rust benchmark harness and corpus onto the clean frozen V2 checkout. Only benchmark-driver files are replaced; codec library sources and the frozen commit identity are unchanged. The original bytes are restored in a `finally` path, the checkout must be clean afterward, and the evidence manifest records the shared harness digest used by V3 and V2.
 
 The release comparison is fail-closed. In addition to matching commits, corpus and fixture hashes, runner fingerprint, benchmark profile, and build recipe, it requires all gates in `perf-gates.json`. The primary throughput requirements are:
 

--- a/scripts/request-header-codec/compare_performance.py
+++ b/scripts/request-header-codec/compare_performance.py
@@ -41,6 +41,11 @@ def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def canonical_text_digest(path: Path) -> str:
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
 def percentile(values: list[float], probability: float) -> float:
     ordered = sorted(values)
     position = (len(ordered) - 1) * probability
@@ -100,13 +105,18 @@ def gate_result(actual: float, operator: str, threshold: float) -> dict[str, Any
     return {"pass": passed, "actual": actual, "operator": operator, "threshold": threshold}
 
 
-def checked_file(root: Path, manifest: dict[str, Any], name: str) -> tuple[Path, dict[str, Any]]:
+def checked_path(root: Path, manifest: dict[str, Any], name: str) -> Path:
     entry = manifest.get("files", {}).get(name)
     if not isinstance(entry, dict) or set(entry) != {"path", "sha256"}:
         raise ValueError(f"evidence manifest is missing the exact {name} file identity")
     path = (root / entry["path"]).resolve()
     if not path.is_file() or digest(path) != entry["sha256"]:
         raise ValueError(f"evidence file digest mismatch: {name}")
+    return path
+
+
+def checked_file(root: Path, manifest: dict[str, Any], name: str) -> tuple[Path, dict[str, Any]]:
+    path = checked_path(root, manifest, name)
     return path, read_json(path)
 
 
@@ -146,7 +156,7 @@ def validate_gates(gates_path: Path, gates: dict[str, Any]) -> None:
     if gates["gates"]["PERF-04"].get("appliesTo") != ["PERF-01", "PERF-02", "PERF-03"]:
         raise ValueError("PERF-04 must apply independently to PERF-01 through PERF-03")
     recipe = (gates_path.parent.parent.parent / gates["buildRecipe"]["path"]).resolve()
-    if not recipe.is_file() or digest(recipe) != gates["buildRecipe"]["sha256"]:
+    if not recipe.is_file() or canonical_text_digest(recipe) != gates["buildRecipe"]["sha256"]:
         raise ValueError("perf-gates.json build recipe digest is stale")
 
 
@@ -233,11 +243,12 @@ def main() -> None:
     validate_gates(args.gates.resolve(), gates)
     if manifest.get("schemaVersion") != 1 or manifest.get("mode") != "release":
         raise ValueError("only a release evidence bundle can produce a performance attestation")
-    if manifest.get("gatesSha256") != digest(args.gates):
+    if manifest.get("gatesSha256") != canonical_text_digest(args.gates):
         raise ValueError("evidence was collected with different performance gates")
 
     corpus_path, corpus = checked_file(root, manifest, "corpus")
     runner_path, _ = checked_file(root, manifest, "runner")
+    rust_benchmark_harness_path = checked_path(root, manifest, "rustBenchmarkHarness")
     _, v3 = checked_file(root, manifest, "v3")
     v2_replay_path, v2 = checked_file(root, manifest, "v2Replay")
     v2_manifest_path, v2_manifest = checked_file(root, manifest, "v2Manifest")
@@ -262,6 +273,12 @@ def main() -> None:
         raise ValueError("V2 replay does not reference the frozen baseline manifest")
     if v2_replay_path == v2_manifest_path:
         raise ValueError("same-run V2 replay cannot reuse the historical manifest file")
+    rust_benchmark_harness_sha = digest(rust_benchmark_harness_path)
+    if {
+        v3.get("benchmarkHarnessSha256"),
+        v2.get("benchmarkHarnessSha256"),
+    } != {rust_benchmark_harness_sha}:
+        raise ValueError("V3 and V2 replay did not use the bundled Rust benchmark harness")
 
     validate_runtime_identity([v3, v2, java], corpus, digest(runner_path))
     v3_samples = sample_index(v3)

--- a/scripts/request-header-codec/measure-build.ps1
+++ b/scripts/request-header-codec/measure-build.ps1
@@ -24,6 +24,8 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$Output,
 
+    [string]$Repository,
+
     [int]$Runs = 0,
 
     [switch]$DiagnosticAllowRecipeOverride,
@@ -33,7 +35,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $scriptRoot = Split-Path -Parent $PSCommandPath
-$repoRoot = (Resolve-Path -LiteralPath (Join-Path $scriptRoot '..\..')).Path
+$repoRoot = if ($Repository) {
+    (Resolve-Path -LiteralPath $Repository).Path
+} else {
+    (Resolve-Path -LiteralPath (Join-Path $scriptRoot '..\..')).Path
+}
 $recipePath = Join-Path $scriptRoot 'perf-build-recipe-v1.json'
 $recipe = Get-Content -LiteralPath $recipePath -Raw | ConvertFrom-Json
 $recipeRuns = [int]$recipe.repetitions
@@ -79,6 +85,11 @@ function Get-StringSha256([string]$Value) {
     } finally {
         $sha.Dispose()
     }
+}
+
+function Get-CanonicalTextSha256([string]$Path) {
+    $text = [System.IO.File]::ReadAllText($Path).Replace("`r`n", "`n").Replace("`r", "`n")
+    return Get-StringSha256 $text
 }
 
 function Get-Median([long[]]$Values) {
@@ -219,7 +230,7 @@ $document = [ordered]@{
     sourceCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
     buildRecipe = [ordered]@{
         id = $recipe.id
-        sha256 = (Get-FileHash -LiteralPath $recipePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        sha256 = Get-CanonicalTextSha256 $recipePath
     }
     mode = $Mode
     variant = $Variant

--- a/scripts/request-header-codec/normalize_criterion.py
+++ b/scripts/request-header-codec/normalize_criterion.py
@@ -50,6 +50,7 @@ def main() -> None:
     parser.add_argument("--corpus", type=Path, required=True)
     parser.add_argument("--fixture-manifest", type=Path, required=True)
     parser.add_argument("--runner", type=Path, required=True)
+    parser.add_argument("--benchmark-harness", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--role", required=True)
     parser.add_argument("--commit", required=True)
@@ -111,6 +112,7 @@ def main() -> None:
         "corpusSha256": digest(args.corpus),
         "fixtureManifestSha256": digest(args.fixture_manifest),
         "runnerFingerprintSha256": digest(args.runner),
+        "benchmarkHarnessSha256": digest(args.benchmark_harness),
         "runner": read_json(args.runner),
         "sampleCount": len(normalized),
         "missingCases": missing,

--- a/scripts/request-header-codec/run-benchmarks.ps1
+++ b/scripts/request-header-codec/run-benchmarks.ps1
@@ -81,6 +81,11 @@ function Get-StringSha256([string]$Value) {
     }
 }
 
+function Get-CanonicalTextSha256([string]$Path) {
+    $text = [System.IO.File]::ReadAllText($Path).Replace("`r`n", "`n").Replace("`r", "`n")
+    return Get-StringSha256 $text
+}
+
 function Get-ProcessOutput([string]$FileName, [string]$Arguments) {
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = $FileName
@@ -207,7 +212,10 @@ function Invoke-RustBenchmark(
     [string]$RunnerPath,
     [string]$Destination,
     [string]$Role,
-    [string]$BaselineManifestPath
+    [string]$BaselineManifestPath,
+    [string]$BenchmarkHarnessPath,
+    [string]$BenchmarkCorpusPath,
+    [bool]$UseReplayOverlay
 ) {
     $raw = Join-Path $Destination 'criterion-raw'
     $allocations = Join-Path $Destination 'allocations.json'
@@ -235,8 +243,30 @@ function Invoke-RustBenchmark(
         }
         $env:ROCKETMQ_HEADER_CODEC_CRITERION_DIR = $raw
         $env:ROCKETMQ_HEADER_CODEC_ALLOC_OUTPUT = $allocations
-        Push-Location $Repository
+        $overlay = @()
+        $locationPushed = $false
         try {
+            if ($UseReplayOverlay) {
+                $harnessDestination = Join-Path $Repository 'rocketmq-protocol\benches\request_header_codec.rs'
+                $corpusDestination = Join-Path $Repository 'scripts\request-header-codec\perf-corpus-v1.json'
+                $overlay = @(
+                    [pscustomobject]@{
+                        Destination = $harnessDestination
+                        OriginalBytes = [System.IO.File]::ReadAllBytes($harnessDestination)
+                        OverlayBytes = [System.IO.File]::ReadAllBytes($BenchmarkHarnessPath)
+                    },
+                    [pscustomobject]@{
+                        Destination = $corpusDestination
+                        OriginalBytes = [System.IO.File]::ReadAllBytes($corpusDestination)
+                        OverlayBytes = [System.IO.File]::ReadAllBytes($BenchmarkCorpusPath)
+                    }
+                )
+                foreach ($entry in $overlay) {
+                    [System.IO.File]::WriteAllBytes($entry.Destination, $entry.OverlayBytes)
+                }
+            }
+            Push-Location $Repository
+            $locationPushed = $true
             $previousErrorPreference = $ErrorActionPreference
             try {
                 $ErrorActionPreference = 'Continue'
@@ -249,7 +279,18 @@ function Invoke-RustBenchmark(
                 throw "Rust Criterion failed with exit code $criterionExitCode"
             }
         } finally {
-            Pop-Location
+            if ($locationPushed) {
+                Pop-Location
+            }
+            if ($overlay.Count -gt 0) {
+                foreach ($entry in $overlay) {
+                    [System.IO.File]::WriteAllBytes($entry.Destination, $entry.OriginalBytes)
+                }
+                $replayStatus = (& git -C $Repository status --short) -join "`n"
+                if ($LASTEXITCODE -ne 0 -or $replayStatus) {
+                    throw "V2 replay overlay did not restore a clean worktree: $replayStatus"
+                }
+            }
         }
     } finally {
         $env:ROCKETMQ_HEADER_CODEC_WARMUP_SECONDS = $oldWarmup
@@ -263,7 +304,8 @@ function Invoke-RustBenchmark(
     $normalizeArguments = @(
         (Join-Path $scriptRoot 'normalize_criterion.py'), '--raw-dir', $raw, '--corpus', $corpusPath,
         '--fixture-manifest', $fixtureManifest, '--runner', $RunnerPath, '--output', $normalized,
-        '--role', $Role, '--commit', $commit, '--profile', $profile, '--allocations', $allocations
+        '--role', $Role, '--commit', $commit, '--profile', $profile, '--allocations', $allocations,
+        '--benchmark-harness', $BenchmarkHarnessPath
     )
     if ($BaselineManifestPath) {
         $normalizeArguments += @('--baseline-manifest', $BaselineManifestPath)
@@ -276,9 +318,9 @@ function Invoke-RustBenchmark(
 }
 
 function Invoke-BuildEvidence([string]$Repository, [string]$Variant, [string]$Destination) {
-    $measureScript = Join-Path $Repository 'scripts\request-header-codec\measure-build.ps1'
+    $measureScript = Join-Path $scriptRoot 'measure-build.ps1'
     if (-not (Test-Path -LiteralPath $measureScript)) {
-        throw "Build measurement helper is absent from $Repository"
+        throw 'Build measurement helper is absent from the release harness'
     }
     $clean = Join-Path $Destination "$Variant-clean.json"
     $incremental = Join-Path $Destination "$Variant-incremental.json"
@@ -287,11 +329,14 @@ function Invoke-BuildEvidence([string]$Repository, [string]$Variant, [string]$De
     }
     $common = @{
         Variant = $Variant
+        Repository = $Repository
     }
     if ($Quick) {
         $common['Runs'] = 1
         $common['DiagnosticAllowRecipeOverride'] = $true
     }
+    $sourceCommit = (& git -C $Repository rev-parse HEAD).Trim()
+    Assert-CleanCommit $Repository $sourceCommit "$Variant build source"
     & $measureScript -Mode clean -Output $clean @common | Out-Host
     if ($LASTEXITCODE -ne 0) {
         throw "$Variant clean-build measurement failed"
@@ -300,6 +345,7 @@ function Invoke-BuildEvidence([string]$Repository, [string]$Variant, [string]$De
     if ($LASTEXITCODE -ne 0) {
         throw "$Variant incremental-build measurement failed"
     }
+    Assert-CleanCommit $Repository $sourceCommit "$Variant build source after measurement"
     return @($clean, $incremental)
 }
 
@@ -313,9 +359,11 @@ function Add-FileIdentity([System.Collections.Specialized.OrderedDictionary]$Fil
 }
 
 Assert-CleanCommit $javaRoot $expectedJavaCommit 'Java oracle'
+$currentRustCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
+Assert-CleanCommit $repoRoot $currentRustCommit 'Rust release candidate'
 $gatesDocument = Get-Content -LiteralPath $gatesPath -Raw | ConvertFrom-Json
 $recipePath = Join-Path $repoRoot $gatesDocument.buildRecipe.path
-$recipeHash = (Get-FileHash -LiteralPath $recipePath -Algorithm SHA256).Hash.ToLowerInvariant()
+$recipeHash = Get-CanonicalTextSha256 $recipePath
 if ($recipeHash -ne $gatesDocument.buildRecipe.sha256) {
     throw 'perf-gates.json references a stale build recipe digest'
 }
@@ -331,6 +379,9 @@ $inputDirectory = Join-Path $outputRoot 'inputs'
 New-Item -ItemType Directory -Force -Path $inputDirectory | Out-Null
 $corpusCopy = Join-Path $inputDirectory 'perf-corpus-v1.json'
 Copy-Item -LiteralPath $corpusPath -Destination $corpusCopy -Force
+$benchmarkHarnessCopy = Join-Path $inputDirectory 'request_header_codec.rs'
+Copy-Item -LiteralPath (Join-Path $repoRoot 'rocketmq-protocol\benches\request_header_codec.rs') `
+    -Destination $benchmarkHarnessCopy -Force
 
 $javaNormalized = Join-Path $outputRoot 'java\java.json'
 if (-not ($Resume -and (Test-Path -LiteralPath $javaNormalized))) {
@@ -340,6 +391,7 @@ $files = [ordered]@{}
 Add-FileIdentity $files 'corpus' $corpusCopy
 Add-FileIdentity $files 'runner' $runnerPath
 Add-FileIdentity $files 'java' $javaNormalized
+Add-FileIdentity $files 'rustBenchmarkHarness' $benchmarkHarnessCopy
 
 if ($Mode -eq 'Release') {
     $v2Root = (Resolve-Path -LiteralPath $V2Worktree).Path
@@ -347,11 +399,13 @@ if ($Mode -eq 'Release') {
     Assert-CleanCommit $v2Root ((Get-Content -LiteralPath $v2ManifestPath -Raw | ConvertFrom-Json).commit) 'V2 replay'
     $v3Normalized = Join-Path $outputRoot 'rust\v3\release-candidate.json'
     if (-not ($Resume -and (Test-Path -LiteralPath $v3Normalized))) {
-        $v3Normalized = Invoke-RustBenchmark $repoRoot $runnerPath (Join-Path $outputRoot 'rust\v3') 'release-candidate' $null
+        $v3Normalized = Invoke-RustBenchmark $repoRoot $runnerPath (Join-Path $outputRoot 'rust\v3') `
+            'release-candidate' $null $benchmarkHarnessCopy $corpusCopy $false
     }
     $v2Normalized = Join-Path $outputRoot 'rust\v2\v2-replay.json'
     if (-not ($Resume -and (Test-Path -LiteralPath $v2Normalized))) {
-        $v2Normalized = Invoke-RustBenchmark $v2Root $runnerPath (Join-Path $outputRoot 'rust\v2') 'v2-replay' $v2ManifestPath
+        $v2Normalized = Invoke-RustBenchmark $v2Root $runnerPath (Join-Path $outputRoot 'rust\v2') `
+            'v2-replay' $v2ManifestPath $benchmarkHarnessCopy $corpusCopy $true
     }
     $v3Build = Invoke-BuildEvidence $repoRoot 'v3' (Join-Path $outputRoot 'build')
     $v2Build = Invoke-BuildEvidence $v2Root 'v2-replay' (Join-Path $outputRoot 'build')
@@ -370,7 +424,8 @@ if ($Mode -eq 'Release') {
     $role = if ($Mode -eq 'PostP0') { 'post-p0' } else { 'phase1-hardened' }
     $rustNormalized = Join-Path $outputRoot "rust\$role.json"
     if (-not ($Resume -and (Test-Path -LiteralPath $rustNormalized))) {
-        $rustNormalized = Invoke-RustBenchmark $repoRoot $runnerPath (Join-Path $outputRoot 'rust') $role $null
+        $rustNormalized = Invoke-RustBenchmark $repoRoot $runnerPath (Join-Path $outputRoot 'rust') `
+            $role $null $benchmarkHarnessCopy $corpusCopy $false
     }
     $build = Invoke-BuildEvidence $repoRoot $role (Join-Path $outputRoot 'build')
     Add-FileIdentity $files 'v2' $rustNormalized
@@ -399,7 +454,7 @@ $manifest = [ordered]@{
     schemaVersion = 1
     mode = $manifestMode
     quickDiagnostic = [bool]$Quick
-    gatesSha256 = (Get-FileHash -LiteralPath $gatesPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    gatesSha256 = Get-CanonicalTextSha256 $gatesPath
     buildRecipe = [ordered]@{
         id = $gatesDocument.buildRecipe.id
         sha256 = $gatesDocument.buildRecipe.sha256


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8987

### Brief Description

Make the frozen hardened V2 codec replay the current 48-operation request-header performance corpus without changing its library sources or commit identity. The release runner bundles the current Rust benchmark driver, applies it and the corpus as a temporary replay overlay, restores the original bytes in `finally`, and rejects a dirty replay checkout. Normalized V3 and V2 evidence now records the same bundled harness SHA-256, and the comparison rejects harness drift.

The build measurement helper can target either source checkout while retaining one helper and recipe identity. Gate and build recipe source hashes use canonical LF bytes so the frozen digests remain valid on Windows CRLF checkouts. The performance README now reports the correct operation count and replay contract.

### How Did You Test This Change?

- PowerShell parser validation for `run-benchmarks.ps1` and `measure-build.ps1`: passed.
- `python -m py_compile scripts/request-header-codec/normalize_criterion.py scripts/request-header-codec/compare_performance.py`: passed.
- `python scripts/request-header-codec/generate_perf_corpus.py --check`: passed with 48 production operations.
- Quick Release runner with pinned Java, current V3, and frozen hardened V2: passed with 48 samples and zero missing cases for every runtime; V3 and V2 used the bundled matching harness digest, and the V2 checkout was clean at the frozen commit afterward.
- `python scripts/request-header-codec/compare_performance.py --evidence target/request-header-codec-perf/quick-8987 --gates scripts/request-header-codec/perf-gates.json`: rejected the Quick bundle as diagnostic-only, as required.
- `git diff --check`: passed.
