### PR TITLE
[ISSUE #9032]✨Add target-environment Evidence source qualification

### DIFF
--- a/rocketmq-sre/config/implementation/implementation-status.v1.json
+++ b/rocketmq-sre/config/implementation/implementation-status.v1.json
@@ -91,10 +91,19 @@
           "kind": "smoke",
           "path": "rocketmq-sre/scripts/phase00-smoke.ps1",
           "qualification": "required-signals"
+        },
+        {
+          "kind": "configuration",
+          "path": "rocketmq-sre/config/qualification/target-evidence-sources.v1.json"
+        },
+        {
+          "kind": "test",
+          "path": "rocketmq-sre/scripts/check_target_evidence_source_qualification.py"
         }
       ],
       "limitations": [
         "Broker, NameServer, Controller, Proxy, and MCP Required Signals are qualified through bounded Canonical Evidence in the disposable Compose environment; production backend certification remains environment-specific.",
+        "A fail-closed target-environment report contract now covers all 32 production-required Evidence routes and all six source types, but no organization-specific machine-local report has been supplied, so production certification remains false.",
         "Twenty-one optional Evidence requirements retain explicit stable not-production-verified routes."
       ]
     },

--- a/rocketmq-sre/config/qualification/target-evidence-sources.v1.json
+++ b/rocketmq-sre/config/qualification/target-evidence-sources.v1.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "rocketmq-sre.target-evidence-source-qualification.v1",
+  "operating_mode": "read_only",
+  "production_certified": false,
+  "grants_execution_authority": false,
+  "unattended_autonomous_execution": false,
+  "source_of_truth": {
+    "path": "rocketmq-sre/config/qualification/diagnostic-packs.v1.json",
+    "schema_version": "rocketmq-sre.diagnostic-pack-qualification.v1",
+    "required_pack_count": 32,
+    "required_route_count": 32
+  },
+  "required_source_types": [
+    {
+      "source": "admin-query",
+      "maximum_freshness_seconds": 300
+    },
+    {
+      "source": "kubernetes",
+      "maximum_freshness_seconds": 600
+    },
+    {
+      "source": "prometheus",
+      "maximum_freshness_seconds": 120
+    },
+    {
+      "source": "rocketmq-mcp",
+      "maximum_freshness_seconds": 300
+    },
+    {
+      "source": "runtime",
+      "maximum_freshness_seconds": 60
+    },
+    {
+      "source": "topology",
+      "maximum_freshness_seconds": 600
+    }
+  ],
+  "report_contract": {
+    "schema_version": "rocketmq-sre.target-evidence-source-qualification-report.v1",
+    "machine_local_only": true,
+    "allowed_roots": [
+      "D:\\rocketmq-sre-evidence",
+      "F:\\rocketmq-sre-evidence"
+    ],
+    "maximum_report_age_hours": 24,
+    "maximum_validity_days": 90,
+    "minimum_samples_per_route": 3,
+    "requires_every_route_exactly_once": true,
+    "requires_opaque_environment_refs": true,
+    "requires_opaque_identity_refs": true
+  },
+  "required_route_assertions": [
+    "query_executed",
+    "canonical_schema_valid",
+    "tenant_scope_enforced",
+    "cluster_scope_enforced",
+    "freshness_enforced",
+    "row_bound_enforced",
+    "byte_bound_enforced",
+    "redaction_verified",
+    "missing_semantics_verified"
+  ],
+  "safety": {
+    "target_mutations": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0,
+    "model_provider_calls": 0,
+    "credentials_recorded": false,
+    "message_bodies_recorded": false,
+    "evidence_payloads_recorded": false
+  }
+}

--- a/rocketmq-sre/scripts/check_target_evidence_source_qualification.py
+++ b/rocketmq-sre/scripts/check_target_evidence_source_qualification.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate target-environment Evidence source qualification."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SRE_ROOT = REPOSITORY_ROOT / "rocketmq-sre"
+DEFAULT_MANIFEST = SRE_ROOT / "config" / "qualification" / "target-evidence-sources.v1.json"
+DEFAULT_PACK_MANIFEST = SRE_ROOT / "config" / "qualification" / "diagnostic-packs.v1.json"
+MANIFEST_SCHEMA = "rocketmq-sre.target-evidence-source-qualification.v1"
+REPORT_SCHEMA = "rocketmq-sre.target-evidence-source-qualification-report.v1"
+PACK_SCHEMA = "rocketmq-sre.diagnostic-pack-qualification.v1"
+EXPECTED_SOURCE_LIMITS = (
+    ("admin-query", 300),
+    ("kubernetes", 600),
+    ("prometheus", 120),
+    ("rocketmq-mcp", 300),
+    ("runtime", 60),
+    ("topology", 600),
+)
+ALLOWED_REPORT_ROOTS = (r"D:\rocketmq-sre-evidence", r"F:\rocketmq-sre-evidence")
+MAXIMUM_REPORT_AGE_HOURS = 24
+MAXIMUM_VALIDITY_DAYS = 90
+MINIMUM_SAMPLES_PER_ROUTE = 3
+REQUIRED_ROUTE_ASSERTIONS = (
+    "query_executed",
+    "canonical_schema_valid",
+    "tenant_scope_enforced",
+    "cluster_scope_enforced",
+    "freshness_enforced",
+    "row_bound_enforced",
+    "byte_bound_enforced",
+    "redaction_verified",
+    "missing_semantics_verified",
+)
+REQUIRED_BINDING_ASSERTIONS = (
+    "production_backend",
+    "tls_verified",
+    "workload_identity_verified",
+    "tenant_scope_verified",
+    "cluster_scope_verified",
+)
+READ_ONLY_SUMMARY = {
+    "expected_routes": 32,
+    "passed_routes": 32,
+    "source_types": 6,
+    "target_mutations": 0,
+    "executor_calls": 0,
+    "execution_agent_calls": 0,
+    "model_provider_calls": 0,
+    "credentials_recorded": False,
+    "message_bodies_recorded": False,
+    "evidence_payloads_recorded": False,
+}
+REF_PATTERNS = {
+    "environment_ref": re.compile(r"^environment://[a-z0-9][a-z0-9._/-]{2,127}$"),
+    "integration_ref": re.compile(r"^integration://[a-z0-9][a-z0-9._/-]{2,127}$"),
+    "identity_ref": re.compile(r"^identity://[a-z0-9][a-z0-9._/-]{2,127}$"),
+    "owner_ref": re.compile(r"^owner://[a-z0-9][a-z0-9._/-]{2,127}$"),
+}
+REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+EMAIL_PATTERN = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+SENSITIVE_PATTERN = re.compile(
+    r"(?i)(bearer\s+\S+|api[_-]?key|client[_-]?secret|access[_-]?key|password|private\s+key|"
+    r"-----begin|token[=:]\s*\S+|secret[=:]\s*\S+)"
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def canonical_digest(value: dict[str, Any]) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def required_routes(pack_manifest: dict[str, Any]) -> tuple[tuple[str, str, str, str], ...]:
+    routes: list[tuple[str, str, str, str]] = []
+    packs = pack_manifest.get("packs")
+    if not isinstance(packs, list):
+        raise ValueError("DiagnosticPack manifest packs must be an array")
+    for pack in packs:
+        if not isinstance(pack, dict) or not isinstance(pack.get("id"), str):
+            raise ValueError("DiagnosticPack entries must contain an id")
+        evidence = pack.get("required_evidence")
+        if not isinstance(evidence, list):
+            raise ValueError(f"DiagnosticPack {pack['id']} required_evidence must be an array")
+        for requirement in evidence:
+            if not isinstance(requirement, dict):
+                raise ValueError(f"DiagnosticPack {pack['id']} required Evidence must be an object")
+            fields = (pack["id"], requirement.get("key"), requirement.get("source"), requirement.get("resource_prefix"))
+            if not all(isinstance(field, str) and field for field in fields):
+                raise ValueError(f"DiagnosticPack {pack['id']} has an incomplete required Evidence route")
+            routes.append(fields)  # type: ignore[arg-type]
+    return tuple(routes)
+
+
+def validate_manifest(manifest: dict[str, Any], pack_manifest: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected_header = {
+        "schema_version": MANIFEST_SCHEMA,
+        "operating_mode": "read_only",
+        "production_certified": False,
+        "grants_execution_authority": False,
+        "unattended_autonomous_execution": False,
+    }
+    for field, expected in expected_header.items():
+        if manifest.get(field) != expected:
+            findings.append(f"{field} must remain {expected!r}")
+
+    try:
+        routes = required_routes(pack_manifest)
+    except ValueError as error:
+        findings.append(str(error))
+        routes = ()
+    packs = pack_manifest.get("packs")
+    if pack_manifest.get("schema_version") != PACK_SCHEMA:
+        findings.append("DiagnosticPack source schema drifted")
+    if pack_manifest.get("pack_count") != 32 or not isinstance(packs, list) or len(packs) != 32:
+        findings.append("DiagnosticPack source must contain exactly 32 packs")
+    if len(routes) != 32 or len(set(routes)) != len(routes):
+        findings.append("DiagnosticPack source must contain 32 unique required Evidence routes")
+
+    source_of_truth = manifest.get("source_of_truth")
+    if source_of_truth != {
+        "path": "rocketmq-sre/config/qualification/diagnostic-packs.v1.json",
+        "schema_version": PACK_SCHEMA,
+        "required_pack_count": 32,
+        "required_route_count": 32,
+    }:
+        findings.append("source_of_truth contract drifted")
+    source_limits = manifest.get("required_source_types")
+    actual_limits = ()
+    if isinstance(source_limits, list):
+        actual_limits = tuple(
+            (entry.get("source"), entry.get("maximum_freshness_seconds"))
+            for entry in source_limits
+            if isinstance(entry, dict)
+        )
+    if actual_limits != EXPECTED_SOURCE_LIMITS:
+        findings.append("required source freshness limits drifted")
+    if {route[2] for route in routes} != {source for source, _ in EXPECTED_SOURCE_LIMITS}:
+        findings.append("required source types no longer match the DiagnosticPack routes")
+
+    if manifest.get("report_contract") != {
+        "schema_version": REPORT_SCHEMA,
+        "machine_local_only": True,
+        "allowed_roots": list(ALLOWED_REPORT_ROOTS),
+        "maximum_report_age_hours": MAXIMUM_REPORT_AGE_HOURS,
+        "maximum_validity_days": MAXIMUM_VALIDITY_DAYS,
+        "minimum_samples_per_route": MINIMUM_SAMPLES_PER_ROUTE,
+        "requires_every_route_exactly_once": True,
+        "requires_opaque_environment_refs": True,
+        "requires_opaque_identity_refs": True,
+    }:
+        findings.append("report_contract drifted")
+    if manifest.get("required_route_assertions") != list(REQUIRED_ROUTE_ASSERTIONS):
+        findings.append("required route assertions drifted")
+    summary_fields = {"expected_routes", "passed_routes", "source_types"}
+    expected_safety = {key: value for key, value in READ_ONLY_SUMMARY.items() if key not in summary_fields}
+    if manifest.get("safety") != expected_safety:
+        findings.append("read-only safety contract drifted")
+    return findings
+
+
+def parse_timestamp(value: Any, field: str, findings: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        findings.append(f"{field} must be an RFC 3339 timestamp")
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        findings.append(f"{field} must be an RFC 3339 timestamp")
+        return None
+    if parsed.tzinfo is None:
+        findings.append(f"{field} must include a timezone")
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def iter_strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from iter_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_strings(child)
+
+
+def report_path_is_allowed(report_path: str, allowed_roots: list[str]) -> bool:
+    normalized = report_path.replace("/", "\\")
+    parts = normalized.split("\\")
+    if ".." in parts or "." in parts or not re.match(r"^[A-Za-z]:\\", normalized):
+        return False
+    folded = normalized.casefold()
+    for root in allowed_roots:
+        root_folded = root.rstrip("\\").casefold()
+        if folded == root_folded or folded.startswith(f"{root_folded}\\"):
+            return True
+    return False
+
+
+def validate_report(
+    report: dict[str, Any],
+    manifest: dict[str, Any],
+    pack_manifest: dict[str, Any],
+    *,
+    report_path: str,
+    now: datetime | None = None,
+) -> list[str]:
+    findings = validate_manifest(manifest, pack_manifest)
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if not report_path_is_allowed(report_path, list(ALLOWED_REPORT_ROOTS)):
+        findings.append("qualification report must remain under an allowed machine-local root")
+
+    if report.get("schema_version") != REPORT_SCHEMA:
+        findings.append(f"schema_version must be {REPORT_SCHEMA}")
+    for field, pattern in REF_PATTERNS.items():
+        if field == "environment_ref" and not pattern.fullmatch(str(report.get(field, ""))):
+            findings.append(f"{field} must be an opaque {field.removesuffix('_ref')}:// reference")
+    if not REVISION_PATTERN.fullmatch(str(report.get("source_revision", ""))):
+        findings.append("source_revision must be a 40- or 64-character lowercase hexadecimal revision")
+    if report.get("catalog_digest") != canonical_digest(pack_manifest):
+        findings.append("catalog_digest does not match the current DiagnosticPack source of truth")
+    for field in ("production_certified", "grants_execution_authority", "unattended_autonomous_execution"):
+        if report.get(field) is not False:
+            findings.append(f"{field} must remain false")
+    if report.get("evidence_sources_qualified") is not True:
+        findings.append("evidence_sources_qualified must be true for an accepted target report")
+
+    observed_at = parse_timestamp(report.get("observed_at"), "observed_at", findings)
+    valid_until = parse_timestamp(report.get("valid_until"), "valid_until", findings)
+    if observed_at is not None and valid_until is not None:
+        maximum_validity = timedelta(days=MAXIMUM_VALIDITY_DAYS)
+        if valid_until <= observed_at or valid_until - observed_at > maximum_validity:
+            findings.append("qualification validity window is invalid or exceeds the contract limit")
+        maximum_age = timedelta(hours=MAXIMUM_REPORT_AGE_HOURS)
+        if now < observed_at or now - observed_at > maximum_age or now >= valid_until:
+            findings.append("qualification report is expired or not currently valid")
+
+    strings = list(iter_strings(report))
+    if any(EMAIL_PATTERN.search(value) for value in strings):
+        findings.append("qualification report must not contain a personal identifier")
+    if any(SENSITIVE_PATTERN.search(value) for value in strings):
+        findings.append("qualification report must not contain sensitive material")
+
+    expected_sources = {source for source, _ in EXPECTED_SOURCE_LIMITS}
+    bindings = report.get("source_bindings")
+    actual_sources: list[str] = []
+    if not isinstance(bindings, list):
+        findings.append("source_bindings must be an array")
+        bindings = []
+    for index, binding in enumerate(bindings):
+        location = f"source_bindings[{index}]"
+        if not isinstance(binding, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        source = binding.get("source")
+        if isinstance(source, str):
+            actual_sources.append(source)
+        for field in ("integration_ref", "identity_ref", "owner_ref"):
+            if not REF_PATTERNS[field].fullmatch(str(binding.get(field, ""))):
+                findings.append(f"{location}.{field} must be an opaque {field.removesuffix('_ref')}:// reference")
+        for field in REQUIRED_BINDING_ASSERTIONS:
+            if binding.get(field) is not True:
+                findings.append(f"{location}.{field} must be true")
+    if set(actual_sources) != expected_sources or len(actual_sources) != len(expected_sources):
+        findings.append("source binding set must cover every required source exactly once")
+
+    try:
+        expected_routes = set(required_routes(pack_manifest))
+    except ValueError:
+        expected_routes = set()
+    route_results = report.get("route_results")
+    if not isinstance(route_results, list):
+        findings.append("route_results must be an array")
+        route_results = []
+    actual_routes: list[tuple[str, str, str, str]] = []
+    freshness_limits = dict(EXPECTED_SOURCE_LIMITS)
+    minimum_samples = MINIMUM_SAMPLES_PER_ROUTE
+    for index, result in enumerate(route_results):
+        location = f"route_results[{index}]"
+        if not isinstance(result, dict):
+            findings.append(f"{location} must be an object")
+            continue
+        route = tuple(str(result.get(field, "")) for field in ("pack_id", "evidence_key", "source", "resource_prefix"))
+        actual_routes.append(route)  # type: ignore[arg-type]
+        if route not in expected_routes:
+            findings.append(f"{location} is an unexpected route result")
+        if result.get("status") != "passed":
+            findings.append(f"{location} must pass")
+        sample_count = result.get("sample_count")
+        if not isinstance(sample_count, int) or isinstance(sample_count, bool) or sample_count < minimum_samples:
+            findings.append(f"{location}.sample_count is below the required minimum")
+        if not DIGEST_PATTERN.fullmatch(str(result.get("evidence_digest", ""))):
+            findings.append(f"{location}.evidence_digest must be a lowercase SHA-256 digest")
+        for field in REQUIRED_ROUTE_ASSERTIONS:
+            if result.get(field) is not True:
+                findings.append(f"{location}.{field} must be true")
+        route_observed = parse_timestamp(result.get("observed_at"), f"{location}.observed_at", findings)
+        source = route[2]
+        if observed_at is not None and route_observed is not None and source in freshness_limits:
+            age = observed_at - route_observed
+            if age < timedelta(0) or age > timedelta(seconds=freshness_limits[source]):
+                findings.append(f"{location} is outside its source freshness window")
+
+    duplicate_routes = {route for route, count in Counter(actual_routes).items() if count > 1}
+    for route in sorted(duplicate_routes):
+        findings.append(f"duplicate route result: {'/'.join(route)}")
+    for route in sorted(expected_routes - set(actual_routes)):
+        findings.append(f"missing required route: {'/'.join(route)}")
+
+    if report.get("summary") != READ_ONLY_SUMMARY:
+        findings.append("read-only summary does not match the required 32-route qualification result")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--pack-manifest", type=Path, default=DEFAULT_PACK_MANIFEST)
+    parser.add_argument("--report", type=Path)
+    arguments = parser.parse_args()
+    manifest = load_json(arguments.manifest)
+    pack_manifest = load_json(arguments.pack_manifest)
+    if arguments.report is None:
+        findings = validate_manifest(manifest, pack_manifest)
+    else:
+        report = load_json(arguments.report)
+        findings = validate_report(
+            report,
+            manifest,
+            pack_manifest,
+            report_path=str(arguments.report),
+        )
+    if findings:
+        for finding in findings:
+            print(f"ERROR: {finding}")
+        return 1
+    routes = required_routes(pack_manifest)
+    print(
+        "TARGET_EVIDENCE_SOURCE_QUALIFICATION_OK "
+        f"routes={len(routes)} sources={len({route[2] for route in routes})} "
+        f"report={'accepted' if arguments.report else 'not_provided'} "
+        "production_certified=false grants_execution_authority=false"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-sre/scripts/tests/test_check_target_evidence_source_qualification.py
+++ b/rocketmq-sre/scripts/tests/test_check_target_evidence_source_qualification.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for target-environment Evidence source qualification."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_target_evidence_source_qualification.py"
+SPEC = importlib.util.spec_from_file_location("check_target_evidence_source_qualification", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TargetEvidenceSourceQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = MODULE.load_json(MODULE.DEFAULT_MANIFEST)
+        cls.pack_manifest = MODULE.load_json(MODULE.DEFAULT_PACK_MANIFEST)
+        cls.now = datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc)
+
+    def valid_report(self) -> dict:
+        routes = MODULE.required_routes(self.pack_manifest)
+        sources = sorted({route[2] for route in routes})
+        return {
+            "schema_version": "rocketmq-sre.target-evidence-source-qualification-report.v1",
+            "environment_ref": "environment://production/primary",
+            "source_revision": "a" * 40,
+            "catalog_digest": MODULE.canonical_digest(self.pack_manifest),
+            "observed_at": "2026-08-07T11:55:00Z",
+            "valid_until": "2026-09-06T11:55:00Z",
+            "evidence_sources_qualified": True,
+            "production_certified": False,
+            "grants_execution_authority": False,
+            "unattended_autonomous_execution": False,
+            "source_bindings": [
+                {
+                    "source": source,
+                    "integration_ref": f"integration://production/{source}",
+                    "identity_ref": f"identity://production/{source}",
+                    "owner_ref": f"owner://production/{source}",
+                    "production_backend": True,
+                    "tls_verified": True,
+                    "workload_identity_verified": True,
+                    "tenant_scope_verified": True,
+                    "cluster_scope_verified": True,
+                }
+                for source in sources
+            ],
+            "route_results": [
+                {
+                    "pack_id": pack_id,
+                    "evidence_key": evidence_key,
+                    "source": source,
+                    "resource_prefix": resource_prefix,
+                    "status": "passed",
+                    "sample_count": 3,
+                    "observed_at": "2026-08-07T11:54:00Z",
+                    "evidence_digest": f"sha256:{index:064x}",
+                    "query_executed": True,
+                    "canonical_schema_valid": True,
+                    "tenant_scope_enforced": True,
+                    "cluster_scope_enforced": True,
+                    "freshness_enforced": True,
+                    "row_bound_enforced": True,
+                    "byte_bound_enforced": True,
+                    "redaction_verified": True,
+                    "missing_semantics_verified": True,
+                }
+                for index, (pack_id, evidence_key, source, resource_prefix) in enumerate(routes, start=1)
+            ],
+            "summary": {
+                "expected_routes": 32,
+                "passed_routes": 32,
+                "source_types": 6,
+                "target_mutations": 0,
+                "executor_calls": 0,
+                "execution_agent_calls": 0,
+                "model_provider_calls": 0,
+                "credentials_recorded": False,
+                "message_bodies_recorded": False,
+                "evidence_payloads_recorded": False,
+            },
+        }
+
+    def validate(self, report: dict, path: str = r"D:\rocketmq-sre-evidence\target\report.json") -> list[str]:
+        return MODULE.validate_report(
+            report,
+            self.manifest,
+            self.pack_manifest,
+            report_path=path,
+            now=self.now,
+        )
+
+    def test_committed_contract_tracks_all_required_routes(self) -> None:
+        self.assertEqual(MODULE.validate_manifest(self.manifest, self.pack_manifest), [])
+        routes = MODULE.required_routes(self.pack_manifest)
+        self.assertEqual(len(routes), 32)
+        self.assertEqual(
+            {route[2] for route in routes},
+            {"admin-query", "kubernetes", "prometheus", "rocketmq-mcp", "runtime", "topology"},
+        )
+
+    def test_accepts_complete_machine_local_report(self) -> None:
+        self.assertEqual(self.validate(self.valid_report()), [])
+
+    def test_rejects_missing_duplicate_and_unexpected_routes(self) -> None:
+        report = self.valid_report()
+        report["route_results"].pop()
+        report["route_results"].append(copy.deepcopy(report["route_results"][0]))
+        report["route_results"][1]["pack_id"] = "unexpected.v1"
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("missing required route" in finding for finding in findings))
+        self.assertTrue(any("duplicate route result" in finding for finding in findings))
+        self.assertTrue(any("unexpected route result" in finding for finding in findings))
+
+    def test_rejects_failed_or_incomplete_route_proof(self) -> None:
+        report = self.valid_report()
+        route = report["route_results"][0]
+        route["status"] = "missing"
+        route["sample_count"] = 2
+        route["redaction_verified"] = False
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("must pass" in finding for finding in findings))
+        self.assertTrue(any("sample_count" in finding for finding in findings))
+        self.assertTrue(any("redaction_verified" in finding for finding in findings))
+
+    def test_rejects_stale_expired_or_overlong_attestation(self) -> None:
+        report = self.valid_report()
+        report["observed_at"] = "2026-08-01T00:00:00Z"
+        report["valid_until"] = "2027-08-01T00:00:00Z"
+        report["route_results"][0]["observed_at"] = "2026-08-01T00:00:00Z"
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("validity window" in finding for finding in findings))
+        self.assertTrue(any("expired or not currently valid" in finding for finding in findings))
+        self.assertTrue(any("freshness window" in finding for finding in findings))
+
+    def test_rejects_missing_or_unverified_source_binding(self) -> None:
+        report = self.valid_report()
+        report["source_bindings"].pop()
+        report["source_bindings"][0]["tls_verified"] = False
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("source binding set" in finding for finding in findings))
+        self.assertTrue(any("tls_verified" in finding for finding in findings))
+
+    def test_rejects_sensitive_content_and_personal_identifiers(self) -> None:
+        report = self.valid_report()
+        report["source_bindings"][0]["owner_ref"] = "operator@example.com"
+        report["source_bindings"][1]["identity_ref"] = "Bearer secret-value"
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("personal identifier" in finding for finding in findings))
+        self.assertTrue(any("sensitive material" in finding for finding in findings))
+
+    def test_rejects_nonopaque_refs_and_invalid_revision_or_digest(self) -> None:
+        report = self.valid_report()
+        report["environment_ref"] = "production-primary"
+        report["source_revision"] = "main"
+        report["catalog_digest"] = "sha256:" + "0" * 64
+        report["source_bindings"][0]["integration_ref"] = "https://internal.example"
+        report["route_results"][0]["evidence_digest"] = "invalid"
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("environment_ref" in finding for finding in findings))
+        self.assertTrue(any("source_revision" in finding for finding in findings))
+        self.assertTrue(any("catalog_digest" in finding for finding in findings))
+        self.assertTrue(any("integration_ref" in finding for finding in findings))
+        self.assertTrue(any("evidence_digest" in finding for finding in findings))
+
+    def test_rejects_report_outside_machine_local_evidence_roots(self) -> None:
+        report = self.valid_report()
+
+        findings = self.validate(report, r"C:\Users\operator\report.json")
+        escaped = self.validate(report, r"D:\rocketmq-sre-evidence\..\outside\report.json")
+
+        self.assertTrue(any("allowed machine-local root" in finding for finding in findings))
+        self.assertTrue(any("allowed machine-local root" in finding for finding in escaped))
+
+    def test_rejects_authority_or_product_certification_claims(self) -> None:
+        report = self.valid_report()
+        report["production_certified"] = True
+        report["grants_execution_authority"] = True
+        report["unattended_autonomous_execution"] = True
+        report["summary"]["target_mutations"] = 1
+
+        findings = self.validate(report)
+
+        self.assertTrue(any("production_certified" in finding for finding in findings))
+        self.assertTrue(any("grants_execution_authority" in finding for finding in findings))
+        self.assertTrue(any("unattended_autonomous_execution" in finding for finding in findings))
+        self.assertTrue(any("read-only summary" in finding for finding in findings))
+
+    def test_rejects_summary_drift(self) -> None:
+        report = self.valid_report()
+        report["summary"]["passed_routes"] = 31
+        report["summary"]["source_types"] = 5
+
+        self.assertTrue(any("summary" in finding for finding in self.validate(report)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9032

### Brief Description

Add a versioned target-environment Evidence source qualification contract that derives the complete 32-route catalog from the existing DiagnosticPack source of truth. Add a fail-closed checker for six target source bindings, freshness, bounds, scope, redaction, missing semantics, catalog drift, report expiry, and machine-local evidence paths. The contract cannot certify the complete product, grant execution authority, enable unattended autonomy, call a model provider, or mutate a target.

Update the machine-readable implementation status to record the new contract while keeping Evidence sources partial and production certification false until an organization-specific report is supplied.

### How Did You Test This Change?

- `python -m unittest discover -s scripts/tests -p 'test_*.py'` (119 tests)
- `python scripts/check_target_evidence_source_qualification.py`
- `python scripts/check_implementation_status.py`
- `python scripts/check_source_layout.py`
- `python scripts/check_execution_dependency_boundary.py`
- `git diff --cached --check`

No Rust or Cargo files changed, so this change did not create or reuse a Cargo target directory.