### PR TITLE
[ISSUE #9013]🚀Qualify a credential-free local model endpoint

### DIFF
--- a/rocketmq-sre/README.md
+++ b/rocketmq-sre/README.md
@@ -125,6 +125,22 @@ instead of silently degrading the contract.
 See [Model compatibility](docs/compatibility.md) and
 [Extension guide](docs/phase05-extension-guide.md).
 
+The credential-free local-runtime qualification uses a disposable, loopback-
+only Ollama container and the pinned `qwen2.5:0.5b` model. It makes exactly one
+bounded OpenAI-compatible chat request through the production Model Gateway
+adapter. The run records only digests, sizes, token counts, safety assertions,
+and cleanup state; it never records the endpoint, prompt, response, credential,
+or machine-local path. The container, dedicated model volume, process
+environment, and any runtime image introduced by the run are removed before
+the report is accepted. Pulling the pinned runtime and model uses their public
+artifact registries, but no external model-provider inference endpoint is
+called.
+
+```powershell
+.\scripts\local-model-qualification.ps1 -Mode Check
+.\scripts\local-model-qualification.ps1
+```
+
 The DeepSeek Responses integration includes bounded semantic SSE, cooperative
 cancellation, stable provider-error mapping, structured output, and read-only
 tool selection. The conversational operations flow validates a selected tool
@@ -383,8 +399,8 @@ that Autonomous promotion prerequisites are satisfied, but it never performs
 that live transition and never dispatches an unattended target mutation. The
 scripted primary and Critic identities are contract fixtures only; provider
 credentials and model network calls are forbidden. DeepSeek-backed diagnosis
-is intentionally integrated last, after the remaining non-model readiness
-work, when an API key is supplied.
+is qualified separately with a locally supplied secret and remains advisory,
+read-only, and outside the autonomy promotion decision.
 
 Run from `rocketmq-sre/`; the harness creates and destroys its own cluster,
 keeps build output on `D:` and `F:`, and writes the redacted report outside the

--- a/rocketmq-sre/README.zh-CN.md
+++ b/rocketmq-sre/README.zh-CN.md
@@ -106,6 +106,18 @@ embedding、reranking、数据分类、区域、成本和上下文能力。路�
 参见[模型兼容性](docs/compatibility.md)和
 [扩展指南](docs/phase05-extension-guide.md)。
 
+无凭据本地运行时资格验证使用一次性、仅绑定 loopback 的 Ollama 容器和固定的
+`qwen2.5:0.5b` 模型，通过生产 Model Gateway adapter 只发起一次有界的
+OpenAI-compatible chat 请求。报告仅记录 digest、大小、token 计数、安全断言和清理状态，
+不会记录 endpoint、prompt、response、凭据或本机路径。容器、专用模型卷、进程环境以及
+本次运行新引入的运行时镜像会在报告被接受前清除。拉取固定运行时与模型时会访问其公共
+制品仓库，但不会调用任何外部模型 Provider 推理端点。
+
+```powershell
+.\scripts\local-model-qualification.ps1 -Mode Check
+.\scripts\local-model-qualification.ps1
+```
+
 DeepSeek Responses 接入支持有界语义 SSE、协作式取消、稳定的 Provider 错误映射、
 结构化输出和只读 Tool selection。对话式运维链路会根据固定 registry 校验模型选择
 的 Tool，通过 Connector 执行查询，持久化 Canonical Evidence 和不可变的回答 revision；
@@ -313,8 +325,8 @@ python scripts/check_r2_action_qualification.py
 
 真实目标执行的上限固定为 `Supervised`。资格验证可以计算 Autonomous 晋级条件是否满足，但不会
 执行该实时状态转换，也不会下发无人值守的目标变更。脚本化的主模型与 Critic 身份仅用于契约夹具；
-模型凭据和模型网络调用均被禁止。使用 DeepSeek 的真实 AI 诊断会在其余非模型就绪工作完成后最后
-接入，届时再提供 API key。
+模型凭据和模型网络调用均被禁止。DeepSeek 真实诊断通过本地提供的 secret 单独完成资格验证，
+继续保持建议性、只读，并且不参与 Autonomous 晋级决策。
 
 在 `rocketmq-sre/` 中运行；工具会自行创建并销毁集群，构建产物保留在 `D:` 和 `F:`，脱敏报告
 写入仓库外：

--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -396,6 +396,21 @@
         },
         {
           "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/local-model.v1.json",
+          "qualification": "local-model"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_local_model_qualification.py",
+          "qualification": "local-model"
+        },
+        {
+          "kind": "smoke",
+          "path": "rocketmq-sre/scripts/local-model-qualification.ps1",
+          "qualification": "local-model"
+        },
+        {
+          "kind": "configuration",
           "path": "rocketmq-sre/config/qualification/deepseek-diagnosis.v1.json",
           "qualification": "deepseek-diagnosis"
         },
@@ -435,6 +450,7 @@
       ],
       "limitations": [
         "DeepSeek Responses API diagnosis, bounded semantic streaming, cancellation, read-only tool selection, evidence-cited answers, and fallback from a failed primary passed credential-gated disposable-environment qualifications; selected tools were not executed and every result remained read-only.",
+        "The credential-free Ollama profile passed a single bounded OpenAI-compatible chat request against a qualification-owned loopback container using qwen2.5:0.5b; the model volume, container, process environment, and newly pulled runtime image were removed before the sanitized report was accepted.",
         "Zhipu GLM and Kimi/Moonshot remain descriptor, profile, transport, and contract tested rather than live-endpoint certified; production credentials, deployment-specific networking, sustained provider load, and operator handoff remain environment-specific."
       ]
     },

--- a/rocketmq-sre/config/qualification/local-model.v1.json
+++ b/rocketmq-sre/config/qualification/local-model.v1.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "rocketmq-sre.local-model-qualification.v1",
+  "environment": "disposable_docker_loopback_ollama",
+  "operating_mode": "supervised_read_only",
+  "production_certified": false,
+  "unattended_autonomous_execution": false,
+  "runtime": {
+    "provider": "ollama",
+    "protocol": "openai_compatible_chat_completions",
+    "image": "ollama/ollama:0.13.3",
+    "endpoint_scope": "loopback_only",
+    "credential_required": false
+  },
+  "model": {
+    "id": "qwen2.5:0.5b",
+    "maximum_artifact_bytes": 450000000
+  },
+  "limits": {
+    "model_calls": 1,
+    "request_timeout_seconds": 120,
+    "maximum_response_bytes": 65536,
+    "maximum_content_bytes": 4096
+  },
+  "safety": {
+    "external_model_provider_calls": 0,
+    "target_mutations": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0,
+    "secrets_recorded": false,
+    "prompts_recorded": false,
+    "responses_recorded": false,
+    "message_bodies_recorded": false
+  },
+  "repository_evidence": {
+    "profile": "rocketmq-sre/crates/rocketmq-sre-model-gateway/src/profile.rs",
+    "live_test_path": "rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/live_local_model_smoke.rs",
+    "live_test": "live_ollama_openai_compatible_endpoint_when_explicitly_configured",
+    "runner": "rocketmq-sre/scripts/local-model-qualification.ps1",
+    "checker": "rocketmq-sre/scripts/check_local_model_qualification.py"
+  },
+  "live_report": {
+    "schema_version": "rocketmq-sre.local-model-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "secrets_recorded": false,
+    "prompts_recorded": false,
+    "responses_recorded": false,
+    "message_bodies_recorded": false
+  }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/live_local_model_smoke.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-model-gateway/tests/live_local_model_smoke.rs
@@ -1,0 +1,138 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_sre_contracts::CorrelationId;
+use rocketmq_sre_model_gateway::AsyncBuiltinProviderClient;
+use rocketmq_sre_model_gateway::CanonicalModelRequest;
+use rocketmq_sre_model_gateway::HttpModelTransport;
+use rocketmq_sre_model_gateway::HttpTransportConfig;
+use rocketmq_sre_model_gateway::InvocationContext;
+use rocketmq_sre_model_gateway::ModelMessage;
+use rocketmq_sre_model_gateway::ModelRole;
+use rocketmq_sre_model_gateway::ProviderHealth;
+use rocketmq_sre_model_gateway::ToolChoice;
+use rocketmq_sre_model_gateway::builtin_provider_profiles;
+use rocketmq_sre_model_gateway::current_unix_ms;
+use serde_json::json;
+use url::Url;
+
+const ENDPOINT_ENV: &str = "ROCKETMQ_SRE_LOCAL_MODEL_QUALIFICATION_ENDPOINT";
+const MODEL_ENV: &str = "ROCKETMQ_SRE_LOCAL_MODEL_QUALIFICATION_MODEL";
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_BYTES: usize = 4 * 1024;
+const REQUEST_TIMEOUT_SECONDS: u64 = 120;
+
+/// Credential-free live smoke for a qualification-owned loopback Ollama
+/// endpoint. The test is ignored by default and never prints the prompt,
+/// response, endpoint, or any credential material.
+#[tokio::test]
+#[ignore = "requires an explicitly configured qualification-owned loopback Ollama endpoint"]
+async fn live_ollama_openai_compatible_endpoint_when_explicitly_configured() {
+    let endpoint = std::env::var(ENDPOINT_ENV).expect("local qualification endpoint must be configured");
+    let parsed = Url::parse(&endpoint).expect("local qualification endpoint must be a URL");
+    assert_eq!(
+        parsed.scheme(),
+        "http",
+        "local qualification endpoint must use loopback HTTP"
+    );
+    assert_eq!(
+        parsed.host_str(),
+        Some("127.0.0.1"),
+        "local qualification endpoint must use 127.0.0.1"
+    );
+    assert!(
+        parsed.port().is_some(),
+        "local qualification endpoint must use an explicit random port"
+    );
+    assert_eq!(
+        parsed.path(),
+        "/v1",
+        "local qualification endpoint must expose the OpenAI-compatible /v1 root"
+    );
+    assert!(parsed.query().is_none() && parsed.fragment().is_none());
+
+    let model = std::env::var(MODEL_ENV).expect("local qualification model must be configured");
+    assert_eq!(
+        model, "qwen2.5:0.5b",
+        "qualification model must remain bounded and pinned"
+    );
+    let mut profile = builtin_provider_profiles()
+        .into_iter()
+        .find(|candidate| candidate.id == "ollama")
+        .expect("built-in Ollama profile");
+    profile.endpoint = endpoint;
+    profile.model = model.clone();
+    profile.model_revision = "qualification-qwen2.5-0.5b".to_owned();
+    profile.endpoint_instance = "qualification-loopback".to_owned();
+    profile.health = ProviderHealth::Healthy;
+    profile.credential_ref = None;
+    profile.validate().expect("qualification Ollama profile");
+
+    let transport = Arc::new(
+        HttpModelTransport::new(
+            HttpTransportConfig::default()
+                .with_timeouts(Duration::from_secs(5), Duration::from_secs(REQUEST_TIMEOUT_SECONDS))
+                .with_body_limits(32 * 1024, MAX_RESPONSE_BYTES),
+        )
+        .expect("local model HTTP transport"),
+    );
+    let client = AsyncBuiltinProviderClient::new(profile, transport).expect("local model client");
+    let correlation_id = CorrelationId::new();
+    let mut request = CanonicalModelRequest::new(
+        correlation_id,
+        model,
+        vec![ModelMessage::text(
+            ModelRole::User,
+            "Return the single word OK. Do not include analysis or sensitive data.",
+        )],
+    );
+    request.tool_choice = ToolChoice::None;
+    request.max_output_tokens = Some(32);
+    request.temperature_milli = Some(0);
+    let mut context = InvocationContext::new(correlation_id);
+    context.deadline_unix_ms = Some(current_unix_ms().saturating_add(REQUEST_TIMEOUT_SECONDS * 1_000));
+    context.max_response_bytes = MAX_RESPONSE_BYTES;
+
+    let response = client
+        .invoke(&context, &request, None)
+        .await
+        .expect("qualification-owned local model call");
+    let response_bytes = response.content.len();
+    assert!(response_bytes > 0, "local model returned empty content");
+    assert!(
+        response_bytes <= MAX_CONTENT_BYTES,
+        "local model content exceeded the qualification bound"
+    );
+    assert!(
+        response.tool_calls.is_empty(),
+        "local model qualification must not select tools"
+    );
+    assert_eq!(response.provider, "ollama");
+    assert!(!response.model.trim().is_empty());
+
+    let marker = json!({
+        "provider": response.provider,
+        "model_family": "local",
+        "response_non_empty": true,
+        "response_bytes": response_bytes,
+        "tool_calls": response.tool_calls.len(),
+        "credential_present": false,
+        "input_tokens": response.usage.input_tokens.or(response.input_tokens),
+        "output_tokens": response.usage.output_tokens.or(response.output_tokens)
+    });
+    println!("LOCAL_MODEL_QUALIFICATION_OK {marker}");
+}

--- a/rocketmq-sre/scripts/check_local_model_qualification.py
+++ b/rocketmq-sre/scripts/check_local_model_qualification.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the credential-free local-model qualification contract and report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "local-model.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.local-model-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.local-model-qualification-report.v1"
+ENVIRONMENT = "disposable_docker_loopback_ollama"
+IMAGE = "ollama/ollama:0.13.3"
+MODEL = "qwen2.5:0.5b"
+REVISION = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+SENSITIVE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~-]+|\bsk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+FORBIDDEN_REPORT_FIELDS = {
+    "api_key",
+    "credential",
+    "credential_value",
+    "endpoint",
+    "endpoint_url",
+    "local_path",
+    "model_prompt",
+    "prompt",
+    "prompt_body",
+    "provider_response",
+    "response",
+    "response_body",
+    "message_body",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def all_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [text for child in value for text in all_strings(child)]
+    if isinstance(value, dict):
+        return [text for key, child in value.items() for text in (*all_strings(key), *all_strings(child))]
+    return []
+
+
+def all_keys(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [key for child in value for key in all_keys(child)]
+    if isinstance(value, dict):
+        return [str(key) for key, child in value.items()] + [key for child in value.values() for key in all_keys(child)]
+    return []
+
+
+def repository_file(raw_path: Any, location: str, findings: list[str]) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        findings.append(f"{location} must be a non-empty repository path")
+        return None
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or "docs" in path.parts:
+        findings.append(f"{location} must be repository implementation evidence")
+        return None
+    resolved = REPOSITORY_ROOT / Path(*path.parts)
+    if not resolved.is_file():
+        findings.append(f"{location} does not exist: {raw_path}")
+        return None
+    return resolved
+
+
+def parse_timestamp(value: Any, location: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{location} must be an RFC 3339 timestamp")
+        return None
+
+
+def validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected = {
+        "schema_version": MANIFEST_SCHEMA,
+        "environment": ENVIRONMENT,
+        "operating_mode": "supervised_read_only",
+        "production_certified": False,
+        "unattended_autonomous_execution": False,
+    }
+    for field, value in expected.items():
+        if manifest.get(field) != value:
+            findings.append(f"{field} must remain {value!r}")
+
+    runtime = manifest.get("runtime")
+    expected_runtime = {
+        "provider": "ollama",
+        "protocol": "openai_compatible_chat_completions",
+        "image": IMAGE,
+        "endpoint_scope": "loopback_only",
+        "credential_required": False,
+    }
+    if runtime != expected_runtime:
+        findings.append("runtime contract drifted from pinned credential-free loopback Ollama")
+    if manifest.get("model") != {"id": MODEL, "maximum_artifact_bytes": 450_000_000}:
+        findings.append("model contract drifted from the bounded qwen2.5:0.5b artifact")
+    if manifest.get("limits") != {
+        "model_calls": 1,
+        "request_timeout_seconds": 120,
+        "maximum_response_bytes": 65_536,
+        "maximum_content_bytes": 4_096,
+    }:
+        findings.append("local-model invocation bounds drifted")
+    if manifest.get("safety") != {
+        "external_model_provider_calls": 0,
+        "target_mutations": 0,
+        "executor_calls": 0,
+        "execution_agent_calls": 0,
+        "secrets_recorded": False,
+        "prompts_recorded": False,
+        "responses_recorded": False,
+        "message_bodies_recorded": False,
+    }:
+        findings.append("local-model safety boundary drifted")
+
+    evidence = manifest.get("repository_evidence")
+    if not isinstance(evidence, dict):
+        findings.append("repository_evidence must be an object")
+    else:
+        live_test_path = repository_file(
+            evidence.get("live_test_path"), "repository_evidence.live_test_path", findings
+        )
+        for field in ("profile", "runner", "checker"):
+            repository_file(evidence.get(field), f"repository_evidence.{field}", findings)
+        test_name = evidence.get("live_test")
+        if live_test_path is not None and (
+            not isinstance(test_name, str) or test_name not in live_test_path.read_text(encoding="utf-8")
+        ):
+            findings.append("repository_evidence.live_test is absent from its live_test_path")
+
+    report = manifest.get("live_report")
+    if not isinstance(report, dict) or report.get("schema_version") != REPORT_SCHEMA:
+        findings.append("live_report contract is missing or unsupported")
+    else:
+        if report.get("machine_local_only") is not True:
+            findings.append("live reports must remain machine-local")
+        if set(report.get("allowed_roots", [])) != {r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence"}:
+            findings.append("live report roots must be restricted to D: or F:")
+        for field in ("secrets_recorded", "prompts_recorded", "responses_recorded", "message_bodies_recorded"):
+            if report.get(field) is not False:
+                findings.append(f"live_report.{field} must be false")
+    if any(SENSITIVE.search(value) for value in all_strings(manifest)):
+        findings.append("manifest contains credential-like material")
+    return findings
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected = {
+        "schema_version": REPORT_SCHEMA,
+        "status": "passed",
+        "environment": ENVIRONMENT,
+        "operating_mode": "supervised_read_only",
+    }
+    for field, value in expected.items():
+        if report.get(field) != value:
+            findings.append(f"report.{field} must be {value!r}")
+    revision = report.get("candidate_commit")
+    if not isinstance(revision, str) or not REVISION.fullmatch(revision):
+        findings.append("candidate_commit must be a full lowercase Git SHA")
+    if report.get("source_clean") is not True:
+        findings.append("qualification source must be clean")
+    started = parse_timestamp(report.get("started_at"), "started_at", findings)
+    finished = parse_timestamp(report.get("finished_at"), "finished_at", findings)
+    if started and finished and finished < started:
+        findings.append("finished_at must not precede started_at")
+
+    runtime = report.get("runtime")
+    if not isinstance(runtime, dict):
+        findings.append("runtime proof must be an object")
+    else:
+        exact = {
+            "provider": "ollama",
+            "protocol": "openai_compatible_chat_completions",
+            "image": IMAGE,
+            "model": MODEL,
+            "endpoint_scope": "loopback_only",
+            "model_calls": 1,
+            "response_non_empty": True,
+            "tool_calls": 0,
+            "credential_present": False,
+            "artifact_download_network": True,
+        }
+        for field, value in exact.items():
+            if runtime.get(field) != value:
+                findings.append(f"runtime.{field} must be {value!r}")
+        for field in ("image_id", "model_digest"):
+            value = runtime.get(field)
+            if not isinstance(value, str) or not DIGEST.fullmatch(value):
+                findings.append(f"runtime.{field} must be a sha256 digest")
+        size = runtime.get("model_size_bytes")
+        if not isinstance(size, int) or isinstance(size, bool) or not 0 < size <= 450_000_000:
+            findings.append("runtime.model_size_bytes must remain within the artifact bound")
+        response_bytes = runtime.get("response_bytes")
+        if not isinstance(response_bytes, int) or isinstance(response_bytes, bool) or not 0 < response_bytes <= 4_096:
+            findings.append("runtime.response_bytes must be between one and 4096")
+        for field in ("input_tokens", "output_tokens"):
+            value = runtime.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                findings.append(f"runtime.{field} must be a positive token count")
+
+    expected_safety = {
+        "production_certified": False,
+        "unattended_autonomous_execution": False,
+        "external_model_provider_calls": 0,
+        "target_mutations": 0,
+        "executor_calls": 0,
+        "execution_agent_calls": 0,
+        "secrets_recorded": False,
+        "prompts_recorded": False,
+        "responses_recorded": False,
+        "message_bodies_recorded": False,
+    }
+    if report.get("safety") != expected_safety:
+        findings.append("safety proof drifted from the supervised local-only boundary")
+    cleanup = report.get("cleanup")
+    expected_cleanup = {
+        "container_removed": True,
+        "volume_removed": True,
+        "endpoint_environment_cleared": True,
+        "model_environment_cleared": True,
+        "image_state_restored": True,
+    }
+    if not isinstance(cleanup, dict) or any(cleanup.get(field) != value for field, value in expected_cleanup.items()):
+        findings.append("cleanup proof is incomplete")
+    elif not isinstance(cleanup.get("image_preexisting_before"), bool):
+        findings.append("cleanup.image_preexisting_before must be boolean")
+    if FORBIDDEN_REPORT_FIELDS.intersection(key.lower() for key in all_keys(report)):
+        findings.append("report contains a forbidden payload or machine-local path field")
+    if any(SENSITIVE.search(value) for value in all_strings(report)):
+        findings.append("report contains credential-like material")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        findings = validate_manifest(load_json(args.manifest))
+        if args.report is not None:
+            findings.extend(validate_report(load_json(args.report)))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"LOCAL_MODEL_QUALIFICATION_FAILED unable_to_load={error}")
+        return 1
+    if findings:
+        for finding in findings:
+            print(f"LOCAL_MODEL_QUALIFICATION_FINDING {finding}")
+        print(f"LOCAL_MODEL_QUALIFICATION_FAILED findings={len(findings)}")
+        return 1
+    suffix = " report=passed" if args.report is not None else ""
+    print(f"LOCAL_MODEL_QUALIFICATION_OK provider=ollama model={MODEL}{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/local-model-qualification.ps1
+++ b/rocketmq-sre/scripts/local-model-qualification.ps1
@@ -1,0 +1,319 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Check', 'Run')]
+    [string]$Mode = 'Run',
+
+    [string]$CargoTargetDir = 'D:\BuildCache\rocketmq-sre-local-model',
+
+    [string]$EvidenceRoot = 'D:\rocketmq-sre-evidence',
+
+    [string]$OllamaImage = 'ollama/ollama:0.13.3',
+
+    [string]$Model = 'qwen2.5:0.5b'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
+$manifestPath = Join-Path $sreRoot 'config\qualification\local-model.v1.json'
+$checkerPath = Join-Path $scriptDirectory 'check_local_model_qualification.py'
+$endpointEnvironment = 'ROCKETMQ_SRE_LOCAL_MODEL_QUALIFICATION_ENDPOINT'
+$modelEnvironment = 'ROCKETMQ_SRE_LOCAL_MODEL_QUALIFICATION_MODEL'
+
+function Assert-DataPath([string]$Path, [string]$Description) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    if (
+        -not $root.Equals('D:\', [StringComparison]::OrdinalIgnoreCase) -and
+        -not $root.Equals('F:\', [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        throw "$Description must use the D or F drive."
+    }
+}
+
+function Invoke-Native([string]$Command, [string[]]$Arguments, [string]$Description) {
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Get-DockerImageId([string]$Image) {
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = @(& docker image inspect --format '{{.Id}}' $Image 2>$null)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    if ($exitCode -ne 0) {
+        return $null
+    }
+    return ($output -join '').Trim()
+}
+
+function Test-DockerObjectAbsent([string[]]$Arguments) {
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & docker @Arguments 2>$null | Out-Null
+        return $LASTEXITCODE -ne 0
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+}
+
+if ($OllamaImage -ne 'ollama/ollama:0.13.3') {
+    throw 'The qualification runtime image must remain pinned to ollama/ollama:0.13.3.'
+}
+if ($Model -ne 'qwen2.5:0.5b') {
+    throw 'The qualification model must remain pinned to qwen2.5:0.5b.'
+}
+Assert-DataPath $CargoTargetDir 'Cargo target directory'
+Assert-DataPath $EvidenceRoot 'qualification Evidence root'
+$resolvedTarget = [IO.Path]::GetFullPath($CargoTargetDir)
+$resolvedEvidenceRoot = [IO.Path]::GetFullPath($EvidenceRoot).TrimEnd('\')
+$allowedEvidenceRoots = @(
+    [IO.Path]::GetFullPath('D:\rocketmq-sre-evidence').TrimEnd('\'),
+    [IO.Path]::GetFullPath('F:\rocketmq-sre-evidence').TrimEnd('\')
+)
+if (-not ($allowedEvidenceRoots -contains $resolvedEvidenceRoot)) {
+    throw 'Qualification reports must use D:\rocketmq-sre-evidence or F:\rocketmq-sre-evidence.'
+}
+
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath) 'local-model manifest validation'
+if ($Mode -eq 'Check') {
+    Write-Host 'LOCAL_MODEL_QUALIFICATION_CHECK_OK'
+    exit 0
+}
+
+Invoke-Native docker @('version', '--format', '{{.Server.Version}}') 'Docker server availability check'
+$revision = (& git -C $repositoryRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or $revision -notmatch '^[0-9a-f]{40}$') {
+    throw 'Unable to determine the qualification source revision.'
+}
+$dirty = & git -C $repositoryRoot status --porcelain=v1
+if ($LASTEXITCODE -ne 0 -or -not [string]::IsNullOrWhiteSpace(($dirty -join ''))) {
+    throw 'Local-model qualification requires a committed, clean source tree.'
+}
+
+$startedAt = [DateTimeOffset]::UtcNow
+$runName = 'local-model-{0}-{1}' -f `
+    $startedAt.ToString('yyyyMMdd-HHmmss'), ([Guid]::NewGuid().ToString('N'))
+$runRoot = [IO.Path]::GetFullPath((Join-Path $resolvedEvidenceRoot $runName))
+$expectedEvidencePrefix = $resolvedEvidenceRoot + '\'
+if (-not $runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Qualification output escaped the configured Evidence root.'
+}
+$reportPath = Join-Path $runRoot 'qualification-report.v1.json'
+New-Item -ItemType Directory -Force -Path $runRoot, $resolvedTarget | Out-Null
+
+$suffix = [Guid]::NewGuid().ToString('N')
+$containerName = "rocketmq-sre-ollama-$suffix"
+$volumeName = "rocketmq-sre-ollama-model-$suffix"
+$imageIdBefore = Get-DockerImageId $OllamaImage
+$imageExistedBefore = -not [string]::IsNullOrWhiteSpace($imageIdBefore)
+$containerCreated = $false
+$volumeCreated = $false
+$containerRemoved = $false
+$volumeRemoved = $false
+$endpointEnvironmentCleared = $false
+$modelEnvironmentCleared = $false
+$imageStateRestored = $false
+$testPassed = $false
+$marker = $null
+$qualificationError = $null
+$imageId = $null
+$modelDigest = $null
+$modelSize = 0
+try {
+    Invoke-Native docker @('volume', 'create', $volumeName) 'qualification model volume creation'
+    $volumeCreated = $true
+    $containerId = & docker run --detach --name $containerName `
+        --publish '127.0.0.1::11434' `
+        --volume "${volumeName}:/root/.ollama" `
+        $OllamaImage
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($containerId -join ''))) {
+        throw 'Unable to start the qualification-owned Ollama container.'
+    }
+    $containerCreated = $true
+    $imageId = Get-DockerImageId $OllamaImage
+    if ($imageId -notmatch '^sha256:[0-9a-f]{64}$') {
+        throw 'Unable to resolve the pinned Ollama image digest.'
+    }
+    $portMapping = (& docker port $containerName '11434/tcp').Trim()
+    if ($LASTEXITCODE -ne 0 -or $portMapping -notmatch '127\.0\.0\.1:(?<port>\d+)$') {
+        throw 'Unable to determine the loopback-only Ollama port.'
+    }
+    $ollamaPort = [int]$Matches.port
+
+    $ready = $false
+    for ($attempt = 0; $attempt -lt 120; $attempt++) {
+        try {
+            $version = Invoke-RestMethod -Method Get -Uri "http://127.0.0.1:$ollamaPort/api/version" -TimeoutSec 2
+            if (-not [string]::IsNullOrWhiteSpace([string]$version.version)) {
+                $ready = $true
+                break
+            }
+        }
+        catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    if (-not $ready) {
+        throw 'Qualification-owned Ollama did not become ready.'
+    }
+
+    Invoke-Native docker @('exec', $containerName, 'ollama', 'pull', $Model) 'bounded local model pull'
+    $tags = Invoke-RestMethod -Method Get -Uri "http://127.0.0.1:$ollamaPort/api/tags" -TimeoutSec 10
+    $qualifiedModels = @($tags.models | Where-Object { $_.name -eq $Model -or $_.model -eq $Model })
+    if ($qualifiedModels.Count -ne 1) {
+        throw 'The qualification-owned Ollama runtime did not expose exactly one pinned model.'
+    }
+    $modelDigest = [string]$qualifiedModels[0].digest
+    if ($modelDigest -match '^[0-9a-f]{64}$') {
+        $modelDigest = "sha256:$modelDigest"
+    }
+    $modelSize = [int64]$qualifiedModels[0].size
+    if ($modelDigest -notmatch '^sha256:[0-9a-f]{64}$' -or $modelSize -lt 1 -or $modelSize -gt 450000000) {
+        throw 'The local model digest or artifact size violated the qualification contract.'
+    }
+
+    [Environment]::SetEnvironmentVariable(
+        $endpointEnvironment,
+        "http://127.0.0.1:$ollamaPort/v1",
+        'Process'
+    )
+    [Environment]::SetEnvironmentVariable($modelEnvironment, $Model, 'Process')
+    $cargoArguments = @(
+        'test', '--locked',
+        '--manifest-path', (Join-Path $sreRoot 'Cargo.toml'),
+        '--target-dir', $resolvedTarget,
+        '-p', 'rocketmq-sre-model-gateway', '--test', 'live_local_model_smoke',
+        'live_ollama_openai_compatible_endpoint_when_explicitly_configured',
+        '--', '--ignored', '--exact', '--nocapture'
+    )
+    $savedErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $testOutput = @(& cargo @cargoArguments 2>&1)
+        $cargoExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $savedErrorActionPreference
+    }
+    if ($cargoExitCode -ne 0) {
+        throw "Local-model test failed with exit code $cargoExitCode; model payloads were not retained."
+    }
+    $markerLine = @($testOutput | ForEach-Object { [string]$_ } | Where-Object {
+        $_ -match '^LOCAL_MODEL_QUALIFICATION_OK '
+    })
+    if ($markerLine.Count -ne 1) {
+        throw 'The local-model test did not emit exactly one sanitized result marker.'
+    }
+    $markerJson = $markerLine[0].Substring('LOCAL_MODEL_QUALIFICATION_OK '.Length)
+    $marker = $markerJson | ConvertFrom-Json
+    $testPassed = $true
+}
+catch {
+    $qualificationError = $_.Exception.Message
+}
+finally {
+    [Environment]::SetEnvironmentVariable($endpointEnvironment, $null, 'Process')
+    [Environment]::SetEnvironmentVariable($modelEnvironment, $null, 'Process')
+    $endpointEnvironmentCleared = [string]::IsNullOrEmpty(
+        [Environment]::GetEnvironmentVariable($endpointEnvironment, 'Process')
+    )
+    $modelEnvironmentCleared = [string]::IsNullOrEmpty(
+        [Environment]::GetEnvironmentVariable($modelEnvironment, 'Process')
+    )
+    if ($containerCreated) {
+        & docker rm --force --volumes $containerName *> $null
+    }
+    $containerRemoved = Test-DockerObjectAbsent -Arguments @('container', 'inspect', $containerName)
+    if ($volumeCreated) {
+        & docker volume rm --force $volumeName *> $null
+    }
+    $volumeRemoved = Test-DockerObjectAbsent -Arguments @('volume', 'inspect', $volumeName)
+    if (-not $imageExistedBefore) {
+        & docker image rm --force $OllamaImage *> $null
+        $imageStateRestored = [string]::IsNullOrWhiteSpace((Get-DockerImageId $OllamaImage))
+    }
+    else {
+        $imageStateRestored = (Get-DockerImageId $OllamaImage) -eq $imageIdBefore
+    }
+}
+
+if (
+    $null -ne $qualificationError -or -not $testPassed -or $null -eq $marker -or
+    -not $containerRemoved -or -not $volumeRemoved -or
+    -not $endpointEnvironmentCleared -or -not $modelEnvironmentCleared -or
+    -not $imageStateRestored
+) {
+    if ($runRoot.StartsWith($expectedEvidencePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
+    }
+    throw 'Local-model qualification or cleanup did not pass.'
+}
+
+$report = [ordered]@{
+    schema_version = 'rocketmq-sre.local-model-qualification-report.v1'
+    candidate_commit = $revision
+    source_clean = $true
+    environment = 'disposable_docker_loopback_ollama'
+    operating_mode = 'supervised_read_only'
+    started_at = $startedAt.ToString('o')
+    finished_at = [DateTimeOffset]::UtcNow.ToString('o')
+    status = 'passed'
+    runtime = [ordered]@{
+        provider = [string]$marker.provider
+        protocol = 'openai_compatible_chat_completions'
+        image = $OllamaImage
+        image_id = $imageId
+        model = $Model
+        model_digest = $modelDigest
+        model_size_bytes = $modelSize
+        endpoint_scope = 'loopback_only'
+        model_calls = 1
+        response_non_empty = [bool]$marker.response_non_empty
+        response_bytes = [int]$marker.response_bytes
+        tool_calls = [int]$marker.tool_calls
+        credential_present = [bool]$marker.credential_present
+        input_tokens = [int]$marker.input_tokens
+        output_tokens = [int]$marker.output_tokens
+        artifact_download_network = $true
+    }
+    safety = [ordered]@{
+        production_certified = $false
+        unattended_autonomous_execution = $false
+        external_model_provider_calls = 0
+        target_mutations = 0
+        executor_calls = 0
+        execution_agent_calls = 0
+        secrets_recorded = $false
+        prompts_recorded = $false
+        responses_recorded = $false
+        message_bodies_recorded = $false
+    }
+    cleanup = [ordered]@{
+        container_removed = $containerRemoved
+        volume_removed = $volumeRemoved
+        endpoint_environment_cleared = $endpointEnvironmentCleared
+        model_environment_cleared = $modelEnvironmentCleared
+        image_preexisting_before = $imageExistedBefore
+        image_state_restored = $imageStateRestored
+    }
+}
+$json = $report | ConvertTo-Json -Depth 8
+[IO.File]::WriteAllText($reportPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+Invoke-Native python @($checkerPath, '--manifest', $manifestPath, '--report', $reportPath) `
+    'local-model qualification report validation'
+Write-Host "LOCAL_MODEL_LIVE_QUALIFICATION_OK report=$reportPath provider=ollama model=$Model production_certified=false"

--- a/rocketmq-sre/scripts/tests/test_check_local_model_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_local_model_qualification.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the credential-free local-model qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_local_model_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_local_model_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_report() -> dict:
+    return {
+        "schema_version": MODULE.REPORT_SCHEMA,
+        "candidate_commit": "a" * 40,
+        "source_clean": True,
+        "environment": MODULE.ENVIRONMENT,
+        "operating_mode": "supervised_read_only",
+        "started_at": "2026-08-06T00:00:00Z",
+        "finished_at": "2026-08-06T00:01:00Z",
+        "status": "passed",
+        "runtime": {
+            "provider": "ollama",
+            "protocol": "openai_compatible_chat_completions",
+            "image": MODULE.IMAGE,
+            "image_id": "sha256:" + "1" * 64,
+            "model": MODULE.MODEL,
+            "model_digest": "sha256:" + "2" * 64,
+            "model_size_bytes": 398_000_000,
+            "endpoint_scope": "loopback_only",
+            "model_calls": 1,
+            "response_non_empty": True,
+            "response_bytes": 2,
+            "tool_calls": 0,
+            "credential_present": False,
+            "input_tokens": 12,
+            "output_tokens": 1,
+            "artifact_download_network": True,
+        },
+        "safety": {
+            "production_certified": False,
+            "unattended_autonomous_execution": False,
+            "external_model_provider_calls": 0,
+            "target_mutations": 0,
+            "executor_calls": 0,
+            "execution_agent_calls": 0,
+            "secrets_recorded": False,
+            "prompts_recorded": False,
+            "responses_recorded": False,
+            "message_bodies_recorded": False,
+        },
+        "cleanup": {
+            "container_removed": True,
+            "volume_removed": True,
+            "endpoint_environment_cleared": True,
+            "model_environment_cleared": True,
+            "image_preexisting_before": False,
+            "image_state_restored": True,
+        },
+    }
+
+
+class LocalModelQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_valid_report_passes(self) -> None:
+        self.assertEqual(MODULE.validate_report(valid_report()), [])
+
+    def test_rejects_external_or_credentialed_runtime(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["runtime"]["endpoint_scope"] = "public"
+        manifest["runtime"]["credential_required"] = True
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("runtime contract drifted from pinned credential-free loopback Ollama", findings)
+
+    def test_rejects_extra_model_calls_or_oversized_output(self) -> None:
+        report = valid_report()
+        report["runtime"]["model_calls"] = 2
+        report["runtime"]["response_bytes"] = 4_097
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("runtime.model_calls must be 1", findings)
+        self.assertIn("runtime.response_bytes must be between one and 4096", findings)
+
+    def test_rejects_mutation_production_or_external_provider_claims(self) -> None:
+        report = valid_report()
+        report["safety"]["production_certified"] = True
+        report["safety"]["target_mutations"] = 1
+        report["safety"]["external_model_provider_calls"] = 1
+
+        self.assertIn(
+            "safety proof drifted from the supervised local-only boundary",
+            MODULE.validate_report(report),
+        )
+
+    def test_rejects_payload_machine_path_or_secret(self) -> None:
+        report = valid_report()
+        report["endpoint_url"] = "http://127.0.0.1:11434/v1"
+        report["response_body"] = "Bearer qualification-token"
+
+        findings = MODULE.validate_report(report)
+
+        self.assertIn("report contains a forbidden payload or machine-local path field", findings)
+        self.assertIn("report contains credential-like material", findings)
+
+    def test_rejects_incomplete_cleanup(self) -> None:
+        report = valid_report()
+        report["cleanup"]["volume_removed"] = False
+
+        self.assertIn("cleanup proof is incomplete", MODULE.validate_report(report))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9013

### Brief Description

Add a credential-free local-model qualification for the AI SRE Model Gateway. The qualification pins Ollama 0.13.3 and qwen2.5:0.5b, accepts only a qualification-owned loopback endpoint, performs exactly one bounded OpenAI-compatible chat invocation, and records no prompt, response, endpoint, credential, or machine-local path.

The change includes a versioned qualification manifest, an ignored live integration test, a fail-closed report validator with negative tests, and a PowerShell runner that removes its container, dedicated model volume, process environment, and newly introduced image before accepting a sanitized report. The implementation status and bilingual SRE README now distinguish this live local-runtime proof from production certification and from the existing DeepSeek qualification.

### How Did You Test This Change?

- `python -B -m unittest discover -s scripts/tests -p 'test_*.py'` (84 tests passed)
- `python -B scripts/check_implementation_status.py` (passed)
- `python -B scripts/check_source_layout.py` (passed, zero `mod.rs` files)
- `python -B scripts/check_execution_dependency_boundary.py` (passed)
- `python -B scripts/check_read_gateway_boundary.py` (passed)
- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check` (passed)
- `cargo check --locked --workspace` (passed)
- `cargo test --locked --workspace --all-features` (passed)
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` (passed)
- `cargo doc --locked --workspace --no-deps` (passed)
- `.\scripts\local-model-qualification.ps1 -Mode Check` (passed)
- `.\scripts\local-model-qualification.ps1` (passed against the pinned loopback Ollama runtime; one model call, zero tool or mutation calls, and cleanup state verified)
