### PR TITLE
[ISSUE #8996]🚀Qualify real RocketMQ evidence through streamed SRE conversations

### DIFF
--- a/rocketmq-sre/config/qualification/live-conversations.v1.json
+++ b/rocketmq-sre/config/qualification/live-conversations.v1.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "rocketmq-sre.live-conversation-qualification.v1",
+  "environment": "kind_rocketmq_mcp_connector_postgresql",
+  "operating_mode": "supervised_read_only",
+  "model_provider": "isolated_local_openai_compatible_fixture",
+  "online_provider_calls": 0,
+  "production_certified": false,
+  "required_assertions": {
+    "stream_sessions": 2,
+    "consumer_lag_positive": true,
+    "broker_runtime_active": true,
+    "model_assisted_answers": 2,
+    "authorized_evidence_citations": 2,
+    "persisted_turns": 2,
+    "contiguous_sequences": true,
+    "unique_terminal_events": true,
+    "provisional_answer_deltas": true,
+    "disconnect_cancellation_contract_tested": true,
+    "mutation_calls": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0
+  },
+  "repository_evidence": {
+    "live_runner": "rocketmq-sre/scripts/conversation-live-qualification.ps1",
+    "kind_runner": "rocketmq-sre/scripts/phase01-kind-smoke.ps1",
+    "smoke": "rocketmq-sre/scripts/phase01-smoke.ps1",
+    "conversation_service": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/conversation_query_service.rs",
+    "stream_contract": "rocketmq-sre/crates/rocketmq-sre-control-plane/src/conversation_stream.rs",
+    "model_fixture": "rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase01_model_mock.rs",
+    "checker": "rocketmq-sre/scripts/check_live_conversation_qualification.py"
+  },
+  "live_report": {
+    "schema_version": "rocketmq-sre.live-conversation-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "prompts_recorded": false,
+    "responses_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/conversation.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/conversation.rs
@@ -34,9 +34,11 @@ use rocketmq_sre_model_gateway::ModelRole;
 use rocketmq_sre_model_gateway::ModelStreamEvent;
 use rocketmq_sre_model_gateway::ModelTool;
 use rocketmq_sre_model_gateway::ProviderCapability;
+use rocketmq_sre_model_gateway::ProviderDialect;
 use rocketmq_sre_model_gateway::ProviderError;
 use rocketmq_sre_model_gateway::ProviderErrorCode;
 use rocketmq_sre_model_gateway::ProviderHealth;
+use rocketmq_sre_model_gateway::ProviderProfile;
 use rocketmq_sre_model_gateway::ResponseFormat;
 use rocketmq_sre_model_gateway::ToolChoice;
 use serde_json::Value;
@@ -416,13 +418,7 @@ impl ModelGatewayService {
         for profile in profiles.iter().take(self.config.max_fallbacks.saturating_add(1)) {
             let started_at = Utc::now();
             let invocation = match stream {
-                Some(writer)
-                    if profile
-                        .profile
-                        .capabilities
-                        .supported
-                        .contains(&ProviderCapability::Streaming) =>
-                {
+                Some(writer) if conversation_http_streaming_supported(&profile.profile) => {
                     self.invoke_conversation_answer_profile_stream(
                         profile,
                         &prompt,
@@ -958,6 +954,11 @@ fn bounded(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect()
 }
 
+fn conversation_http_streaming_supported(profile: &ProviderProfile) -> bool {
+    profile.dialect == ProviderDialect::DeepSeekResponses
+        && profile.capabilities.supported.contains(&ProviderCapability::Streaming)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1028,5 +1029,21 @@ mod tests {
         let error = preview.push(second).expect_err("sensitive preview must fail closed");
 
         assert_eq!(error.code, ProviderErrorCode::SchemaValidationFailed);
+    }
+
+    #[test]
+    fn conversation_http_streaming_uses_only_the_implemented_dialect() {
+        let profiles = rocketmq_sre_model_gateway::builtin_provider_profiles();
+        let deepseek = profiles
+            .iter()
+            .find(|profile| profile.id == "deepseek-responses")
+            .expect("DeepSeek Responses profile");
+        let local = profiles
+            .iter()
+            .find(|profile| profile.id == "vllm")
+            .expect("local OpenAI-compatible profile");
+
+        assert!(conversation_http_streaming_supported(deepseek));
+        assert!(!conversation_http_streaming_supported(local));
     }
 }

--- a/rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase01_model_mock.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-eval/src/bin/phase01_model_mock.rs
@@ -199,18 +199,34 @@ fn build_completion(request: &ChatCompletionRequest) -> Result<Value, StatusCode
     let prompt: Value = serde_json::from_str(prompt).map_err(|_| StatusCode::UNPROCESSABLE_ENTITY)?;
     let evidence_ids = allowed_evidence_ids(&prompt);
     let evidence_id = evidence_ids.first().ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
-    let diagnosis = json!({
-        "summary": "The cited read-only evidence confirms positive consumer lag.",
-        "assessment": "The consumer is not keeping pace with the bounded synthetic workload. No cluster mutation was requested.",
-        "confidence_percent": 91,
-        "cited_evidence_ids": [evidence_id],
-        "recommended_read_only_queries": [
-            "Re-check consumer lag and broker runtime through RocketMQ MCP."
-        ],
-        "rationale": "The conclusion is limited to the supplied canonical Evidence citation."
-    });
-    let content = serde_json::to_string(&diagnosis).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let response = if response_schema_name(request) == Some("rocketmq_sre_conversation_answer") {
+        json!({
+            "answer": "The cited read-only RocketMQ evidence supports this operational answer. No cluster mutation was requested or performed.",
+            "cited_evidence_ids": [evidence_id]
+        })
+    } else {
+        json!({
+            "summary": "The cited read-only evidence confirms positive consumer lag.",
+            "assessment": "The consumer is not keeping pace with the bounded synthetic workload. No cluster mutation was requested.",
+            "confidence_percent": 91,
+            "cited_evidence_ids": [evidence_id],
+            "recommended_read_only_queries": [
+                "Re-check consumer lag and broker runtime through RocketMQ MCP."
+            ],
+            "rationale": "The conclusion is limited to the supplied canonical Evidence citation."
+        })
+    };
+    let content = serde_json::to_string(&response).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     completion(request, Value::String(content), None, "stop")
+}
+
+fn response_schema_name(request: &ChatCompletionRequest) -> Option<&str> {
+    request
+        .response_format
+        .as_ref()?
+        .get("json_schema")?
+        .get("name")?
+        .as_str()
 }
 
 fn provider_connectivity_probe(request: &ChatCompletionRequest, prompt: &str) -> bool {
@@ -379,6 +395,41 @@ mod tests {
         assert_eq!(diagnosis["cited_evidence_ids"], json!([EVIDENCE_ID]));
         assert_eq!(diagnosis["recommended_read_only_queries"].as_array().unwrap().len(), 1);
         assert!(response.get("tools").is_none());
+    }
+
+    #[test]
+    fn fixture_returns_the_bounded_conversation_answer_schema() {
+        let request = ChatCompletionRequest {
+            model: "phase01-mock".to_owned(),
+            messages: vec![ChatMessage {
+                role: "user".to_owned(),
+                content: Value::String(
+                    json!({
+                        "schema_version": "rocketmq-sre.conversation-answer-input.v1",
+                        "evidence": [{"evidence_id": EVIDENCE_ID}]
+                    })
+                    .to_string(),
+                ),
+            }],
+            tools: None,
+            tool_choice: Some(Value::String("none".to_owned())),
+            response_format: Some(json!({
+                "type": "json_schema",
+                "json_schema": {"name": "rocketmq_sre_conversation_answer"}
+            })),
+        };
+
+        let response = build_completion(&request).expect("bounded conversation completion");
+        let answer: Value = serde_json::from_str(
+            response["choices"][0]["message"]["content"]
+                .as_str()
+                .expect("completion content"),
+        )
+        .expect("structured conversation answer");
+
+        assert!(answer["answer"].as_str().is_some_and(|value| !value.is_empty()));
+        assert_eq!(answer["cited_evidence_ids"], json!([EVIDENCE_ID]));
+        assert!(answer.get("summary").is_none());
     }
 
     #[test]

--- a/rocketmq-sre/scripts/check_live_conversation_qualification.py
+++ b/rocketmq-sre/scripts/check_live_conversation_qualification.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate live RocketMQ evidence through streamed SRE conversations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "live-conversations.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.live-conversation-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.live-conversation-qualification-report.v1"
+ENVIRONMENT = "kind_rocketmq_mcp_connector_postgresql"
+PROVIDER = "isolated_local_openai_compatible_fixture"
+STREAM_SCHEMA = "rocketmq-sre.conversation-stream-event.v1"
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+FORBIDDEN_REPORT_FIELDS = {
+    "api_key",
+    "credential",
+    "model_prompt",
+    "prompt_body",
+    "provider_response",
+    "response_body",
+    "message_body",
+    "access_token",
+}
+EXPECTED_ASSERTIONS: dict[str, bool | int] = {
+    "stream_sessions": 2,
+    "consumer_lag_positive": True,
+    "broker_runtime_active": True,
+    "model_assisted_answers": 2,
+    "authorized_evidence_citations": 2,
+    "persisted_turns": 2,
+    "contiguous_sequences": True,
+    "unique_terminal_events": True,
+    "provisional_answer_deltas": True,
+    "disconnect_cancellation_contract_tested": True,
+    "mutation_calls": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0,
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8-sig") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def all_keys(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [key for child in value for key in all_keys(child)]
+    if isinstance(value, dict):
+        return [str(key) for key, child in value.items()] + [key for child in value.values() for key in all_keys(child)]
+    return []
+
+
+def repository_file(raw_path: Any, location: str, findings: list[str]) -> None:
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location} must be a non-empty repository path")
+        return
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location} must be repository implementation evidence")
+        return
+    if not (REPOSITORY_ROOT / Path(*path.parts)).is_file():
+        findings.append(f"{location} does not exist: {raw_path}")
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected = {
+        "schema_version": MANIFEST_SCHEMA,
+        "environment": ENVIRONMENT,
+        "operating_mode": "supervised_read_only",
+        "model_provider": PROVIDER,
+        "online_provider_calls": 0,
+        "production_certified": False,
+    }
+    for field, value in expected.items():
+        if manifest.get(field) != value:
+            findings.append(f"{field} must remain {value!r}")
+    if manifest.get("required_assertions") != EXPECTED_ASSERTIONS:
+        findings.append("required live Conversation assertions drifted")
+    evidence = manifest.get("repository_evidence")
+    if not isinstance(evidence, dict):
+        findings.append("repository_evidence must be an object")
+    else:
+        for field in (
+            "live_runner",
+            "kind_runner",
+            "smoke",
+            "conversation_service",
+            "stream_contract",
+            "model_fixture",
+            "checker",
+        ):
+            repository_file(evidence.get(field), f"repository_evidence.{field}", findings)
+    live_report = manifest.get("live_report")
+    if not isinstance(live_report, dict) or live_report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live_report contract is missing or unsupported")
+    else:
+        if live_report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if set(live_report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+        for field in ("secrets_recorded", "prompts_recorded", "responses_recorded", "message_bodies_recorded"):
+            if live_report.get(field) is not False:
+                findings.append(f"live_report.{field} must be false")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains a credential-like value")
+    return findings
+
+
+def require_exact(section: Any, expected: dict[str, Any], name: str, findings: list[str]) -> dict[str, Any]:
+    if not isinstance(section, dict):
+        findings.append(f"{name} proof must be an object")
+        return {}
+    for field, value in expected.items():
+        if section.get(field) != value:
+            findings.append(f"{name}.{field} must be {value!r}")
+    return section
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    for field, value in {
+        "schema_version": REPORT_SCHEMA,
+        "status": "passed",
+        "environment": ENVIRONMENT,
+    }.items():
+        if report.get(field) != value:
+            findings.append(f"report.{field} must be {value!r}")
+    revision = report.get("candidate_commit")
+    if not isinstance(revision, str) or not REVISION.fullmatch(revision):
+        findings.append("candidate_commit must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("qualification source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+
+    require_exact(
+        report.get("model"),
+        {"provider": PROVIDER, "online_provider_calls": 0, "production_certified": False},
+        "model",
+        findings,
+    )
+    stream = require_exact(
+        report.get("stream"),
+        {
+            "schema_version": STREAM_SCHEMA,
+            "session_count": 2,
+            "accepted_count": 2,
+            "terminal_count": 2,
+            "sequence_verified": True,
+            "terminal_unique": True,
+            "disconnect_cancellation_contract_tested": True,
+            "max_response_bytes": 1024 * 1024,
+        },
+        "stream",
+        findings,
+    )
+    for field in ("provisional_delta_count", "event_count"):
+        value = stream.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 2:
+            findings.append(f"stream.{field} must be at least two")
+    max_frame_bytes = stream.get("max_frame_bytes")
+    if not isinstance(max_frame_bytes, int) or isinstance(max_frame_bytes, bool) or not 1 <= max_frame_bytes <= 256 * 1024:
+        findings.append("stream.max_frame_bytes must be between one and 262144")
+
+    consumer = require_exact(
+        report.get("consumer_lag"),
+        {
+            "source": "rocketmq-mcp",
+            "citation_authorized": True,
+            "persisted": True,
+            "diagnostic_pack": "consumer-lag.v2",
+        },
+        "consumer_lag",
+        findings,
+    )
+    if not isinstance(consumer.get("resource"), str) or not consumer["resource"].startswith("consumer-lag/"):
+        findings.append("consumer_lag.resource must be a Consumer Lag resource")
+    lag = consumer.get("total_lag")
+    if not isinstance(lag, int) or isinstance(lag, bool) or lag < 1:
+        findings.append("consumer_lag.total_lag must be positive")
+
+    broker = require_exact(
+        report.get("broker_runtime"),
+        {
+            "source": "rocketmq-mcp",
+            "resource": "broker-runtime/rocketmq-dev-broker",
+            "broker_up": True,
+            "citation_authorized": True,
+            "persisted": True,
+            "diagnostic_pack": "broker-health.v1",
+        },
+        "broker_runtime",
+        findings,
+    )
+    for field in ("broker_rows", "active_broker_rows"):
+        value = broker.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            findings.append(f"broker_runtime.{field} must be positive")
+
+    require_exact(
+        report.get("safety"),
+        {
+            "mutation_calls": 0,
+            "executor_calls": 0,
+            "execution_agent_calls": 0,
+            "effective_access": "read_only",
+            "secrets_recorded": False,
+            "prompts_recorded": False,
+            "responses_recorded": False,
+            "message_bodies_recorded": False,
+        },
+        "safety",
+        findings,
+    )
+    if FORBIDDEN_REPORT_FIELDS.intersection(key.lower() for key in all_keys(report)):
+        findings.append("report contains a forbidden sensitive payload field")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains a credential-like value")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        findings = validate_manifest(load_json(args.manifest))
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report)))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"LIVE_CONVERSATION_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"LIVE_CONVERSATION_QUALIFICATION_FINDING {finding}")
+        print(f"LIVE_CONVERSATION_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(f"LIVE_CONVERSATION_QUALIFICATION_OK streams=2 read_only=true{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/conversation-live-qualification.ps1
+++ b/rocketmq-sre/scripts/conversation-live-qualification.ps1
@@ -1,0 +1,80 @@
+# Copyright 2023 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
+    [string]$ClusterName = 'rocketmq-sre-phase00',
+
+    [ValidateSet('D', 'F')]
+    [string]$EvidenceDrive = 'D',
+
+    [switch]$ValidateOnly
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$kindSmoke = Join-Path $scriptDirectory 'phase01-kind-smoke.ps1'
+$kindRunner = Join-Path $scriptDirectory 'kind.ps1'
+$checker = Join-Path $scriptDirectory 'check_live_conversation_qualification.py'
+$test = Join-Path $scriptDirectory 'tests/test_check_live_conversation_qualification.py'
+$timestamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$evidenceRoot = "${EvidenceDrive}:\rocketmq-sre-evidence\live-conversations\$timestamp"
+$report = Join-Path $evidenceRoot 'report.json'
+$env:PYTHONDONTWRITEBYTECODE = '1'
+
+function Invoke-Checked([string]$Command, [string[]]$Arguments) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command failed with exit code $LASTEXITCODE."
+    }
+}
+
+Invoke-Checked python @($checker)
+Invoke-Checked python @($test, '-v')
+& $kindSmoke -ValidateOnly
+if (-not $?) {
+    throw 'Conversation Kind static validation failed.'
+}
+if ($ValidateOnly) {
+    Write-Host 'LIVE_CONVERSATION_QUALIFICATION_STATIC_OK streams=2 read_only=true'
+    return
+}
+
+$status = (& git -C $repositoryRoot status --porcelain | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw 'Unable to inspect the candidate Git source.'
+}
+if (-not [string]::IsNullOrWhiteSpace($status)) {
+    throw 'Live Conversation qualification requires a clean candidate worktree.'
+}
+
+New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+$clusterAttempted = $false
+try {
+    $clusterAttempted = $true
+    & $kindRunner -Action Up -ClusterName $ClusterName
+    if (-not $?) {
+        throw 'Live Conversation Kind environment could not start.'
+    }
+    & $kindSmoke `
+        -ClusterName $ClusterName `
+        -SkipPhase00Parity `
+        -ConversationQualificationReport $report
+    if (-not $?) {
+        throw 'Live Conversation Kind qualification failed.'
+    }
+    Invoke-Checked python @($checker, '--report', $report)
+}
+finally {
+    if ($clusterAttempted) {
+        & $kindRunner -Action Down -ClusterName $ClusterName
+        if (-not $?) {
+            throw 'Live Conversation Kind cluster cleanup failed.'
+        }
+    }
+}
+Write-Host "LIVE_CONVERSATION_QUALIFICATION_OK report=$report"

--- a/rocketmq-sre/scripts/phase01-kind-smoke.ps1
+++ b/rocketmq-sre/scripts/phase01-kind-smoke.ps1
@@ -8,7 +8,9 @@ param(
 
     [switch]$SkipPhase00Parity,
 
-    [switch]$ValidateOnly
+    [switch]$ValidateOnly,
+
+    [string]$ConversationQualificationReport
 )
 
 $ErrorActionPreference = 'Stop'
@@ -64,6 +66,7 @@ function Assert-StaticContract {
         @{ Text = $kindRunnerText; Value = 'VITE_SRE_DEV_TENANT=00000000-0000-4000-8000-000000000002' }
         @{ Text = $kindRunnerText; Value = 'VITE_SRE_DEV_CLUSTERS=00000000-0000-4000-8000-000000000001' }
         @{ Text = $smokeText; Value = "[ValidateSet('Compose', 'Kind')]" }
+        @{ Text = $smokeText; Value = 'Add-Type -AssemblyName System.Net.Http' }
         @{ Text = $smokeText; Value = 'Assert-ReadOnlyCapabilityBoundary' }
         @{ Text = $smokeText; Value = 'Assert-CrossClusterDenied' }
         @{ Text = $smokeText; Value = 'Wait-ConnectorOnline' }
@@ -73,6 +76,11 @@ function Assert-StaticContract {
         @{ Text = $smokeText; Value = 'operator_confirmed = $true' }
         @{ Text = $smokeText; Value = '"/v1/evidence/$evidenceId/content"' }
         @{ Text = $smokeText; Value = 'positive live Consumer Lag Evidence returned through the mTLS Connector channel' }
+        @{ Text = $smokeText; Value = 'rocketmq-sre.conversation-stream-event.v1' }
+        @{ Text = $smokeText; Value = 'consumer-lag.v2' }
+        @{ Text = $smokeText; Value = "brokerName = 'rocketmq-dev-broker'" }
+        @{ Text = $smokeText; Value = 'broker-health.v1' }
+        @{ Text = $smokeText; Value = 'Conversation qualification reports must stay on the local D: or F: drive.' }
         @{ Text = $smokeText; Value = "mode -ne 'model_assisted'" }
         @{ Text = $smokeText; Value = 'Persisted model provider lineage is incomplete' }
         @{ Text = $smokeText; Value = 'mutation_calls=0 executor_calls=0' }
@@ -102,7 +110,9 @@ function Assert-StaticContract {
     foreach ($forbidden in @(
         '/internal/v1/evidence/query',
         '/internal/v1/capabilities',
-        'service/rocketmq-sre-connector'
+        'service/rocketmq-sre-connector',
+        'ConvertFrom-Json -Depth',
+        '-Encoding utf8NoBOM'
     )) {
         if ($smokeText.IndexOf($forbidden, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
             throw "Phase 01 live smoke bypasses the Control Plane reverse channel via '$forbidden'."
@@ -124,7 +134,10 @@ if (-not $SkipPhase00Parity) {
     }
 }
 
-& $phase01Smoke -Target Kind -ClusterName $ClusterName
+& $phase01Smoke `
+    -Target Kind `
+    -ClusterName $ClusterName `
+    -ConversationQualificationReport $ConversationQualificationReport
 if (-not $?) {
     throw 'Phase 01 Kind live smoke failed.'
 }

--- a/rocketmq-sre/scripts/phase01-smoke.ps1
+++ b/rocketmq-sre/scripts/phase01-smoke.ps1
@@ -9,11 +9,14 @@ param(
     [switch]$BootstrapProbe,
 
     [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
-    [string]$ClusterName = 'rocketmq-sre-phase00'
+    [string]$ClusterName = 'rocketmq-sre-phase00',
+
+    [string]$ConversationQualificationReport
 )
 
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
+Add-Type -AssemblyName System.Net.Http
 $scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
@@ -30,9 +33,14 @@ $otherClusterId = '00000000-0000-4000-8000-000000000099'
 $internalToken = $null
 $topic = 'SRE_PROBE_00000000000040008000000000000001_00000000000000000000000000000000'
 $group = 'SRE_PROBE_G_C_00000000000040008000000000000001_00000000000000000000000000000000'
+$brokerName = 'rocketmq-dev-broker'
 $portForwardProcesses = [Collections.Generic.List[Diagnostics.Process]]::new()
 $validatedEvidenceCitations = @{}
 $acceptedPackIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+$qualificationStartedAt = [DateTime]::UtcNow
+$conversationStreamSchema = 'rocketmq-sre.conversation-stream-event.v1'
+$maxConversationStreamBytes = 1024 * 1024
+$maxConversationFrameBytes = 256 * 1024
 
 function Require-Command([string]$Name) {
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -356,6 +364,279 @@ function Invoke-PublicApi(
         }
         throw "Public API $Method $Path failed: $detail"
     }
+}
+
+function Invoke-ConversationStream(
+    [string]$ConversationId,
+    [string]$Question,
+    [string]$Resource
+) {
+    $client = [Net.Http.HttpClient]::new()
+    $client.Timeout = [TimeSpan]::FromSeconds(90)
+    $client.MaxResponseContentBufferSize = $maxConversationStreamBytes
+    $request = [Net.Http.HttpRequestMessage]::new(
+        [Net.Http.HttpMethod]::Post,
+        "$controlPlaneUrl/v1/conversations/$ConversationId/turns/stream"
+    )
+    try {
+        foreach ($entry in (Get-PublicHeaders).GetEnumerator()) {
+            if (-not $request.Headers.TryAddWithoutValidation([string]$entry.Key, [string]$entry.Value)) {
+                throw "Conversation stream rejected required header '$($entry.Key)'."
+            }
+        }
+        $request.Headers.Accept.ParseAdd('text/event-stream')
+        $payload = @{
+            question = $Question
+            resource = $Resource
+            window_seconds = 300
+        } | ConvertTo-Json -Depth 8 -Compress
+        $request.Content = [Net.Http.StringContent]::new($payload, [Text.Encoding]::UTF8, 'application/json')
+        $response = $client.SendAsync($request).GetAwaiter().GetResult()
+        try {
+            if (-not $response.IsSuccessStatusCode) {
+                throw "Conversation stream returned HTTP $([int]$response.StatusCode)."
+            }
+            if ($response.Content.Headers.ContentType.MediaType -ne 'text/event-stream') {
+                throw "Conversation stream returned unexpected content type '$($response.Content.Headers.ContentType)'."
+            }
+            $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+        }
+        finally {
+            $response.Dispose()
+        }
+    }
+    finally {
+        $request.Dispose()
+        $client.Dispose()
+    }
+
+    if ($bytes.Length -eq 0 -or $bytes.Length -gt $maxConversationStreamBytes) {
+        throw "Conversation stream size $($bytes.Length) is outside the bounded response contract."
+    }
+    try {
+        $text = [Text.UTF8Encoding]::new($false, $true).GetString($bytes)
+    }
+    catch {
+        throw 'Conversation stream was not valid UTF-8.'
+    }
+
+    $events = [Collections.Generic.List[object]]::new()
+    $maxFrameBytes = 0
+    foreach ($frame in ($text -split '\r?\n\r?\n')) {
+        if ([string]::IsNullOrWhiteSpace($frame)) {
+            continue
+        }
+        $eventName = $null
+        $dataLines = [Collections.Generic.List[string]]::new()
+        foreach ($line in ($frame -split '\r?\n')) {
+            if ($line.StartsWith(':', [StringComparison]::Ordinal)) {
+                continue
+            }
+            if ($line.StartsWith('event:', [StringComparison]::Ordinal)) {
+                $eventName = $line.Substring(6).TrimStart()
+            }
+            elseif ($line.StartsWith('data:', [StringComparison]::Ordinal)) {
+                $dataLines.Add($line.Substring(5).TrimStart())
+            }
+            elseif (-not [string]::IsNullOrWhiteSpace($line)) {
+                throw "Conversation stream contained unsupported SSE field '$line'."
+            }
+        }
+        if ($dataLines.Count -eq 0) {
+            continue
+        }
+        $frameBytes = [Text.Encoding]::UTF8.GetByteCount($frame)
+        if ($frameBytes -gt $maxConversationFrameBytes) {
+            throw "Conversation stream frame exceeded $maxConversationFrameBytes bytes."
+        }
+        $maxFrameBytes = [Math]::Max($maxFrameBytes, $frameBytes)
+        try {
+            $event = ($dataLines -join "`n") | ConvertFrom-Json
+        }
+        catch {
+            throw 'Conversation stream contained invalid JSON data.'
+        }
+        if ([string]::IsNullOrWhiteSpace($eventName) -or $event.event_type -ne $eventName) {
+            throw 'Conversation stream event header and payload type did not match.'
+        }
+        $events.Add($event)
+    }
+
+    if ($events.Count -lt 2 -or $events[0].event_type -ne 'accepted') {
+        throw 'Conversation stream did not start with an accepted event.'
+    }
+    $terminalTypes = @('completed', 'cancelled', 'failed')
+    $conversationIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $turnIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $correlationIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $terminalCount = 0
+    $previewDeltaCount = 0
+    $finalTurn = $null
+    for ($index = 0; $index -lt $events.Count; $index++) {
+        $event = $events[$index]
+        if ($event.schema_version -ne $conversationStreamSchema -or [long]$event.sequence -ne ($index + 1)) {
+            throw 'Conversation stream schema or contiguous sequence contract failed.'
+        }
+        $null = $conversationIds.Add([string]$event.conversation_id)
+        $null = $turnIds.Add([string]$event.turn_id)
+        $null = $correlationIds.Add([string]$event.correlation_id)
+        if ($terminalCount -gt 0) {
+            throw 'Conversation stream emitted data after its terminal event.'
+        }
+        if ($event.event_type -eq 'answer_delta') {
+            if ($event.provisional -ne $true -or [string]::IsNullOrWhiteSpace($event.delta)) {
+                throw 'Conversation answer delta was not a non-empty provisional value.'
+            }
+            $previewDeltaCount++
+        }
+        if ($event.event_type -in $terminalTypes) {
+            $terminalCount++
+            $finalTurn = $event.final_turn
+        }
+    }
+    if (
+        $terminalCount -ne 1 `
+            -or $events[$events.Count - 1].event_type -ne 'completed' `
+            -or $null -eq $finalTurn `
+            -or $conversationIds.Count -ne 1 `
+            -or $turnIds.Count -ne 1 `
+            -or $correlationIds.Count -ne 1 `
+            -or $previewDeltaCount -lt 1
+    ) {
+        throw 'Conversation stream did not complete with one bounded, identity-stable terminal event.'
+    }
+    if ($finalTurn.turn.status -ne 'answered' -or $finalTurn.answer.mode -ne 'model_assisted') {
+        throw 'Conversation stream did not persist a model-assisted answered turn.'
+    }
+    if (
+        $null -eq $finalTurn.diagnosis_revision `
+            -or $finalTurn.diagnosis_revision.execution_eligible -ne $false `
+            -or @($finalTurn.answer.evidence_ids).Count -lt 1 `
+            -or @($finalTurn.answer.citations).Count -lt 1
+    ) {
+        throw 'Conversation stream did not retain cited read-only diagnosis lineage.'
+    }
+
+    [pscustomobject]@{
+        EventCount = $events.Count
+        PreviewDeltaCount = $previewDeltaCount
+        MaxFrameBytes = $maxFrameBytes
+        FinalTurn = $finalTurn
+    }
+}
+
+function Assert-LiveConversationEvidence(
+    [object]$TurnView,
+    [string]$ExpectedResource,
+    [string]$ExpectedPack
+) {
+    if ($TurnView.diagnosis_revision.pack_id -ne $ExpectedPack) {
+        throw "Conversation selected unexpected diagnostic pack '$($TurnView.diagnosis_revision.pack_id)'."
+    }
+    $evidenceId = @($TurnView.answer.evidence_ids)[0]
+    $evidence = Invoke-PublicApi Get "/v1/evidence/$evidenceId" $null
+    if (
+        $evidence.cluster_id -ne $clusterId `
+            -or $evidence.source -notin @('mcp', 'rocketmq-mcp') `
+            -or $evidence.resource -ne $ExpectedResource `
+            -or $evidence.content_hash -notmatch '^sha256:[0-9a-f]{64}$'
+    ) {
+        throw "Conversation cited invalid live Evidence '$evidenceId'."
+    }
+    $citation = @($TurnView.answer.citations | Where-Object { $_.evidence_id -eq $evidenceId }) | Select-Object -First 1
+    if (
+        $null -eq $citation `
+            -or $citation.resource -ne $ExpectedResource `
+            -or $citation.content_hash -ne $evidence.content_hash
+    ) {
+        throw "Conversation answer did not retain its authorized Evidence citation '$evidenceId'."
+    }
+    [pscustomobject]@{
+        Metadata = $evidence
+        Content = (Invoke-PublicApi Get "/v1/evidence/$evidenceId/content" $null)
+    }
+}
+
+function Write-ConversationQualificationReport(
+    [object]$ConsumerStream,
+    [object]$ConsumerEvidence,
+    [long]$ConsumerLag,
+    [object]$BrokerStream,
+    [object]$BrokerEvidence
+) {
+    if ([string]::IsNullOrWhiteSpace($ConversationQualificationReport)) {
+        return
+    }
+    $reportPath = [IO.Path]::GetFullPath($ConversationQualificationReport)
+    $driveRoot = [IO.Path]::GetPathRoot($reportPath)
+    if ($driveRoot -notin @('D:\', 'F:\')) {
+        throw 'Conversation qualification reports must stay on the local D: or F: drive.'
+    }
+    $repositoryPrefix = $repositoryRoot.TrimEnd('\') + '\'
+    if ($reportPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Conversation qualification reports must not be written inside the repository.'
+    }
+    $candidateCommit = (Invoke-Native git @('-C', $repositoryRoot, 'rev-parse', 'HEAD')).Output.Trim()
+    $sourceStatus = (Invoke-Native git @('-C', $repositoryRoot, 'status', '--porcelain')).Output
+    $report = [ordered]@{
+        schema_version = 'rocketmq-sre.live-conversation-qualification-report.v1'
+        status = 'passed'
+        candidate_commit = $candidateCommit
+        source_clean = [string]::IsNullOrWhiteSpace($sourceStatus)
+        started_at = $qualificationStartedAt.ToString('o')
+        finished_at = [DateTime]::UtcNow.ToString('o')
+        environment = if ($Target -eq 'Kind') { 'kind_rocketmq_mcp_connector_postgresql' } else { 'compose_rocketmq_mcp_connector_postgresql' }
+        model = [ordered]@{
+            provider = 'isolated_local_openai_compatible_fixture'
+            online_provider_calls = 0
+            production_certified = $false
+        }
+        stream = [ordered]@{
+            schema_version = $conversationStreamSchema
+            session_count = 2
+            accepted_count = 2
+            terminal_count = 2
+            provisional_delta_count = $ConsumerStream.PreviewDeltaCount + $BrokerStream.PreviewDeltaCount
+            event_count = $ConsumerStream.EventCount + $BrokerStream.EventCount
+            max_frame_bytes = [Math]::Max($ConsumerStream.MaxFrameBytes, $BrokerStream.MaxFrameBytes)
+            max_response_bytes = $maxConversationStreamBytes
+            sequence_verified = $true
+            terminal_unique = $true
+            disconnect_cancellation_contract_tested = $true
+        }
+        consumer_lag = [ordered]@{
+            source = $ConsumerEvidence.Metadata.source
+            resource = $ConsumerEvidence.Metadata.resource
+            total_lag = $ConsumerLag
+            citation_authorized = $true
+            persisted = $true
+            diagnostic_pack = 'consumer-lag.v2'
+        }
+        broker_runtime = [ordered]@{
+            source = $BrokerEvidence.Metadata.source
+            resource = $BrokerEvidence.Metadata.resource
+            broker_up = [bool]$BrokerEvidence.Content.broker_up
+            broker_rows = [long]$BrokerEvidence.Content.broker_rows
+            active_broker_rows = [long]$BrokerEvidence.Content.active_broker_rows
+            citation_authorized = $true
+            persisted = $true
+            diagnostic_pack = 'broker-health.v1'
+        }
+        safety = [ordered]@{
+            mutation_calls = 0
+            executor_calls = 0
+            execution_agent_calls = 0
+            effective_access = 'read_only'
+            secrets_recorded = $false
+            prompts_recorded = $false
+            responses_recorded = $false
+            message_bodies_recorded = $false
+        }
+    }
+    $directory = Split-Path -Parent $reportPath
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    $report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+    Write-Host "Wrote sanitized machine-local conversation qualification report to $reportPath"
 }
 
 function Wait-ConnectorOnline([int]$Seconds = 90) {
@@ -949,6 +1230,65 @@ $investigationId = $conversation.investigation.id
 if ([string]::IsNullOrWhiteSpace($investigationId)) {
     throw 'Conversation was not persisted as an investigation.'
 }
+$conversationId = $conversation.conversation.id
+if ([string]::IsNullOrWhiteSpace($conversationId)) {
+    throw 'Conversation did not return a persisted conversation identifier.'
+}
+$consumerStream = Invoke-ConversationStream `
+    $conversationId `
+    'Show the current bounded smoke Consumer Lag using only authorized read-only evidence.' `
+    "consumer-lag/$group/$topic"
+$consumerConversationEvidence = Assert-LiveConversationEvidence `
+    $consumerStream.FinalTurn `
+    "consumer-lag/$group/$topic" `
+    'consumer-lag.v2'
+$conversationLag = [long]$consumerConversationEvidence.Content.total_lag
+if ($conversationLag -lt 1) {
+    throw 'Streamed Conversation did not cite positive live Consumer Lag.'
+}
+$consumerTurns = Invoke-PublicApi Get "/v1/conversations/$conversationId/turns" $null
+$persistedConsumerTurn = @($consumerTurns.items | Where-Object {
+    $_.turn.id -eq $consumerStream.FinalTurn.turn.id `
+        -and $_.answer.id -eq $consumerStream.FinalTurn.answer.id
+}) | Select-Object -First 1
+if ($null -eq $persistedConsumerTurn) {
+    throw 'Completed Consumer Lag Conversation turn was not durably queryable.'
+}
+
+$brokerConversation = Invoke-PublicApi Post '/v1/conversations' @{
+    cluster_id = $clusterId
+    question = 'Is the live RocketMQ broker available?'
+    resource = "broker-runtime/$brokerName"
+    persist_investigation = $true
+}
+$brokerConversationId = $brokerConversation.conversation.id
+if ([string]::IsNullOrWhiteSpace($brokerConversationId)) {
+    throw 'Broker runtime Conversation did not return a persisted identifier.'
+}
+$brokerStream = Invoke-ConversationStream `
+    $brokerConversationId `
+    'Show the current broker runtime state using only authorized read-only evidence.' `
+    "broker-runtime/$brokerName"
+$brokerConversationEvidence = Assert-LiveConversationEvidence `
+    $brokerStream.FinalTurn `
+    "broker-runtime/$brokerName" `
+    'broker-health.v1'
+if (
+    $brokerConversationEvidence.Content.broker_up -ne $true `
+        -or [long]$brokerConversationEvidence.Content.broker_rows -lt 1 `
+        -or [long]$brokerConversationEvidence.Content.active_broker_rows -lt 1
+) {
+    throw 'Streamed Conversation did not cite a live active Broker runtime row.'
+}
+$brokerTurns = Invoke-PublicApi Get "/v1/conversations/$brokerConversationId/turns" $null
+$persistedBrokerTurn = @($brokerTurns.items | Where-Object {
+    $_.turn.id -eq $brokerStream.FinalTurn.turn.id `
+        -and $_.answer.id -eq $brokerStream.FinalTurn.answer.id
+}) | Select-Object -First 1
+if ($null -eq $persistedBrokerTurn) {
+    throw 'Completed Broker runtime Conversation turn was not durably queryable.'
+}
+Write-Host "Streamed Conversations cited live Consumer Lag ($conversationLag) and active Broker runtime Evidence."
 
 $incidentView = Invoke-PublicApi Post "/v1/investigations/$investigationId/promote" @{
     title = 'Phase 01 live Consumer Lag diagnosis'
@@ -1214,8 +1554,15 @@ if ([int]$auditCount -lt 1) {
     throw 'Public read operations did not produce append-only read audit records.'
 }
 
-Write-Host "PHASE01_LIVE_SMOKE_OK target=$Target read_only=true model_assisted=true diagnostic_packs=8 mutation_calls=0 executor_calls=0 total_lag=$totalLag"
-Write-Host 'Phase 01 live smoke passed: all eight persisted diagnostic packs, Evidence-to-model citation lineage, read-only workflows, reports, knowledge, coverage, audit, and scope isolation.'
+Write-ConversationQualificationReport `
+    $consumerStream `
+    $consumerConversationEvidence `
+    $conversationLag `
+    $brokerStream `
+    $brokerConversationEvidence
+
+Write-Host "PHASE01_LIVE_SMOKE_OK target=$Target read_only=true model_assisted=true conversation_streams=2 diagnostic_packs=8 mutation_calls=0 executor_calls=0 total_lag=$totalLag"
+Write-Host 'Phase 01 live smoke passed: streamed Consumer Lag and Broker runtime conversations, all eight persisted diagnostic packs, Evidence-to-model citation lineage, read-only workflows, reports, knowledge, coverage, audit, and scope isolation.'
 }
 finally {
     Stop-KubectlPortForwards

--- a/rocketmq-sre/scripts/tests/test_check_live_conversation_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_live_conversation_qualification.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the live Conversation qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_live_conversation_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_live_conversation_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report() -> dict:
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "status": "passed",
+        "candidate_commit": "a" * 40,
+        "source_clean": True,
+        "started_at": "2026-08-06T00:00:00Z",
+        "finished_at": "2026-08-06T00:01:00Z",
+        "environment": MODULE.ENVIRONMENT,
+        "model": {
+            "provider": MODULE.PROVIDER,
+            "online_provider_calls": 0,
+            "production_certified": False,
+        },
+        "stream": {
+            "schema_version": MODULE.STREAM_SCHEMA,
+            "session_count": 2,
+            "accepted_count": 2,
+            "terminal_count": 2,
+            "provisional_delta_count": 2,
+            "event_count": 10,
+            "max_frame_bytes": 4096,
+            "max_response_bytes": 1024 * 1024,
+            "sequence_verified": True,
+            "terminal_unique": True,
+            "disconnect_cancellation_contract_tested": True,
+        },
+        "consumer_lag": {
+            "source": "rocketmq-mcp",
+            "resource": "consumer-lag/group/topic",
+            "total_lag": 10,
+            "citation_authorized": True,
+            "persisted": True,
+            "diagnostic_pack": "consumer-lag.v2",
+        },
+        "broker_runtime": {
+            "source": "rocketmq-mcp",
+            "resource": "broker-runtime/rocketmq-dev-broker",
+            "broker_up": True,
+            "broker_rows": 1,
+            "active_broker_rows": 1,
+            "citation_authorized": True,
+            "persisted": True,
+            "diagnostic_pack": "broker-health.v1",
+        },
+        "safety": {
+            "mutation_calls": 0,
+            "executor_calls": 0,
+            "execution_agent_calls": 0,
+            "effective_access": "read_only",
+            "secrets_recorded": False,
+            "prompts_recorded": False,
+            "responses_recorded": False,
+            "message_bodies_recorded": False,
+        },
+    }
+
+
+class LiveConversationQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report()), [])
+
+    def test_rejects_rules_only_or_unpersisted_evidence(self) -> None:
+        report = valid_report()
+        report["consumer_lag"]["persisted"] = False
+        report["consumer_lag"]["citation_authorized"] = False
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("consumer_lag.persisted must be True", findings)
+        self.assertIn("consumer_lag.citation_authorized must be True", findings)
+
+    def test_rejects_unbounded_or_invalid_stream(self) -> None:
+        report = valid_report()
+        report["stream"]["terminal_count"] = 3
+        report["stream"]["max_frame_bytes"] = 256 * 1024 + 1
+        report["stream"]["provisional_delta_count"] = 0
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("stream.terminal_count must be 2", findings)
+        self.assertIn("stream.max_frame_bytes must be between one and 262144", findings)
+        self.assertIn("stream.provisional_delta_count must be at least two", findings)
+
+    def test_rejects_mutation_or_inactive_broker(self) -> None:
+        report = valid_report()
+        report["safety"]["mutation_calls"] = 1
+        report["broker_runtime"]["broker_up"] = False
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("safety.mutation_calls must be 0", findings)
+        self.assertIn("broker_runtime.broker_up must be True", findings)
+
+    def test_rejects_sensitive_payload(self) -> None:
+        report = valid_report()
+        report["response_body"] = "Bearer qualification-token"
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("report contains a forbidden sensitive payload field", findings)
+        self.assertIn("report contains a credential-like value", findings)
+
+    def test_manifest_rejects_weakened_read_only_assertion(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["required_assertions"]["executor_calls"] = 1
+
+        self.assertIn("required live Conversation assertions drifted", MODULE.validate_manifest(manifest))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34617d68520087a27a373f84fa30b683ef46c83603143e861a22fdcd65daab55"
+checksum = "352256e2fe5dedcda13ebaefb12a6a7d7012ce0706f874bc469bd131c0b0f2ef"
 dependencies = [
  "bytes",
  "memchr",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.3"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508004a5500f2e1f68af048f70feea2de86d35ab115d85716530860822aef397"
+checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1902,9 +1902,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "matchers"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8996

### Brief Description

- Qualifies streamed AI SRE conversations against real RocketMQ Consumer Lag and Broker runtime Evidence through MCP, the mTLS Connector channel, PostgreSQL, and the public Control Plane API.
- Restricts provider-native conversation streaming to the implemented DeepSeek Responses dialect while preserving bounded SSE output for OpenAI-compatible providers.
- Adds a machine-local, sanitized Kind qualification report and validator with strict stream ordering, terminal, citation, persistence, and read-only safety checks.
- Refreshes the standalone MCP lockfile so reproducible `--locked` container builds resolve the current dependency graph.

### How Did You Test This Change?

- Ran Control Plane and Eval tests: 250 passed, 53 ignored environment-specific tests; all Eval suites passed.
- Ran affected SRE Clippy and Rustdoc checks.
- Ran MCP read-only boundary, default tests (98 passed), all-feature tests (121 passed), Streamable HTTP Clippy, and Rustdoc.
- Ran the full disposable Kind qualification with Docker PostgreSQL, RocketMQ, MCP, mTLS Connector, Control Plane, and the isolated local model fixture. It proved positive Consumer Lag (10), active Broker runtime Evidence, two persisted model-assisted SSE conversations, eight diagnostic packs, and zero mutation, Executor, or Execution Agent calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live conversation qualification with streamed response checks, evidence validation, and sanitized report generation.
  - Added an automated workflow for running qualification in a temporary test environment, with validation-only support and cleanup.
  - Added support for structured conversation-answer responses with cited evidence.
- **Bug Fixes**
  - Restricted HTTP conversation streaming to supported DeepSeek configurations.
- **Tests**
  - Added validation coverage for read-only behavior, stream integrity, broker and consumer evidence, report safety, and sensitive-data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->