### PR TITLE
[ISSUE #9037]✨Require auditable owner approval for Autonomous promotion

### DIFF
--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy.rs
@@ -25,6 +25,8 @@ mod service;
 #[cfg(test)]
 mod logger_ttl_lifecycle_tests;
 #[cfg(test)]
+mod model_tests;
+#[cfg(test)]
 mod operations_repository_tests;
 #[cfg(test)]
 mod repository_tests;

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/logger_ttl_lifecycle_tests.rs
@@ -290,6 +290,7 @@ async fn qualify_r1_action(
                 target_mode: AutonomyMode::Shadow,
                 reason: Some("start bounded logger qualification".to_owned()),
                 owner_confirmed: false,
+                owner_approval_ref: None,
             },
         )
         .await
@@ -341,6 +342,7 @@ async fn qualify_r1_action(
                     target_mode: AutonomyMode::Supervised,
                     reason: Some("window must not be bypassed".to_owned()),
                     owner_confirmed: true,
+                    owner_approval_ref: None,
                 },
             )
             .await
@@ -359,6 +361,7 @@ async fn qualify_r1_action(
                 target_mode: AutonomyMode::Supervised,
                 reason: Some("Shadow sample and window targets met".to_owned()),
                 owner_confirmed: true,
+                owner_approval_ref: None,
             },
         )
         .await
@@ -461,6 +464,7 @@ async fn qualify_r1_action(
                     target_mode: AutonomyMode::Autonomous,
                     reason: Some("autonomous window must not be bypassed".to_owned()),
                     owner_confirmed: true,
+                    owner_approval_ref: Some("approval://qualification/autonomy-window".to_owned()),
                 },
             )
             .await
@@ -548,6 +552,7 @@ async fn qualify_r1_action(
                     target_mode: AutonomyMode::Supervised,
                     reason: Some("owner reviewed bounded qualification failure".to_owned()),
                     owner_confirmed: true,
+                    owner_approval_ref: None,
                 },
             )
             .await
@@ -580,6 +585,7 @@ async fn qualify_r1_action(
                 target_mode: AutonomyMode::Autonomous,
                 reason: Some("Supervised target and observation window met".to_owned()),
                 owner_confirmed: true,
+                owner_approval_ref: Some("approval://qualification/autonomy-promotion".to_owned()),
             },
         )
         .await

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/model.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/model.rs
@@ -62,7 +62,8 @@ pub(crate) struct CreateAutonomyPolicyRequest {
 }
 
 /// Human lifecycle change. Autonomous promotion additionally requires the
-/// owner-confirmed flag and current qualification.
+/// owner-confirmed flag, an opaque approval reference, and current
+/// qualification.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AutonomyTransitionRequest {
@@ -70,6 +71,39 @@ pub(crate) struct AutonomyTransitionRequest {
     pub(crate) reason: Option<String>,
     #[serde(default)]
     pub(crate) owner_confirmed: bool,
+    #[serde(default)]
+    pub(crate) owner_approval_ref: Option<String>,
+}
+
+impl AutonomyTransitionRequest {
+    pub(crate) fn validated_owner_approval_ref(&self) -> Option<&str> {
+        let value = self.owner_approval_ref.as_deref()?;
+        if value.trim() != value || value.chars().count() > 160 {
+            return None;
+        }
+        let reference = value.strip_prefix("approval://")?;
+        let boundary_valid = reference
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
+            && reference
+                .chars()
+                .next_back()
+                .is_some_and(|character| character.is_ascii_lowercase() || character.is_ascii_digit());
+        if reference.chars().count() < 3
+            || !boundary_valid
+            || reference.contains("..")
+            || reference.contains("//")
+            || !reference.chars().all(|character| {
+                character.is_ascii_lowercase()
+                    || character.is_ascii_digit()
+                    || matches!(character, '.' | '-' | '_' | '/')
+            })
+        {
+            return None;
+        }
+        Some(value)
+    }
 }
 
 /// Query one action/cluster scope.

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/model_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/model_tests.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_sre_contracts::AutonomyMode;
+
+use super::model::AutonomyTransitionRequest;
+
+#[test]
+fn autonomous_transition_accepts_only_a_bounded_opaque_approval_reference() {
+    let request = AutonomyTransitionRequest {
+        target_mode: AutonomyMode::Autonomous,
+        reason: Some("target qualification and owner review completed".to_owned()),
+        owner_confirmed: true,
+        owner_approval_ref: Some("approval://target/autonomy/logger-ttl".to_owned()),
+    };
+
+    assert_eq!(
+        request.validated_owner_approval_ref(),
+        Some("approval://target/autonomy/logger-ttl")
+    );
+}
+
+#[test]
+fn approval_reference_rejects_missing_url_personal_and_unbounded_values() {
+    for approval_ref in [
+        None,
+        Some("https://approvals.example/123"),
+        Some("operator@example.com"),
+        Some("approval://target/../escape"),
+        Some("approval://TARGET/autonomy"),
+        Some("approval://target/token=value"),
+    ] {
+        let request = AutonomyTransitionRequest {
+            target_mode: AutonomyMode::Autonomous,
+            reason: None,
+            owner_confirmed: true,
+            owner_approval_ref: approval_ref.map(str::to_owned),
+        };
+
+        assert!(request.validated_owner_approval_ref().is_none());
+    }
+
+    let request = AutonomyTransitionRequest {
+        target_mode: AutonomyMode::Autonomous,
+        reason: None,
+        owner_confirmed: true,
+        owner_approval_ref: Some(format!("approval://target/{}", "a".repeat(160))),
+    };
+    assert!(request.validated_owner_approval_ref().is_none());
+}
+
+#[test]
+fn transition_json_keeps_non_autonomous_callers_compatible() {
+    let request: AutonomyTransitionRequest = serde_json::from_value(serde_json::json!({
+        "target_mode": "supervised",
+        "reason": "qualified shadow cohort",
+        "owner_confirmed": true
+    }))
+    .expect("legacy non-Autonomous transition request");
+
+    assert!(request.owner_approval_ref.is_none());
+}

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository.rs
@@ -220,6 +220,7 @@ impl PostgresRepository {
                     &lifecycle,
                     &definition.action_version,
                     Some(lifecycle.mode),
+                    None,
                     "policy_definition_changed",
                     actor,
                 )
@@ -270,6 +271,7 @@ impl PostgresRepository {
                     &mut transaction,
                     &lifecycle,
                     &definition.action_version,
+                    None,
                     None,
                     "policy_definition_created",
                     actor,
@@ -392,6 +394,7 @@ impl PostgresRepository {
         next: &AutonomyLifecycleState,
         action_version: &str,
         owner_confirmed: bool,
+        owner_approval_ref: Option<&str>,
         reason_code: &str,
     ) -> Result<(), ControlPlaneError> {
         let mut transaction = self.pool.begin().await?;
@@ -436,6 +439,7 @@ impl PostgresRepository {
             next,
             action_version,
             Some(current.mode),
+            owner_approval_ref,
             reason_code,
             &next.updated_by,
         )
@@ -1546,6 +1550,7 @@ impl PostgresRepository {
                     &next,
                     &effective.action_version,
                     Some(current.mode),
+                    None,
                     reason,
                     actor,
                 )
@@ -1758,6 +1763,7 @@ async fn insert_lifecycle_event(
     state: &AutonomyLifecycleState,
     action_version: &str,
     from_mode: Option<AutonomyMode>,
+    owner_approval_ref: Option<&str>,
     reason_code: &str,
     actor: &str,
 ) -> Result<(), ControlPlaneError> {
@@ -1765,11 +1771,11 @@ async fn insert_lifecycle_event(
         "INSERT INTO autonomy_lifecycle_events (
             event_id, tenant_id, cluster_id, action_id, action_version,
             from_mode, to_mode, previous_mode, lifecycle_revision,
-            reason_code, actor_subject, event_snapshot, occurred_at
+            reason_code, actor_subject, owner_approval_ref, event_snapshot, occurred_at
          ) VALUES (
             $1, $2, $3, $4, $5,
             $6, $7, $8, $9,
-            $10, $11, $12, $13
+            $10, $11, $12, $13, $14
          )",
     )
     .bind(Uuid::new_v4())
@@ -1783,6 +1789,7 @@ async fn insert_lifecycle_event(
     .bind(i64::try_from(state.lifecycle_revision).map_err(|_| invalid_request("lifecycle revision is too large"))?)
     .bind(reason_code)
     .bind(actor)
+    .bind(owner_approval_ref)
     .bind(json_value(state)?)
     .bind(state.updated_at)
     .execute(&mut **transaction)

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/repository_tests.rs
@@ -85,6 +85,7 @@ async fn postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent
             &shadow,
             &stored.action_version,
             false,
+            None,
             "repository_test_shadow",
         )
         .await
@@ -179,6 +180,7 @@ async fn postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent
             &supervised,
             &stored.action_version,
             true,
+            None,
             "repository_test_supervised",
         )
         .await
@@ -271,6 +273,7 @@ async fn postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent
             autonomous_qualified: true,
             critic_ready: true,
             owner_confirmed: true,
+            owner_approval_ref_valid: true,
             ..PromotionQualification::default()
         },
         now + Duration::seconds(9),
@@ -282,10 +285,31 @@ async fn postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent
             &autonomous,
             &stored.action_version,
             true,
+            Some("approval://qualification/repository-autonomous"),
             "repository_test_autonomous",
         )
         .await
         .expect("persist Autonomous");
+    let owner_approval_ref: Option<String> = sqlx::query_scalar(
+        "SELECT owner_approval_ref
+         FROM autonomy_lifecycle_events
+         WHERE tenant_id = $1 AND cluster_id = $2
+           AND action_id = $3 AND action_version = $4
+           AND to_mode = 'autonomous'
+         ORDER BY sequence_id DESC
+         LIMIT 1",
+    )
+    .bind(fixture.tenant_id.as_uuid())
+    .bind(fixture.cluster_id.as_uuid())
+    .bind(ExecutionAction::ObservabilityLoggerLevelTtl.id())
+    .bind(&stored.action_version)
+    .fetch_one(&repository.pool)
+    .await
+    .expect("persisted Autonomous owner approval reference");
+    assert_eq!(
+        owner_approval_ref.as_deref(),
+        Some("approval://qualification/repository-autonomous")
+    );
     let grant = AutonomyGrant {
         issuer: "rocketmq-sre-control-plane".to_owned(),
         audience: "rocketmq-sre-executor".to_owned(),

--- a/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/service.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-control-plane/src/autonomy/service.rs
@@ -241,6 +241,7 @@ impl AutonomyService {
         request: &AutonomyTransitionRequest,
     ) -> Result<AutonomyScopeView, ControlPlaneError> {
         require_human_operator(auth)?;
+        let owner_approval_ref = transition_owner_approval_ref(request)?;
         let current = self.scope(auth, scope).await?;
         let qualification = PromotionQualification {
             shadow_qualified: current.qualification.shadow_observation_window_met
@@ -251,6 +252,7 @@ impl AutonomyService {
                 && current.qualification.recent_rollbacks <= current.policy.max_recent_rollbacks,
             critic_ready: current.qualification.autonomous_cohort.is_some(),
             owner_confirmed: request.owner_confirmed,
+            owner_approval_ref_valid: owner_approval_ref.is_some(),
         };
         let next = AutonomyStateMachine::transition(
             &current.lifecycle,
@@ -268,6 +270,7 @@ impl AutonomyService {
                 &next,
                 &current.policy.action_version,
                 request.owner_confirmed,
+                owner_approval_ref,
                 transition_reason(request.target_mode),
             )
             .await?;
@@ -1494,5 +1497,25 @@ const fn transition_reason(mode: AutonomyMode) -> &'static str {
         AutonomyMode::Supervised => "operator_enabled_supervised",
         AutonomyMode::Autonomous => "owner_confirmed_autonomous",
         AutonomyMode::Paused => "operator_paused",
+    }
+}
+
+fn transition_owner_approval_ref(request: &AutonomyTransitionRequest) -> Result<Option<&str>, ControlPlaneError> {
+    match (request.target_mode, request.owner_approval_ref.as_deref()) {
+        (AutonomyMode::Autonomous, None) => Err(ControlPlaneError::validation(
+            "owner_approval_ref_required",
+            "Autonomous promotion requires an opaque action-owner approval reference",
+        )),
+        (AutonomyMode::Autonomous, Some(_)) => request.validated_owner_approval_ref().map(Some).ok_or_else(|| {
+            ControlPlaneError::validation(
+                "invalid_owner_approval_ref",
+                "owner approval reference must use the bounded approval:// format",
+            )
+        }),
+        (_, Some(_)) => Err(ControlPlaneError::validation(
+            "owner_approval_ref_not_applicable",
+            "owner approval reference is accepted only for Autonomous promotion",
+        )),
+        (_, None) => Ok(None),
     }
 }

--- a/rocketmq-sre/crates/rocketmq-sre-core/src/automation_state.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-core/src/automation_state.rs
@@ -34,6 +34,7 @@ pub struct PromotionQualification {
     pub autonomous_qualified: bool,
     pub critic_ready: bool,
     pub owner_confirmed: bool,
+    pub owner_approval_ref_valid: bool,
 }
 
 /// Fail-closed lifecycle transition error.
@@ -45,6 +46,7 @@ pub enum AutonomyTransitionError {
     QualificationMissing,
     CriticNotReady,
     OwnerConfirmationRequired,
+    OwnerApprovalReferenceRequired,
     PauseReasonRequired,
     RevisionExhausted,
 }
@@ -61,6 +63,9 @@ impl fmt::Display for AutonomyTransitionError {
             Self::CriticNotReady => formatter.write_str("autonomous promotion requires a valid heterogeneous critic"),
             Self::OwnerConfirmationRequired => {
                 formatter.write_str("autonomous promotion requires action owner confirmation")
+            }
+            Self::OwnerApprovalReferenceRequired => {
+                formatter.write_str("autonomous promotion requires an auditable owner approval reference")
             }
             Self::PauseReasonRequired => formatter.write_str("paused autonomy requires a bounded reason"),
             Self::RevisionExhausted => formatter.write_str("autonomy lifecycle revision is exhausted"),
@@ -121,6 +126,9 @@ impl AutonomyStateMachine {
                 }
                 if !qualification.owner_confirmed {
                     return Err(AutonomyTransitionError::OwnerConfirmationRequired);
+                }
+                if !qualification.owner_approval_ref_valid {
+                    return Err(AutonomyTransitionError::OwnerApprovalReferenceRequired);
                 }
             }
             (AutonomyMode::Shadow | AutonomyMode::Supervised | AutonomyMode::Autonomous, AutonomyMode::Paused)
@@ -201,6 +209,7 @@ mod tests {
             autonomous_qualified: true,
             critic_ready: true,
             owner_confirmed: true,
+            owner_approval_ref_valid: true,
         };
         let shadow = AutonomyStateMachine::transition(
             &state(AutonomyMode::Disabled),
@@ -224,6 +233,27 @@ mod tests {
         .expect("supervised");
         assert_eq!(supervised.mode, AutonomyMode::Supervised);
         assert_eq!(supervised.lifecycle_revision, 3);
+    }
+
+    #[test]
+    fn autonomous_promotion_requires_an_owner_approval_reference() {
+        let result = AutonomyStateMachine::transition(
+            &state(AutonomyMode::Supervised),
+            AutonomyMode::Autonomous,
+            AutonomyActor::HumanOperator,
+            "operator",
+            None,
+            PromotionQualification {
+                autonomous_qualified: true,
+                critic_ready: true,
+                owner_confirmed: true,
+                owner_approval_ref_valid: false,
+                ..PromotionQualification::default()
+            },
+            chrono::Utc::now(),
+        );
+
+        assert_eq!(result, Err(AutonomyTransitionError::OwnerApprovalReferenceRequired));
     }
 
     #[test]

--- a/rocketmq-sre/migrations/0058_autonomy_owner_approval_ref.sql
+++ b/rocketmq-sre/migrations/0058_autonomy_owner_approval_ref.sql
@@ -1,0 +1,17 @@
+-- Copyright 2026 The RocketMQ Rust Authors
+-- Licensed under the Apache License, Version 2.0.
+
+ALTER TABLE autonomy_lifecycle_events
+    ADD COLUMN owner_approval_ref TEXT;
+
+ALTER TABLE autonomy_lifecycle_events
+    ADD CONSTRAINT autonomy_lifecycle_events_owner_approval_ref_format
+    CHECK (
+        owner_approval_ref IS NULL
+        OR (
+            char_length(owner_approval_ref) BETWEEN 14 AND 160
+            AND owner_approval_ref ~ '^approval://[a-z0-9][a-z0-9._/-]*[a-z0-9]$'
+            AND position('..' IN substring(owner_approval_ref FROM 12)) = 0
+            AND position('//' IN substring(owner_approval_ref FROM 12)) = 0
+        )
+    );


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9037

### Brief Description

Require a bounded opaque owner approval reference when promoting an autonomy lifecycle from Supervised to Autonomous. Persist the reference in append-only lifecycle events, fail closed on missing or malformed references, and preserve compatibility for non-Autonomous transition requests.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-sre-core -p rocketmq-sre-control-plane -- --check`
- `cargo check --locked -p rocketmq-sre-core -p rocketmq-sre-control-plane`
- `cargo test --locked -p rocketmq-sre-core automation_state::tests`
- `cargo test --locked -p rocketmq-sre-control-plane autonomy::model_tests`
- `cargo test --locked -p rocketmq-sre-control-plane autonomy::repository_tests::postgres_autonomy_state_cohorts_and_controls_are_durable_and_idempotent -- --ignored --exact` against Docker PostgreSQL 17
- `cargo clippy --locked -p rocketmq-sre-core -p rocketmq-sre-control-plane --all-targets --all-features -- -D warnings`
- `cargo doc --locked -p rocketmq-sre-core -p rocketmq-sre-control-plane --no-deps`
- `python -m unittest discover -s scripts/tests -p test_*.py -v` (131 passed)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner approval references to autonomous promotion requests.
  * Autonomous promotions now require a valid approval reference.
  * Approval references are recorded with lifecycle events for auditability.

* **Bug Fixes**
  * Invalid, missing, or improperly formatted approval references are rejected.
  * Non-autonomous transitions remain compatible without an approval reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->