### PR TITLE
[ISSUE #9007]✨Retain validated binary request header fields for lazy decoding

### DIFF
--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -20,6 +20,7 @@
 
 mod codec;
 mod error;
+mod field_source;
 mod schema;
 mod sink;
 mod value;
@@ -30,6 +31,7 @@ mod private {
 
 pub use codec::HeaderCodec;
 pub use error::HeaderCodecError;
+pub(crate) use field_source::BinaryHeaderFields;
 pub use schema::AliasConflictPolicy;
 pub use schema::DynamicCollisionPolicy;
 pub use schema::FlattenPresenceSpec;

--- a/rocketmq-protocol/src/protocol/header_codec/field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/field_source.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+
+use crate::HeaderMap;
+
+const KEY_LENGTH_BYTES: usize = 2;
+const VALUE_LENGTH_BYTES: usize = 4;
+const MAX_INITIAL_MAP_CAPACITY: usize = 1024;
+
+fn malformed_binary_fields(reason: &'static str) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+        format: "binary-header-fields",
+        message: reason.to_string(),
+    })
+}
+
+/// A validated, immutable ROCKETMQ extension-field payload.
+///
+/// Construction validates the complete payload before it is retained by a
+/// remoting command. Subsequent scans therefore need no allocation and cannot
+/// observe mutable bytes.
+#[derive(Clone)]
+pub(crate) struct BinaryHeaderFields {
+    payload: Bytes,
+    entry_count: usize,
+}
+
+impl BinaryHeaderFields {
+    /// Validates and retains one complete extension-field payload.
+    pub(crate) fn new(payload: Bytes) -> rocketmq_error::RocketMQResult<Self> {
+        let mut entry_count = 0usize;
+        Self::parse(&payload, &mut |_key, _value| {
+            entry_count = entry_count.saturating_add(1);
+            Ok(())
+        })?;
+        Ok(Self { payload, entry_count })
+    }
+
+    /// Visits the logical non-empty entries without allocating field strings.
+    pub(crate) fn try_for_each<'a>(
+        &'a self,
+        visitor: &mut dyn FnMut(&'a str, &'a str) -> rocketmq_error::RocketMQResult<()>,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        Self::parse(&self.payload, visitor)
+    }
+
+    /// Materializes the compatibility map. The payload has already been
+    /// validated, so a second parse can fail only if this module's immutable
+    /// representation invariant is broken.
+    pub(crate) fn materialize(&self) -> HeaderMap {
+        let mut map = HeaderMap::with_capacity(self.entry_count.min(MAX_INITIAL_MAP_CAPACITY));
+        let result = self.try_for_each(&mut |key, value| {
+            map.insert(CheetahString::from_slice(key), CheetahString::from_slice(value));
+            Ok(())
+        });
+        if result.is_err() {
+            map.clear();
+        }
+        map
+    }
+
+    fn parse<'a>(
+        payload: &'a [u8],
+        visitor: &mut dyn FnMut(&'a str, &'a str) -> rocketmq_error::RocketMQResult<()>,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let mut cursor = 0usize;
+        while cursor < payload.len() {
+            let key_length = Self::read_u16(payload, &mut cursor)?;
+            if key_length == 0 {
+                return Err(malformed_binary_fields("extension-field key is empty"));
+            }
+            let key = Self::read_utf8(payload, &mut cursor, key_length, "truncated extension-field key")?;
+
+            let value_length = Self::read_i32(payload, &mut cursor)?;
+            if value_length < 0 {
+                return Err(malformed_binary_fields("extension-field value length is negative"));
+            }
+            let value = Self::read_utf8(
+                payload,
+                &mut cursor,
+                value_length as usize,
+                "truncated extension-field value",
+            )?;
+
+            // Java-compatible ROCKETMQ map decoding treats zero-length values
+            // as absent rather than storing an empty string.
+            if !value.is_empty() {
+                visitor(key, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_u16(payload: &[u8], cursor: &mut usize) -> rocketmq_error::RocketMQResult<usize> {
+        let bytes = Self::take(payload, cursor, KEY_LENGTH_BYTES, "missing extension-field key length")?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]) as usize)
+    }
+
+    fn read_i32(payload: &[u8], cursor: &mut usize) -> rocketmq_error::RocketMQResult<i32> {
+        let bytes = Self::take(
+            payload,
+            cursor,
+            VALUE_LENGTH_BYTES,
+            "missing extension-field value length",
+        )?;
+        Ok(i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn read_utf8<'a>(
+        payload: &'a [u8],
+        cursor: &mut usize,
+        length: usize,
+        truncated_reason: &'static str,
+    ) -> rocketmq_error::RocketMQResult<&'a str> {
+        let bytes = Self::take(payload, cursor, length, truncated_reason)?;
+        std::str::from_utf8(bytes).map_err(|_| malformed_binary_fields("extension-field text is not valid UTF-8"))
+    }
+
+    fn take<'a>(
+        payload: &'a [u8],
+        cursor: &mut usize,
+        length: usize,
+        reason: &'static str,
+    ) -> rocketmq_error::RocketMQResult<&'a [u8]> {
+        let end = cursor
+            .checked_add(length)
+            .ok_or_else(|| malformed_binary_fields(reason))?;
+        let bytes = payload
+            .get(*cursor..end)
+            .ok_or_else(|| malformed_binary_fields(reason))?;
+        *cursor = end;
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BufMut;
+    use bytes::BytesMut;
+
+    use super::*;
+
+    fn entry(out: &mut BytesMut, key: &[u8], value: &[u8]) {
+        out.put_u16(key.len() as u16);
+        out.extend_from_slice(key);
+        out.put_i32(value.len() as i32);
+        out.extend_from_slice(value);
+    }
+
+    #[test]
+    fn validates_and_materializes_duplicate_and_empty_values() {
+        let mut payload = BytesMut::new();
+        entry(&mut payload, b"key", b"first");
+        entry(&mut payload, b"empty", b"");
+        entry(&mut payload, b"key", b"last");
+
+        let fields = BinaryHeaderFields::new(payload.freeze()).unwrap();
+        let map = fields.materialize();
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("key").map(CheetahString::as_str), Some("last"));
+        assert!(!map.contains_key("empty"));
+    }
+
+    #[test]
+    fn rejects_truncated_negative_empty_key_and_invalid_utf8_payloads() {
+        let invalid_payloads = [
+            Bytes::from_static(&[0]),
+            Bytes::from_static(&[0, 1]),
+            Bytes::from_static(&[0, 1, b'k', 0, 0, 0]),
+            Bytes::from_static(&[0, 1, b'k', 0xff, 0xff, 0xff, 0xff]),
+            Bytes::from_static(&[0, 0, 0, 0, 0, 1, b'v']),
+            Bytes::from_static(&[0, 1, 0xff, 0, 0, 0, 1, b'v']),
+            Bytes::from_static(&[0, 1, b'k', 0, 0, 0, 1, 0xff]),
+        ];
+
+        for payload in invalid_payloads {
+            assert!(BinaryHeaderFields::new(payload).is_err());
+        }
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -26,6 +26,7 @@ use cheetah_string::CheetahString;
 use rocketmq_model::version::RocketMqVersion;
 use serde::ser::SerializeMap;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
@@ -36,6 +37,7 @@ use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_field_merge::merge_header_and_dynamic;
 use crate::protocol::LanguageCode;
@@ -47,14 +49,15 @@ pub const REMOTING_VERSION_KEY: &str = "rocketmq.remoting.version";
 
 static REQUEST_ID: std::sync::LazyLock<Arc<AtomicI32>> = std::sync::LazyLock::new(|| Arc::new(AtomicI32::new(0)));
 
-fn serialize_ext_fields<S>(
-    ext_fields: &Option<HashMap<CheetahString, CheetahString>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+mod extension_fields;
+
+use extension_fields::ExtensionFields;
+
+fn serialize_ext_fields<S>(ext_fields: &ExtensionFields, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let Some(ext_fields) = ext_fields else {
+    let Some(ext_fields) = ext_fields.as_map() else {
         return serializer.serialize_none();
     };
     let mut entries = ext_fields.iter().collect::<Vec<_>>();
@@ -64,6 +67,13 @@ where
         map.serialize_entry(key, value)?;
     }
     map.end()
+}
+
+fn deserialize_ext_fields<'de, D>(deserializer: D) -> Result<ExtensionFields, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<HashMap<CheetahString, CheetahString>>::deserialize(deserializer).map(ExtensionFields::from_option)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -81,8 +91,13 @@ pub struct RemotingCommand {
     flag: i32,
     remark: Option<CheetahString>,
 
-    #[serde(rename = "extFields", serialize_with = "serialize_ext_fields")]
-    ext_fields: Option<HashMap<CheetahString, CheetahString>>,
+    #[serde(
+        rename = "extFields",
+        default,
+        serialize_with = "serialize_ext_fields",
+        deserialize_with = "deserialize_ext_fields"
+    )]
+    ext_fields: ExtensionFields,
 
     #[serde(skip)]
     body: Option<Bytes>,
@@ -127,7 +142,7 @@ impl fmt::Display for RemotingCommand {
             self.opaque,
             self.flag,
             self.remark.as_ref().unwrap_or(&CheetahString::default()),
-            self.ext_fields,
+            self.ext_fields.as_map(),
             self.serialize_type
         )
     }
@@ -153,7 +168,7 @@ impl RemotingCommand {
             opaque,
             flag: 0,
             remark: None,
-            ext_fields: None,
+            ext_fields: ExtensionFields::default(),
             body: None,
             suspended: false,
             command_custom_header: None,
@@ -259,7 +274,7 @@ impl RemotingCommand {
     {
         self.invalidate_materialized_custom_header();
         if let Some(header_fields) = command_custom_header.as_ref().and_then(|header| header.to_map()) {
-            self.ext_fields.get_or_insert_with(HashMap::new).extend(header_fields);
+            self.ext_fields.get_or_insert_map().extend(header_fields);
         }
         self.command_custom_header = None;
         self.custom_header_to_net = true;
@@ -344,7 +359,14 @@ impl RemotingCommand {
 
     #[inline]
     pub fn set_ext_fields(mut self, ext_fields: HashMap<CheetahString, CheetahString>) -> Self {
-        self.ext_fields = Some(ext_fields);
+        self.ext_fields.replace_map(ext_fields);
+        self.custom_header_to_net = false;
+        self
+    }
+
+    #[inline]
+    pub(crate) fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
+        self.ext_fields = ExtensionFields::from_rocketmq_raw(ext_fields);
         self.custom_header_to_net = false;
         self
     }
@@ -486,8 +508,8 @@ impl RemotingCommand {
         }
 
         if let Some(header) = self.command_custom_header_ref() {
-            let merged = merge_header_and_dynamic(header, self.ext_fields.as_ref())?;
-            self.ext_fields = Some(merged);
+            let merged = merge_header_and_dynamic(header, self.ext_fields.as_map())?;
+            self.ext_fields.replace_map(merged);
         }
         self.custom_header_to_net = true;
         Ok(())
@@ -503,7 +525,7 @@ impl RemotingCommand {
             return;
         }
 
-        let owned_keys = match (self.command_custom_header_ref(), self.ext_fields.as_ref()) {
+        let owned_keys = match (self.command_custom_header_ref(), self.ext_fields.as_map()) {
             (Some(header), Some(fields)) => {
                 let mut keys = fields
                     .keys()
@@ -517,7 +539,7 @@ impl RemotingCommand {
             }
             _ => Vec::new(),
         };
-        if let Some(fields) = self.ext_fields.as_mut() {
+        if let Some(fields) = self.ext_fields.as_map_mut() {
             for key in owned_keys {
                 fields.remove(&key);
             }
@@ -656,7 +678,7 @@ impl RemotingCommand {
             size += remark.len() + 20; // "remark":"..." + quotes
         }
 
-        if let Some(ref ext) = self.ext_fields {
+        if let Some(ext) = self.ext_fields.as_map() {
             // Approximate: each entry adds ~30 bytes overhead + key/value lengths
             size += ext.iter().map(|(k, v)| k.len() + v.len() + 30).sum::<usize>();
         }
@@ -866,7 +888,7 @@ impl RemotingCommand {
 
     #[inline]
     pub fn ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
-        self.ext_fields.as_ref()
+        self.ext_fields.as_map()
     }
 
     #[inline]
@@ -893,14 +915,14 @@ impl RemotingCommand {
     where
         T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
     {
-        match self.ext_fields {
+        match self.ext_fields.as_map() {
             None => Err(rocketmq_error::RocketMQError::Serialization(
                 rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
                     message: "ExtFields is None".to_string(),
                 },
             )),
-            Some(ref header) => T::from(header),
+            Some(header) => T::from(header),
         }
     }
 
@@ -909,14 +931,14 @@ impl RemotingCommand {
         T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
         T: Default + CommandCustomHeader,
     {
-        match self.ext_fields {
+        match self.ext_fields.as_map() {
             None => Err(rocketmq_error::RocketMQError::Serialization(
                 rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
                     message: "ExtFields is None".to_string(),
                 },
             )),
-            Some(ref header) => {
+            Some(header) => {
                 let mut target = T::default();
                 if target.support_fast_codec() {
                     target.decode_fast(header)?;
@@ -994,7 +1016,7 @@ impl RemotingCommand {
     }
 
     pub fn add_ext_field(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) -> &mut Self {
-        if let Some(ref mut ext) = self.ext_fields {
+        if let Some(ext) = self.ext_fields.as_map_mut() {
             ext.insert(key.into(), value.into());
         }
         self
@@ -1014,7 +1036,7 @@ impl RemotingCommand {
 
     #[inline]
     pub fn get_ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
-        self.ext_fields.as_ref()
+        self.ext_fields.as_map()
     }
 
     pub fn read_custom_header_ref<T>(&self) -> Option<&T>
@@ -1144,7 +1166,7 @@ impl RemotingCommand {
 
     #[inline]
     pub fn add_ext_field_if_not_exist(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) {
-        if let Some(ref mut ext) = self.ext_fields {
+        if let Some(ext) = self.ext_fields.as_map_mut() {
             ext.entry(key.into()).or_insert(value.into());
         }
     }
@@ -1155,8 +1177,8 @@ impl RemotingCommand {
     /// This method is idempotent and safe to call multiple times.
     #[inline]
     pub fn ensure_ext_fields_initialized(&mut self) {
-        if self.ext_fields.is_none() {
-            self.ext_fields = Some(std::collections::HashMap::new());
+        if self.ext_fields.is_absent() {
+            let _ = self.ext_fields.get_or_insert_map();
         }
     }
 
@@ -1443,6 +1465,92 @@ mod tests {
         assert!(decoded
             .ext_fields()
             .is_some_and(|fields| !fields.contains_key("transactionId")));
+    }
+
+    #[test]
+    fn rocketmq_decode_keeps_extension_fields_raw_until_compatibility_map_access() {
+        let mut command = RemotingCommand::create_remoting_command(1)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([
+                (
+                    CheetahString::from_static_str("alpha"),
+                    CheetahString::from_static_str("first"),
+                ),
+                (
+                    CheetahString::from_static_str("beta"),
+                    CheetahString::from_static_str("second"),
+                ),
+            ]));
+        let mut encoded = BytesMut::new();
+        command.try_fast_header_encode(&mut encoded).unwrap();
+
+        let decoded = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+
+        assert!(decoded.ext_fields.is_rocketmq_raw());
+        assert!(!decoded.ext_fields.has_materialized_map());
+        let cloned = decoded.clone();
+        assert!(cloned.ext_fields.is_rocketmq_raw());
+        assert!(!cloned.ext_fields.has_materialized_map());
+
+        let fields = decoded.ext_fields().unwrap();
+        assert_eq!(fields.get("alpha").map(CheetahString::as_str), Some("first"));
+        assert_eq!(fields.get("beta").map(CheetahString::as_str), Some("second"));
+        assert!(decoded.ext_fields.is_rocketmq_raw());
+        assert!(decoded.ext_fields.has_materialized_map());
+        assert!(!cloned.ext_fields.has_materialized_map());
+
+        let json = serde_json::to_value(&cloned).unwrap();
+        assert_eq!(json["extFields"]["alpha"], "first");
+        assert_eq!(json["extFields"]["beta"], "second");
+        assert!(cloned.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn mutating_raw_extension_fields_materializes_and_invalidates_the_raw_view() {
+        let mut command = RemotingCommand::create_remoting_command(1)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([(
+                CheetahString::from_static_str("alpha"),
+                CheetahString::from_static_str("first"),
+            )]));
+        let mut encoded = BytesMut::new();
+        command.try_fast_header_encode(&mut encoded).unwrap();
+        let mut decoded = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+        assert!(decoded.ext_fields.is_rocketmq_raw());
+
+        decoded.add_ext_field("beta", "second");
+
+        assert!(!decoded.ext_fields.is_rocketmq_raw());
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get("alpha"))
+                .map(CheetahString::as_str),
+            Some("first")
+        );
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get("beta"))
+                .map(CheetahString::as_str),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn rocketmq_envelope_rejects_invalid_utf8_before_returning_a_command() {
+        let mut command = RemotingCommand::create_remoting_command(1)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([(
+                CheetahString::from_static_str("key"),
+                CheetahString::from_static_str("v"),
+            )]));
+        let mut encoded = BytesMut::new();
+        command.try_fast_header_encode(&mut encoded).unwrap();
+        let last = encoded.len() - 1;
+        encoded[last] = 0xff;
+
+        assert!(RemotingCommand::decode(&mut encoded).is_err());
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::OnceLock;
+
+use super::BinaryHeaderFields;
+use crate::HeaderMap;
+
+#[derive(Default)]
+pub(super) enum ExtensionFields {
+    #[default]
+    Absent,
+    Materialized(HeaderMap),
+    RocketMqRaw {
+        fields: BinaryHeaderFields,
+        materialized: OnceLock<HeaderMap>,
+    },
+}
+
+impl Clone for ExtensionFields {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Absent => Self::Absent,
+            Self::Materialized(map) => Self::Materialized(map.clone()),
+            Self::RocketMqRaw { fields, materialized } => {
+                let cloned_cache = OnceLock::new();
+                if let Some(map) = materialized.get() {
+                    let _ = cloned_cache.set(map.clone());
+                }
+                Self::RocketMqRaw {
+                    fields: fields.clone(),
+                    materialized: cloned_cache,
+                }
+            }
+        }
+    }
+}
+
+impl ExtensionFields {
+    pub(super) fn from_option(fields: Option<HeaderMap>) -> Self {
+        fields.map_or(Self::Absent, Self::Materialized)
+    }
+
+    pub(super) fn from_rocketmq_raw(fields: BinaryHeaderFields) -> Self {
+        Self::RocketMqRaw {
+            fields,
+            materialized: OnceLock::new(),
+        }
+    }
+
+    pub(super) fn replace_map(&mut self, fields: HeaderMap) {
+        *self = Self::Materialized(fields);
+    }
+
+    pub(super) fn as_map(&self) -> Option<&HeaderMap> {
+        match self {
+            Self::Absent => None,
+            Self::Materialized(fields) => Some(fields),
+            Self::RocketMqRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
+        }
+    }
+
+    pub(super) fn as_map_mut(&mut self) -> Option<&mut HeaderMap> {
+        match self {
+            Self::Absent => None,
+            Self::Materialized(fields) => Some(fields),
+            Self::RocketMqRaw { fields, .. } => {
+                let fields = fields.materialize();
+                *self = Self::Materialized(fields);
+                self.as_map_mut()
+            }
+        }
+    }
+
+    pub(super) fn get_or_insert_map(&mut self) -> &mut HeaderMap {
+        match self {
+            Self::Materialized(fields) => fields,
+            Self::Absent => {
+                *self = Self::Materialized(HeaderMap::new());
+                self.get_or_insert_map()
+            }
+            Self::RocketMqRaw { fields, .. } => {
+                let fields = fields.materialize();
+                *self = Self::Materialized(fields);
+                self.get_or_insert_map()
+            }
+        }
+    }
+
+    pub(super) fn is_absent(&self) -> bool {
+        matches!(self, Self::Absent)
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_rocketmq_raw(&self) -> bool {
+        matches!(self, Self::RocketMqRaw { .. })
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_materialized_map(&self) -> bool {
+        match self {
+            Self::Absent => false,
+            Self::Materialized(_) => true,
+            Self::RocketMqRaw { materialized, .. } => materialized.get().is_some(),
+        }
+    }
+}

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -22,6 +22,7 @@ use bytes::BytesMut;
 use cheetah_string::CheetahString;
 
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_field_merge::has_custom_ext_collision;
 use crate::protocol::header_field_merge::merge_header_and_dynamic;
@@ -36,6 +37,13 @@ fn decoding_error(required: usize, available: usize) -> rocketmq_error::RocketMQ
     rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
         format: "binary",
         message: format!("required {required} bytes, got {available}"),
+    })
+}
+
+fn trailing_header_error(remaining: usize) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+        format: "binary",
+        message: format!("ROCKETMQ header has {remaining} trailing bytes after extension fields"),
     })
 }
 
@@ -402,7 +410,7 @@ impl RocketMQSerializable {
         }
 
         let ext_fields_length = header_buffer.get_i32();
-        let ext = if ext_fields_length > 0 {
+        let payload = if ext_fields_length > 0 {
             let ext_fields_length = ext_fields_length as usize;
             if ext_fields_length > header_len {
                 return Err(decoding_error(ext_fields_length, header_len));
@@ -410,12 +418,16 @@ impl RocketMQSerializable {
             if ext_fields_length > header_buffer.remaining() {
                 return Err(decoding_error(ext_fields_length, header_buffer.remaining()));
             }
-            Self::map_deserialize(header_buffer, ext_fields_length)?
+            header_buffer.split_to(ext_fields_length).freeze()
         } else {
-            HashMap::new()
+            Bytes::new()
         };
+        if header_buffer.has_remaining() {
+            return Err(trailing_header_error(header_buffer.remaining()));
+        }
+        let ext = BinaryHeaderFields::new(payload)?;
 
-        Ok(cmd.set_remark_option(remark).set_ext_fields(ext))
+        Ok(cmd.set_remark_option(remark).set_binary_ext_fields(ext))
     }
 
     /// Optimized map deserialization with capacity hint and better error handling
@@ -626,5 +638,15 @@ mod tests {
         if RocketMQSerializable::rocket_mq_protocol_decode(&mut buf, header_len).is_ok() {
             panic!("truncated ext fields should decode to error");
         }
+    }
+
+    #[test]
+    fn rocketmq_protocol_decode_rejects_bytes_after_declared_ext_fields() {
+        let mut buf = minimal_header_without_ext_len();
+        buf.put_i32(0);
+        buf.put_u8(1);
+        let header_len = buf.len();
+
+        assert!(RocketMQSerializable::rocket_mq_protocol_decode(&mut buf, header_len).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- retain validated ROCKETMQ extension-field payloads in `RemotingCommand` without eagerly building a header map
- materialize and cache the compatibility map only for existing map APIs or legacy decoders
- preserve clone, Serde, dynamic mutation, duplicate-key, empty-value, unknown-field, V2, and handwritten fast-decoder behavior
- reject invalid UTF-8, negative/truncated field lengths, empty keys, and trailing header bytes before returning a command
- keep the existing module layout without adding `mod.rs` or handwritten production `java_type` metadata

Closes #9007

## Validation

Passed:

- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test -p rocketmq-protocol --all-features` (1441 unit tests plus integration, UI, and doctests)
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff --check`

Repository baseline limitations:

- the unmodified official Clippy command stops in `rocketmq-model` on existing Cheetah 3.0 deprecations and `clippy::useless_conversion`
- workspace and standalone-example `cargo fmt --all -- --check` stop on Windows path-length error 206
- standalone-example Clippy with `--locked` stops because its checked-in lock file requires refresh

## Performance Diagnostics

A same-machine baseline/candidate comparison used release benchmark executables built from `adbebd9e` and this change. Across the 12 ROCKETMQ full-frame decode cases, the diagnostic geometric-mean speedup was approximately `1.197x`; the minimum observed case speedup after extended resampling was approximately `1.036x`. The benchmark executable grew by approximately `0.515%`.

These numbers select and validate the optimization direction only. They are not release qualification and do not replace the complete performance attestation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing RocketMQ binary extension fields, including lazy decoding and on-demand materialization.
  * Preserved duplicate-key behavior with the latest value taking precedence.
  * Added validation for malformed payloads, invalid UTF-8, empty keys, negative lengths, truncation, and trailing data.

* **Bug Fixes**
  * Improved extension-field handling during serialization, deserialization, mutation, cloning, and display.
  * Prevented invalid or undeclared binary header data from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->