### PR TITLE
[ISSUE #9045]✨Optimize JSON request header field decoding

### DIFF
--- a/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
@@ -14,9 +14,7 @@
 
 use std::fmt;
 
-use bytes::BufMut;
 use bytes::Bytes;
-use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use serde::de::DeserializeSeed;
 use serde::de::MapAccess;
@@ -88,8 +86,9 @@ impl<'de> Visitor<'de> for JsonHeaderFieldsVisitor {
             .size_hint()
             .unwrap_or_default()
             .min(MAX_INITIAL_MAP_CAPACITY)
-            .saturating_mul(ESTIMATED_FIELD_BYTES);
-        let mut payload = BytesMut::with_capacity(initial_capacity);
+            .saturating_mul(ESTIMATED_FIELD_BYTES)
+            .max(MIN_INITIAL_PAYLOAD_CAPACITY);
+        let mut payload = Vec::with_capacity(initial_capacity);
         let mut entry_count = 0usize;
 
         while map
@@ -101,14 +100,14 @@ impl<'de> Visitor<'de> for JsonHeaderFieldsVisitor {
         }
 
         Ok(JsonHeaderFields {
-            payload: payload.freeze(),
+            payload: Bytes::from(payload),
             entry_count,
         })
     }
 }
 
 struct JsonFieldTextSeed<'a> {
-    payload: &'a mut BytesMut,
+    payload: &'a mut Vec<u8>,
 }
 
 impl<'de> DeserializeSeed<'de> for JsonFieldTextSeed<'_> {
@@ -123,7 +122,7 @@ impl<'de> DeserializeSeed<'de> for JsonFieldTextSeed<'_> {
 }
 
 struct JsonFieldTextVisitor<'a> {
-    payload: &'a mut BytesMut,
+    payload: &'a mut Vec<u8>,
 }
 
 impl JsonFieldTextVisitor<'_> {
@@ -135,13 +134,8 @@ impl JsonFieldTextVisitor<'_> {
         let additional = FIELD_LENGTH_BYTES
             .checked_add(value.len())
             .ok_or_else(|| E::custom("JSON extension-field length overflow"))?;
-        let reserve = if self.payload.capacity() == 0 {
-            additional.max(MIN_INITIAL_PAYLOAD_CAPACITY)
-        } else {
-            additional
-        };
-        self.payload.reserve(reserve);
-        self.payload.put_u32(length);
+        self.payload.reserve(additional);
+        self.payload.extend_from_slice(&length.to_be_bytes());
         self.payload.extend_from_slice(value.as_bytes());
         Ok(())
     }
@@ -225,7 +219,10 @@ impl<'a> JsonHeaderFieldIter<'a> {
 
     #[inline]
     fn read_utf8(&mut self, length: usize) -> &'a str {
-        std::str::from_utf8(self.take(length)).expect("validated JSON header field UTF-8 changed")
+        let bytes = self.take(length);
+        // SAFETY: `JsonHeaderFields` is private and its payload is populated only
+        // from strings accepted by Serde. The iterator preserves byte boundaries.
+        unsafe { std::str::from_utf8_unchecked(bytes) }
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9045

### Brief Description

This change reduces JSON request-header decode overhead without changing the wire format or public API.

- Builds the compact extension-field payload with a bounded, preallocated `Vec<u8>` and converts it to `Bytes` without copying.
- Removes repeated UTF-8 validation when scanning the private immutable payload. The unsafe conversion is protected by the invariant that only Serde-validated strings can construct the payload.
- Preserves lazy compatibility-map materialization, duplicate-field ordering, escaped text, Unicode, empty values, typed errors, and clone behavior.
- Adds no dependency, module entry file, or production type annotation metadata.

An isolated same-commit A/B run covered all 12 checked-in JSON decode cases. Every median improved, ranging from about 4% to 33%; the Java-critical send-response case improved by about 12%. The benchmark executable became 3,584 bytes smaller and its `.text` section became 4,152 bytes smaller.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --all-features` (1,456 unit tests plus integration, UI, and documentation tests)
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from the standalone fuzz project
- Isolated Criterion A/B benchmark with 30 samples per JSON decode case

The unfiltered workspace Clippy command still stops on seven pre-existing `rocketmq-model` deprecation/useless-conversion findings. Workspace-wide formatting and standalone example formatting still hit Windows error 206; example Clippy with `--locked` still reports the pre-existing stale lock file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved RocketMQ protocol payload encoding and decoding for more consistent message handling.
  * Enhanced support for larger and smaller payload sizes through bounded buffering.
  * Standardized length encoding and validated text conversion for improved interoperability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->