### PR TITLE
[ISSUE #9028]📝Align AI SRE provider compatibility with implemented adapters

### DIFF
--- a/rocketmq-sre/docs/compatibility.md
+++ b/rocketmq-sre/docs/compatibility.md
@@ -1,8 +1,8 @@
-# Phase 00 协议兼容性
+# AI SRE 协议兼容性
 
 ## 固定版本
 
-| Surface | Phase 00 版本 |
+| Surface | 基线版本 |
 | --- | --- |
 | MCP protocol | `2025-11-25` |
 | MCP business schema | `rocketmq-mcp.v2` |
@@ -22,7 +22,7 @@
 - Offboarding 使用 tombstone + identity revoke，保留能力快照和审计事件。
 
 稳定错误 envelope 至少包含 `code`、脱敏 `message`、`retryable` 与
-`correlation_id`。Phase 00 必须支持：
+`correlation_id`。兼容层至少支持：
 
 - `unsupported_schema_major`
 - `missing_required_feature`
@@ -36,17 +36,30 @@
 
 ## 模型协议适配矩阵
 
-Phase 00 只提供 ProviderDescriptor 与能力 fixture，不进行外部网络调用。
+Model Gateway 已实现 Canonical Model IR、Provider profile、同步/异步 HTTP
+transport、流式响应、有界输出、稳定错误映射、secret reference 和有限
+fallback。表中的“契约测试”表示 request/response、鉴权头、结构化输出、只读
+Tool 和错误映射已通过本地协议测试；“disposable live”表示通过受控本地环境访问
+真实 endpoint，不等同生产认证。
 
-| Provider | 协议族 | Streaming | Tools | Structured output | Embeddings |
-| --- | --- | ---: | ---: | ---: | ---: |
-| OpenAI-compatible | OpenAI | 是 | 是 | 是 | 是 |
-| Anthropic | Anthropic Messages | 是 | 是 | 是 | 否 |
-| Gemini | Google Gemini | 是 | 是 | 是 | 是 |
-| AWS Bedrock | Bedrock Converse | 是 | 是 | 是 | 取决于模型 |
-| DeepSeek | OpenAI-compatible | 是 | 是 | 是 | 否 |
-| 智谱 GLM | OpenAI-compatible / GLM | 是 | 是 | 是 | 是 |
-| Kimi / Moonshot | OpenAI-compatible | 是 | 是 | 是 | 否 |
-| 本地模型 | OpenAI-compatible | 取决于运行时 | 取决于模型 | 取决于模型 | 取决于模型 |
+| Provider | 协议族 | Streaming | Tools | Structured output | Embeddings | 实现成熟度 | 真实 endpoint 资格 |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| OpenAI-compatible | OpenAI Chat Completions-compatible | 是 | 是 | 是 | 是 | adapter 与 transport 已实现并完成契约测试 | 本地 Ollama profile 已通过 disposable live；不代表任意兼容 endpoint 已认证 |
+| Anthropic | Anthropic Messages | 是 | 是 | 是 | 否 | adapter、鉴权与 transport 已实现并完成契约测试 | 未做真实 endpoint 认证 |
+| Gemini | Google Gemini | 是 | 是 | 是 | 是 | adapter、鉴权与 transport 已实现并完成契约测试 | 未做真实 endpoint 认证 |
+| AWS Bedrock | Bedrock Converse | 是 | 是 | 是 | 取决于模型 | adapter、SigV4 与 transport 已实现并完成契约测试 | 未做真实 endpoint 认证 |
+| DeepSeek | Responses API / OpenAI-compatible / Anthropic-compatible | 是 | 是 | 是 | 否 | profile、adapter、语义 SSE、取消与有限 fallback 已实现并完成契约测试 | `deepseek-v4-flash` Responses API 已通过凭据门控的 disposable live 诊断与 fallback 资格 |
+| 智谱 GLM | OpenAI-compatible / GLM | 是 | 是 | 是 | 是 | profile、adapter 与 transport 已实现并完成契约测试 | 未做真实 endpoint 认证 |
+| Kimi / Moonshot | OpenAI-compatible，含可选 MFJS capability | 是 | 是 | 是 | 否 | profile、adapter 与 transport 已实现并完成契约测试 | 未做真实 endpoint 认证 |
+| 本地模型 | OpenAI-compatible | 取决于运行时 | 取决于模型 | 取决于模型 | 取决于模型 | adapter、loopback 约束与本地资格 runner 已实现 | Ollama `qwen2.5:0.5b` 已通过无凭据 disposable live 基础资格 |
 
-真实 Provider 认证、速率限制、成本路由、网络调用与模型回退属于后续阶段。
+所有真实 Provider 凭据都必须通过仓库外 secret file、环境引用或 SecretProvider
+注入，不得写入代码、配置、日志、Evidence 或资格报告。DeepSeek live 资格仅使用
+脱敏合成 Evidence，模型选择的 Tool 仍须经过固定只读 registry 校验；模型本身不
+获得 RocketMQ、Executor 或 Execution Agent 的 mutation authority。
+
+当前没有任何 Provider 被仓库声明为生产认证。生产凭据、数据驻留、网络出口、
+持续负载、配额/成本、故障转移策略和运维交接仍需部署环境单独认证。机器可校验的
+当前成熟度与限制以
+[`implementation-status.v1.json`](../config/implementation/implementation-status.v1.json)
+为准。

--- a/rocketmq-sre/scripts/tests/test_provider_compatibility_documentation.py
+++ b/rocketmq-sre/scripts/tests/test_provider_compatibility_documentation.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contracts for the current model-provider compatibility documentation."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+SRE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ProviderCompatibilityDocumentationTest(unittest.TestCase):
+    def test_matrix_tracks_implemented_and_live_qualified_profiles(self) -> None:
+        compatibility = (SRE_ROOT / "docs" / "compatibility.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("只提供 ProviderDescriptor 与能力 fixture", compatibility)
+        for provider in (
+            "OpenAI-compatible",
+            "Anthropic",
+            "Gemini",
+            "AWS Bedrock",
+            "DeepSeek",
+            "智谱 GLM",
+            "Kimi / Moonshot",
+            "本地模型",
+        ):
+            self.assertIn(provider, compatibility)
+        self.assertIn("deepseek-v4-flash", compatibility)
+        self.assertIn("Ollama `qwen2.5:0.5b`", compatibility)
+        self.assertIn("当前没有任何 Provider 被仓库声明为生产认证", compatibility)
+
+    def test_status_manifest_link_resolves(self) -> None:
+        status_manifest = SRE_ROOT / "config" / "implementation" / "implementation-status.v1.json"
+        self.assertTrue(status_manifest.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9028

### Brief Description

Replace the obsolete fixture-only Model Gateway statement with a current provider maturity matrix. The guide now distinguishes implemented and contract-tested adapters from disposable live qualifications and production certification, records the credential-gated DeepSeek Responses and credential-free local Ollama results, and keeps Zhipu GLM and Kimi/Moonshot explicitly non-live-certified. Add a small documentation contract test so the stale fixture-only claim cannot silently return.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_provider_compatibility_documentation -v`
- `python -m unittest discover -s scripts/tests -p 'test_*.py' -v` (97 tests passed)
- `python scripts/check_implementation_status.py`
- `git diff --check`

No live provider credential or endpoint was accessed. This documentation-only change does not modify Rust or Cargo configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated protocol compatibility guidance to use the AI SRE baseline.
  * Clarified compatibility-layer requirements for error envelopes.
  * Expanded the model adaptation matrix with maturity, endpoint qualification, transport capabilities, contract testing, credentials, permissions, and production authentication boundaries.
  * Added references to implementation status configuration.

* **Tests**
  * Added validation to ensure implemented and live-qualified providers, representative models, production certification status, and the implementation status manifest are accurately documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->