### PR TITLE
[ISSUE #9041]✨Remove redundant request header hot-path scans

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -46,7 +46,6 @@ pub(super) fn manual_fast_helpers(model: &HeaderModel, codec_trait: &TokenStream
     let error_type = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
     let sink_trait = quote!(#protocol_path::protocol::header_codec::EncodeSink);
     let encode = local_encode_body(model, codec_trait, protocol_path);
-    let len_hint = local_len_hint_body(model, protocol_path);
 
     quote! {
         #[inline]
@@ -55,11 +54,6 @@ pub(super) fn manual_fast_helpers(model: &HeaderModel, codec_trait: &TokenStream
             sink: &mut __RequestHeaderSink,
         ) -> Result<(), #error_type> {
             #encode
-        }
-
-        #[inline]
-        fn __request_header_codec_v3_local_encoded_len_hint(&self) -> usize {
-            #len_hint
         }
     }
 }
@@ -202,30 +196,6 @@ fn encode_selected_body<'a>(
         <Self as #codec_trait>::validate_for_wire(self)?;
         #(#writes)*
         Ok(())
-    }
-}
-
-fn local_len_hint_body(model: &HeaderModel, protocol_path: &syn::Path) -> TokenStream {
-    let value_trait = quote!(#protocol_path::protocol::header_codec::HeaderValue);
-    let adds = model.fields.iter().filter(|field| !field.flattened).map(|field| {
-        let ident = &field.ident;
-        let overhead = 6_usize.saturating_add(field.key.value.len());
-        if field.option_inner.is_some() {
-            quote! {
-                if let Some(value) = &self.#ident {
-                    len = len.saturating_add(#overhead).saturating_add(#value_trait::encoded_len(value));
-                }
-            }
-        } else {
-            quote! {
-                len = len.saturating_add(#overhead).saturating_add(#value_trait::encoded_len(&self.#ident));
-            }
-        }
-    });
-    quote! {
-        let mut len = 0usize;
-        #(#adds)*
-        len
     }
 }
 

--- a/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
@@ -40,7 +40,6 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
 
             fn encode_direct_binary(&self, out: &mut #bytes_mut) -> Result<(), #codec_error> {
                 let checkpoint = out.len();
-                out.reserve(<Self as #codec_trait>::encoded_len_hint(self));
                 let result = {
                     let mut sink = #binary_sink::new(out);
                     <Self as #codec_trait>::encode_into(self, &mut sink)

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -29,7 +29,9 @@ use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header_codec::BinarySink;
 use crate::protocol::header_codec::HeaderCodec;
 use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_codec::HeaderFieldContext;
 use crate::protocol::header_codec::HeaderFieldSource;
+use crate::protocol::header_codec::HeaderValue;
 use crate::protocol::header_codec::JsonSink;
 use crate::protocol::header_codec::MapSink;
 use crate::protocol::header_codec::ResolvedHeaderKey;
@@ -140,7 +142,6 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
         let checkpoint = out.len();
         // Java's V2 fast codec writes only the compact a..n fields. Inherited
         // topic/RPC fields remain available through the compatibility map.
-        out.reserve(self.__request_header_codec_v3_local_encoded_len_hint());
         let result = {
             let mut sink = BinarySink::new(out);
             self.__request_header_codec_v3_encode_local(&mut sink)
@@ -320,12 +321,152 @@ impl FromMap for SendMessageRequestHeaderV2 {
     }
 
     fn from_field_source(source: &dyn HeaderFieldSource) -> Result<Self::Target, Self::Error> {
-        <Self as HeaderCodec>::decode_from_source(source)
+        Self::decode_from_field_source(source)
             .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))
     }
 }
 
 impl SendMessageRequestHeaderV2 {
+    fn decode_from_field_source(source: &dyn HeaderFieldSource) -> Result<Self, HeaderCodecError> {
+        #[derive(Default)]
+        struct SourceFields<'a> {
+            a: Option<&'a str>,
+            b: Option<&'a str>,
+            c: Option<&'a str>,
+            d: Option<&'a str>,
+            e: Option<&'a str>,
+            f: Option<&'a str>,
+            g: Option<&'a str>,
+            h: Option<&'a str>,
+            i: Option<&'a str>,
+            j: Option<&'a str>,
+            k: Option<&'a str>,
+            l: Option<&'a str>,
+            m: Option<&'a str>,
+            n: Option<&'a str>,
+            broker_name: Option<&'a str>,
+            broker_name_alias: Option<&'a str>,
+            namespace: Option<&'a str>,
+            namespace_alias: Option<&'a str>,
+            namespaced: Option<&'a str>,
+            namespaced_alias: Option<&'a str>,
+            oneway: Option<&'a str>,
+            oneway_alias: Option<&'a str>,
+            lo: Option<&'a str>,
+        }
+
+        #[inline(always)]
+        fn required<T: HeaderValue>(
+            raw: Option<&str>,
+            header: &'static str,
+            key: &'static str,
+        ) -> Result<T, HeaderCodecError> {
+            let context = HeaderFieldContext::new(header, key, T::KIND, None);
+            T::decode(raw.ok_or(HeaderCodecError::Missing { header, key })?, context)
+        }
+
+        #[inline(always)]
+        fn optional<T: HeaderValue>(
+            raw: Option<&str>,
+            header: &'static str,
+            key: &'static str,
+        ) -> Result<Option<T>, HeaderCodecError> {
+            let context = HeaderFieldContext::new(header, key, T::KIND, None);
+            raw.map(|value| T::decode(value, context)).transpose()
+        }
+
+        let mut fields = SourceFields::default();
+        source.visit_fields_while(&mut |key, value| {
+            match key {
+                FIELD_A => fields.a = Some(value),
+                FIELD_B => fields.b = Some(value),
+                FIELD_C => fields.c = Some(value),
+                FIELD_D => fields.d = Some(value),
+                FIELD_E => fields.e = Some(value),
+                FIELD_F => fields.f = Some(value),
+                FIELD_G => fields.g = Some(value),
+                FIELD_H => fields.h = Some(value),
+                FIELD_I => fields.i = Some(value),
+                FIELD_J => fields.j = Some(value),
+                FIELD_K => fields.k = Some(value),
+                FIELD_L => fields.l = Some(value),
+                FIELD_M => fields.m = Some(value),
+                FIELD_N => fields.n = Some(value),
+                FIELD_BROKER_NAME => fields.broker_name = Some(value),
+                "brokerName" => fields.broker_name_alias = Some(value),
+                FIELD_NAMESPACE => fields.namespace = Some(value),
+                "namespace" => fields.namespace_alias = Some(value),
+                FIELD_NAMESPACED => fields.namespaced = Some(value),
+                "namespaced" => fields.namespaced_alias = Some(value),
+                FIELD_ONEWAY => fields.oneway = Some(value),
+                "oneway" => fields.oneway_alias = Some(value),
+                FIELD_LO => fields.lo = Some(value),
+                _ => {}
+            }
+            true
+        });
+
+        let header_type = <Self as HeaderCodec>::TYPE_ID;
+        let a = required(fields.a, header_type, FIELD_A)?;
+        let b = required(fields.b, header_type, FIELD_B)?;
+        let c = required(fields.c, header_type, FIELD_C)?;
+        let d = required(fields.d, header_type, FIELD_D)?;
+        let e = required(fields.e, header_type, FIELD_E)?;
+        let f = required(fields.f, header_type, FIELD_F)?;
+        let g = required(fields.g, header_type, FIELD_G)?;
+        let h = required(fields.h, header_type, FIELD_H)?;
+        let i = optional(fields.i, header_type, FIELD_I)?;
+        let j = optional(fields.j, header_type, FIELD_J)?;
+        let k = optional(fields.k, header_type, FIELD_K)?;
+        let l = optional(fields.l, header_type, FIELD_L)?;
+        let m = optional(fields.m, header_type, FIELD_M)?;
+        let n = optional(fields.n, header_type, FIELD_N)?;
+
+        let rpc_type = <RpcRequestHeader as HeaderCodec>::TYPE_ID;
+        let rpc_request_header = RpcRequestHeader {
+            namespace: optional(fields.namespace.or(fields.namespace_alias), rpc_type, FIELD_NAMESPACE)?,
+            namespaced: optional(
+                fields.namespaced.or(fields.namespaced_alias),
+                rpc_type,
+                FIELD_NAMESPACED,
+            )?,
+            broker_name: optional(
+                fields.broker_name.or(fields.broker_name_alias),
+                rpc_type,
+                FIELD_BROKER_NAME,
+            )?,
+            oneway: optional(fields.oneway.or(fields.oneway_alias), rpc_type, FIELD_ONEWAY)?,
+        };
+        <RpcRequestHeader as HeaderCodec>::validate_for_wire(&rpc_request_header)?;
+
+        let topic_type = <TopicRequestHeader as HeaderCodec>::TYPE_ID;
+        let topic_request_header = TopicRequestHeader {
+            rpc_request_header: Some(rpc_request_header),
+            lo: optional(fields.lo, topic_type, FIELD_LO)?,
+        };
+        <TopicRequestHeader as HeaderCodec>::validate_for_wire(&topic_request_header)?;
+
+        let header = Self {
+            a,
+            b,
+            c,
+            d,
+            e,
+            f,
+            g,
+            h,
+            i,
+            j,
+            k,
+            l,
+            m,
+            n,
+            topic_request_header: Some(topic_request_header),
+        };
+        <Self as HeaderCodec>::validate_for_wire(&header)?;
+        Ok(header)
+    }
+
     pub fn create_send_message_request_header_v1(this: &Self) -> SendMessageRequestHeader {
         let topic_request_header = this.n.as_ref().map(|broker_name| TopicRequestHeader {
             rpc_request_header: Some(RpcRequestHeader {
@@ -636,6 +777,50 @@ mod tests {
         assert_eq!(decoded.c, header.c);
         assert_eq!(decoded.d, header.d);
         assert_eq!(decoded.g, header.g);
+    }
+
+    #[test]
+    fn single_scan_field_source_decode_matches_generated_v3_semantics() {
+        let mut fields = required_fast_fields();
+        fields.extend([
+            (FIELD_I.into(), "properties".into()),
+            (FIELD_J.into(), "3".into()),
+            (FIELD_K.into(), "true".into()),
+            (FIELD_L.into(), "5".into()),
+            (FIELD_M.into(), "false".into()),
+            (FIELD_N.into(), "v2-broker".into()),
+            (FIELD_NAMESPACE.into(), "canonical-namespace".into()),
+            ("namespace".into(), "alias-namespace".into()),
+            (FIELD_NAMESPACED.into(), "true".into()),
+            ("namespaced".into(), "false".into()),
+            (FIELD_BROKER_NAME.into(), "canonical-broker".into()),
+            ("brokerName".into(), "alias-broker".into()),
+            (FIELD_ONEWAY.into(), "false".into()),
+            ("oneway".into(), "true".into()),
+            (FIELD_LO.into(), "true".into()),
+        ]);
+
+        let expected = <SendMessageRequestHeaderV2 as HeaderCodec>::decode_from_source(&fields).unwrap();
+        let actual = SendMessageRequestHeaderV2::decode_from_field_source(&fields).unwrap();
+
+        assert_eq!(actual.to_map(), expected.to_map());
+    }
+
+    #[test]
+    fn single_scan_field_source_decode_preserves_v3_error_classification() {
+        for (key, value) in [(FIELD_J, "invalid-i32"), (FIELD_NAMESPACED, "invalid-bool")] {
+            let mut fields = required_fast_fields();
+            fields.insert(key.into(), value.into());
+
+            let expected = <SendMessageRequestHeaderV2 as HeaderCodec>::decode_from_source(&fields)
+                .unwrap_err()
+                .to_string();
+            let actual = SendMessageRequestHeaderV2::decode_from_field_source(&fields)
+                .unwrap_err()
+                .to_string();
+
+            assert_eq!(actual, expected, "classification drifted for {key}");
+        }
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -696,9 +696,7 @@ impl RemotingCommand {
     #[inline]
     fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
         let begin_index = dst.len();
-        let estimated_header_size = RocketMQSerializable::estimate_encode_size(self);
-
-        dst.reserve(8usize.saturating_add(estimated_header_size));
+        dst.reserve(8 + RocketMQSerializable::INITIAL_ENCODE_CAPACITY);
         dst.put_i64(0); // Placeholder for total_length + serialize_type
 
         let capability = self.custom_header_encode_capability();
@@ -1419,6 +1417,19 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct NoPreflightLengthHeader;
+
+    impl CommandCustomHeader for NoPreflightLengthHeader {
+        fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+            Some(HashMap::from([("field".into(), "value".into())]))
+        }
+
+        fn encoded_len_hint(&self) -> usize {
+            panic!("ROCKETMQ frame encoding must not preflight custom-header lengths")
+        }
+    }
+
     #[test]
     fn test_remoting_command() {
         let command = RemotingCommand::create_remoting_command(1)
@@ -1463,6 +1474,24 @@ mod tests {
         let (total, _) = RemotingCommand::checked_frame_lengths(0, max_body, SerializeType::JSON).unwrap();
         assert_eq!(total, i32::MAX);
         assert!(RemotingCommand::checked_frame_lengths(0, max_body + 1, SerializeType::JSON).is_err());
+    }
+
+    #[test]
+    fn rocketmq_frame_encoding_does_not_preflight_custom_header_lengths() {
+        let mut command = RemotingCommand::create_request_command(1, NoPreflightLengthHeader)
+            .set_serialize_type(SerializeType::ROCKETMQ);
+        let mut encoded = BytesMut::new();
+
+        command.try_fast_header_encode(&mut encoded).unwrap();
+
+        let decoded = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get("field"))
+                .map(CheetahString::as_str),
+            Some("value")
+        );
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -56,6 +56,8 @@ fn sorted_ext_fields(map: &HashMap<CheetahString, CheetahString>) -> Vec<(&Cheet
 pub struct RocketMQSerializable;
 
 impl RocketMQSerializable {
+    pub(crate) const INITIAL_ENCODE_CAPACITY: usize = 512;
+
     #[inline]
     fn estimated_map_capacity(encoded_len: usize) -> usize {
         (encoded_len / MAP_ENTRY_ENCODED_BYTES_ESTIMATE).clamp(MIN_MAP_CAPACITY, MAX_MAP_CAPACITY)
@@ -148,6 +150,10 @@ impl RocketMQSerializable {
         buf: &mut BytesMut,
         capability: HeaderEncodeCapability,
     ) -> Result<usize, HeaderCodecError> {
+        // A bounded initial allocation is cheaper than walking every typed and
+        // dynamic field before immediately walking them again to encode. Large
+        // headers retain BytesMut's normal growth behavior.
+        buf.reserve(Self::INITIAL_ENCODE_CAPACITY);
         let checkpoint = buf.len();
         let result = Self::try_rocketmq_protocol_encode_inner(cmd, buf, capability);
         if result.is_err() {
@@ -162,10 +168,6 @@ impl RocketMQSerializable {
         capability: HeaderEncodeCapability,
     ) -> Result<usize, HeaderCodecError> {
         let begin_index = buf.len();
-
-        // Estimate required capacity and reserve upfront to reduce reallocations
-        let estimated_size = Self::estimate_encode_size(cmd);
-        buf.reserve(estimated_size);
 
         // Write fixed-size header fields (total: 15 bytes)
         buf.put_u16(cmd.code() as u16); // 2 bytes
@@ -245,38 +247,6 @@ impl RocketMQSerializable {
     #[inline]
     fn checked_dynamic_value_length(length: usize) -> Result<i32, HeaderCodecError> {
         i32::try_from(length).map_err(|_| HeaderCodecError::DynamicValueLengthOverflow)
-    }
-
-    /// Estimate the size needed for encoding to reduce reallocations
-    #[inline]
-    pub(crate) fn estimate_encode_size(cmd: &RemotingCommand) -> usize {
-        let mut size = 17usize; // Fixed header fields (13) plus the ext-map length (4).
-
-        // Remark size
-        if let Some(remark) = cmd.remark() {
-            size = size.saturating_add(4usize.saturating_add(remark.len())); // length prefix + data
-        } else {
-            size = size.saturating_add(4); // just the length prefix (0)
-        }
-
-        // Ext fields size (approximate)
-        if let Some(ext) = cmd.ext_fields() {
-            for (k, v) in ext.iter() {
-                if !k.is_empty() {
-                    size = size
-                        .saturating_add(2)
-                        .saturating_add(k.len())
-                        .saturating_add(4)
-                        .saturating_add(v.len());
-                }
-            }
-        }
-
-        if let Some(header) = cmd.command_custom_header_ref() {
-            size = size.saturating_add(header.encoded_len_hint());
-        }
-
-        size
     }
 
     pub fn rocket_mq_protocol_encode_bytes(cmd: &RemotingCommand) -> Bytes {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9041

### Brief Description

Remove repeated request-header hot-path passes while preserving the existing wire and fallback contracts.

- Replace full ROCKETMQ capacity preflight traversal with one bounded initial reservation and normal growth for oversized headers.
- Remove duplicate generated and manual direct-binary length-hint reservations.
- Decode `SendMessageRequestHeaderV2` local and flattened fields in one borrowed source scan with canonical alias precedence and classified V3 errors intact.
- Keep Java-compatible frame bytes, rollback, overflow handling, dynamic collision behavior, and map compatibility unchanged.

Focused A/B diagnostics on the same host reduced the SendV2 ROCKETMQ and JSON decode medians by about 28.4% and 17.0%, respectively, and reduced the benchmark artifact and `.text` sizes by about 0.33%. These diagnostics guide this implementation unit and do not replace the complete performance attestation.

### How Did You Test This Change?

- `cargo test --locked -p rocketmq-macros`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol -p rocketmq-macros --all-targets --all-features --no-deps -- -D warnings -A deprecated`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz/`
- Cross-language verification of all 24 Rust frames with the pinned Java production decoder
- Focused 40-sample Criterion A/B for the four SendV2 production entrypoints
- Deterministic PE artifact and `.text` measurement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Streamlined RocketMQ header encoding by removing preflight length estimation.
  * Encoding now uses bounded initial buffering while preserving rollback behavior on failures.

* **Bug Fixes**
  * Improved direct decoding for message request headers, including optional fields, aliases, nested headers, and validation.
  * Preserved error classification and verified compatibility with existing generated decoding behavior.

* **Tests**
  * Added coverage confirming encoding and decoding do not invoke removed length-estimation logic.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->