### PR TITLE
[ISSUE #9059]✨Reduce request header codec code generation

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -16,9 +16,12 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 
 use super::model::{
-    AliasConflict, FieldModel, FlattenPresence, HeaderModel, HeaderRange, LookupPlan, MissingPolicy, ValueKind,
-    WireName,
+    AliasConflict, FieldModel, FlattenPresence, HeaderModel, HeaderRange, MissingPolicy, ValueKind, WireName,
 };
+
+// Keep small flat decoders at the production call site without duplicating
+// larger or recursively flattened state machines in every compatibility shim.
+const MAX_ALWAYS_INLINE_SOURCE_FIELDS: usize = 6;
 
 pub(super) fn context_declarations(model: &HeaderModel) -> TokenStream {
     let protocol_path = &model.protocol_path;
@@ -66,10 +69,15 @@ pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> Tok
     let source_type = quote!(#protocol_path::protocol::header_codec::HeaderFieldSource);
     let validate = validation_body(model, &error_type);
     let encode = encode_body(model, codec_trait, protocol_path);
-    let decode = decode_body(model, codec_trait, &error_type, protocol_path);
     let decode_source = decode_source_body(model, codec_trait, &error_type, protocol_path);
-    let contains = contains_body(model, codec_trait);
-    let contains_source = contains_source_body(codec_trait);
+    let decode_source_inline = if model.fast
+        && !model.fields.iter().any(|field| field.flattened)
+        && model.fields.len() <= MAX_ALWAYS_INLINE_SOURCE_FIELDS
+    {
+        quote!(#[inline(always)])
+    } else {
+        quote!(#[inline])
+    };
     let len_hint = len_hint_body(model, codec_trait, protocol_path);
 
     quote! {
@@ -88,22 +96,17 @@ pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> Tok
 
         #[inline]
         fn decode_from_map(map: &#map_type) -> Result<Self, #error_type> {
-            #decode
+            <Self as #codec_trait>::decode_from_source(map)
         }
 
-        #[inline]
+        #decode_source_inline
         fn decode_from_source(source: &dyn #source_type) -> Result<Self, #error_type> {
             #decode_source
         }
 
         #[inline]
         fn contains_any_field(map: &#map_type) -> bool {
-            #contains
-        }
-
-        #[inline]
-        fn contains_any_field_source(source: &dyn #source_type) -> bool {
-            #contains_source
+            <Self as #codec_trait>::contains_any_field_source(map)
         }
 
         #[inline]
@@ -212,65 +215,6 @@ fn range_check(field: &FieldModel, protocol_path: &syn::Path, value: TokenStream
     }
 }
 
-fn decode_body(
-    model: &HeaderModel,
-    codec_trait: &TokenStream,
-    error_type: &TokenStream,
-    protocol_path: &syn::Path,
-) -> TokenStream {
-    let scalar_count = model.fields.iter().filter(|field| !field.flattened).count();
-    let has_flatten = model.fields.iter().any(|field| field.flattened);
-    let scan = match model.lookup {
-        LookupPlan::Scan => true,
-        LookupPlan::Get => false,
-        LookupPlan::Auto => !has_flatten && scalar_count >= 4,
-    };
-
-    let scalar_fields: Vec<_> = model.fields.iter().filter(|field| !field.flattened).collect();
-    let local_declarations = scalar_fields.iter().map(|field| {
-        let local = raw_ident(field);
-        quote!(let mut #local = None;)
-    });
-    let lookup = if scan {
-        let arms = scalar_fields
-            .iter()
-            .flat_map(|field| candidate_arms(field, error_type, codec_trait));
-        quote! {
-            for (key, value) in map {
-                let value = value.as_str();
-                match key.as_str() {
-                    #(#arms)*
-                    _ => {}
-                }
-            }
-        }
-    } else {
-        let lookups = scalar_fields
-            .iter()
-            .flat_map(|field| candidate_lookups(field, error_type, codec_trait));
-        quote!(#(#lookups)*)
-    };
-    let normalize_locals = scalar_fields.iter().map(|field| {
-        let local = raw_ident(field);
-        quote!(let #local = #local.map(|(value, _precedence)| value);)
-    });
-    let construct_fields = model
-        .fields
-        .iter()
-        .map(|field| construct_field(field, codec_trait, error_type, protocol_path, DecodeInput::Map));
-
-    quote! {
-        #(#local_declarations)*
-        #lookup
-        #(#normalize_locals)*
-        let header = Self {
-            #(#construct_fields)*
-        };
-        <Self as #codec_trait>::validate_for_wire(&header)?;
-        Ok(header)
-    }
-}
-
 fn decode_source_body(
     model: &HeaderModel,
     codec_trait: &TokenStream,
@@ -291,7 +235,7 @@ fn decode_source_body(
     let construct_fields = model
         .fields
         .iter()
-        .map(|field| construct_field(field, codec_trait, error_type, protocol_path, DecodeInput::Source));
+        .map(|field| construct_field(field, codec_trait, error_type, protocol_path));
 
     quote! {
         #(#candidate_declarations)*
@@ -309,37 +253,6 @@ fn decode_source_body(
         <Self as #codec_trait>::validate_for_wire(&header)?;
         Ok(header)
     }
-}
-
-#[derive(Clone, Copy)]
-enum DecodeInput {
-    Map,
-    Source,
-}
-
-fn candidate_arms(field: &FieldModel, error_type: &TokenStream, codec_trait: &TokenStream) -> Vec<TokenStream> {
-    field_candidates(field)
-        .map(|(name, precedence)| {
-            let name = literal(&name.value, name.span);
-            let update = candidate_update(field, error_type, codec_trait, precedence);
-            quote!(#name => { #update })
-        })
-        .collect()
-}
-
-fn candidate_lookups(field: &FieldModel, error_type: &TokenStream, codec_trait: &TokenStream) -> Vec<TokenStream> {
-    field_candidates(field)
-        .map(|(name, precedence)| {
-            let name = literal(&name.value, name.span);
-            let update = candidate_update(field, error_type, codec_trait, precedence);
-            quote! {
-                if let Some(value) = map.get(#name) {
-                    let value = value.as_str();
-                    #update
-                }
-            }
-        })
-        .collect()
 }
 
 fn source_candidate_arms(field: &FieldModel) -> Vec<TokenStream> {
@@ -404,68 +317,17 @@ fn field_candidates(field: &FieldModel) -> impl Iterator<Item = (&WireName, u16)
     )
 }
 
-fn candidate_update(
-    field: &FieldModel,
-    error_type: &TokenStream,
-    codec_trait: &TokenStream,
-    precedence: u16,
-) -> TokenStream {
-    let local = raw_ident(field);
-    let key = literal(&field.key.value, field.key.span);
-    let conflict_header = quote!(<Self as #codec_trait>::TYPE_ID);
-    let conflict = quote! {
-        return Err(#error_type::Conflict {
-                header: #conflict_header,
-                key: #key,
-        });
-    };
-    match field.alias_conflict {
-        AliasConflict::Error => quote! {
-            match #local {
-                None => #local = Some((value, #precedence)),
-                Some((_selected, selected_precedence)) if #precedence == selected_precedence => {
-                    #local = Some((value, #precedence));
-                }
-                Some((selected, selected_precedence)) => {
-                    if selected != value {
-                        #conflict
-                    }
-                    if #precedence < selected_precedence {
-                        #local = Some((value, #precedence));
-                    }
-                }
-            }
-        },
-        AliasConflict::PreferCanonical => quote! {
-            match #local {
-                None => #local = Some((value, #precedence)),
-                Some((_selected, selected_precedence)) if #precedence <= selected_precedence => {
-                    #local = Some((value, #precedence));
-                }
-                Some(_) => {}
-            }
-        },
-    }
-}
-
 fn construct_field(
     field: &FieldModel,
     codec_trait: &TokenStream,
     error_type: &TokenStream,
     protocol_path: &syn::Path,
-    input: DecodeInput,
 ) -> TokenStream {
     let ident = &field.ident;
     if field.flattened {
         let base_type = field.option_inner.as_ref().unwrap_or(&field.ty);
-        let decode = match input {
-            DecodeInput::Map => quote!(<#base_type as #codec_trait>::decode_from_map(map)),
-            DecodeInput::Source => quote!(<#base_type as #codec_trait>::decode_from_source(source)),
-        };
-        let contains = match input {
-            DecodeInput::Map => quote!(<#base_type as #codec_trait>::contains_any_field(map)),
-            DecodeInput::Source => quote!(<#base_type as #codec_trait>::contains_any_field_source(source)),
-        };
+        let decode = quote!(<#base_type as #codec_trait>::decode_from_source(source));
+        let contains = quote!(<#base_type as #codec_trait>::contains_any_field_source(source));
         return if field.option_inner.is_some() {
             match field.flatten_presence.unwrap_or(FlattenPresence::Always) {
                 FlattenPresence::Always => quote!(#ident: Some(#decode?),),
@@ -516,36 +378,6 @@ fn construct_field(
                 None => #path(),
             },
         },
-    }
-}
-
-fn contains_body(model: &HeaderModel, codec_trait: &TokenStream) -> TokenStream {
-    let checks = model.fields.iter().map(|field| {
-        if field.flattened {
-            let base_type = field.option_inner.as_ref().unwrap_or(&field.ty);
-            quote!(<#base_type as #codec_trait>::contains_any_field(map))
-        } else {
-            let names = std::iter::once(&field.key)
-                .chain(field.aliases.iter())
-                .map(|name| literal(&name.value, name.span));
-            quote!(false #(|| map.contains_key(#names))*)
-        }
-    });
-    quote!(false #(|| #checks)*)
-}
-
-fn contains_source_body(codec_trait: &TokenStream) -> TokenStream {
-    quote! {
-        let mut contains = false;
-        source.visit_fields_while(&mut |key, _value| {
-            if <Self as #codec_trait>::contains_wire_key(key) {
-                contains = true;
-                false
-            } else {
-                true
-            }
-        });
-        contains
     }
 }
 

--- a/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_shim.rs
@@ -26,6 +26,7 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
     let map_type = quote!(#protocol_path::HeaderMap);
     let field_source = quote!(#protocol_path::protocol::header_codec::HeaderFieldSource);
     let codec_error = quote!(#protocol_path::protocol::header_codec::HeaderCodecError);
+    let into_rocketmq_error = quote!(#protocol_path::protocol::header_codec::into_rocketmq_error);
     let rocketmq_error = quote!(#protocol_path::__request_header_codec::RocketMQError);
     let map_sink = quote!(#protocol_path::protocol::header_codec::MapSink);
     let fast_methods = if model.fast {
@@ -79,7 +80,7 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
         impl #impl_generics #command_trait for #ident #ty_generics #where_clause {
             fn check_fields(&self) -> Result<(), #rocketmq_error> {
                 <Self as #codec_trait>::validate_for_wire(self)
-                    .map_err(|error| #rocketmq_error::request_header_error(error.to_string()))
+                    .map_err(#into_rocketmq_error)
             }
 
             fn to_map(&self) -> Option<#map_type> {
@@ -127,12 +128,12 @@ pub(super) fn generate(model: &HeaderModel, generics: &Generics, codec_trait: &T
 
             fn from(map: &#map_type) -> Result<Self::Target, Self::Error> {
                 <Self as #codec_trait>::decode_from_map(map)
-                    .map_err(|error| #rocketmq_error::request_header_error(error.to_string()))
+                    .map_err(#into_rocketmq_error)
             }
 
             fn from_field_source(source: &dyn #field_source) -> Result<Self::Target, Self::Error> {
                 <Self as #codec_trait>::decode_from_source(source)
-                    .map_err(|error| #rocketmq_error::request_header_error(error.to_string()))
+                    .map_err(#into_rocketmq_error)
             }
         }
     }

--- a/rocketmq-protocol/src/protocol/header_codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec.rs
@@ -33,6 +33,8 @@ mod private {
 }
 
 pub use codec::HeaderCodec;
+#[doc(hidden)]
+pub use error::into_rocketmq_error;
 pub use error::HeaderCodecError;
 pub(crate) use field_source::BinaryHeaderFields;
 pub use field_source::HeaderFieldSource;

--- a/rocketmq-protocol/src/protocol/header_codec/codec.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/codec.rs
@@ -82,8 +82,16 @@ pub trait HeaderCodec: Sized {
     /// Returns whether this header or a flattened child owns a source field.
     #[inline]
     fn contains_any_field_source(source: &dyn HeaderFieldSource) -> bool {
-        let map = source.to_header_map();
-        Self::contains_any_field(&map)
+        let mut contains = false;
+        source.visit_fields_while(&mut |key, _value| {
+            if Self::contains_wire_key(key) {
+                contains = true;
+                false
+            } else {
+                true
+            }
+        });
+        contains
     }
 
     /// Estimates the encoded ROCKETMQ extension-field payload length.

--- a/rocketmq-protocol/src/protocol/header_codec/error.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/error.rs
@@ -128,3 +128,11 @@ pub enum HeaderCodecError {
         header: &'static str,
     },
 }
+
+/// Adapts a classified codec error to the legacy remoting error boundary.
+#[doc(hidden)]
+#[cold]
+#[inline(never)]
+pub fn into_rocketmq_error(error: HeaderCodecError) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::request_header_error(error.to_string())
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9059

### Brief Description

This change reduces `RequestHeaderCodecV3` expansion by routing generated map decoding through the borrowed field-source decoder instead of emitting a second decode state machine. It also makes the default source presence check allocation-free, keeps only small flat fast decoders force-inlined, and shares the cold legacy error adapter across generated shims.

Canonical keys, aliases, defaults, flatten presence, validation, inferred Rust wire kinds, Java signed-range checks, classified errors, and existing container attribute syntax remain compatible. The change adds no `mod.rs` files and no production `java_type` annotations.

A same-host single-run diagnostic using the checked-in build measurement recipe reported the following growth relative to the pinned hardened V2 baseline:

- clean build wall time: `-0.05%`
- clean build process-tree peak memory: `-0.58%`
- benchmark artifact bytes: `+2.68%`
- benchmark raw `.text`: `+2.92%`
- deterministic incremental build wall time: `+3.16%`

These diagnostic results are within the documented build and size limits but do not replace the full release performance attestation.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-macros -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-macros --all-features`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_typed_map --all-features`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry --all-features`
- `cargo clippy --locked -p rocketmq-macros -p rocketmq-protocol --all-targets --all-features -- -D warnings -A deprecated -A clippy::useless-conversion`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff HEAD^ --check`

The root `cargo fmt --all -- --check` command is blocked on Windows by OS error 206 after workspace file expansion. The exact workspace Clippy command remains blocked by pre-existing `rocketmq-model` deprecation and useless-conversion warnings; the affected macro and protocol packages pass the scoped `-D warnings` command above. The standalone example's checked-in lockfile also requires an unrelated dependency refresh before its locked Clippy gate can run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-header decoding across map and source inputs.
  * Ensured flattened fields are consistently decoded and checked for presence.
  * Improved detection of recognized header fields without unnecessary intermediate processing.
  * Standardized conversion of header codec errors into RocketMQ errors for clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->