### PR TITLE
[ISSUE #9019]✨Decode JSON request header fields without map materialization

### DIFF
--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -21,6 +21,7 @@
 mod codec;
 mod error;
 mod field_source;
+mod json_field_source;
 mod schema;
 mod sink;
 mod value;
@@ -34,6 +35,7 @@ pub use codec::HeaderCodec;
 pub use error::HeaderCodecError;
 pub(crate) use field_source::BinaryHeaderFields;
 pub use field_source::HeaderFieldSource;
+pub(crate) use json_field_source::JsonHeaderFields;
 pub use schema::AliasConflictPolicy;
 pub use schema::DynamicCollisionPolicy;
 pub use schema::FlattenPresenceSpec;

--- a/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
@@ -1,0 +1,246 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use serde::de::DeserializeSeed;
+use serde::de::MapAccess;
+use serde::de::Visitor;
+use serde::Deserialize;
+use serde::Deserializer;
+
+use super::private::FieldSourceSealed;
+use super::HeaderFieldSource;
+use crate::HeaderMap;
+
+const FIELD_LENGTH_BYTES: usize = 4;
+const ESTIMATED_FIELD_BYTES: usize = 32;
+const MIN_INITIAL_PAYLOAD_CAPACITY: usize = 256;
+const MAX_INITIAL_MAP_CAPACITY: usize = 1024;
+
+/// A compact, immutable JSON extension-field payload.
+///
+/// Serde writes decoded key/value text into one length-prefixed byte buffer.
+/// This preserves JSON empty strings and duplicate input order without
+/// allocating one owned string or hash-table entry per field.
+#[derive(Clone)]
+pub(crate) struct JsonHeaderFields {
+    payload: Bytes,
+    entry_count: usize,
+}
+
+impl JsonHeaderFields {
+    pub(crate) fn materialize(&self) -> HeaderMap {
+        let mut map = HeaderMap::with_capacity(self.entry_count.min(MAX_INITIAL_MAP_CAPACITY));
+        for (key, value) in self.iter() {
+            map.insert(CheetahString::from_slice(key), CheetahString::from_slice(value));
+        }
+        map
+    }
+
+    #[inline]
+    fn iter(&self) -> JsonHeaderFieldIter<'_> {
+        JsonHeaderFieldIter {
+            payload: &self.payload,
+            cursor: 0,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonHeaderFields {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(JsonHeaderFieldsVisitor)
+    }
+}
+
+struct JsonHeaderFieldsVisitor;
+
+impl<'de> Visitor<'de> for JsonHeaderFieldsVisitor {
+    type Value = JsonHeaderFields;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON object whose extension-field values are strings")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let initial_capacity = map
+            .size_hint()
+            .unwrap_or_default()
+            .min(MAX_INITIAL_MAP_CAPACITY)
+            .saturating_mul(ESTIMATED_FIELD_BYTES);
+        let mut payload = BytesMut::with_capacity(initial_capacity);
+        let mut entry_count = 0usize;
+
+        while map
+            .next_key_seed(JsonFieldTextSeed { payload: &mut payload })?
+            .is_some()
+        {
+            map.next_value_seed(JsonFieldTextSeed { payload: &mut payload })?;
+            entry_count = entry_count.saturating_add(1);
+        }
+
+        Ok(JsonHeaderFields {
+            payload: payload.freeze(),
+            entry_count,
+        })
+    }
+}
+
+struct JsonFieldTextSeed<'a> {
+    payload: &'a mut BytesMut,
+}
+
+impl<'de> DeserializeSeed<'de> for JsonFieldTextSeed<'_> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(JsonFieldTextVisitor { payload: self.payload })
+    }
+}
+
+struct JsonFieldTextVisitor<'a> {
+    payload: &'a mut BytesMut,
+}
+
+impl JsonFieldTextVisitor<'_> {
+    fn append<E>(self, value: &str) -> Result<(), E>
+    where
+        E: serde::de::Error,
+    {
+        let length = u32::try_from(value.len()).map_err(|_| E::custom("JSON extension-field text exceeds u32"))?;
+        let additional = FIELD_LENGTH_BYTES
+            .checked_add(value.len())
+            .ok_or_else(|| E::custom("JSON extension-field length overflow"))?;
+        let reserve = if self.payload.capacity() == 0 {
+            additional.max(MIN_INITIAL_PAYLOAD_CAPACITY)
+        } else {
+            additional
+        };
+        self.payload.reserve(reserve);
+        self.payload.put_u32(length);
+        self.payload.extend_from_slice(value.as_bytes());
+        Ok(())
+    }
+}
+
+impl<'de> Visitor<'de> for JsonFieldTextVisitor<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON extension-field string")
+    }
+
+    #[inline]
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.append(value)
+    }
+
+    #[inline]
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.append(value)
+    }
+
+    #[inline]
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.append(&value)
+    }
+}
+
+impl FieldSourceSealed for JsonHeaderFields {}
+
+impl HeaderFieldSource for JsonHeaderFields {
+    #[inline]
+    fn visit_fields_while<'a>(&'a self, visitor: &mut dyn FnMut(&'a str, &'a str) -> bool) {
+        for (key, value) in self.iter() {
+            if !visitor(key, value) {
+                break;
+            }
+        }
+    }
+
+    #[inline]
+    fn to_header_map(&self) -> HeaderMap {
+        self.materialize()
+    }
+}
+
+struct JsonHeaderFieldIter<'a> {
+    payload: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> JsonHeaderFieldIter<'a> {
+    #[inline]
+    fn take(&mut self, length: usize) -> &'a [u8] {
+        let end = self
+            .cursor
+            .checked_add(length)
+            .expect("validated JSON header field offset overflowed");
+        let bytes = self
+            .payload
+            .get(self.cursor..end)
+            .expect("validated JSON header field boundary changed");
+        self.cursor = end;
+        bytes
+    }
+
+    #[inline]
+    fn read_u32(&mut self) -> usize {
+        let bytes = self.take(FIELD_LENGTH_BYTES);
+        u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize
+    }
+
+    #[inline]
+    fn read_utf8(&mut self, length: usize) -> &'a str {
+        std::str::from_utf8(self.take(length)).expect("validated JSON header field UTF-8 changed")
+    }
+}
+
+impl<'a> Iterator for JsonHeaderFieldIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.payload.len() {
+            return None;
+        }
+        let key_length = self.read_u32();
+        let key = self.read_utf8(key_length);
+        let value_length = self.read_u32();
+        let value = self.read_utf8(value_length);
+        Some((key, value))
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -39,6 +39,7 @@ use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_codec::JsonHeaderFields;
 use crate::protocol::header_field_merge::merge_header_and_dynamic;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
@@ -73,7 +74,8 @@ fn deserialize_ext_fields<'de, D>(deserializer: D) -> Result<ExtensionFields, D:
 where
     D: Deserializer<'de>,
 {
-    Option::<HashMap<CheetahString, CheetahString>>::deserialize(deserializer).map(ExtensionFields::from_option)
+    Option::<JsonHeaderFields>::deserialize(deserializer)
+        .map(|fields| fields.map_or_else(ExtensionFields::default, ExtensionFields::from_json_raw))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -1275,6 +1277,15 @@ impl AsMut<RemotingCommand> for RemotingCommand {
 mod tests {
     use super::*;
 
+    fn json_header_with_ext_fields(ext_fields: &str) -> BytesMut {
+        BytesMut::from(
+            format!(
+                r#"{{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"extFields":{ext_fields},"serializeTypeCurrentRPC":"JSON"}}"#
+            )
+            .as_bytes(),
+        )
+    }
+
     #[derive(Debug, Default, PartialEq, Eq)]
     struct TestCustomHeader {
         value: i32,
@@ -1520,6 +1531,156 @@ mod tests {
         assert_eq!(json["extFields"]["alpha"], "first");
         assert_eq!(json["extFields"]["beta"], "second");
         assert!(cloned.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn json_decode_keeps_extension_fields_raw_until_compatibility_map_access() {
+        use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+        let mut header = json_header_with_ext_fields(
+            r#"{"ns":"first","namespace":"legacy","ns":"last","nsd":"false","empty":"","escaped":"line\n\"quoted\"\\tail","unicode":"火箭"}"#,
+        );
+        let header_length = header.len();
+        let command = RemotingCommand::header_decode(&mut header, header_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+
+        assert!(command.ext_fields.is_json_raw());
+        assert!(!command.ext_fields.has_materialized_map());
+        let cloned = command.clone();
+        assert!(cloned.ext_fields.is_json_raw());
+        assert!(!cloned.ext_fields.has_materialized_map());
+
+        let decoded = command.decode_command_custom_header::<RpcRequestHeader>().unwrap();
+        assert_eq!(decoded.namespace.as_deref(), Some("last"));
+        assert_eq!(decoded.namespaced, Some(false));
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let fields = command.ext_fields().unwrap();
+        assert_eq!(fields.get("ns").map(CheetahString::as_str), Some("last"));
+        assert_eq!(fields.get("empty").map(CheetahString::as_str), Some(""));
+        assert_eq!(
+            fields.get("escaped").map(CheetahString::as_str),
+            Some("line\n\"quoted\"\\tail")
+        );
+        assert_eq!(fields.get("unicode").map(CheetahString::as_str), Some("火箭"));
+        assert!(command.ext_fields.is_json_raw());
+        assert!(command.ext_fields.has_materialized_map());
+        assert!(!cloned.ext_fields.has_materialized_map());
+
+        let json = serde_json::to_value(&cloned).unwrap();
+        assert_eq!(json["extFields"]["ns"], "last");
+        assert_eq!(json["extFields"]["empty"], "");
+        assert_eq!(json["extFields"]["unicode"], "火箭");
+        assert!(cloned.ext_fields.is_json_raw());
+        assert!(cloned.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn json_decode_preserves_absent_null_and_empty_extension_fields() {
+        let mut missing = BytesMut::from(
+            r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"serializeTypeCurrentRPC":"JSON"}"#
+                .as_bytes(),
+        );
+        let missing_length = missing.len();
+        let missing_command = RemotingCommand::header_decode(&mut missing, missing_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+        assert!(missing_command.ext_fields().is_none());
+
+        let mut null = json_header_with_ext_fields("null");
+        let null_length = null.len();
+        let null_command = RemotingCommand::header_decode(&mut null, null_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+        assert!(null_command.ext_fields().is_none());
+
+        let mut empty = json_header_with_ext_fields("{}");
+        let empty_length = empty.len();
+        let empty_command = RemotingCommand::header_decode(&mut empty, empty_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+        assert!(empty_command.ext_fields.is_json_raw());
+        assert!(!empty_command.ext_fields.has_materialized_map());
+        assert!(empty_command.ext_fields().unwrap().is_empty());
+        assert!(empty_command.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn v3_production_json_decode_uses_raw_fields_without_materializing_the_map() {
+        use crate::protocol::header::notification_request_header::NotificationRequestHeader;
+
+        let header = NotificationRequestHeader {
+            consumer_group: "group-a".into(),
+            topic: "topic-a".into(),
+            queue_id: 3,
+            poll_time: 15_000,
+            born_time: 1_720_000_000_000,
+            ..Default::default()
+        };
+        let mut encoded = BytesMut::new();
+        RemotingCommand::create_request_command(1, header)
+            .set_serialize_type(SerializeType::JSON)
+            .try_fast_header_encode(&mut encoded)
+            .unwrap();
+        let command = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+        assert!(command.ext_fields.is_json_raw());
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let standard = command
+            .decode_command_custom_header::<NotificationRequestHeader>()
+            .unwrap();
+        assert_eq!(standard.queue_id, 3);
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let fast = command
+            .decode_command_custom_header_fast::<NotificationRequestHeader>()
+            .unwrap();
+        assert_eq!(fast.queue_id, 3);
+        assert!(!command.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn json_raw_fallback_and_mutation_materialize_the_compatibility_map() {
+        let mut header = json_header_with_ext_fields(r#"{"value":"7"}"#);
+        let header_length = header.len();
+        let mut command = RemotingCommand::header_decode(&mut header, header_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+        assert!(command.ext_fields.is_json_raw());
+        assert!(!command.ext_fields.has_materialized_map());
+
+        let decoded = command.decode_command_custom_header::<TestCustomHeader>().unwrap();
+        assert_eq!(decoded.value, 7);
+        assert!(command.ext_fields.is_json_raw());
+        assert!(command.ext_fields.has_materialized_map());
+
+        command.add_ext_field("added", "field");
+        assert!(!command.ext_fields.is_json_raw());
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("value"))
+                .map(CheetahString::as_str),
+            Some("7")
+        );
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("added"))
+                .map(CheetahString::as_str),
+            Some("field")
+        );
+    }
+
+    #[test]
+    fn json_envelope_rejects_non_string_extension_field_values() {
+        for value in ["7", "true", "null", "{}", "[]"] {
+            let mut header = json_header_with_ext_fields(&format!(r#"{{"value":{value}}}"#));
+            let header_length = header.len();
+
+            assert!(RemotingCommand::header_decode(&mut header, header_length, SerializeType::JSON).is_err());
+        }
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
@@ -16,6 +16,7 @@ use std::sync::OnceLock;
 
 use super::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderFieldSource;
+use crate::protocol::header_codec::JsonHeaderFields;
 use crate::HeaderMap;
 
 #[derive(Default)]
@@ -25,6 +26,10 @@ pub(super) enum ExtensionFields {
     Materialized(HeaderMap),
     RocketMqRaw {
         fields: BinaryHeaderFields,
+        materialized: OnceLock<HeaderMap>,
+    },
+    JsonRaw {
+        fields: JsonHeaderFields,
         materialized: OnceLock<HeaderMap>,
     },
 }
@@ -44,17 +49,30 @@ impl Clone for ExtensionFields {
                     materialized: cloned_cache,
                 }
             }
+            Self::JsonRaw { fields, materialized } => {
+                let cloned_cache = OnceLock::new();
+                if let Some(map) = materialized.get() {
+                    let _ = cloned_cache.set(map.clone());
+                }
+                Self::JsonRaw {
+                    fields: fields.clone(),
+                    materialized: cloned_cache,
+                }
+            }
         }
     }
 }
 
 impl ExtensionFields {
-    pub(super) fn from_option(fields: Option<HeaderMap>) -> Self {
-        fields.map_or(Self::Absent, Self::Materialized)
-    }
-
     pub(super) fn from_rocketmq_raw(fields: BinaryHeaderFields) -> Self {
         Self::RocketMqRaw {
+            fields,
+            materialized: OnceLock::new(),
+        }
+    }
+
+    pub(super) fn from_json_raw(fields: JsonHeaderFields) -> Self {
+        Self::JsonRaw {
             fields,
             materialized: OnceLock::new(),
         }
@@ -69,12 +87,14 @@ impl ExtensionFields {
             Self::Absent => None,
             Self::Materialized(fields) => Some(fields),
             Self::RocketMqRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
+            Self::JsonRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
         }
     }
 
     pub(super) fn as_field_source(&self) -> Option<&dyn HeaderFieldSource> {
         match self {
             Self::RocketMqRaw { fields, .. } => Some(fields),
+            Self::JsonRaw { fields, .. } => Some(fields),
             Self::Absent | Self::Materialized(_) => None,
         }
     }
@@ -84,6 +104,11 @@ impl ExtensionFields {
             Self::Absent => None,
             Self::Materialized(fields) => Some(fields),
             Self::RocketMqRaw { fields, .. } => {
+                let fields = fields.materialize();
+                *self = Self::Materialized(fields);
+                self.as_map_mut()
+            }
+            Self::JsonRaw { fields, .. } => {
                 let fields = fields.materialize();
                 *self = Self::Materialized(fields);
                 self.as_map_mut()
@@ -103,6 +128,11 @@ impl ExtensionFields {
                 *self = Self::Materialized(fields);
                 self.get_or_insert_map()
             }
+            Self::JsonRaw { fields, .. } => {
+                let fields = fields.materialize();
+                *self = Self::Materialized(fields);
+                self.get_or_insert_map()
+            }
         }
     }
 
@@ -116,11 +146,17 @@ impl ExtensionFields {
     }
 
     #[cfg(test)]
+    pub(super) fn is_json_raw(&self) -> bool {
+        matches!(self, Self::JsonRaw { .. })
+    }
+
+    #[cfg(test)]
     pub(super) fn has_materialized_map(&self) -> bool {
         match self {
             Self::Absent => false,
             Self::Materialized(_) => true,
             Self::RocketMqRaw { materialized, .. } => materialized.get().is_some(),
+            Self::JsonRaw { materialized, .. } => materialized.get().is_some(),
         }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9019

### Brief Description

- Decode JSON `extFields` strings into one length-prefixed compact arena instead of eagerly constructing a `HeaderMap`.
- Expose the validated JSON representation through the existing sealed `HeaderFieldSource`, so generated V3 headers use the production normal and fast direct-decode paths.
- Materialize and cache the compatibility map only for map access, serialization, V2/manual fallback, or mutation.
- Preserve missing, null, empty-object, empty-string, duplicate-key last-wins, alias, Unicode, escape, malformed-input, clone, and mutation behavior for both serde-json and simd-json.
- Keep the implementation fully safe, add no `mod.rs`, and add no production `java_type` annotations.

### How Did You Test This Change?

Passed:

- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy -p rocketmq-protocol --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion`
- `cargo test -p rocketmq-protocol --all-features` (1,450 unit tests plus integration, UI, and doctests)
- `cargo test -p rocketmq-protocol --all-features --test request_header_codec_v3_registry` (8 tests)
- `cargo test -p rocketmq-protocol --all-features --test request_header_java_compatibility` (4 tests)
- `cargo test -p rocketmq-macros` (13 tests)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `python scripts/request-header-codec/compare_header_schema.py` (143 mappings, 0 differences)
- `python scripts/request-header-codec/generate_perf_corpus.py --check` (48 production operations current)
- Renamed-consumer offline check after refreshing its stale lock resolution, with the checked-in lock restored afterward
- `git diff --check`

Diagnostic release measurements used adjacent, alternating baseline/candidate runs of the 12 production JSON decode cases. The short-run geometric mean was approximately `1.209x`; focused longer reruns of the initially closest cases remained above baseline. The benchmark executable grew by 512 bytes (`0.0114%`). These diagnostics are not release performance attestation.

Known repository baselines remain unchanged: root and standalone-example formatting hit Windows path-length error 206; official workspace Clippy stops in existing CheetahString deprecations/useless conversions; standalone example Clippy still has the existing CheetahString 2.1/3.0 split; the renamed-consumer locked/offline check requires its stale lock refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving JSON-based extension fields in their original form.
  * Extension fields now retain empty values, duplicate keys, escaped text, Unicode, and string-value semantics.
  * Fields can be accessed directly or converted into the standard header map when needed.
* **Bug Fixes**
  * Improved validation for malformed, oversized, overflowing, or non-string extension-field values.
* **Tests**
  * Added coverage for JSON access, custom-header decoding, field mutation, and compatibility-map conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->