### PR TITLE
[ISSUE #9048]🐛Generate typed Model Gateway capability contracts

### DIFF
--- a/rocketmq-sre/openapi/rocketmq-sre-phase05.openapi.json
+++ b/rocketmq-sre/openapi/rocketmq-sre-phase05.openapi.json
@@ -1511,9 +1511,32 @@
         "operationId": "getModelCapabilities",
         "responses": {
           "200": {
-            "$ref": "#/components/responses/JsonObject"
+            "description": "Sanitized Model Gateway capability status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelCapabilitiesResponse"
+                }
+              }
+            }
           }
-        }
+        },
+        "summary": "Get sanitized Model Gateway capabilities",
+        "security": [
+          {
+            "oidc": [
+              "rocketmq:read"
+            ]
+          },
+          {
+            "oidc": [
+              "rocketmq:diagnose"
+            ]
+          }
+        ],
+        "tags": [
+          "Models"
+        ]
       }
     },
     "/v1/models/status": {
@@ -1521,9 +1544,32 @@
         "operationId": "getModelStatus",
         "responses": {
           "200": {
-            "$ref": "#/components/responses/JsonObject"
+            "description": "Sanitized Model Gateway capability status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelCapabilitiesResponse"
+                }
+              }
+            }
           }
-        }
+        },
+        "summary": "Get sanitized Model Gateway runtime status",
+        "security": [
+          {
+            "oidc": [
+              "rocketmq:read"
+            ]
+          },
+          {
+            "oidc": [
+              "rocketmq:diagnose"
+            ]
+          }
+        ],
+        "tags": [
+          "Models"
+        ]
       }
     },
     "/v1/models/invocations": {
@@ -31762,6 +31808,310 @@
             "maxLength": 512
           }
         }
+      },
+      "ModelProviderCapability": {
+        "type": "string",
+        "enum": [
+          "chat",
+          "text",
+          "json_object",
+          "json_schema",
+          "tool_calling",
+          "tool_choice_required",
+          "tool_choice_specific",
+          "strict_tools",
+          "vision",
+          "reasoning",
+          "streaming",
+          "embeddings",
+          "rerank",
+          "kimi_mfjs"
+        ]
+      },
+      "ModelProviderCapabilities": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "supported",
+          "max_input_tokens",
+          "max_output_tokens"
+        ],
+        "properties": {
+          "supported": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "$ref": "#/components/schemas/ModelProviderCapability"
+            }
+          },
+          "max_input_tokens": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_output_tokens": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ModelProviderDescriptor": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "version",
+          "owner",
+          "supported_versions",
+          "config_schema",
+          "status",
+          "deprecation",
+          "protocols",
+          "supports_streaming",
+          "supports_tools",
+          "supports_structured_output",
+          "supports_embeddings"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "supported_versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SchemaVersion"
+            }
+          },
+          "required_capabilities": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "config_schema": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DescriptorStatus"
+          },
+          "deprecation": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Deprecation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "protocols": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "supports_streaming": {
+            "type": "boolean"
+          },
+          "supports_tools": {
+            "type": "boolean"
+          },
+          "supports_structured_output": {
+            "type": "boolean"
+          },
+          "supports_embeddings": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ModelProfileStatus": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "profile_name",
+          "provider_family",
+          "protocol_family",
+          "model_family",
+          "model_name",
+          "model_revision",
+          "endpoint_instance",
+          "region",
+          "capabilities",
+          "priority",
+          "credential_configured",
+          "credential_owner",
+          "health",
+          "last_health_observed_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "profile_name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "provider_family": {
+            "type": "string",
+            "minLength": 1
+          },
+          "protocol_family": {
+            "type": "string",
+            "minLength": 1
+          },
+          "model_family": {
+            "type": "string",
+            "minLength": 1
+          },
+          "model_name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "model_revision": {
+            "type": "string",
+            "minLength": 1
+          },
+          "endpoint_instance": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Opaque endpoint instance identifier, never an endpoint URL."
+          },
+          "region": {
+            "type": "string",
+            "minLength": 1
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/ModelProviderCapabilities"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "credential_configured": {
+            "type": "boolean"
+          },
+          "credential_owner": {
+            "type": "string",
+            "enum": [
+              "gateway",
+              "adapter"
+            ]
+          },
+          "health": {
+            "type": "string",
+            "enum": [
+              "unknown",
+              "healthy",
+              "degraded",
+              "quarantined",
+              "disabled"
+            ]
+          },
+          "last_health_observed_at": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ModelCapabilitiesResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "network_calls_supported",
+          "network_calls_enabled",
+          "rules_only_available",
+          "max_fallbacks",
+          "profiles",
+          "fallback_order",
+          "providers",
+          "observed_at"
+        ],
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "const": "rocketmq-sre.model-capabilities.v1"
+          },
+          "network_calls_supported": {
+            "type": "boolean",
+            "const": true
+          },
+          "network_calls_enabled": {
+            "type": "boolean"
+          },
+          "rules_only_available": {
+            "type": "boolean",
+            "const": true
+          },
+          "max_fallbacks": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelProfileStatus"
+            }
+          },
+          "fallback_order": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelProviderDescriptor"
+            }
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
       }
     }
   },
@@ -31848,6 +32198,10 @@
     {
       "name": "Bounded Autonomy",
       "description": "Operator-only action and cluster lifecycle controls, qualification, freezes, and kill switches. Autonomous promotion requires an owner-confirmed approval reference."
+    },
+    {
+      "name": "Models",
+      "description": "Sanitized Model Gateway capabilities, runtime health, lifecycle, and bounded smoke operations."
     }
   ],
   "x-rocketmq-bounded-r1-autonomy-supported": true,

--- a/rocketmq-sre/scripts/extend_model_capabilities_openapi.mjs
+++ b/rocketmq-sre/scripts/extend_model_capabilities_openapi.mjs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+// Licensed under the Apache License, Version 2.0.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { extendModelCapabilities } from "./openapi/model_capabilities.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const path = join(root, "openapi", "rocketmq-sre-phase05.openapi.json");
+const document = JSON.parse(readFileSync(path, "utf8"));
+
+extendModelCapabilities({
+  document,
+  schemas: document.components.schemas,
+});
+
+writeFileSync(path, `${JSON.stringify(document, null, 2)}\n`);

--- a/rocketmq-sre/scripts/generate_phase5_openapi.mjs
+++ b/rocketmq-sre/scripts/generate_phase5_openapi.mjs
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { extendBoundedAutonomySettings } from "./openapi/bounded_autonomy_settings.mjs";
+import { extendModelCapabilities } from "./openapi/model_capabilities.mjs";
 import { extendOperationsAnalytics } from "./openapi/operations_analytics.mjs";
 import { extendPhase5FleetAndDr } from "./openapi/phase5_fleet_dr.mjs";
 import { extendPhase5GovernanceAndFinOps } from "./openapi/phase5_governance_finops.mjs";
@@ -109,6 +110,7 @@ extendBoundedAutonomySettings({
   uuid,
   digest,
 });
+extendModelCapabilities({ document, schemas });
 
 const phase5Prefixes = [
   ["/v1/fleet/", "Fleet"],

--- a/rocketmq-sre/scripts/openapi/model_capabilities.mjs
+++ b/rocketmq-sre/scripts/openapi/model_capabilities.mjs
@@ -1,0 +1,237 @@
+// Copyright 2026 The RocketMQ Rust Authors
+// Licensed under the Apache License, Version 2.0.
+
+export function extendModelCapabilities({ document, schemas }) {
+  for (const required of [
+    "SchemaVersion",
+    "DescriptorStatus",
+    "Deprecation",
+  ]) {
+    if (!Object.hasOwn(schemas, required)) {
+      throw new Error(`model capability contract requires ${required}`);
+    }
+  }
+
+  const nullable = (schema) => ({
+    oneOf: [schema, { type: "null" }],
+  });
+  const timestamp = { type: "string", format: "date-time" };
+  const uuid = { type: "string", format: "uuid" };
+
+  schemas.ModelProviderCapability = {
+    type: "string",
+    enum: [
+      "chat",
+      "text",
+      "json_object",
+      "json_schema",
+      "tool_calling",
+      "tool_choice_required",
+      "tool_choice_specific",
+      "strict_tools",
+      "vision",
+      "reasoning",
+      "streaming",
+      "embeddings",
+      "rerank",
+      "kimi_mfjs",
+    ],
+  };
+  schemas.ModelProviderCapabilities = {
+    type: "object",
+    additionalProperties: false,
+    required: ["supported", "max_input_tokens", "max_output_tokens"],
+    properties: {
+      supported: {
+        type: "array",
+        uniqueItems: true,
+        items: { $ref: "#/components/schemas/ModelProviderCapability" },
+      },
+      max_input_tokens: nullable({
+        type: "integer",
+        format: "uint32",
+        minimum: 0,
+      }),
+      max_output_tokens: nullable({
+        type: "integer",
+        format: "uint32",
+        minimum: 0,
+      }),
+    },
+  };
+  schemas.ModelProviderDescriptor = {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "id",
+      "version",
+      "owner",
+      "supported_versions",
+      "config_schema",
+      "status",
+      "deprecation",
+      "protocols",
+      "supports_streaming",
+      "supports_tools",
+      "supports_structured_output",
+      "supports_embeddings",
+    ],
+    properties: {
+      id: { type: "string", minLength: 1 },
+      version: { type: "string", minLength: 1 },
+      owner: { type: "string", minLength: 1 },
+      supported_versions: {
+        type: "array",
+        items: { $ref: "#/components/schemas/SchemaVersion" },
+      },
+      required_capabilities: {
+        type: "array",
+        uniqueItems: true,
+        items: { type: "string", minLength: 1 },
+      },
+      config_schema: {
+        type: "object",
+        additionalProperties: true,
+      },
+      status: { $ref: "#/components/schemas/DescriptorStatus" },
+      deprecation: nullable({ $ref: "#/components/schemas/Deprecation" }),
+      protocols: {
+        type: "array",
+        uniqueItems: true,
+        items: { type: "string", minLength: 1 },
+      },
+      supports_streaming: { type: "boolean" },
+      supports_tools: { type: "boolean" },
+      supports_structured_output: { type: "boolean" },
+      supports_embeddings: { type: "boolean" },
+    },
+  };
+  schemas.ModelProfileStatus = {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "id",
+      "profile_name",
+      "provider_family",
+      "protocol_family",
+      "model_family",
+      "model_name",
+      "model_revision",
+      "endpoint_instance",
+      "region",
+      "capabilities",
+      "priority",
+      "credential_configured",
+      "credential_owner",
+      "health",
+      "last_health_observed_at",
+    ],
+    properties: {
+      id: uuid,
+      profile_name: { type: "string", minLength: 1 },
+      provider_family: { type: "string", minLength: 1 },
+      protocol_family: { type: "string", minLength: 1 },
+      model_family: { type: "string", minLength: 1 },
+      model_name: { type: "string", minLength: 1 },
+      model_revision: { type: "string", minLength: 1 },
+      endpoint_instance: {
+        type: "string",
+        minLength: 1,
+        description: "Opaque endpoint instance identifier, never an endpoint URL.",
+      },
+      region: { type: "string", minLength: 1 },
+      capabilities: {
+        $ref: "#/components/schemas/ModelProviderCapabilities",
+      },
+      priority: {
+        type: "integer",
+        format: "uint16",
+        minimum: 0,
+        maximum: 65535,
+      },
+      credential_configured: { type: "boolean" },
+      credential_owner: { type: "string", enum: ["gateway", "adapter"] },
+      health: {
+        type: "string",
+        enum: ["unknown", "healthy", "degraded", "quarantined", "disabled"],
+      },
+      last_health_observed_at: nullable(timestamp),
+    },
+  };
+  schemas.ModelCapabilitiesResponse = {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "network_calls_supported",
+      "network_calls_enabled",
+      "rules_only_available",
+      "max_fallbacks",
+      "profiles",
+      "fallback_order",
+      "providers",
+      "observed_at",
+    ],
+    properties: {
+      schema_version: {
+        type: "string",
+        const: "rocketmq-sre.model-capabilities.v1",
+      },
+      network_calls_supported: { type: "boolean", const: true },
+      network_calls_enabled: { type: "boolean" },
+      rules_only_available: { type: "boolean", const: true },
+      max_fallbacks: { type: "integer", minimum: 0 },
+      profiles: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ModelProfileStatus" },
+      },
+      fallback_order: {
+        type: "array",
+        uniqueItems: true,
+        items: uuid,
+      },
+      providers: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ModelProviderDescriptor" },
+      },
+      observed_at: timestamp,
+    },
+  };
+
+  for (const [path, summary] of [
+    ["/v1/models/capabilities", "Get sanitized Model Gateway capabilities"],
+    ["/v1/models/status", "Get sanitized Model Gateway runtime status"],
+  ]) {
+    const operation = document.paths[path]?.get;
+    if (!operation) {
+      throw new Error(`missing model capability operation ${path}`);
+    }
+    operation.summary = summary;
+    operation.security = [
+      { oidc: ["rocketmq:read"] },
+      { oidc: ["rocketmq:diagnose"] },
+    ];
+    operation.responses["200"] = {
+      description: "Sanitized Model Gateway capability status",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/ModelCapabilitiesResponse" },
+        },
+      },
+    };
+  }
+
+  if (!(document.tags ?? []).some((tag) => tag.name === "Models")) {
+    document.tags = [
+      ...(document.tags ?? []),
+      {
+        name: "Models",
+        description:
+          "Sanitized Model Gateway capabilities, runtime health, lifecycle, and bounded smoke operations.",
+      },
+    ];
+  }
+  for (const path of ["/v1/models/capabilities", "/v1/models/status"]) {
+    document.paths[path].get.tags = ["Models"];
+  }
+}

--- a/rocketmq-sre/ui/package.json
+++ b/rocketmq-sre/ui/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3004",
+    "generate:openapi:models": "node ../scripts/extend_model_capabilities_openapi.mjs",
     "generate:openapi:autonomy": "node ../scripts/extend_bounded_autonomy_openapi.mjs",
     "generate:openapi:conversation": "node ../scripts/extend_conversation_openapi.mjs",
-    "generate:api": "npm run generate:openapi:autonomy && npm run generate:openapi:conversation && openapi-typescript ../openapi/rocketmq-sre-phase05.openapi.json -o ./src/api/generated.d.ts",
+    "generate:api": "npm run generate:openapi:models && npm run generate:openapi:autonomy && npm run generate:openapi:conversation && openapi-typescript ../openapi/rocketmq-sre-phase05.openapi.json -o ./src/api/generated.d.ts",
     "check:api": "openapi-typescript ../openapi/rocketmq-sre-phase05.openapi.json -o ./src/api/generated.d.ts --check",
     "lint": "eslint . --max-warnings=0",
     "test": "vitest",

--- a/rocketmq-sre/ui/src/api/generated.d.ts
+++ b/rocketmq-sre/ui/src/api/generated.d.ts
@@ -752,6 +752,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get sanitized Model Gateway capabilities */
         get: operations["getModelCapabilities"];
         put?: never;
         post?: never;
@@ -768,6 +769,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get sanitized Model Gateway runtime status */
         get: operations["getModelStatus"];
         put?: never;
         post?: never;
@@ -7838,6 +7840,67 @@ export interface components {
             active: boolean;
             reason: string;
         };
+        /** @enum {string} */
+        ModelProviderCapability: "chat" | "text" | "json_object" | "json_schema" | "tool_calling" | "tool_choice_required" | "tool_choice_specific" | "strict_tools" | "vision" | "reasoning" | "streaming" | "embeddings" | "rerank" | "kimi_mfjs";
+        ModelProviderCapabilities: {
+            supported: components["schemas"]["ModelProviderCapability"][];
+            max_input_tokens: number | null;
+            max_output_tokens: number | null;
+        };
+        ModelProviderDescriptor: {
+            id: string;
+            version: string;
+            owner: string;
+            supported_versions: components["schemas"]["SchemaVersion"][];
+            required_capabilities?: string[];
+            config_schema: {
+                [key: string]: unknown;
+            };
+            status: components["schemas"]["DescriptorStatus"];
+            deprecation: components["schemas"]["Deprecation"] | null;
+            protocols: string[];
+            supports_streaming: boolean;
+            supports_tools: boolean;
+            supports_structured_output: boolean;
+            supports_embeddings: boolean;
+        };
+        ModelProfileStatus: {
+            /** Format: uuid */
+            id: string;
+            profile_name: string;
+            provider_family: string;
+            protocol_family: string;
+            model_family: string;
+            model_name: string;
+            model_revision: string;
+            /** @description Opaque endpoint instance identifier, never an endpoint URL. */
+            endpoint_instance: string;
+            region: string;
+            capabilities: components["schemas"]["ModelProviderCapabilities"];
+            /** Format: uint16 */
+            priority: number;
+            credential_configured: boolean;
+            /** @enum {string} */
+            credential_owner: "gateway" | "adapter";
+            /** @enum {string} */
+            health: "unknown" | "healthy" | "degraded" | "quarantined" | "disabled";
+            last_health_observed_at: string | null;
+        };
+        ModelCapabilitiesResponse: {
+            /** @constant */
+            schema_version: "rocketmq-sre.model-capabilities.v1";
+            /** @constant */
+            network_calls_supported: true;
+            network_calls_enabled: boolean;
+            /** @constant */
+            rules_only_available: true;
+            max_fallbacks: number;
+            profiles: components["schemas"]["ModelProfileStatus"][];
+            fallback_order: string[];
+            providers: components["schemas"]["ModelProviderDescriptor"][];
+            /** Format: date-time */
+            observed_at: string;
+        };
     };
     responses: {
         /** @description Successful scoped response */
@@ -9042,7 +9105,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["responses"]["JsonObject"];
+            /** @description Sanitized Model Gateway capability status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelCapabilitiesResponse"];
+                };
+            };
         };
     };
     getModelStatus: {
@@ -9054,7 +9125,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            200: components["responses"]["JsonObject"];
+            /** @description Sanitized Model Gateway capability status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelCapabilitiesResponse"];
+                };
+            };
         };
     };
     listModelInvocations: {

--- a/rocketmq-sre/ui/src/api/openapiContract.test.ts
+++ b/rocketmq-sre/ui/src/api/openapiContract.test.ts
@@ -248,6 +248,83 @@ describe("checked-in Phase 5 OpenAPI", () => {
     ).toBe(false);
   });
 
+  it("publishes typed and sanitized model capability status", () => {
+    const operation =
+      specification.paths["/v1/models/capabilities"].get;
+    const schemas = specification.components.schemas;
+
+    expect(
+      operation.responses["200"].content["application/json"].schema.$ref,
+    ).toBe("#/components/schemas/ModelCapabilitiesResponse");
+    expect(
+      specification.paths["/v1/models/status"].get.responses["200"].content[
+        "application/json"
+      ].schema.$ref,
+    ).toBe("#/components/schemas/ModelCapabilitiesResponse");
+    expect(operation.security).toEqual([
+      { oidc: ["rocketmq:read"] },
+      { oidc: ["rocketmq:diagnose"] },
+    ]);
+    expect(schemas.ModelCapabilitiesResponse.required).toEqual(
+      expect.arrayContaining([
+        "schema_version",
+        "network_calls_supported",
+        "network_calls_enabled",
+        "rules_only_available",
+        "max_fallbacks",
+        "profiles",
+        "fallback_order",
+        "providers",
+        "observed_at",
+      ]),
+    );
+    expect(
+      schemas.ModelCapabilitiesResponse.properties.schema_version.const,
+    ).toBe("rocketmq-sre.model-capabilities.v1");
+    expect(
+      schemas.ModelCapabilitiesResponse.properties.profiles.items.$ref,
+    ).toBe("#/components/schemas/ModelProfileStatus");
+
+    const profile = schemas.ModelProfileStatus;
+    expect(profile.additionalProperties).toBe(false);
+    expect(profile.required).toEqual(
+      expect.arrayContaining([
+        "id",
+        "profile_name",
+        "protocol_family",
+        "capabilities",
+        "priority",
+        "credential_configured",
+        "credential_owner",
+        "health",
+        "last_health_observed_at",
+      ]),
+    );
+    expect(profile.properties.capabilities.$ref).toBe(
+      "#/components/schemas/ModelProviderCapabilities",
+    );
+    expect(profile.properties).not.toHaveProperty("credential_ref");
+    expect(profile.properties).not.toHaveProperty("credential");
+    expect(profile.properties).not.toHaveProperty("token");
+    expect(profile.properties).not.toHaveProperty("secret");
+    expect(profile.properties).not.toHaveProperty("endpoint");
+    expect(profile.properties).not.toHaveProperty("endpoint_url");
+
+    expect(
+      schemas.ModelProviderCapability.enum,
+    ).toEqual(
+      expect.arrayContaining([
+        "chat",
+        "json_schema",
+        "tool_calling",
+        "streaming",
+      ]),
+    );
+    expect(schemas.ModelProviderDescriptor.properties).not.toHaveProperty(
+      "credential_ref",
+    );
+  });
+
   it("publishes read-only bounded autonomy outcome and report queries", () => {
     const outcomes =
       specification.paths["/v1/autonomy/outcomes"];

--- a/rocketmq-sre/ui/src/api/types.ts
+++ b/rocketmq-sre/ui/src/api/types.ts
@@ -720,35 +720,9 @@ export interface KnowledgeItem {
   updated_at: string;
 }
 
-export interface ModelProfile {
-  id: string;
-  profile_name: string;
-  provider_family: string;
-  protocol_family: string;
-  model_family: string;
-  model_name: string;
-  model_revision: string;
-  endpoint_instance: string;
-  region: string;
-  capabilities: string[] | Record<string, boolean>;
-  priority: number;
-  credential_configured: boolean;
-  credential_owner: string;
-  health: "unknown" | "healthy" | "degraded" | "quarantined" | "disabled";
-  last_health_observed_at: string | null;
-}
-
-export interface ModelCapabilitiesResponse {
-  schema_version: string;
-  network_calls_supported: boolean;
-  network_calls_enabled: boolean;
-  rules_only_available: boolean;
-  max_fallbacks: number;
-  fallback_order: string[];
-  providers: CapabilityCatalogResponse["providers"];
-  profiles: ModelProfile[];
-  observed_at: string;
-}
+export type ModelProfile = ApiSchemas["ModelProfileStatus"];
+export type ModelCapabilitiesResponse =
+  ApiSchemas["ModelCapabilitiesResponse"];
 
 export type ModelProfileLifecycleState =
   | "draft"

--- a/rocketmq-sre/ui/src/data/phase1Demo.ts
+++ b/rocketmq-sre/ui/src/data/phase1Demo.ts
@@ -654,31 +654,30 @@ export const phase1Models: ModelCapabilitiesResponse = {
   fallback_order: [
     "70000000-0000-4000-8000-000000000001",
   ],
-  providers: [
-    "openai-compatible",
-    "anthropic",
-    "gemini",
-    "bedrock",
-    "deepseek",
-    "zhipu-glm",
-    "kimi-moonshot",
-    "local-openai-compatible",
-  ].map((id) => ({
+  providers: ([
+    ["openai", "openai-compatible", true, true, true],
+    ["anthropic", "anthropic-messages", true, true, false],
+    ["google-gemini", "gemini-generate-content", true, true, true],
+    ["aws-bedrock", "bedrock-converse", true, true, true],
+    ["deepseek", "openai-compatible", true, true, false],
+    ["zhipu-glm", "openai-compatible", true, true, true],
+    ["kimi-moonshot", "openai-compatible", true, true, false],
+    ["local-openai-compatible", "openai-compatible", true, false, false],
+  ] as const).map(([id, protocol, supportsTools, structuredOutput, embeddings]) => ({
     id,
-    protocols:
-      id === "anthropic"
-        ? ["anthropic-messages"]
-        : id === "gemini"
-          ? ["gemini-generate-content"]
-          : id === "bedrock"
-            ? ["aws-bedrock-converse"]
-            : ["openai-compatible"],
+    version: "1.0.0",
+    owner: "rocketmq-sre",
+    supported_versions: [
+      { family: "rocketmq-sre.model", major: 1, minor: 0 },
+    ],
+    config_schema: { type: "object" },
+    status: "active" as const,
+    deprecation: null,
+    protocols: [protocol],
     supports_streaming: true,
-    supports_tools: id !== "local-openai-compatible",
-    supports_structured_output: true,
-    supports_embeddings: ["openai-compatible", "local-openai-compatible"].includes(
-      id,
-    ),
+    supports_tools: supportsTools,
+    supports_structured_output: structuredOutput,
+    supports_embeddings: embeddings,
   })),
   profiles: [
     {
@@ -691,7 +690,11 @@ export const phase1Models: ModelCapabilitiesResponse = {
       model_revision: "v1",
       endpoint_instance: "control-plane",
       region: "local",
-      capabilities: ["structured_output"],
+      capabilities: {
+        supported: ["chat", "text", "json_schema"],
+        max_input_tokens: null,
+        max_output_tokens: null,
+      },
       priority: 0,
       credential_configured: false,
       credential_owner: "gateway",
@@ -708,7 +711,11 @@ export const phase1Models: ModelCapabilitiesResponse = {
       model_revision: "configured-not-verified",
       endpoint_instance: "cn-primary",
       region: "cn",
-      capabilities: ["structured_output", "tools"],
+      capabilities: {
+        supported: ["chat", "text", "json_schema", "tool_calling"],
+        max_input_tokens: null,
+        max_output_tokens: null,
+      },
       priority: 10,
       credential_configured: false,
       credential_owner: "gateway",
@@ -725,7 +732,11 @@ export const phase1Models: ModelCapabilitiesResponse = {
       model_revision: "configured-not-verified",
       endpoint_instance: "cn-primary",
       region: "cn",
-      capabilities: ["structured_output", "tools"],
+      capabilities: {
+        supported: ["chat", "text", "json_schema", "tool_calling"],
+        max_input_tokens: null,
+        max_output_tokens: null,
+      },
       priority: 20,
       credential_configured: false,
       credential_owner: "gateway",
@@ -742,7 +753,11 @@ export const phase1Models: ModelCapabilitiesResponse = {
       model_revision: "configured-not-verified",
       endpoint_instance: "cn-primary",
       region: "cn",
-      capabilities: ["structured_output", "tools"],
+      capabilities: {
+        supported: ["chat", "text", "json_schema", "tool_calling"],
+        max_input_tokens: null,
+        max_output_tokens: null,
+      },
       priority: 30,
       credential_configured: false,
       credential_owner: "gateway",

--- a/rocketmq-sre/ui/src/features/models/modelCapabilityPresentation.test.ts
+++ b/rocketmq-sre/ui/src/features/models/modelCapabilityPresentation.test.ts
@@ -64,7 +64,11 @@ function capabilities({
         model_revision: "v4-flash",
         endpoint_instance: "deepseek:cn",
         region: "cn",
-        capabilities: ["chat", "json_schema"],
+        capabilities: {
+          supported: ["chat", "json_schema"],
+          max_input_tokens: null,
+          max_output_tokens: null,
+        },
         priority: 10,
         credential_configured,
         credential_owner: "gateway",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9048

### Brief Description

Define the real `rocketmq-sre.model-capabilities.v1` response in the checked-in OpenAPI document instead of exposing `JsonObject`. The reusable generator now covers sanitized runtime profiles, provider descriptors, capability enums, network and fallback state, read-or-diagnose authorization, and both model capability/status operations. The SRE UI consumes generated schemas rather than a handwritten duplicate, and its DeepSeek, Zhipu GLM, and Kimi/Moonshot demo fixtures now match the Rust wire structures.

### How Did You Test This Change?

- `npm run generate:api` twice with identical OpenAPI and TypeScript SHA-256 output
- `npm run lint`
- `npm test -- --run` (30 test files, 92 tests)
- `npm test -- --run src/api/openapiContract.test.ts src/features/models/modelCapabilityPresentation.test.ts src/pages/SystemStatusPage.test.tsx` (3 test files, 11 tests)
- `npm run check:api`
- `npm run build`
- `node --check rocketmq-sre/scripts/extend_model_capabilities_openapi.mjs`
- `node --check rocketmq-sre/scripts/openapi/model_capabilities.mjs`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured model capability and runtime status information, including provider details, supported features, profile health, and token limits.
  * Added documented Models API endpoints with sanitized responses and appropriate access controls.
  * Updated demo model data to display provider metadata and capability details.

* **Documentation**
  * Expanded generated API documentation and types for model capabilities and status responses.

* **Tests**
  * Added contract coverage verifying response structure, required fields, security scopes, and secret-data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->