### PR TITLE
[ISSUE #8992]🐛Restore minimal LZ4 feature compilation

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34617d68520087a27a373f84fa30b683ef46c83603143e861a22fdcd65daab55"
+checksum = "352256e2fe5dedcda13ebaefb12a6a7d7012ce0706f874bc469bd131c0b0f2ef"
 dependencies = [
  "bytes",
  "memchr",
@@ -1875,9 +1875,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "maplit"

--- a/rocketmq-protocol/Cargo.toml
+++ b/rocketmq-protocol/Cargo.toml
@@ -34,7 +34,7 @@ byteorder = "1.5.0"
 bitvec = "1.0.1"
 cheetah-string.workspace = true
 flate2 = { version = "1.1.9", features = ["zlib"], default-features = false }
-lz4_flex = { version = "0.14", default-features = false }
+lz4_flex = { version = "0.14", default-features = false, features = ["alloc"] }
 itoa = "1.0.18"
 memchr = "2.8.0"
 rocketmq-error = { workspace = true, features = ["with_serde"] }

--- a/rocketmq-sre/Cargo.lock
+++ b/rocketmq-sre/Cargo.lock
@@ -2182,9 +2182,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "matchers"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8992

### Brief Description

- Enable the `lz4_flex` `alloc` feature explicitly for the no-default-feature model and protocol dependency graphs.
- Refresh the SRE and fuzz lockfiles to the already-selected `lz4_flex` 0.14 release.
- Preserve the existing compression APIs and wire behavior.

### How Did You Test This Change?

- `cargo check -p rocketmq-model -p rocketmq-protocol --no-default-features`
- `cargo test -p rocketmq-model --no-default-features --lib compression`
- `cargo test -p rocketmq-protocol --no-default-features compression`
- `cargo check --locked --manifest-path fuzz/Cargo.toml`
- `cargo check --locked -p rocketmq-sre-control-plane` from `rocketmq-sre`
- `cargo fmt -p rocketmq-model -p rocketmq-protocol -- --check`
- `git diff --check`

The full AGENTS routing check remains blocked by the pre-existing stale MCP standalone lockfile after the upstream `lz4_flex` version bump; this pull request does not overwrite the separately modified MCP lockfile.
