### PR TITLE
[ISSUE #9017]🐛Make Required Signal Evidence queryable

### DIFF
--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -57,7 +57,7 @@
       "maturity": {
         "implemented": true,
         "contract_tested": true,
-        "live_smoke_passed": false,
+        "live_smoke_passed": true,
         "production_certified": false
       },
       "evidence": [
@@ -76,10 +76,25 @@
         {
           "kind": "test",
           "path": "rocketmq-sre/crates/rocketmq-sre-connector/tests/read_gateway_contract.rs"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/required-signals.v1.json",
+          "qualification": "required-signals"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/tests/test_check_required_signals_qualification.py",
+          "qualification": "required-signals"
+        },
+        {
+          "kind": "smoke",
+          "path": "rocketmq-sre/scripts/phase00-smoke.ps1",
+          "qualification": "required-signals"
         }
       ],
       "limitations": [
-        "All 32 required Evidence requirements have fixed read-only query routes; live backend qualification remains environment-specific.",
+        "Broker, NameServer, Controller, Proxy, and MCP Required Signals are qualified through bounded Canonical Evidence in the disposable Compose environment; production backend certification remains environment-specific.",
         "Twenty-one optional Evidence requirements retain explicit stable not-production-verified routes."
       ]
     },

--- a/rocketmq-sre/config/qualification/required-signals.v1.json
+++ b/rocketmq-sre/config/qualification/required-signals.v1.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "rocketmq-sre.required-signals-qualification.v1",
+  "environment": "disposable_compose_otlp_backends",
+  "operating_mode": "read_only",
+  "production_certified": false,
+  "limits": {
+    "query_window_minutes": 10,
+    "retry_seconds": 120,
+    "maximum_components": 5
+  },
+  "components": [
+    {
+      "query_component": "broker",
+      "evidence_component": "broker",
+      "representative_requirement_id": "broker.availability",
+      "canonical_metric": "rocketmq_broker_up_ratio",
+      "collector_metric": "rocketmq_rocketmq_broker_up_ratio"
+    },
+    {
+      "query_component": "nameserver",
+      "evidence_component": "name_server",
+      "representative_requirement_id": "nameserver.active_brokers",
+      "canonical_metric": "rocketmq_namesrv_active_brokers",
+      "collector_metric": "rocketmq_rocketmq_namesrv_active_brokers"
+    },
+    {
+      "query_component": "controller",
+      "evidence_component": "controller",
+      "representative_requirement_id": "controller.quorum_health",
+      "canonical_metric": "rocketmq_controller_quorum_health_ratio",
+      "collector_metric": "rocketmq_rocketmq_controller_quorum_health_ratio"
+    },
+    {
+      "query_component": "proxy",
+      "evidence_component": "proxy",
+      "representative_requirement_id": "proxy.availability",
+      "canonical_metric": "rocketmq_proxy_up_ratio",
+      "collector_metric": "rocketmq_rocketmq_proxy_up_ratio"
+    },
+    {
+      "query_component": "mcp",
+      "evidence_component": "mcp",
+      "representative_requirement_id": "mcp.operation_requests",
+      "canonical_metric": "rocketmq_mcp_requests_total",
+      "collector_metric": "rocketmq_rocketmq_mcp_requests_total"
+    }
+  ],
+  "safety": {
+    "caller_promql": false,
+    "target_mutations": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0,
+    "message_bodies_recorded": false,
+    "credentials_recorded": false
+  }
+}

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/prometheus.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/prometheus.rs
@@ -37,6 +37,7 @@ use crate::ConnectorErrorCode;
 
 const PROMETHEUS_EVIDENCE_SCHEMA: &str = "rocketmq.prometheus-evidence.v1";
 const TELEMETRY_CLUSTER_LABEL: &str = "rocketmq_cluster";
+const ROCKETMQ_SERVICE_NAMESPACE_PREFIX: &str = "rocketmq_";
 const SEVEN_DAYS: Duration = Duration::days(7);
 const THIRTY_DAYS: Duration = Duration::days(30);
 
@@ -174,7 +175,7 @@ impl PrometheusSource {
         let endpoint = base_url
             .join(kind.endpoint())
             .map_err(|_| ConnectorError::configuration("Prometheus query URL cannot be constructed"))?;
-        let expression = format!("{metric}{{{}}}", selector.join(","));
+        let expression = metric_expression(metric, &selector.join(","));
         let (start, end) = kind.effective_range(requested_start, requested_end);
         if end
             .signed_duration_since(start)
@@ -406,6 +407,15 @@ fn validate_metric(metric: &str) -> Result<(), ConnectorError> {
     Ok(())
 }
 
+fn metric_expression(metric: &str, selector: &str) -> String {
+    let canonical = format!("{metric}{{{selector}}}");
+    if metric.starts_with(ROCKETMQ_SERVICE_NAMESPACE_PREFIX) && !metric.starts_with("rocketmq_rocketmq_") {
+        format!("{canonical} or {ROCKETMQ_SERVICE_NAMESPACE_PREFIX}{metric}{{{selector}}}")
+    } else {
+        canonical
+    }
+}
+
 fn validate_label(label: &str) -> Result<(), ConnectorError> {
     if label.is_empty()
         || label.len() > 255
@@ -465,6 +475,15 @@ mod tests {
         let thirty_day = parse_resource("prometheus/trend/30d/rocketmq_store_size").expect("thirty-day trend resource");
         assert_eq!(thirty_day, (PrometheusQueryKind::Trend30d, "rocketmq_store_size"));
         assert!(parse_resource("query/up or vector(1)").is_err());
+    }
+
+    #[test]
+    fn metric_expression_preserves_non_rocketmq_and_explicit_namespaced_metrics() {
+        assert_eq!(metric_expression("up", "job=\"prometheus\""), "up{job=\"prometheus\"}");
+        assert_eq!(
+            metric_expression("rocketmq_rocketmq_broker_up", "rocketmq_cluster=\"local\""),
+            "rocketmq_rocketmq_broker_up{rocketmq_cluster=\"local\"}"
+        );
     }
 
     #[test]
@@ -623,7 +642,9 @@ mod tests {
         assert_eq!(requests[0].0, "/api/v1/query_range");
         assert_eq!(
             requests[0].1.get("query").map(String::as_str),
-            Some("rocketmq_broker_up{rocketmq_cluster=\"local\"}")
+            Some(
+                "rocketmq_broker_up{rocketmq_cluster=\"local\"} or rocketmq_rocketmq_broker_up{rocketmq_cluster=\"local\"}"
+            )
         );
         let start = requests[0].1["start"].parse::<i64>().expect("start");
         let end = requests[0].1["end"].parse::<i64>().expect("end");

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
@@ -124,6 +124,7 @@ impl RequiredSignalsSource {
         let context = session.context();
         let component = normalize_component(resource)?;
         let manifest = parse_manifest(component, manifest_source(component)?)?;
+        let signal_max_rows = per_signal_row_budget(max_rows, manifest.signals.len());
         let mut shared = SharedReads::default();
         let mut observations = Vec::with_capacity(manifest.signals.len());
 
@@ -142,7 +143,7 @@ impl RequiredSignalsSource {
                                 metric_resource,
                                 start,
                                 end,
-                                max_rows,
+                                signal_max_rows,
                                 max_bytes,
                                 context.deadline,
                                 context.cancel,
@@ -160,7 +161,7 @@ impl RequiredSignalsSource {
                                 log_resource,
                                 start,
                                 end,
-                                max_rows,
+                                signal_max_rows,
                                 max_bytes,
                                 context.deadline,
                                 context.cancel,
@@ -184,7 +185,7 @@ impl RequiredSignalsSource {
                                     trace_resource,
                                     start,
                                     end,
-                                    max_rows,
+                                    signal_max_rows,
                                     max_bytes,
                                     context.deadline,
                                     context.cancel,
@@ -208,6 +209,14 @@ impl RequiredSignalsSource {
 
         aggregate(manifest.component, observations)
     }
+}
+
+fn per_signal_row_budget(max_rows: usize, signal_count: usize) -> usize {
+    let reserved_observations = max_rows.saturating_sub(signal_count);
+    reserved_observations
+        .checked_div(signal_count.saturating_mul(3))
+        .unwrap_or_default()
+        .max(1)
 }
 
 fn normalize_component(resource: &str) -> Result<&'static str, ConnectorError> {
@@ -525,6 +534,14 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn composite_row_budget_reserves_space_for_every_observation() {
+        assert_eq!(per_signal_row_budget(500, 7), 23);
+        assert_eq!(per_signal_row_budget(500, 13), 12);
+        assert_eq!(per_signal_row_budget(1, 13), 1);
+        assert_eq!(per_signal_row_budget(500, 0), 1);
+    }
 
     #[test]
     fn embedded_manifests_have_fixed_fail_closed_routes() {

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/runtime_diagnostics.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/runtime_diagnostics.rs
@@ -37,21 +37,8 @@ use crate::read_gateway::ReadSession;
 
 const RUNTIME_RESOURCE_URI: &str = "rocketmq://system/runtime/v1";
 const OBSERVABILITY_RESOURCE_URI: &str = "rocketmq://system/observability/v1";
-const SYSTEM_RESOURCE_SCHEMA: &str = "rocketmq-mcp.system-resource.v1";
 const COMPONENT_SOURCE: &str = "rocketmq_process";
 const COMPONENTS_RESOURCE: &str = "runtime/components";
-
-#[derive(Deserialize)]
-struct SystemResourceEnvelope<T> {
-    schema_version: String,
-    resource: String,
-    source: String,
-    partial: bool,
-    #[serde(default)]
-    warnings: Vec<String>,
-    kind: String,
-    data: T,
-}
 
 #[derive(Deserialize)]
 struct ComponentRuntimeEnvelope {
@@ -290,70 +277,38 @@ fn component_source_unavailable() -> ConnectorError {
 }
 
 fn project_runtime(raw: Value) -> Result<SourceOutput, ConnectorError> {
-    let envelope: SystemResourceEnvelope<RuntimeDiagnosticsViewV1> =
-        serde_json::from_value(raw).map_err(|_| schema_mismatch("runtime"))?;
-    validate_envelope(&envelope, RUNTIME_RESOURCE_URI, "runtime")?;
-    if envelope.data.schema_version != RuntimeDiagnosticsViewV1::SCHEMA_VERSION {
+    let diagnostics: RuntimeDiagnosticsViewV1 = serde_json::from_value(raw).map_err(|_| schema_mismatch("runtime"))?;
+    if diagnostics.schema_version != RuntimeDiagnosticsViewV1::SCHEMA_VERSION {
         return Err(schema_mismatch("runtime"));
     }
-    let observed_at = envelope.data.observed_at;
-    let mut output = SourceOutput::available(
+    let observed_at = diagnostics.observed_at;
+    Ok(SourceOutput::available(
         json!({
             "schema_version": "rocketmq.sre-runtime-evidence.v1",
             "exposure": "mcp_system_resource",
-            "diagnostics": envelope.data
+            "diagnostics": diagnostics
         }),
         observed_at,
     )
-    .with_exposure(EvidenceExposure::RuntimeDiagnostics);
-    apply_envelope_status(&mut output, envelope.partial, envelope.warnings);
-    Ok(output)
+    .with_exposure(EvidenceExposure::RuntimeDiagnostics))
 }
 
 fn project_observability(raw: Value) -> Result<SourceOutput, ConnectorError> {
-    let envelope: SystemResourceEnvelope<ObservabilityStatusViewV1> =
+    let status: ObservabilityStatusViewV1 =
         serde_json::from_value(raw).map_err(|_| schema_mismatch("observability"))?;
-    validate_envelope(&envelope, OBSERVABILITY_RESOURCE_URI, "observability")?;
-    if envelope.data.schema_version != ObservabilityStatusViewV1::SCHEMA_VERSION {
+    if status.schema_version != ObservabilityStatusViewV1::SCHEMA_VERSION {
         return Err(schema_mismatch("observability"));
     }
-    let observed_at = envelope.data.observed_at;
-    let mut output = SourceOutput::available(
+    let observed_at = status.observed_at;
+    Ok(SourceOutput::available(
         json!({
             "schema_version": "rocketmq.sre-observability-evidence.v1",
             "exposure": "mcp_system_resource",
-            "status": envelope.data
+            "status": status
         }),
         observed_at,
     )
-    .with_exposure(EvidenceExposure::RuntimeDiagnostics);
-    apply_envelope_status(&mut output, envelope.partial, envelope.warnings);
-    Ok(output)
-}
-
-fn validate_envelope<T>(
-    envelope: &SystemResourceEnvelope<T>,
-    expected_resource: &str,
-    expected_kind: &str,
-) -> Result<(), ConnectorError> {
-    if envelope.schema_version != SYSTEM_RESOURCE_SCHEMA
-        || envelope.resource != expected_resource
-        || envelope.source != "mcp_process"
-        || envelope.kind != expected_kind
-    {
-        return Err(schema_mismatch(expected_kind));
-    }
-    Ok(())
-}
-
-fn apply_envelope_status(output: &mut SourceOutput, partial: bool, warnings: Vec<String>) {
-    if partial {
-        output.partial = true;
-        output.coverage = CoverageStatus::Partial;
-    }
-    if !warnings.is_empty() {
-        output.warnings.push("runtime_diagnostics_source_warning".to_owned());
-    }
+    .with_exposure(EvidenceExposure::RuntimeDiagnostics))
 }
 
 fn schema_mismatch(kind: &str) -> ConnectorError {
@@ -369,34 +324,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn runtime_projection_requires_versioned_wrapper_and_preserves_capacity() {
+    fn runtime_projection_accepts_gateway_validated_data_and_preserves_capacity() {
         let raw = json!({
-            "schema_version": SYSTEM_RESOURCE_SCHEMA,
-            "resource": RUNTIME_RESOURCE_URI,
-            "source": "mcp_process",
-            "partial": false,
-            "warnings": [],
-            "kind": "runtime",
-            "data": {
-                "schema_version": RuntimeDiagnosticsViewV1::SCHEMA_VERSION,
-                "observed_at": "2026-07-27T00:00:00Z",
-                "component": "mcp",
-                "lifecycle_state": "open",
-                "task_group_count": 2,
-                "task_count": 3,
-                "task_kinds": [],
-                "blocking_lanes": [{
-                    "lane": "metadata_io",
-                    "max_concurrency": 4,
-                    "max_queue_depth": 16,
-                    "queued": 2,
-                    "running": 1,
-                    "timed_out_still_running": 0,
-                    "blocking_still_running": 0,
-                    "task_kinds": []
-                }],
-                "truncated": false
-            }
+            "schema_version": RuntimeDiagnosticsViewV1::SCHEMA_VERSION,
+            "observed_at": "2026-07-27T00:00:00Z",
+            "component": "mcp",
+            "lifecycle_state": "open",
+            "task_group_count": 2,
+            "task_count": 3,
+            "task_kinds": [],
+            "blocking_lanes": [{
+                "lane": "metadata_io",
+                "max_concurrency": 4,
+                "max_queue_depth": 16,
+                "queued": 2,
+                "running": 1,
+                "timed_out_still_running": 0,
+                "blocking_still_running": 0,
+                "task_kinds": []
+            }],
+            "truncated": false
         });
         let output = project_runtime(raw).expect("runtime projection");
         assert_eq!(output.content["diagnostics"]["blocking_lanes"][0]["max_concurrency"], 4);
@@ -404,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_projection_rejects_unversioned_or_wrong_resource_payloads() {
+    fn runtime_projection_rejects_unversioned_data() {
         assert!(project_runtime(json!({"data": {}})).is_err());
     }
 

--- a/rocketmq-sre/scripts/check_required_signals_qualification.py
+++ b/rocketmq-sre/scripts/check_required_signals_qualification.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate the disposable Required Signals live-qualification contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "required-signals.v1.json"
+EXPECTED_SCHEMA = "rocketmq-sre.required-signals-qualification.v1"
+EXPECTED_COMPONENTS = (
+    ("broker", "broker", "broker.availability", "rocketmq_broker_up_ratio"),
+    ("nameserver", "name_server", "nameserver.active_brokers", "rocketmq_namesrv_active_brokers"),
+    (
+        "controller",
+        "controller",
+        "controller.quorum_health",
+        "rocketmq_controller_quorum_health_ratio",
+    ),
+    ("proxy", "proxy", "proxy.availability", "rocketmq_proxy_up_ratio"),
+    ("mcp", "mcp", "mcp.operation_requests", "rocketmq_mcp_requests_total"),
+)
+MANIFEST_FILES = {
+    "broker": "broker.yaml",
+    "nameserver": "nameserver.yaml",
+    "controller": "controller.yaml",
+    "proxy": "proxy.yaml",
+    "mcp": "mcp.yaml",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def validate_manifest(manifest: dict[str, Any], sre_root: Path = SRE_ROOT) -> list[str]:
+    findings: list[str] = []
+    expected_header = {
+        "schema_version": EXPECTED_SCHEMA,
+        "environment": "disposable_compose_otlp_backends",
+        "operating_mode": "read_only",
+        "production_certified": False,
+    }
+    for field, expected in expected_header.items():
+        if manifest.get(field) != expected:
+            findings.append(f"{field} must remain {expected!r}")
+    if manifest.get("limits") != {
+        "query_window_minutes": 10,
+        "retry_seconds": 120,
+        "maximum_components": 5,
+    }:
+        findings.append("qualification limits drifted")
+    if manifest.get("safety") != {
+        "caller_promql": False,
+        "target_mutations": 0,
+        "executor_calls": 0,
+        "execution_agent_calls": 0,
+        "message_bodies_recorded": False,
+        "credentials_recorded": False,
+    }:
+        findings.append("read-only safety boundary drifted")
+
+    components = manifest.get("components")
+    if not isinstance(components, list):
+        findings.append("components must be an array")
+        return findings
+    actual = []
+    for component in components:
+        if not isinstance(component, dict):
+            findings.append("each component must be an object")
+            continue
+        actual.append(
+            (
+                component.get("query_component"),
+                component.get("evidence_component"),
+                component.get("representative_requirement_id"),
+                component.get("canonical_metric"),
+            )
+        )
+        canonical = component.get("canonical_metric")
+        if isinstance(canonical, str) and component.get("collector_metric") != f"rocketmq_{canonical}":
+            findings.append(f"{component.get('query_component')} Collector alias is inconsistent")
+    if tuple(actual) != EXPECTED_COMPONENTS:
+        findings.append("component qualification matrix drifted")
+
+    for query_component, _, requirement_id, canonical_metric in EXPECTED_COMPONENTS:
+        path = sre_root / "config" / "observability" / "required-signals" / MANIFEST_FILES[query_component]
+        text = path.read_text(encoding="utf-8")
+        if f"requirement_id: {requirement_id}" not in text:
+            findings.append(f"{query_component} representative requirement is absent from its signal manifest")
+        if f"query_resource: metrics/{canonical_metric}" not in text:
+            findings.append(f"{query_component} canonical metric route drifted")
+
+    source = (sre_root / "crates" / "rocketmq-sre-connector" / "src" / "sources" / "prometheus.rs").read_text(
+        encoding="utf-8"
+    )
+    for marker in (
+        "ROCKETMQ_SERVICE_NAMESPACE_PREFIX",
+        "fn metric_expression",
+        'format!("{canonical} or {ROCKETMQ_SERVICE_NAMESPACE_PREFIX}{metric}{{{selector}}}")',
+    ):
+        if marker not in source:
+            findings.append(f"Prometheus alias resolver is missing {marker}")
+
+    composite = (
+        sre_root
+        / "crates"
+        / "rocketmq-sre-connector"
+        / "src"
+        / "sources"
+        / "required_signals.rs"
+    ).read_text(encoding="utf-8")
+    for marker in ("fn per_signal_row_budget", "signal_max_rows"):
+        if marker not in composite:
+            findings.append(f"Required Signals aggregate is missing {marker}")
+
+    runtime = (
+        sre_root
+        / "crates"
+        / "rocketmq-sre-connector"
+        / "src"
+        / "sources"
+        / "runtime_diagnostics.rs"
+    ).read_text(encoding="utf-8")
+    if "serde_json::from_value(raw).map_err(|_| schema_mismatch(\"runtime\"))" not in runtime:
+        findings.append("runtime diagnostics no longer consumes gateway-validated System Resource data")
+
+    repository_root = sre_root.parent
+    mcp_app = (repository_root / "rocketmq-tools" / "rocketmq-mcp" / "src" / "app.rs").read_text(
+        encoding="utf-8"
+    )
+    mcp_server = (
+        repository_root / "rocketmq-tools" / "rocketmq-mcp" / "src" / "protocol" / "server.rs"
+    ).read_text(encoding="utf-8")
+    for marker, source_name, source_text in (
+        ("McpMetricsRecorder::from_handle", "MCP application", mcp_app),
+        ("with_metrics(self.app.metrics().clone())", "MCP protocol server", mcp_server),
+    ):
+        if marker not in source_text:
+            findings.append(f"{source_name} is missing instance-owned request metrics")
+
+    smoke = (sre_root / "scripts" / "phase00-smoke.ps1").read_text(encoding="utf-8")
+    for marker in (
+        "config/qualification/required-signals.v1.json",
+        "Assert-RequiredSignalsQualification",
+        "representative_requirement_id",
+    ):
+        if marker not in smoke:
+            findings.append(f"live smoke is missing {marker}")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    arguments = parser.parse_args()
+    findings = validate_manifest(load_json(arguments.manifest))
+    if findings:
+        for finding in findings:
+            print(f"ERROR: {finding}")
+        return 1
+    print("Required Signals qualification contract is valid for five read-only component routes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/phase00-smoke.ps1
+++ b/rocketmq-sre/scripts/phase00-smoke.ps1
@@ -14,6 +14,7 @@ $sreRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory '..'))
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $sreRoot '..'))
 $composeDirectory = Join-Path $sreRoot 'deploy/dev'
 $composeFile = Join-Path $composeDirectory 'compose.yaml'
+$requiredSignalsQualificationPath = Join-Path $sreRoot 'config/qualification/required-signals.v1.json'
 $clusterId = '00000000-0000-4000-8000-000000000001'
 $tenantId = '00000000-0000-4000-8000-000000000002'
 $topic = 'SRE_PROBE_00000000000040008000000000000001_00000000000000000000000000000000'
@@ -105,6 +106,119 @@ function Invoke-EvidenceQuery {
         throw 'Connector Evidence schema family is not rocketmq-sre.evidence.'
     }
     return $evidence
+}
+
+function Invoke-RequiredSignalsEvidence([string]$Component, [int]$WindowMinutes) {
+    $end = [DateTime]::UtcNow
+    $body = @{
+        query = @{
+            query_id = [Guid]::NewGuid().ToString()
+            correlation_id = [Guid]::NewGuid().ToString()
+            tenant_id = $tenantId
+            cluster_id = $clusterId
+            source = 'required-signals'
+            resource = "component/$Component"
+            time_range = @{
+                start = $end.AddMinutes(-$WindowMinutes).ToString('o')
+                end = $end.ToString('o')
+            }
+        }
+        mcp_cluster = 'sre-dev'
+        operation = @{ kind = 'cluster_overview' }
+    } | ConvertTo-Json -Depth 8
+    $evidence = Invoke-RestMethod `
+        -Method Post `
+        -Uri 'http://127.0.0.1:8091/internal/v1/evidence/query' `
+        -Headers @{ Authorization = "Bearer $internalToken" } `
+        -ContentType 'application/json' `
+        -Body $body `
+        -TimeoutSec 30
+    if ($evidence.content_hash -notmatch '^sha256:[0-9a-f]{64}$') {
+        throw "Required Signals Evidence for '$Component' has no canonical hash."
+    }
+    if ($evidence.schema.family -ne 'rocketmq-sre.evidence') {
+        throw "Required Signals Evidence for '$Component' has an incompatible schema."
+    }
+    return $evidence
+}
+
+function Assert-RequiredSignalsQualification {
+    $qualification = Get-Content -Raw -LiteralPath $requiredSignalsQualificationPath | ConvertFrom-Json
+    $components = @($qualification.components)
+    if (
+        $qualification.production_certified `
+            -or $qualification.operating_mode -ne 'read_only' `
+            -or $components.Count -ne [int]$qualification.limits.maximum_components
+    ) {
+        throw 'Required Signals qualification contract is not bounded and read-only.'
+    }
+
+    foreach ($component in $components) {
+        $deadline = [DateTime]::UtcNow.AddSeconds([int]$qualification.limits.retry_seconds)
+        $lastFailure = 'no Evidence response'
+        do {
+            try {
+                $evidence = Invoke-RequiredSignalsEvidence `
+                    -Component $component.query_component `
+                    -WindowMinutes ([int]$qualification.limits.query_window_minutes)
+                if ($evidence.content.storage -ne 'inline') {
+                    throw 'Required Signals Evidence is not bounded inline content.'
+                }
+                $value = $evidence.content.value
+                if (
+                    $value.schema_version -ne 'rocketmq.sre.required-signals-evidence.v1' `
+                        -or $value.component -ne $component.evidence_component
+                ) {
+                    throw 'Required Signals aggregate identity does not match the qualification contract.'
+                }
+                $observations = @($value.observations)
+                if ($observations.Count -eq 0) {
+                    throw 'Required Signals aggregate contains no observations.'
+                }
+                $unsupportedStatus = @(
+                    $observations | Where-Object {
+                        $_.status -notin @('available', 'missing', 'not_production_verified')
+                    }
+                )
+                if ($unsupportedStatus.Count -gt 0) {
+                    throw 'Required Signals aggregate contains an unsupported status.'
+                }
+                $representative = @(
+                    $observations | Where-Object {
+                        $_.requirement_id -eq $component.representative_requirement_id
+                    }
+                )
+                if (
+                    $representative.Count -ne 1 `
+                        -or $representative[0].status -ne 'available' `
+                        -or $representative[0].query_source -ne 'prometheus' `
+                        -or $representative[0].content.metric -ne $component.canonical_metric
+                ) {
+                    throw "Representative metric '$($component.representative_requirement_id)' is not available."
+                }
+                $sampleCount = 0
+                foreach ($series in @($representative[0].content.series)) {
+                    $sampleCount += @($series.samples).Count
+                }
+                if ($sampleCount -lt 1) {
+                    throw "Representative metric '$($component.representative_requirement_id)' has no samples."
+                }
+                Write-Host (
+                    "Required Signals qualified: component=$($component.query_component) " +
+                    "requirement=$($component.representative_requirement_id) evidence=$($evidence.content_hash)"
+                )
+                $lastFailure = $null
+                break
+            }
+            catch {
+                $lastFailure = $_.Exception.Message
+            }
+            Start-Sleep -Seconds 2
+        } while ([DateTime]::UtcNow -lt $deadline)
+        if ($null -ne $lastFailure) {
+            throw "Required Signals qualification failed for '$($component.query_component)': $lastFailure"
+        }
+    }
 }
 
 function Get-InlineLag([object]$Evidence) {
@@ -470,6 +584,7 @@ Wait-Http 'http://127.0.0.1:9090/-/ready' | Out-Null
 Wait-Http 'http://127.0.0.1:3100/ready' | Out-Null
 Wait-Http 'http://127.0.0.1:3200/ready' | Out-Null
 Assert-ObservabilityQueries
+Assert-RequiredSignalsQualification
 $headers = @{ Authorization = "Bearer $internalToken" }
 $capabilities = Invoke-RestMethod `
     -Uri 'http://127.0.0.1:8091/internal/v1/capabilities' `

--- a/rocketmq-sre/scripts/tests/test_check_required_signals_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_required_signals_qualification.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Required Signals qualification validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_required_signals_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_required_signals_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RequiredSignalsQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+
+    def test_committed_manifest_is_valid(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest), [])
+
+    def test_rejects_production_certification_or_mutation(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["production_certified"] = True
+        manifest["safety"]["target_mutations"] = 1
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("production_certified must remain False", findings)
+        self.assertIn("read-only safety boundary drifted", findings)
+
+    def test_rejects_missing_component_or_metric_alias_drift(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["components"].pop()
+        manifest["components"][0]["collector_metric"] = "wrong_metric"
+
+        findings = MODULE.validate_manifest(manifest)
+
+        self.assertIn("component qualification matrix drifted", findings)
+        self.assertIn("broker Collector alias is inconsistent", findings)
+
+    def test_rejects_unbounded_query_window(self) -> None:
+        manifest = copy.deepcopy(self.manifest)
+        manifest["limits"]["query_window_minutes"] = 1_440
+
+        self.assertIn("qualification limits drifted", MODULE.validate_manifest(manifest))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rocketmq-tools/rocketmq-mcp/src/app.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/app.rs
@@ -73,6 +73,7 @@ impl McpShutdownReport {
 pub struct McpApp {
     config: McpConfig,
     guard: Guard,
+    metrics: rocketmq_observability::metrics::mcp::McpMetricsRecorder,
     query: Arc<QueryFacade<AdminCoreSessionFactory>>,
     client_runtime: Arc<ClientRuntime>,
     service_context: rocketmq_runtime::ChildServiceContext,
@@ -107,6 +108,7 @@ impl McpApp {
     ) -> Result<Self, crate::error::McpError> {
         let guard = Guard::new(config.security.clone(), config.audit.clone(), &config.clusters)
             .map_err(|error| crate::error::McpError::InvalidConfig(error.to_string()))?;
+        let metrics = rocketmq_observability::metrics::mcp::McpMetricsRecorder::from_handle(&telemetry_handle);
         let client_runtime = ClientRuntime::try_new(
             service_context.component("rocketmq-mcp-client"),
             ClientRuntimeConfig::default(),
@@ -117,6 +119,7 @@ impl McpApp {
         Ok(Self {
             config,
             guard,
+            metrics,
             query,
             client_runtime,
             service_context,
@@ -195,6 +198,10 @@ impl McpApp {
 
     pub fn guard(&self) -> &Guard {
         &self.guard
+    }
+
+    pub(crate) fn metrics(&self) -> &rocketmq_observability::metrics::mcp::McpMetricsRecorder {
+        &self.metrics
     }
 
     pub(crate) fn query(&self) -> &Arc<QueryFacade<AdminCoreSessionFactory>> {

--- a/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/protocol/server.rs
@@ -47,6 +47,7 @@ use crate::resources;
 use crate::tools;
 use crate::tools::executor::ToolExecutor;
 use rocketmq_observability::metrics::mcp::McpErrorKind;
+use rocketmq_observability::metrics::mcp::McpMetricsRecorder;
 use rocketmq_observability::metrics::mcp::McpOperationKind;
 use rocketmq_observability::metrics::mcp::McpOperationOutcome;
 
@@ -56,13 +57,19 @@ pub struct RocketmqMcpServer {
 }
 
 struct ResourceSpanRecorder {
+    metrics: McpMetricsRecorder,
+    operation: &'static str,
+    started_at: Instant,
     outcome: McpOperationOutcome,
     span: tracing::Span,
 }
 
 impl ResourceSpanRecorder {
-    fn new(operation: &'static str) -> Self {
+    fn new(metrics: McpMetricsRecorder, operation: &'static str) -> Self {
         Self {
+            metrics,
+            operation,
+            started_at: Instant::now(),
             outcome: McpOperationOutcome::Failure,
             span: rocketmq_observability::trace::mcp::resource_span(operation),
         }
@@ -90,6 +97,12 @@ impl ResourceSpanRecorder {
 impl Drop for ResourceSpanRecorder {
     fn drop(&mut self) {
         rocketmq_observability::trace::mcp::record_outcome(&self.span, self.outcome);
+        self.metrics.record_operation(
+            McpOperationKind::Resource,
+            self.operation,
+            self.outcome,
+            self.started_at.elapsed(),
+        );
     }
 }
 
@@ -174,7 +187,7 @@ impl ServerHandler for RocketmqMcpServer {
         let operation = crate::resources::uri::RocketmqResourceUri::parse(&request.uri)
             .map(|resource| resource.kind.metric_operation())
             .unwrap_or("invalid_resource_uri");
-        let mut span_recorder = ResourceSpanRecorder::new(operation);
+        let mut span_recorder = ResourceSpanRecorder::new(self.app.metrics().clone(), operation);
         let span = span_recorder.span();
         let result = async {
             let started_at = Instant::now();
@@ -302,6 +315,7 @@ impl ServerHandler for RocketmqMcpServer {
         let query = self.app.query().as_ref().clone().with_cancellation(context.ct.clone());
         let access = self.access_context(&context)?;
         let result = ToolExecutor::new(query, self.app.guard().clone())
+            .with_metrics(self.app.metrics().clone())
             .with_request_context(access)
             .call_with_request_id(request, &request_id_string(&context.id))
             .await;

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -24,6 +24,7 @@ use rmcp::model::JsonObject;
 use rmcp::model::Resource;
 use rmcp::ErrorData;
 use rocketmq_observability::metrics::mcp::McpErrorKind;
+use rocketmq_observability::metrics::mcp::McpMetricsRecorder;
 use rocketmq_observability::metrics::mcp::McpOperationKind;
 use rocketmq_observability::metrics::mcp::McpOperationOutcome;
 use tracing::Instrument;
@@ -179,6 +180,7 @@ impl ToolExecutionError {
 }
 
 struct ToolOperationRecorder {
+    metrics: McpMetricsRecorder,
     operation: &'static str,
     started_at: Instant,
     outcome: McpOperationOutcome,
@@ -186,8 +188,9 @@ struct ToolOperationRecorder {
 }
 
 impl ToolOperationRecorder {
-    fn new(operation: &'static str) -> Self {
+    fn new(metrics: McpMetricsRecorder, operation: &'static str) -> Self {
         Self {
+            metrics,
             operation,
             started_at: Instant::now(),
             outcome: McpOperationOutcome::Failure,
@@ -217,7 +220,7 @@ impl ToolOperationRecorder {
 impl Drop for ToolOperationRecorder {
     fn drop(&mut self) {
         rocketmq_observability::trace::mcp::record_outcome(&self.span, self.outcome);
-        rocketmq_observability::metrics::mcp::record_operation(
+        self.metrics.record_operation(
             McpOperationKind::Tool,
             self.operation,
             self.outcome,
@@ -252,11 +255,12 @@ impl From<GuardError> for ToolExecutionError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct ToolExecutor<A> {
     adapter: A,
     guard: Guard,
     context: RequestContext,
+    metrics: McpMetricsRecorder,
 }
 
 impl<A> ToolExecutor<A>
@@ -269,7 +273,13 @@ where
             adapter,
             guard,
             context,
+            metrics: McpMetricsRecorder::noop(),
         }
+    }
+
+    pub(crate) fn with_metrics(mut self, metrics: McpMetricsRecorder) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     pub(crate) fn with_request_context(mut self, context: RequestContext) -> Self {
@@ -290,7 +300,7 @@ where
         let operation = ToolId::resolve(request.name.as_ref())
             .map(|tool_id| tool_id.descriptor().name)
             .unwrap_or("unknown_tool");
-        let mut operation_recorder = ToolOperationRecorder::new(operation);
+        let mut operation_recorder = ToolOperationRecorder::new(self.metrics.clone(), operation);
         let span = operation_recorder.span();
         let result = self
             .execute(request, request_id, &mut operation_recorder)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9017

### Brief Description

- resolve canonical and Collector-namespaced RocketMQ metric names without allowing caller-provided PromQL
- preserve a bounded share of rows for every Required Signal and consume validated MCP System Resource data directly
- connect MCP tool and resource request telemetry to the application-owned metrics recorder
- add a five-component read-only qualification contract, smoke assertions, negative validation tests, and truthful implementation maturity evidence

### How Did You Test This Change?

- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --locked --workspace`
- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python scripts/check_required_signals_qualification.py`
- `python -m unittest scripts.tests.test_check_required_signals_qualification -v`
- `python scripts/check_implementation_status.py`
- MCP: `cargo check --locked`, read-only boundary, default/all-feature tests, Streamable HTTP Clippy, and Rustdoc all passed
- MCP-local `cargo fmt -- --check` passed; `cargo fmt --all -- --check` could not execute on Windows because path-dependency expansion exceeded the OS command-line length limit (`os error 206`)
- disposable Docker Compose live qualification returned canonical hashed Evidence with available representative metrics for Broker, NameServer, Controller, Proxy, and MCP; production certification remains explicitly false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added qualification coverage for required RocketMQ signals across Broker, NameServer, Controller, Proxy, and MCP.
  * Added live smoke validation for component evidence, representative metrics, and read-only safety requirements.
  * Added MCP operation metrics for tracking outcomes and durations.

* **Bug Fixes**
  * Improved RocketMQ metric discovery across supported naming variants.
  * Prevented signal queries from exceeding aggregate row limits.
  * Updated diagnostics handling to validate direct payloads and reject unversioned data.

* **Quality**
  * Added automated validation and test coverage for qualification rules and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->