### PR TITLE
[ISSUE #9022]🐛Restore the AI SRE Compose smoke workflow

### DIFF
--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/conversation_query.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/workflow/conversation_query.rs
@@ -36,8 +36,12 @@ const MAX_IDENTIFIER_BYTES: usize = 255;
 const APPROVED_METRICS: &[&str] = &[
     "rocketmq_broker_up",
     "rocketmq_broker_up_ratio",
+    "rocketmq_controller_quorum_health_ratio",
     "rocketmq_consumer_lag_messages",
     "rocketmq_consumer_lag_latency",
+    "rocketmq_mcp_requests_total",
+    "rocketmq_namesrv_active_brokers",
+    "rocketmq_proxy_up_ratio",
     "rocketmq_store_flush_latency",
     "rocketmq_store_ha_replication_lag_bytes",
 ];
@@ -390,8 +394,16 @@ pub(super) fn diagnostic_pack_for_intent(intent: &ConversationQueryIntent) -> &'
                 "store-pressure.v1"
             } else if intent.resource.ends_with("rocketmq_store_ha_replication_lag_bytes") {
                 "broker-ha.v1"
+            } else if intent.resource.ends_with("rocketmq_controller_quorum_health_ratio") {
+                "controller-ha.v1"
             } else if intent.resource.contains("consumer_lag") {
                 "consumer-lag.v2"
+            } else if intent.resource.ends_with("rocketmq_namesrv_active_brokers") {
+                "namesrv-route.v1"
+            } else if intent.resource.ends_with("rocketmq_proxy_up_ratio") {
+                "proxy-connectivity.v1"
+            } else if intent.resource.ends_with("rocketmq_mcp_requests_total") {
+                "telemetry-pipeline.v1"
             } else {
                 "broker-health.v1"
             }
@@ -569,6 +581,13 @@ mod tests {
             ("metrics/range/rocketmq_store_flush_latency", "store-pressure.v1"),
             ("metrics/range/rocketmq_store_ha_replication_lag_bytes", "broker-ha.v1"),
             ("metrics/range/rocketmq_consumer_lag_messages", "consumer-lag.v2"),
+            (
+                "metrics/range/rocketmq_controller_quorum_health_ratio",
+                "controller-ha.v1",
+            ),
+            ("metrics/range/rocketmq_namesrv_active_brokers", "namesrv-route.v1"),
+            ("metrics/range/rocketmq_proxy_up_ratio", "proxy-connectivity.v1"),
+            ("metrics/range/rocketmq_mcp_requests_total", "telemetry-pipeline.v1"),
             ("metrics/instant/rocketmq_broker_up", "broker-health.v1"),
         ];
         for (resource, expected) in cases {

--- a/rocketmq-sre/deploy/dev/compose.yaml
+++ b/rocketmq-sre/deploy/dev/compose.yaml
@@ -23,12 +23,16 @@ x-rocketmq-environment: &rocketmq-environment
 
 x-dev-issuer-url: &dev-issuer-url https://dev-issuer-tls:8443
 
+x-rocketmq-build-args: &rocketmq-build-args
+  SOURCE_REVISION: ${SOURCE_REVISION:-0000000000000000000000000000000000000000}
+
 services:
   namesrv:
     build:
       context: ../../..
       dockerfile: docker/Dockerfile.base
       target: namesrv
+      args: *rocketmq-build-args
     command: ["--configFile", "/etc/rocketmq/namesrv.toml"]
     environment:
       <<: *rocketmq-environment
@@ -53,6 +57,7 @@ services:
       context: ../../..
       dockerfile: docker/Dockerfile.base
       target: controller
+      args: *rocketmq-build-args
     command: ["--config-file", "/etc/rocketmq/controller.toml"]
     environment:
       <<: *rocketmq-environment
@@ -78,6 +83,7 @@ services:
       context: ../../..
       dockerfile: docker/Dockerfile.base
       target: broker
+      args: *rocketmq-build-args
     command: ["--configFile", "/etc/rocketmq/broker.toml"]
     depends_on:
       - namesrv
@@ -108,6 +114,7 @@ services:
       context: ../../..
       dockerfile: docker/Dockerfile.base
       target: proxy
+      args: *rocketmq-build-args
     command: ["--config", "/etc/rocketmq/proxy.toml"]
     depends_on:
       - namesrv
@@ -186,6 +193,7 @@ services:
       ROCKETMQ_SRE_CONFIG_DIR: /opt/rocketmq-sre/config
       ROCKETMQ_SRE_MIGRATIONS_DIR: /opt/rocketmq-sre/migrations
       ROCKETMQ_SRE_INTERNAL_TOKEN: phase00-internal-token
+      ROCKETMQ_SRE_GRANT_SIGNING_KEY: phase00-development-grant-signing-key-000001
       ROCKETMQ_SRE_AGENT_ACK_KEY: phase03-development-agent-ack-key-00000001
       ROCKETMQ_SRE_EXECUTOR_URL: http://sre-executor:8094
       ROCKETMQ_SRE_EXECUTOR_TIMEOUT_SECONDS: "240"
@@ -401,6 +409,7 @@ services:
       context: ../../..
       dockerfile: docker/Dockerfile.base
       target: mcp
+      args: *rocketmq-build-args
     command:
       [
         "--config",

--- a/rocketmq-sre/scripts/check_required_signals_qualification.py
+++ b/rocketmq-sre/scripts/check_required_signals_qualification.py
@@ -167,9 +167,18 @@ def validate_manifest(manifest: dict[str, Any], sre_root: Path = SRE_ROOT) -> li
         "config/qualification/required-signals.v1.json",
         "Assert-RequiredSignalsQualification",
         "representative_requirement_id",
+        "/v1/conversations",
+        "/v1/evidence/",
+        "metrics/range/",
     ):
         if marker not in smoke:
             findings.append(f"live smoke is missing {marker}")
+    for forbidden in (
+        "127.0.0.1:8091/internal/v1/evidence/query",
+        "127.0.0.1:8091/internal/v1/capabilities",
+    ):
+        if forbidden in smoke:
+            findings.append("live smoke bypasses the authenticated reverse Connector channel")
     return findings
 
 

--- a/rocketmq-sre/scripts/dev.ps1
+++ b/rocketmq-sre/scripts/dev.ps1
@@ -63,6 +63,18 @@ function Compose-Arguments([string[]]$Arguments) {
     ) + $Arguments
 }
 
+function Get-RepositorySourceRevision {
+    Require-Command git
+    $revision = (& git -C $repositoryRoot rev-parse HEAD 2>&1 | Out-String).Trim().ToLowerInvariant()
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to derive SOURCE_REVISION from the current repository: $revision"
+    }
+    if ($revision -notmatch '^[0-9a-f]{40}$' -or $revision -eq ('0' * 40)) {
+        throw "The current repository revision is not a non-zero 40-character lowercase hexadecimal commit."
+    }
+    return $revision
+}
+
 function Assert-CertificateDirectory {
     if (-not $certificateDirectory.StartsWith(
         $expectedCertificateRoot + [IO.Path]::DirectorySeparatorChar,
@@ -497,6 +509,15 @@ if (-not (Test-Path -LiteralPath $composeFile -PathType Leaf)) {
     throw "Compose file was not found at $composeFile"
 }
 
+$composeActions = @('Up', 'Down', 'Status', 'Reset')
+$restoreSourceRevision = $composeActions -contains $Action
+$hadSourceRevision = Test-Path Env:SOURCE_REVISION
+$previousSourceRevision = if ($hadSourceRevision) { $env:SOURCE_REVISION } else { $null }
+if ($restoreSourceRevision) {
+    $env:SOURCE_REVISION = Get-RepositorySourceRevision
+}
+
+try {
 switch ($Action) {
     'Certs' {
         New-DevelopmentCertificates
@@ -557,5 +578,16 @@ switch ($Action) {
                 Remove-Item -Force
         }
         Write-Host 'Phase 00 containers, volumes, and generated certificate files were removed.'
+    }
+}
+}
+finally {
+    if ($restoreSourceRevision) {
+        if ($hadSourceRevision) {
+            $env:SOURCE_REVISION = $previousSourceRevision
+        }
+        else {
+            Remove-Item Env:SOURCE_REVISION -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/rocketmq-sre/scripts/phase00-smoke.ps1
+++ b/rocketmq-sre/scripts/phase00-smoke.ps1
@@ -71,75 +71,95 @@ function Wait-Http([string]$Uri, [int]$Seconds = 90) {
     throw "Timed out waiting for $Uri"
 }
 
-function Invoke-EvidenceQuery {
-    $at = [DateTime]::UtcNow.ToString('o')
-    $body = @{
-        query = @{
-            query_id = [Guid]::NewGuid().ToString()
-            correlation_id = [Guid]::NewGuid().ToString()
-            tenant_id = $tenantId
-            cluster_id = $clusterId
-            source = 'rocketmq-mcp'
-            resource = "consumer-groups/$group/lag/$topic"
-            time_range = @{ start = $at; end = $at }
+function Wait-ConnectorNotReady([int]$Seconds = 45) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($Seconds)
+    $lastStatus = 'not_observed'
+    do {
+        $response = Invoke-Docker (Compose-Arguments @(
+            'exec', '-T', 'sre-connector',
+            'curl', '--silent', '--show-error',
+            '--write-out', "`n%{http_code}",
+            'http://127.0.0.1:8091/readyz'
+        )) -Capture
+        $lines = @($response -split "\r?\n")
+        $lastStatus = $lines[-1]
+        $body = ($lines[0..($lines.Count - 2)] -join "`n") | ConvertFrom-Json
+        if ($lastStatus -eq '503' -and $body.status -eq 'not_ready') {
+            return
         }
-        mcp_cluster = 'sre-dev'
-        operation = @{
-            kind = 'consumer_lag'
-            topic = $topic
-            consumer_group = $group
-            limit = 50
-        }
-    } | ConvertTo-Json -Depth 8
-    $headers = @{ Authorization = "Bearer $internalToken" }
-    $evidence = Invoke-RestMethod `
+        Start-Sleep -Seconds 2
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw "Connector readiness was not revoked after offboard (last HTTP $lastStatus)."
+}
+
+function Invoke-ConversationEvidence(
+    [string]$Question,
+    [string]$Resource,
+    [int]$WindowSeconds = 600
+) {
+    $headers = Get-PublicApiHeaders
+    $conversationBody = @{
+        cluster_id = $clusterId
+        question = $Question
+        resource = $Resource
+        persist_investigation = $false
+    } | ConvertTo-Json
+    $conversation = Invoke-RestMethod `
         -Method Post `
-        -Uri 'http://127.0.0.1:8091/internal/v1/evidence/query' `
+        -Uri 'http://127.0.0.1:8090/v1/conversations' `
         -Headers $headers `
         -ContentType 'application/json' `
-        -Body $body `
+        -Body $conversationBody `
+        -TimeoutSec 30
+    $conversationId = $conversation.conversation.id
+    if ([string]::IsNullOrWhiteSpace($conversationId)) {
+        throw 'Control Plane did not create a conversation for the bounded read query.'
+    }
+
+    $turnBody = @{
+        question = $Question
+        resource = $Resource
+        window_seconds = $WindowSeconds
+    } | ConvertTo-Json
+    $turn = Invoke-RestMethod `
+        -Method Post `
+        -Uri "http://127.0.0.1:8090/v1/conversations/$conversationId/turns" `
+        -Headers $headers `
+        -ContentType 'application/json' `
+        -Body $turnBody `
+        -TimeoutSec 45
+    $evidenceIds = @($turn.answer.evidence_ids)
+    if ($turn.turn.status -ne 'answered' -or $evidenceIds.Count -ne 1) {
+        throw (
+            'Control Plane conversation did not return exactly one answered Evidence reference ' +
+            "(status=$($turn.turn.status), evidence_count=$($evidenceIds.Count))."
+        )
+    }
+    $evidence = Invoke-RestMethod `
+        -Uri "http://127.0.0.1:8090/v1/evidence/$($evidenceIds[0])" `
+        -Headers $headers `
         -TimeoutSec 30
     if ($evidence.content_hash -notmatch '^sha256:[0-9a-f]{64}$') {
-        throw 'Connector Evidence did not contain a canonical SHA-256 hash.'
+        throw 'Conversation Evidence did not contain a canonical SHA-256 hash.'
     }
     if ($evidence.schema.family -ne 'rocketmq-sre.evidence') {
-        throw 'Connector Evidence schema family is not rocketmq-sre.evidence.'
+        throw 'Conversation Evidence schema family is not rocketmq-sre.evidence.'
     }
     return $evidence
 }
 
-function Invoke-RequiredSignalsEvidence([string]$Component, [int]$WindowMinutes) {
-    $end = [DateTime]::UtcNow
-    $body = @{
-        query = @{
-            query_id = [Guid]::NewGuid().ToString()
-            correlation_id = [Guid]::NewGuid().ToString()
-            tenant_id = $tenantId
-            cluster_id = $clusterId
-            source = 'required-signals'
-            resource = "component/$Component"
-            time_range = @{
-                start = $end.AddMinutes(-$WindowMinutes).ToString('o')
-                end = $end.ToString('o')
-            }
-        }
-        mcp_cluster = 'sre-dev'
-        operation = @{ kind = 'cluster_overview' }
-    } | ConvertTo-Json -Depth 8
-    $evidence = Invoke-RestMethod `
-        -Method Post `
-        -Uri 'http://127.0.0.1:8091/internal/v1/evidence/query' `
-        -Headers @{ Authorization = "Bearer $internalToken" } `
-        -ContentType 'application/json' `
-        -Body $body `
-        -TimeoutSec 30
-    if ($evidence.content_hash -notmatch '^sha256:[0-9a-f]{64}$') {
-        throw "Required Signals Evidence for '$Component' has no canonical hash."
-    }
-    if ($evidence.schema.family -ne 'rocketmq-sre.evidence') {
-        throw "Required Signals Evidence for '$Component' has an incompatible schema."
-    }
-    return $evidence
+function Invoke-EvidenceQuery {
+    Invoke-ConversationEvidence `
+        -Question "Show Consumer Lag for $group on $topic." `
+        -Resource "consumer-lag/$group/$topic" `
+        -WindowSeconds 300
+}
+
+function Invoke-RequiredSignalsEvidence([string]$CanonicalMetric, [int]$WindowMinutes) {
+    Invoke-ConversationEvidence `
+        -Question "Show the bounded range for $CanonicalMetric." `
+        -Resource "metrics/range/$CanonicalMetric" `
+        -WindowSeconds ($WindowMinutes * 60)
 }
 
 function Assert-RequiredSignalsQualification {
@@ -159,45 +179,21 @@ function Assert-RequiredSignalsQualification {
         do {
             try {
                 $evidence = Invoke-RequiredSignalsEvidence `
-                    -Component $component.query_component `
+                    -CanonicalMetric $component.canonical_metric `
                     -WindowMinutes ([int]$qualification.limits.query_window_minutes)
                 if ($evidence.content.storage -ne 'inline') {
                     throw 'Required Signals Evidence is not bounded inline content.'
                 }
                 $value = $evidence.content.value
                 if (
-                    $value.schema_version -ne 'rocketmq.sre.required-signals-evidence.v1' `
-                        -or $value.component -ne $component.evidence_component
+                    $evidence.source -ne 'prometheus' `
+                        -or $value.schema_version -ne 'rocketmq.prometheus-evidence.v1' `
+                        -or $value.metric -ne $component.canonical_metric
                 ) {
-                    throw 'Required Signals aggregate identity does not match the qualification contract.'
-                }
-                $observations = @($value.observations)
-                if ($observations.Count -eq 0) {
-                    throw 'Required Signals aggregate contains no observations.'
-                }
-                $unsupportedStatus = @(
-                    $observations | Where-Object {
-                        $_.status -notin @('available', 'missing', 'not_production_verified')
-                    }
-                )
-                if ($unsupportedStatus.Count -gt 0) {
-                    throw 'Required Signals aggregate contains an unsupported status.'
-                }
-                $representative = @(
-                    $observations | Where-Object {
-                        $_.requirement_id -eq $component.representative_requirement_id
-                    }
-                )
-                if (
-                    $representative.Count -ne 1 `
-                        -or $representative[0].status -ne 'available' `
-                        -or $representative[0].query_source -ne 'prometheus' `
-                        -or $representative[0].content.metric -ne $component.canonical_metric
-                ) {
-                    throw "Representative metric '$($component.representative_requirement_id)' is not available."
+                    throw 'Required Signals metric Evidence does not match the qualification contract.'
                 }
                 $sampleCount = 0
-                foreach ($series in @($representative[0].content.series)) {
+                foreach ($series in @($value.series)) {
                     $sampleCount += @($series.samples).Count
                 }
                 if ($sampleCount -lt 1) {
@@ -279,6 +275,28 @@ function Wait-LagBelow([long]$UpperBound, [int]$Seconds = 60) {
         Start-Sleep -Seconds 2
     } while ([DateTime]::UtcNow -lt $deadline)
     throw "Timed out waiting for Consumer Lag below ${UpperBound}: $lastFailure."
+}
+
+function Drain-ProbeLag([int]$MaxBatches = 12) {
+    $evidence = Invoke-EvidenceQuery
+    $lag = Get-InlineLag $evidence
+    for ($batch = 1; $batch -le $MaxBatches -and $lag -gt 0; $batch++) {
+        Invoke-Docker (Compose-Arguments @(
+            '--profile', 'smoke', 'run', '--rm',
+            '-e', 'ROCKETMQ_SRE_PROBE_MAX_MESSAGES=1',
+            'sre-probe', 'consume'
+        )) | Out-Host
+        $snapshot = Wait-LagBelow -UpperBound $lag -Seconds 30
+        $evidence = $snapshot.Evidence
+        $lag = $snapshot.TotalLag
+    }
+    if ($lag -gt 0) {
+        throw "Consumer Lag remained at $lag after $MaxBatches bounded drain batches."
+    }
+    return [PSCustomObject]@{
+        Evidence = $evidence
+        TotalLag = $lag
+    }
 }
 
 function Get-ClusterState {
@@ -425,7 +443,7 @@ function Wait-McpTraceSince(
 
 function Get-McpToolRequestCount {
     $query = [Uri]::EscapeDataString(
-        'sum(rocketmq_rocketmq_mcp_requests_total{operation_kind="tool",operation="rocketmq_get_consumer_lag"})'
+        'sum(rocketmq_mcp_requests_total{operation_kind="tool",operation="rocketmq_get_consumer_lag"})'
     )
     $response = Invoke-RestMethod `
         -Uri "http://127.0.0.1:9090/api/v1/query?query=$query" `
@@ -585,12 +603,8 @@ Wait-Http 'http://127.0.0.1:3100/ready' | Out-Null
 Wait-Http 'http://127.0.0.1:3200/ready' | Out-Null
 Assert-ObservabilityQueries
 Assert-RequiredSignalsQualification
-$headers = @{ Authorization = "Bearer $internalToken" }
-$capabilities = Invoke-RestMethod `
-    -Uri 'http://127.0.0.1:8091/internal/v1/capabilities' `
-    -Headers $headers `
-    -TimeoutSec 15
-$resources = @($capabilities.clusters.'sre-dev'.resources)
+$capabilities = Get-ClusterCapability
+$resources = @($capabilities.manifest.resources)
 if ($resources -notcontains 'rocketmq://system/runtime/v1') {
     throw 'MCP runtime resource is missing from the verified capability surface.'
 }
@@ -608,7 +622,11 @@ Invoke-Docker (Compose-Arguments @('restart', 'postgres'))
 Invoke-Docker (Compose-Arguments @('up', '--detach', '--wait', 'postgres'))
 Invoke-Docker (Compose-Arguments @('restart', 'sre-control-plane'))
 Wait-Http 'http://127.0.0.1:8090/readyz' | Out-Null
+Invoke-Docker (Compose-Arguments @('restart', 'sre-control-plane-mtls'))
+Invoke-Docker (Compose-Arguments @('up', '--detach', '--wait', 'sre-control-plane-mtls'))
+Wait-Http 'http://127.0.0.1:8091/readyz' | Out-Null
 $persisted = Wait-ClusterReady
+Wait-ConnectorChannelOnline | Out-Null
 if ($persisted.id -ne $clusterId) {
     throw 'PostgreSQL/Control Plane restart did not preserve the onboarded cluster.'
 }
@@ -632,8 +650,7 @@ Wait-McpTraceSince 'RocketMQ MCP TOOL' $recoveryTraceStart
 Write-Host 'Collector recovery exported a new MCP Tool metric and trace.'
 Assert-ObservabilityQueries
 Wait-Http 'http://127.0.0.1:8091/readyz' | Out-Null
-Invoke-Docker (Compose-Arguments @('--profile', 'smoke', 'run', '--rm', 'sre-probe', 'consume'))
-$finalLagSnapshot = Wait-LagBelow -UpperBound 1
+$finalLagSnapshot = Drain-ProbeLag
 Write-Host "Post-outage Consumer Lag recovered to $($finalLagSnapshot.TotalLag)."
 
 $oldJwksDocument = Invoke-Docker (Compose-Arguments @(
@@ -709,7 +726,7 @@ $offboardBody = @{
 $offboarded = Invoke-RestMethod `
     -Method Post `
     -Uri "http://127.0.0.1:8090/v1/clusters/$clusterId/offboard" `
-    -Headers @{ Authorization = "Bearer $internalToken" } `
+    -Headers (Get-PublicApiHeaders) `
     -ContentType 'application/json' `
     -Body $offboardBody `
     -TimeoutSec 15
@@ -761,31 +778,7 @@ if ($persistedOffboarded.state -ne 'offboarded' -or $null -eq $persistedOffboard
 }
 Wait-Http 'http://127.0.0.1:8090/readyz' | Out-Null
 
-$connectorReadyResponse = Invoke-Docker (Compose-Arguments @(
-    'exec', '-T', 'sre-connector',
-    'curl', '--silent', '--show-error',
-    '--write-out', "`n%{http_code}",
-    'http://127.0.0.1:8091/readyz'
-)) -Capture
-$connectorReadyLines = @($connectorReadyResponse -split "\r?\n")
-$connectorReadyStatus = $connectorReadyLines[-1]
-$connectorReadyBody = ($connectorReadyLines[0..($connectorReadyLines.Count - 2)] -join "`n") | ConvertFrom-Json
-if ($connectorReadyStatus -ne '503' -or $connectorReadyBody.status -ne 'not_ready') {
-    throw "Connector readiness was not revoked after offboard (HTTP $connectorReadyStatus)."
-}
-
-$connectorCapabilities = Invoke-RestMethod `
-    -Uri 'http://127.0.0.1:8091/internal/v1/capabilities' `
-    -Headers @{ Authorization = "Bearer $internalToken" } `
-    -TimeoutSec 15
-$cachedClusters = @($connectorCapabilities.clusters.psobject.Properties)
-if (
-    $connectorCapabilities.ready `
-        -or $connectorCapabilities.last_error_code -ne 'cluster_not_allowed' `
-        -or $cachedClusters.Count -ne 0
-) {
-    throw 'Connector did not clear readiness and the verified capability cache after offboard.'
-}
+Wait-ConnectorNotReady
 
 $identityCounts = Invoke-Docker (Compose-Arguments @(
     'exec', '-T', 'postgres',
@@ -806,5 +799,5 @@ if (
     throw "Connector identity revocation was not persisted (counts=$identityCounts)."
 }
 
-Write-Host 'Offboard preserved Control Plane readiness, revoked Connector readiness, cleared capability cache, and persisted identity revocation.'
+Write-Host 'Offboard preserved Control Plane readiness, revoked Connector readiness, and persisted identity revocation.'
 Write-Host 'PHASE00_COMPOSE_SMOKE_OK'

--- a/rocketmq-sre/scripts/tests/test_phase00_compose_contract.py
+++ b/rocketmq-sre/scripts/tests/test_phase00_compose_contract.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the reproducible Phase 00 Compose workflow."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+SRE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class Phase00ComposeContractTest(unittest.TestCase):
+    def test_rocketmq_images_receive_the_current_source_revision(self) -> None:
+        compose = (SRE_ROOT / "deploy" / "dev" / "compose.yaml").read_text(encoding="utf-8")
+        dev_script = (SRE_ROOT / "scripts" / "dev.ps1").read_text(encoding="utf-8")
+
+        self.assertIn("SOURCE_REVISION: ${SOURCE_REVISION:-0000000000000000000000000000000000000000}", compose)
+        self.assertEqual(compose.count("args: *rocketmq-build-args"), 5)
+        self.assertIn("git -C $repositoryRoot rev-parse HEAD", dev_script)
+        self.assertIn("Remove-Item Env:SOURCE_REVISION", dev_script)
+
+    def test_control_plane_uses_a_valid_development_grant_key(self) -> None:
+        compose = (SRE_ROOT / "deploy" / "dev" / "compose.yaml").read_text(encoding="utf-8")
+        match = re.search(r"ROCKETMQ_SRE_GRANT_SIGNING_KEY:\s*([^\s]+)", compose)
+
+        self.assertIsNotNone(match)
+        self.assertGreaterEqual(len(match.group(1)), 32)
+
+    def test_ui_runtime_and_toolchain_peer_versions_are_aligned(self) -> None:
+        package = json.loads((SRE_ROOT / "ui" / "package.json").read_text(encoding="utf-8"))
+        lock = json.loads((SRE_ROOT / "ui" / "package-lock.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(package["dependencies"]["react"], "^18.3.1")
+        self.assertEqual(package["dependencies"]["react-dom"], "^18.3.1")
+        self.assertEqual(package["devDependencies"]["typescript"], "^5.9.3")
+        self.assertEqual(lock["packages"]["node_modules/react"]["version"], "18.3.1")
+        self.assertEqual(lock["packages"]["node_modules/react-dom"]["version"], "18.3.1")
+
+    def test_smoke_uses_the_reverse_connector_conversation_path(self) -> None:
+        smoke = (SRE_ROOT / "scripts" / "phase00-smoke.ps1").read_text(encoding="utf-8")
+
+        self.assertIn("/v1/conversations", smoke)
+        self.assertIn("/v1/evidence/", smoke)
+        self.assertIn("'restart', 'sre-control-plane-mtls'", smoke)
+        self.assertIn("rocketmq_mcp_requests_total", smoke)
+        self.assertIn("'ROCKETMQ_SRE_PROBE_MAX_MESSAGES=1'", smoke)
+        self.assertIn("function Drain-ProbeLag([int]$MaxBatches = 12)", smoke)
+        self.assertIn("function Wait-ConnectorNotReady([int]$Seconds = 45)", smoke)
+        self.assertIn("-Headers (Get-PublicApiHeaders)", smoke)
+        self.assertNotIn("rocketmq_rocketmq_mcp_requests_total", smoke)
+        self.assertNotIn("127.0.0.1:8091/internal/v1/evidence/query", smoke)
+        self.assertNotIn("127.0.0.1:8091/internal/v1/capabilities", smoke)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rocketmq-sre/ui/package-lock.json
+++ b/rocketmq-sre/ui/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.487.0",
         "oidc-client-ts": "^3.3.0",
-        "react": "^19.2.8",
+        "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^3.6.0"
       },
@@ -27,7 +27,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^26.1.2",
-        "@types/react": "^19.2.18",
+        "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^6.0.5",
         "eslint": "^10.8.0",
@@ -36,7 +36,7 @@
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
         "openapi-typescript": "^7.13.0",
-        "typescript": "^7.0.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^8.1.5",
         "vitest": "^4.1.10"
@@ -1918,13 +1918,21 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
-      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -1986,346 +1994,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -4300,10 +3968,13 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4722,38 +4393,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/rocketmq-sre/ui/package.json
+++ b/rocketmq-sre/ui/package.json
@@ -23,7 +23,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.487.0",
     "oidc-client-ts": "^3.3.0",
-    "react": "^19.2.8",
+    "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^3.6.0"
   },
@@ -34,7 +34,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^26.1.2",
-    "@types/react": "^19.2.18",
+    "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^6.0.5",
     "eslint": "^10.8.0",
@@ -43,7 +43,7 @@
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "openapi-typescript": "^7.13.0",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9022

### Brief Description

- route Compose smoke evidence and representative required-signal queries through the Control Plane conversation API and authenticated reverse Connector channel
- make local images reproducible with the checked-out source revision, provide a valid development grant-signing key, and align the UI React and TypeScript peer versions
- harden PostgreSQL and mTLS sidecar restart recovery, Collector outage recovery, JWKS rotation, bounded probe draining, and asynchronous offboard verification
- add contract coverage that prevents direct Connector bypasses and configuration drift

### How Did You Test This Change?

- `./rocketmq-sre/scripts/dev.ps1 -Action Up`
- `./rocketmq-sre/scripts/phase00-smoke.ps1 -Target Compose` (`PHASE00_COMPOSE_SMOKE_OK`)
- `cargo check --locked --workspace`
- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- `python -m unittest discover -s scripts/tests -p 'test_*.py' -v`
- `npm ci`, `npm run lint`, `npm run check:api`, `npm run test -- --run`, and `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conversation-query metrics for controller quorum health, MCP requests, active NameServer brokers, and proxy availability.
  - Added diagnostic-pack support for the new metrics.

- **Bug Fixes**
  - Improved smoke-test coverage for conversation, evidence, metrics, connector readiness, and Control Plane restart scenarios.
  - Strengthened validation to prevent unsupported unauthenticated endpoint usage.

- **Tests**
  - Added regression checks for service revision tracking, development configuration, endpoint coverage, metrics validation, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->