### PR TITLE
[ISSUE #9026]🐛Map standard OIDC roles to AI SRE service roles

### DIFF
--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/auth.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/auth.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -63,9 +64,19 @@ struct OidcClaims {
     scope: String,
     #[serde(default)]
     roles: Vec<String>,
+    #[serde(default)]
+    realm_access: OidcRoleAccess,
+    #[serde(default)]
+    resource_access: BTreeMap<String, OidcRoleAccess>,
     rocketmq_tenant: String,
     #[serde(default)]
     rocketmq_clusters: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct OidcRoleAccess {
+    #[serde(default)]
+    roles: Vec<String>,
 }
 
 impl AuthService {
@@ -239,7 +250,7 @@ async fn authorize_oidc(
         })
         .collect::<Result<BTreeSet<_>, _>>()?;
     enforce_cluster_scope(&clusters, cluster)?;
-    let mut roles = claims.roles.into_iter().collect::<BTreeSet<_>>();
+    let mut roles = oidc_roles(&claims, audience);
     for scope in claims.scope.split_ascii_whitespace() {
         match scope {
             "rocketmq:diagnose" | "rocketmq:sre" => {
@@ -269,6 +280,39 @@ async fn authorize_oidc(
         clusters,
         roles,
     })
+}
+
+fn oidc_roles(claims: &OidcClaims, audience: &str) -> BTreeSet<String> {
+    let audience_roles = claims
+        .resource_access
+        .get(audience)
+        .into_iter()
+        .flat_map(|access| access.roles.iter());
+    let mut roles = BTreeSet::new();
+    for role in claims
+        .roles
+        .iter()
+        .chain(claims.realm_access.roles.iter())
+        .chain(audience_roles)
+    {
+        if role.is_empty() {
+            continue;
+        }
+        roles.insert(role.clone());
+        match role.as_str() {
+            "executor" | "executor-service" => {
+                roles.insert("executor_service".to_owned());
+            }
+            "execution-agent" => {
+                roles.insert("execution_agent".to_owned());
+            }
+            "model_governance" => {
+                roles.insert("model-governance".to_owned());
+            }
+            _ => {}
+        }
+    }
+    roles
 }
 
 async fn fetch_jwks(client: &reqwest::Client, url: &url::Url) -> Result<JwkSet, ControlPlaneError> {
@@ -325,6 +369,8 @@ fn header<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[tokio::test]
@@ -358,5 +404,57 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn oidc_roles_accept_standard_realm_and_audience_client_claims() {
+        let claims: OidcClaims = serde_json::from_value(json!({
+            "sub": "sre-operator",
+            "scope": "rocketmq:read",
+            "roles": ["top-level-role"],
+            "realm_access": {
+                "roles": ["operator", "approver", "executor-service"]
+            },
+            "resource_access": {
+                "rocketmq-sre-control-plane": {
+                    "roles": ["execution-agent"]
+                },
+                "unrelated-client": {
+                    "roles": ["admin"]
+                }
+            },
+            "rocketmq_tenant": TenantId::new().to_string(),
+            "rocketmq_clusters": [ClusterId::new().to_string()]
+        }))
+        .expect("standard OIDC claims");
+
+        let roles = oidc_roles(&claims, "rocketmq-sre-control-plane");
+        assert!(roles.contains("top-level-role"));
+        assert!(roles.contains("operator"));
+        assert!(roles.contains("approver"));
+        assert!(roles.contains("executor_service"));
+        assert!(roles.contains("execution_agent"));
+        assert!(!roles.contains("admin"));
+    }
+
+    #[test]
+    fn oidc_role_aliases_are_narrow_and_empty_roles_are_ignored() {
+        let claims: OidcClaims = serde_json::from_value(json!({
+            "sub": "service-identity",
+            "scope": "rocketmq:read",
+            "realm_access": {
+                "roles": ["", "executor", "model_governance", "unknown-role"]
+            },
+            "rocketmq_tenant": TenantId::new().to_string(),
+            "rocketmq_clusters": []
+        }))
+        .expect("OIDC service claims");
+
+        let roles = oidc_roles(&claims, "rocketmq-sre-control-plane");
+        assert!(!roles.contains(""));
+        assert!(roles.contains("executor_service"));
+        assert!(roles.contains("model-governance"));
+        assert!(roles.contains("unknown-role"));
+        assert!(!roles.contains("execution_agent"));
     }
 }

--- a/rocketmq-sre/deploy/dev/enterprise-realm.json
+++ b/rocketmq-sre/deploy/dev/enterprise-realm.json
@@ -8,6 +8,8 @@
     "realm": [
       { "name": "operator" },
       { "name": "approver" },
+      { "name": "executor-service" },
+      { "name": "execution-agent" },
       { "name": "model-governance" }
     ]
   },

--- a/rocketmq-sre/scripts/enterprise-integrations-smoke.ps1
+++ b/rocketmq-sre/scripts/enterprise-integrations-smoke.ps1
@@ -190,6 +190,12 @@ try {
             throw "OIDC token is missing $scope."
         }
     }
+    $realmRoles = @($claims.realm_access.roles)
+    foreach ($role in @('operator', 'approver', 'model-governance')) {
+        if ($realmRoles -notcontains $role) {
+            throw "OIDC token is missing the standard realm role $role."
+        }
+    }
 
     $beforeKeys = @((Invoke-BoundedGet `
         'https://localhost:8445/realms/rocketmq-sre/protocol/openid-connect/certs' `
@@ -246,6 +252,7 @@ try {
             issuer = $discovery.issuer
             audience_verified = $true
             tenant_cluster_scope_verified = $true
+            standard_realm_role_mapping_verified = $true
             signing_key_rotation_verified = $true
         }
         secrets = [ordered]@{

--- a/rocketmq-sre/scripts/tests/test_enterprise_identity_contract.py
+++ b/rocketmq-sre/scripts/tests/test_enterprise_identity_contract.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contracts for the enterprise OIDC role fixtures and qualification smoke."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+SRE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class EnterpriseIdentityContractTest(unittest.TestCase):
+    def test_realm_declares_human_and_service_roles(self) -> None:
+        realm = json.loads(
+            (SRE_ROOT / "deploy" / "dev" / "enterprise-realm.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        role_names = {role["name"] for role in realm["roles"]["realm"]}
+
+        self.assertTrue(
+            {"operator", "approver", "executor-service", "execution-agent"}
+            <= role_names
+        )
+        operator = next(user for user in realm["users"] if user["username"] == "sre-operator")
+        self.assertTrue({"operator", "approver"} <= set(operator["realmRoles"]))
+
+    def test_smoke_requires_standard_realm_role_claims(self) -> None:
+        smoke = (SRE_ROOT / "scripts" / "enterprise-integrations-smoke.ps1").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("$claims.realm_access.roles", smoke)
+        self.assertIn("'operator', 'approver', 'model-governance'", smoke)
+        self.assertIn("standard_realm_role_mapping_verified = $true", smoke)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9026

### Brief Description

Accept standard OIDC realm roles and audience-specific client roles in the AI SRE control plane, while excluding roles issued to unrelated clients. Canonicalize the bounded executor, execution-agent, and model-governance aliases used by internal authorization checks. Extend the development Keycloak realm and enterprise qualification contract so human and service identities use the same role shape expected in deployment.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`
- `cargo check --locked --workspace`
- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `python -m unittest discover -s scripts/tests -p 'test_*.py' -v`
- `git diff --check`

The live enterprise smoke did not reach its functional assertions because Docker Hub returned EOF while pulling the MinIO image. The smoke cleaned up successfully and Docker returned to its exact pre-run image, container, volume, and build-cache baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded enterprise identity role mapping to support realm-level and application-specific roles.
  * Added executor service and execution agent roles to the enterprise configuration.
  * Standardized role aliases and ignored empty role entries.

* **Tests**
  * Added validation for role claims, client isolation, required service roles, and smoke-test evidence.
  * Smoke tests now verify operator, approver, and model-governance roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->