### PR TITLE
[ISSUE #9015]✨Move remaining benchmark request headers to generated direct codecs

### DIFF
--- a/rocketmq-protocol/src/protocol/header/consume_message_directly_result_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/consume_message_directly_result_request_header.rs
@@ -13,16 +13,22 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.ConsumeMessageDirectlyResultRequestHeader",
+    lookup = "scan",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsumeMessageDirectlyResultRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
     pub client_id: Option<CheetahString>,
     pub msg_id: Option<CheetahString>,
@@ -31,6 +37,7 @@ pub struct ConsumeMessageDirectlyResultRequestHeader {
     pub topic_sys_flag: Option<i32>,
     pub group_sys_flag: Option<i32>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/controller/clean_broker_data_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/clean_broker_data_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -21,16 +21,33 @@ fn default_invoke_time() -> u64 {
     rocketmq_model::time::current_millis()
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.controller.admin.CleanControllerBrokerDataRequestHeader",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct CleanBrokerDataRequestHeader {
     pub cluster_name: Option<CheetahString>,
-    #[required]
+    #[header(required)]
     pub broker_name: CheetahString,
     pub broker_controller_ids_to_clean: Option<CheetahString>,
     #[serde(rename = "isCleanLivingBroker", alias = "cleanLivingBroker")]
+    #[header(
+        key = "isCleanLivingBroker",
+        alias = "cleanLivingBroker",
+        alias_conflict = "prefer_canonical",
+        default,
+        default_semantic = "literal:false"
+    )]
     pub clean_living_broker: bool,
     #[serde(default = "default_invoke_time")]
+    #[header(
+        default_with = "default_invoke_time",
+        default_semantic = "dynamic:current_time_millis",
+        range = "i64"
+    )]
     pub invoke_time: u64,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_consumer_status_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_status_request_header.rs
@@ -13,25 +13,32 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
 /// Request header for getting consumer status from client.
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetConsumerStatusRequestHeader",
+    lookup = "scan",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetConsumerStatusRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
     pub client_addr: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,31 +24,37 @@ use crate::protocol::remoting_command::RemotingCommand;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader",
+    lookup = "scan",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub producer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub default_topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub default_topic_queue_nums: i32,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
-    #[required]
+    #[header(required)]
     pub sys_flag: i32,
 
-    #[required]
+    #[header(required)]
     pub born_timestamp: i64,
 
-    #[required]
+    #[header(required)]
     pub flag: i32,
 
     pub properties: Option<CheetahString>,
@@ -57,6 +63,7 @@ pub struct SendMessageRequestHeader {
     pub batch: Option<bool>,
     pub max_reconsume_times: Option<i32>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
@@ -20,13 +20,19 @@ use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.namesrv.DeleteTopicFromNamesrvRequestHeader",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteTopicFromNamesrvRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
     pub cluster_name: Option<CheetahString>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_consume_queue_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_consume_queue_request_header.rs
@@ -13,25 +13,36 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryConsumeQueueRequestHeader",
+    lookup = "scan",
+    fast
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryConsumeQueueRequestHeader {
+    #[header(default, default_semantic = "literal:")]
     pub topic: CheetahString,
 
+    #[header(default, default_semantic = "literal:0")]
     pub queue_id: i32,
 
+    #[header(default, default_semantic = "literal:0")]
     pub index: i64,
 
+    #[header(default, default_semantic = "literal:0")]
     pub count: i32,
 
     pub consumer_group: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -19,13 +19,19 @@ use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
+use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
+use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
+use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as NamesrvTopicRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header_codec::{
@@ -146,7 +152,13 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<RpcRequestHeader>(),
         register::<TopicRequestHeader>(),
         register::<NamesrvTopicRequestHeader>(),
+        register::<ConsumeMessageDirectlyResultRequestHeader>(),
+        register::<CleanBrokerDataRequestHeader>(),
+        register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
+        register::<SendMessageRequestHeader>(),
+        register::<DeleteTopicFromNamesrvRequestHeader>(),
+        register::<QueryConsumeQueueRequestHeader>(),
         register::<SearchOffsetRequestHeader>(),
         register::<SearchOffsetResponseHeader>(),
         register::<PullMessageRequestHeader>(),
@@ -155,6 +167,55 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<SendMessageResponseHeader>(),
         register::<NotificationRequestHeader>(),
     ]
+}
+
+#[test]
+fn performance_corpus_headers_use_generated_direct_codecs() {
+    const {
+        assert!(<ConsumeMessageDirectlyResultRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<CleanBrokerDataRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<GetConsumerStatusRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<SendMessageRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<DeleteTopicFromNamesrvRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<QueryConsumeQueueRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<GetLiteClientInfoRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<SendMessageRequestHeaderV2 as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<SendMessageResponseHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<NotificationRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<PullMessageRequestHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+        assert!(<PullMessageResponseHeader as FromMap>::SUPPORTS_HEADER_FIELD_SOURCE);
+    }
+
+    let corpus: serde_json::Value =
+        serde_json::from_str(include_str!("../../scripts/request-header-codec/perf-corpus-v1.json"))
+            .expect("checked-in performance corpus");
+    let registered: HashMap<_, _> = registry()
+        .into_iter()
+        .map(|schema| (schema.type_id, schema.direct_binary))
+        .collect();
+
+    for case in corpus["cases"].as_array().expect("corpus cases") {
+        let type_id = case["header"].as_str().expect("corpus header type ID");
+        assert!(
+            registered.contains_key(type_id),
+            "{type_id} must use a generated direct source codec"
+        );
+    }
+
+    for type_id in [
+        ConsumeMessageDirectlyResultRequestHeader::TYPE_ID,
+        CleanBrokerDataRequestHeader::TYPE_ID,
+        GetConsumerStatusRequestHeader::TYPE_ID,
+        SendMessageRequestHeader::TYPE_ID,
+        DeleteTopicFromNamesrvRequestHeader::TYPE_ID,
+        QueryConsumeQueueRequestHeader::TYPE_ID,
+    ] {
+        assert_eq!(
+            registered.get(type_id),
+            Some(&true),
+            "{type_id} must use direct binary encoding"
+        );
+    }
 }
 
 fn rust_kind(kind: HeaderValueKind) -> &'static str {

--- a/scripts/request-header-codec/compare_header_schema.py
+++ b/scripts/request-header-codec/compare_header_schema.py
@@ -31,6 +31,7 @@ FIELD_PATTERN = re.compile(
 RENAME_PATTERN = re.compile(r'\brename\s*=\s*"([^"]+)"')
 ALIAS_PATTERN = re.compile(r'\balias\s*=\s*"([^"]+)"')
 DEFAULT_PATTERN = re.compile(r'\bdefault\s*=\s*"([^"]+)"')
+HEADER_REQUIRED_PATTERN = re.compile(r"#\[\s*header\s*\([\s\S]*?\brequired\b[\s\S]*?\)\s*\]")
 
 
 @dataclass(frozen=True)
@@ -177,7 +178,7 @@ def parse_direct_fields(entry: dict[str, object], repo_root: Path) -> list[tuple
         key = key_match.group(1) if key_match else snake_to_camel(name)
         aliases = tuple(ALIAS_PATTERN.findall(attrs))
         default_match = DEFAULT_PATTERN.search(attrs)
-        required = "#[required]" in attrs
+        required = "#[required]" in attrs or HEADER_REQUIRED_PATTERN.search(attrs) is not None
         flatten = bool(re.search(r"#\[serde\([^]]*\bflatten\b", attrs))
         wire_type = normalize_type(rust_type)
         if (

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -66,6 +66,17 @@
         "rust": "rocketmq-protocol/src/protocol/header/notification_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotificationRequestHeader.java"
       }
+    },
+    {
+      "rustType": "QueryConsumeQueueRequestHeader",
+      "field": "topic",
+      "semantic": "literal:",
+      "owner": "rocketmq-rust protocol maintainers",
+      "reason": "Preserves the public non-optional Rust field while accepting a Java frame that omits the nullable topic",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/query_consume_queue_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumeQueueRequestHeader.java"
+      }
     }
   ],
   "nameMappings": [


### PR DESCRIPTION
## Summary

- migrate the six remaining request-header benchmark types from RequestHeaderCodecV2 to generated RequestHeaderCodecV3 source decode and direct binary encode
- preserve Java required, alias, default, flatten, and signed-range semantics without production java_type metadata
- register every 48-operation corpus type and make the static Java schema checker understand V3 header(required)

## Validation

- cargo fmt -p rocketmq-protocol -- --check
- cargo test -p rocketmq-macros
- cargo test -p rocketmq-protocol --all-features (1445 unit tests plus integration, UI, and doctests)
- cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion
- cargo +nightly-2026-07-05 check --locked --all-targets --all-features (fuzz)
- python scripts/request-header-codec/compare_header_schema.py (143 mappings, zero differences)
- python scripts/request-header-codec/generate_perf_corpus.py --check (48 operations current)
- renamed dependency fixture unlocked/offline check passed; its required locked/offline check remains blocked by the pre-existing frozen dependency lock drift

## Diagnostics

The six migrated types improved the 24 affected scenarios by about 1.679x geometric mean in same-machine short release diagnostics. The slowest affected scenario was about 0.987x, while ROCKETMQ encode/decode geometric means were about 4.499x/1.407x. The benchmark artifact increased 1.399%. These are optimization diagnostics, not PERF-01 through PERF-09 release qualification.

The required workspace Clippy command still stops in unchanged rocketmq-model CheetahString 3.0 deprecations and useless conversion findings. Workspace and standalone example formatting still hit Windows error 206; the example Clippy also retains its independent CheetahString 2.1/3.0 type mismatch. No mod.rs file was added or changed.

Closes #9015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated several RocketMQ request headers to use the latest header encoding and validation behavior.
  * Required fields are now validated more consistently, with improved defaults and field-presence handling.
  * Enhanced compatibility for topic, consumer, broker, and message operation requests.

* **Tests**
  * Added coverage confirming registered request headers support optimized binary encoding and generated field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->