### PR TITLE
[ISSUE #8998]✨Reduce request header frame encoding allocations

### DIFF
--- a/rocketmq-protocol/src/protocol/command_custom_header.rs
+++ b/rocketmq-protocol/src/protocol/command_custom_header.rs
@@ -121,7 +121,10 @@ pub trait CommandCustomHeader: AsAny {
     ///
     /// Implementations must require only shared access so cloned remoting
     /// commands can encode the same immutable header. Callers must check
-    /// [`Self::encode_capability`] before invoking this method.
+    /// [`Self::encode_capability`] before invoking this method. Implementations
+    /// are responsible for validating the header before the first write; the
+    /// frame entrypoint does not pre-validate because map and binary encoders
+    /// already own the authoritative validation boundary.
     ///
     /// # Errors
     ///

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -547,9 +547,6 @@ impl RemotingCommand {
 
     #[inline]
     fn try_fast_header_encode_inner(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
-        if let Some(header) = self.command_custom_header_ref() {
-            header.check_fields()?;
-        }
         match self.serialize_type {
             SerializeType::JSON => self.fast_encode_json(dst),
             SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst),
@@ -562,30 +559,29 @@ impl RemotingCommand {
         self.try_make_custom_header_to_net()
             .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
 
-        // Pre-calculate approximate header size to reduce reallocations
         let estimated_header_size = self.estimate_json_header_size();
         let body_length = self.body.as_ref().map_or(0, |b| b.len());
+        let begin_index = dst.len();
 
-        // Reserve only prefix + header. The body remains an independent `Bytes` segment for
-        // plaintext vectored writes and is coalesced later only by the TLS writer.
         dst.reserve(8 + estimated_header_size);
+        dst.put_i64(0);
+        let header_index = dst.len();
 
-        // Encode header using simd-json for better performance when available
         #[cfg(feature = "simd")]
-        let encode_result = simd_json::to_vec(self);
+        let encode_result = simd_json::to_writer((&mut *dst).writer(), self);
 
         #[cfg(not(feature = "simd"))]
-        let encode_result = serde_json::to_vec(self);
+        let encode_result = serde_json::to_writer((&mut *dst).writer(), self);
 
-        let header_bytes = encode_result.map_err(|error| {
+        encode_result.map_err(|error| {
             rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string())
         })?;
+        let header_length = dst.len() - header_index;
         let (total_length, marked_header_length) =
-            Self::checked_frame_lengths(header_bytes.len(), body_length, SerializeType::JSON)?;
+            Self::checked_frame_lengths(header_length, body_length, SerializeType::JSON)?;
 
-        dst.put_i32(total_length);
-        dst.put_i32(marked_header_length);
-        dst.put_slice(&header_bytes);
+        dst[begin_index..begin_index + 4].copy_from_slice(&total_length.to_be_bytes());
+        dst[begin_index + 4..begin_index + 8].copy_from_slice(&marked_header_length.to_be_bytes());
         Ok(())
     }
 
@@ -593,9 +589,9 @@ impl RemotingCommand {
     #[inline]
     fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
         let begin_index = dst.len();
+        let estimated_header_size = RocketMQSerializable::estimate_encode_size(self);
 
-        // Reserve space for total_length (4 bytes) and serialize_type (4 bytes)
-        dst.reserve(8);
+        dst.reserve(8usize.saturating_add(estimated_header_size));
         dst.put_i64(0); // Placeholder for total_length + serialize_type
 
         let capability = self.custom_header_encode_capability();

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -232,21 +232,25 @@ impl RocketMQSerializable {
 
     /// Estimate the size needed for encoding to reduce reallocations
     #[inline]
-    fn estimate_encode_size(cmd: &RemotingCommand) -> usize {
-        let mut size = 17; // Fixed header fields (13) plus the ext-map length (4).
+    pub(crate) fn estimate_encode_size(cmd: &RemotingCommand) -> usize {
+        let mut size = 17usize; // Fixed header fields (13) plus the ext-map length (4).
 
         // Remark size
         if let Some(remark) = cmd.remark() {
-            size += 4 + remark.len(); // length prefix + data
+            size = size.saturating_add(4usize.saturating_add(remark.len())); // length prefix + data
         } else {
-            size += 4; // just the length prefix (0)
+            size = size.saturating_add(4); // just the length prefix (0)
         }
 
         // Ext fields size (approximate)
         if let Some(ext) = cmd.ext_fields() {
             for (k, v) in ext.iter() {
                 if !k.is_empty() {
-                    size += 2 + k.len() + 4 + v.len();
+                    size = size
+                        .saturating_add(2)
+                        .saturating_add(k.len())
+                        .saturating_add(4)
+                        .saturating_add(v.len());
                 }
             }
         }

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
@@ -31,9 +33,10 @@ use rocketmq_protocol::protocol::header_codec::{
 };
 #[allow(deprecated, reason = "verifies the source-compatible legacy adapter delegates to V3")]
 use rocketmq_protocol::protocol::FastCodesHeader;
+use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader;
-use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderEncodeCapability, HeaderMap};
+use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderEncodeCapability, HeaderMap, RemotingCommand};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -93,6 +96,27 @@ struct RegisteredSchema {
     local_fields: &'static [HeaderFieldSpec],
     fields: Vec<HeaderFieldSpec>,
     flattens: Vec<HeaderFlattenSpec>,
+}
+
+static VALIDATION_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "fixtures::SingleValidationHeader",
+    crate = "rocketmq_protocol",
+    validate = "Self::count_validation",
+    fast
+)]
+struct SingleValidationHeader {
+    #[header(required)]
+    value: CheetahString,
+}
+
+impl SingleValidationHeader {
+    fn count_validation(&self) -> Result<(), HeaderCodecError> {
+        VALIDATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
 }
 
 fn register<T: HeaderCodec + CommandCustomHeader + Default>() -> RegisteredSchema {
@@ -353,6 +377,25 @@ fn typed_validation_errors_remain_classified_and_redacted() {
         })
     ));
     assert!(map.is_empty());
+}
+
+#[test]
+fn frame_encoding_validates_each_typed_header_once() {
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        VALIDATION_CALLS.store(0, Ordering::Relaxed);
+        let header = SingleValidationHeader { value: "value".into() };
+        let mut command = RemotingCommand::create_request_command(100, header).set_serialize_type(serialize_type);
+        let mut encoded = BytesMut::new();
+
+        command.try_fast_header_encode(&mut encoded).unwrap();
+
+        assert!(!encoded.is_empty());
+        assert_eq!(
+            VALIDATION_CALLS.load(Ordering::Relaxed),
+            1,
+            "{serialize_type:?} must validate through its authoritative encoder exactly once"
+        );
+    }
 }
 
 fn decode_fast_fields(encoded: &[u8]) -> HeaderMap {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #8998

### Brief Description

Validate typed request headers only in their authoritative map or direct-binary encoder instead of repeating validation at the frame entrypoint. Reserve the ROCKETMQ prefix and estimated header capacity together, and serialize JSON directly into the destination buffer before checked length backpatching. Existing collision handling, wire fixtures, length limits, and destination rollback remain unchanged.

A same-machine 10-sample diagnostic A/B reported `1.061x` weighted ROCKETMQ encode speedup, `1.075x` weighted JSON encode speedup, and `1.068x` across all production encode operations. Every ROCKETMQ encode case used one fewer allocation; JSON encode cases used two to four fewer allocations. These diagnostic values are not release-gate evidence.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check` - passed.
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_registry` - passed, 7 tests.
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility` - passed, 4 tests.
- `cargo test -p rocketmq-protocol remoting_command::tests::` - passed, 15 tests.
- `cargo test -p rocketmq-protocol --all-features` - passed, including 1,434 unit tests, integration tests, UI tests, and doctests.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/` - passed.
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings` - blocked by four pre-existing Cheetah 3.0 deprecations; the same findings reproduce on the unmodified base commit.
- The locked renamed-consumer and standalone example checks stop before compilation because their checked-in lock files require an existing dependency refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved message encoding efficiency by reducing unnecessary processing and memory allocation.
  * Optimized JSON and RocketMQ frame generation for faster serialization.

* **Reliability**
  * Improved handling of large message metadata to prevent size-calculation overflow.
  * Ensured message headers are validated consistently during encoding.

* **Documentation**
  * Clarified validation requirements for custom message headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->