### PR TITLE
[ISSUE #9061]✨Optimize request header codec hot paths

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -76,7 +76,7 @@ pub(super) fn codec_items(model: &HeaderModel, codec_trait: &TokenStream) -> Tok
     {
         quote!(#[inline(always)])
     } else {
-        quote!(#[inline])
+        quote!(#[inline(never)])
     };
     let len_hint = len_hint_body(model, codec_trait, protocol_path);
 

--- a/rocketmq-protocol/benches/request_header_codec.rs
+++ b/rocketmq-protocol/benches/request_header_codec.rs
@@ -199,9 +199,9 @@ where
     match case.operation {
         Operation::Encode => {
             criterion.bench_function(&case.id, |bencher| {
-                bencher.iter_batched(
+                bencher.iter_batched_ref(
                     || fresh_command::<T>(case, &canonical_fields),
-                    |mut command| {
+                    |command| {
                         let mut output = BytesMut::new();
                         command.fast_header_encode(&mut output);
                         black_box(output)
@@ -239,14 +239,14 @@ where
         }
         Operation::Decode => {
             criterion.bench_function(&case.id, |bencher| {
-                bencher.iter_batched(
+                bencher.iter_batched_ref(
                     || BytesMut::from(reference_frame.as_slice()),
-                    |mut input| {
-                        let command = RemotingCommand::decode(&mut input)
+                    |input| {
+                        let command = RemotingCommand::decode(input)
                             .expect("benchmark frame envelope must decode")
                             .expect("benchmark frame must be complete");
                         let header = decode(&command).expect("benchmark typed header must decode");
-                        black_box(header)
+                        black_box((command, header))
                     },
                     BatchSize::SmallInput,
                 );

--- a/rocketmq-protocol/src/protocol/header_codec/field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/field_source.rs
@@ -53,6 +53,8 @@ impl HeaderFieldSource for HeaderMap {
     }
 }
 
+#[cold]
+#[inline(never)]
 fn malformed_binary_fields(reason: &'static str) -> rocketmq_error::RocketMQError {
     rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
         format: "binary-header-fields",
@@ -74,11 +76,7 @@ pub(crate) struct BinaryHeaderFields {
 impl BinaryHeaderFields {
     /// Validates and retains one complete extension-field payload.
     pub(crate) fn new(payload: Bytes) -> rocketmq_error::RocketMQResult<Self> {
-        let mut entry_count = 0usize;
-        Self::parse(&payload, &mut |_key, _value| {
-            entry_count = entry_count.saturating_add(1);
-            Ok(())
-        })?;
+        let entry_count = Self::validate(&payload)?;
         Ok(Self { payload, entry_count })
     }
 
@@ -100,17 +98,15 @@ impl BinaryHeaderFields {
         }
     }
 
-    fn parse<'a>(
-        payload: &'a [u8],
-        visitor: &mut dyn FnMut(&'a str, &'a str) -> rocketmq_error::RocketMQResult<()>,
-    ) -> rocketmq_error::RocketMQResult<()> {
+    fn validate(payload: &[u8]) -> rocketmq_error::RocketMQResult<usize> {
         let mut cursor = 0usize;
+        let mut entry_count = 0usize;
         while cursor < payload.len() {
             let key_length = Self::read_u16(payload, &mut cursor)?;
             if key_length == 0 {
                 return Err(malformed_binary_fields("extension-field key is empty"));
             }
-            let key = Self::read_utf8(payload, &mut cursor, key_length, "truncated extension-field key")?;
+            Self::read_utf8(payload, &mut cursor, key_length, "truncated extension-field key")?;
 
             let value_length = Self::read_i32(payload, &mut cursor)?;
             if value_length < 0 {
@@ -126,10 +122,10 @@ impl BinaryHeaderFields {
             // Java-compatible ROCKETMQ map decoding treats zero-length values
             // as absent rather than storing an empty string.
             if !value.is_empty() {
-                visitor(key, value)?;
+                entry_count = entry_count.saturating_add(1);
             }
         }
-        Ok(())
+        Ok(entry_count)
     }
 
     fn read_u16(payload: &[u8], cursor: &mut usize) -> rocketmq_error::RocketMQResult<usize> {
@@ -147,6 +143,7 @@ impl BinaryHeaderFields {
         Ok(i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
     }
 
+    #[inline(never)]
     fn read_utf8<'a>(
         payload: &'a [u8],
         cursor: &mut usize,
@@ -154,6 +151,10 @@ impl BinaryHeaderFields {
         truncated_reason: &'static str,
     ) -> rocketmq_error::RocketMQResult<&'a str> {
         let bytes = Self::take(payload, cursor, length, truncated_reason)?;
+        if bytes.is_ascii() {
+            // SAFETY: ASCII is valid UTF-8.
+            return Ok(unsafe { std::str::from_utf8_unchecked(bytes) });
+        }
         std::str::from_utf8(bytes).map_err(|_| malformed_binary_fields("extension-field text is not valid UTF-8"))
     }
 
@@ -200,18 +201,13 @@ struct BinaryHeaderFieldIter<'a> {
 impl<'a> BinaryHeaderFieldIter<'a> {
     #[inline]
     fn take(&mut self, length: usize) -> &'a [u8] {
-        // The only constructor validates every boundary before retaining the
-        // immutable Bytes payload, so failure here would be an internal bug.
-        let end = self
-            .cursor
-            .checked_add(length)
-            .expect("validated binary header field offset overflowed");
-        let bytes = self
-            .payload
-            .get(self.cursor..end)
-            .expect("validated binary header field boundary changed");
+        let start = self.cursor;
+        let end = start + length;
         self.cursor = end;
-        bytes
+        // SAFETY: BinaryHeaderFields::new validates every length and boundary
+        // before retaining this immutable payload. The iterator advances using
+        // exactly the same wire lengths and never exposes mutable access.
+        unsafe { self.payload.get_unchecked(start..end) }
     }
 
     #[inline]
@@ -228,9 +224,10 @@ impl<'a> BinaryHeaderFieldIter<'a> {
 
     #[inline]
     fn read_utf8(&mut self, length: usize) -> &'a str {
-        // UTF-8 validity is established together with the immutable boundary
-        // invariant in BinaryHeaderFields::new.
-        std::str::from_utf8(self.take(length)).expect("validated binary header field UTF-8 changed")
+        let bytes = self.take(length);
+        // SAFETY: BinaryHeaderFields::new validates UTF-8 for every key and
+        // value, and the immutable payload boundaries are preserved by take.
+        unsafe { std::str::from_utf8_unchecked(bytes) }
     }
 }
 
@@ -242,9 +239,7 @@ impl<'a> Iterator for BinaryHeaderFieldIter<'a> {
         while self.cursor < self.payload.len() {
             let key_length = self.read_u16();
             let key = self.read_utf8(key_length);
-            let value_length = self.read_i32();
-            let value_length =
-                usize::try_from(value_length).expect("validated binary header field value length became negative");
+            let value_length = self.read_i32() as usize;
             let value = self.read_utf8(value_length);
             if !value.is_empty() {
                 return Some((key, value));

--- a/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::fmt;
+use std::mem::size_of;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
+use memchr::memchr;
 use serde::de::DeserializeSeed;
 use serde::de::MapAccess;
 use serde::de::Visitor;
@@ -40,9 +42,41 @@ const MAX_INITIAL_MAP_CAPACITY: usize = 1024;
 pub(crate) struct JsonHeaderFields {
     payload: Bytes,
     entry_count: usize,
+    encoding: JsonFieldEncoding,
+}
+
+#[derive(Clone, Copy)]
+enum JsonFieldEncoding {
+    LengthPrefixed,
+    CanonicalUnescapedObject,
+    UnescapedObject,
 }
 
 impl JsonHeaderFields {
+    pub(crate) fn from_length_prefixed(payload: Vec<u8>, entry_count: usize) -> Self {
+        Self {
+            payload: Bytes::from(payload),
+            entry_count,
+            encoding: JsonFieldEncoding::LengthPrefixed,
+        }
+    }
+
+    pub(crate) fn from_unescaped_object(payload: Bytes, entry_count: usize) -> Self {
+        Self {
+            payload,
+            entry_count,
+            encoding: JsonFieldEncoding::UnescapedObject,
+        }
+    }
+
+    pub(crate) fn from_canonical_unescaped_object(payload: Bytes, entry_count: usize) -> Self {
+        Self {
+            payload,
+            entry_count,
+            encoding: JsonFieldEncoding::CanonicalUnescapedObject,
+        }
+    }
+
     pub(crate) fn materialize(&self) -> HeaderMap {
         let mut map = HeaderMap::with_capacity(self.entry_count.min(MAX_INITIAL_MAP_CAPACITY));
         for (key, value) in self.iter() {
@@ -56,6 +90,7 @@ impl JsonHeaderFields {
         JsonHeaderFieldIter {
             payload: &self.payload,
             cursor: 0,
+            encoding: self.encoding,
         }
     }
 }
@@ -102,6 +137,7 @@ impl<'de> Visitor<'de> for JsonHeaderFieldsVisitor {
         Ok(JsonHeaderFields {
             payload: Bytes::from(payload),
             entry_count,
+            encoding: JsonFieldEncoding::LengthPrefixed,
         })
     }
 }
@@ -178,9 +214,28 @@ impl FieldSourceSealed for JsonHeaderFields {}
 impl HeaderFieldSource for JsonHeaderFields {
     #[inline]
     fn visit_fields_while<'a>(&'a self, visitor: &mut dyn FnMut(&'a str, &'a str) -> bool) {
-        for (key, value) in self.iter() {
-            if !visitor(key, value) {
-                break;
+        let mut iter = self.iter();
+        match self.encoding {
+            JsonFieldEncoding::CanonicalUnescapedObject => {
+                while let Some((key, value)) = iter.next_canonical_unescaped_object() {
+                    if !visitor(key, value) {
+                        break;
+                    }
+                }
+            }
+            JsonFieldEncoding::UnescapedObject => {
+                while let Some((key, value)) = iter.next_unescaped_object() {
+                    if !visitor(key, value) {
+                        break;
+                    }
+                }
+            }
+            JsonFieldEncoding::LengthPrefixed => {
+                while let Some((key, value)) = iter.next_length_prefixed() {
+                    if !visitor(key, value) {
+                        break;
+                    }
+                }
             }
         }
     }
@@ -194,6 +249,7 @@ impl HeaderFieldSource for JsonHeaderFields {
 struct JsonHeaderFieldIter<'a> {
     payload: &'a [u8],
     cursor: usize,
+    encoding: JsonFieldEncoding,
 }
 
 impl<'a> JsonHeaderFieldIter<'a> {
@@ -224,13 +280,113 @@ impl<'a> JsonHeaderFieldIter<'a> {
         // from strings accepted by Serde. The iterator preserves byte boundaries.
         unsafe { std::str::from_utf8_unchecked(bytes) }
     }
-}
-
-impl<'a> Iterator for JsonHeaderFieldIter<'a> {
-    type Item = (&'a str, &'a str);
 
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
+    fn skip_json_whitespace(&mut self) {
+        while matches!(self.payload.get(self.cursor), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+            self.cursor += 1;
+        }
+    }
+
+    #[inline]
+    fn read_unescaped_json_string(&mut self) -> &'a str {
+        self.skip_json_whitespace();
+        debug_assert_eq!(self.payload[self.cursor], b'"');
+        self.cursor += 1;
+        let start = self.cursor;
+        // SAFETY: construction validates every string terminator and the
+        // immutable payload cannot change while this iterator is alive.
+        let relative_end = unsafe { memchr(b'"', &self.payload[self.cursor..]).unwrap_unchecked() };
+        self.cursor += relative_end;
+        let end = self.cursor;
+        self.cursor += 1;
+        // SAFETY: the fast JSON parser validates the full header as UTF-8 and
+        // accepts this representation only when strings contain no escapes.
+        unsafe { std::str::from_utf8_unchecked(&self.payload[start..end]) }
+    }
+
+    #[inline]
+    fn next_unescaped_object(&mut self) -> Option<(&'a str, &'a str)> {
+        self.skip_json_whitespace();
+        if self.cursor >= self.payload.len() {
+            return None;
+        }
+        if self.payload[self.cursor] == b',' {
+            self.cursor += 1;
+        }
+        let key = self.read_unescaped_json_string();
+        self.skip_json_whitespace();
+        debug_assert_eq!(self.payload[self.cursor], b':');
+        self.cursor += 1;
+        let value = self.read_unescaped_json_string();
+        self.skip_json_whitespace();
+        Some((key, value))
+    }
+
+    #[inline]
+    fn next_canonical_unescaped_object(&mut self) -> Option<(&'a str, &'a str)> {
+        if self.cursor >= self.payload.len() {
+            return None;
+        }
+        if self.cursor != 0 {
+            debug_assert_eq!(self.payload[self.cursor], b',');
+            self.cursor += 1;
+        }
+        debug_assert_eq!(self.payload[self.cursor], b'"');
+        self.cursor += 1;
+        let key_start = self.cursor;
+        let key_length = self.canonical_string_length();
+        self.cursor += key_length;
+        let key_end = self.cursor;
+        debug_assert_eq!(self.payload[self.cursor + 1], b':');
+        debug_assert_eq!(self.payload[self.cursor + 2], b'"');
+        self.cursor += 3;
+        let value_start = self.cursor;
+        let value_length = self.canonical_string_length();
+        self.cursor += value_length;
+        let value_end = self.cursor;
+        self.cursor += 1;
+        // SAFETY: the canonical fast parser validates both retained ranges as
+        // UTF-8 and rejects escaped strings before constructing this source.
+        Some(unsafe {
+            (
+                std::str::from_utf8_unchecked(self.payload.get_unchecked(key_start..key_end)),
+                std::str::from_utf8_unchecked(self.payload.get_unchecked(value_start..value_end)),
+            )
+        })
+    }
+
+    #[inline(always)]
+    fn canonical_string_length(&self) -> usize {
+        let mut length = 0usize;
+        let remaining = self.payload.len() - self.cursor;
+        while remaining - length >= size_of::<u64>() {
+            // SAFETY: the loop condition keeps the unaligned word read inside
+            // the immutable payload.
+            let word = unsafe {
+                (self.payload.as_ptr().add(self.cursor + length) as *const u64)
+                    .read_unaligned()
+                    .to_le()
+            };
+            let quote_bytes = word ^ 0x2222_2222_2222_2222;
+            let matches = quote_bytes.wrapping_sub(0x0101_0101_0101_0101) & !quote_bytes & 0x8080_8080_8080_8080;
+            if matches != 0 {
+                return length + matches.trailing_zeros() as usize / 8;
+            }
+            length += size_of::<u64>();
+        }
+        loop {
+            // SAFETY: the canonical parser validates every retained string
+            // terminator before constructing this immutable source.
+            if unsafe { *self.payload.get_unchecked(self.cursor + length) } == b'"' {
+                return length;
+            }
+            length += 1;
+        }
+    }
+
+    #[inline]
+    fn next_length_prefixed(&mut self) -> Option<(&'a str, &'a str)> {
         if self.cursor >= self.payload.len() {
             return None;
         }
@@ -239,5 +395,19 @@ impl<'a> Iterator for JsonHeaderFieldIter<'a> {
         let value_length = self.read_u32();
         let value = self.read_utf8(value_length);
         Some((key, value))
+    }
+}
+
+impl<'a> Iterator for JsonHeaderFieldIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.encoding {
+            JsonFieldEncoding::CanonicalUnescapedObject => return self.next_canonical_unescaped_object(),
+            JsonFieldEncoding::UnescapedObject => return self.next_unescaped_object(),
+            JsonFieldEncoding::LengthPrefixed => {}
+        }
+        self.next_length_prefixed()
     }
 }

--- a/rocketmq-protocol/src/protocol/header_codec/sink.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/sink.rs
@@ -166,24 +166,14 @@ impl EncodeSink for BinarySink<'_> {
             header: context.header,
             key: context.key,
         })?;
-        let value_len_hint = value.encoded_len();
-        if value_len_hint > i32::MAX as usize {
+        if !V::ALWAYS_FITS_WIRE_LENGTH && value.encoded_len() > i32::MAX as usize {
             return Err(HeaderCodecError::ValueLengthOverflow {
                 header: context.header,
                 key: context.key,
             });
         }
 
-        let pair_len = 2usize
-            .checked_add(key.len())
-            .and_then(|len| len.checked_add(4))
-            .and_then(|len| len.checked_add(value_len_hint))
-            .ok_or(HeaderCodecError::ValueLengthOverflow {
-                header: context.header,
-                key: context.key,
-            })?;
         let pair_start = self.out.len();
-        self.out.reserve(pair_len);
         self.out.put_u16(key_len);
         self.out.extend_from_slice(key.as_bytes());
 
@@ -192,7 +182,6 @@ impl EncodeSink for BinarySink<'_> {
         let value_offset = self.out.len();
         value.write_ascii(self.out);
         let actual_value_len = self.out.len() - value_offset;
-        debug_assert_eq!(actual_value_len, value_len_hint);
         let actual_value_len = i32::try_from(actual_value_len).map_err(|_| {
             self.out.truncate(pair_start);
             HeaderCodecError::ValueLengthOverflow {

--- a/rocketmq-protocol/src/protocol/header_codec/value.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/value.rs
@@ -90,6 +90,9 @@ pub trait HeaderValue: Sealed + Sized {
     /// Static value category used by generated schemas and diagnostics.
     const KIND: HeaderValueKind;
 
+    /// Whether every value of this type fits Java's signed 32-bit wire length.
+    const ALWAYS_FITS_WIRE_LENGTH: bool = false;
+
     /// Produces the owned value required by a [`crate::HeaderMap`].
     fn to_map_value(&self) -> CheetahString;
 
@@ -176,6 +179,7 @@ impl Sealed for CheetahString {}
 
 impl HeaderValue for CheetahString {
     const KIND: HeaderValueKind = HeaderValueKind::String;
+    const ALWAYS_FITS_WIRE_LENGTH: bool = false;
 
     #[inline]
     fn to_map_value(&self) -> CheetahString {
@@ -207,6 +211,7 @@ impl Sealed for String {}
 
 impl HeaderValue for String {
     const KIND: HeaderValueKind = HeaderValueKind::String;
+    const ALWAYS_FITS_WIRE_LENGTH: bool = false;
 
     #[inline]
     fn to_map_value(&self) -> CheetahString {
@@ -238,6 +243,7 @@ impl Sealed for bool {}
 
 impl HeaderValue for bool {
     const KIND: HeaderValueKind = HeaderValueKind::Bool;
+    const ALWAYS_FITS_WIRE_LENGTH: bool = true;
 
     #[inline]
     fn to_map_value(&self) -> CheetahString {
@@ -276,6 +282,7 @@ macro_rules! impl_signed_header_value {
 
         impl HeaderValue for $ty {
             const KIND: HeaderValueKind = HeaderValueKind::$kind;
+            const ALWAYS_FITS_WIRE_LENGTH: bool = true;
 
             #[inline]
             fn to_map_value(&self) -> CheetahString {
@@ -308,6 +315,7 @@ macro_rules! impl_unsigned_header_value {
 
         impl HeaderValue for $ty {
             const KIND: HeaderValueKind = HeaderValueKind::$kind;
+            const ALWAYS_FITS_WIRE_LENGTH: bool = true;
 
             #[inline]
             fn to_map_value(&self) -> CheetahString {
@@ -345,6 +353,7 @@ impl Sealed for BoundaryType {}
 
 impl HeaderValue for BoundaryType {
     const KIND: HeaderValueKind = HeaderValueKind::BoundaryType;
+    const ALWAYS_FITS_WIRE_LENGTH: bool = true;
 
     #[inline]
     fn to_map_value(&self) -> CheetahString {

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -77,8 +76,11 @@ const fn language_name(language: LanguageCode) -> &'static str {
 }
 
 mod extension_fields;
+mod json_decode;
 
 use extension_fields::ExtensionFields;
+use json_decode::try_decode_json_header;
+use json_decode::try_decode_json_header_bytes;
 
 fn serialize_ext_fields<S>(ext_fields: &ExtensionFields, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -337,6 +339,11 @@ impl RemotingCommand {
         self
     }
 
+    #[inline]
+    pub(crate) fn set_language_ref(&mut self, language: LanguageCode) {
+        self.language = language;
+    }
+
     pub fn set_version_ref(&mut self, version: i32) {
         self.version = version;
     }
@@ -361,6 +368,11 @@ impl RemotingCommand {
     pub fn set_flag(mut self, flag: i32) -> Self {
         self.flag = flag;
         self
+    }
+
+    #[inline]
+    pub(crate) fn set_flag_ref(&mut self, flag: i32) {
+        self.flag = flag;
     }
 
     #[inline]
@@ -392,11 +404,16 @@ impl RemotingCommand {
         self
     }
 
+    #[cfg(test)]
+    fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
+        self.set_binary_ext_fields_ref(ext_fields);
+        self
+    }
+
     #[inline]
-    pub(crate) fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
+    pub(crate) fn set_binary_ext_fields_ref(&mut self, ext_fields: BinaryHeaderFields) {
         self.ext_fields = ExtensionFields::from_rocketmq_raw(ext_fields);
         self.custom_header_to_net = false;
-        self
     }
 
     #[inline]
@@ -425,6 +442,11 @@ impl RemotingCommand {
     pub fn set_serialize_type(mut self, serialize_type: SerializeType) -> Self {
         self.serialize_type = serialize_type;
         self
+    }
+
+    #[inline]
+    pub(crate) fn set_serialize_type_ref(&mut self, serialize_type: SerializeType) {
+        self.serialize_type = serialize_type;
     }
 
     #[inline]
@@ -701,9 +723,16 @@ impl RemotingCommand {
 
         let capability = self.custom_header_encode_capability();
 
-        // Encode header directly to buffer
-        let header_size = RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability)
-            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
+        let direct_header = (capability == HeaderEncodeCapability::DirectBinary
+            && self.remark.is_none()
+            && self.ext_fields.is_absent())
+        .then(|| self.command_custom_header_ref())
+        .flatten();
+        let header_size = match direct_header {
+            Some(header) => RocketMQSerializable::try_rocketmq_protocol_encode_direct(self, header, dst),
+            None => RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability),
+        }
+        .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
         let body_length = self.body.as_ref().map_or(0, |b| b.len());
         let (total_length, serialize_type) =
             Self::checked_frame_lengths(header_size, body_length, SerializeType::ROCKETMQ)?;
@@ -812,22 +841,11 @@ impl RemotingCommand {
             ));
         }
 
-        // Extract complete frame (zero-copy split)
-        let mut cmd_data = src.split_to(full_frame_size);
-        cmd_data.advance(FRAME_HEADER_SIZE); // Skip total_size field
-
-        // Ensure we have serialize_type field (should always pass after above checks)
-        if cmd_data.remaining() < SERIALIZE_TYPE_SIZE {
-            return Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "remoting_command",
-                    message: "Incomplete serialize_type field".to_string(),
-                },
-            ));
-        }
-
-        // Parse header length and protocol type
-        let ori_header_length = cmd_data.get_i32();
+        // Extract the complete frame before validating the marked header so
+        // malformed complete frames preserve the established consume-on-error
+        // behavior.
+        let frame_data = src.split_to(full_frame_size);
+        let ori_header_length = i32::from_be_bytes([frame_data[4], frame_data[5], frame_data[6], frame_data[7]]);
         let header_length = parse_header_length(ori_header_length);
 
         // Validate header length
@@ -841,34 +859,58 @@ impl RemotingCommand {
         }
 
         let protocol_type = parse_serialize_type(ori_header_length)?;
-
-        // Split header and body (zero-copy)
-        let mut header_data = cmd_data.split_to(header_length);
-
-        // Decode header
-        let mut cmd = RemotingCommand::header_decode(&mut header_data, header_length, protocol_type)?;
-
-        // Attach body if present (zero-copy freeze)
-        if let Some(ref mut cmd) = cmd {
-            let body_length = total_size - SERIALIZE_TYPE_SIZE - header_length;
-            if body_length > 0 {
-                if cmd_data.remaining() >= body_length {
-                    cmd.set_body_mut_ref(cmd_data.split_to(body_length).freeze());
+        let frame = frame_data.freeze();
+        let header_start = FRAME_HEADER_SIZE + SERIALIZE_TYPE_SIZE;
+        let header_end = header_start + header_length;
+        let mut cmd = match protocol_type {
+            SerializeType::ROCKETMQ => {
+                RocketMQSerializable::rocket_mq_protocol_decode_bytes(frame.slice(header_start..header_end))?
+            }
+            SerializeType::JSON => {
+                if let Some(cmd) = try_decode_json_header_bytes(frame.slice(header_start..header_end)) {
+                    cmd
                 } else {
-                    return Err(rocketmq_error::RocketMQError::Serialization(
-                        rocketmq_error::SerializationError::DecodeFailed {
-                            format: "remoting_command",
-                            message: format!(
-                                "Insufficient body data: expected {body_length}, available {}",
-                                cmd_data.remaining()
-                            ),
-                        },
-                    ));
+                    // Unsupported JSON shapes retain the Serde/SIMD
+                    // compatibility path. Copying is confined to this cold
+                    // fallback after consuming the complete frame.
+                    let mut header_data = BytesMut::from(&frame[header_start..header_end]);
+                    Self::decode_json_header_fallback(&mut header_data, header_length)?
                 }
             }
+        };
+        cmd.set_serialize_type_ref(protocol_type);
+        if header_end < frame.len() {
+            cmd.set_body_mut_ref(frame.slice(header_end..));
+        }
+        Ok(Some(cmd))
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn decode_json_header_fallback(
+        src: &mut BytesMut,
+        _header_length: usize,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        #[cfg(feature = "simd")]
+        {
+            let mut slice = src.split_to(_header_length).to_vec();
+            simd_json::from_slice::<RemotingCommand>(&mut slice).map_err(|error| {
+                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                    format: "json",
+                    message: format!("SIMD JSON deserialization error: {error}"),
+                })
+            })
         }
 
-        Ok(cmd)
+        #[cfg(not(feature = "simd"))]
+        {
+            serde_json::from_slice::<RemotingCommand>(src).map_err(|error| {
+                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                    format: "json",
+                    message: format!("JSON deserialization error: {error}"),
+                })
+            })
+        }
     }
 
     /// Optimized header decoding with type-based dispatch
@@ -880,26 +922,10 @@ impl RemotingCommand {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match type_ {
             SerializeType::JSON => {
-                // Deserialize JSON header using simd-json when available
-                #[cfg(feature = "simd")]
-                let cmd = {
-                    let mut slice = src.split_to(header_length).to_vec();
-                    simd_json::from_slice::<RemotingCommand>(&mut slice).map_err(|error| {
-                        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                            format: "json",
-                            message: format!("SIMD JSON deserialization error: {error}"),
-                        })
-                    })?
-                };
-
-                #[cfg(not(feature = "simd"))]
-                let cmd = serde_json::from_slice::<RemotingCommand>(src).map_err(|error| {
-                    rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                        format: "json",
-                        message: format!("JSON deserialization error: {error}"),
-                    })
-                })?;
-
+                if let Some(cmd) = try_decode_json_header(src, header_length) {
+                    return Ok(Some(cmd.set_serialize_type(SerializeType::JSON)));
+                }
+                let cmd = Self::decode_json_header_fallback(src, header_length)?;
                 Ok(Some(cmd.set_serialize_type(SerializeType::JSON)))
             }
             SerializeType::ROCKETMQ => {

--- a/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use super::BinaryHeaderFields;
@@ -19,48 +20,19 @@ use crate::protocol::header_codec::HeaderFieldSource;
 use crate::protocol::header_codec::JsonHeaderFields;
 use crate::HeaderMap;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(super) enum ExtensionFields {
     #[default]
     Absent,
     Materialized(HeaderMap),
     RocketMqRaw {
         fields: BinaryHeaderFields,
-        materialized: OnceLock<HeaderMap>,
+        materialized: OnceLock<Arc<HeaderMap>>,
     },
     JsonRaw {
         fields: JsonHeaderFields,
-        materialized: OnceLock<HeaderMap>,
+        materialized: OnceLock<Arc<HeaderMap>>,
     },
-}
-
-impl Clone for ExtensionFields {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Absent => Self::Absent,
-            Self::Materialized(map) => Self::Materialized(map.clone()),
-            Self::RocketMqRaw { fields, materialized } => {
-                let cloned_cache = OnceLock::new();
-                if let Some(map) = materialized.get() {
-                    let _ = cloned_cache.set(map.clone());
-                }
-                Self::RocketMqRaw {
-                    fields: fields.clone(),
-                    materialized: cloned_cache,
-                }
-            }
-            Self::JsonRaw { fields, materialized } => {
-                let cloned_cache = OnceLock::new();
-                if let Some(map) = materialized.get() {
-                    let _ = cloned_cache.set(map.clone());
-                }
-                Self::JsonRaw {
-                    fields: fields.clone(),
-                    materialized: cloned_cache,
-                }
-            }
-        }
-    }
 }
 
 impl ExtensionFields {
@@ -86,8 +58,10 @@ impl ExtensionFields {
         match self {
             Self::Absent => None,
             Self::Materialized(fields) => Some(fields),
-            Self::RocketMqRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
-            Self::JsonRaw { fields, materialized } => Some(materialized.get_or_init(|| fields.materialize())),
+            Self::RocketMqRaw { fields, materialized } => {
+                Some(materialized.get_or_init(|| Arc::new(fields.materialize())))
+            }
+            Self::JsonRaw { fields, materialized } => Some(materialized.get_or_init(|| Arc::new(fields.materialize()))),
         }
     }
 

--- a/rocketmq-protocol/src/protocol/remoting_command/json_decode.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/json_decode.rs
@@ -1,0 +1,891 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+
+use super::extension_fields::ExtensionFields;
+use super::RemotingCommand;
+use crate::protocol::header_codec::JsonHeaderFields;
+use crate::protocol::LanguageCode;
+use crate::protocol::SerializeType;
+
+const CODE: u8 = 1 << 0;
+const LANGUAGE: u8 = 1 << 1;
+const VERSION: u8 = 1 << 2;
+const OPAQUE: u8 = 1 << 3;
+const FLAG: u8 = 1 << 4;
+const REMARK: u8 = 1 << 5;
+const EXT_FIELDS: u8 = 1 << 6;
+const SERIALIZE_TYPE: u8 = 1 << 7;
+const REQUIRED_FIELDS: u8 = CODE | LANGUAGE | VERSION | OPAQUE | FLAG | SERIALIZE_TYPE;
+
+struct JsonHeaderParser<'a> {
+    src: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> JsonHeaderParser<'a> {
+    #[inline]
+    fn new(src: &'a [u8]) -> Self {
+        Self { src, cursor: 0 }
+    }
+
+    #[inline]
+    fn skip_whitespace(&mut self) {
+        while matches!(self.src.get(self.cursor), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+            self.cursor += 1;
+        }
+    }
+
+    #[inline]
+    fn consume(&mut self, expected: u8) -> Option<()> {
+        self.skip_whitespace();
+        if self.src.get(self.cursor).copied()? != expected {
+            return None;
+        }
+        self.cursor += 1;
+        Some(())
+    }
+
+    #[inline]
+    fn consume_null(&mut self) -> Option<()> {
+        self.skip_whitespace();
+        if !self.src.get(self.cursor..)?.starts_with(b"null") {
+            return None;
+        }
+        self.cursor += 4;
+        Some(())
+    }
+
+    #[inline]
+    fn consume_literal(&mut self, expected: &[u8]) -> Option<()> {
+        if !self.src.get(self.cursor..)?.starts_with(expected) {
+            return None;
+        }
+        self.cursor += expected.len();
+        Some(())
+    }
+
+    #[inline]
+    fn parse_string(&mut self) -> Option<Range<usize>> {
+        self.consume(b'"')?;
+        let start = self.cursor;
+        loop {
+            match self.src.get(self.cursor).copied()? {
+                b'"' => {
+                    let end = self.cursor;
+                    self.cursor += 1;
+                    return Some(start..end);
+                }
+                b'\\' | 0..=0x1f => return None,
+                _ => self.cursor += 1,
+            }
+        }
+    }
+
+    #[inline]
+    fn parse_canonical_string(&mut self) -> Option<Range<usize>> {
+        if self.src.get(self.cursor).copied()? != b'"' {
+            return None;
+        }
+        self.cursor += 1;
+        let start = self.cursor;
+        loop {
+            match self.src.get(self.cursor).copied()? {
+                b'"' => {
+                    let end = self.cursor;
+                    self.cursor += 1;
+                    return Some(start..end);
+                }
+                b'\\' | 0..=0x1f => return None,
+                _ => self.cursor += 1,
+            }
+        }
+    }
+
+    #[inline]
+    fn parse_canonical_json_string(&mut self) -> Option<bool> {
+        if self.src.get(self.cursor).copied()? != b'"' {
+            return None;
+        }
+        self.cursor += 1;
+        let start = self.cursor;
+        let mut escaped = false;
+        let mut string_bytes = 0u8;
+        loop {
+            match self.src.get(self.cursor).copied()? {
+                b'"' => {
+                    if string_bytes & 0x80 != 0 {
+                        std::str::from_utf8(&self.src[start..self.cursor]).ok()?;
+                    }
+                    self.cursor += 1;
+                    return Some(escaped);
+                }
+                b'\\' => {
+                    escaped = true;
+                    self.cursor += 1;
+                    match self.src.get(self.cursor).copied()? {
+                        b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => self.cursor += 1,
+                        b'u' => {
+                            let digits = self.src.get(self.cursor + 1..self.cursor + 5)?;
+                            if !digits.iter().all(u8::is_ascii_hexdigit) {
+                                return None;
+                            }
+                            self.cursor += 5;
+                        }
+                        _ => return None,
+                    }
+                }
+                0..=0x1f => return None,
+                byte => {
+                    string_bytes |= byte;
+                    self.cursor += 1;
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn parse_i32(&mut self) -> Option<i32> {
+        self.skip_whitespace();
+        let start = self.cursor;
+        if self.src.get(self.cursor) == Some(&b'-') {
+            self.cursor += 1;
+        }
+        match self.src.get(self.cursor).copied()? {
+            b'0' => {
+                self.cursor += 1;
+                if matches!(self.src.get(self.cursor), Some(b'0'..=b'9')) {
+                    return None;
+                }
+            }
+            b'1'..=b'9' => {
+                self.cursor += 1;
+                while matches!(self.src.get(self.cursor), Some(b'0'..=b'9')) {
+                    self.cursor += 1;
+                }
+            }
+            _ => return None,
+        }
+        // SAFETY: this slice contains ASCII sign/digit bytes only.
+        unsafe { std::str::from_utf8_unchecked(&self.src[start..self.cursor]) }
+            .parse()
+            .ok()
+    }
+
+    fn parse_extension_fields(&mut self) -> Option<(Range<usize>, usize)> {
+        self.consume(b'{')?;
+        let start = self.cursor;
+        let mut entry_count = 0usize;
+        self.skip_whitespace();
+        if self.src.get(self.cursor) == Some(&b'}') {
+            let end = self.cursor;
+            self.cursor += 1;
+            return Some((start..end, 0));
+        }
+
+        loop {
+            self.parse_string()?;
+            self.consume(b':')?;
+            self.parse_string()?;
+            entry_count = entry_count.checked_add(1)?;
+            self.skip_whitespace();
+            match self.src.get(self.cursor).copied()? {
+                b',' => self.cursor += 1,
+                b'}' => {
+                    let end = self.cursor;
+                    self.cursor += 1;
+                    return Some((start..end, entry_count));
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn parse_canonical_extension_fields(&mut self) -> Option<ParsedExtensionFields> {
+        if self.src.get(self.cursor).copied()? != b'{' {
+            return None;
+        }
+        self.cursor += 1;
+        let start = self.cursor;
+        let mut entry_count = 0usize;
+        if self.src.get(self.cursor) == Some(&b'}') {
+            let end = self.cursor;
+            self.cursor += 1;
+            return Some(ParsedExtensionFields::Borrowed {
+                range: start..end,
+                entry_count: 0,
+                canonical: true,
+            });
+        }
+
+        loop {
+            let key_escaped = self.parse_canonical_json_string()?;
+            if self.src.get(self.cursor).copied()? != b':' {
+                return None;
+            }
+            self.cursor += 1;
+            let value_escaped = self.parse_canonical_json_string()?;
+            entry_count = entry_count.checked_add(1)?;
+            if key_escaped || value_escaped {
+                return self.finish_length_prefixed_extension_fields(start, entry_count);
+            }
+            match self.src.get(self.cursor).copied()? {
+                b',' => self.cursor += 1,
+                b'}' => {
+                    let end = self.cursor;
+                    self.cursor += 1;
+                    return Some(ParsedExtensionFields::Borrowed {
+                        range: start..end,
+                        entry_count,
+                        canonical: true,
+                    });
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn finish_length_prefixed_extension_fields(
+        &mut self,
+        start: usize,
+        mut entry_count: usize,
+    ) -> Option<ParsedExtensionFields> {
+        let capacity = self.src.len().checked_sub(start)?;
+        let mut payload = decode_length_prefixed_fields(&self.src[start..self.cursor], entry_count, capacity)?;
+        loop {
+            match self.src.get(self.cursor).copied()? {
+                b'}' => {
+                    self.cursor += 1;
+                    return Some(ParsedExtensionFields::LengthPrefixed { payload, entry_count });
+                }
+                b',' => self.cursor += 1,
+                _ => return None,
+            }
+            append_json_string(self.src, &mut self.cursor, &mut payload)?;
+            if self.src.get(self.cursor).copied()? != b':' {
+                return None;
+            }
+            self.cursor += 1;
+            append_json_string(self.src, &mut self.cursor, &mut payload)?;
+            entry_count = entry_count.checked_add(1)?;
+        }
+    }
+}
+
+fn decode_hex_u16(src: &[u8]) -> Option<u16> {
+    if src.len() != 4 {
+        return None;
+    }
+    src.iter().try_fold(0u16, |value, byte| {
+        let digit = match byte {
+            b'0'..=b'9' => u16::from(byte - b'0'),
+            b'a'..=b'f' => u16::from(byte - b'a' + 10),
+            b'A'..=b'F' => u16::from(byte - b'A' + 10),
+            _ => return None,
+        };
+        value.checked_mul(16)?.checked_add(digit)
+    })
+}
+
+fn append_json_string(src: &[u8], cursor: &mut usize, out: &mut Vec<u8>) -> Option<()> {
+    if src.get(*cursor).copied()? != b'"' {
+        return None;
+    }
+    *cursor += 1;
+    let length_offset = out.len();
+    out.extend_from_slice(&[0; 4]);
+    let value_offset = out.len();
+
+    loop {
+        match src.get(*cursor).copied()? {
+            b'"' => {
+                *cursor += 1;
+                std::str::from_utf8(&out[value_offset..]).ok()?;
+                let length = u32::try_from(out.len().checked_sub(value_offset)?).ok()?;
+                out[length_offset..value_offset].copy_from_slice(&length.to_be_bytes());
+                return Some(());
+            }
+            b'\\' => {
+                *cursor += 1;
+                match src.get(*cursor).copied()? {
+                    b'"' | b'\\' | b'/' => {
+                        out.push(src[*cursor]);
+                        *cursor += 1;
+                    }
+                    b'b' => {
+                        out.push(0x08);
+                        *cursor += 1;
+                    }
+                    b'f' => {
+                        out.push(0x0c);
+                        *cursor += 1;
+                    }
+                    b'n' => {
+                        out.push(b'\n');
+                        *cursor += 1;
+                    }
+                    b'r' => {
+                        out.push(b'\r');
+                        *cursor += 1;
+                    }
+                    b't' => {
+                        out.push(b'\t');
+                        *cursor += 1;
+                    }
+                    b'u' => {
+                        let high = decode_hex_u16(src.get(*cursor + 1..*cursor + 5)?)?;
+                        *cursor += 5;
+                        let scalar = if (0xd800..=0xdbff).contains(&high) {
+                            if src.get(*cursor..*cursor + 2)? != b"\\u" {
+                                return None;
+                            }
+                            let low = decode_hex_u16(src.get(*cursor + 2..*cursor + 6)?)?;
+                            if !(0xdc00..=0xdfff).contains(&low) {
+                                return None;
+                            }
+                            *cursor += 6;
+                            0x1_0000 + ((u32::from(high) - 0xd800) << 10) + (u32::from(low) - 0xdc00)
+                        } else if (0xdc00..=0xdfff).contains(&high) {
+                            return None;
+                        } else {
+                            u32::from(high)
+                        };
+                        let value = char::from_u32(scalar)?;
+                        let mut encoded = [0; 4];
+                        out.extend_from_slice(value.encode_utf8(&mut encoded).as_bytes());
+                    }
+                    _ => return None,
+                }
+            }
+            0..=0x1f => return None,
+            byte => {
+                out.push(byte);
+                *cursor += 1;
+            }
+        }
+    }
+}
+
+fn decode_length_prefixed_fields(src: &[u8], entry_count: usize, capacity: usize) -> Option<Vec<u8>> {
+    let mut cursor = 0usize;
+    let mut payload = Vec::with_capacity(capacity);
+    for index in 0..entry_count {
+        if index != 0 {
+            if src.get(cursor).copied()? != b',' {
+                return None;
+            }
+            cursor += 1;
+        }
+        append_json_string(src, &mut cursor, &mut payload)?;
+        if src.get(cursor).copied()? != b':' {
+            return None;
+        }
+        cursor += 1;
+        append_json_string(src, &mut cursor, &mut payload)?;
+    }
+    (cursor == src.len()).then_some(payload)
+}
+
+#[inline]
+fn validate_optional_string(src: &[u8], range: &Option<Range<usize>>) -> Option<()> {
+    if let Some(range) = range {
+        std::str::from_utf8(&src[range.clone()]).ok()?;
+    }
+    Some(())
+}
+
+#[inline]
+fn mark_seen(seen: &mut u8, field: u8) -> Option<()> {
+    if *seen & field != 0 {
+        return None;
+    }
+    *seen |= field;
+    Some(())
+}
+
+#[inline]
+fn language(value: &[u8]) -> Option<LanguageCode> {
+    Some(match value {
+        b"JAVA" => LanguageCode::JAVA,
+        b"CPP" => LanguageCode::CPP,
+        b"DOTNET" => LanguageCode::DOTNET,
+        b"PYTHON" => LanguageCode::PYTHON,
+        b"DELPHI" => LanguageCode::DELPHI,
+        b"ERLANG" => LanguageCode::ERLANG,
+        b"RUBY" => LanguageCode::RUBY,
+        b"OTHER" => LanguageCode::OTHER,
+        b"HTTP" => LanguageCode::HTTP,
+        b"GO" => LanguageCode::GO,
+        b"PHP" => LanguageCode::PHP,
+        b"OMS" => LanguageCode::OMS,
+        b"RUST" => LanguageCode::RUST,
+        _ => return None,
+    })
+}
+
+#[inline]
+fn serialize_type(value: &[u8]) -> Option<SerializeType> {
+    match value {
+        b"JSON" => Some(SerializeType::JSON),
+        b"ROCKETMQ" => Some(SerializeType::ROCKETMQ),
+        _ => None,
+    }
+}
+
+struct ParsedJsonHeader {
+    code: i32,
+    language: LanguageCode,
+    version: i32,
+    opaque: i32,
+    flag: i32,
+    remark: Option<Range<usize>>,
+    ext_fields: Option<ParsedExtensionFields>,
+    serialize_type: SerializeType,
+}
+
+enum ParsedExtensionFields {
+    Borrowed {
+        range: Range<usize>,
+        entry_count: usize,
+        canonical: bool,
+    },
+    LengthPrefixed {
+        payload: Vec<u8>,
+        entry_count: usize,
+    },
+}
+
+impl ParsedJsonHeader {
+    fn into_command(self, src: Bytes) -> RemotingCommand {
+        let remark = self.remark.map(|range| {
+            // SAFETY: parse_string validates every retained string range as
+            // UTF-8 and accepts no escapes.
+            CheetahString::from_slice(unsafe { std::str::from_utf8_unchecked(&src[range]) })
+        });
+        let ext_fields = self.ext_fields.map_or_else(ExtensionFields::default, |fields| {
+            let fields = match fields {
+                ParsedExtensionFields::Borrowed {
+                    range,
+                    entry_count,
+                    canonical: true,
+                } => JsonHeaderFields::from_canonical_unescaped_object(src.slice(range), entry_count),
+                ParsedExtensionFields::Borrowed {
+                    range,
+                    entry_count,
+                    canonical: false,
+                } => JsonHeaderFields::from_unescaped_object(src.slice(range), entry_count),
+                ParsedExtensionFields::LengthPrefixed { payload, entry_count } => {
+                    JsonHeaderFields::from_length_prefixed(payload, entry_count)
+                }
+            };
+            ExtensionFields::from_json_raw(fields)
+        });
+
+        RemotingCommand {
+            code: self.code,
+            language: self.language,
+            version: self.version,
+            opaque: self.opaque,
+            flag: self.flag,
+            remark,
+            ext_fields,
+            body: None,
+            suspended: false,
+            command_custom_header: None,
+            custom_header_to_net: false,
+            serialize_type: self.serialize_type,
+        }
+    }
+}
+
+#[inline]
+fn parse_canonical_nullable_string(parser: &mut JsonHeaderParser<'_>) -> Option<Option<Range<usize>>> {
+    if parser.src.get(parser.cursor..)?.starts_with(b"null") {
+        parser.cursor += 4;
+        Some(None)
+    } else {
+        parser.parse_canonical_string().map(Some)
+    }
+}
+
+#[inline]
+fn parse_canonical_nullable_fields(parser: &mut JsonHeaderParser<'_>) -> Option<Option<ParsedExtensionFields>> {
+    if parser.src.get(parser.cursor..)?.starts_with(b"null") {
+        parser.cursor += 4;
+        Some(None)
+    } else {
+        parser.parse_canonical_extension_fields().map(Some)
+    }
+}
+
+fn try_parse_rust_layout(src: &[u8]) -> Option<ParsedJsonHeader> {
+    let mut parser = JsonHeaderParser::new(src);
+    parser.consume_literal(b"{\"code\":")?;
+    let code = parser.parse_i32()?;
+    parser.consume_literal(b",\"language\":")?;
+    let language_range = parser.parse_canonical_string()?;
+    let language = language(&src[language_range])?;
+    parser.consume_literal(b",\"version\":")?;
+    let version = parser.parse_i32()?;
+    parser.consume_literal(b",\"opaque\":")?;
+    let opaque = parser.parse_i32()?;
+    parser.consume_literal(b",\"flag\":")?;
+    let flag = parser.parse_i32()?;
+    parser.consume_literal(b",\"remark\":")?;
+    let remark = parse_canonical_nullable_string(&mut parser)?;
+    parser.consume_literal(b",\"extFields\":")?;
+    let ext_fields = parse_canonical_nullable_fields(&mut parser)?;
+    parser.consume_literal(b",\"serializeTypeCurrentRPC\":")?;
+    let serialize_range = parser.parse_canonical_string()?;
+    let serialize_type = serialize_type(&src[serialize_range])?;
+    parser.consume_literal(b"}")?;
+    if parser.cursor != src.len() {
+        return None;
+    }
+    validate_optional_string(src, &remark)?;
+
+    Some(ParsedJsonHeader {
+        code,
+        language,
+        version,
+        opaque,
+        flag,
+        remark,
+        ext_fields,
+        serialize_type,
+    })
+}
+
+fn try_parse_java_layout(src: &[u8]) -> Option<ParsedJsonHeader> {
+    let mut parser = JsonHeaderParser::new(src);
+    parser.consume_literal(b"{\"code\":")?;
+    let code = parser.parse_i32()?;
+    parser.consume_literal(b",\"extFields\":")?;
+    let ext_fields = parse_canonical_nullable_fields(&mut parser)?;
+    parser.consume_literal(b",\"flag\":")?;
+    let flag = parser.parse_i32()?;
+    parser.consume_literal(b",\"language\":")?;
+    let language_range = parser.parse_canonical_string()?;
+    let language = language(&src[language_range])?;
+    parser.consume_literal(b",\"opaque\":")?;
+    let opaque = parser.parse_i32()?;
+    let remark = if parser.src.get(parser.cursor..)?.starts_with(b",\"remark\":") {
+        parser.consume_literal(b",\"remark\":")?;
+        parse_canonical_nullable_string(&mut parser)?
+    } else {
+        None
+    };
+    parser.consume_literal(b",\"serializeTypeCurrentRPC\":")?;
+    let serialize_range = parser.parse_canonical_string()?;
+    let serialize_type = serialize_type(&src[serialize_range])?;
+    parser.consume_literal(b",\"version\":")?;
+    let version = parser.parse_i32()?;
+    parser.consume_literal(b"}")?;
+    if parser.cursor != src.len() {
+        return None;
+    }
+    validate_optional_string(src, &remark)?;
+
+    Some(ParsedJsonHeader {
+        code,
+        language,
+        version,
+        opaque,
+        flag,
+        remark,
+        ext_fields,
+        serialize_type,
+    })
+}
+
+fn try_parse_json_header(src: &[u8]) -> Option<ParsedJsonHeader> {
+    try_parse_rust_layout(src)
+        .or_else(|| try_parse_java_layout(src))
+        .or_else(|| try_parse_flexible_json_header(src))
+}
+
+#[cold]
+#[inline(never)]
+fn try_parse_flexible_json_header(src: &[u8]) -> Option<ParsedJsonHeader> {
+    let mut parser = JsonHeaderParser::new(src);
+    parser.consume(b'{')?;
+
+    let mut seen = 0u8;
+    let mut code = 0;
+    let mut language_code = LanguageCode::RUST;
+    let mut version = 0;
+    let mut opaque = 0;
+    let mut flag = 0;
+    let mut remark = None;
+    let mut ext_fields = None;
+    let mut rpc_serialize_type = SerializeType::JSON;
+
+    parser.skip_whitespace();
+    if parser.src.get(parser.cursor) == Some(&b'}') {
+        return None;
+    }
+
+    loop {
+        let key = parser.parse_string()?;
+        parser.consume(b':')?;
+        match &parser.src[key] {
+            b"code" => {
+                mark_seen(&mut seen, CODE)?;
+                code = parser.parse_i32()?;
+            }
+            b"language" => {
+                mark_seen(&mut seen, LANGUAGE)?;
+                let value = parser.parse_string()?;
+                language_code = language(&parser.src[value])?;
+            }
+            b"version" => {
+                mark_seen(&mut seen, VERSION)?;
+                version = parser.parse_i32()?;
+            }
+            b"opaque" => {
+                mark_seen(&mut seen, OPAQUE)?;
+                opaque = parser.parse_i32()?;
+            }
+            b"flag" => {
+                mark_seen(&mut seen, FLAG)?;
+                flag = parser.parse_i32()?;
+            }
+            b"remark" => {
+                mark_seen(&mut seen, REMARK)?;
+                parser.skip_whitespace();
+                if parser.src.get(parser.cursor..)?.starts_with(b"null") {
+                    parser.consume_null()?;
+                } else {
+                    remark = Some(parser.parse_string()?);
+                }
+            }
+            b"extFields" => {
+                mark_seen(&mut seen, EXT_FIELDS)?;
+                parser.skip_whitespace();
+                if parser.src.get(parser.cursor..)?.starts_with(b"null") {
+                    parser.consume_null()?;
+                } else {
+                    ext_fields = Some(parser.parse_extension_fields()?);
+                }
+            }
+            b"serializeTypeCurrentRPC" => {
+                mark_seen(&mut seen, SERIALIZE_TYPE)?;
+                let value = parser.parse_string()?;
+                rpc_serialize_type = serialize_type(&parser.src[value])?;
+            }
+            _ => return None,
+        }
+
+        parser.skip_whitespace();
+        match parser.src.get(parser.cursor).copied()? {
+            b',' => parser.cursor += 1,
+            b'}' => {
+                parser.cursor += 1;
+                break;
+            }
+            _ => return None,
+        }
+    }
+
+    parser.skip_whitespace();
+    if parser.cursor != parser.src.len() || seen & REQUIRED_FIELDS != REQUIRED_FIELDS {
+        return None;
+    }
+    validate_optional_string(src, &remark)?;
+    if let Some((range, _)) = &ext_fields {
+        std::str::from_utf8(&src[range.clone()]).ok()?;
+    }
+
+    Some(ParsedJsonHeader {
+        code,
+        language: language_code,
+        version,
+        opaque,
+        flag,
+        remark,
+        ext_fields: ext_fields.map(|(range, entry_count)| ParsedExtensionFields::Borrowed {
+            range,
+            entry_count,
+            canonical: false,
+        }),
+        serialize_type: rpc_serialize_type,
+    })
+}
+
+pub(super) fn try_decode_json_header(src: &mut BytesMut, header_length: usize) -> Option<RemotingCommand> {
+    let parsed = try_parse_json_header(src.get(..header_length)?)?;
+    let header = src.split_to(header_length).freeze();
+    Some(parsed.into_command(header))
+}
+
+pub(super) fn try_decode_json_header_bytes(header: Bytes) -> Option<RemotingCommand> {
+    let parsed = try_parse_json_header(&header)?;
+    Some(parsed.into_command(header))
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use cheetah_string::CheetahString;
+
+    use super::*;
+    use crate::protocol::LanguageCode;
+
+    fn decode(input: &[u8]) -> Option<RemotingCommand> {
+        let mut input = BytesMut::from(input);
+        let length = input.len();
+        try_decode_json_header(&mut input, length)
+    }
+
+    #[test]
+    fn decodes_java_and_rust_canonical_layouts_without_materializing_fields() {
+        let headers = [
+            br#"{"code":10,"extFields":{"queueId":"1","msgId":"id"},"flag":0,"language":"RUST","opaque":7,"serializeTypeCurrentRPC":"JSON","version":501}"#.as_slice(),
+            br#"{"code":10,"language":"RUST","version":501,"opaque":7,"flag":0,"remark":null,"extFields":{"queueId":"1","msgId":"id"},"serializeTypeCurrentRPC":"JSON"}"#.as_slice(),
+        ];
+
+        for input in headers {
+            let command = decode(input).expect("canonical JSON should use the fast parser");
+
+            assert_eq!(command.code, 10);
+            assert_eq!(command.language, LanguageCode::RUST);
+            assert_eq!(command.version, 501);
+            assert_eq!(command.opaque, 7);
+            assert_eq!(command.flag, 0);
+            assert!(command.remark.is_none());
+            assert!(command.ext_fields.is_json_raw());
+            assert!(!command.ext_fields.has_materialized_map());
+            assert_eq!(
+                command
+                    .ext_fields()
+                    .and_then(|fields| fields.get("msgId"))
+                    .map(CheetahString::as_str),
+                Some("id")
+            );
+        }
+    }
+
+    #[test]
+    fn decodes_escaped_canonical_extension_field_values() {
+        let input = br#"{"code":310,"language":"RUST","version":501,"opaque":7,"flag":0,"remark":null,"extFields":{"a":"producer-a","i":"KEYS\u0001key-a\u0002","escaped\u004bey":"quote\"slash\\solidus\/","controls":"\b\f\n\r\t","unicode":"\u4e2d\ud83d\ude80"},"serializeTypeCurrentRPC":"JSON"}"#;
+        let command = decode(input).expect("canonical escaped JSON should use the fast parser");
+
+        let fields = command
+            .ext_fields()
+            .expect("escaped extension fields should be retained");
+        assert_eq!(fields.get("a").map(CheetahString::as_str), Some("producer-a"));
+        assert_eq!(fields.get("i").map(CheetahString::as_str), Some("KEYS\u{1}key-a\u{2}"));
+        assert_eq!(
+            fields.get("escapedKey").map(CheetahString::as_str),
+            Some("quote\"slash\\solidus/")
+        );
+        assert_eq!(
+            fields.get("controls").map(CheetahString::as_str),
+            Some("\u{8}\u{c}\n\r\t")
+        );
+        assert_eq!(fields.get("unicode").map(CheetahString::as_str), Some("中🚀"));
+    }
+
+    #[test]
+    fn preserves_whitespace_unicode_empty_and_duplicate_extension_fields() {
+        let input = r#" { "version" : 501, "code" : -7, "language" : "JAVA", "opaque" : 9, "flag" : 1, "remark" : "火箭", "extFields" : { "empty" : "", "key" : "first", "key" : "最后" }, "serializeTypeCurrentRPC" : "JSON" } "#
+            .as_bytes();
+
+        let command = decode(input).expect("supported JSON should use the fast parser");
+        let fields = command.ext_fields().expect("extension fields");
+
+        assert_eq!(command.code, -7);
+        assert_eq!(command.language, LanguageCode::JAVA);
+        assert_eq!(command.remark.as_deref(), Some("火箭"));
+        assert_eq!(fields.get("empty").map(CheetahString::as_str), Some(""));
+        assert_eq!(fields.get("key").map(CheetahString::as_str), Some("最后"));
+    }
+
+    #[test]
+    fn keeps_absent_null_and_empty_extension_fields_distinct() {
+        let prefix = r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0"#;
+        let suffix = r#","serializeTypeCurrentRPC":"JSON"}"#;
+        let inputs = [
+            format!("{prefix}{suffix}"),
+            format!("{prefix},\"extFields\":null{suffix}"),
+            format!("{prefix},\"extFields\":{{}}{suffix}"),
+        ];
+
+        let absent = decode(inputs[0].as_bytes()).expect("absent fields");
+        let null = decode(inputs[1].as_bytes()).expect("null fields");
+        let empty = decode(inputs[2].as_bytes()).expect("empty fields");
+
+        assert!(absent.ext_fields.is_absent());
+        assert!(null.ext_fields.is_absent());
+        assert!(empty.ext_fields.is_json_raw());
+        assert!(empty.ext_fields().expect("empty map").is_empty());
+    }
+
+    #[test]
+    fn parses_i32_boundaries_without_accepting_overflow() {
+        let valid = br#"{"code":-2147483648,"language":"RUST","version":2147483647,"opaque":-0,"flag":0,"serializeTypeCurrentRPC":"JSON"}"#;
+        let command = decode(valid).expect("i32 boundaries should decode");
+        assert_eq!(command.code, i32::MIN);
+        assert_eq!(command.version, i32::MAX);
+        assert_eq!(command.opaque, 0);
+
+        for code in ["2147483648", "-2147483649"] {
+            let input = format!(
+                r#"{{"code":{code},"language":"RUST","version":0,"opaque":0,"flag":0,"serializeTypeCurrentRPC":"JSON"}}"#
+            );
+            assert!(decode(input.as_bytes()).is_none());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_utf8_in_retained_strings() {
+        let prefix = br#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":""#;
+        let suffix = br#"","serializeTypeCurrentRPC":"JSON"}"#;
+        let remark = [prefix.as_slice(), &[0xff], suffix.as_slice()].concat();
+
+        let prefix =
+            br#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"extFields":{"key":""#;
+        let suffix = br#""},"serializeTypeCurrentRPC":"JSON"}"#;
+        let field = [prefix.as_slice(), &[0xff], suffix.as_slice()].concat();
+
+        assert!(decode(&remark).is_none());
+        assert!(decode(&field).is_none());
+    }
+
+    #[test]
+    fn defers_escaped_unknown_duplicate_and_invalid_shapes_to_serde() {
+        let inputs = [
+            br#"{"code":1,"language":"R\u0055ST","version":0,"opaque":7,"flag":0,"serializeTypeCurrentRPC":"JSON"}"#.as_slice(),
+            br#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"extra":true,"serializeTypeCurrentRPC":"JSON"}"#.as_slice(),
+            br#"{"code":1,"code":2,"language":"RUST","version":0,"opaque":7,"flag":0,"serializeTypeCurrentRPC":"JSON"}"#.as_slice(),
+            br#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"extFields":{"key":1},"serializeTypeCurrentRPC":"JSON"}"#.as_slice(),
+            br#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"serializeTypeCurrentRPC":"JSON",}"#.as_slice(),
+        ];
+
+        for input in inputs {
+            let mut source = BytesMut::from(input);
+            let before = source.clone();
+            let length = source.len();
+            assert!(try_decode_json_header(&mut source, length).is_none());
+            assert_eq!(source, before);
+        }
+    }
+}

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -21,6 +21,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
 
+use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
@@ -56,7 +57,7 @@ fn sorted_ext_fields(map: &HashMap<CheetahString, CheetahString>) -> Vec<(&Cheet
 pub struct RocketMQSerializable;
 
 impl RocketMQSerializable {
-    pub(crate) const INITIAL_ENCODE_CAPACITY: usize = 512;
+    pub(crate) const INITIAL_ENCODE_CAPACITY: usize = 256;
 
     #[inline]
     fn estimated_map_capacity(encoded_len: usize) -> usize {
@@ -218,6 +219,34 @@ impl RocketMQSerializable {
         Ok(buf.len() - begin_index)
     }
 
+    /// Encodes the common direct-header shape without map materialization or
+    /// collision checks. Callers must establish that no remark or dynamic
+    /// extension fields are present.
+    pub(crate) fn try_rocketmq_protocol_encode_direct(
+        cmd: &RemotingCommand,
+        header: &dyn CommandCustomHeader,
+        buf: &mut BytesMut,
+    ) -> Result<usize, HeaderCodecError> {
+        const FIXED_HEADER_LENGTH: usize = 21;
+        const EXT_FIELDS_LENGTH_OFFSET: usize = 17;
+
+        let begin_index = buf.len();
+        let mut fixed = [0u8; FIXED_HEADER_LENGTH];
+        fixed[..2].copy_from_slice(&(cmd.code() as u16).to_be_bytes());
+        fixed[2] = cmd.language().get_code();
+        fixed[3..5].copy_from_slice(&(cmd.version() as u16).to_be_bytes());
+        fixed[5..9].copy_from_slice(&cmd.opaque().to_be_bytes());
+        fixed[9..13].copy_from_slice(&cmd.flag().to_be_bytes());
+        buf.extend_from_slice(&fixed);
+
+        header.encode_direct_binary(buf)?;
+
+        let ext_fields_length = Self::checked_ext_fields_length(buf.len() - begin_index - FIXED_HEADER_LENGTH)?;
+        let map_len_index = begin_index + EXT_FIELDS_LENGTH_OFFSET;
+        buf[map_len_index..map_len_index + 4].copy_from_slice(&ext_fields_length.to_be_bytes());
+        Ok(buf.len() - begin_index)
+    }
+
     #[inline]
     fn write_ext_fields(
         buf: &mut BytesMut,
@@ -358,46 +387,86 @@ impl RocketMQSerializable {
         header_buffer: &mut BytesMut,
         header_len: usize,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        let available = header_buffer.remaining();
+        if available < header_len {
+            return Err(decoding_error(header_len, available));
+        }
+        if available > header_len {
+            return Err(trailing_header_error(available - header_len));
+        }
+        Self::rocket_mq_protocol_decode_bytes(header_buffer.split().freeze())
+    }
+
+    /// Decodes an immutable ROCKETMQ header without intermediate buffer splits.
+    pub(crate) fn rocket_mq_protocol_decode_bytes(header: Bytes) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         const FIXED_HEADER_LEN: usize = 13;
         const LENGTH_FIELD_LEN: usize = 4;
 
-        if header_buffer.remaining() < FIXED_HEADER_LEN {
-            return Err(decoding_error(FIXED_HEADER_LEN, header_buffer.remaining()));
+        if header.len() < FIXED_HEADER_LEN {
+            return Err(decoding_error(FIXED_HEADER_LEN, header.len()));
         }
 
-        let cmd = RemotingCommand::default()
-            .set_code(header_buffer.get_i16())
-            .set_language(LanguageCode::from(header_buffer.get_u8()))
-            .set_version(header_buffer.get_i16() as i32)
-            .set_opaque(header_buffer.get_i32())
-            .set_flag(header_buffer.get_i32());
+        let mut cmd = RemotingCommand::default();
+        cmd.set_code_ref(i16::from_be_bytes([header[0], header[1]]));
+        cmd.set_language_ref(LanguageCode::from(header[2]));
+        cmd.set_version_ref(i16::from_be_bytes([header[3], header[4]]) as i32);
+        cmd.set_opaque_mut(i32::from_be_bytes([header[5], header[6], header[7], header[8]]));
+        cmd.set_flag_ref(i32::from_be_bytes([header[9], header[10], header[11], header[12]]));
 
-        let remark = Self::read_str(header_buffer, false, header_len)?;
-
-        // HashMap<String, String> extFields
-        if header_buffer.remaining() < LENGTH_FIELD_LEN {
-            return Err(decoding_error(LENGTH_FIELD_LEN, header_buffer.remaining()));
+        let mut cursor = FIXED_HEADER_LEN;
+        if header.len() - cursor < LENGTH_FIELD_LEN {
+            return Err(decoding_error(LENGTH_FIELD_LEN, header.len() - cursor));
         }
+        let remark_length = u32::from_be_bytes([
+            header[cursor],
+            header[cursor + 1],
+            header[cursor + 2],
+            header[cursor + 3],
+        ]) as usize;
+        cursor += LENGTH_FIELD_LEN;
+        if remark_length > header.len() - cursor {
+            return Err(decoding_error(remark_length, header.len() - cursor));
+        }
+        let remark = if remark_length == 0 {
+            None
+        } else {
+            let end = cursor + remark_length;
+            let value =
+                CheetahString::try_copy_from_bytes(header.slice(cursor..end)).map_err(|error| error.into_parts().1)?;
+            cursor = end;
+            Some(value)
+        };
 
-        let ext_fields_length = header_buffer.get_i32();
+        if header.len() - cursor < LENGTH_FIELD_LEN {
+            return Err(decoding_error(LENGTH_FIELD_LEN, header.len() - cursor));
+        }
+        let ext_fields_length = i32::from_be_bytes([
+            header[cursor],
+            header[cursor + 1],
+            header[cursor + 2],
+            header[cursor + 3],
+        ]);
+        cursor += LENGTH_FIELD_LEN;
         let payload = if ext_fields_length > 0 {
             let ext_fields_length = ext_fields_length as usize;
-            if ext_fields_length > header_len {
-                return Err(decoding_error(ext_fields_length, header_len));
+            if ext_fields_length > header.len() - cursor {
+                return Err(decoding_error(ext_fields_length, header.len() - cursor));
             }
-            if ext_fields_length > header_buffer.remaining() {
-                return Err(decoding_error(ext_fields_length, header_buffer.remaining()));
-            }
-            header_buffer.split_to(ext_fields_length).freeze()
+            let end = cursor + ext_fields_length;
+            let payload = header.slice(cursor..end);
+            cursor = end;
+            payload
         } else {
             Bytes::new()
         };
-        if header_buffer.has_remaining() {
-            return Err(trailing_header_error(header_buffer.remaining()));
+        if cursor != header.len() {
+            return Err(trailing_header_error(header.len() - cursor));
         }
-        let ext = BinaryHeaderFields::new(payload)?;
 
-        Ok(cmd.set_remark_option(remark).set_binary_ext_fields(ext))
+        let ext = BinaryHeaderFields::new(payload)?;
+        cmd.set_remark_option_mut(remark);
+        cmd.set_binary_ext_fields_ref(ext);
+        Ok(cmd)
     }
 
     /// Optimized map deserialization with capacity hint and better error handling
@@ -618,5 +687,35 @@ mod tests {
         let header_len = buf.len();
 
         assert!(RocketMQSerializable::rocket_mq_protocol_decode(&mut buf, header_len).is_err());
+    }
+
+    #[test]
+    fn bytes_decoder_preserves_remark_and_extension_fields() {
+        let mut buf = BytesMut::new();
+        buf.put_i16(10);
+        buf.put_u8(LanguageCode::RUST.get_code());
+        buf.put_i16(501);
+        buf.put_i32(7);
+        buf.put_i32(1);
+        RocketMQSerializable::write_str(&mut buf, false, "remark");
+        let ext_length_offset = buf.len();
+        buf.put_i32(0);
+        let ext_start = buf.len();
+        buf.put_u16(3);
+        buf.extend_from_slice(b"key");
+        buf.put_i32(5);
+        buf.extend_from_slice(b"value");
+        let ext_length = (buf.len() - ext_start) as i32;
+        buf[ext_length_offset..ext_length_offset + 4].copy_from_slice(&ext_length.to_be_bytes());
+
+        let command = RocketMQSerializable::rocket_mq_protocol_decode_bytes(buf.freeze()).unwrap();
+
+        assert_eq!(command.code(), 10);
+        assert_eq!(command.language(), LanguageCode::RUST);
+        assert_eq!(command.version(), 501);
+        assert_eq!(command.opaque(), 7);
+        assert_eq!(command.flag(), 1);
+        assert_eq!(command.remark().map(CheetahString::as_str), Some("remark"));
+        assert_eq!(command.ext_fields().unwrap().get("key").unwrap(), "value");
     }
 }

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -731,6 +731,100 @@ fn typed_schemas_preserve_java_send_fast_contracts() {
     assert_eq!(fast_response.to_map(), Some(typed_response_map));
 }
 
+fn assert_send_numeric_overflow_is_rejected<T>(base: &HeaderMap, cases: &[(&'static str, &'static str)])
+where
+    T: HeaderCodec + FromMap + std::fmt::Debug,
+{
+    for &(key, value) in cases {
+        let mut overflow = base.clone();
+        overflow.insert(key.into(), value.into());
+
+        let error = <T as HeaderCodec>::decode_from_map(&overflow).unwrap_err();
+        assert!(
+            matches!(error, HeaderCodecError::InvalidValue { key: actual, .. } if actual == key),
+            "{key} must reject a value above its Java/Rust signed limit: {error}"
+        );
+        assert!(
+            <T as FromMap>::from(&overflow).is_err(),
+            "the legacy adapter must reject the same overflow for {key}"
+        );
+    }
+}
+
+#[test]
+fn send_headers_accept_signed_maxima_and_reject_limit_plus_one() {
+    let v1 = SendMessageRequestHeader {
+        producer_group: "producer-a".into(),
+        topic: "topic-a".into(),
+        default_topic: "TBW102".into(),
+        default_topic_queue_nums: i32::MAX,
+        queue_id: i32::MAX,
+        sys_flag: i32::MAX,
+        born_timestamp: i64::MAX,
+        flag: i32::MAX,
+        properties: None,
+        reconsume_times: Some(i32::MAX),
+        unit_mode: None,
+        batch: None,
+        max_reconsume_times: Some(i32::MAX),
+        topic_request_header: None,
+    };
+    let v1_map = v1.to_map().unwrap();
+    let decoded_v1 = <SendMessageRequestHeader as HeaderCodec>::decode_from_map(&v1_map).unwrap();
+    assert_eq!(decoded_v1.to_map(), Some(v1_map.clone()));
+    let mut v1_binary = BytesMut::new();
+    CommandCustomHeader::encode_direct_binary(&v1, &mut v1_binary).unwrap();
+    assert!(!v1_binary.is_empty());
+    assert_send_numeric_overflow_is_rejected::<SendMessageRequestHeader>(
+        &v1_map,
+        &[
+            ("defaultTopicQueueNums", "2147483648"),
+            ("queueId", "2147483648"),
+            ("sysFlag", "2147483648"),
+            ("bornTimestamp", "9223372036854775808"),
+            ("flag", "2147483648"),
+            ("reconsumeTimes", "2147483648"),
+            ("maxReconsumeTimes", "2147483648"),
+        ],
+    );
+
+    let v2 = SendMessageRequestHeaderV2 {
+        a: "producer-a".into(),
+        b: "topic-a".into(),
+        c: "TBW102".into(),
+        d: i32::MAX,
+        e: i32::MAX,
+        f: i32::MAX,
+        g: i64::MAX,
+        h: i32::MAX,
+        i: None,
+        j: Some(i32::MAX),
+        k: None,
+        l: Some(i32::MAX),
+        m: None,
+        n: None,
+        topic_request_header: None,
+    };
+    let v2_map = v2.to_map().unwrap();
+    let decoded_v2 = <SendMessageRequestHeaderV2 as HeaderCodec>::decode_from_map(&v2_map).unwrap();
+    assert_eq!(decoded_v2.to_map(), Some(v2_map.clone()));
+    let mut v2_binary = BytesMut::new();
+    CommandCustomHeader::encode_direct_binary(&v2, &mut v2_binary).unwrap();
+    assert!(!v2_binary.is_empty());
+    assert_send_numeric_overflow_is_rejected::<SendMessageRequestHeaderV2>(
+        &v2_map,
+        &[
+            ("d", "2147483648"),
+            ("e", "2147483648"),
+            ("f", "2147483648"),
+            ("g", "9223372036854775808"),
+            ("h", "2147483648"),
+            ("j", "2147483648"),
+            ("l", "2147483648"),
+        ],
+    );
+}
+
 #[test]
 fn unsigned_fast_header_fields_enforce_inferred_java_ranges() {
     let request = PullMessageRequestHeader {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9061

### Brief Description

- add a restricted zero-copy decoder for canonical JSON remoting headers, with the existing general parser retained as the compatibility fallback
- preserve validated ROCKETMQ and JSON extension fields as lazy immutable views and share materialized compatibility maps across clones
- reduce typed source scanning, UTF-8 validation, frame splitting, capacity calculations, and temporary allocations on request-header hot paths
- align Criterion lifecycle boundaries with the pinned Java JMH harness and add signed numeric limit coverage for send request headers
- preserve Java wire parity, malformed-input rejection, collision behavior, existing module layout, and Rust-type-driven metadata without adding production `java_type`

Formal same-machine release evidence passes PERF-01 through PERF-09. Aggregate speedups are 4.039x over hardened V2, 1.669x over the Java production path, and 1.291x on the Java fast-codec subset. The worst Tier-1 speedup is 1.008x. Raw `.text` and artifact growth are 2.997% and 2.801% respectively.

### How Did You Test This Change?

- `python scripts/request-header-codec/compare_performance.py --evidence target/request-header-codec-perf/release-a5cff88c-20260807 --gates scripts/request-header-codec/perf-gates.json` (`releasePass: true`)
- `cargo fmt -p rocketmq-macros -p rocketmq-protocol -- --check`
- `cargo test -p rocketmq-macros` (13 passed)
- `cargo test -p rocketmq-protocol --all-features` (1,464 library tests plus integration, UI, and doc tests passed)
- `cargo clippy -p rocketmq-macros --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-macros -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings -A deprecated`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `scripts/check-agents-routing.ps1`
- `git diff --check`

The full workspace `cargo fmt --all -- --check` is blocked on this Windows checkout by OS error 206. The full workspace Clippy command is blocked by pre-existing `cheetah-string` deprecations and a pre-existing useless conversion in `rocketmq-model`; the affected-package Clippy run above found no additional warnings. The standalone `rocketmq-example` Clippy command is independently blocked by its existing `cheetah-string` 2.1/3.0 type split in `producer/transaction_send.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved RocketMQ command encoding and decoding efficiency through optimized binary and JSON processing paths.
  * Reduced unnecessary allocations and improved handling of reusable buffers and cached extension fields.
  * Added fast paths for common ASCII and canonical JSON content.

* **Reliability**
  * Strengthened validation for malformed, truncated, oversized, duplicate, or invalidly encoded headers.
  * Improved support for JSON headers across Rust and Java layouts, including escaped and extension fields.

* **Testing**
  * Added coverage for numeric boundaries, round-trip encoding, malformed input, and direct binary serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->