### PR TITLE
[ISSUE #9011]✨Decode typed request headers directly from binary fields

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -17,6 +17,7 @@ use quote::{format_ident, quote};
 
 use super::model::{
     AliasConflict, FieldModel, FlattenPresence, HeaderModel, HeaderRange, LookupPlan, MissingPolicy, ValueKind,
+    WireName,
 };
 
 pub(super) fn context_declarations(model: &HeaderModel) -> TokenStream {
@@ -68,10 +69,13 @@ pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> Tok
     let error_type = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
     let sink_trait = quote!(#protocol_path::protocol::header_codec::EncodeSink);
     let map_type = quote!(#protocol_path::HeaderMap);
+    let source_type = quote!(#protocol_path::protocol::header_codec::HeaderFieldSource);
     let validate = validation_body(model, &error_type);
     let encode = encode_body(model, codec_trait, protocol_path);
     let decode = decode_body(model, codec_trait, &error_type, protocol_path);
+    let decode_source = decode_source_body(model, codec_trait, &error_type, protocol_path);
     let contains = contains_body(model, codec_trait);
+    let contains_source = contains_source_body(codec_trait);
     let len_hint = len_hint_body(model, codec_trait, protocol_path);
 
     quote! {
@@ -94,8 +98,18 @@ pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> Tok
         }
 
         #[inline]
+        fn decode_from_source(source: &dyn #source_type) -> Result<Self, #error_type> {
+            #decode_source
+        }
+
+        #[inline]
         fn contains_any_field(map: &#map_type) -> bool {
             #contains
+        }
+
+        #[inline]
+        fn contains_any_field_source(source: &dyn #source_type) -> bool {
+            #contains_source
         }
 
         #[inline]
@@ -253,6 +267,7 @@ fn decode_body(
             .flat_map(|field| candidate_arms(field, error_type, codec_trait));
         quote! {
             for (key, value) in map {
+                let value = value.as_str();
                 match key.as_str() {
                     #(#arms)*
                     _ => {}
@@ -272,7 +287,7 @@ fn decode_body(
     let construct_fields = model
         .fields
         .iter()
-        .map(|field| construct_field(field, codec_trait, error_type, protocol_path));
+        .map(|field| construct_field(field, codec_trait, error_type, protocol_path, DecodeInput::Map));
 
     quote! {
         #(#local_declarations)*
@@ -286,15 +301,54 @@ fn decode_body(
     }
 }
 
+fn decode_source_body(
+    model: &HeaderModel,
+    codec_trait: &TokenStream,
+    error_type: &TokenStream,
+    protocol_path: &syn::Path,
+) -> TokenStream {
+    let scalar_fields: Vec<_> = model.fields.iter().filter(|field| !field.flattened).collect();
+    let candidate_declarations = scalar_fields.iter().flat_map(|field| {
+        field_candidates(field).map(|(_name, precedence)| {
+            let local = raw_candidate_ident(field, precedence);
+            quote!(let mut #local = None;)
+        })
+    });
+    let arms = scalar_fields.iter().flat_map(|field| source_candidate_arms(field));
+    let normalize_locals = scalar_fields
+        .iter()
+        .map(|field| source_candidate_normalization(field, error_type, codec_trait));
+    let construct_fields = model
+        .fields
+        .iter()
+        .map(|field| construct_field(field, codec_trait, error_type, protocol_path, DecodeInput::Source));
+
+    quote! {
+        #(#candidate_declarations)*
+        source.visit_fields_while(&mut |key, value| {
+            match key {
+                #(#arms)*
+                _ => {}
+            }
+            true
+        });
+        #(#normalize_locals)*
+        let header = Self {
+            #(#construct_fields)*
+        };
+        <Self as #codec_trait>::validate_for_wire(&header)?;
+        Ok(header)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DecodeInput {
+    Map,
+    Source,
+}
+
 fn candidate_arms(field: &FieldModel, error_type: &TokenStream, codec_trait: &TokenStream) -> Vec<TokenStream> {
-    std::iter::once((&field.key, 0_u16))
-        .chain(
-            field
-                .aliases
-                .iter()
-                .enumerate()
-                .map(|(index, alias)| (alias, (index + 1) as u16)),
-        )
+    field_candidates(field)
         .map(|(name, precedence)| {
             let name = literal(&name.value, name.span);
             let update = candidate_update(field, error_type, codec_trait, precedence);
@@ -304,24 +358,80 @@ fn candidate_arms(field: &FieldModel, error_type: &TokenStream, codec_trait: &To
 }
 
 fn candidate_lookups(field: &FieldModel, error_type: &TokenStream, codec_trait: &TokenStream) -> Vec<TokenStream> {
-    std::iter::once((&field.key, 0_u16))
-        .chain(
-            field
-                .aliases
-                .iter()
-                .enumerate()
-                .map(|(index, alias)| (alias, (index + 1) as u16)),
-        )
+    field_candidates(field)
         .map(|(name, precedence)| {
             let name = literal(&name.value, name.span);
             let update = candidate_update(field, error_type, codec_trait, precedence);
             quote! {
                 if let Some(value) = map.get(#name) {
+                    let value = value.as_str();
                     #update
                 }
             }
         })
         .collect()
+}
+
+fn source_candidate_arms(field: &FieldModel) -> Vec<TokenStream> {
+    field_candidates(field)
+        .map(|(name, precedence)| {
+            let name = literal(&name.value, name.span);
+            let local = raw_candidate_ident(field, precedence);
+            quote!(#name => { #local = Some(value); })
+        })
+        .collect()
+}
+
+fn source_candidate_normalization(
+    field: &FieldModel,
+    error_type: &TokenStream,
+    codec_trait: &TokenStream,
+) -> TokenStream {
+    let local = raw_ident(field);
+    let candidates: Vec<_> = field_candidates(field)
+        .map(|(_name, precedence)| raw_candidate_ident(field, precedence))
+        .collect();
+    match field.alias_conflict {
+        AliasConflict::PreferCanonical => quote! {
+            let #local = None #(.or(#candidates))*;
+        },
+        AliasConflict::Error => {
+            let key = literal(&field.key.value, field.key.span);
+            let selections = candidates.iter().map(|candidate| {
+                quote! {
+                    if let Some(value) = #candidate {
+                        match selected {
+                            None => selected = Some(value),
+                            Some(current) if current == value => {}
+                            Some(_) => {
+                                return Err(#error_type::Conflict {
+                                    header: <Self as #codec_trait>::TYPE_ID,
+                                    key: #key,
+                                });
+                            }
+                        }
+                    }
+                }
+            });
+            quote! {
+                let #local = {
+                    let mut selected = None;
+                    #(#selections)*
+                    selected
+                };
+            }
+        }
+    }
+}
+
+fn field_candidates(field: &FieldModel) -> impl Iterator<Item = (&WireName, u16)> {
+    std::iter::once((&field.key, 0_u16)).chain(
+        field
+            .aliases
+            .iter()
+            .enumerate()
+            .map(|(index, alias)| (alias, (index + 1) as u16)),
+    )
 }
 
 fn candidate_update(
@@ -333,16 +443,22 @@ fn candidate_update(
     let local = raw_ident(field);
     let key = literal(&field.key.value, field.key.span);
     let conflict_header = quote!(<Self as #codec_trait>::TYPE_ID);
+    let conflict = quote! {
+        return Err(#error_type::Conflict {
+                header: #conflict_header,
+                key: #key,
+        });
+    };
     match field.alias_conflict {
         AliasConflict::Error => quote! {
             match #local {
                 None => #local = Some((value, #precedence)),
+                Some((_selected, selected_precedence)) if #precedence == selected_precedence => {
+                    #local = Some((value, #precedence));
+                }
                 Some((selected, selected_precedence)) => {
-                    if selected.as_str() != value.as_str() {
-                        return Err(#error_type::Conflict {
-                            header: #conflict_header,
-                            key: #key,
-                        });
+                    if selected != value {
+                        #conflict
                     }
                     if #precedence < selected_precedence {
                         #local = Some((value, #precedence));
@@ -353,7 +469,7 @@ fn candidate_update(
         AliasConflict::PreferCanonical => quote! {
             match #local {
                 None => #local = Some((value, #precedence)),
-                Some((_selected, selected_precedence)) if #precedence < selected_precedence => {
+                Some((_selected, selected_precedence)) if #precedence <= selected_precedence => {
                     #local = Some((value, #precedence));
                 }
                 Some(_) => {}
@@ -367,23 +483,32 @@ fn construct_field(
     codec_trait: &TokenStream,
     error_type: &TokenStream,
     protocol_path: &syn::Path,
+    input: DecodeInput,
 ) -> TokenStream {
     let ident = &field.ident;
     if field.flattened {
         let base_type = field.option_inner.as_ref().unwrap_or(&field.ty);
+        let decode = match input {
+            DecodeInput::Map => quote!(<#base_type as #codec_trait>::decode_from_map(map)),
+            DecodeInput::Source => quote!(<#base_type as #codec_trait>::decode_from_source(source)),
+        };
+        let contains = match input {
+            DecodeInput::Map => quote!(<#base_type as #codec_trait>::contains_any_field(map)),
+            DecodeInput::Source => quote!(<#base_type as #codec_trait>::contains_any_field_source(source)),
+        };
         return if field.option_inner.is_some() {
             match field.flatten_presence.unwrap_or(FlattenPresence::Always) {
-                FlattenPresence::Always => quote!(#ident: Some(<#base_type as #codec_trait>::decode_from_map(map)?),),
+                FlattenPresence::Always => quote!(#ident: Some(#decode?),),
                 FlattenPresence::Any => quote! {
-                    #ident: if <#base_type as #codec_trait>::contains_any_field(map) {
-                        Some(<#base_type as #codec_trait>::decode_from_map(map)?)
+                    #ident: if #contains {
+                        Some(#decode?)
                     } else {
                         None
                     },
                 },
             }
         } else {
-            quote!(#ident: <#base_type as #codec_trait>::decode_from_map(map)?,)
+            quote!(#ident: #decode?,)
         };
     }
 
@@ -394,7 +519,7 @@ fn construct_field(
     match field.missing.as_ref().expect("validated scalar missing policy") {
         MissingPolicy::Optional => quote! {
             #ident: #local
-                .map(|raw| <#base_type as #value_trait>::decode(raw.as_str(), Self::#context))
+                .map(|raw| <#base_type as #value_trait>::decode(raw, Self::#context))
                 .transpose()?,
         },
         MissingPolicy::Required => {
@@ -404,20 +529,20 @@ fn construct_field(
                     #local.ok_or(#error_type::Missing {
                         header: <Self as #codec_trait>::TYPE_ID,
                         key: #key,
-                    })?.as_str(),
+                    })?,
                     Self::#context,
                 )?,
             }
         }
         MissingPolicy::Default => quote! {
             #ident: match #local {
-                Some(raw) => <#base_type as #value_trait>::decode(raw.as_str(), Self::#context)?,
+                Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
                 None => <#base_type as ::core::default::Default>::default(),
             },
         },
         MissingPolicy::DefaultWith(path) => quote! {
             #ident: match #local {
-                Some(raw) => <#base_type as #value_trait>::decode(raw.as_str(), Self::#context)?,
+                Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
                 None => #path(),
             },
         },
@@ -437,6 +562,21 @@ fn contains_body(model: &HeaderModel, codec_trait: &TokenStream) -> TokenStream 
         }
     });
     quote!(false #(|| #checks)*)
+}
+
+fn contains_source_body(codec_trait: &TokenStream) -> TokenStream {
+    quote! {
+        let mut contains = false;
+        source.visit_fields_while(&mut |key, _value| {
+            if <Self as #codec_trait>::contains_wire_key(key) {
+                contains = true;
+                false
+            } else {
+                true
+            }
+        });
+        contains
+    }
 }
 
 fn len_hint_body(model: &HeaderModel, codec_trait: &TokenStream, protocol_path: &syn::Path) -> TokenStream {
@@ -494,6 +634,15 @@ fn raw_ident(field: &FieldModel) -> syn::Ident {
     format_ident!(
         "__request_header_codec_v3_raw_{}",
         field.ident,
+        span = Span::call_site()
+    )
+}
+
+fn raw_candidate_ident(field: &FieldModel, precedence: u16) -> syn::Ident {
+    format_ident!(
+        "__request_header_codec_v3_raw_{}_{}",
+        field.ident,
+        precedence,
         span = Span::call_site()
     )
 }

--- a/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
@@ -24,6 +24,7 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
     let command_trait = quote!(#protocol_path::protocol::command_custom_header::CommandCustomHeader);
     let from_map_trait = quote!(#protocol_path::protocol::command_custom_header::FromMap);
     let map_type = quote!(#protocol_path::HeaderMap);
+    let field_source = quote!(#protocol_path::protocol::header_codec::HeaderFieldSource);
     let codec_error = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
     let rocketmq_error = quote!(#protocol_path::__request_header_codec::RocketMQError);
     let map_sink = quote!(#protocol_path::protocol::header_codec::MapSink);
@@ -102,9 +103,15 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
         impl #impl_generics #from_map_trait for #ident #ty_generics #where_clause {
             type Error = #rocketmq_error;
             type Target = Self;
+            const SUPPORTS_HEADER_FIELD_SOURCE: bool = true;
 
             fn from(map: &#map_type) -> Result<Self::Target, Self::Error> {
                 <Self as #codec_trait>::decode_from_map(map)
+                    .map_err(|error| #rocketmq_error::request_header_error(error.to_string()))
+            }
+
+            fn from_field_source(source: &dyn #field_source) -> Result<Self::Target, Self::Error> {
+                <Self as #codec_trait>::decode_from_source(source)
                     .map_err(|error| #rocketmq_error::request_header_error(error.to_string()))
             }
         }

--- a/rocketmq-protocol/src/protocol/command_custom_header.rs
+++ b/rocketmq-protocol/src/protocol/command_custom_header.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use cheetah_string::CheetahString;
 
 use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_codec::HeaderFieldSource;
 use crate::protocol::header_codec::ResolvedHeaderKey;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
@@ -261,8 +262,23 @@ pub trait FromMap {
     type Error: From<rocketmq_error::RocketMQError>;
 
     type Target;
+
+    /// Whether production decode may call [`Self::from_field_source`] without
+    /// first materializing the compatibility map.
+    const SUPPORTS_HEADER_FIELD_SOURCE: bool = false;
+
     /// Converts the implementing type from a map.
     ///
     /// Returns an instance of `Self::Target` that is created from the provided map.
     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error>;
+
+    /// Converts the implementing type from a borrowed field source.
+    ///
+    /// Generated V3 implementations override this method. The default is an
+    /// additive compatibility fallback for existing implementations and is not
+    /// selected by production dispatch while the capability remains `false`.
+    fn from_field_source(source: &dyn HeaderFieldSource) -> Result<Self::Target, Self::Error> {
+        let map = source.to_header_map();
+        Self::from(&map)
+    }
 }

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -29,6 +29,7 @@ use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header_codec::BinarySink;
 use crate::protocol::header_codec::HeaderCodec;
 use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_codec::HeaderFieldSource;
 use crate::protocol::header_codec::MapSink;
 use crate::protocol::header_codec::ResolvedHeaderKey;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
@@ -290,9 +291,15 @@ impl FromMap for SendMessageRequestHeaderV2 {
     type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
+    const SUPPORTS_HEADER_FIELD_SOURCE: bool = true;
 
     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
         <Self as HeaderCodec>::decode_from_map(map)
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))
+    }
+
+    fn from_field_source(source: &dyn HeaderFieldSource) -> Result<Self::Target, Self::Error> {
+        <Self as HeaderCodec>::decode_from_source(source)
             .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))
     }
 }
@@ -593,6 +600,21 @@ mod tests {
             map.get(&CheetahString::from_static_str("n")).unwrap(),
             "test_broker_name"
         );
+    }
+
+    #[test]
+    fn manual_v3_shim_opts_into_direct_field_source_decode() {
+        let header = minimal_header_v2();
+        let fields = header.to_map().unwrap();
+
+        const { assert!(<SendMessageRequestHeaderV2 as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE) };
+        let decoded = <SendMessageRequestHeaderV2 as FromMap>::from_field_source(&fields).unwrap();
+
+        assert_eq!(decoded.a, header.a);
+        assert_eq!(decoded.b, header.b);
+        assert_eq!(decoded.c, header.c);
+        assert_eq!(decoded.d, header.d);
+        assert_eq!(decoded.g, header.g);
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -27,11 +27,13 @@ mod value;
 
 mod private {
     pub trait Sealed {}
+    pub trait FieldSourceSealed {}
 }
 
 pub use codec::HeaderCodec;
 pub use error::HeaderCodecError;
 pub(crate) use field_source::BinaryHeaderFields;
+pub use field_source::HeaderFieldSource;
 pub use schema::AliasConflictPolicy;
 pub use schema::DynamicCollisionPolicy;
 pub use schema::FlattenPresenceSpec;

--- a/rocketmq-protocol/src/protocol/header_codec/codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/codec.rs
@@ -14,6 +14,7 @@
 
 use super::EncodeSink;
 use super::HeaderCodecError;
+use super::HeaderFieldSource;
 use super::HeaderFieldSpec;
 use super::HeaderFlattenSpec;
 use super::ResolvedHeaderKey;
@@ -61,8 +62,29 @@ pub trait HeaderCodec: Sized {
     /// Returns a typed missing, conflict, conversion, range, or validation error.
     fn decode_from_map(map: &HeaderMap) -> Result<Self, HeaderCodecError>;
 
+    /// Decodes this header directly from a borrowed field source.
+    ///
+    /// Generated V3 codecs override this method with a zero-materialization
+    /// scan. The default keeps manually implemented codecs source-compatible.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same classified failures as [`Self::decode_from_map`].
+    #[inline]
+    fn decode_from_source(source: &dyn HeaderFieldSource) -> Result<Self, HeaderCodecError> {
+        let map = source.to_header_map();
+        Self::decode_from_map(&map)
+    }
+
     /// Returns whether this header or any flattened child owns a present key.
     fn contains_any_field(map: &HeaderMap) -> bool;
+
+    /// Returns whether this header or a flattened child owns a source field.
+    #[inline]
+    fn contains_any_field_source(source: &dyn HeaderFieldSource) -> bool {
+        let map = source.to_header_map();
+        Self::contains_any_field(&map)
+    }
 
     /// Estimates the encoded ROCKETMQ extension-field payload length.
     ///

--- a/rocketmq-protocol/src/protocol/header_codec/field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/field_source.rs
@@ -15,11 +15,43 @@
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 
+use super::private::FieldSourceSealed;
 use crate::HeaderMap;
 
 const KEY_LENGTH_BYTES: usize = 2;
 const VALUE_LENGTH_BYTES: usize = 4;
 const MAX_INITIAL_MAP_CAPACITY: usize = 1024;
+
+/// A validated, borrowed view of remoting command extension fields.
+///
+/// This trait is sealed because source implementations must guarantee that
+/// every visited key and value is valid immutable UTF-8 for the full source
+/// borrow. Returning `false` from the visitor stops the scan early.
+pub trait HeaderFieldSource: FieldSourceSealed {
+    /// Visits fields without allocating owned key/value strings.
+    fn visit_fields_while<'a>(&'a self, visitor: &mut dyn FnMut(&'a str, &'a str) -> bool);
+
+    /// Produces the owned compatibility representation.
+    fn to_header_map(&self) -> HeaderMap;
+}
+
+impl FieldSourceSealed for HeaderMap {}
+
+impl HeaderFieldSource for HeaderMap {
+    #[inline]
+    fn visit_fields_while<'a>(&'a self, visitor: &mut dyn FnMut(&'a str, &'a str) -> bool) {
+        for (key, value) in self {
+            if !visitor(key.as_str(), value.as_str()) {
+                break;
+            }
+        }
+    }
+
+    #[inline]
+    fn to_header_map(&self) -> HeaderMap {
+        self.clone()
+    }
+}
 
 fn malformed_binary_fields(reason: &'static str) -> rocketmq_error::RocketMQError {
     rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
@@ -50,27 +82,22 @@ impl BinaryHeaderFields {
         Ok(Self { payload, entry_count })
     }
 
-    /// Visits the logical non-empty entries without allocating field strings.
-    pub(crate) fn try_for_each<'a>(
-        &'a self,
-        visitor: &mut dyn FnMut(&'a str, &'a str) -> rocketmq_error::RocketMQResult<()>,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        Self::parse(&self.payload, visitor)
-    }
-
     /// Materializes the compatibility map. The payload has already been
-    /// validated, so a second parse can fail only if this module's immutable
-    /// representation invariant is broken.
+    /// validated, so iteration uses its immutable representation invariant.
     pub(crate) fn materialize(&self) -> HeaderMap {
         let mut map = HeaderMap::with_capacity(self.entry_count.min(MAX_INITIAL_MAP_CAPACITY));
-        let result = self.try_for_each(&mut |key, value| {
+        for (key, value) in self.iter() {
             map.insert(CheetahString::from_slice(key), CheetahString::from_slice(value));
-            Ok(())
-        });
-        if result.is_err() {
-            map.clear();
         }
         map
+    }
+
+    #[inline]
+    fn iter(&self) -> BinaryHeaderFieldIter<'_> {
+        BinaryHeaderFieldIter {
+            payload: &self.payload,
+            cursor: 0,
+        }
     }
 
     fn parse<'a>(
@@ -144,6 +171,86 @@ impl BinaryHeaderFields {
             .ok_or_else(|| malformed_binary_fields(reason))?;
         *cursor = end;
         Ok(bytes)
+    }
+}
+
+impl FieldSourceSealed for BinaryHeaderFields {}
+
+impl HeaderFieldSource for BinaryHeaderFields {
+    #[inline]
+    fn visit_fields_while<'a>(&'a self, visitor: &mut dyn FnMut(&'a str, &'a str) -> bool) {
+        for (key, value) in self.iter() {
+            if !visitor(key, value) {
+                break;
+            }
+        }
+    }
+
+    #[inline]
+    fn to_header_map(&self) -> HeaderMap {
+        self.materialize()
+    }
+}
+
+struct BinaryHeaderFieldIter<'a> {
+    payload: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> BinaryHeaderFieldIter<'a> {
+    #[inline]
+    fn take(&mut self, length: usize) -> &'a [u8] {
+        // The only constructor validates every boundary before retaining the
+        // immutable Bytes payload, so failure here would be an internal bug.
+        let end = self
+            .cursor
+            .checked_add(length)
+            .expect("validated binary header field offset overflowed");
+        let bytes = self
+            .payload
+            .get(self.cursor..end)
+            .expect("validated binary header field boundary changed");
+        self.cursor = end;
+        bytes
+    }
+
+    #[inline]
+    fn read_u16(&mut self) -> usize {
+        let bytes = self.take(KEY_LENGTH_BYTES);
+        u16::from_be_bytes([bytes[0], bytes[1]]) as usize
+    }
+
+    #[inline]
+    fn read_i32(&mut self) -> i32 {
+        let bytes = self.take(VALUE_LENGTH_BYTES);
+        i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+    }
+
+    #[inline]
+    fn read_utf8(&mut self, length: usize) -> &'a str {
+        // UTF-8 validity is established together with the immutable boundary
+        // invariant in BinaryHeaderFields::new.
+        std::str::from_utf8(self.take(length)).expect("validated binary header field UTF-8 changed")
+    }
+}
+
+impl<'a> Iterator for BinaryHeaderFieldIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.cursor < self.payload.len() {
+            let key_length = self.read_u16();
+            let key = self.read_utf8(key_length);
+            let value_length = self.read_i32();
+            let value_length =
+                usize::try_from(value_length).expect("validated binary header field value length became negative");
+            let value = self.read_utf8(value_length);
+            if !value.is_empty() {
+                return Some((key, value));
+            }
+        }
+        None
     }
 }
 

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -915,6 +915,11 @@ impl RemotingCommand {
     where
         T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
     {
+        if T::SUPPORTS_HEADER_FIELD_SOURCE {
+            if let Some(source) = self.ext_fields.as_field_source() {
+                return T::from_field_source(source);
+            }
+        }
         match self.ext_fields.as_map() {
             None => Err(rocketmq_error::RocketMQError::Serialization(
                 rocketmq_error::SerializationError::DecodeFailed {
@@ -931,6 +936,11 @@ impl RemotingCommand {
         T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
         T: Default + CommandCustomHeader,
     {
+        if T::SUPPORTS_HEADER_FIELD_SOURCE {
+            if let Some(source) = self.ext_fields.as_field_source() {
+                return T::from_field_source(source);
+            }
+        }
         match self.ext_fields.as_map() {
             None => Err(rocketmq_error::RocketMQError::Serialization(
                 rocketmq_error::SerializationError::DecodeFailed {
@@ -1270,6 +1280,13 @@ mod tests {
         value: i32,
     }
 
+    #[derive(Debug, Default, rocketmq_macros::RequestHeaderCodecV3)]
+    #[header(type_id = "rocketmq_protocol::tests::RawStrictAliasHeader")]
+    struct RawStrictAliasHeader {
+        #[header(key = "canonical", alias = "legacy")]
+        value: Option<CheetahString>,
+    }
+
     impl CommandCustomHeader for TestCustomHeader {
         fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
             Some(HashMap::from([(
@@ -1503,6 +1520,86 @@ mod tests {
         assert_eq!(json["extFields"]["alpha"], "first");
         assert_eq!(json["extFields"]["beta"], "second");
         assert!(cloned.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn v3_production_decode_uses_raw_fields_without_materializing_the_map() {
+        use crate::protocol::header::notification_request_header::NotificationRequestHeader;
+
+        let header = NotificationRequestHeader {
+            consumer_group: "group-a".into(),
+            topic: "topic-a".into(),
+            queue_id: 3,
+            poll_time: 15_000,
+            born_time: 1_720_000_000_000,
+            ..Default::default()
+        };
+        let mut encoded = BytesMut::new();
+        RemotingCommand::create_request_command(1, header)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .try_fast_header_encode(&mut encoded)
+            .unwrap();
+        let command = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+        assert!(command.ext_fields.is_rocketmq_raw());
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let standard = command
+            .decode_command_custom_header::<NotificationRequestHeader>()
+            .unwrap();
+        assert_eq!(standard.queue_id, 3);
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let fast = command
+            .decode_command_custom_header_fast::<NotificationRequestHeader>()
+            .unwrap();
+        assert_eq!(fast.queue_id, 3);
+        assert!(!command.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn raw_direct_decode_preserves_duplicate_and_alias_precedence_without_a_map() {
+        use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+        fn append_field(out: &mut BytesMut, key: &str, value: &str) {
+            out.put_u16(key.len() as u16);
+            out.extend_from_slice(key.as_bytes());
+            out.put_i32(value.len() as i32);
+            out.extend_from_slice(value.as_bytes());
+        }
+
+        let mut payload = BytesMut::new();
+        append_field(&mut payload, "ns", "first-canonical");
+        append_field(&mut payload, "namespace", "legacy");
+        append_field(&mut payload, "ns", "last-canonical");
+        append_field(&mut payload, "nsd", "true");
+        append_field(&mut payload, "nsd", "false");
+        let command = RemotingCommand::create_remoting_command(1)
+            .set_binary_ext_fields(BinaryHeaderFields::new(payload.freeze()).unwrap());
+
+        let decoded = command.decode_command_custom_header::<RpcRequestHeader>().unwrap();
+
+        assert_eq!(decoded.namespace.as_deref(), Some("last-canonical"));
+        assert_eq!(decoded.namespaced, Some(false));
+        assert!(command.ext_fields.is_rocketmq_raw());
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let mut converged = BytesMut::new();
+        append_field(&mut converged, "canonical", "superseded");
+        append_field(&mut converged, "legacy", "final");
+        append_field(&mut converged, "canonical", "final");
+        let command = RemotingCommand::create_remoting_command(1)
+            .set_binary_ext_fields(BinaryHeaderFields::new(converged.freeze()).unwrap());
+        let decoded = command.decode_command_custom_header::<RawStrictAliasHeader>().unwrap();
+        assert_eq!(decoded.value.as_deref(), Some("final"));
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let mut conflicting = BytesMut::new();
+        append_field(&mut conflicting, "canonical", "canonical-value");
+        append_field(&mut conflicting, "legacy", "legacy-value");
+        let command = RemotingCommand::create_remoting_command(1)
+            .set_binary_ext_fields(BinaryHeaderFields::new(conflicting.freeze()).unwrap());
+        assert!(command.decode_command_custom_header::<RawStrictAliasHeader>().is_err());
+        assert!(!command.ext_fields.has_materialized_map());
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
@@ -15,6 +15,7 @@
 use std::sync::OnceLock;
 
 use super::BinaryHeaderFields;
+use crate::protocol::header_codec::HeaderFieldSource;
 use crate::HeaderMap;
 
 #[derive(Default)]
@@ -68,6 +69,13 @@ impl ExtensionFields {
             Self::Absent => None,
             Self::Materialized(fields) => Some(fields),
             Self::RocketMqRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
+        }
+    }
+
+    pub(super) fn as_field_source(&self) -> Option<&dyn HeaderFieldSource> {
+        match self {
+            Self::RocketMqRaw { fields, .. } => Some(fields),
+            Self::Absent | Self::Materialized(_) => None,
         }
     }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_typed_map.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_typed_map.rs
@@ -15,7 +15,7 @@
 use cheetah_string::CheetahString;
 use rocketmq_macros::{RequestHeaderCodecV2, RequestHeaderCodecV3};
 use rocketmq_protocol::protocol::header_codec::{
-    AliasConflictPolicy, FlattenPresenceSpec, HeaderCodec, HeaderCodecError, HeaderPresence,
+    AliasConflictPolicy, FlattenPresenceSpec, HeaderCodec, HeaderCodecError, HeaderFieldSource, HeaderPresence,
 };
 use rocketmq_protocol::{CommandCustomHeader, FromMap, HeaderMap};
 
@@ -143,6 +143,63 @@ fn typed_map_round_trip_uses_one_shared_destination_and_exact_hint() {
         header
     );
     assert_eq!(<TypedMapHeaderV3 as FromMap>::from(&map).unwrap(), header);
+}
+
+#[test]
+fn direct_field_source_matches_map_decode_for_values_and_errors() {
+    let map = sample_header().to_map().unwrap();
+    let map_decoded = <TypedMapHeaderV3 as HeaderCodec>::decode_from_map(&map).unwrap();
+    let source: &dyn HeaderFieldSource = &map;
+
+    assert_eq!(
+        <TypedMapHeaderV3 as HeaderCodec>::decode_from_source(source).unwrap(),
+        map_decoded
+    );
+    assert!(<TypedMapHeaderV3 as HeaderCodec>::contains_any_field_source(source));
+    const { assert!(<TypedMapHeaderV3 as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE) };
+    assert_eq!(
+        <TypedMapHeaderV3 as FromMap>::from_field_source(source).unwrap(),
+        map_decoded
+    );
+
+    let mut conflicting = map;
+    conflicting.insert("legacyTraceId".into(), "different".into());
+    let map_error = <TypedMapHeaderV3 as HeaderCodec>::decode_from_map(&conflicting).unwrap_err();
+    let source_error = <TypedMapHeaderV3 as HeaderCodec>::decode_from_source(&conflicting).unwrap_err();
+    assert!(matches!(map_error, HeaderCodecError::Conflict { .. }));
+    assert!(matches!(source_error, HeaderCodecError::Conflict { .. }));
+    assert_eq!(map_error.to_string(), source_error.to_string());
+
+    for (key, value) in [
+        ("queueId", "not-an-integer"),
+        ("queueId", "2147483648"),
+        ("attempts", "-1"),
+    ] {
+        let mut invalid = sample_header().to_map().unwrap();
+        invalid.insert(key.into(), value.into());
+        let map_error = <TypedMapHeaderV3 as HeaderCodec>::decode_from_map(&invalid).unwrap_err();
+        let source_error = <TypedMapHeaderV3 as HeaderCodec>::decode_from_source(&invalid).unwrap_err();
+        assert_eq!(map_error.to_string(), source_error.to_string(), "{key}={value}");
+    }
+
+    let mut missing = sample_header().to_map().unwrap();
+    missing.remove("requestId");
+    assert!(matches!(
+        <TypedMapHeaderV3 as HeaderCodec>::decode_from_source(&missing),
+        Err(HeaderCodecError::Missing {
+            header: "fixtures::TypedMapHeaderV3",
+            key: "requestId"
+        })
+    ));
+
+    for key in ["topic", "routingQueueId"] {
+        missing.remove(key);
+    }
+    missing.insert("requestId".into(), "request-7".into());
+    assert!(<TypedMapHeaderV3 as HeaderCodec>::decode_from_source(&missing)
+        .unwrap()
+        .routing
+        .is_none());
 }
 
 #[test]


### PR DESCRIPTION
Closes #9011

## What changed

- add a sealed borrowed `HeaderFieldSource` over validated binary fields and existing maps
- generate direct `RequestHeaderCodecV3` decoding without materializing `HeaderMap`
- preserve same-key last-value-wins and canonical/alias conflict behavior
- route production normal and fast typed decode through the direct source for capable V3 headers
- retain map fallback for V2 and handwritten codecs, with an explicit opt-in for the manual send-message V3 shim
- prove direct production decode does not initialize the lazy map cache

## Compatibility

- existing map APIs and wire bytes are unchanged
- source and map decoding retain value and error-classification parity
- supported direct semantic failures do not retry through a map
- no `mod.rs` was added
- no production `java_type` metadata was added; Rust types remain authoritative and unsigned Java bounds continue to use `range`

## Validation

Passed:

- `cargo test -p rocketmq-macros` (13 tests)
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_typed_map` (6 tests)
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_registry` (7 tests)
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_ui`
- `cargo test -p rocketmq-protocol --test request_header_codec_runtime_ui`
- focused remoting raw-source and manual send-message tests
- `cargo test -p rocketmq-protocol --all-features` (1,445 unit tests plus integration, UI, and doctests)
- `cargo test -p rocketmq-protocol --all-features` regression suite
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo fmt -p rocketmq-protocol -p rocketmq-macros -- --check`
- `cargo clippy -p rocketmq-protocol -p rocketmq-macros --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion`
- `git diff --check`

Known repository baselines:

- root and `rocketmq-example` full `cargo fmt --all -- --check` stop with Windows path-length error 206; affected-package formatting passes
- official workspace Clippy stops in unchanged `rocketmq-model` CheetahString 3.0 deprecated uses and one useless conversion
- `rocketmq-example` Clippy stops because its standalone dependency remains CheetahString 2.1 while current shared path crates use 3.0
- the renamed-consumer locked fixture requires the existing CheetahString/lz4 lock refresh; an unlocked offline check compiles and the generated lock diff is excluded here

## Diagnostic performance

An interleaved same-machine release diagnostic against PR #9010 across 12 production ROCKETMQ decode scenarios produced an unweighted geometric-mean speedup of about `1.283x`; the minimum scenario was about `1.022x`. The benchmark artifact grew by about `0.675%`. These are directional diagnostics only and are not PERF-01 through PERF-09 release evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct decoding of request headers from raw field sources, alongside existing map-based decoding.
  - Added field-presence checks and capability reporting for supported custom headers.
  - Preserved support for aliases, flattened fields, and raw header values during decoding.

- **Bug Fixes**
  - Improved handling of duplicate and conflicting header names, including canonical-name and alias precedence.
  - Added consistent validation for missing fields, invalid values, and conflicting aliases across decoding paths.
  - Extended coverage for standard and fast command decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->