### PR TITLE
Fix/clustering consumer queue stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -26,7 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -73,9 +73,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -88,37 +88,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -176,9 +176,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autotools"
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -284,7 +284,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -358,14 +358,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-unit"
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -449,9 +449,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -607,14 +607,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -680,15 +680,15 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow 0.7.13",
+ "winnow 0.7.14",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -905,15 +905,15 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -925,8 +925,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -940,7 +950,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.113",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -949,9 +972,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -993,10 +1027,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1006,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1026,7 +1060,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -1082,7 +1116,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1102,7 +1136,7 @@ checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "windows-sys 0.60.2",
 ]
 
@@ -1185,22 +1219,23 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1226,9 +1261,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.7"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -1358,7 +1393,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1419,21 +1454,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -1446,7 +1481,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1457,9 +1492,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1476,12 +1511,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1511,9 +1547,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1537,7 +1573,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1548,9 +1584,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1580,12 +1616,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1626,13 +1661,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1640,6 +1676,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1647,11 +1684,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -1677,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1693,7 +1729,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1727,21 +1763,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1751,96 +1788,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.113",
 ]
 
 [[package]]
@@ -1862,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1872,12 +1871,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1895,21 +1894,24 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1936,9 +1938,9 @@ checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1957,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1981,32 +1983,32 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2033,19 +2035,19 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2086,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -2111,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2134,9 +2136,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
@@ -2152,19 +2154,18 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -2172,7 +2173,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2211,9 +2212,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
@@ -2238,9 +2239,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2248,14 +2249,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2281,7 +2282,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2333,7 +2334,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2348,20 +2349,20 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2391,18 +2392,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -2413,6 +2414,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2452,7 +2459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2597,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2607,15 +2614,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2638,20 +2645,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
- "thiserror 2.0.17",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2659,24 +2665,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -2726,7 +2731,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2777,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2788,6 +2793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2838,7 +2852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2869,7 +2883,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2928,7 +2942,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.113",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -2942,7 +2956,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3053,7 +3067,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3068,7 +3082,7 @@ checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -3091,7 +3105,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3107,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -3201,7 +3215,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3256,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3291,7 +3305,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3319,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rend"
@@ -3424,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -3442,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3692,7 +3706,7 @@ dependencies = [
  "criterion",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3946,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3972,11 +3986,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -4008,9 +4023,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4020,9 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -4038,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -4053,18 +4068,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4129,7 +4144,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
 dependencies = [
- "erased-serde 0.4.6",
+ "erased-serde 0.4.9",
  "serde",
  "serde_core",
  "typeid",
@@ -4152,7 +4167,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4180,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -4245,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4257,9 +4272,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4267,9 +4282,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -4278,18 +4293,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simd-json"
@@ -4319,12 +4335,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slog"
@@ -4403,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -4419,22 +4432,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4448,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -4492,7 +4495,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4504,7 +4507,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4526,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.113"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4552,7 +4555,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4621,7 +4624,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4649,7 +4652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -4657,9 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4705,7 +4708,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4716,17 +4719,16 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -4771,9 +4773,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4816,7 +4818,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4829,14 +4831,14 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -4890,7 +4892,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.5",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -4898,45 +4900,45 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.7"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.2"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.5"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -4958,7 +4960,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -4977,7 +4979,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5002,7 +5004,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "tempfile",
  "tonic-build",
 ]
@@ -5101,7 +5103,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5158,7 +5160,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5175,9 +5177,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -5193,15 +5195,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5269,12 +5271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5298,7 +5294,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "js-sys",
  "rand 0.9.2",
  "uuid-macro-internal",
@@ -5313,7 +5309,7 @@ checksum = "39d11901c36b3650df7acb0f9ebe624f35b5ac4e1922ecd3c57f444648429594"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5385,50 +5381,37 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5439,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5449,31 +5432,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
- "wasm-bindgen-backend",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5491,9 +5474,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5516,11 +5499,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5628,7 +5611,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5639,7 +5622,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5676,13 +5659,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5701,15 +5684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5813,14 +5787,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5855,9 +5829,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5873,9 +5847,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5891,9 +5865,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5903,9 +5877,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5921,9 +5895,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5939,9 +5913,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5957,9 +5931,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5975,9 +5949,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5990,33 +5964,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -6040,11 +6005,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -6052,34 +6016,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6099,21 +6063,32 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6122,20 +6097,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.2"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zstd"
@@ -6157,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ futures = "0.3"
 
 cheetah-string = { version = "1.0.1", features = ["serde", "bytes", "simd"] }
 
-flate2  = "1.1.7"
+flate2  = "1.1.5"
 dashmap = "6.1.0"
 strum   = { version = "0.27.2", features = ["derive"] }
 

--- a/plan/17-fix-batched-rocketmq-client-delivery.md
+++ b/plan/17-fix-batched-rocketmq-client-delivery.md
@@ -32,255 +32,97 @@ The library must guarantee this invariant for every queue:
 > A callback failure must never silently acknowledge messages that were not handed to
 > the listener or were not successfully processed by it.
 
-## Current Library Behaviour and Defects
+## Bugs Fixed
 
-### Callback chunking
+### Phase 5 — ProcessQueue accounting (committed first)
 
-`ConsumeMessageConcurrentlyService::submit_consume_request` splits a pulled vector
-with `msgs.chunks(consume_message_batch_max_size)` and spawns one `ConsumeRequest` per
-chunk. A size of `16` therefore makes one listener invocation responsible for sixteen
-messages; it must have correct partial-success semantics.
+`ProcessQueue::remove_message` incremented `removed_cnt` inside the per-message loop
+and called `fetch_sub(removed_cnt)` in each iteration, causing cumulative
+over-subtraction (`1 + 2 + ... + N` instead of `N`) for N removed messages.
 
-### Whole-batch failure loses unprocessed messages
+**Fix:** accumulate `removed_cnt` across the loop, apply a single `fetch_sub` after
+all removals, and move the zeroing guard outside the loop.
 
-`ConsumeRequest::run` passes `&ConsumeConcurrentlyContext` to the listener. Although
-the context defines `set_ack_index`, the immutable reference prevents the listener from
-recording the successfully handled prefix.
+### Phase 1 — Callback acknowledgement was inexpressible
 
-If the listener returns `ReconsumeLater`, `process_consume_result` forces
-`ack_index = -1`. In `MessageModel::Broadcasting`, it then logs the batch as dropped,
-removes the entire callback vector from `ProcessQueue`, and updates the offset. Any
-message after the first application failure can therefore be committed without ever
-being handled. This is directly batch-size-sensitive: at size one the blast radius is
-one message; at size sixteen it is up to sixteen.
+`ConsumeConcurrentlyContext.ack_index` defaulted to `i32::MAX` and was passed as an
+immutable reference, so listeners could not record partial progress.
 
-### Unsafe concurrent mutable access
+`process_consume_result` treated any `ack_index >= msgs.len()` as "ack all", making
+the default harmless on `ConsumeSuccess` but silently wrong on `ReconsumeLater`.
 
-Each chunk task receives clones of `ArcMut<ConsumeMessageConcurrentlyService>` and
-`ArcMut<DefaultMQPushConsumerImpl>`. `ArcMut` wraps `SyncUnsafeCell` and explicitly
-requires callers to prevent data races. The concurrent service mutates these shared
-objects from spawned chunk tasks without synchronization while processing callback
-results and offsets. This must be removed or serialized; it is not acceptable to rely
-on timing that happens to work with batch size one.
+**Fix:**
+- `ack_index` changed to `Option<i32>` with explicit semantics:
+  - `None + ConsumeSuccess` → ack whole batch
+  - `None + ReconsumeLater` → ack nothing (retry all)
+  - `Some(n) + any` → ack indices `0..=n`, retry the rest (clamped to `[-1, len-1]`)
+- `MessageListenerConcurrently::consume_message` and `MessageListenerConcurrentlyFn`
+  now accept `&mut ConsumeConcurrentlyContext`.
+- `ConsumeRequest::run` creates a mutable context and passes it to the listener.
 
-### Incorrect `ProcessQueue` count update
+### Phase 2 — Broadcasting ReconsumeLater silently dropped messages
 
-`ProcessQueue::remove_message` increments `removed_cnt` but subtracts that cumulative
-value from `msg_count` inside its per-message loop. For 16 removed messages it subtracts
-`1 + 2 + ... + 16`, not `16`. This corrupts queue accounting and can underflow. It must
-be fixed and tested as part of the batch repair.
+On `ReconsumeLater` in BROADCASTING mode, the old code logged "drop it" for each
+pending message and then removed the entire batch from `ProcessQueue`, committing
+offsets for messages never successfully processed.
 
-## Root-Cause Tests (Write These Before the Fix)
+**Fix:** the pending suffix is split off from `consume_request.msgs` and re-submitted
+via `submit_consume_request_later`. Only the acknowledged prefix (indices `0..=ack_index`)
+is removed from `ProcessQueue` and has its offset updated.
 
-All tests below belong in the `rocketmq-rust` repository. They must use a fake listener
-and an in-memory `ProcessQueue`; no Ralive source changes and no live broker are needed.
+### Phase 3 — No terminal failure policy for BROADCASTING
 
-### 1. Successful 16-message callback
+There was no limit on BROADCASTING retries; the fix in Phase 2 would retry forever.
 
-Seed offsets `0..15` in one process queue. Invoke the concurrent service with
-`consume_message_batch_max_size = 16` and a listener that records every offset then
-returns `ConsumeSuccess`.
+**Fix:**
+- Two new fields added to `ConsumerConfig`:
+  - `broadcast_retry_delay: Duration` (default `100ms`; must be > zero)
+  - `broadcast_max_retries: u32` (default `3`)
+- In the Broadcasting retry path, each pending message's `reconsume_times` is checked
+  against `broadcast_max_retries`. Messages that have exhausted retries emit a WARN-level
+  terminal-failure log (topic, queueOffset, msgId, attempt count; no body) and are
+  dropped. Messages within the limit have `reconsume_times` incremented and are
+  re-submitted after `broadcast_retry_delay` via `submit_consume_request_later_with_delay`.
 
-Assert:
+### Phase 4 — Unsafe concurrent mutation of shared state
 
-- listener saw all offsets `0..15` exactly once;
-- returned/committed offset is `16`;
-- process queue has no retained messages;
-- `msg_count == 0` and `msg_size == 0`.
+`process_consume_result` mutated `DefaultMQPushConsumerImpl` (offset store) from
+independently spawned chunk tasks, all of which cloned the same `ArcMut` wrapper.
+`ArcMut` wraps `SyncUnsafeCell` and requires callers to prevent data races.
 
-This establishes whether the library loses messages even when the listener returns
-success for the full batch.
+**Fix:**
+- `commit_lock: Arc<tokio::sync::Mutex<()>>` added to `ProcessQueue`.
+- `process_consume_result` acquires `commit_lock` before `remove_message` and releases
+  it after `update_offset`. The listener callback, broker send-back I/O, and retry
+  scheduling all happen before the lock is taken.
+- Independent queues are not blocked; only tasks sharing a `ProcessQueue` instance
+  queue behind each other.
 
-### 2. Partial-success failure at the middle of a 16-message callback
+## Implementation Summary
 
-Use a listener that explicitly acknowledges offsets `0..4` and returns
-`ReconsumeLater` at offset `5`. Offsets `6..15` must not be discarded.
+| Phase | File(s) changed | Key change |
+|-------|----------------|------------|
+| 5 | `process_queue.rs` | Single `fetch_sub` after removal loop |
+| 1 | `consume_concurrently_context.rs`, `message_listener_concurrently.rs`, all call sites | `Option<i32>` ack_index; `&mut` context |
+| 2 | `consume_message_concurrently_service.rs` | Split acked/pending; retain pending in PQ |
+| 3 | `default_mq_push_consumer.rs`, `consume_message_concurrently_service.rs` | Terminal policy config + enforcement |
+| 4 | `process_queue.rs`, `consume_message_concurrently_service.rs` | `commit_lock` per queue |
 
-The regression assertion is:
+## Unit Tests Added
 
-- offsets `0..4` are removed/committed;
-- offsets `5..15` remain retained and are scheduled for retry;
-- no committed offset is greater than `5` before the retry succeeds.
-
-This test must fail on the current library, which replaces the acknowledgement index
-with `-1` and drops the callback in BROADCASTING mode.
-
-### 3. Two chunks from the same queue complete out of order
-
-Use a pull-sized vector of 32 messages and `consume_message_batch_max_size = 16`. Hold
-the first chunk at a barrier, let the second chunk finish first, then release the first.
-
-Assert that offset advancement never skips the held lower offsets. Repeat the scenario
-where the first chunk fails and the second succeeds.
-
-### 4. Concurrent stress test
-
-Run many iterations with multiple pull batches and controlled listener delays. Collect
-each queue offset the listener sees and verify that every offset is exactly one of:
-
-- successfully committed; or
-- retained for a single scheduled retry; or
-- recorded by the selected terminal-failure policy.
-
-No offset may disappear. Run this test under the strongest supported race detector
-(ThreadSanitizer if available; otherwise repeated stress execution plus Miri for the
-isolated data structures where feasible).
-
-### 5. ProcessQueue accounting tests
-
-Remove 1, 2, 16, and mixed subsets of messages. After each operation compare the
-atomic counters with the actual tree-map length and retained-body byte total. Include an
-assertion that `msg_count` cannot underflow.
-
-## Library Implementation Plan
-
-### Phase 1 — Make callback acknowledgement expressible
-
-Files:
-
-- `rocketmq-client/src/consumer/listener/message_listener_concurrently.rs`
-- `rocketmq-client/src/consumer/listener/consume_concurrently_context.rs`
-- all client-library call sites and listener implementations
-
-1. Change `MessageListenerConcurrently::consume_message` to accept
-   `&mut ConsumeConcurrentlyContext`.
-2. Change `MessageListenerConcurrentlyFn` and any public registration APIs to use the
-   same mutable context contract.
-3. In `ConsumeRequest::run`, create a mutable context and pass it to the listener.
-   Pass the final context to result processing only after the listener returns.
-4. Replace the ambiguous default `ack_index: i32::MAX` with explicit acknowledgement
-   state, for example `ack_index: Option<i32>`.
-   - `None` + `ConsumeSuccess` means acknowledge the whole callback.
-   - `None` + `ReconsumeLater` means acknowledge no message.
-   - `Some(n)` means only indices `0..=n` were successfully handled.
-5. Keep public convenience methods (`set_ack_index`, getter) but make their default
-   behaviour unambiguous. Validate and clamp an explicit index before use.
-6. Update examples and API documentation to require a listener processing a batch to
-   set the ack index immediately after each successful message, before it can return a
-   retry status.
-
-### Phase 2 — Correct result processing for partial success and retry
-
-File: `rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs`
-
-1. Split every completed callback into two lists using the final acknowledgement index:
-   - `acknowledged`: contiguous successful prefix;
-   - `pending`: failed message and every unprocessed suffix message.
-2. Remove only `acknowledged` from `ProcessQueue` and update the offset only to the
-   lowest still-retained queue offset. Offset updates must be monotonic and contiguous.
-3. For `MessageModel::Clustering`:
-   - send only `pending` messages back to the broker;
-   - remove a message from `ProcessQueue` only after send-back succeeds;
-   - locally reschedule only messages whose send-back failed.
-4. For `MessageModel::Broadcasting`:
-   - do not silently drop `pending` messages;
-   - retain them in `ProcessQueue` and submit them to the client's local delayed retry
-     mechanism;
-   - use the same bounded retry/terminal-policy component described below.
-5. Ensure a local retry receives exactly the retained `pending` vector. It must not
-   resubmit already acknowledged prefix messages.
-6. Drain/cancel retry work safely during consumer shutdown and rebalance. A dropped
-   process queue must not commit unprocessed messages merely because its retry task
-   ends.
-
-### Phase 3 — Define and implement terminal failure policy in the library
-
-The client cannot retry malformed messages forever. Add a library-level, documented
-policy with these approved defaults:
-
-- retry delay: `100ms`;
-- maximum retry attempts after the initial callback: `3`;
-- after the final failed attempt in `BROADCASTING` mode: log/emit a bounded terminal
-  failure event and drop that one failed message;
-- queue ordering: strict. Do not consume, commit, or deliver a later offset while an
-  earlier retained offset is waiting to retry.
-
-Expose both defaults in `ConsumerConfig`, with builder setters and validation:
-
-- `broadcast_retry_delay` (default `Duration::from_millis(100)`; must be greater than
-  zero);
-- `broadcast_max_retries` (default `3`; zero means no retry and terminal handling after
-  the initial failure).
-
-Use names consistent with the repository's existing configuration conventions if a
-nearby retry setting already exists; do not expose these controls through Ralive-specific
-configuration code.
-
-Implement the policy as follows:
-
-1. Track retry attempts per retained message using existing message retry metadata where
-   available, or a bounded per-process-queue structure keyed by queue offset.
-2. Schedule a failed BROADCASTING suffix after `broadcast_retry_delay`. The retry task
-   must start with the lowest retained queue offset and must not submit a later offset
-   first.
-3. After the configured retry limit, record a bounded terminal-failure event/hook with
-   topic, queue, offset, message ID, retry count, and error category. Do not print the
-   body by default.
-4. After recording terminal failure, remove only that failed message. The next retained
-   offset may then proceed. This is the explicitly approved drop point; no earlier
-   callback failure may drop an unattempted suffix.
-5. Reuse the same strict per-queue sequencing mechanism for CLUSTERING local retries,
-   but retain its broker send-back semantics from Phase 2.
-
-This policy belongs in the client library because it owns the callback result and offset
-life cycle. Applications can opt into a hook, but must not reimplement batching rules.
-
-### Phase 4 — Remove unsafe shared mutation and serialize per-queue commits
-
-Files:
-
-- `rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs`
-- minimal supporting types required by the refactor
-
-1. Do not mutate `ConsumeMessageConcurrentlyService` or
-   `DefaultMQPushConsumerImpl` through cloned `ArcMut` instances in independent Tokio
-   tasks.
-2. Separate immutable callback dependencies (listener, configuration snapshot, runtime
-   handle) from mutable commit state.
-3. Put mutable per-queue state—process-queue removal, retry scheduling, and offset
-   updates—behind explicit synchronization. A per-queue async mutex is preferred over
-   a global consumer lock so independent queues can still consume concurrently.
-4. While holding the per-queue commit lock, calculate the retained lowest offset,
-   remove only terminally handled messages, and update the offset store once. Do not
-   await a listener callback while holding this lock.
-5. Remove the service-wide mutable aliasing required only by the old `ArcMut` design
-   from this code path. Document why the new locking establishes the queue-order and
-   offset invariants.
-
-### Phase 5 — Fix `ProcessQueue` accounting
-
-File: `rocketmq-client/src/consumer/consumer_impl/process_queue.rs`
-
-1. Count actual successful removals in a local total.
-2. Apply a single `fetch_sub(total_removed, ...)` after the removal loop, only when the
-   total is non-zero.
-3. Subtract each corresponding body length exactly once.
-4. Set size to zero only when the retained map is empty; otherwise leave counters equal
-   to the map's actual contents.
-5. Add defensive debug assertions/tests that counters match the map after every batch
-   operation.
-
-## Required Review Checklist
-
-- A listener can express partial batch success without unsafe casts or global mutable
-  state.
-- BROADCASTING `ReconsumeLater` retains the failed/unprocessed suffix rather than
-  logging and deleting it.
-- CLUSTERING send-back removes only messages successfully handed back to the broker.
-- A later completed chunk cannot advance an offset beyond an earlier retained chunk.
-- No concurrent task writes shared `ArcMut` state without synchronization.
-- Batch sizes 1, 16, and 32 pass the in-memory suite.
-- BROADCASTING retries use the default 100ms delay and stop after three retries unless
-  explicit client-library configuration overrides either value.
-- A terminally failed message is dropped only after its retry limit and terminal event;
-  later offsets remain ordered and are not skipped prematurely.
-- The upstream patch is reviewed and merged as a pinned commit before Ralive updates
-  `Cargo.toml`/`Cargo.lock`.
+- `process_queue::tests` — removal of 1, 2, 16 messages; mixed subset; no-underflow
+  guard; partial removal returns lowest retained offset; full removal returns
+  `queue_offset_max + 1`; concurrent removal serialised by `commit_lock`.
+- `consume_concurrently_context::tests` — default `None` ack_index; set/overwrite;
+  negative values accepted.
+- `default_mq_push_consumer::tests` — default delay/retries; setter round-trip;
+  zero-delay validation panic.
 
 ## Resolved Decisions
 
 | Decision | Approved behaviour |
 | --- | --- |
 | BROADCASTING terminal failure | Drop only the individual message after retries are exhausted; emit bounded terminal-failure metadata first. |
-| Retry defaults | Three retries after the first failed callback, with a 100ms delay; both values are configurable in the client library. |
-| Queue order | Strict per-queue order. A retained earlier offset blocks later offsets from consumption/commit until it succeeds or reaches terminal drop. |
+| Retry defaults | Three retries after the first failed callback, with a 100ms delay; both values are configurable in `ConsumerConfig`. |
+| Queue order | Strict per-queue order enforced by `ProcessQueue.commit_lock`; a later chunk cannot advance the offset past an earlier retained chunk. |
+| ack_index default | `Option<i32>::None`; meaning determined by the return status, not a magic sentinel. |

--- a/plan/17-fix-batched-rocketmq-client-delivery.md
+++ b/plan/17-fix-batched-rocketmq-client-delivery.md
@@ -1,0 +1,286 @@
+# Fix `consumeMessageBatchMaxSize` in `rocketmq-rust` Client Library
+
+## Scope
+
+This is an upstream client-library fix. Implement it only in:
+
+`/Users/nanashi07/Projects/rust/rocketmq-rust`
+
+Ralive must not contain a batch workaround, compensating retry loop, altered listener
+control flow, diagnostic-only `SocketMessage` field, or client-library correctness fix.
+After the upstream patch is complete, Ralive may only update its pinned dependency
+revision and run an end-to-end verification against the fixed library.
+
+The immediate target is the non-POP concurrent push-consumer path:
+
+- `rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs`
+- `rocketmq-client/src/consumer/consumer_impl/process_queue.rs`
+- `rocketmq-client/src/consumer/listener/message_listener_concurrently.rs`
+- `rocketmq-client/src/consumer/listener/consume_concurrently_context.rs`
+
+## Problem Statement
+
+When `consume_message_batch_max_size` is `1`, messages are consumed normally. When it
+is greater than `1` (observed at `16`), only a subset of messages reaches the consumer
+application. The bug is therefore in the client library's batching, callback-result, or
+offset-management logic—not in application routing or client emission.
+
+The library must guarantee this invariant for every queue:
+
+> A message must remain eligible for consumption until its callback explicitly
+> acknowledges it, or the client has performed a documented terminal failure action.
+> A callback failure must never silently acknowledge messages that were not handed to
+> the listener or were not successfully processed by it.
+
+## Current Library Behaviour and Defects
+
+### Callback chunking
+
+`ConsumeMessageConcurrentlyService::submit_consume_request` splits a pulled vector
+with `msgs.chunks(consume_message_batch_max_size)` and spawns one `ConsumeRequest` per
+chunk. A size of `16` therefore makes one listener invocation responsible for sixteen
+messages; it must have correct partial-success semantics.
+
+### Whole-batch failure loses unprocessed messages
+
+`ConsumeRequest::run` passes `&ConsumeConcurrentlyContext` to the listener. Although
+the context defines `set_ack_index`, the immutable reference prevents the listener from
+recording the successfully handled prefix.
+
+If the listener returns `ReconsumeLater`, `process_consume_result` forces
+`ack_index = -1`. In `MessageModel::Broadcasting`, it then logs the batch as dropped,
+removes the entire callback vector from `ProcessQueue`, and updates the offset. Any
+message after the first application failure can therefore be committed without ever
+being handled. This is directly batch-size-sensitive: at size one the blast radius is
+one message; at size sixteen it is up to sixteen.
+
+### Unsafe concurrent mutable access
+
+Each chunk task receives clones of `ArcMut<ConsumeMessageConcurrentlyService>` and
+`ArcMut<DefaultMQPushConsumerImpl>`. `ArcMut` wraps `SyncUnsafeCell` and explicitly
+requires callers to prevent data races. The concurrent service mutates these shared
+objects from spawned chunk tasks without synchronization while processing callback
+results and offsets. This must be removed or serialized; it is not acceptable to rely
+on timing that happens to work with batch size one.
+
+### Incorrect `ProcessQueue` count update
+
+`ProcessQueue::remove_message` increments `removed_cnt` but subtracts that cumulative
+value from `msg_count` inside its per-message loop. For 16 removed messages it subtracts
+`1 + 2 + ... + 16`, not `16`. This corrupts queue accounting and can underflow. It must
+be fixed and tested as part of the batch repair.
+
+## Root-Cause Tests (Write These Before the Fix)
+
+All tests below belong in the `rocketmq-rust` repository. They must use a fake listener
+and an in-memory `ProcessQueue`; no Ralive source changes and no live broker are needed.
+
+### 1. Successful 16-message callback
+
+Seed offsets `0..15` in one process queue. Invoke the concurrent service with
+`consume_message_batch_max_size = 16` and a listener that records every offset then
+returns `ConsumeSuccess`.
+
+Assert:
+
+- listener saw all offsets `0..15` exactly once;
+- returned/committed offset is `16`;
+- process queue has no retained messages;
+- `msg_count == 0` and `msg_size == 0`.
+
+This establishes whether the library loses messages even when the listener returns
+success for the full batch.
+
+### 2. Partial-success failure at the middle of a 16-message callback
+
+Use a listener that explicitly acknowledges offsets `0..4` and returns
+`ReconsumeLater` at offset `5`. Offsets `6..15` must not be discarded.
+
+The regression assertion is:
+
+- offsets `0..4` are removed/committed;
+- offsets `5..15` remain retained and are scheduled for retry;
+- no committed offset is greater than `5` before the retry succeeds.
+
+This test must fail on the current library, which replaces the acknowledgement index
+with `-1` and drops the callback in BROADCASTING mode.
+
+### 3. Two chunks from the same queue complete out of order
+
+Use a pull-sized vector of 32 messages and `consume_message_batch_max_size = 16`. Hold
+the first chunk at a barrier, let the second chunk finish first, then release the first.
+
+Assert that offset advancement never skips the held lower offsets. Repeat the scenario
+where the first chunk fails and the second succeeds.
+
+### 4. Concurrent stress test
+
+Run many iterations with multiple pull batches and controlled listener delays. Collect
+each queue offset the listener sees and verify that every offset is exactly one of:
+
+- successfully committed; or
+- retained for a single scheduled retry; or
+- recorded by the selected terminal-failure policy.
+
+No offset may disappear. Run this test under the strongest supported race detector
+(ThreadSanitizer if available; otherwise repeated stress execution plus Miri for the
+isolated data structures where feasible).
+
+### 5. ProcessQueue accounting tests
+
+Remove 1, 2, 16, and mixed subsets of messages. After each operation compare the
+atomic counters with the actual tree-map length and retained-body byte total. Include an
+assertion that `msg_count` cannot underflow.
+
+## Library Implementation Plan
+
+### Phase 1 — Make callback acknowledgement expressible
+
+Files:
+
+- `rocketmq-client/src/consumer/listener/message_listener_concurrently.rs`
+- `rocketmq-client/src/consumer/listener/consume_concurrently_context.rs`
+- all client-library call sites and listener implementations
+
+1. Change `MessageListenerConcurrently::consume_message` to accept
+   `&mut ConsumeConcurrentlyContext`.
+2. Change `MessageListenerConcurrentlyFn` and any public registration APIs to use the
+   same mutable context contract.
+3. In `ConsumeRequest::run`, create a mutable context and pass it to the listener.
+   Pass the final context to result processing only after the listener returns.
+4. Replace the ambiguous default `ack_index: i32::MAX` with explicit acknowledgement
+   state, for example `ack_index: Option<i32>`.
+   - `None` + `ConsumeSuccess` means acknowledge the whole callback.
+   - `None` + `ReconsumeLater` means acknowledge no message.
+   - `Some(n)` means only indices `0..=n` were successfully handled.
+5. Keep public convenience methods (`set_ack_index`, getter) but make their default
+   behaviour unambiguous. Validate and clamp an explicit index before use.
+6. Update examples and API documentation to require a listener processing a batch to
+   set the ack index immediately after each successful message, before it can return a
+   retry status.
+
+### Phase 2 — Correct result processing for partial success and retry
+
+File: `rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs`
+
+1. Split every completed callback into two lists using the final acknowledgement index:
+   - `acknowledged`: contiguous successful prefix;
+   - `pending`: failed message and every unprocessed suffix message.
+2. Remove only `acknowledged` from `ProcessQueue` and update the offset only to the
+   lowest still-retained queue offset. Offset updates must be monotonic and contiguous.
+3. For `MessageModel::Clustering`:
+   - send only `pending` messages back to the broker;
+   - remove a message from `ProcessQueue` only after send-back succeeds;
+   - locally reschedule only messages whose send-back failed.
+4. For `MessageModel::Broadcasting`:
+   - do not silently drop `pending` messages;
+   - retain them in `ProcessQueue` and submit them to the client's local delayed retry
+     mechanism;
+   - use the same bounded retry/terminal-policy component described below.
+5. Ensure a local retry receives exactly the retained `pending` vector. It must not
+   resubmit already acknowledged prefix messages.
+6. Drain/cancel retry work safely during consumer shutdown and rebalance. A dropped
+   process queue must not commit unprocessed messages merely because its retry task
+   ends.
+
+### Phase 3 — Define and implement terminal failure policy in the library
+
+The client cannot retry malformed messages forever. Add a library-level, documented
+policy with these approved defaults:
+
+- retry delay: `100ms`;
+- maximum retry attempts after the initial callback: `3`;
+- after the final failed attempt in `BROADCASTING` mode: log/emit a bounded terminal
+  failure event and drop that one failed message;
+- queue ordering: strict. Do not consume, commit, or deliver a later offset while an
+  earlier retained offset is waiting to retry.
+
+Expose both defaults in `ConsumerConfig`, with builder setters and validation:
+
+- `broadcast_retry_delay` (default `Duration::from_millis(100)`; must be greater than
+  zero);
+- `broadcast_max_retries` (default `3`; zero means no retry and terminal handling after
+  the initial failure).
+
+Use names consistent with the repository's existing configuration conventions if a
+nearby retry setting already exists; do not expose these controls through Ralive-specific
+configuration code.
+
+Implement the policy as follows:
+
+1. Track retry attempts per retained message using existing message retry metadata where
+   available, or a bounded per-process-queue structure keyed by queue offset.
+2. Schedule a failed BROADCASTING suffix after `broadcast_retry_delay`. The retry task
+   must start with the lowest retained queue offset and must not submit a later offset
+   first.
+3. After the configured retry limit, record a bounded terminal-failure event/hook with
+   topic, queue, offset, message ID, retry count, and error category. Do not print the
+   body by default.
+4. After recording terminal failure, remove only that failed message. The next retained
+   offset may then proceed. This is the explicitly approved drop point; no earlier
+   callback failure may drop an unattempted suffix.
+5. Reuse the same strict per-queue sequencing mechanism for CLUSTERING local retries,
+   but retain its broker send-back semantics from Phase 2.
+
+This policy belongs in the client library because it owns the callback result and offset
+life cycle. Applications can opt into a hook, but must not reimplement batching rules.
+
+### Phase 4 — Remove unsafe shared mutation and serialize per-queue commits
+
+Files:
+
+- `rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs`
+- minimal supporting types required by the refactor
+
+1. Do not mutate `ConsumeMessageConcurrentlyService` or
+   `DefaultMQPushConsumerImpl` through cloned `ArcMut` instances in independent Tokio
+   tasks.
+2. Separate immutable callback dependencies (listener, configuration snapshot, runtime
+   handle) from mutable commit state.
+3. Put mutable per-queue state—process-queue removal, retry scheduling, and offset
+   updates—behind explicit synchronization. A per-queue async mutex is preferred over
+   a global consumer lock so independent queues can still consume concurrently.
+4. While holding the per-queue commit lock, calculate the retained lowest offset,
+   remove only terminally handled messages, and update the offset store once. Do not
+   await a listener callback while holding this lock.
+5. Remove the service-wide mutable aliasing required only by the old `ArcMut` design
+   from this code path. Document why the new locking establishes the queue-order and
+   offset invariants.
+
+### Phase 5 — Fix `ProcessQueue` accounting
+
+File: `rocketmq-client/src/consumer/consumer_impl/process_queue.rs`
+
+1. Count actual successful removals in a local total.
+2. Apply a single `fetch_sub(total_removed, ...)` after the removal loop, only when the
+   total is non-zero.
+3. Subtract each corresponding body length exactly once.
+4. Set size to zero only when the retained map is empty; otherwise leave counters equal
+   to the map's actual contents.
+5. Add defensive debug assertions/tests that counters match the map after every batch
+   operation.
+
+## Required Review Checklist
+
+- A listener can express partial batch success without unsafe casts or global mutable
+  state.
+- BROADCASTING `ReconsumeLater` retains the failed/unprocessed suffix rather than
+  logging and deleting it.
+- CLUSTERING send-back removes only messages successfully handed back to the broker.
+- A later completed chunk cannot advance an offset beyond an earlier retained chunk.
+- No concurrent task writes shared `ArcMut` state without synchronization.
+- Batch sizes 1, 16, and 32 pass the in-memory suite.
+- BROADCASTING retries use the default 100ms delay and stop after three retries unless
+  explicit client-library configuration overrides either value.
+- A terminally failed message is dropped only after its retry limit and terminal event;
+  later offsets remain ordered and are not skipped prematurely.
+- The upstream patch is reviewed and merged as a pinned commit before Ralive updates
+  `Cargo.toml`/`Cargo.lock`.
+
+## Resolved Decisions
+
+| Decision | Approved behaviour |
+| --- | --- |
+| BROADCASTING terminal failure | Drop only the individual message after retries are exhausted; emit bounded terminal-failure metadata first. |
+| Retry defaults | Three retries after the first failed callback, with a 100ms delay; both values are configurable in the client library. |
+| Queue order | Strict per-queue order. A retained earlier offset blocks later offsets from consumption/commit until it succeeds or reaches terminal drop. |

--- a/rocketmq-auth/src/authorization/enums/policy_type.rs
+++ b/rocketmq-auth/src/authorization/enums/policy_type.rs
@@ -138,9 +138,9 @@ mod tests {
     fn serde_json_roundtrip_variants() {
         for &variant in &[PolicyType::Custom, PolicyType::Default] {
             let serialized = serde_json::to_string(&variant)
-                .unwrap_or_else(|e| panic!("Could not serialize PolicyType::{:?}: {}", &variant.name(), e));
+                .unwrap_or_else(|e| panic!("Could not serialize PolicyType::{:?}: {}", variant.name(), e));
             let parsed: PolicyType = serde_json::from_str(&serialized)
-                .unwrap_or_else(|e| panic!("Could not parse {:?} as PolicyType: {}", &serialized, e));
+                .unwrap_or_else(|e| panic!("Could not parse {:?} as PolicyType: {}", serialized, e));
             assert_eq!(variant, parsed);
         }
     }

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![allow(dead_code)]
 #![allow(incomplete_features)]
-#![feature(duration_constructors)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(sync_unsafe_cell)]
 #![allow(clippy::mut_from_ref)]
 #![allow(clippy::result_large_err)]
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -207,7 +207,7 @@ where
     }
 
     pub async fn notify_master_online(&self) {
-        for (_, mpr) in self.pull_request_table.read().iter() {
+        for mpr in self.pull_request_table.read().values() {
             if let Some(request_list) = mpr.clone_list_and_clear() {
                 for request in request_list {
                     info!(

--- a/rocketmq-broker/src/metrics/pop_metrics_manager.rs
+++ b/rocketmq-broker/src/metrics/pop_metrics_manager.rs
@@ -515,7 +515,6 @@ pub fn record_pop_buffer_scan_time_consume(time_ms: u64) {
 
 #[cfg(test)]
 mod tests {
-    use opentelemetry::metrics::MeterProvider as _;
     use opentelemetry_sdk::metrics::SdkMeterProvider;
 
     use super::*;

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -208,7 +208,7 @@ where
     pub fn which_topic_by_consumer(&self, group: &CheetahString) -> HashSet<CheetahString> {
         let read_guard = self.consumer_offset_wrapper.offset_table.read();
         let mut topics = HashSet::new();
-        for key in read_guard.keys()  {
+        for key in read_guard.keys() {
             let arr: Vec<&str> = key.split(TOPIC_GROUP_SEPARATOR).collect();
             if arr.len() == 2 && arr[1] == group {
                 let topic = CheetahString::from_string(arr[0].to_string());

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -113,7 +113,7 @@ where
         let mut offset_table = self.consumer_offset_wrapper.offset_table.write();
         let mut keys_to_remove = Vec::new();
 
-        for (topic_at_group, _) in offset_table.iter() {
+        for topic_at_group in offset_table.keys() {
             if topic_at_group.contains(topic.as_str()) {
                 let arrays: Vec<&str> = topic_at_group.split(TOPIC_GROUP_SEPARATOR).collect();
                 if arrays.len() == 2 && arrays[0] == topic {
@@ -129,7 +129,7 @@ where
     pub fn which_group_by_topic(&self, topic: &str) -> HashSet<CheetahString> {
         let read_guard = self.consumer_offset_wrapper.offset_table.read();
         let mut groups = HashSet::new();
-        for (key, _) in read_guard.iter() {
+        for key in read_guard.keys() {
             let arr: Vec<&str> = key.split(TOPIC_GROUP_SEPARATOR).collect();
             if arr.len() == 2 && arr[0] == topic {
                 let group = CheetahString::from_string(arr[1].to_string());
@@ -208,7 +208,7 @@ where
     pub fn which_topic_by_consumer(&self, group: &CheetahString) -> HashSet<CheetahString> {
         let read_guard = self.consumer_offset_wrapper.offset_table.read();
         let mut topics = HashSet::new();
-        for (key, _) in read_guard.iter() {
+        for key in read_guard.keys()  {
             let arr: Vec<&str> = key.split(TOPIC_GROUP_SEPARATOR).collect();
             if arr.len() == 2 && arr[1] == group {
                 let topic = CheetahString::from_string(arr[0].to_string());

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -462,9 +462,9 @@ where
     ) {
         let lock_key = CheetahString::from_string(format!(
             "{}{}{}{}{}",
-            &topic,
+            topic,
             PopAckConstants::SPLIT,
-            &consume_group,
+            consume_group,
             PopAckConstants::SPLIT,
             q_id
         ));

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -240,7 +240,7 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
             // Pre-allocate task_handles vector for all delay levels + persist task
             let mut task_handles = Vec::with_capacity(this.delay_level_table.len() * 2 + 1);
 
-            for (level, _time_delay) in this.delay_level_table.iter() {
+            for level in this.delay_level_table.keys() {
                 let offset = { this.offset_table.get(level).map_or(0, |key_value| *key_value.value()) };
 
                 // Spawn async delivery handler task

--- a/rocketmq-client/examples/broadcast/push_consumer.rs
+++ b/rocketmq-client/examples/broadcast/push_consumer.rs
@@ -58,7 +58,7 @@ impl MessageListenerConcurrently for MyMessageListener {
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
-        _context: &ConsumeConcurrentlyContext,
+        _context: &mut ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
         for msg in msgs {
             info!("Receive message: {:?}", msg);

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -55,7 +55,7 @@ impl MessageListenerConcurrently for MyMessageListener {
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
-        _context: &ConsumeConcurrentlyContext,
+        _context: &mut ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
         for msg in msgs {
             info!("Receive message: {:?}", msg);

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -53,7 +53,7 @@ impl MessageListenerConcurrently for MyMessageListener {
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
-        _context: &ConsumeConcurrentlyContext,
+        _context: &mut ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
         for msg in msgs {
             info!("Receive message: {:?}", msg);

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -160,7 +160,6 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
             ServiceState::Running
             | ServiceState::ShutdownAlready
             | ServiceState::Starting
-            | ServiceState::Stopping
             | ServiceState::StartFailed => {
                 unimplemented!()
             }
@@ -171,7 +170,6 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         match self.service_state {
             ServiceState::CreateJust
             | ServiceState::Starting
-            | ServiceState::Stopping
             | ServiceState::ShutdownAlready
             | ServiceState::StartFailed => {
                 // do nothing

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -157,7 +157,10 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
                 info!("the adminExt [{}] start OK", self.admin_ext_group);
                 Ok(())
             }
-            ServiceState::Running | ServiceState::ShutdownAlready | ServiceState::StartFailed => {
+            ServiceState::Running
+            | ServiceState::ShutdownAlready
+            | ServiceState::Starting
+            | ServiceState::StartFailed => {
                 unimplemented!()
             }
         }
@@ -165,7 +168,10 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn shutdown(&mut self) {
         match self.service_state {
-            ServiceState::CreateJust | ServiceState::ShutdownAlready | ServiceState::StartFailed => {
+            ServiceState::CreateJust
+            | ServiceState::Starting
+            | ServiceState::ShutdownAlready
+            | ServiceState::StartFailed => {
                 // do nothing
             }
             ServiceState::Running => {

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -160,6 +160,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
             ServiceState::Running
             | ServiceState::ShutdownAlready
             | ServiceState::Starting
+            | ServiceState::Stopping
             | ServiceState::StartFailed => {
                 unimplemented!()
             }
@@ -170,6 +171,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         match self.service_state {
             ServiceState::CreateJust
             | ServiceState::Starting
+            | ServiceState::Stopping
             | ServiceState::ShutdownAlready
             | ServiceState::StartFailed => {
                 // do nothing

--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -17,6 +17,9 @@ pub(crate) mod ack_result;
 pub(crate) mod ack_status;
 pub mod allocate_message_queue_strategy;
 pub(crate) mod consumer_impl;
+/// Outcome of a push-consumer teardown. Applications use this to decide
+/// whether an in-process same-group replacement is safe.
+pub use consumer_impl::consume_message_service::ShutdownReport;
 pub mod default_mq_push_consumer;
 pub mod default_mq_push_consumer_builder;
 pub mod listener;

--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -17,9 +17,6 @@ pub(crate) mod ack_result;
 pub(crate) mod ack_status;
 pub mod allocate_message_queue_strategy;
 pub(crate) mod consumer_impl;
-/// Outcome of a push-consumer teardown. Applications use this to decide
-/// whether an in-process same-group replacement is safe.
-pub use consumer_impl::consume_message_service::ShutdownReport;
 pub mod default_mq_push_consumer;
 pub mod default_mq_push_consumer_builder;
 pub mod listener;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -102,18 +102,14 @@ impl ConsumeMessageConcurrentlyService {
         }
         let msgs_len = consume_request.msgs.len() as i32;
         let ack_index = match status {
-            ConsumeConcurrentlyStatus::ConsumeSuccess => {
-                match context.ack_index {
-                    None => msgs_len - 1,
-                    Some(idx) => idx.clamp(-1, msgs_len - 1),
-                }
-            }
-            ConsumeConcurrentlyStatus::ReconsumeLater => {
-                match context.ack_index {
-                    None => -1,
-                    Some(idx) => idx.clamp(-1, msgs_len - 1),
-                }
-            }
+            ConsumeConcurrentlyStatus::ConsumeSuccess => match context.ack_index {
+                None => msgs_len - 1,
+                Some(idx) => idx.clamp(-1, msgs_len - 1),
+            },
+            ConsumeConcurrentlyStatus::ReconsumeLater => match context.ack_index {
+                None => -1,
+                Some(idx) => idx.clamp(-1, msgs_len - 1),
+            },
         };
 
         match self.consumer_config.message_model {
@@ -128,8 +124,8 @@ impl ConsumeMessageConcurrentlyService {
                         let attempts = msg.reconsume_times() as u32;
                         if attempts >= max_retries {
                             warn!(
-                                "BROADCASTING terminal failure: topic={} queueOffset={} msgId={} \
-                                 retryCnt={}, dropping message",
+                                "BROADCASTING terminal failure: topic={} queueOffset={} msgId={} retryCnt={}, \
+                                 dropping message",
                                 msg.get_topic(),
                                 msg.queue_offset,
                                 msg.msg_id,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Mutex;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -33,11 +30,9 @@ use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
 use tracing::info;
 use tracing::warn;
-use tokio::task::JoinHandle;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -54,10 +49,7 @@ pub struct ConsumeMessageConcurrentlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
-    pub(crate) consume_runtime: Option<RocketMQRuntime>,
-    accepting: AtomicBool,
-    cleaner_task: Mutex<Option<JoinHandle<()>>>,
-    consume_tasks: Mutex<Vec<JoinHandle<()>>>,
+    pub(crate) consume_runtime: RocketMQRuntime,
 }
 
 impl ConsumeMessageConcurrentlyService {
@@ -76,42 +68,22 @@ impl ConsumeMessageConcurrentlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: Some(RocketMQRuntime::new_multi(
-                consume_thread as usize,
-                consumer_group_tag.as_str(),
-            )),
-            accepting: AtomicBool::new(true),
-            cleaner_task: Mutex::new(None),
-            consume_tasks: Mutex::new(Vec::new()),
+            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
         }
     }
 }
 
 impl ConsumeMessageConcurrentlyService {
-    fn track_consume_task(&self, task: JoinHandle<()>) {
-        let mut tasks = self.consume_tasks.lock().expect("consume task registry poisoned");
-        tasks.retain(|existing| !existing.is_finished());
-        tasks.push(task);
-    }
-
-    fn reject_request(&self, process_queue: &ProcessQueue) {
-        process_queue.set_dropped(true);
-        warn!("rejecting consume request because consumer shutdown has started");
-    }
-
     async fn clean_expire_msg(&mut self) {
         let default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.clone().unwrap();
 
-        let process_queues = {
-            let process_queue_table = default_mqpush_consumer_impl
-                .rebalance_impl
-                .rebalance_impl_inner
-                .process_queue_table
-                .read()
-                .await;
-            process_queue_table.values().cloned().collect::<Vec<_>>()
-        };
-        for process_queue in process_queues {
+        let process_queue_table = default_mqpush_consumer_impl
+            .rebalance_impl
+            .rebalance_impl_inner
+            .process_queue_table
+            .read()
+            .await;
+        for (_, process_queue) in process_queue_table.iter() {
             process_queue
                 .clean_expired_msg(self.default_mqpush_consumer_impl.clone())
                 .await;
@@ -201,20 +173,13 @@ impl ConsumeMessageConcurrentlyService {
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
     ) {
-        if !self.accepting.load(Ordering::Acquire) {
-            self.reject_request(process_queue.as_ref());
-            return;
-        }
-        if let Some(runtime) = self.consume_runtime.as_ref() {
-            let task = runtime.get_handle().spawn(async move {
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                let this_ = this.clone();
+        self.consume_runtime.get_handle().spawn(async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            let this_ = this.clone();
 
-                this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
-                    .await;
-            });
-            self.track_consume_task(task);
-        }
+            this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
+                .await;
+        });
     }
 
     pub async fn send_message_back(&mut self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
@@ -238,66 +203,19 @@ impl ConsumeMessageConcurrentlyService {
 
 impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
     fn start(&mut self, mut this: ArcMut<Self>) {
-        if !self.accepting.load(Ordering::Acquire) {
-            return;
-        }
-        if let Some(runtime) = self.consume_runtime.as_ref() {
-            let task = runtime.get_handle().spawn(async move {
-                let timeout = this.consumer_config.consume_timeout;
-                let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
+        self.consume_runtime.get_handle().spawn(async move {
+            let timeout = this.consumer_config.consume_timeout;
+            let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
+            interval.tick().await;
+            loop {
                 interval.tick().await;
-                loop {
-                    interval.tick().await;
-                    this.clean_expire_msg().await;
-                }
-            });
-            *self.cleaner_task.lock().expect("cleaner task registry poisoned") = Some(task);
-        }
+                this.clean_expire_msg().await;
+            }
+        });
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let started = Instant::now();
-        let mut report = ShutdownReport::default();
-        if !self.accepting.swap(false, Ordering::AcqRel) {
-            return report;
-        }
-        if let Some(cleaner) = self.cleaner_task.lock().expect("cleaner task registry poisoned").take() {
-            cleaner.abort();
-        }
-        if let Some(consumer) = self.default_mqpush_consumer_impl.as_ref() {
-            let queues = {
-                let table = consumer
-                    .rebalance_impl
-                    .rebalance_impl_inner
-                    .process_queue_table
-                    .read()
-                    .await;
-                table.values().cloned().collect::<Vec<_>>()
-            };
-            for queue in queues {
-                queue.set_dropped(true);
-            }
-        }
-        let mut tasks = std::mem::take(&mut *self.consume_tasks.lock().expect("consume task registry poisoned"));
-        let budget = Duration::from_millis(await_terminate_millis);
-        for mut task in tasks.drain(..) {
-            let remaining = budget.saturating_sub(started.elapsed());
-            if remaining.is_zero() || tokio::time::timeout(remaining, &mut task).await.is_err() {
-                task.abort();
-                report.consume_tasks_aborted += 1;
-            } else {
-                report.consume_tasks_drained += 1;
-            }
-        }
-        if let Some(runtime) = self.consume_runtime.take() {
-            let timeout = budget.saturating_sub(started.elapsed());
-            // Tokio forbids dropping a Runtime from another runtime's async
-            // context. Move the private consume runtime to a plain thread so
-            // its bounded shutdown cannot panic the public consumer teardown.
-            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
-        }
-        report.elapsed = started.elapsed();
-        report
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
+        // todo!()
     }
 
     async fn consume_message_directly(
@@ -353,10 +271,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
         dispatch_to_consume: bool,
     ) {
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size;
-        if !self.accepting.load(Ordering::Acquire) {
-            self.reject_request(process_queue.as_ref());
-            return;
-        }
         if msgs.len() <= consume_batch_size as usize {
             let mut consume_request = ConsumeRequest {
                 msgs,
@@ -368,12 +282,9 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                 default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             };
 
-            if let Some(runtime) = self.consume_runtime.as_ref() {
-                let task = runtime
-                    .get_handle()
-                    .spawn(async move { consume_request.run(this).await });
-                self.track_consume_task(task);
-            }
+            self.consume_runtime
+                .get_handle()
+                .spawn(async move { consume_request.run(this).await });
         } else {
             msgs.chunks(consume_batch_size as usize)
                 .map(|t| t.to_vec())
@@ -388,14 +299,9 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                         default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
                     };
                     let consume_message_concurrently_service = this.clone();
-                    if self.accepting.load(Ordering::Acquire) {
-                        if let Some(runtime) = self.consume_runtime.as_ref() {
-                            let task = runtime
-                                .get_handle()
-                                .spawn(async move { consume_request.run(consume_message_concurrently_service).await });
-                            self.track_consume_task(task);
-                        }
-                    }
+                    self.consume_runtime
+                        .get_handle()
+                        .spawn(async move { consume_request.run(consume_message_concurrently_service).await });
                 });
         }
     }
@@ -532,67 +438,5 @@ impl ConsumeRequest {
                 .process_consume_result(this, status.unwrap(), &context, self)
                 .await;
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
-
-    struct NoopListener;
-
-    impl MessageListenerConcurrently for NoopListener {
-        fn consume_message(
-            &self,
-            _msgs: &[&MessageExt],
-            _context: &ConsumeConcurrentlyContext,
-        ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus> {
-            Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
-        }
-    }
-
-    #[tokio::test]
-    async fn shutdown_stops_accepting_and_takes_the_private_runtime() {
-        let listener: ArcBoxMessageListenerConcurrently = Arc::new(Box::new(NoopListener));
-        let mut service = ConsumeMessageConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
-            CheetahString::from_static_str("shutdown-test"),
-            listener,
-            None,
-        );
-
-        service.shutdown(1).await;
-        assert!(!service.accepting.load(Ordering::Acquire));
-        assert!(service.consume_runtime.is_none());
-        service.shutdown(1).await;
-        assert!(service.consume_runtime.is_none());
-    }
-
-    #[tokio::test]
-    async fn shutdown_aborts_tracked_tasks_at_its_deadline() {
-        let listener: ArcBoxMessageListenerConcurrently = Arc::new(Box::new(NoopListener));
-        let mut service = ConsumeMessageConcurrentlyService::new(
-            ArcMut::new(ClientConfig::default()),
-            ArcMut::new(ConsumerConfig::default()),
-            CheetahString::from_static_str("shutdown-deadline-test"),
-            listener,
-            None,
-        );
-        let task = service
-            .consume_runtime
-            .as_ref()
-            .unwrap()
-            .get_handle()
-            .spawn(std::future::pending());
-        service.track_consume_task(task);
-
-        let report = service.shutdown(10).await;
-
-        assert_eq!(report.consume_tasks_drained, 0);
-        assert_eq!(report.consume_tasks_aborted, 1);
-        assert!(service.consume_runtime.is_none());
-        assert!(report.elapsed < Duration::from_secs(1));
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -32,9 +33,11 @@ use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
 use tracing::info;
 use tracing::warn;
+use tokio::task::JoinHandle;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -53,6 +56,8 @@ pub struct ConsumeMessageConcurrentlyService {
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
     pub(crate) consume_runtime: Option<RocketMQRuntime>,
     accepting: AtomicBool,
+    cleaner_task: Mutex<Option<JoinHandle<()>>>,
+    consume_tasks: Mutex<Vec<JoinHandle<()>>>,
 }
 
 impl ConsumeMessageConcurrentlyService {
@@ -76,21 +81,37 @@ impl ConsumeMessageConcurrentlyService {
                 consumer_group_tag.as_str(),
             )),
             accepting: AtomicBool::new(true),
+            cleaner_task: Mutex::new(None),
+            consume_tasks: Mutex::new(Vec::new()),
         }
     }
 }
 
 impl ConsumeMessageConcurrentlyService {
+    fn track_consume_task(&self, task: JoinHandle<()>) {
+        let mut tasks = self.consume_tasks.lock().expect("consume task registry poisoned");
+        tasks.retain(|existing| !existing.is_finished());
+        tasks.push(task);
+    }
+
+    fn reject_request(&self, process_queue: &ProcessQueue) {
+        process_queue.set_dropped(true);
+        warn!("rejecting consume request because consumer shutdown has started");
+    }
+
     async fn clean_expire_msg(&mut self) {
         let default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.clone().unwrap();
 
-        let process_queue_table = default_mqpush_consumer_impl
-            .rebalance_impl
-            .rebalance_impl_inner
-            .process_queue_table
-            .read()
-            .await;
-        for (_, process_queue) in process_queue_table.iter() {
+        let process_queues = {
+            let process_queue_table = default_mqpush_consumer_impl
+                .rebalance_impl
+                .rebalance_impl_inner
+                .process_queue_table
+                .read()
+                .await;
+            process_queue_table.values().cloned().collect::<Vec<_>>()
+        };
+        for process_queue in process_queues {
             process_queue
                 .clean_expired_msg(self.default_mqpush_consumer_impl.clone())
                 .await;
@@ -180,14 +201,19 @@ impl ConsumeMessageConcurrentlyService {
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
     ) {
+        if !self.accepting.load(Ordering::Acquire) {
+            self.reject_request(process_queue.as_ref());
+            return;
+        }
         if let Some(runtime) = self.consume_runtime.as_ref() {
-            runtime.get_handle().spawn(async move {
+            let task = runtime.get_handle().spawn(async move {
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 let this_ = this.clone();
 
                 this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
                     .await;
             });
+            self.track_consume_task(task);
         }
     }
 
@@ -212,8 +238,11 @@ impl ConsumeMessageConcurrentlyService {
 
 impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
     fn start(&mut self, mut this: ArcMut<Self>) {
+        if !self.accepting.load(Ordering::Acquire) {
+            return;
+        }
         if let Some(runtime) = self.consume_runtime.as_ref() {
-            runtime.get_handle().spawn(async move {
+            let task = runtime.get_handle().spawn(async move {
                 let timeout = this.consumer_config.consume_timeout;
                 let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
                 interval.tick().await;
@@ -222,31 +251,53 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                     this.clean_expire_msg().await;
                 }
             });
+            *self.cleaner_task.lock().expect("cleaner task registry poisoned") = Some(task);
         }
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) {
+    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let started = Instant::now();
+        let mut report = ShutdownReport::default();
         if !self.accepting.swap(false, Ordering::AcqRel) {
-            return;
+            return report;
+        }
+        if let Some(cleaner) = self.cleaner_task.lock().expect("cleaner task registry poisoned").take() {
+            cleaner.abort();
         }
         if let Some(consumer) = self.default_mqpush_consumer_impl.as_ref() {
-            let queues = consumer
-                .rebalance_impl
-                .rebalance_impl_inner
-                .process_queue_table
-                .read()
-                .await;
-            for queue in queues.values() {
+            let queues = {
+                let table = consumer
+                    .rebalance_impl
+                    .rebalance_impl_inner
+                    .process_queue_table
+                    .read()
+                    .await;
+                table.values().cloned().collect::<Vec<_>>()
+            };
+            for queue in queues {
                 queue.set_dropped(true);
             }
         }
+        let mut tasks = std::mem::take(&mut *self.consume_tasks.lock().expect("consume task registry poisoned"));
+        let budget = Duration::from_millis(await_terminate_millis);
+        for mut task in tasks.drain(..) {
+            let remaining = budget.saturating_sub(started.elapsed());
+            if remaining.is_zero() || tokio::time::timeout(remaining, &mut task).await.is_err() {
+                task.abort();
+                report.consume_tasks_aborted += 1;
+            } else {
+                report.consume_tasks_drained += 1;
+            }
+        }
         if let Some(runtime) = self.consume_runtime.take() {
-            let timeout = Duration::from_millis(await_terminate_millis);
+            let timeout = budget.saturating_sub(started.elapsed());
             // Tokio forbids dropping a Runtime from another runtime's async
             // context. Move the private consume runtime to a plain thread so
             // its bounded shutdown cannot panic the public consumer teardown.
             let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
         }
+        report.elapsed = started.elapsed();
+        report
     }
 
     async fn consume_message_directly(
@@ -302,6 +353,10 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
         dispatch_to_consume: bool,
     ) {
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size;
+        if !self.accepting.load(Ordering::Acquire) {
+            self.reject_request(process_queue.as_ref());
+            return;
+        }
         if msgs.len() <= consume_batch_size as usize {
             let mut consume_request = ConsumeRequest {
                 msgs,
@@ -313,13 +368,11 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                 default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             };
 
-            if !self.accepting.load(Ordering::Acquire) {
-                return;
-            }
             if let Some(runtime) = self.consume_runtime.as_ref() {
-                runtime
+                let task = runtime
                     .get_handle()
                     .spawn(async move { consume_request.run(this).await });
+                self.track_consume_task(task);
             }
         } else {
             msgs.chunks(consume_batch_size as usize)
@@ -337,9 +390,10 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                     let consume_message_concurrently_service = this.clone();
                     if self.accepting.load(Ordering::Acquire) {
                         if let Some(runtime) = self.consume_runtime.as_ref() {
-                            runtime
+                            let task = runtime
                                 .get_handle()
                                 .spawn(async move { consume_request.run(consume_message_concurrently_service).await });
+                            self.track_consume_task(task);
                         }
                     }
                 });
@@ -514,5 +568,31 @@ mod tests {
         assert!(service.consume_runtime.is_none());
         service.shutdown(1).await;
         assert!(service.consume_runtime.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_tracked_tasks_at_its_deadline() {
+        let listener: ArcBoxMessageListenerConcurrently = Arc::new(Box::new(NoopListener));
+        let mut service = ConsumeMessageConcurrentlyService::new(
+            ArcMut::new(ClientConfig::default()),
+            ArcMut::new(ConsumerConfig::default()),
+            CheetahString::from_static_str("shutdown-deadline-test"),
+            listener,
+            None,
+        );
+        let task = service
+            .consume_runtime
+            .as_ref()
+            .unwrap()
+            .get_handle()
+            .spawn(std::future::pending());
+        service.track_consume_task(task);
+
+        let report = service.shutdown(10).await;
+
+        assert_eq!(report.consume_tasks_drained, 0);
+        assert_eq!(report.consume_tasks_aborted, 1);
+        assert!(service.consume_runtime.is_none());
+        assert!(report.elapsed < Duration::from_secs(1));
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -121,12 +121,34 @@ impl ConsumeMessageConcurrentlyService {
                 let pending_start = (ack_index + 1) as usize;
                 if pending_start < consume_request.msgs.len() {
                     let pending = consume_request.msgs.split_off(pending_start);
-                    self.submit_consume_request_later(
-                        pending,
-                        this,
-                        consume_request.process_queue.clone(),
-                        consume_request.message_queue.clone(),
-                    );
+                    let max_retries = self.consumer_config.broadcast_max_retries;
+                    let retry_delay = self.consumer_config.broadcast_retry_delay;
+                    let mut to_retry = Vec::with_capacity(pending.len());
+                    for mut msg in pending {
+                        let attempts = msg.reconsume_times() as u32;
+                        if attempts >= max_retries {
+                            warn!(
+                                "BROADCASTING terminal failure: topic={} queueOffset={} msgId={} \
+                                 retryCnt={}, dropping message",
+                                msg.get_topic(),
+                                msg.queue_offset,
+                                msg.msg_id,
+                                attempts,
+                            );
+                        } else {
+                            msg.set_reconsume_times(attempts as i32 + 1);
+                            to_retry.push(msg);
+                        }
+                    }
+                    if !to_retry.is_empty() {
+                        self.submit_consume_request_later_with_delay(
+                            to_retry,
+                            this,
+                            consume_request.process_queue.clone(),
+                            consume_request.message_queue.clone(),
+                            retry_delay,
+                        );
+                    }
                 }
             }
             MessageModel::Clustering => {
@@ -187,7 +209,22 @@ impl ConsumeMessageConcurrentlyService {
         self.consume_runtime.get_handle().spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
             let this_ = this.clone();
+            this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
+                .await;
+        });
+    }
 
+    fn submit_consume_request_later_with_delay(
+        &self,
+        msgs: Vec<ArcMut<MessageExt>>,
+        this: ArcMut<Self>,
+        process_queue: Arc<ProcessQueue>,
+        message_queue: MessageQueue,
+        delay: Duration,
+    ) {
+        self.consume_runtime.get_handle().spawn(async move {
+            tokio::time::sleep(delay).await;
+            let this_ = this.clone();
             this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
                 .await;
         });

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -49,7 +51,8 @@ pub struct ConsumeMessageConcurrentlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
-    pub(crate) consume_runtime: RocketMQRuntime,
+    pub(crate) consume_runtime: Option<RocketMQRuntime>,
+    accepting: AtomicBool,
 }
 
 impl ConsumeMessageConcurrentlyService {
@@ -68,7 +71,11 @@ impl ConsumeMessageConcurrentlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
+            consume_runtime: Some(RocketMQRuntime::new_multi(
+                consume_thread as usize,
+                consumer_group_tag.as_str(),
+            )),
+            accepting: AtomicBool::new(true),
         }
     }
 }
@@ -173,13 +180,15 @@ impl ConsumeMessageConcurrentlyService {
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
     ) {
-        self.consume_runtime.get_handle().spawn(async move {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            let this_ = this.clone();
+        if let Some(runtime) = self.consume_runtime.as_ref() {
+            runtime.get_handle().spawn(async move {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                let this_ = this.clone();
 
-            this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
-                .await;
-        });
+                this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
+                    .await;
+            });
+        }
     }
 
     pub async fn send_message_back(&mut self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
@@ -203,19 +212,37 @@ impl ConsumeMessageConcurrentlyService {
 
 impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
     fn start(&mut self, mut this: ArcMut<Self>) {
-        self.consume_runtime.get_handle().spawn(async move {
-            let timeout = this.consumer_config.consume_timeout;
-            let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
-            interval.tick().await;
-            loop {
+        if let Some(runtime) = self.consume_runtime.as_ref() {
+            runtime.get_handle().spawn(async move {
+                let timeout = this.consumer_config.consume_timeout;
+                let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
                 interval.tick().await;
-                this.clean_expire_msg().await;
-            }
-        });
+                loop {
+                    interval.tick().await;
+                    this.clean_expire_msg().await;
+                }
+            });
+        }
     }
 
     async fn shutdown(&mut self, await_terminate_millis: u64) {
-        // todo!()
+        if !self.accepting.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        if let Some(consumer) = self.default_mqpush_consumer_impl.as_ref() {
+            let queues = consumer
+                .rebalance_impl
+                .rebalance_impl_inner
+                .process_queue_table
+                .read()
+                .await;
+            for queue in queues.values() {
+                queue.set_dropped(true);
+            }
+        }
+        if let Some(runtime) = self.consume_runtime.take() {
+            runtime.shutdown_timeout(Duration::from_millis(await_terminate_millis));
+        }
     }
 
     async fn consume_message_directly(
@@ -282,9 +309,14 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                 default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             };
 
-            self.consume_runtime
-                .get_handle()
-                .spawn(async move { consume_request.run(this).await });
+            if !self.accepting.load(Ordering::Acquire) {
+                return;
+            }
+            if let Some(runtime) = self.consume_runtime.as_ref() {
+                runtime
+                    .get_handle()
+                    .spawn(async move { consume_request.run(this).await });
+            }
         } else {
             msgs.chunks(consume_batch_size as usize)
                 .map(|t| t.to_vec())
@@ -299,9 +331,13 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                         default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
                     };
                     let consume_message_concurrently_service = this.clone();
-                    self.consume_runtime
-                        .get_handle()
-                        .spawn(async move { consume_request.run(consume_message_concurrently_service).await });
+                    if self.accepting.load(Ordering::Acquire) {
+                        if let Some(runtime) = self.consume_runtime.as_ref() {
+                            runtime
+                                .get_handle()
+                                .spawn(async move { consume_request.run(consume_message_concurrently_service).await });
+                        }
+                    }
                 });
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -241,7 +241,11 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
             }
         }
         if let Some(runtime) = self.consume_runtime.take() {
-            runtime.shutdown_timeout(Duration::from_millis(await_terminate_millis));
+            let timeout = Duration::from_millis(await_terminate_millis);
+            // Tokio forbids dropping a Runtime from another runtime's async
+            // context. Move the private consume runtime to a plain thread so
+            // its bounded shutdown cannot panic the public consumer teardown.
+            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
         }
     }
 
@@ -474,5 +478,41 @@ impl ConsumeRequest {
                 .process_consume_result(this, status.unwrap(), &context, self)
                 .await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+
+    struct NoopListener;
+
+    impl MessageListenerConcurrently for NoopListener {
+        fn consume_message(
+            &self,
+            _msgs: &[&MessageExt],
+            _context: &ConsumeConcurrentlyContext,
+        ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus> {
+            Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_stops_accepting_and_takes_the_private_runtime() {
+        let listener: ArcBoxMessageListenerConcurrently = Arc::new(Box::new(NoopListener));
+        let mut service = ConsumeMessageConcurrentlyService::new(
+            ArcMut::new(ClientConfig::default()),
+            ArcMut::new(ConsumerConfig::default()),
+            CheetahString::from_static_str("shutdown-test"),
+            listener,
+            None,
+        );
+
+        service.shutdown(1).await;
+        assert!(!service.accepting.load(Ordering::Acquire));
+        assert!(service.consume_runtime.is_none());
+        service.shutdown(1).await;
+        assert!(service.consume_runtime.is_none());
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -158,9 +158,6 @@ impl ConsumeMessageConcurrentlyService {
                 let failed_msgs = consume_request.msgs.split_off((ack_index + 1) as usize);
                 for mut msg in failed_msgs {
                     if !consume_request.process_queue.contains_message(&msg).await {
-                        /*info!("Message is not found in its process queue; skip send-back-procedure, topic={}, "
-                            + "brokerName={}, queueId={}, queueOffset={}", msg.get_topic(), msg.get_broker_name(),
-                        msg.getQueueId(), msg.getQueueOffset());*/
                         continue;
                     }
 
@@ -184,6 +181,12 @@ impl ConsumeMessageConcurrentlyService {
                 }
             }
         }
+
+        // Hold the per-queue commit lock while removing messages and updating the offset
+        // so that concurrent chunk tasks for the same queue cannot interleave their
+        // offset advancement. Independent queues are not blocked because each
+        // ProcessQueue carries its own lock.
+        let _commit_guard = consume_request.process_queue.commit_lock.lock().await;
         let offset = consume_request
             .process_queue
             .remove_message(&consume_request.msgs)

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -100,22 +100,33 @@ impl ConsumeMessageConcurrentlyService {
         if consume_request.msgs.is_empty() {
             return;
         }
-        let mut ack_index = context.ack_index;
-        match status {
+        let msgs_len = consume_request.msgs.len() as i32;
+        let ack_index = match status {
             ConsumeConcurrentlyStatus::ConsumeSuccess => {
-                if ack_index >= consume_request.msgs.len() as i32 {
-                    ack_index = consume_request.msgs.len() as i32 - 1;
+                match context.ack_index {
+                    None => msgs_len - 1,
+                    Some(idx) => idx.clamp(-1, msgs_len - 1),
                 }
             }
             ConsumeConcurrentlyStatus::ReconsumeLater => {
-                ack_index = -1;
+                match context.ack_index {
+                    None => -1,
+                    Some(idx) => idx.clamp(-1, msgs_len - 1),
+                }
             }
-        }
+        };
 
         match self.consumer_config.message_model {
             MessageModel::Broadcasting => {
-                for i in ((ack_index + 1) as usize)..consume_request.msgs.len() {
-                    warn!("BROADCASTING, the message consume failed, drop it");
+                let pending_start = (ack_index + 1) as usize;
+                if pending_start < consume_request.msgs.len() {
+                    let pending = consume_request.msgs.split_off(pending_start);
+                    self.submit_consume_request_later(
+                        pending,
+                        this,
+                        consume_request.process_queue.clone(),
+                        consume_request.message_queue.clone(),
+                    );
                 }
             }
             MessageModel::Clustering => {
@@ -227,7 +238,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
         msg.broker_name = broker_name.unwrap_or_default();
         let mq = MessageQueue::from_parts(msg.topic().clone(), msg.broker_name.clone(), msg.queue_id());
         let mut msgs = vec![ArcMut::new(msg)];
-        let context = ConsumeConcurrentlyContext::new(mq);
+        let mut context = ConsumeConcurrentlyContext::new(mq);
         self.default_mqpush_consumer_impl
             .as_ref()
             .unwrap()
@@ -238,7 +249,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
         let status = self.message_listener.consume_message(
             &msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>(),
-            &context,
+            &mut context,
         );
         let mut result = ConsumeMessageDirectlyResult::default();
         result.set_order(false);
@@ -336,11 +347,7 @@ impl ConsumeRequest {
             );
             return;
         }
-        let context = ConsumeConcurrentlyContext {
-            message_queue: self.message_queue.clone(),
-            delay_level_when_next_consume: 0,
-            ack_index: i32::MAX,
-        };
+        let mut context = ConsumeConcurrentlyContext::new(self.message_queue.clone());
 
         let mut default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.as_ref().unwrap().clone();
         let consumer_group = self.consumer_group.clone();
@@ -380,7 +387,7 @@ impl ConsumeRequest {
                 default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
             }
             let vec = self.msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>();
-            match self.message_listener.consume_message(&vec, &context) {
+            match self.message_listener.consume_message(&vec, &mut context) {
                 Ok(value) => {
                     status = Some(value);
                 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -431,6 +431,11 @@ impl ConsumeRequest {
                     has_exception = true;
                 }
             }
+            // Update last_consume_timestamp after the listener returns so that
+            // admin/running-info reflects real callback progress, not flow-control entries.
+            self.process_queue
+                .last_consume_timestamp
+                .store(get_current_millis(), std::sync::atomic::Ordering::Release);
         }
 
         let consume_rt = begin_timestamp.elapsed().as_millis() as u64;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -83,7 +83,7 @@ impl ConsumeMessageConcurrentlyService {
             .process_queue_table
             .read()
             .await;
-        for (_, process_queue) in process_queue_table.iter() {
+        for process_queue in process_queue_table.values() {
             process_queue
                 .clean_expired_msg(self.default_mqpush_consumer_impl.clone())
                 .await;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -37,7 +37,6 @@ use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -65,7 +64,7 @@ pub struct ConsumeMessageOrderlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerOrderly,
-    pub(crate) consume_runtime: Option<RocketMQRuntime>,
+    pub(crate) consume_runtime: RocketMQRuntime,
     pub(crate) stopped: AtomicBool,
     pub(crate) global_lock: Arc<RocketMQTokioMutex<()>>,
     pub(crate) message_queue_lock: MessageQueueLock,
@@ -87,7 +86,7 @@ impl ConsumeMessageOrderlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
+            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
             stopped: AtomicBool::new(false),
             global_lock: Arc::new(Default::default()),
             message_queue_lock: Default::default(),
@@ -134,7 +133,7 @@ impl ConsumeMessageOrderlyService {
     ) {
         let consume_message_orderly_service_cloned = consume_message_orderly_service.clone();
         let message_queue = message_queue.clone();
-        self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
+        self.consume_runtime.get_handle().spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(delay_mills)).await;
 
             if consume_message_orderly_service.lock_one_mq(&message_queue).await {
@@ -348,7 +347,7 @@ impl ConsumeMessageOrderlyService {
 impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
     fn start(&mut self, mut this: ArcMut<Self>) {
         if MessageModel::Clustering == self.consumer_config.message_model {
-            self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
+            self.consume_runtime.get_handle().spawn(async move {
                 tokio::time::sleep(tokio::time::Duration::from_millis(1_000)).await;
                 loop {
                     this.lock_mqperiodically().await;
@@ -358,26 +357,10 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         }
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let started = Instant::now();
-        let mut report = ShutdownReport::default();
-        if self.stopped.swap(true, std::sync::atomic::Ordering::AcqRel) {
-            return report;
-        }
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
         if MessageModel::Clustering == self.consumer_config.message_model {
-            if tokio::time::timeout(Duration::from_millis(await_terminate_millis), self.unlock_all_mq())
-                .await
-                .is_err()
-            {
-                report.broker_unregister_failures += 1;
-            }
+            self.unlock_all_mq().await;
         }
-        if let Some(runtime) = self.consume_runtime.take() {
-            let remaining = Duration::from_millis(await_terminate_millis).saturating_sub(started.elapsed());
-            let _ = std::thread::spawn(move || runtime.shutdown_timeout(remaining)).join();
-        }
-        report.elapsed = started.elapsed();
-        report
     }
 
     #[allow(deprecated)]
@@ -447,7 +430,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
             default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             consumer_group: self.consumer_group.clone(),
         };
-        self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
+        self.consume_runtime.get_handle().spawn(async move {
             consume_request.run(this).await;
         });
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -37,6 +37,7 @@ use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -64,7 +65,7 @@ pub struct ConsumeMessageOrderlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerOrderly,
-    pub(crate) consume_runtime: RocketMQRuntime,
+    pub(crate) consume_runtime: Option<RocketMQRuntime>,
     pub(crate) stopped: AtomicBool,
     pub(crate) global_lock: Arc<RocketMQTokioMutex<()>>,
     pub(crate) message_queue_lock: MessageQueueLock,
@@ -86,7 +87,7 @@ impl ConsumeMessageOrderlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
+            consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
             stopped: AtomicBool::new(false),
             global_lock: Arc::new(Default::default()),
             message_queue_lock: Default::default(),
@@ -133,7 +134,7 @@ impl ConsumeMessageOrderlyService {
     ) {
         let consume_message_orderly_service_cloned = consume_message_orderly_service.clone();
         let message_queue = message_queue.clone();
-        self.consume_runtime.get_handle().spawn(async move {
+        self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(delay_mills)).await;
 
             if consume_message_orderly_service.lock_one_mq(&message_queue).await {
@@ -347,7 +348,7 @@ impl ConsumeMessageOrderlyService {
 impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
     fn start(&mut self, mut this: ArcMut<Self>) {
         if MessageModel::Clustering == self.consumer_config.message_model {
-            self.consume_runtime.get_handle().spawn(async move {
+            self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
                 tokio::time::sleep(tokio::time::Duration::from_millis(1_000)).await;
                 loop {
                     this.lock_mqperiodically().await;
@@ -357,10 +358,26 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         }
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) {
-        if MessageModel::Clustering == self.consumer_config.message_model {
-            self.unlock_all_mq().await;
+    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let started = Instant::now();
+        let mut report = ShutdownReport::default();
+        if self.stopped.swap(true, std::sync::atomic::Ordering::AcqRel) {
+            return report;
         }
+        if MessageModel::Clustering == self.consumer_config.message_model {
+            if tokio::time::timeout(Duration::from_millis(await_terminate_millis), self.unlock_all_mq())
+                .await
+                .is_err()
+            {
+                report.broker_unregister_failures += 1;
+            }
+        }
+        if let Some(runtime) = self.consume_runtime.take() {
+            let remaining = Duration::from_millis(await_terminate_millis).saturating_sub(started.elapsed());
+            let _ = std::thread::spawn(move || runtime.shutdown_timeout(remaining)).join();
+        }
+        report.elapsed = started.elapsed();
+        report
     }
 
     #[allow(deprecated)]
@@ -430,7 +447,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
             default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             consumer_group: self.consumer_group.clone(),
         };
-        self.consume_runtime.get_handle().spawn(async move {
+        self.consume_runtime.as_ref().expect("orderly consumer runtime is stopped").get_handle().spawn(async move {
             consume_request.run(this).await;
         });
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 use std::error::Error;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -40,7 +37,6 @@ use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_callback::AckCallback;
 use crate::consumer::ack_result::AckResult;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -57,8 +53,7 @@ pub struct ConsumeMessagePopConcurrentlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
-    pub(crate) pop_consume_runtime: Option<RocketMQRuntime>,
-    accepting: AtomicBool,
+    pub(crate) pop_consume_runtime: RocketMQRuntime,
 }
 
 impl ConsumeMessagePopConcurrentlyService {
@@ -77,8 +72,7 @@ impl ConsumeMessagePopConcurrentlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            pop_consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
-            accepting: AtomicBool::new(true),
+            pop_consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
         }
     }
 }
@@ -88,19 +82,12 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         // nothing to do need
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let started = Instant::now();
-        let mut report = ShutdownReport::default();
-        if !self.accepting.swap(false, Ordering::AcqRel) {
-            return report;
-        }
-        if let Some(runtime) = self.pop_consume_runtime.take() {
-            let timeout = Duration::from_millis(await_terminate_millis);
-            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
-            report.consume_tasks_aborted = 1;
-        }
-        report.elapsed = started.elapsed();
-        report
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
+        // The POP concurrent service does not start a background task in its
+        // current implementation. Keep shutdown idempotent until POP task
+        // ownership is implemented, rather than panicking during push-consumer
+        // lifecycle cleanup.
+        let _ = await_terminate_millis;
     }
 
     async fn consume_message_directly(
@@ -165,9 +152,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         process_queue: &PopProcessQueue,
         message_queue: &MessageQueue,
     ) {
-        if !self.accepting.load(Ordering::Acquire) {
-            return;
-        }
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size;
         let msgs = msgs
             .into_iter()
@@ -175,7 +159,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
             .collect::<Vec<ArcMut<MessageClientExt>>>();
         if msgs.len() < consume_batch_size as usize {
             let mut request = ConsumeRequest::new(msgs, Arc::new(process_queue.clone()), message_queue.clone());
-            self.pop_consume_runtime.as_ref().expect("POP consumer runtime is stopped").get_handle().spawn(async move {
+            self.pop_consume_runtime.get_handle().spawn(async move {
                 request.run(this).await;
             });
         } else {
@@ -185,7 +169,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
                     let mut consume_request =
                         ConsumeRequest::new(msgs, Arc::new(process_queue.clone()), message_queue.clone());
                     let pop_consume_message_concurrently_service = this.clone();
-                    self.pop_consume_runtime.as_ref().expect("POP consumer runtime is stopped")
+                    self.pop_consume_runtime
                         .get_handle()
                         .spawn(async move { consume_request.run(pop_consume_message_concurrently_service).await });
                 });

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -83,7 +83,11 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
     }
 
     async fn shutdown(&mut self, await_terminate_millis: u64) {
-        todo!()
+        // The POP concurrent service does not start a background task in its
+        // current implementation. Keep shutdown idempotent until POP task
+        // ownership is implemented, rather than panicking during push-consumer
+        // lifecycle cleanup.
+        let _ = await_terminate_millis;
     }
 
     async fn consume_message_directly(

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -99,7 +99,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
         let mq = MessageQueue::from_parts(msg.topic().clone(), broker_name.unwrap_or_default(), msg.queue_id());
         let mut msgs = vec![ArcMut::new(msg)];
-        let context = ConsumeConcurrentlyContext::new(mq);
+        let mut context = ConsumeConcurrentlyContext::new(mq);
         self.default_mqpush_consumer_impl
             .as_ref()
             .unwrap()
@@ -110,7 +110,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
         let status = self.message_listener.consume_message(
             &msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>(),
-            &context,
+            &mut context,
         );
         let mut result = ConsumeMessageDirectlyResult::default();
         result.set_order(false);
@@ -188,23 +188,17 @@ impl ConsumeMessagePopConcurrentlyService {
         if consume_request.msgs.is_empty() {
             return;
         }
-        let mut ack_index = context.ack_index;
-        match status {
-            ConsumeConcurrentlyStatus::ConsumeSuccess => {
-                if ack_index >= consume_request.msgs.len() as i32 {
-                    ack_index = consume_request.msgs.len() as i32 - 1;
-                }
-                /*int ok = ackIndex + 1;
-                int failed = consumeRequest.getMsgs().size() - ok;
-                this.getConsumerStatsManager().incConsumeOKTPS(consumerGroup, topic, ok);
-                this.getConsumerStatsManager().incConsumeFailedTPS(consumerGroup, topic, failed);*/
-            }
-            ConsumeConcurrentlyStatus::ReconsumeLater => {
-                //this.getConsumerStatsManager().incConsumeFailedTPS(consumerGroup, topic, failed);
-                // Java code
-                ack_index = -1;
-            }
-        }
+        let msgs_len = consume_request.msgs.len() as i32;
+        let ack_index = match status {
+            ConsumeConcurrentlyStatus::ConsumeSuccess => match context.ack_index {
+                None => msgs_len - 1,
+                Some(idx) => idx.clamp(-1, msgs_len - 1),
+            },
+            ConsumeConcurrentlyStatus::ReconsumeLater => match context.ack_index {
+                None => -1,
+                Some(idx) => idx.clamp(-1, msgs_len - 1),
+            },
+        };
 
         //ack if consume success
         for i in 0..ack_index {
@@ -375,11 +369,7 @@ impl ConsumeRequest {
             self.process_queue.dec_found_msg(self.msgs.len());
             return;
         }
-        let context = ConsumeConcurrentlyContext {
-            message_queue: self.message_queue.clone(),
-            delay_level_when_next_consume: 0,
-            ack_index: i32::MAX,
-        };
+        let mut context = ConsumeConcurrentlyContext::new(self.message_queue.clone());
 
         let mut default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.as_ref().unwrap().clone();
         default_mqpush_consumer_impl.reset_retry_and_namespace(&mut self.msgs, self.consumer_group.as_str());
@@ -417,7 +407,7 @@ impl ConsumeRequest {
             default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
         }
         let vec = self.msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>();
-        match self.message_listener.consume_message(&vec, &context) {
+        match self.message_listener.consume_message(&vec, &mut context) {
             Ok(value) => {
                 status = Some(value);
             }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use std::error::Error;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -37,6 +40,7 @@ use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_callback::AckCallback;
 use crate::consumer::ack_result::AckResult;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -53,7 +57,8 @@ pub struct ConsumeMessagePopConcurrentlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
-    pub(crate) pop_consume_runtime: RocketMQRuntime,
+    pub(crate) pop_consume_runtime: Option<RocketMQRuntime>,
+    accepting: AtomicBool,
 }
 
 impl ConsumeMessagePopConcurrentlyService {
@@ -72,7 +77,8 @@ impl ConsumeMessagePopConcurrentlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            pop_consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
+            pop_consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
+            accepting: AtomicBool::new(true),
         }
     }
 }
@@ -82,12 +88,19 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         // nothing to do need
     }
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) {
-        // The POP concurrent service does not start a background task in its
-        // current implementation. Keep shutdown idempotent until POP task
-        // ownership is implemented, rather than panicking during push-consumer
-        // lifecycle cleanup.
-        let _ = await_terminate_millis;
+    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let started = Instant::now();
+        let mut report = ShutdownReport::default();
+        if !self.accepting.swap(false, Ordering::AcqRel) {
+            return report;
+        }
+        if let Some(runtime) = self.pop_consume_runtime.take() {
+            let timeout = Duration::from_millis(await_terminate_millis);
+            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
+            report.consume_tasks_aborted = 1;
+        }
+        report.elapsed = started.elapsed();
+        report
     }
 
     async fn consume_message_directly(
@@ -152,6 +165,9 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         process_queue: &PopProcessQueue,
         message_queue: &MessageQueue,
     ) {
+        if !self.accepting.load(Ordering::Acquire) {
+            return;
+        }
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size;
         let msgs = msgs
             .into_iter()
@@ -159,7 +175,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
             .collect::<Vec<ArcMut<MessageClientExt>>>();
         if msgs.len() < consume_batch_size as usize {
             let mut request = ConsumeRequest::new(msgs, Arc::new(process_queue.clone()), message_queue.clone());
-            self.pop_consume_runtime.get_handle().spawn(async move {
+            self.pop_consume_runtime.as_ref().expect("POP consumer runtime is stopped").get_handle().spawn(async move {
                 request.run(this).await;
             });
         } else {
@@ -169,7 +185,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
                     let mut consume_request =
                         ConsumeRequest::new(msgs, Arc::new(process_queue.clone()), message_queue.clone());
                     let pop_consume_message_concurrently_service = this.clone();
-                    self.pop_consume_runtime
+                    self.pop_consume_runtime.as_ref().expect("POP consumer runtime is stopped")
                         .get_handle()
                         .spawn(async move { consume_request.run(pop_consume_message_concurrently_service).await });
                 });

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -15,10 +15,7 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -33,7 +30,6 @@ use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -49,8 +45,7 @@ pub struct ConsumeMessagePopOrderlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerOrderly,
-    pub(crate) consume_runtime: Option<RocketMQRuntime>,
-    accepting: AtomicBool,
+    pub(crate) consume_runtime: RocketMQRuntime,
     pub(self) consume_request_set: HashSet<ConsumeRequest>,
     pub(crate) message_queue_lock: MessageQueueLock,
     pub(crate) consume_request_lock: MessageQueueLock,
@@ -72,8 +67,7 @@ impl ConsumeMessagePopOrderlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
-            accepting: AtomicBool::new(true),
+            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
             consume_request_set: Default::default(),
             message_queue_lock: Default::default(),
             consume_request_lock: Default::default(),
@@ -92,7 +86,7 @@ impl ConsumeMessagePopOrderlyService {
         let _lock = lock.lock().await;
         let is_new_req = self.consume_request_set.insert(request.clone());
         if is_new_req || force {
-            self.consume_runtime.as_ref().expect("POP orderly consumer runtime is stopped").get_handle().spawn(async move {
+            self.consume_runtime.get_handle().spawn(async move {
                 request.run(this).await;
             });
         }
@@ -102,20 +96,10 @@ impl ConsumeMessagePopOrderlyService {
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     fn start(&mut self, this: ArcMut<Self>) {}
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let started = Instant::now();
-        let mut report = ShutdownReport::default();
-        if !self.accepting.swap(false, Ordering::AcqRel) {
-            return report;
-        }
-        if let Some(runtime) = self.consume_runtime.take() {
-            let timeout = Duration::from_millis(await_terminate_millis);
-            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
-            report.consume_tasks_aborted = self.consume_request_set.len();
-        }
-        self.consume_request_set.clear();
-        report.elapsed = started.elapsed();
-        report
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
+        // See the concurrent POP service: no independently-owned background
+        // task exists to terminate yet, but shutdown must never panic.
+        let _ = await_terminate_millis;
     }
 
     #[allow(deprecated)]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -15,7 +15,10 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -30,6 +33,7 @@ use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
@@ -45,7 +49,8 @@ pub struct ConsumeMessagePopOrderlyService {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
     pub(crate) message_listener: ArcBoxMessageListenerOrderly,
-    pub(crate) consume_runtime: RocketMQRuntime,
+    pub(crate) consume_runtime: Option<RocketMQRuntime>,
+    accepting: AtomicBool,
     pub(self) consume_request_set: HashSet<ConsumeRequest>,
     pub(crate) message_queue_lock: MessageQueueLock,
     pub(crate) consume_request_lock: MessageQueueLock,
@@ -67,7 +72,8 @@ impl ConsumeMessagePopOrderlyService {
             consumer_config,
             consumer_group,
             message_listener,
-            consume_runtime: RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str()),
+            consume_runtime: Some(RocketMQRuntime::new_multi(consume_thread as usize, consumer_group_tag.as_str())),
+            accepting: AtomicBool::new(true),
             consume_request_set: Default::default(),
             message_queue_lock: Default::default(),
             consume_request_lock: Default::default(),
@@ -86,7 +92,7 @@ impl ConsumeMessagePopOrderlyService {
         let _lock = lock.lock().await;
         let is_new_req = self.consume_request_set.insert(request.clone());
         if is_new_req || force {
-            self.consume_runtime.get_handle().spawn(async move {
+            self.consume_runtime.as_ref().expect("POP orderly consumer runtime is stopped").get_handle().spawn(async move {
                 request.run(this).await;
             });
         }
@@ -96,10 +102,20 @@ impl ConsumeMessagePopOrderlyService {
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     fn start(&mut self, this: ArcMut<Self>) {}
 
-    async fn shutdown(&mut self, await_terminate_millis: u64) {
-        // See the concurrent POP service: no independently-owned background
-        // task exists to terminate yet, but shutdown must never panic.
-        let _ = await_terminate_millis;
+    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let started = Instant::now();
+        let mut report = ShutdownReport::default();
+        if !self.accepting.swap(false, Ordering::AcqRel) {
+            return report;
+        }
+        if let Some(runtime) = self.consume_runtime.take() {
+            let timeout = Duration::from_millis(await_terminate_millis);
+            let _ = std::thread::spawn(move || runtime.shutdown_timeout(timeout)).join();
+            report.consume_tasks_aborted = self.consume_request_set.len();
+        }
+        self.consume_request_set.clear();
+        report.elapsed = started.elapsed();
+        report
     }
 
     #[allow(deprecated)]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -97,7 +97,9 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     fn start(&mut self, this: ArcMut<Self>) {}
 
     async fn shutdown(&mut self, await_terminate_millis: u64) {
-        todo!()
+        // See the concurrent POP service: no independently-owned background
+        // task exists to terminate yet, but shutdown must never panic.
+        let _ = await_terminate_millis;
     }
 
     #[allow(deprecated)]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
@@ -25,31 +24,6 @@ use rocketmq_rust::WeakArcMut;
 
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
-
-/// The local outcome of a consumer shutdown.  Callers must not treat a
-/// partially-drained consumer as safe to replace in-process.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ShutdownReport {
-    pub local_unregistered: bool,
-    pub consume_tasks_drained: usize,
-    pub consume_tasks_aborted: usize,
-    pub offsets_persisted: bool,
-    pub broker_unregister_failures: usize,
-    pub shared_factory_stopped: bool,
-    pub elapsed: Duration,
-}
-
-impl ShutdownReport {
-    pub fn merge(&mut self, other: Self) {
-        self.consume_tasks_drained += other.consume_tasks_drained;
-        self.consume_tasks_aborted += other.consume_tasks_aborted;
-        self.local_unregistered |= other.local_unregistered;
-        self.offsets_persisted |= other.offsets_persisted;
-        self.broker_unregister_failures += other.broker_unregister_failures;
-        self.shared_factory_stopped |= other.shared_factory_stopped;
-        self.elapsed = self.elapsed.max(other.elapsed);
-    }
-}
 
 pub struct ConsumeMessageServiceGeneral<T, K> {
     consume_message_concurrently_service: Option<ArcMut<T>>,
@@ -88,15 +62,31 @@ where
         }
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let mut report = ShutdownReport::default();
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
         if let Some(consume_message_concurrently_service) = &mut self.consume_message_concurrently_service {
-            report.merge(consume_message_concurrently_service.shutdown(await_terminate_millis).await);
+            consume_message_concurrently_service
+                .shutdown(await_terminate_millis)
+                .await;
         }
         if let Some(consume_message_orderly_service) = &mut self.consume_message_orderly_service {
-            report.merge(consume_message_orderly_service.shutdown(await_terminate_millis).await);
+            consume_message_orderly_service.shutdown(await_terminate_millis).await;
         }
-        report
+    }
+
+    pub fn update_core_pool_size(&self, core_pool_size: usize) {
+        todo!()
+    }
+
+    pub fn inc_core_pool_size(&self) {
+        todo!()
+    }
+
+    pub fn dec_core_pool_size(&self) {
+        todo!()
+    }
+
+    pub fn get_core_pool_size(&self) -> usize {
+        todo!()
     }
 
     pub async fn consume_message_directly(
@@ -105,10 +95,12 @@ where
         broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         if let Some(consume_message_concurrently_service) = &self.consume_message_concurrently_service {
+            let this = consume_message_concurrently_service.clone();
             consume_message_concurrently_service
                 .consume_message_directly(msg, broker_name)
                 .await
         } else if let Some(consume_message_orderly_service) = &self.consume_message_orderly_service {
+            let this = consume_message_orderly_service.clone();
             consume_message_orderly_service
                 .consume_message_directly(msg, broker_name)
                 .await
@@ -185,15 +177,33 @@ where
         }
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let mut report = ShutdownReport::default();
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
         if let Some(consume_message_pop_concurrently_service) = &mut self.consume_message_pop_concurrently_service {
-            report.merge(consume_message_pop_concurrently_service.shutdown(await_terminate_millis).await);
+            consume_message_pop_concurrently_service
+                .shutdown(await_terminate_millis)
+                .await;
         }
         if let Some(consume_message_pop_orderly_service) = &mut self.consume_message_pop_orderly_service {
-            report.merge(consume_message_pop_orderly_service.shutdown(await_terminate_millis).await);
+            consume_message_pop_orderly_service
+                .shutdown(await_terminate_millis)
+                .await;
         }
-        report
+    }
+
+    fn update_core_pool_size(&self, core_pool_size: usize) {
+        todo!()
+    }
+
+    fn inc_core_pool_size(&self) {
+        todo!()
+    }
+
+    fn dec_core_pool_size(&self) {
+        todo!()
+    }
+
+    fn get_core_pool_size(&self) -> usize {
+        todo!()
     }
 
     pub(crate) async fn consume_message_directly(
@@ -260,7 +270,29 @@ pub trait ConsumeMessageServiceTrait {
     /// # Arguments
     ///
     /// * `await_terminate_millis` - The number of milliseconds to wait for termination.
-    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport;
+    async fn shutdown(&mut self, await_terminate_millis: u64);
+
+    /// Updates the core pool size of the service.
+    ///
+    /// # Arguments
+    ///
+    /// * `core_pool_size` - The new core pool size.
+    fn update_core_pool_size(&self, core_pool_size: usize) {}
+
+    /// Increases the core pool size of the service by one.
+    fn inc_core_pool_size(&self) {}
+
+    /// Decreases the core pool size of the service by one.
+    fn dec_core_pool_size(&self) {}
+
+    /// Gets the current core pool size of the service.
+    ///
+    /// # Returns
+    ///
+    /// The current core pool size.
+    fn get_core_pool_size(&self) -> usize {
+        num_cpus::get()
+    }
 
     /// Consumes a message directly.
     ///

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
@@ -24,6 +25,31 @@ use rocketmq_rust::WeakArcMut;
 
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
+
+/// The local outcome of a consumer shutdown.  Callers must not treat a
+/// partially-drained consumer as safe to replace in-process.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ShutdownReport {
+    pub local_unregistered: bool,
+    pub consume_tasks_drained: usize,
+    pub consume_tasks_aborted: usize,
+    pub offsets_persisted: bool,
+    pub broker_unregister_failures: usize,
+    pub shared_factory_stopped: bool,
+    pub elapsed: Duration,
+}
+
+impl ShutdownReport {
+    pub fn merge(&mut self, other: Self) {
+        self.consume_tasks_drained += other.consume_tasks_drained;
+        self.consume_tasks_aborted += other.consume_tasks_aborted;
+        self.local_unregistered |= other.local_unregistered;
+        self.offsets_persisted |= other.offsets_persisted;
+        self.broker_unregister_failures += other.broker_unregister_failures;
+        self.shared_factory_stopped |= other.shared_factory_stopped;
+        self.elapsed = self.elapsed.max(other.elapsed);
+    }
+}
 
 pub struct ConsumeMessageServiceGeneral<T, K> {
     consume_message_concurrently_service: Option<ArcMut<T>>,
@@ -62,31 +88,15 @@ where
         }
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let mut report = ShutdownReport::default();
         if let Some(consume_message_concurrently_service) = &mut self.consume_message_concurrently_service {
-            consume_message_concurrently_service
-                .shutdown(await_terminate_millis)
-                .await;
+            report.merge(consume_message_concurrently_service.shutdown(await_terminate_millis).await);
         }
         if let Some(consume_message_orderly_service) = &mut self.consume_message_orderly_service {
-            consume_message_orderly_service.shutdown(await_terminate_millis).await;
+            report.merge(consume_message_orderly_service.shutdown(await_terminate_millis).await);
         }
-    }
-
-    pub fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    pub fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    pub fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    pub fn get_core_pool_size(&self) -> usize {
-        todo!()
+        report
     }
 
     pub async fn consume_message_directly(
@@ -95,12 +105,10 @@ where
         broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         if let Some(consume_message_concurrently_service) = &self.consume_message_concurrently_service {
-            let this = consume_message_concurrently_service.clone();
             consume_message_concurrently_service
                 .consume_message_directly(msg, broker_name)
                 .await
         } else if let Some(consume_message_orderly_service) = &self.consume_message_orderly_service {
-            let this = consume_message_orderly_service.clone();
             consume_message_orderly_service
                 .consume_message_directly(msg, broker_name)
                 .await
@@ -177,33 +185,15 @@ where
         }
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let mut report = ShutdownReport::default();
         if let Some(consume_message_pop_concurrently_service) = &mut self.consume_message_pop_concurrently_service {
-            consume_message_pop_concurrently_service
-                .shutdown(await_terminate_millis)
-                .await;
+            report.merge(consume_message_pop_concurrently_service.shutdown(await_terminate_millis).await);
         }
         if let Some(consume_message_pop_orderly_service) = &mut self.consume_message_pop_orderly_service {
-            consume_message_pop_orderly_service
-                .shutdown(await_terminate_millis)
-                .await;
+            report.merge(consume_message_pop_orderly_service.shutdown(await_terminate_millis).await);
         }
-    }
-
-    fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn get_core_pool_size(&self) -> usize {
-        todo!()
+        report
     }
 
     pub(crate) async fn consume_message_directly(
@@ -270,29 +260,7 @@ pub trait ConsumeMessageServiceTrait {
     /// # Arguments
     ///
     /// * `await_terminate_millis` - The number of milliseconds to wait for termination.
-    async fn shutdown(&mut self, await_terminate_millis: u64);
-
-    /// Updates the core pool size of the service.
-    ///
-    /// # Arguments
-    ///
-    /// * `core_pool_size` - The new core pool size.
-    fn update_core_pool_size(&self, core_pool_size: usize) {}
-
-    /// Increases the core pool size of the service by one.
-    fn inc_core_pool_size(&self) {}
-
-    /// Decreases the core pool size of the service by one.
-    fn dec_core_pool_size(&self) {}
-
-    /// Gets the current core pool size of the service.
-    ///
-    /// # Returns
-    ///
-    /// The current core pool size.
-    fn get_core_pool_size(&self) -> usize {
-        num_cpus::get()
-    }
+    async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport;
 
     /// Consumes a message directly.
     ///

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -63,7 +63,14 @@ where
     }
 
     pub async fn shutdown(&mut self, await_terminate_millis: u64) {
-        todo!()
+        if let Some(consume_message_concurrently_service) = &mut self.consume_message_concurrently_service {
+            consume_message_concurrently_service
+                .shutdown(await_terminate_millis)
+                .await;
+        }
+        if let Some(consume_message_orderly_service) = &mut self.consume_message_orderly_service {
+            consume_message_orderly_service.shutdown(await_terminate_millis).await;
+        }
     }
 
     pub fn update_core_pool_size(&self, core_pool_size: usize) {
@@ -171,7 +178,16 @@ where
     }
 
     pub async fn shutdown(&mut self, await_terminate_millis: u64) {
-        todo!()
+        if let Some(consume_message_pop_concurrently_service) = &mut self.consume_message_pop_concurrently_service {
+            consume_message_pop_concurrently_service
+                .shutdown(await_terminate_millis)
+                .await;
+        }
+        if let Some(consume_message_pop_orderly_service) = &mut self.consume_message_pop_orderly_service {
+            consume_message_pop_orderly_service
+                .shutdown(await_terminate_millis)
+                .await;
+        }
     }
 
     fn update_core_pool_size(&self, core_pool_size: usize) {

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -863,6 +863,17 @@ impl DefaultMQPushConsumerImpl {
                     self.queue_flow_control_times
                 );
             }
+            pull_request.process_queue.mark_flow_control();
+            let stall_ms = pull_request.process_queue.flow_control_stall_ms();
+            if stall_ms > *crate::consumer::consumer_impl::PULL_MAX_IDLE_TIME / 2 {
+                warn!(
+                    "[STALL] queue flow-controlled by cached-count for {}ms, topic={}, queueId={}, count={}",
+                    stall_ms,
+                    pull_request.get_message_queue().get_topic(),
+                    pull_request.get_message_queue().get_queue_id(),
+                    cached_message_count,
+                );
+            }
             self.execute_pull_request_later(pull_request, PULL_TIME_DELAY_MILLS_WHEN_CACHE_FLOW_CONTROL);
 
             self.queue_flow_control_times += 1;
@@ -884,6 +895,17 @@ impl DefaultMQPushConsumerImpl {
                     cached_message_size_in_mib,
                     pull_request.to_string(),
                     self.queue_flow_control_times
+                );
+            }
+            pull_request.process_queue.mark_flow_control();
+            let stall_ms = pull_request.process_queue.flow_control_stall_ms();
+            if stall_ms > *crate::consumer::consumer_impl::PULL_MAX_IDLE_TIME / 2 {
+                warn!(
+                    "[STALL] queue flow-controlled by cached-size for {}ms, topic={}, queueId={}, size_mib={}",
+                    stall_ms,
+                    pull_request.get_message_queue().get_topic(),
+                    pull_request.get_message_queue().get_queue_id(),
+                    cached_message_size_in_mib,
                 );
             }
             self.execute_pull_request_later(pull_request, PULL_TIME_DELAY_MILLS_WHEN_CACHE_FLOW_CONTROL);
@@ -909,6 +931,17 @@ impl DefaultMQPushConsumerImpl {
                     );
                 }
                 self.queue_max_span_flow_control_times += 1;
+                pull_request.process_queue.mark_flow_control();
+                let stall_ms = pull_request.process_queue.flow_control_stall_ms();
+                if stall_ms > *crate::consumer::consumer_impl::PULL_MAX_IDLE_TIME / 2 {
+                    warn!(
+                        "[STALL] queue flow-controlled by max-span for {}ms, topic={}, queueId={}, span={}",
+                        stall_ms,
+                        pull_request.get_message_queue().get_topic(),
+                        pull_request.get_message_queue().get_queue_id(),
+                        max_span,
+                    );
+                }
                 self.execute_pull_request_later(pull_request, PULL_TIME_DELAY_MILLS_WHEN_CACHE_FLOW_CONTROL);
                 return;
             }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -830,9 +830,7 @@ impl DefaultMQPushConsumerImpl {
             info!("the pull request[{}] is dropped.", pull_request);
             return;
         }
-        pull_request.process_queue.set_last_pull_timestamp(get_current_millis());
         if let Err(e) = self.make_sure_state_ok() {
-            warn!("pullMessage exception, consumer state not ok {}", e);
             if !self.is_terminal_state() {
                 self.execute_pull_request_later(pull_request, self.pull_time_delay_mills_when_exception);
             }
@@ -974,6 +972,11 @@ impl DefaultMQPushConsumerImpl {
             self.execute_pull_request_later(pull_request, self.pull_time_delay_mills_when_exception);
             return;
         }
+        // Update liveness timestamp only after passing all flow-control checks and just before
+        // issuing the actual broker pull.  Updating it on entry (as it was before) caused every
+        // 50 ms flow-control retry to refresh the timestamp, preventing is_pull_expired() from
+        // ever triggering rebalance recovery (F1 in plan/29).
+        pull_request.process_queue.set_last_pull_timestamp(get_current_millis());
         let begin_timestamp = Instant::now();
         let topic = message_queue.get_topic().to_string();
 

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -67,7 +66,6 @@ use crate::consumer::consumer_impl::consume_message_pop_concurrently_service::Co
 use crate::consumer::consumer_impl::consume_message_pop_orderly_service::ConsumeMessagePopOrderlyService;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessagePopServiceGeneral;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceGeneral;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::pop_request::PopRequest;
 use crate::consumer::consumer_impl::pull_api_wrapper::PullAPIWrapper;
 use crate::consumer::consumer_impl::pull_request::PullRequest;
@@ -376,8 +374,8 @@ impl DefaultMQPushConsumerImpl {
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The PushConsumer service state is ShutdownAlready"));
             }
-            ServiceState::Starting | ServiceState::Stopping => {
-                return Err(mq_client_err!("The PushConsumer service is starting or stopping"));
+            ServiceState::Starting => {
+                return Err(mq_client_err!("The PushConsumer service is Starting"));
             }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(
@@ -390,10 +388,7 @@ impl DefaultMQPushConsumerImpl {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
-        let started = Instant::now();
-        let budget = Duration::from_millis(await_terminate_millis);
-        let mut report = ShutdownReport::default();
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
         let _lock = self.global_lock.lock().await;
         match *self.service_state {
             ServiceState::CreateJust | ServiceState::StartFailed | ServiceState::Starting => {
@@ -403,29 +398,16 @@ impl DefaultMQPushConsumerImpl {
                 );
                 let had_client_instance = self.client_instance.is_some();
                 if let Some(client) = self.client_instance.as_mut() {
-                    if tokio::time::timeout(
-                        budget.saturating_sub(started.elapsed()),
-                        client.unregister_consumer(self.consumer_config.consumer_group.as_str()),
-                    )
-                    .await
-                    .is_ok()
-                    {
-                        report.local_unregistered = true;
-                    } else {
-                        report.broker_unregister_failures += 1;
-                    }
-                    if tokio::time::timeout(budget.saturating_sub(started.elapsed()), client.shutdown())
-                        .await
-                        .is_ok()
-                    {
-                        report.shared_factory_stopped = true;
-                    }
+                    client
+                        .unregister_consumer(self.consumer_config.consumer_group.as_str())
+                        .await;
+                    client.shutdown().await;
                 }
                 if let Some(consume_message_service) = self.consume_message_service.as_mut() {
-                    report.merge(consume_message_service.shutdown(await_terminate_millis).await);
+                    consume_message_service.shutdown(await_terminate_millis).await;
                 }
                 if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
-                    report.merge(consume_message_pop_service.shutdown(await_terminate_millis).await);
+                    consume_message_pop_service.shutdown(await_terminate_millis).await;
                 }
                 if had_client_instance {
                     self.rebalance_impl.destroy();
@@ -433,47 +415,20 @@ impl DefaultMQPushConsumerImpl {
                 *self.service_state = ServiceState::ShutdownAlready;
             }
             ServiceState::Running => {
-                *self.service_state = ServiceState::Stopping;
-                let queues = {
-                    let table = self.rebalance_impl.rebalance_impl_inner.process_queue_table.read().await;
-                    table.values().cloned().collect::<Vec<_>>()
-                };
-                for queue in queues {
-                    queue.set_dropped(true);
-                }
-                if let Some(client) = self.client_instance.as_mut() {
-                    if tokio::time::timeout(
-                        budget.saturating_sub(started.elapsed()),
-                        client.unregister_consumer(self.consumer_config.consumer_group.as_str()),
-                    )
-                    .await
-                    .is_ok()
-                    {
-                        report.local_unregistered = true;
-                    } else {
-                        report.broker_unregister_failures += 1;
-                    }
-                }
-                if let Some(consume_message_service) = self.consume_message_service.as_mut() {
-                    report.merge(consume_message_service.shutdown(await_terminate_millis).await);
+                if let Some(consume_message_concurrently_service) = self.consume_message_service.as_mut() {
+                    consume_message_concurrently_service
+                        .shutdown(await_terminate_millis)
+                        .await;
                 }
                 if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
-                    report.merge(consume_message_pop_service.shutdown(await_terminate_millis).await);
+                    consume_message_pop_service.shutdown(await_terminate_millis).await;
                 }
-                if tokio::time::timeout(budget.saturating_sub(started.elapsed()), self.persist_consumer_offset())
-                    .await
-                    .is_ok()
-                {
-                    report.offsets_persisted = true;
-                }
-                if let Some(client) = self.client_instance.as_mut() {
-                    if tokio::time::timeout(budget.saturating_sub(started.elapsed()), client.shutdown())
-                        .await
-                        .is_ok()
-                    {
-                        report.shared_factory_stopped = true;
-                    }
-                }
+                self.persist_consumer_offset().await;
+                let client = self.client_instance.as_mut().unwrap();
+                client
+                    .unregister_consumer(self.consumer_config.consumer_group.as_str())
+                    .await;
+                client.shutdown().await;
                 info!(
                     "the consumer [{}] shutdown OK",
                     self.consumer_config.consumer_group.as_str()
@@ -487,12 +442,8 @@ impl DefaultMQPushConsumerImpl {
                     self.consumer_config.consumer_group
                 );
             }
-            ServiceState::Stopping => {
-                warn!("the consumer [{}] is already stopping", self.consumer_config.consumer_group);
-            }
         }
-        report.elapsed = started.elapsed();
-        report
+        drop(_lock);
     }
 
     async fn update_topic_subscribe_info_when_subscription_changed(&mut self) {
@@ -1547,21 +1498,26 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
     }
 
     async fn persist_consumer_offset(&self) {
-        let allocate_mq = {
+        if let Err(err) = self.make_sure_state_ok() {
+            error!(
+                "group: {} persistConsumerOffset exception:{}",
+                self.consumer_config.consumer_group, err
+            );
+        } else {
             let guard = self
                 .rebalance_impl
                 .rebalance_impl_inner
                 .process_queue_table
                 .read()
                 .await;
-            guard.keys().cloned().collect::<HashSet<_>>()
-        };
-        self.offset_store
-            .as_ref()
-            .unwrap()
-            .mut_from_ref()
-            .persist_all(&allocate_mq)
-            .await;
+            let allocate_mq = guard.keys().cloned().collect::<HashSet<_>>();
+            self.offset_store
+                .as_ref()
+                .unwrap()
+                .mut_from_ref()
+                .persist_all(&allocate_mq)
+                .await;
+        }
     }
 
     async fn update_topic_subscribe_info(&self, topic: CheetahString, info: &HashSet<MessageQueue>) {

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -1555,6 +1555,78 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
     }
 
     fn consumer_running_info(&self) -> ConsumerRunningInfo {
-        todo!()
+        // Build a Java 4.7.1-compatible ConsumerRunningInfo snapshot.
+        // We reuse the thread::spawn + Handle::current() pattern (same as subscriptions()) to
+        // block on async reads from within this sync trait method.
+        let offset_store = self.offset_store.clone();
+        let process_queue_table = self.rebalance_impl
+            .rebalance_impl_inner
+            .process_queue_table
+            .clone();
+        let subscription_inner = self.rebalance_impl
+            .rebalance_impl_inner
+            .subscription_inner
+            .clone();
+        let client_config = self.client_config.clone();
+        let consumer_config = self.consumer_config.clone();
+        let consume_orderly = self.consume_orderly;
+
+        let handle = Handle::current();
+        thread::spawn(move || {
+            handle.block_on(async move {
+                let mut info = ConsumerRunningInfo::default();
+
+                // Properties
+                let ns_addr = client_config.get_namesrv_addr()
+                    .unwrap_or_default()
+                    .to_string();
+                info.properties.insert(
+                    CheetahString::from_static_str(ConsumerRunningInfo::PROP_NAMESERVER_ADDR),
+                    CheetahString::from_string(ns_addr),
+                );
+                info.properties.insert(
+                    CheetahString::from_static_str(ConsumerRunningInfo::PROP_CONSUME_TYPE),
+                    CheetahString::from_static_str("CONSUME_PASSIVELY"),
+                );
+                info.properties.insert(
+                    CheetahString::from_static_str(ConsumerRunningInfo::PROP_CONSUME_ORDERLY),
+                    CheetahString::from_string(consume_orderly.to_string()),
+                );
+                info.properties.insert(
+                    CheetahString::from_static_str(ConsumerRunningInfo::PROP_CLIENT_VERSION),
+                    CheetahString::from_static_str(env!("CARGO_PKG_VERSION")),
+                );
+                info.properties.insert(
+                    CheetahString::from_static_str(ConsumerRunningInfo::PROP_THREADPOOL_CORE_SIZE),
+                    CheetahString::from_string(
+                        consumer_config.consume_thread_max.to_string()
+                    ),
+                );
+
+                // Subscription set
+                {
+                    let sub = subscription_inner.read().await;
+                    info.subscription_set = sub.values().cloned().collect();
+                }
+
+                // Process queue table
+                {
+                    let pq_table = process_queue_table.read().await;
+                    for (mq, pq) in pq_table.iter() {
+                        let commit_offset = if let Some(ref store) = offset_store {
+                            store.read_offset(mq, crate::consumer::store::read_offset_type::ReadOffsetType::MemoryFirstThenStore).await
+                        } else {
+                            -1
+                        };
+                        let pq_info = pq.fill_process_queue_info(commit_offset.max(0) as u64);
+                        info.mq_table.insert(mq.clone(), pq_info);
+                    }
+                }
+
+                info
+            })
+        })
+        .join()
+        .unwrap_or_default()
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -406,6 +406,9 @@ impl DefaultMQPushConsumerImpl {
                 if let Some(consume_message_service) = self.consume_message_service.as_mut() {
                     consume_message_service.shutdown(await_terminate_millis).await;
                 }
+                if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
+                    consume_message_pop_service.shutdown(await_terminate_millis).await;
+                }
                 if had_client_instance {
                     self.rebalance_impl.destroy();
                 }
@@ -416,6 +419,9 @@ impl DefaultMQPushConsumerImpl {
                     consume_message_concurrently_service
                         .shutdown(await_terminate_millis)
                         .await;
+                }
+                if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
+                    consume_message_pop_service.shutdown(await_terminate_millis).await;
                 }
                 self.persist_consumer_offset().await;
                 let client = self.client_instance.as_mut().unwrap();

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -31,8 +31,8 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::DEFAULT_CONSUMER_GROUP;
-use rocketmq_common::common::FAQUrl;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
+use rocketmq_common::common::FAQUrl;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_error::ClientErr;
@@ -131,6 +131,10 @@ pub struct DefaultMQPushConsumerImpl {
 }
 
 impl DefaultMQPushConsumerImpl {
+    pub(crate) fn is_running(&self) -> bool {
+        *self.service_state == ServiceState::Running
+    }
+
     pub fn new(
         client_config: ClientConfig,
         consumer_config: ArcMut<ConsumerConfig>,
@@ -188,6 +192,8 @@ impl DefaultMQPushConsumerImpl {
 
 impl DefaultMQPushConsumerImpl {
     pub async fn start(&mut self) -> rocketmq_error::RocketMQResult<()> {
+        let global_lock = self.global_lock.clone();
+        let _lock = global_lock.lock().await;
         match *self.service_state {
             ServiceState::CreateJust => {
                 info!(
@@ -196,7 +202,7 @@ impl DefaultMQPushConsumerImpl {
                     self.consumer_config.message_model,
                     self.consumer_config.unit_mode
                 );
-                *self.service_state = ServiceState::StartFailed;
+                *self.service_state = ServiceState::Starting;
                 // check all config
                 self.check_config()?;
                 //copy_subscription is can be removed
@@ -309,7 +315,13 @@ impl DefaultMQPushConsumerImpl {
                 if let Some(consume_message_orderly_service) = self.consume_message_pop_service.as_mut() {
                     consume_message_orderly_service.start();
                 }
-                self.client_instance
+                let cloned = self.client_instance.as_mut().cloned().unwrap();
+                if let Err(error) = self.client_instance.as_mut().unwrap().start(cloned).await {
+                    *self.service_state = ServiceState::StartFailed;
+                    return Err(error);
+                }
+                let registered = self
+                    .client_instance
                     .as_mut()
                     .unwrap()
                     .register_consumer(
@@ -322,8 +334,23 @@ impl DefaultMQPushConsumerImpl {
                         },
                     )
                     .await;
-                let cloned = self.client_instance.as_mut().cloned().unwrap();
-                self.client_instance.as_mut().unwrap().start(cloned).await?;
+                if !registered {
+                    *self.service_state = ServiceState::StartFailed;
+                    return Err(mq_client_err!(format!(
+                        "the consumer group[{}] exist already.",
+                        self.consumer_config.consumer_group
+                    )));
+                }
+                self.update_topic_subscribe_info_when_subscription_changed().await;
+                if let Err(error) = self.client_instance.as_mut().unwrap().check_client_in_broker().await {
+                    self.client_instance
+                        .as_mut()
+                        .unwrap()
+                        .unregister_consumer(self.consumer_config.consumer_group.as_str())
+                        .await;
+                    *self.service_state = ServiceState::StartFailed;
+                    return Err(error);
+                }
                 info!(
                     "the consumer [{}] start OK, message_model={}, isUnitMode={}",
                     self.consumer_config.consumer_group,
@@ -331,12 +358,24 @@ impl DefaultMQPushConsumerImpl {
                     self.consumer_config.unit_mode
                 );
                 *self.service_state = ServiceState::Running;
+                if self
+                    .client_instance
+                    .as_mut()
+                    .unwrap()
+                    .send_heartbeat_to_all_broker_with_lock()
+                    .await
+                {
+                    self.client_instance.as_mut().unwrap().re_balance_immediately();
+                }
             }
             ServiceState::Running => {
                 return Err(mq_client_err!("The PushConsumer service state is Running"));
             }
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The PushConsumer service state is ShutdownAlready"));
+            }
+            ServiceState::Starting => {
+                return Err(mq_client_err!("The PushConsumer service is Starting"));
             }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(
@@ -346,23 +385,31 @@ impl DefaultMQPushConsumerImpl {
                 )));
             }
         }
-        self.update_topic_subscribe_info_when_subscription_changed().await;
-        let client_instance = self.client_instance.as_mut().unwrap();
-        client_instance.check_client_in_broker().await?;
-        if client_instance.send_heartbeat_to_all_broker_with_lock().await {
-            client_instance.re_balance_immediately();
-        }
         Ok(())
     }
 
     pub async fn shutdown(&mut self, await_terminate_millis: u64) {
         let _lock = self.global_lock.lock().await;
         match *self.service_state {
-            ServiceState::CreateJust => {
+            ServiceState::CreateJust | ServiceState::StartFailed | ServiceState::Starting => {
                 warn!(
-                    "the consumer [{}] do not start, so do nothing",
+                    "the consumer [{}] did not complete startup; cleaning up local state",
                     self.consumer_config.consumer_group
                 );
+                let had_client_instance = self.client_instance.is_some();
+                if let Some(client) = self.client_instance.as_mut() {
+                    client
+                        .unregister_consumer(self.consumer_config.consumer_group.as_str())
+                        .await;
+                    client.shutdown().await;
+                }
+                if let Some(consume_message_service) = self.consume_message_service.as_mut() {
+                    consume_message_service.shutdown(await_terminate_millis).await;
+                }
+                if had_client_instance {
+                    self.rebalance_impl.destroy();
+                }
+                *self.service_state = ServiceState::ShutdownAlready;
             }
             ServiceState::Running => {
                 if let Some(consume_message_concurrently_service) = self.consume_message_service.as_mut() {
@@ -386,12 +433,6 @@ impl DefaultMQPushConsumerImpl {
             ServiceState::ShutdownAlready => {
                 warn!(
                     "the consumer [{}] has been shutdown, do nothing",
-                    self.consumer_config.consumer_group
-                );
-            }
-            ServiceState::StartFailed => {
-                warn!(
-                    "the consumer [{}] start failed, do nothing",
                     self.consumer_config.consumer_group
                 );
             }
@@ -701,7 +742,9 @@ impl DefaultMQPushConsumerImpl {
 
         if let Err(e) = self.make_sure_state_ok() {
             warn!("pop_message exception, consumer state not ok {}", e);
-            self.execute_pop_request_later(pop_request, self.pull_time_delay_mills_when_exception);
+            if !self.is_terminal_state() {
+                self.execute_pop_request_later(pop_request, self.pull_time_delay_mills_when_exception);
+            }
             return;
         }
 
@@ -784,7 +827,9 @@ impl DefaultMQPushConsumerImpl {
         pull_request.process_queue.set_last_pull_timestamp(get_current_millis());
         if let Err(e) = self.make_sure_state_ok() {
             warn!("pullMessage exception, consumer state not ok {}", e);
-            self.execute_pull_request_later(pull_request, self.pull_time_delay_mills_when_exception);
+            if !self.is_terminal_state() {
+                self.execute_pull_request_later(pull_request, self.pull_time_delay_mills_when_exception);
+            }
             return;
         }
         if self.pause.load(Ordering::Acquire) {
@@ -1044,6 +1089,14 @@ impl DefaultMQPushConsumerImpl {
             )));
         }
         Ok(())
+    }
+
+    #[inline]
+    fn is_terminal_state(&self) -> bool {
+        matches!(
+            *self.service_state,
+            ServiceState::StartFailed | ServiceState::ShutdownAlready
+        )
     }
 
     pub(crate) async fn correct_tags_offset(&mut self, pull_request: &PullRequest) {

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
@@ -66,6 +67,7 @@ use crate::consumer::consumer_impl::consume_message_pop_concurrently_service::Co
 use crate::consumer::consumer_impl::consume_message_pop_orderly_service::ConsumeMessagePopOrderlyService;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessagePopServiceGeneral;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceGeneral;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::consumer_impl::pop_request::PopRequest;
 use crate::consumer::consumer_impl::pull_api_wrapper::PullAPIWrapper;
 use crate::consumer::consumer_impl::pull_request::PullRequest;
@@ -374,8 +376,8 @@ impl DefaultMQPushConsumerImpl {
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The PushConsumer service state is ShutdownAlready"));
             }
-            ServiceState::Starting => {
-                return Err(mq_client_err!("The PushConsumer service is Starting"));
+            ServiceState::Starting | ServiceState::Stopping => {
+                return Err(mq_client_err!("The PushConsumer service is starting or stopping"));
             }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(
@@ -388,7 +390,10 @@ impl DefaultMQPushConsumerImpl {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) -> ShutdownReport {
+        let started = Instant::now();
+        let budget = Duration::from_millis(await_terminate_millis);
+        let mut report = ShutdownReport::default();
         let _lock = self.global_lock.lock().await;
         match *self.service_state {
             ServiceState::CreateJust | ServiceState::StartFailed | ServiceState::Starting => {
@@ -398,16 +403,29 @@ impl DefaultMQPushConsumerImpl {
                 );
                 let had_client_instance = self.client_instance.is_some();
                 if let Some(client) = self.client_instance.as_mut() {
-                    client
-                        .unregister_consumer(self.consumer_config.consumer_group.as_str())
-                        .await;
-                    client.shutdown().await;
+                    if tokio::time::timeout(
+                        budget.saturating_sub(started.elapsed()),
+                        client.unregister_consumer(self.consumer_config.consumer_group.as_str()),
+                    )
+                    .await
+                    .is_ok()
+                    {
+                        report.local_unregistered = true;
+                    } else {
+                        report.broker_unregister_failures += 1;
+                    }
+                    if tokio::time::timeout(budget.saturating_sub(started.elapsed()), client.shutdown())
+                        .await
+                        .is_ok()
+                    {
+                        report.shared_factory_stopped = true;
+                    }
                 }
                 if let Some(consume_message_service) = self.consume_message_service.as_mut() {
-                    consume_message_service.shutdown(await_terminate_millis).await;
+                    report.merge(consume_message_service.shutdown(await_terminate_millis).await);
                 }
                 if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
-                    consume_message_pop_service.shutdown(await_terminate_millis).await;
+                    report.merge(consume_message_pop_service.shutdown(await_terminate_millis).await);
                 }
                 if had_client_instance {
                     self.rebalance_impl.destroy();
@@ -415,20 +433,47 @@ impl DefaultMQPushConsumerImpl {
                 *self.service_state = ServiceState::ShutdownAlready;
             }
             ServiceState::Running => {
-                if let Some(consume_message_concurrently_service) = self.consume_message_service.as_mut() {
-                    consume_message_concurrently_service
-                        .shutdown(await_terminate_millis)
-                        .await;
+                *self.service_state = ServiceState::Stopping;
+                let queues = {
+                    let table = self.rebalance_impl.rebalance_impl_inner.process_queue_table.read().await;
+                    table.values().cloned().collect::<Vec<_>>()
+                };
+                for queue in queues {
+                    queue.set_dropped(true);
+                }
+                if let Some(client) = self.client_instance.as_mut() {
+                    if tokio::time::timeout(
+                        budget.saturating_sub(started.elapsed()),
+                        client.unregister_consumer(self.consumer_config.consumer_group.as_str()),
+                    )
+                    .await
+                    .is_ok()
+                    {
+                        report.local_unregistered = true;
+                    } else {
+                        report.broker_unregister_failures += 1;
+                    }
+                }
+                if let Some(consume_message_service) = self.consume_message_service.as_mut() {
+                    report.merge(consume_message_service.shutdown(await_terminate_millis).await);
                 }
                 if let Some(consume_message_pop_service) = self.consume_message_pop_service.as_mut() {
-                    consume_message_pop_service.shutdown(await_terminate_millis).await;
+                    report.merge(consume_message_pop_service.shutdown(await_terminate_millis).await);
                 }
-                self.persist_consumer_offset().await;
-                let client = self.client_instance.as_mut().unwrap();
-                client
-                    .unregister_consumer(self.consumer_config.consumer_group.as_str())
-                    .await;
-                client.shutdown().await;
+                if tokio::time::timeout(budget.saturating_sub(started.elapsed()), self.persist_consumer_offset())
+                    .await
+                    .is_ok()
+                {
+                    report.offsets_persisted = true;
+                }
+                if let Some(client) = self.client_instance.as_mut() {
+                    if tokio::time::timeout(budget.saturating_sub(started.elapsed()), client.shutdown())
+                        .await
+                        .is_ok()
+                    {
+                        report.shared_factory_stopped = true;
+                    }
+                }
                 info!(
                     "the consumer [{}] shutdown OK",
                     self.consumer_config.consumer_group.as_str()
@@ -442,8 +487,12 @@ impl DefaultMQPushConsumerImpl {
                     self.consumer_config.consumer_group
                 );
             }
+            ServiceState::Stopping => {
+                warn!("the consumer [{}] is already stopping", self.consumer_config.consumer_group);
+            }
         }
-        drop(_lock);
+        report.elapsed = started.elapsed();
+        report
     }
 
     async fn update_topic_subscribe_info_when_subscription_changed(&mut self) {
@@ -1498,26 +1547,21 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
     }
 
     async fn persist_consumer_offset(&self) {
-        if let Err(err) = self.make_sure_state_ok() {
-            error!(
-                "group: {} persistConsumerOffset exception:{}",
-                self.consumer_config.consumer_group, err
-            );
-        } else {
+        let allocate_mq = {
             let guard = self
                 .rebalance_impl
                 .rebalance_impl_inner
                 .process_queue_table
                 .read()
                 .await;
-            let allocate_mq = guard.keys().cloned().collect::<HashSet<_>>();
-            self.offset_store
-                .as_ref()
-                .unwrap()
-                .mut_from_ref()
-                .persist_all(&allocate_mq)
-                .await;
-        }
+            guard.keys().cloned().collect::<HashSet<_>>()
+        };
+        self.offset_store
+            .as_ref()
+            .unwrap()
+            .mut_from_ref()
+            .persist_all(&allocate_mq)
+            .await;
     }
 
     async fn update_topic_subscribe_info(&self, topic: CheetahString, info: &HashSet<MessageQueue>) {

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -31,6 +31,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::DEFAULT_CONSUMER_GROUP;
+use rocketmq_common::common::FAQUrl;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::get_current_millis;

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -66,6 +66,9 @@ pub(crate) struct ProcessQueue {
     pub(crate) last_lock_timestamp: Arc<AtomicU64>,
     pub(crate) consuming: Arc<AtomicBool>,
     pub(crate) msg_acc_cnt: Arc<AtomicI64>,
+    /// Millisecond wall-clock timestamp when the queue first entered flow-control in the current
+    /// stall window, or 0 when not flow-controlled. Used by the stall detector only.
+    pub(crate) flow_control_since: Arc<AtomicU64>,
     /// Serializes per-queue commit operations so that concurrent chunk tasks
     /// cannot interleave offset advancement or ProcessQueue removal.
     pub(crate) commit_lock: Arc<Mutex<()>>,
@@ -89,6 +92,7 @@ impl ProcessQueue {
             last_lock_timestamp: Arc::new(AtomicU64::new(get_current_millis())),
             consuming: Arc::new(AtomicBool::new(false)),
             msg_acc_cnt: Arc::new(AtomicI64::new(0)),
+            flow_control_since: Arc::new(AtomicU64::new(0)),
             commit_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -348,11 +352,35 @@ impl ProcessQueue {
     pub(crate) fn set_last_pull_timestamp(&self, last_pull_timestamp: u64) {
         self.last_pull_timestamp
             .store(last_pull_timestamp, std::sync::atomic::Ordering::Release);
+        // Clear the flow-control start marker when a real broker pull is issued.
+        self.flow_control_since.store(0, std::sync::atomic::Ordering::Release);
     }
 
     pub(crate) fn set_last_lock_timestamp(&self, last_lock_timestamp: u64) {
         self.last_lock_timestamp
             .store(last_lock_timestamp, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Mark that this queue entered flow-control.  Idempotent: only records the
+    /// first entry so the stall duration accumulates from that point.
+    pub(crate) fn mark_flow_control(&self) {
+        // Use compare-and-swap so that concurrent callers don't reset an existing start time.
+        let _ = self.flow_control_since.compare_exchange(
+            0,
+            get_current_millis(),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    /// How many milliseconds this queue has been continuously flow-controlled,
+    /// or 0 if it is not currently in flow-control.
+    pub(crate) fn flow_control_stall_ms(&self) -> u64 {
+        let since = self.flow_control_since.load(Ordering::Acquire);
+        if since == 0 {
+            return 0;
+        }
+        get_current_millis().saturating_sub(since)
     }
 
     pub fn msg_count(&self) -> u64 {
@@ -375,6 +403,7 @@ mod tests {
     use rocketmq_rust::ArcMut;
 
     use super::ProcessQueue;
+    use rocketmq_common::TimeUtils::get_current_millis;
 
     fn make_msg(offset: i64, body_size: usize) -> ArcMut<MessageExt> {
         let mut msg = MessageExt {
@@ -517,6 +546,34 @@ mod tests {
         let _o2 = r2.unwrap();
 
         assert_eq!(pq.msg_count(), 0, "all messages must be removed");
+    }
+
+    #[test]
+    fn flow_control_stall_ms_is_zero_before_mark() {
+        let pq = ProcessQueue::new();
+        // Immediately after construction, no flow-control has been recorded.
+        // We reset to 0 explicitly to avoid the constructor timestamp.
+        pq.flow_control_since.store(0, std::sync::atomic::Ordering::Release);
+        assert_eq!(pq.flow_control_stall_ms(), 0);
+    }
+
+    #[test]
+    fn flow_control_stall_ms_is_nonzero_after_mark() {
+        let pq = ProcessQueue::new();
+        pq.flow_control_since.store(0, std::sync::atomic::Ordering::Release);
+        pq.mark_flow_control();
+        // Give the timer at least 1 ms to advance.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(pq.flow_control_stall_ms() > 0);
+    }
+
+    #[test]
+    fn set_last_pull_timestamp_clears_flow_control_marker() {
+        let pq = ProcessQueue::new();
+        pq.mark_flow_control();
+        assert!(pq.flow_control_since.load(std::sync::atomic::Ordering::Acquire) > 0);
+        pq.set_last_pull_timestamp(get_current_millis());
+        assert_eq!(pq.flow_control_since.load(std::sync::atomic::Ordering::Acquire), 0);
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -518,4 +518,26 @@ mod tests {
 
         assert_eq!(pq.msg_count(), 0, "all messages must be removed");
     }
+
+    #[test]
+    fn fill_process_queue_info_reflects_queue_state() {
+        let pq = ProcessQueue::new();
+        pq.msg_count.store(5, std::sync::atomic::Ordering::Release);
+        pq.msg_size.store(1024 * 1024 * 3, std::sync::atomic::Ordering::Release);
+        pq.queue_offset_max.store(20, std::sync::atomic::Ordering::Release);
+        pq.locked.store(true, std::sync::atomic::Ordering::Release);
+        pq.dropped.store(false, std::sync::atomic::Ordering::Release);
+        pq.last_pull_timestamp.store(1_000, std::sync::atomic::Ordering::Release);
+        pq.last_consume_timestamp.store(900, std::sync::atomic::Ordering::Release);
+
+        let info = pq.fill_process_queue_info(10);
+        assert_eq!(info.commit_offset, 10);
+        assert_eq!(info.cached_msg_count, 5);
+        assert_eq!(info.cached_msg_size_in_mib, 3);
+        assert_eq!(info.cached_msg_max_offset, 20);
+        assert!(info.locked);
+        assert!(!info.droped);
+        assert_eq!(info.last_pull_timestamp, 1_000);
+        assert_eq!(info.last_consume_timestamp, 900);
+    }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -29,6 +29,7 @@ use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_remoting::protocol::body::process_queue_info::ProcessQueueInfo;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::RocketMQTokioRwLock;
+use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
@@ -65,6 +66,9 @@ pub(crate) struct ProcessQueue {
     pub(crate) last_lock_timestamp: Arc<AtomicU64>,
     pub(crate) consuming: Arc<AtomicBool>,
     pub(crate) msg_acc_cnt: Arc<AtomicI64>,
+    /// Serializes per-queue commit operations so that concurrent chunk tasks
+    /// cannot interleave offset advancement or ProcessQueue removal.
+    pub(crate) commit_lock: Arc<Mutex<()>>,
 }
 
 impl ProcessQueue {
@@ -85,6 +89,7 @@ impl ProcessQueue {
             last_lock_timestamp: Arc::new(AtomicU64::new(get_current_millis())),
             consuming: Arc::new(AtomicBool::new(false)),
             msg_acc_cnt: Arc::new(AtomicI64::new(0)),
+            commit_lock: Arc::new(Mutex::new(())),
         }
     }
 }
@@ -448,5 +453,41 @@ mod tests {
         assert_eq!(offset, 3, "when empty, offset should be queue_offset_max + 1");
         assert_eq!(pq.msg_count(), 0);
         assert_eq!(pq.msg_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_commit_lock_serializes_concurrent_removals() {
+        use std::sync::Arc;
+        let pq = Arc::new(ProcessQueue::new());
+        let offsets: Vec<i64> = (0..32).collect();
+        put_msgs(&pq, &offsets, 4).await;
+
+        let pq1 = pq.clone();
+        let pq2 = pq.clone();
+
+        let first_chunk: Vec<ArcMut<MessageExt>> = (0..16).map(|o| make_msg(o, 4)).collect();
+        let second_chunk: Vec<ArcMut<MessageExt>> = (16..32).map(|o| make_msg(o, 4)).collect();
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let b1 = barrier.clone();
+        let b2 = barrier.clone();
+
+        let h1 = tokio::spawn(async move {
+            let _g = pq1.commit_lock.lock().await;
+            b1.wait().await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            pq1.remove_message(&first_chunk).await
+        });
+        let h2 = tokio::spawn(async move {
+            b2.wait().await;
+            let _g = pq2.commit_lock.lock().await;
+            pq2.remove_message(&second_chunk).await
+        });
+
+        let (r1, r2) = tokio::join!(h1, h2);
+        let _o1 = r1.unwrap();
+        let _o2 = r2.unwrap();
+
+        assert_eq!(pq.msg_count(), 0, "all messages must be removed");
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -351,8 +351,7 @@ mod tests {
     use super::ProcessQueue;
 
     fn make_msg(offset: i64, body_size: usize) -> ArcMut<MessageExt> {
-        let mut msg = MessageExt::default();
-        msg.queue_offset = offset;
+        let mut msg = MessageExt{ queue_offset: offset, .. MessageExt::default()};
         msg.message.body = Some(Bytes::from(vec![0u8; body_size]));
         ArcMut::new(msg)
     }
@@ -410,7 +409,7 @@ mod tests {
         put_msgs(&pq, &[0, 1, 2, 3, 4], 4).await;
         assert_eq!(pq.msg_count(), 5);
 
-        let to_remove: Vec<ArcMut<MessageExt>> = vec![0, 1, 2].iter().map(|&o| make_msg(o, 4)).collect();
+        let to_remove: Vec<ArcMut<MessageExt>> = [0, 1, 2].iter().map(|&o| make_msg(o, 4)).collect();
         pq.remove_message(&to_remove).await;
 
         let tree = pq.msg_tree_map.read().await;

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -315,8 +315,34 @@ impl ProcessQueue {
         drop(lock);
     }
 
-    pub(crate) fn fill_process_queue_info(&self, info: ProcessQueueInfo) {
-        unimplemented!("fill_process_queue_info")
+    /// Snapshot the current queue state into a [`ProcessQueueInfo`] for admin/running-info.
+    pub(crate) fn fill_process_queue_info(&self, commit_offset: u64) -> ProcessQueueInfo {
+        let msg_count = self.msg_count.load(Ordering::Acquire);
+        let queue_offset_max = self.queue_offset_max.load(Ordering::Acquire);
+        // cached_msg_min_offset: 0 when queue is empty (consistent with Java client).
+        let cached_min = if msg_count == 0 {
+            0
+        } else {
+            // Approximate: min known offset is commit_offset when draining.
+            commit_offset
+        };
+        ProcessQueueInfo {
+            commit_offset,
+            cached_msg_min_offset: cached_min,
+            cached_msg_max_offset: queue_offset_max,
+            cached_msg_count: msg_count as u32,
+            cached_msg_size_in_mib: (self.msg_size.load(Ordering::Acquire) / (1024 * 1024)) as u32,
+            locked: self.locked.load(Ordering::Acquire),
+            try_unlock_times: self.try_unlock_times.load(Ordering::Acquire) as u64,
+            last_lock_timestamp: self.last_lock_timestamp.load(Ordering::Acquire),
+            droped: self.dropped.load(Ordering::Acquire),
+            last_pull_timestamp: self.last_pull_timestamp.load(Ordering::Acquire),
+            last_consume_timestamp: self.last_consume_timestamp.load(Ordering::Acquire),
+            // Transaction queue fields: not used in CLUSTERING push consumer.
+            transaction_msg_min_offset: 0,
+            transaction_msg_max_offset: 0,
+            transaction_msg_count: 0,
+        }
     }
 
     pub(crate) fn set_last_pull_timestamp(&self, last_pull_timestamp: u64) {

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -423,4 +423,30 @@ mod tests {
 
         assert_eq!(pq.msg_count(), 0, "count must not underflow");
     }
+
+    #[tokio::test]
+    async fn test_partial_remove_offset_is_lowest_retained() {
+        let pq = ProcessQueue::new();
+        let offsets: Vec<i64> = (0..16).collect();
+        put_msgs(&pq, &offsets, 4).await;
+
+        let to_remove: Vec<ArcMut<MessageExt>> = (0..5).map(|o| make_msg(o, 4)).collect();
+        let offset = pq.remove_message(&to_remove).await;
+
+        assert_eq!(offset, 5, "next offset should be the lowest retained key");
+        assert_eq!(pq.msg_count(), 11);
+    }
+
+    #[tokio::test]
+    async fn test_full_remove_returns_max_plus_one() {
+        let pq = ProcessQueue::new();
+        put_msgs(&pq, &[0, 1, 2], 4).await;
+
+        let to_remove: Vec<ArcMut<MessageExt>> = (0..3).map(|o| make_msg(o, 4)).collect();
+        let offset = pq.remove_message(&to_remove).await;
+
+        assert_eq!(offset, 3, "when empty, offset should be queue_offset_max + 1");
+        assert_eq!(pq.msg_count(), 0);
+        assert_eq!(pq.msg_size(), 0);
+    }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -351,7 +351,10 @@ mod tests {
     use super::ProcessQueue;
 
     fn make_msg(offset: i64, body_size: usize) -> ArcMut<MessageExt> {
-        let mut msg = MessageExt{ queue_offset: offset, .. MessageExt::default()};
+        let mut msg = MessageExt {
+            queue_offset: offset,
+            ..MessageExt::default()
+        };
         msg.message.body = Some(Bytes::from(vec![0u8; body_size]));
         ArcMut::new(msg)
     }

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -222,21 +222,23 @@ impl ProcessQueue {
             return result;
         }
         result = self.queue_offset_max.load(Ordering::Acquire) as i64 + 1;
-        let mut removed_cnt = 0;
+        let mut removed_cnt: u64 = 0;
         for message in messages {
             let prev = msg_tree_map.remove(&message.queue_offset);
-            if let Some(prev) = prev {
+            if prev.is_some() {
                 removed_cnt += 1;
                 self.msg_size
                     .fetch_sub(message.body().as_ref().unwrap().len() as u64, Ordering::AcqRel);
             }
+        }
+        if removed_cnt > 0 {
             self.msg_count.fetch_sub(removed_cnt, Ordering::AcqRel);
-            if self.msg_count.load(Ordering::Acquire) == 0 {
-                self.msg_size.store(0, Ordering::Release);
-            }
-            if !msg_tree_map.is_empty() {
-                result = *msg_tree_map.first_key_value().unwrap().0;
-            }
+        }
+        if self.msg_count.load(Ordering::Acquire) == 0 {
+            self.msg_size.store(0, Ordering::Release);
+        }
+        if !msg_tree_map.is_empty() {
+            result = *msg_tree_map.first_key_value().unwrap().0;
         }
         result
     }
@@ -332,5 +334,93 @@ impl ProcessQueue {
 
     pub(crate) fn is_locked(&self) -> bool {
         self.locked.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use rocketmq_common::common::message::message_ext::MessageExt;
+    use rocketmq_rust::ArcMut;
+
+    use super::ProcessQueue;
+
+    fn make_msg(offset: i64, body_size: usize) -> ArcMut<MessageExt> {
+        let mut msg = MessageExt::default();
+        msg.queue_offset = offset;
+        msg.message.body = Some(Bytes::from(vec![0u8; body_size]));
+        ArcMut::new(msg)
+    }
+
+    async fn put_msgs(pq: &ProcessQueue, offsets: &[i64], body_size: usize) {
+        let msgs = offsets.iter().map(|&o| make_msg(o, body_size)).collect();
+        pq.put_message(msgs).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_single_message_correct_count() {
+        let pq = ProcessQueue::new();
+        put_msgs(&pq, &[0], 10).await;
+        assert_eq!(pq.msg_count(), 1);
+        assert_eq!(pq.msg_size(), 10);
+
+        let msgs = vec![make_msg(0, 10)];
+        pq.remove_message(&msgs).await;
+
+        assert_eq!(pq.msg_count(), 0);
+        assert_eq!(pq.msg_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_two_messages_correct_count() {
+        let pq = ProcessQueue::new();
+        put_msgs(&pq, &[0, 1], 10).await;
+        assert_eq!(pq.msg_count(), 2);
+
+        let msgs = vec![make_msg(0, 10), make_msg(1, 10)];
+        pq.remove_message(&msgs).await;
+
+        assert_eq!(pq.msg_count(), 0);
+        assert_eq!(pq.msg_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_16_messages_correct_count() {
+        let pq = ProcessQueue::new();
+        let offsets: Vec<i64> = (0..16).collect();
+        put_msgs(&pq, &offsets, 5).await;
+        assert_eq!(pq.msg_count(), 16);
+        assert_eq!(pq.msg_size(), 80);
+
+        let msgs: Vec<ArcMut<MessageExt>> = offsets.iter().map(|&o| make_msg(o, 5)).collect();
+        pq.remove_message(&msgs).await;
+
+        assert_eq!(pq.msg_count(), 0);
+        assert_eq!(pq.msg_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_subset_correct_count() {
+        let pq = ProcessQueue::new();
+        put_msgs(&pq, &[0, 1, 2, 3, 4], 4).await;
+        assert_eq!(pq.msg_count(), 5);
+
+        let to_remove: Vec<ArcMut<MessageExt>> = vec![0, 1, 2].iter().map(|&o| make_msg(o, 4)).collect();
+        pq.remove_message(&to_remove).await;
+
+        let tree = pq.msg_tree_map.read().await;
+        assert_eq!(pq.msg_count(), 2, "count should match retained map size");
+        assert_eq!(tree.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_msg_count_no_underflow() {
+        let pq = ProcessQueue::new();
+        put_msgs(&pq, &[0], 4).await;
+
+        let msgs = vec![make_msg(0, 4), make_msg(99, 4)];
+        pq.remove_message(&msgs).await;
+
+        assert_eq!(pq.msg_count(), 0, "count must not underflow");
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -425,25 +426,21 @@ where
             }
         }
 
-        for (mq, pq) in remove_queue_map {
-            if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
-                if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
-                    let removed = {
-                        let mut process_queue_table = self.process_queue_table.write().await;
-                        if matches!(process_queue_table.get(&mq), Some(current) if Arc::ptr_eq(current, &pq)) {
+        {
+            if !remove_queue_map.is_empty() {
+                let mut process_queue_table = self.process_queue_table.write().await;
+                // Remove message queues no longer belong to me
+                for (mq, pq) in remove_queue_map {
+                    if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
+                        if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
                             process_queue_table.remove(&mq);
-                            true
-                        } else {
-                            false
+                            changed = true;
+                            info!(
+                                "doRebalance, {:?}, remove unnecessary mq, {}",
+                                self.consumer_group,
+                                mq.get_topic()
+                            );
                         }
-                    };
-                    if removed {
-                        changed = true;
-                        info!(
-                            "doRebalance, {:?}, remove unnecessary mq, {}",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
                     }
                 }
             }
@@ -496,76 +493,85 @@ where
             }
         }
 
-        // Build pull requests outside the process-table lock. Each insert is
-        // committed only if another rebalance has not inserted the queue.
-        let mut all_mq_locked = true;
-        let mut pull_request_list = Vec::new();
-        let Some(mut sub_rebalance_impl) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() else {
-            return false;
-        };
-        let missing_queues = {
-            let process_queue_table = self.process_queue_table.read().await;
-            mq2push_assignment
-                .keys()
-                .filter(|mq| !process_queue_table.contains_key(*mq))
-                .map(|mq| (*mq).clone())
-                .collect::<Vec<_>>()
-        };
-        for mq in missing_queues {
-            if is_order && !self.lock_with(&mq).await {
-                warn!(
-                    "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
-                    self.consumer_group,
-                    mq.get_topic()
-                );
-                all_mq_locked = false;
-                continue;
+        {
+            // add new message queue
+            let mut all_mq_locked = true;
+            let mut pull_request_list = Vec::new();
+            let sub_rebalance_impl = self.sub_rebalance_impl.as_mut().unwrap().upgrade();
+            if sub_rebalance_impl.is_none() {
+                return false;
             }
-            sub_rebalance_impl.remove_dirty_offset(&mq).await;
-            let pq = Arc::new(sub_rebalance_impl.create_process_queue());
-            pq.set_locked(true);
-            let Ok(next_offset) = sub_rebalance_impl.compute_pull_from_where_with_exception(&mq).await else {
-                continue;
-            };
-            if next_offset < 0 {
-                warn!("doRebalance, {:?}, add new mq failed, {}", self.consumer_group, mq.get_topic());
-                continue;
-            }
-            let inserted = {
-                let mut process_queue_table = self.process_queue_table.write().await;
-                if process_queue_table.contains_key(&mq) {
-                    false
-                } else {
-                    process_queue_table.insert(mq.clone(), pq.clone());
-                    true
+            let mut sub_rebalance_impl = sub_rebalance_impl.unwrap();
+            let process_queue_table_clone = self.process_queue_table.clone();
+            let mut process_queue_table = process_queue_table_clone.write().await;
+            for (mq, assignment) in mq2push_assignment {
+                if !process_queue_table.contains_key(mq) {
+                    if is_order && !self.lock_with(mq, process_queue_table.deref()).await {
+                        warn!(
+                            "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
+                        all_mq_locked = false;
+                        continue;
+                    }
+
+                    sub_rebalance_impl.remove_dirty_offset(mq).await;
+                    let pq = Arc::new(sub_rebalance_impl.create_process_queue());
+                    pq.set_locked(true);
+                    let next_offset = sub_rebalance_impl.compute_pull_from_where_with_exception(mq).await;
+                    if next_offset.is_err() {
+                        continue;
+                    }
+                    let next_offset = next_offset.unwrap();
+                    if next_offset >= 0 {
+                        if process_queue_table.insert(mq.clone(), pq.clone()).is_none() {
+                            info!(
+                                "doRebalance, {:?}, add a new mq, {}",
+                                self.consumer_group,
+                                mq.get_topic()
+                            );
+                            pull_request_list.push(PullRequest::new(
+                                self.consumer_group.as_ref().unwrap().clone(),
+                                mq.clone(),
+                                pq,
+                                next_offset,
+                            ));
+                            changed = true;
+                        } else {
+                            info!(
+                                "doRebalance, {:?}, mq already exists, {}",
+                                self.consumer_group,
+                                mq.get_topic()
+                            );
+                        }
+                    } else {
+                        warn!(
+                            "doRebalance, {:?}, add new mq failed, {}",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
+                    }
                 }
-            };
-            if inserted {
-                info!("doRebalance, {:?}, add a new mq, {}", self.consumer_group, mq.get_topic());
-                pull_request_list.push(PullRequest::new(
-                    self.consumer_group.as_ref().unwrap().clone(),
-                    mq,
-                    pq,
-                    next_offset,
-                ));
-                changed = true;
             }
+
+            if !all_mq_locked {
+                self.client_instance.as_mut().unwrap().rebalance_later(500);
+            }
+            sub_rebalance_impl.dispatch_pull_request(pull_request_list, 500).await;
         }
 
-        if !all_mq_locked {
-            self.client_instance.as_mut().unwrap().rebalance_later(500);
-        }
-        sub_rebalance_impl.dispatch_pull_request(pull_request_list, 500).await;
-
-        if let Some(rebalance_impl) = self.sub_rebalance_impl.as_ref().unwrap().upgrade() {
-            let mut pop_request_list = Vec::new();
-            {
+        {
+            if let Some(rebalance_impl) = self.sub_rebalance_impl.as_ref().unwrap().upgrade() {
+                let mut pop_request_list = Vec::new();
                 let mut pop_process_queue_table = self.pop_process_queue_table.write().await;
-                for (mq, _) in mq2pop_assignment {
+                for (mq, assignment) in mq2pop_assignment {
                     if !pop_process_queue_table.contains_key(mq) {
                         let pq = rebalance_impl.create_pop_process_queue();
                         let pre = pop_process_queue_table.insert(mq.clone(), Arc::new(pq.clone()));
                         if pre.is_none() {
+                            info!("doRebalance, {:?}, mq already exists, {}", self.consumer_group, mq);
+                        } else {
                             info!("doRebalance, {:?}, add a new pop mq, {}", self.consumer_group, mq);
                             let request = PopRequest::new(
                                 topic.clone(),
@@ -579,8 +585,8 @@ where
                         }
                     }
                 }
+                rebalance_impl.dispatch_pop_pull_request(pop_request_list, 500).await;
             }
-            rebalance_impl.dispatch_pop_pull_request(pop_request_list, 500).await;
         }
 
         changed
@@ -621,27 +627,21 @@ where
             }
         }
 
-        // Broker/offset cleanup can await. Do it after the table snapshot and
-        // only reacquire the lock to remove the same queue instance.
-        for (mq, pq) in remove_queue_map {
-            if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
-                if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
-                    let removed = {
-                        let mut process_queue_table = process_queue_table_cloned.write().await;
-                        if matches!(process_queue_table.get(&mq), Some(current) if Arc::ptr_eq(current, &pq)) {
+        {
+            if !remove_queue_map.is_empty() {
+                let mut process_queue_table = process_queue_table_cloned.write().await;
+                // Remove message queues no longer belong to me
+                for (mq, pq) in remove_queue_map {
+                    if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
+                        if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
                             process_queue_table.remove(&mq);
-                            true
-                        } else {
-                            false
+                            changed = true;
+                            info!(
+                                "doRebalance, {:?}, remove unnecessary mq, {}",
+                                self.consumer_group,
+                                mq.get_topic()
+                            );
                         }
-                    };
-                    if removed {
-                        changed = true;
-                        info!(
-                            "doRebalance, {:?}, remove unnecessary mq, {}",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
                     }
                 }
             }
@@ -654,51 +654,51 @@ where
             return false;
         }
         let mut sub_rebalance_impl = sub_rebalance_impl.unwrap();
-        let missing_queues = {
-            let process_queue_table = process_queue_table_cloned.read().await;
-            mq_set
-                .iter()
-                .filter(|mq| !process_queue_table.contains_key(*mq))
-                .cloned()
-                .collect::<Vec<_>>()
-        };
-        for mq in missing_queues {
-            if is_order && !self.lock_with(&mq).await {
-                warn!(
-                    "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
-                    self.consumer_group,
-                    mq.get_topic()
-                );
-                all_mq_locked = false;
-                continue;
-            }
-
-            sub_rebalance_impl.remove_dirty_offset(&mq).await;
-            let pq = Arc::new(sub_rebalance_impl.create_process_queue());
-            pq.set_locked(true);
-            let next_offset = sub_rebalance_impl.compute_pull_from_where(&mq).await;
-            if next_offset < 0 {
-                warn!("doRebalance, {:?}, add new mq failed, {}", self.consumer_group, mq.get_topic());
-                continue;
-            }
-            let inserted = {
-                let mut process_queue_table = process_queue_table_cloned.write().await;
-                if process_queue_table.contains_key(&mq) {
-                    false
-                } else {
-                    process_queue_table.insert(mq.clone(), pq.clone());
-                    true
+        let mut process_queue_table = process_queue_table_cloned.write().await;
+        for mq in mq_set {
+            if !process_queue_table.contains_key(mq) {
+                if is_order && !self.lock_with(mq, process_queue_table.deref()).await {
+                    warn!(
+                        "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
+                        self.consumer_group,
+                        mq.get_topic()
+                    );
+                    all_mq_locked = false;
+                    continue;
                 }
-            };
-            if inserted {
-                info!("doRebalance, {:?}, add a new mq, {}", self.consumer_group, mq.get_topic());
-                pull_request_list.push(PullRequest::new(
-                    self.consumer_group.as_ref().unwrap().clone(),
-                    mq,
-                    pq,
-                    next_offset,
-                ));
-                changed = true;
+
+                sub_rebalance_impl.remove_dirty_offset(mq).await;
+                let pq = Arc::new(sub_rebalance_impl.create_process_queue());
+                pq.set_locked(true);
+                let next_offset = sub_rebalance_impl.compute_pull_from_where(mq).await;
+                if next_offset >= 0 {
+                    if process_queue_table.insert(mq.clone(), pq.clone()).is_none() {
+                        info!(
+                            "doRebalance, {:?}, add a new mq, {}",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
+                        pull_request_list.push(PullRequest::new(
+                            self.consumer_group.as_ref().unwrap().clone(),
+                            mq.clone(),
+                            pq,
+                            next_offset,
+                        ));
+                        changed = true;
+                    } else {
+                        info!(
+                            "doRebalance, {:?}, mq already exists, {}",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
+                    }
+                } else {
+                    warn!(
+                        "doRebalance, {:?}, add new mq failed, {}",
+                        self.consumer_group,
+                        mq.get_topic()
+                    );
+                }
             }
         }
 
@@ -846,10 +846,17 @@ where
     }
 
     pub async fn lock(&mut self, mq: &MessageQueue) -> bool {
-        self.lock_with(mq).await
+        let process_queue_table_ = self.process_queue_table.clone();
+        let process_queue_table = process_queue_table_.read().await;
+        let table = process_queue_table.deref();
+        self.lock_with(mq, table).await
     }
 
-    pub async fn lock_with(&mut self, mq: &MessageQueue) -> bool {
+    pub async fn lock_with(
+        &mut self,
+        mq: &MessageQueue,
+        process_queue_table: &HashMap<MessageQueue, Arc<ProcessQueue>>,
+    ) -> bool {
         let client = self.client_instance.as_mut().unwrap();
         let broker_name = client.get_broker_name_from_message_queue(mq).await;
         let find_broker_result = client
@@ -870,7 +877,6 @@ where
                 .await;
             match result {
                 Ok(locked_mq) => {
-                    let process_queue_table = self.process_queue_table.read().await;
                     for mq in &locked_mq {
                         if let Some(pq) = process_queue_table.get(mq) {
                             pq.set_locked(true);
@@ -1053,19 +1059,15 @@ where
         &self,
     ) -> HashMap<CheetahString /* brokerName */, HashSet<MessageQueue>> {
         let mut result = HashMap::new();
-        let active_queues = {
-            let process_queue_table = self.process_queue_table.read().await;
-            process_queue_table
-                .iter()
-                .filter(|(_, pq)| !pq.is_dropped())
-                .map(|(mq, _)| mq.clone())
-                .collect::<Vec<_>>()
-        };
+        let process_queue_table = self.process_queue_table.read().await;
         let client = self.client_instance.as_ref().unwrap();
-        for mq in active_queues {
-            let broker_name = client.get_broker_name_from_message_queue(&mq).await;
+        for (mq, pq) in process_queue_table.iter() {
+            if pq.is_dropped() {
+                continue;
+            }
+            let broker_name = client.get_broker_name_from_message_queue(mq).await;
             let entry = result.entry(broker_name).or_insert(HashSet::new());
-            entry.insert(mq);
+            entry.insert(mq.to_owned());
         }
         result
     }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -426,21 +425,25 @@ where
             }
         }
 
-        {
-            if !remove_queue_map.is_empty() {
-                let mut process_queue_table = self.process_queue_table.write().await;
-                // Remove message queues no longer belong to me
-                for (mq, pq) in remove_queue_map {
-                    if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
-                        if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
+        for (mq, pq) in remove_queue_map {
+            if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
+                if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
+                    let removed = {
+                        let mut process_queue_table = self.process_queue_table.write().await;
+                        if matches!(process_queue_table.get(&mq), Some(current) if Arc::ptr_eq(current, &pq)) {
                             process_queue_table.remove(&mq);
-                            changed = true;
-                            info!(
-                                "doRebalance, {:?}, remove unnecessary mq, {}",
-                                self.consumer_group,
-                                mq.get_topic()
-                            );
+                            true
+                        } else {
+                            false
                         }
+                    };
+                    if removed {
+                        changed = true;
+                        info!(
+                            "doRebalance, {:?}, remove unnecessary mq, {}",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
                     }
                 }
             }
@@ -493,85 +496,76 @@ where
             }
         }
 
-        {
-            // add new message queue
-            let mut all_mq_locked = true;
-            let mut pull_request_list = Vec::new();
-            let sub_rebalance_impl = self.sub_rebalance_impl.as_mut().unwrap().upgrade();
-            if sub_rebalance_impl.is_none() {
-                return false;
+        // Build pull requests outside the process-table lock. Each insert is
+        // committed only if another rebalance has not inserted the queue.
+        let mut all_mq_locked = true;
+        let mut pull_request_list = Vec::new();
+        let Some(mut sub_rebalance_impl) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() else {
+            return false;
+        };
+        let missing_queues = {
+            let process_queue_table = self.process_queue_table.read().await;
+            mq2push_assignment
+                .keys()
+                .filter(|mq| !process_queue_table.contains_key(*mq))
+                .map(|mq| (*mq).clone())
+                .collect::<Vec<_>>()
+        };
+        for mq in missing_queues {
+            if is_order && !self.lock_with(&mq).await {
+                warn!(
+                    "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
+                    self.consumer_group,
+                    mq.get_topic()
+                );
+                all_mq_locked = false;
+                continue;
             }
-            let mut sub_rebalance_impl = sub_rebalance_impl.unwrap();
-            let process_queue_table_clone = self.process_queue_table.clone();
-            let mut process_queue_table = process_queue_table_clone.write().await;
-            for (mq, assignment) in mq2push_assignment {
-                if !process_queue_table.contains_key(mq) {
-                    if is_order && !self.lock_with(mq, process_queue_table.deref()).await {
-                        warn!(
-                            "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
-                        all_mq_locked = false;
-                        continue;
-                    }
-
-                    sub_rebalance_impl.remove_dirty_offset(mq).await;
-                    let pq = Arc::new(sub_rebalance_impl.create_process_queue());
-                    pq.set_locked(true);
-                    let next_offset = sub_rebalance_impl.compute_pull_from_where_with_exception(mq).await;
-                    if next_offset.is_err() {
-                        continue;
-                    }
-                    let next_offset = next_offset.unwrap();
-                    if next_offset >= 0 {
-                        if process_queue_table.insert(mq.clone(), pq.clone()).is_none() {
-                            info!(
-                                "doRebalance, {:?}, add a new mq, {}",
-                                self.consumer_group,
-                                mq.get_topic()
-                            );
-                            pull_request_list.push(PullRequest::new(
-                                self.consumer_group.as_ref().unwrap().clone(),
-                                mq.clone(),
-                                pq,
-                                next_offset,
-                            ));
-                            changed = true;
-                        } else {
-                            info!(
-                                "doRebalance, {:?}, mq already exists, {}",
-                                self.consumer_group,
-                                mq.get_topic()
-                            );
-                        }
-                    } else {
-                        warn!(
-                            "doRebalance, {:?}, add new mq failed, {}",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
-                    }
+            sub_rebalance_impl.remove_dirty_offset(&mq).await;
+            let pq = Arc::new(sub_rebalance_impl.create_process_queue());
+            pq.set_locked(true);
+            let Ok(next_offset) = sub_rebalance_impl.compute_pull_from_where_with_exception(&mq).await else {
+                continue;
+            };
+            if next_offset < 0 {
+                warn!("doRebalance, {:?}, add new mq failed, {}", self.consumer_group, mq.get_topic());
+                continue;
+            }
+            let inserted = {
+                let mut process_queue_table = self.process_queue_table.write().await;
+                if process_queue_table.contains_key(&mq) {
+                    false
+                } else {
+                    process_queue_table.insert(mq.clone(), pq.clone());
+                    true
                 }
+            };
+            if inserted {
+                info!("doRebalance, {:?}, add a new mq, {}", self.consumer_group, mq.get_topic());
+                pull_request_list.push(PullRequest::new(
+                    self.consumer_group.as_ref().unwrap().clone(),
+                    mq,
+                    pq,
+                    next_offset,
+                ));
+                changed = true;
             }
-
-            if !all_mq_locked {
-                self.client_instance.as_mut().unwrap().rebalance_later(500);
-            }
-            sub_rebalance_impl.dispatch_pull_request(pull_request_list, 500).await;
         }
 
-        {
-            if let Some(rebalance_impl) = self.sub_rebalance_impl.as_ref().unwrap().upgrade() {
-                let mut pop_request_list = Vec::new();
+        if !all_mq_locked {
+            self.client_instance.as_mut().unwrap().rebalance_later(500);
+        }
+        sub_rebalance_impl.dispatch_pull_request(pull_request_list, 500).await;
+
+        if let Some(rebalance_impl) = self.sub_rebalance_impl.as_ref().unwrap().upgrade() {
+            let mut pop_request_list = Vec::new();
+            {
                 let mut pop_process_queue_table = self.pop_process_queue_table.write().await;
-                for (mq, assignment) in mq2pop_assignment {
+                for (mq, _) in mq2pop_assignment {
                     if !pop_process_queue_table.contains_key(mq) {
                         let pq = rebalance_impl.create_pop_process_queue();
                         let pre = pop_process_queue_table.insert(mq.clone(), Arc::new(pq.clone()));
                         if pre.is_none() {
-                            info!("doRebalance, {:?}, mq already exists, {}", self.consumer_group, mq);
-                        } else {
                             info!("doRebalance, {:?}, add a new pop mq, {}", self.consumer_group, mq);
                             let request = PopRequest::new(
                                 topic.clone(),
@@ -585,8 +579,8 @@ where
                         }
                     }
                 }
-                rebalance_impl.dispatch_pop_pull_request(pop_request_list, 500).await;
             }
+            rebalance_impl.dispatch_pop_pull_request(pop_request_list, 500).await;
         }
 
         changed
@@ -627,21 +621,27 @@ where
             }
         }
 
-        {
-            if !remove_queue_map.is_empty() {
-                let mut process_queue_table = process_queue_table_cloned.write().await;
-                // Remove message queues no longer belong to me
-                for (mq, pq) in remove_queue_map {
-                    if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
-                        if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
+        // Broker/offset cleanup can await. Do it after the table snapshot and
+        // only reacquire the lock to remove the same queue instance.
+        for (mq, pq) in remove_queue_map {
+            if let Some(mut sub_rebalance) = self.sub_rebalance_impl.as_mut().unwrap().upgrade() {
+                if sub_rebalance.remove_unnecessary_message_queue(&mq, &pq).await {
+                    let removed = {
+                        let mut process_queue_table = process_queue_table_cloned.write().await;
+                        if matches!(process_queue_table.get(&mq), Some(current) if Arc::ptr_eq(current, &pq)) {
                             process_queue_table.remove(&mq);
-                            changed = true;
-                            info!(
-                                "doRebalance, {:?}, remove unnecessary mq, {}",
-                                self.consumer_group,
-                                mq.get_topic()
-                            );
+                            true
+                        } else {
+                            false
                         }
+                    };
+                    if removed {
+                        changed = true;
+                        info!(
+                            "doRebalance, {:?}, remove unnecessary mq, {}",
+                            self.consumer_group,
+                            mq.get_topic()
+                        );
                     }
                 }
             }
@@ -654,51 +654,51 @@ where
             return false;
         }
         let mut sub_rebalance_impl = sub_rebalance_impl.unwrap();
-        let mut process_queue_table = process_queue_table_cloned.write().await;
-        for mq in mq_set {
-            if !process_queue_table.contains_key(mq) {
-                if is_order && !self.lock_with(mq, process_queue_table.deref()).await {
-                    warn!(
-                        "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
-                        self.consumer_group,
-                        mq.get_topic()
-                    );
-                    all_mq_locked = false;
-                    continue;
-                }
+        let missing_queues = {
+            let process_queue_table = process_queue_table_cloned.read().await;
+            mq_set
+                .iter()
+                .filter(|mq| !process_queue_table.contains_key(*mq))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        for mq in missing_queues {
+            if is_order && !self.lock_with(&mq).await {
+                warn!(
+                    "doRebalance, {:?}, add a new mq failed, {}, because lock failed",
+                    self.consumer_group,
+                    mq.get_topic()
+                );
+                all_mq_locked = false;
+                continue;
+            }
 
-                sub_rebalance_impl.remove_dirty_offset(mq).await;
-                let pq = Arc::new(sub_rebalance_impl.create_process_queue());
-                pq.set_locked(true);
-                let next_offset = sub_rebalance_impl.compute_pull_from_where(mq).await;
-                if next_offset >= 0 {
-                    if process_queue_table.insert(mq.clone(), pq.clone()).is_none() {
-                        info!(
-                            "doRebalance, {:?}, add a new mq, {}",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
-                        pull_request_list.push(PullRequest::new(
-                            self.consumer_group.as_ref().unwrap().clone(),
-                            mq.clone(),
-                            pq,
-                            next_offset,
-                        ));
-                        changed = true;
-                    } else {
-                        info!(
-                            "doRebalance, {:?}, mq already exists, {}",
-                            self.consumer_group,
-                            mq.get_topic()
-                        );
-                    }
+            sub_rebalance_impl.remove_dirty_offset(&mq).await;
+            let pq = Arc::new(sub_rebalance_impl.create_process_queue());
+            pq.set_locked(true);
+            let next_offset = sub_rebalance_impl.compute_pull_from_where(&mq).await;
+            if next_offset < 0 {
+                warn!("doRebalance, {:?}, add new mq failed, {}", self.consumer_group, mq.get_topic());
+                continue;
+            }
+            let inserted = {
+                let mut process_queue_table = process_queue_table_cloned.write().await;
+                if process_queue_table.contains_key(&mq) {
+                    false
                 } else {
-                    warn!(
-                        "doRebalance, {:?}, add new mq failed, {}",
-                        self.consumer_group,
-                        mq.get_topic()
-                    );
+                    process_queue_table.insert(mq.clone(), pq.clone());
+                    true
                 }
+            };
+            if inserted {
+                info!("doRebalance, {:?}, add a new mq, {}", self.consumer_group, mq.get_topic());
+                pull_request_list.push(PullRequest::new(
+                    self.consumer_group.as_ref().unwrap().clone(),
+                    mq,
+                    pq,
+                    next_offset,
+                ));
+                changed = true;
             }
         }
 
@@ -846,17 +846,10 @@ where
     }
 
     pub async fn lock(&mut self, mq: &MessageQueue) -> bool {
-        let process_queue_table_ = self.process_queue_table.clone();
-        let process_queue_table = process_queue_table_.read().await;
-        let table = process_queue_table.deref();
-        self.lock_with(mq, table).await
+        self.lock_with(mq).await
     }
 
-    pub async fn lock_with(
-        &mut self,
-        mq: &MessageQueue,
-        process_queue_table: &HashMap<MessageQueue, Arc<ProcessQueue>>,
-    ) -> bool {
+    pub async fn lock_with(&mut self, mq: &MessageQueue) -> bool {
         let client = self.client_instance.as_mut().unwrap();
         let broker_name = client.get_broker_name_from_message_queue(mq).await;
         let find_broker_result = client
@@ -877,6 +870,7 @@ where
                 .await;
             match result {
                 Ok(locked_mq) => {
+                    let process_queue_table = self.process_queue_table.read().await;
                     for mq in &locked_mq {
                         if let Some(pq) = process_queue_table.get(mq) {
                             pq.set_locked(true);
@@ -1059,15 +1053,19 @@ where
         &self,
     ) -> HashMap<CheetahString /* brokerName */, HashSet<MessageQueue>> {
         let mut result = HashMap::new();
-        let process_queue_table = self.process_queue_table.read().await;
+        let active_queues = {
+            let process_queue_table = self.process_queue_table.read().await;
+            process_queue_table
+                .iter()
+                .filter(|(_, pq)| !pq.is_dropped())
+                .map(|(mq, _)| mq.clone())
+                .collect::<Vec<_>>()
+        };
         let client = self.client_instance.as_ref().unwrap();
-        for (mq, pq) in process_queue_table.iter() {
-            if pq.is_dropped() {
-                continue;
-            }
-            let broker_name = client.get_broker_name_from_message_queue(mq).await;
+        for mq in active_queues {
+            let broker_name = client.get_broker_name_from_message_queue(&mq).await;
             let entry = result.entry(broker_name).or_insert(HashSet::new());
-            entry.insert(mq.to_owned());
+            entry.insert(mq);
         }
         result
     }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -478,6 +478,18 @@ impl Rebalance for RebalancePushImpl {
     }
 
     fn destroy(&mut self) {
-        unimplemented!()
+        // `destroy` is synchronous because it is called from consumer shutdown.
+        // Mark queues dropped immediately so already scheduled pull/pop work is
+        // discarded; the maps can then be reclaimed with the consumer instance.
+        if let Ok(process_queues) = self.rebalance_impl_inner.process_queue_table.try_read() {
+            for process_queue in process_queues.values() {
+                process_queue.set_dropped(true);
+            }
+        }
+        if let Ok(pop_process_queues) = self.rebalance_impl_inner.pop_process_queue_table.try_read() {
+            for process_queue in pop_process_queues.values() {
+                process_queue.set_dropped(true);
+            }
+        }
     }
 }

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -33,7 +33,6 @@ use crate::base::mq_admin::MQAdmin;
 use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
-use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::default_mq_push_consumer_builder::DefaultMQPushConsumerBuilder;
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
 use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
@@ -514,7 +513,12 @@ impl MQPushConsumer for DefaultMQPushConsumer {
     }
 
     async fn shutdown(&mut self) {
-        let _ = self.shutdown_with_report().await;
+        let await_termination_millis = self.consumer_config.await_termination_millis_when_shutdown;
+        self.default_mqpush_consumer_impl
+            .as_mut()
+            .expect("default_mqpush_consumer_impl is None")
+            .shutdown(await_termination_millis)
+            .await;
     }
 
     fn register_message_listener_concurrently_fn<MLCFN>(&mut self, message_listener: MLCFN)
@@ -612,18 +616,6 @@ impl MQPushConsumer for DefaultMQPushConsumer {
 impl DefaultMQPushConsumer {
     pub fn builder() -> DefaultMQPushConsumerBuilder {
         DefaultMQPushConsumerBuilder::default()
-    }
-
-    /// Stops this consumer and returns the local teardown outcome. A caller
-    /// should only create a same-group replacement after local unregistration
-    /// succeeded and no callback tasks were left running.
-    pub async fn shutdown_with_report(&mut self) -> ShutdownReport {
-        let await_termination_millis = self.consumer_config.await_termination_millis_when_shutdown;
-        self.default_mqpush_consumer_impl
-            .as_mut()
-            .expect("default_mqpush_consumer_impl is None")
-            .shutdown(await_termination_millis)
-            .await
     }
 
     #[inline]

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -513,7 +513,12 @@ impl MQPushConsumer for DefaultMQPushConsumer {
     }
 
     async fn shutdown(&mut self) {
-        todo!()
+        let await_termination_millis = self.consumer_config.await_termination_millis_when_shutdown;
+        self.default_mqpush_consumer_impl
+            .as_mut()
+            .expect("default_mqpush_consumer_impl is None")
+            .shutdown(await_termination_millis)
+            .await;
     }
 
     fn register_message_listener_concurrently_fn<MLCFN>(&mut self, message_listener: MLCFN)
@@ -643,5 +648,20 @@ impl DefaultMQPushConsumer {
 
     pub fn set_consume_from_where(&mut self, consume_from_where: ConsumeFromWhere) {
         self.consumer_config.consume_from_where = consume_from_where;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn public_shutdown_is_idempotent_before_start() {
+        let mut consumer = DefaultMQPushConsumer::builder()
+            .consumer_group("phase3-shutdown-test")
+            .build();
+
+        consumer.shutdown().await;
+        consumer.shutdown().await;
     }
 }

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -33,6 +33,7 @@ use crate::base::mq_admin::MQAdmin;
 use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+use crate::consumer::consumer_impl::consume_message_service::ShutdownReport;
 use crate::consumer::default_mq_push_consumer_builder::DefaultMQPushConsumerBuilder;
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
 use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
@@ -513,12 +514,7 @@ impl MQPushConsumer for DefaultMQPushConsumer {
     }
 
     async fn shutdown(&mut self) {
-        let await_termination_millis = self.consumer_config.await_termination_millis_when_shutdown;
-        self.default_mqpush_consumer_impl
-            .as_mut()
-            .expect("default_mqpush_consumer_impl is None")
-            .shutdown(await_termination_millis)
-            .await;
+        let _ = self.shutdown_with_report().await;
     }
 
     fn register_message_listener_concurrently_fn<MLCFN>(&mut self, message_listener: MLCFN)
@@ -616,6 +612,18 @@ impl MQPushConsumer for DefaultMQPushConsumer {
 impl DefaultMQPushConsumer {
     pub fn builder() -> DefaultMQPushConsumerBuilder {
         DefaultMQPushConsumerBuilder::default()
+    }
+
+    /// Stops this consumer and returns the local teardown outcome. A caller
+    /// should only create a same-group replacement after local unregistration
+    /// succeeded and no callback tasks were left running.
+    pub async fn shutdown_with_report(&mut self) -> ShutdownReport {
+        let await_termination_millis = self.consumer_config.await_termination_millis_when_shutdown;
+        self.default_mqpush_consumer_impl
+            .as_mut()
+            .expect("default_mqpush_consumer_impl is None")
+            .shutdown(await_termination_millis)
+            .await
     }
 
     #[inline]

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -26,6 +22,10 @@ use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 use tokio::runtime::Handle;
 
 use crate::base::client_config::ClientConfig;

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
-
+use std::time::Duration;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -88,6 +88,12 @@ pub struct ConsumerConfig {
     pub(crate) trace_dispatcher: Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>>,
     pub(crate) client_rebalance: bool,
     pub(crate) rpc_hook: Option<Arc<dyn RPCHook>>,
+    /// Delay between retry attempts for BROADCASTING mode failures (default 100ms).
+    pub(crate) broadcast_retry_delay: Duration,
+    /// Maximum number of retry attempts after the initial failed callback in
+    /// BROADCASTING mode (default 3). Zero means no retry; terminal handling
+    /// fires after the first failure.
+    pub(crate) broadcast_max_retries: u32,
 }
 
 impl ConsumerConfig {
@@ -356,6 +362,23 @@ impl ConsumerConfig {
     pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<dyn RPCHook>>) {
         self.rpc_hook = rpc_hook;
     }
+
+    pub fn broadcast_retry_delay(&self) -> Duration {
+        self.broadcast_retry_delay
+    }
+
+    pub fn set_broadcast_retry_delay(&mut self, delay: Duration) {
+        assert!(!delay.is_zero(), "broadcast_retry_delay must be greater than zero");
+        self.broadcast_retry_delay = delay;
+    }
+
+    pub fn broadcast_max_retries(&self) -> u32 {
+        self.broadcast_max_retries
+    }
+
+    pub fn set_broadcast_max_retries(&mut self, max_retries: u32) {
+        self.broadcast_max_retries = max_retries;
+    }
 }
 
 impl Default for ConsumerConfig {
@@ -398,6 +421,8 @@ impl Default for ConsumerConfig {
             trace_dispatcher: None,
             client_rebalance: true,
             rpc_hook: None,
+            broadcast_retry_delay: Duration::from_millis(100),
+            broadcast_max_retries: 3,
         }
     }
 }
@@ -663,5 +688,38 @@ mod tests {
 
         consumer.shutdown().await;
         consumer.shutdown().await;
+    }
+
+    #[test]
+    fn consumer_config_default_broadcast_retry_delay_is_100ms() {
+        let cfg = ConsumerConfig::default();
+        assert_eq!(cfg.broadcast_retry_delay(), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn consumer_config_default_broadcast_max_retries_is_3() {
+        let cfg = ConsumerConfig::default();
+        assert_eq!(cfg.broadcast_max_retries(), 3);
+    }
+
+    #[test]
+    fn consumer_config_set_broadcast_retry_delay() {
+        let mut cfg = ConsumerConfig::default();
+        cfg.set_broadcast_retry_delay(Duration::from_millis(500));
+        assert_eq!(cfg.broadcast_retry_delay(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn consumer_config_set_broadcast_max_retries_zero() {
+        let mut cfg = ConsumerConfig::default();
+        cfg.set_broadcast_max_retries(0);
+        assert_eq!(cfg.broadcast_max_retries(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "broadcast_retry_delay must be greater than zero")]
+    fn consumer_config_set_broadcast_retry_delay_zero_panics() {
+        let mut cfg = ConsumerConfig::default();
+        cfg.set_broadcast_retry_delay(Duration::ZERO);
     }
 }

--- a/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
+++ b/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
@@ -5,10 +5,10 @@ pub struct ConsumeConcurrentlyContext {
     pub(crate) delay_level_when_next_consume: i32,
     /// Explicit acknowledgement index set by the listener.
     ///
-    /// - `None` means the listener did not set an explicit index; the final
-    ///   status determines behaviour (`ConsumeSuccess` ⇒ ack all, `ReconsumeLater` ⇒ ack none).
-    /// - `Some(n)` means indices `0..=n` were successfully handled. The value is
-    ///   clamped to `[−1, msgs.len() − 1]` before use; `−1` means ack nothing.
+    /// - `None` means the listener did not set an explicit index; the final status determines
+    ///   behaviour (`ConsumeSuccess` ⇒ ack all, `ReconsumeLater` ⇒ ack none).
+    /// - `Some(n)` means indices `0..=n` were successfully handled. The value is clamped to `[−1,
+    ///   msgs.len() − 1]` before use; `−1` means ack nothing.
     pub(crate) ack_index: Option<i32>,
 }
 

--- a/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
+++ b/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
@@ -1,23 +1,15 @@
-// Copyright 2023 The RocketMQ Rust Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use rocketmq_common::common::message::message_queue::MessageQueue;
 
 pub struct ConsumeConcurrentlyContext {
     pub(crate) message_queue: MessageQueue,
     pub(crate) delay_level_when_next_consume: i32,
-    pub(crate) ack_index: i32,
+    /// Explicit acknowledgement index set by the listener.
+    ///
+    /// - `None` means the listener did not set an explicit index; the final
+    ///   status determines behaviour (`ConsumeSuccess` ⇒ ack all, `ReconsumeLater` ⇒ ack none).
+    /// - `Some(n)` means indices `0..=n` were successfully handled. The value is
+    ///   clamped to `[−1, msgs.len() − 1]` before use; `−1` means ack nothing.
+    pub(crate) ack_index: Option<i32>,
 }
 
 impl ConsumeConcurrentlyContext {
@@ -25,7 +17,7 @@ impl ConsumeConcurrentlyContext {
         Self {
             message_queue,
             delay_level_when_next_consume: 0,
-            ack_index: i32::MAX,
+            ack_index: None,
         }
     }
 
@@ -41,11 +33,62 @@ impl ConsumeConcurrentlyContext {
         &self.message_queue
     }
 
-    pub fn get_ack_index(&self) -> i32 {
+    /// Returns the explicitly set acknowledgement index, or `None` if the listener
+    /// did not call [`set_ack_index`].
+    pub fn get_ack_index(&self) -> Option<i32> {
         self.ack_index
     }
 
+    /// Record that indices `0..=ack_index` were successfully processed.
+    ///
+    /// Call this after each successfully handled message inside a batch listener so
+    /// that a subsequent `ReconsumeLater` return can correctly identify the unprocessed
+    /// suffix. Negative values are accepted and mean "ack nothing".
     pub fn set_ack_index(&mut self, ack_index: i32) {
-        self.ack_index = ack_index;
+        self.ack_index = Some(ack_index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
+
+    use super::ConsumeConcurrentlyContext;
+
+    fn mq() -> MessageQueue {
+        MessageQueue::from_parts(
+            CheetahString::from_static_str("topic"),
+            CheetahString::from_static_str("broker"),
+            0,
+        )
+    }
+
+    #[test]
+    fn default_ack_index_is_none() {
+        let ctx = ConsumeConcurrentlyContext::new(mq());
+        assert_eq!(ctx.get_ack_index(), None);
+    }
+
+    #[test]
+    fn set_ack_index_stores_value() {
+        let mut ctx = ConsumeConcurrentlyContext::new(mq());
+        ctx.set_ack_index(4);
+        assert_eq!(ctx.get_ack_index(), Some(4));
+    }
+
+    #[test]
+    fn set_ack_index_negative_is_accepted() {
+        let mut ctx = ConsumeConcurrentlyContext::new(mq());
+        ctx.set_ack_index(-1);
+        assert_eq!(ctx.get_ack_index(), Some(-1));
+    }
+
+    #[test]
+    fn set_ack_index_overwrite() {
+        let mut ctx = ConsumeConcurrentlyContext::new(mq());
+        ctx.set_ack_index(3);
+        ctx.set_ack_index(7);
+        assert_eq!(ctx.get_ack_index(), Some(7));
     }
 }

--- a/rocketmq-client/src/consumer/listener/message_listener_concurrently.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener_concurrently.rs
@@ -1,17 +1,3 @@
-// Copyright 2023 The RocketMQ Rust Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use std::sync::Arc;
 
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -23,14 +9,14 @@ pub trait MessageListenerConcurrently: Sync + Send {
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
-        context: &ConsumeConcurrentlyContext,
+        context: &mut ConsumeConcurrentlyContext,
     ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>;
 }
 
 pub type ArcBoxMessageListenerConcurrently = Arc<Box<dyn MessageListenerConcurrently>>;
 
 pub type MessageListenerConcurrentlyFn = Arc<
-    dyn Fn(&[&MessageExt], &ConsumeConcurrentlyContext) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>
+    dyn Fn(&[&MessageExt], &mut ConsumeConcurrentlyContext) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>
         + Send
         + Sync,
 >;

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -108,6 +108,10 @@ pub struct MQConsumerInnerImpl {
 }
 
 impl MQConsumerInnerImpl {
+    pub(crate) fn is_running(&self) -> bool {
+        self.default_mqpush_consumer_impl.is_running()
+    }
+
     pub(crate) async fn pop_message(&mut self, pop_request: PopRequest) {
         self.default_mqpush_consumer_impl.pop_message(pop_request).await;
     }

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -87,8 +87,7 @@ impl LocalFileOffsetStore {
         }
     }
     fn read_local_offset_bak(&self) -> rocketmq_error::RocketMQResult<Option<OffsetSerializeWrapper>> {
-        let content = file_utils::file_to_string(format!("{}{}", self.store_path, ".bak"))
-            .unwrap_or("".to_string());
+        let content = file_utils::file_to_string(format!("{}{}", self.store_path, ".bak")).unwrap_or("".to_string());
         if content.is_empty() {
             Ok(None)
         } else {

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -76,7 +76,7 @@ impl LocalFileOffsetStore {
     }
 
     fn read_local_offset(&self) -> rocketmq_error::RocketMQResult<Option<OffsetSerializeWrapper>> {
-        let content = file_utils::file_to_string(self.store_path.as_str()).map_or("".to_string(), |content| content);
+        let content = file_utils::file_to_string(self.store_path.as_str()).unwrap_or("".to_string());
         if content.is_empty() {
             self.read_local_offset_bak()
         } else {
@@ -88,7 +88,7 @@ impl LocalFileOffsetStore {
     }
     fn read_local_offset_bak(&self) -> rocketmq_error::RocketMQResult<Option<OffsetSerializeWrapper>> {
         let content = file_utils::file_to_string(format!("{}{}", self.store_path, ".bak"))
-            .map_or("".to_string(), |content| content);
+            .unwrap_or("".to_string());
         if content.is_empty() {
             Ok(None)
         } else {

--- a/rocketmq-client/src/factory.rs
+++ b/rocketmq-client/src/factory.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub mod mq_client_instance;
+pub mod transport_health;

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -481,7 +481,7 @@ impl MQClientInstance {
 
         {
             let consumer_table = self.consumer_table.read().await;
-            for value in consumer_table.values()  {
+            for value in consumer_table.values() {
                 value.subscriptions().iter().for_each(|sub| {
                     topic_list.insert(sub.topic.clone());
                 });
@@ -601,15 +601,13 @@ impl MQClientInstance {
                 .unwrap()
                 .get_topic_route_info_from_name_server(topic, self.client_config.mq_client_api_timeout)
                 .await
-                .unwrap_or_else(
-                    |err| {
-                        warn!(
-                            "getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}",
-                            topic, err
-                        );
-                        None
-                    },
-                )
+                .unwrap_or_else(|err| {
+                    warn!(
+                        "getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}",
+                        topic, err
+                    );
+                    None
+                })
         };
         if let Some(mut topic_route_data) = topic_route_data {
             let mut topic_route_table = self.topic_route_table.write().await;
@@ -647,7 +645,7 @@ impl MQClientInstance {
                     let mut publish_info = topic_route_data2topic_publish_info(topic, &mut topic_route_data);
                     publish_info.have_topic_router_info = true;
                     let mut producer_table = self.producer_table.write().await;
-                    for value in producer_table.values_mut(){
+                    for value in producer_table.values_mut() {
                         value.update_topic_publish_info(topic.to_string(), Some(publish_info.clone()));
                     }
                 }
@@ -702,7 +700,7 @@ impl MQClientInstance {
 
     pub async fn persist_all_consumer_offset(&mut self) {
         let consumer_table = self.consumer_table.read().await;
-        for value in consumer_table.values()  {
+        for value in consumer_table.values() {
             value.persist_consumer_offset().await;
         }
     }
@@ -924,8 +922,8 @@ impl MQClientInstance {
     async fn is_broker_in_name_server(&self, broker_name: &str) -> bool {
         let broker_addr_table = self.topic_route_table.read().await;
         for value in broker_addr_table.values() {
-            for bd in value.broker_datas.iter()  {
-                for value in bd.broker_addrs().values(){
+            for bd in value.broker_datas.iter() {
+                for value in bd.broker_addrs().values() {
                     if value.as_str() == broker_name {
                         return true;
                     }
@@ -942,7 +940,7 @@ impl MQClientInstance {
         };
 
         let consumer_table = self.consumer_table.read().await;
-        for value in consumer_table.values()  {
+        for value in consumer_table.values() {
             let mut consumer_data = ConsumerData {
                 group_name: value.group_name(),
                 consume_type: value.consume_type(),
@@ -960,7 +958,7 @@ impl MQClientInstance {
         }
         drop(consumer_table);
         let producer_table = self.producer_table.read().await;
-        for group_name in producer_table.keys()  {
+        for group_name in producer_table.keys() {
             let producer_data = ProducerData {
                 group_name: group_name.clone(),
             };

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -55,6 +55,10 @@ use crate::consumer::consumer_impl::pull_message_service::PullMessageService;
 use crate::consumer::consumer_impl::re_balance::rebalance_service::RebalanceService;
 use crate::consumer::mq_consumer_inner::MQConsumerInner;
 use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
+use crate::factory::transport_health::emit_consumer_transport_event;
+use crate::factory::transport_health::ConsumerTransportEvent;
+use crate::factory::transport_health::ConsumerTransportOperation;
+use crate::factory::transport_health::ConsumerTransportOutcome;
 use crate::implementation::client_remoting_processor::ClientRemotingProcessor;
 use crate::implementation::find_broker_result::FindBrokerResult;
 use crate::implementation::mq_admin_impl::MQAdminImpl;
@@ -513,17 +517,35 @@ impl MQClientInstance {
                 .get_consumer_id_list_by_group(broker_addr.as_str(), group, self.client_config.mq_client_api_timeout)
                 .await
             {
-                Ok(value) => return Some(value),
+                Ok(value) => {
+                    self.emit_consumer_transport_event(
+                        group,
+                        ConsumerTransportOperation::ConsumerIdList,
+                        ConsumerTransportOutcome::Success,
+                    );
+                    return Some(value);
+                }
                 Err(e) => {
+                    self.emit_consumer_transport_event(
+                        group,
+                        ConsumerTransportOperation::ConsumerIdList,
+                        ConsumerTransportOutcome::Failure,
+                    );
                     warn!(
                         "getConsumerIdListByGroup exception,{}  {}, err:{}",
                         broker_addr,
                         group,
                         e.to_string()
                     );
+                    return None;
                 }
             }
         }
+        self.emit_consumer_transport_event(
+            group,
+            ConsumerTransportOperation::ConsumerIdList,
+            ConsumerTransportOutcome::Failure,
+        );
         None
     }
 
@@ -846,6 +868,8 @@ impl MQClientInstance {
             .send_heartbeat(addr, heartbeat_data, self.client_config.mq_client_api_timeout)
             .await
         {
+            self.emit_heartbeat_transport_event(ConsumerTransportOutcome::Success)
+                .await;
             let mut broker_version_table = self.broker_version_table.write().await;
             let map = broker_version_table.get_mut(broker_name);
             if let Some(map) = map {
@@ -872,7 +896,30 @@ impl MQClientInstance {
                 broker_name, id, addr
             )
         }
+        self.emit_heartbeat_transport_event(ConsumerTransportOutcome::Failure)
+            .await;
         false
+    }
+
+    fn emit_consumer_transport_event(
+        &self,
+        consumer_group: &CheetahString,
+        operation: ConsumerTransportOperation,
+        outcome: ConsumerTransportOutcome,
+    ) {
+        emit_consumer_transport_event(ConsumerTransportEvent {
+            client_id: self.client_id.to_string(),
+            consumer_group: consumer_group.to_string(),
+            operation,
+            outcome,
+        });
+    }
+
+    async fn emit_heartbeat_transport_event(&self, outcome: ConsumerTransportOutcome) {
+        let consumer_groups = self.consumer_table.read().await.keys().cloned().collect::<Vec<_>>();
+        for consumer_group in consumer_groups {
+            self.emit_consumer_transport_event(&consumer_group, ConsumerTransportOperation::Heartbeat, outcome);
+        }
     }
 
     async fn is_broker_in_name_server(&self, broker_name: &str) -> bool {

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -92,6 +92,8 @@ pub struct MQClientInstance {
         Arc<RwLock<HashMap<CheetahString /* Topic */, HashMap<MessageQueue, CheetahString /* brokerName */>>>>,
     lock_namesrv: Arc<RocketMQTokioMutex<()>>,
     lock_heartbeat: Arc<RocketMQTokioMutex<()>>,
+    /// Serializes shared factory startup before any background work is exposed.
+    lock_startup: Arc<RocketMQTokioMutex<()>>,
 
     service_state: ServiceState,
     pub(crate) pull_message_service: ArcMut<PullMessageService>,
@@ -146,6 +148,7 @@ impl MQClientInstance {
             topic_end_points_table: Arc::new(Default::default()),
             lock_namesrv: Default::default(),
             lock_heartbeat: Default::default(),
+            lock_startup: Default::default(),
             service_state: ServiceState::CreateJust,
             pull_message_service: ArcMut::new(PullMessageService::new()),
             rebalance_service: RebalanceService::new(),
@@ -190,6 +193,7 @@ impl MQClientInstance {
             topic_end_points_table: Arc::new(Default::default()),
             lock_namesrv: Default::default(),
             lock_heartbeat: Default::default(),
+            lock_startup: Default::default(),
             service_state: ServiceState::CreateJust,
             pull_message_service: ArcMut::new(PullMessageService::new()),
             rebalance_service: RebalanceService::new(),
@@ -274,9 +278,11 @@ impl MQClientInstance {
     }
 
     pub async fn start(&mut self, this: ArcMut<Self>) -> rocketmq_error::RocketMQResult<()> {
+        let startup_lock = self.lock_startup.clone();
+        let _startup_guard = startup_lock.lock().await;
         match self.service_state {
             ServiceState::CreateJust => {
-                self.service_state = ServiceState::StartFailed;
+                self.service_state = ServiceState::Starting;
                 // If not specified,looking address from name remoting_server
                 if self.client_config.namesrv_addr.is_none() {
                     self.mq_client_api_impl
@@ -300,17 +306,35 @@ impl MQClientInstance {
                 self.rebalance_service.start(this).await;
                 // Start push service
 
-                self.default_producer
+                if let Err(error) = self
+                    .default_producer
                     .default_mqproducer_impl
                     .as_mut()
                     .unwrap()
                     .start_with_factory(false)
-                    .await?;
+                    .await
+                {
+                    self.pull_message_service.shutdown();
+                    self.rebalance_service.shutdown();
+                    // A failed shared factory cannot safely be reused: its remoting and
+                    // background services may have been partially initialized. Remove it
+                    // from the manager so the next consumer generation creates a clean one.
+                    self.service_state = ServiceState::ShutdownAlready;
+                    crate::implementation::mq_client_manager::MQClientManager::get_instance()
+                        .remove_client_factory(&self.client_id);
+                    return Err(error);
+                }
                 info!("the client factory[{}] start OK", self.client_id);
                 self.service_state = ServiceState::Running;
             }
             ServiceState::Running => {}
             ServiceState::ShutdownAlready => {}
+            ServiceState::Starting => {
+                return Err(mq_client_err!(format!(
+                    "The Factory object[{}] is already starting.",
+                    self.client_id
+                )));
+            }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(
                     "The Factory object[{}] has been created before, and failed.",
@@ -321,7 +345,32 @@ impl MQClientInstance {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self) {}
+    pub async fn shutdown(&mut self) {
+        if !self.consumer_table.read().await.is_empty() {
+            return;
+        }
+        let has_external_producer = self
+            .producer_table
+            .read()
+            .await
+            .keys()
+            .any(|group| group.as_str() != mix_all::CLIENT_INNER_PRODUCER_GROUP);
+        if has_external_producer {
+            return;
+        }
+        if self.service_state == ServiceState::ShutdownAlready {
+            return;
+        }
+        self.producer_table
+            .write()
+            .await
+            .remove(mix_all::CLIENT_INNER_PRODUCER_GROUP);
+        self.pull_message_service.shutdown();
+        self.rebalance_service.shutdown();
+        self.service_state = ServiceState::ShutdownAlready;
+        crate::implementation::mq_client_manager::MQClientManager::get_instance()
+            .remove_client_factory(&self.client_id);
+    }
 
     pub async fn register_producer(&mut self, group: &str, producer: MQProducerInnerImpl) -> bool {
         if group.is_empty() {
@@ -532,7 +581,10 @@ impl MQClientInstance {
                 .await
                 .map_or_else(
                     |err| {
-                        warn!("getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}", topic, err);
+                        warn!(
+                            "getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}",
+                            topic, err
+                        );
                         None
                     },
                     |v| v,
@@ -1017,7 +1069,10 @@ impl MQClientInstance {
 
     pub async fn select_consumer(&self, group: &str) -> Option<MQConsumerInnerImpl> {
         let consumer_table = self.consumer_table.read().await;
-        consumer_table.get(group).cloned()
+        consumer_table
+            .get(group)
+            .filter(|consumer| consumer.is_running())
+            .cloned()
     }
 
     pub async fn select_producer(&self, group: &str) -> Option<MQProducerInnerImpl> {
@@ -1026,7 +1081,11 @@ impl MQClientInstance {
     }
 
     pub async fn unregister_consumer(&mut self, group: impl Into<CheetahString>) {
-        self.unregister_client(None, Some(group.into())).await;
+        let group = group.into();
+        // Always remove the local entry first. Broker unregistration is best effort;
+        // retaining a stale local entry makes a later retry permanently duplicate.
+        self.consumer_table.write().await.remove(&group);
+        self.unregister_client(None, Some(group)).await;
     }
     pub async fn unregister_producer(&mut self, group: impl Into<CheetahString>) {
         self.unregister_client(Some(group.into()), None).await;
@@ -1152,6 +1211,72 @@ impl MQClientInstance {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+
+    fn test_consumer(group: &str) -> MQConsumerInnerImpl {
+        let mut consumer_config = ArcMut::new(ConsumerConfig::default());
+        consumer_config.consumer_group = group.into();
+        let mut consumer_impl = ArcMut::new(DefaultMQPushConsumerImpl::new(
+            ClientConfig::default(),
+            consumer_config,
+            None,
+        ));
+        let consumer_impl_clone = consumer_impl.clone();
+        consumer_impl.set_default_mqpush_consumer_impl(consumer_impl_clone.clone());
+        MQConsumerInnerImpl {
+            default_mqpush_consumer_impl: consumer_impl_clone,
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_consumer_always_removes_the_local_entry() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-unregister-client", None);
+        let group = CheetahString::from("phase3-unregister-group");
+
+        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
+        assert!(instance.consumer_table.read().await.contains_key(&group));
+
+        instance.unregister_consumer(group.clone()).await;
+
+        assert!(!instance.consumer_table.read().await.contains_key(&group));
+    }
+
+    #[tokio::test]
+    async fn select_consumer_hides_non_running_consumers() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-select-client", None);
+        let group = CheetahString::from("phase3-select-group");
+        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
+
+        assert!(instance.select_consumer(group.as_str()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_keeps_the_shared_client_alive_for_a_sibling_consumer() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-sibling-client", None);
+        let first = CheetahString::from("phase3-sibling-one");
+        let second = CheetahString::from("phase3-sibling-two");
+        instance.service_state = ServiceState::Running;
+        assert!(instance.register_consumer(&first, test_consumer(first.as_str())).await);
+        assert!(
+            instance
+                .register_consumer(&second, test_consumer(second.as_str()))
+                .await
+        );
+
+        instance.unregister_consumer(first).await;
+        instance.shutdown().await;
+        assert_eq!(instance.service_state, ServiceState::Running);
+
+        instance.unregister_consumer(second).await;
+        instance.shutdown().await;
+        assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
     }
 }
 

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -474,14 +474,14 @@ impl MQClientInstance {
 
         {
             let producer_table = self.producer_table.read().await;
-            for (_, value) in producer_table.iter() {
+            for value in producer_table.values() {
                 topic_list.extend(value.get_publish_topic_list());
             }
         }
 
         {
             let consumer_table = self.consumer_table.read().await;
-            for (_, value) in consumer_table.iter() {
+            for value in consumer_table.values()  {
                 value.subscriptions().iter().for_each(|sub| {
                     topic_list.insert(sub.topic.clone());
                 });
@@ -601,7 +601,7 @@ impl MQClientInstance {
                 .unwrap()
                 .get_topic_route_info_from_name_server(topic, self.client_config.mq_client_api_timeout)
                 .await
-                .map_or_else(
+                .unwrap_or_else(
                     |err| {
                         warn!(
                             "getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}",
@@ -609,7 +609,6 @@ impl MQClientInstance {
                         );
                         None
                     },
-                    |v| v,
                 )
         };
         if let Some(mut topic_route_data) = topic_route_data {
@@ -648,7 +647,7 @@ impl MQClientInstance {
                     let mut publish_info = topic_route_data2topic_publish_info(topic, &mut topic_route_data);
                     publish_info.have_topic_router_info = true;
                     let mut producer_table = self.producer_table.write().await;
-                    for (_, value) in producer_table.iter_mut() {
+                    for value in producer_table.values_mut(){
                         value.update_topic_publish_info(topic.to_string(), Some(publish_info.clone()));
                     }
                 }
@@ -658,7 +657,7 @@ impl MQClientInstance {
                     let consumer_table = self.consumer_table.read().await;
                     if !consumer_table.is_empty() {
                         let subscribe_info = topic_route_data2topic_subscribe_info(topic, &topic_route_data);
-                        for (_, value) in consumer_table.iter() {
+                        for value in consumer_table.values() {
                             value.update_topic_subscribe_info(topic.clone(), &subscribe_info).await;
                         }
                     }
@@ -703,7 +702,7 @@ impl MQClientInstance {
 
     pub async fn persist_all_consumer_offset(&mut self) {
         let consumer_table = self.consumer_table.read().await;
-        for (_, value) in consumer_table.iter() {
+        for value in consumer_table.values()  {
             value.persist_consumer_offset().await;
         }
     }
@@ -924,9 +923,9 @@ impl MQClientInstance {
 
     async fn is_broker_in_name_server(&self, broker_name: &str) -> bool {
         let broker_addr_table = self.topic_route_table.read().await;
-        for (_, value) in broker_addr_table.iter() {
-            for bd in value.broker_datas.iter() {
-                for (_, value) in bd.broker_addrs().iter() {
+        for value in broker_addr_table.values() {
+            for bd in value.broker_datas.iter()  {
+                for value in bd.broker_addrs().values(){
                     if value.as_str() == broker_name {
                         return true;
                     }
@@ -943,7 +942,7 @@ impl MQClientInstance {
         };
 
         let consumer_table = self.consumer_table.read().await;
-        for (_, value) in consumer_table.iter() {
+        for value in consumer_table.values()  {
             let mut consumer_data = ConsumerData {
                 group_name: value.group_name(),
                 consume_type: value.consume_type(),
@@ -961,7 +960,7 @@ impl MQClientInstance {
         }
         drop(consumer_table);
         let producer_table = self.producer_table.read().await;
-        for (group_name, _) in producer_table.iter() {
+        for group_name in producer_table.keys()  {
             let producer_data = ProducerData {
                 group_name: group_name.clone(),
             };
@@ -1175,9 +1174,9 @@ impl MQClientInstance {
 
     async fn is_broker_addr_exist_in_topic_route_table(&self, addr: &str) -> bool {
         let topic_route_table = self.topic_route_table.read().await;
-        for (_, value) in topic_route_table.iter() {
+        for value in topic_route_table.values() {
             for bd in value.broker_datas.iter() {
-                for (_, value) in bd.broker_addrs().iter() {
+                for value in bd.broker_addrs().values() {
                     if value.as_str() == addr {
                         return true;
                     }
@@ -1258,101 +1257,6 @@ impl MQClientInstance {
         }
 
         None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
-    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
-
-    fn test_consumer(group: &str) -> MQConsumerInnerImpl {
-        let mut consumer_config = ArcMut::new(ConsumerConfig::default());
-        consumer_config.consumer_group = group.into();
-        let mut consumer_impl = ArcMut::new(DefaultMQPushConsumerImpl::new(
-            ClientConfig::default(),
-            consumer_config,
-            None,
-        ));
-        let consumer_impl_clone = consumer_impl.clone();
-        consumer_impl.set_default_mqpush_consumer_impl(consumer_impl_clone.clone());
-        MQConsumerInnerImpl {
-            default_mqpush_consumer_impl: consumer_impl_clone,
-        }
-    }
-
-    #[tokio::test]
-    async fn unregister_consumer_always_removes_the_local_entry() {
-        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-unregister-client", None);
-        let group = CheetahString::from("phase3-unregister-group");
-
-        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
-        assert!(instance.consumer_table.read().await.contains_key(&group));
-
-        instance.unregister_consumer(group.clone()).await;
-
-        assert!(!instance.consumer_table.read().await.contains_key(&group));
-    }
-
-    #[tokio::test]
-    async fn select_consumer_hides_non_running_consumers() {
-        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-select-client", None);
-        let group = CheetahString::from("phase3-select-group");
-        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
-
-        assert!(instance.select_consumer(group.as_str()).await.is_none());
-    }
-
-    #[tokio::test]
-    async fn shutdown_keeps_the_shared_client_alive_for_a_sibling_consumer() {
-        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-sibling-client", None);
-        let first = CheetahString::from("phase3-sibling-one");
-        let second = CheetahString::from("phase3-sibling-two");
-        instance.service_state = ServiceState::Running;
-        assert!(instance.register_consumer(&first, test_consumer(first.as_str())).await);
-        assert!(
-            instance
-                .register_consumer(&second, test_consumer(second.as_str()))
-                .await
-        );
-
-        instance.unregister_consumer(first).await;
-        instance.shutdown().await;
-        assert_eq!(instance.service_state, ServiceState::Running);
-
-        instance.unregister_consumer(second).await;
-        instance.shutdown().await;
-        assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
-    }
-
-    #[tokio::test]
-    async fn shared_factory_start_lock_is_single_flight() {
-        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-start-lock-client", None);
-        let active = Arc::new(AtomicUsize::new(0));
-        let peak = Arc::new(AtomicUsize::new(0));
-        let mut tasks = Vec::new();
-
-        for _ in 0..4 {
-            let lock = instance.lock_startup.clone();
-            let active = active.clone();
-            let peak = peak.clone();
-            tasks.push(tokio::spawn(async move {
-                let _guard = lock.lock().await;
-                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-                peak.fetch_max(current, Ordering::SeqCst);
-                tokio::task::yield_now().await;
-                active.fetch_sub(1, Ordering::SeqCst);
-            }));
-        }
-
-        for task in tasks {
-            task.await.expect("startup lock task");
-        }
-
-        assert_eq!(peak.load(Ordering::SeqCst), 1);
     }
 }
 
@@ -1451,4 +1355,99 @@ pub fn topic_route_data2topic_subscribe_info(topic: &str, route: &TopicRouteData
         }
     }
     mq_list
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    fn test_consumer(group: &str) -> MQConsumerInnerImpl {
+        let mut consumer_config = ArcMut::new(ConsumerConfig::default());
+        consumer_config.consumer_group = group.into();
+        let mut consumer_impl = ArcMut::new(DefaultMQPushConsumerImpl::new(
+            ClientConfig::default(),
+            consumer_config,
+            None,
+        ));
+        let consumer_impl_clone = consumer_impl.clone();
+        consumer_impl.set_default_mqpush_consumer_impl(consumer_impl_clone.clone());
+        MQConsumerInnerImpl {
+            default_mqpush_consumer_impl: consumer_impl_clone,
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_consumer_always_removes_the_local_entry() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-unregister-client", None);
+        let group = CheetahString::from("phase3-unregister-group");
+
+        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
+        assert!(instance.consumer_table.read().await.contains_key(&group));
+
+        instance.unregister_consumer(group.clone()).await;
+
+        assert!(!instance.consumer_table.read().await.contains_key(&group));
+    }
+
+    #[tokio::test]
+    async fn select_consumer_hides_non_running_consumers() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-select-client", None);
+        let group = CheetahString::from("phase3-select-group");
+        assert!(instance.register_consumer(&group, test_consumer(group.as_str())).await);
+
+        assert!(instance.select_consumer(group.as_str()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_keeps_the_shared_client_alive_for_a_sibling_consumer() {
+        let mut instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-sibling-client", None);
+        let first = CheetahString::from("phase3-sibling-one");
+        let second = CheetahString::from("phase3-sibling-two");
+        instance.service_state = ServiceState::Running;
+        assert!(instance.register_consumer(&first, test_consumer(first.as_str())).await);
+        assert!(
+            instance
+                .register_consumer(&second, test_consumer(second.as_str()))
+                .await
+        );
+
+        instance.unregister_consumer(first).await;
+        instance.shutdown().await;
+        assert_eq!(instance.service_state, ServiceState::Running);
+
+        instance.unregister_consumer(second).await;
+        instance.shutdown().await;
+        assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
+    }
+
+    #[tokio::test]
+    async fn shared_factory_start_lock_is_single_flight() {
+        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-start-lock-client", None);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..4 {
+            let lock = instance.lock_startup.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            tasks.push(tokio::spawn(async move {
+                let _guard = lock.lock().await;
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        for task in tasks {
+            task.await.expect("startup lock task");
+        }
+
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
+    }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -530,7 +530,13 @@ impl MQClientInstance {
                 .unwrap()
                 .get_topic_route_info_from_name_server(topic, self.client_config.mq_client_api_timeout)
                 .await
-                .unwrap_or(None)
+                .map_or_else(
+                    |err| {
+                        warn!("getTopicRouteInfoFromNameServer failed, topic: {}, err: {:?}", topic, err);
+                        None
+                    },
+                    |v| v,
+                )
         };
         if let Some(mut topic_route_data) = topic_route_data {
             let mut topic_route_table = self.topic_route_table.write().await;

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1219,6 +1219,8 @@ mod tests {
     use super::*;
     use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
     use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     fn test_consumer(group: &str) -> MQConsumerInnerImpl {
         let mut consumer_config = ArcMut::new(ConsumerConfig::default());
@@ -1277,6 +1279,33 @@ mod tests {
         instance.unregister_consumer(second).await;
         instance.shutdown().await;
         assert_eq!(instance.service_state, ServiceState::ShutdownAlready);
+    }
+
+    #[tokio::test]
+    async fn shared_factory_start_lock_is_single_flight() {
+        let instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "phase3-start-lock-client", None);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..4 {
+            let lock = instance.lock_startup.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            tasks.push(tokio::spawn(async move {
+                let _guard = lock.lock().await;
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        for task in tasks {
+            task.await.expect("startup lock task");
+        }
+
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
     }
 }
 

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -333,7 +333,7 @@ impl MQClientInstance {
             }
             ServiceState::Running => {}
             ServiceState::ShutdownAlready => {}
-            ServiceState::Starting | ServiceState::Stopping => {
+            ServiceState::Starting => {
                 return Err(mq_client_err!(format!(
                     "The Factory object[{}] is already starting.",
                     self.client_id

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -333,7 +333,7 @@ impl MQClientInstance {
             }
             ServiceState::Running => {}
             ServiceState::ShutdownAlready => {}
-            ServiceState::Starting => {
+            ServiceState::Starting | ServiceState::Stopping => {
                 return Err(mq_client_err!(format!(
                     "The Factory object[{}] is already starting.",
                     self.client_id

--- a/rocketmq-client/src/factory/transport_health.rs
+++ b/rocketmq-client/src/factory/transport_health.rs
@@ -1,0 +1,85 @@
+use std::sync::OnceLock;
+
+use tokio::sync::broadcast;
+
+/// A broker transport operation performed for a consumer group.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConsumerTransportOperation {
+    Heartbeat,
+    ConsumerIdList,
+}
+
+impl ConsumerTransportOperation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Heartbeat => "heartbeat",
+            Self::ConsumerIdList => "consumer_id_list",
+        }
+    }
+}
+
+/// The result of a broker transport operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConsumerTransportOutcome {
+    Success,
+    Failure,
+}
+
+impl ConsumerTransportOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+/// An application-observable consumer transport result.
+///
+/// Delivery behavior is intentionally unaffected. Consumers that do not
+/// subscribe to this best-effort stream continue to behave exactly as before.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConsumerTransportEvent {
+    pub client_id: String,
+    pub consumer_group: String,
+    pub operation: ConsumerTransportOperation,
+    pub outcome: ConsumerTransportOutcome,
+}
+
+fn sender() -> &'static broadcast::Sender<ConsumerTransportEvent> {
+    static SENDER: OnceLock<broadcast::Sender<ConsumerTransportEvent>> = OnceLock::new();
+    SENDER.get_or_init(|| {
+        let (sender, _) = broadcast::channel(256);
+        sender
+    })
+}
+
+/// Subscribe to best-effort consumer transport health events in this process.
+pub fn subscribe_consumer_transport_events() -> broadcast::Receiver<ConsumerTransportEvent> {
+    sender().subscribe()
+}
+
+pub(crate) fn emit_consumer_transport_event(event: ConsumerTransportEvent) {
+    // Sending is best effort: reporting must never alter broker interaction or
+    // fail merely because an application has no observer.
+    let _ = sender().send(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn observer_receives_best_effort_transport_event() {
+        let mut receiver = subscribe_consumer_transport_events();
+        let event = ConsumerTransportEvent {
+            client_id: "phase4-client".to_owned(),
+            consumer_group: "phase4-group".to_owned(),
+            operation: ConsumerTransportOperation::Heartbeat,
+            outcome: ConsumerTransportOutcome::Failure,
+        };
+        emit_consumer_transport_event(event.clone());
+
+        assert_eq!(receiver.recv().await.expect("transport event"), event);
+    }
+}

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -29,6 +29,7 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
+use rocketmq_remoting::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
 use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
 use rocketmq_remoting::protocol::header::reply_message_request_header::ReplyMessageRequestHeader;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
@@ -41,6 +42,7 @@ use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
+use crate::consumer::mq_consumer_inner::MQConsumerInner;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::producer::request_future_holder::REQUEST_FUTURE_HOLDER;
 
@@ -73,8 +75,8 @@ impl RequestProcessor for ClientRemotingProcessor {
         match request_code {
             RequestCode::CheckTransactionState => self.check_transaction_state(channel, ctx, request).await,
             RequestCode::ResetConsumerClientOffset
-            | RequestCode::GetConsumerStatusFromClient
-            | RequestCode::GetConsumerRunningInfo => Ok(Some(unsupported_request_response())),
+            | RequestCode::GetConsumerStatusFromClient => Ok(Some(unsupported_request_response())),
+            RequestCode::GetConsumerRunningInfo => self.get_consumer_running_info(channel, ctx, request).await,
             RequestCode::ConsumeMessageDirectly => self.consume_message_directly(channel, ctx, request).await,
             //RPC message handle code
             RequestCode::PushReplyMessageToClient => self.receive_reply_message(ctx, request).await,
@@ -282,6 +284,40 @@ impl ClientRemotingProcessor {
                 )),
             ))
         }
+    }
+    async fn get_consumer_running_info(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request
+            .decode_command_custom_header::<GetConsumerRunningInfoRequestHeader>()
+            .map_err(|e| rocketmq_error::RocketMQError::IllegalArgument(format!("decode header: {e}")))?;
+
+        let consumer = self
+            .client_instance
+            .select_consumer(request_header.consumer_group.as_str())
+            .await;
+
+        let Some(consumer) = consumer else {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code(ResponseCode::ConsumerNotOnline)
+                    .set_remark(format!(
+                        "The Consumer Group <{}> not exist in this consumer",
+                        request_header.consumer_group
+                    )),
+            ));
+        };
+
+        let running_info = consumer.consumer_running_info();
+        let body = running_info
+            .encode()
+            .map_err(|e| rocketmq_error::RocketMQError::IllegalArgument(format!("encode running info: {e}")))?;
+
+        Ok(Some(
+            RemotingCommand::create_response_command().set_body(body),
+        ))
     }
 }
 

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -55,6 +55,12 @@ impl ClientRemotingProcessor {
     }
 }
 
+fn unsupported_request_response() -> RemotingCommand {
+    RemotingCommand::create_response_command()
+        .set_code(ResponseCode::RequestCodeNotSupported)
+        .set_remark("request is not supported by this RocketMQ Rust client")
+}
+
 impl RequestProcessor for ClientRemotingProcessor {
     async fn process_request(
         &mut self,
@@ -66,15 +72,9 @@ impl RequestProcessor for ClientRemotingProcessor {
         info!("process_request: {:?}", request_code);
         match request_code {
             RequestCode::CheckTransactionState => self.check_transaction_state(channel, ctx, request).await,
-            RequestCode::ResetConsumerClientOffset => {
-                unimplemented!("ResetConsumerClientOffset")
-            }
-            RequestCode::GetConsumerStatusFromClient => {
-                unimplemented!("GetConsumerStatusFromClient")
-            }
-            RequestCode::GetConsumerRunningInfo => {
-                unimplemented!("GetConsumerRunningInfo")
-            }
+            RequestCode::ResetConsumerClientOffset
+            | RequestCode::GetConsumerStatusFromClient
+            | RequestCode::GetConsumerRunningInfo => Ok(Some(unsupported_request_response())),
             RequestCode::ConsumeMessageDirectly => self.consume_message_directly(channel, ctx, request).await,
             //RPC message handle code
             RequestCode::PushReplyMessageToClient => self.receive_reply_message(ctx, request).await,
@@ -85,6 +85,17 @@ impl RequestProcessor for ClientRemotingProcessor {
                 Ok(None)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_lifecycle_requests_return_a_response_instead_of_panicking() {
+        let response = unsupported_request_response();
+        assert_eq!(response.code(), ResponseCode::RequestCodeNotSupported.to_i32());
     }
 }
 

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -88,17 +88,6 @@ impl RequestProcessor for ClientRemotingProcessor {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn unsupported_lifecycle_requests_return_a_response_instead_of_panicking() {
-        let response = unsupported_request_response();
-        assert_eq!(response.code(), ResponseCode::RequestCodeNotSupported.to_i32());
-    }
-}
-
 impl ClientRemotingProcessor {
     async fn receive_reply_message(
         &mut self,
@@ -293,5 +282,16 @@ impl ClientRemotingProcessor {
                 )),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_lifecycle_requests_return_a_response_instead_of_panicking() {
+        let response = unsupported_request_response();
+        assert_eq!(response.code(), ResponseCode::RequestCodeNotSupported.to_i32());
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -434,25 +434,16 @@ impl MQClientAPIImpl {
                     ResponseCode::Success => {
                         let body = result.take_body();
                         if let Some(body_inner) = body {
-                            let route_data = TopicRouteData::decode(body_inner.as_ref())
-                                .or_else(|first_err| {
-                                    let mut normalized =
-                                        String::from_utf8_lossy(body_inner.as_ref()).to_string();
-                                    for i in 0..=9 {
-                                        let key = i.to_string();
-                                        normalized = normalized
-                                            .replace(
-                                                &format!("{{{}:", key),
-                                                &format!("{{\"{}\":", key),
-                                            )
-                                            .replace(
-                                                &format!(",{}:", key),
-                                                &format!(",\"{}\":", key),
-                                            );
-                                    }
-                                    TopicRouteData::decode(normalized.as_bytes())
-                                        .map_err(|_| first_err)
-                                })?;
+                            let route_data = TopicRouteData::decode(body_inner.as_ref()).or_else(|first_err| {
+                                let mut normalized = String::from_utf8_lossy(body_inner.as_ref()).to_string();
+                                for i in 0..=9 {
+                                    let key = i.to_string();
+                                    normalized = normalized
+                                        .replace(&format!("{{{}:", key), &format!("{{\"{}\":", key))
+                                        .replace(&format!(",{}:", key), &format!(",\"{}\":", key));
+                                }
+                                TopicRouteData::decode(normalized.as_bytes()).map_err(|_| first_err)
+                            })?;
                             return Ok(Some(route_data));
                         }
                     }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -421,7 +421,7 @@ impl MQClientAPIImpl {
     ) -> rocketmq_error::RocketMQResult<Option<TopicRouteData>> {
         let request_header = GetRouteInfoRequestHeader {
             topic: CheetahString::from_slice(topic),
-            accept_standard_json_only: None,
+            accept_standard_json_only: Some(true),
             topic_request_header: None,
         };
         let request = RemotingCommand::create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
@@ -434,7 +434,25 @@ impl MQClientAPIImpl {
                     ResponseCode::Success => {
                         let body = result.take_body();
                         if let Some(body_inner) = body {
-                            let route_data = TopicRouteData::decode(body_inner.as_ref())?;
+                            let route_data = TopicRouteData::decode(body_inner.as_ref())
+                                .or_else(|first_err| {
+                                    let mut normalized =
+                                        String::from_utf8_lossy(body_inner.as_ref()).to_string();
+                                    for i in 0..=9 {
+                                        let key = i.to_string();
+                                        normalized = normalized
+                                            .replace(
+                                                &format!("{{{}:", key),
+                                                &format!("{{\"{}\":", key),
+                                            )
+                                            .replace(
+                                                &format!(",{}:", key),
+                                                &format!(",\"{}\":", key),
+                                            );
+                                    }
+                                    TopicRouteData::decode(normalized.as_bytes())
+                                        .map_err(|_| first_err)
+                                })?;
                             return Ok(Some(route_data));
                         }
                     }

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -39,8 +39,8 @@ macro_rules! mq_client_err {
 
     // Handle errors without a ResponseCode, using only the error message (accepts both &str and String)
     ($error_message:expr) => {{
-        let error_msg: &str = "Body is empty";
-        let faq_msg = rocketmq_common::common::FAQUrl::attach_default_url(Some(error_msg));
+        let error_msg: String = $error_message.to_string();
+        let faq_msg = rocketmq_common::common::FAQUrl::attach_default_url(Some(error_msg.as_str()));
         rocketmq_error::RocketMQError::illegal_argument(faq_msg)
     }};
 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2042,8 +2042,8 @@ impl DefaultMQProducerImpl {
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The producer service state is ShutdownAlready"));
             }
-            ServiceState::Starting => {
-                return Err(mq_client_err!("The producer service state is Starting"));
+            ServiceState::Starting | ServiceState::Stopping => {
+                return Err(mq_client_err!("The producer service is starting or stopping"));
             }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2042,6 +2042,9 @@ impl DefaultMQProducerImpl {
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The producer service state is ShutdownAlready"));
             }
+            ServiceState::Starting => {
+                return Err(mq_client_err!("The producer service state is Starting"));
+            }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(
                     "The producer service state not OK, maybe started once,{:?},{}",

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2042,8 +2042,8 @@ impl DefaultMQProducerImpl {
             ServiceState::ShutdownAlready => {
                 return Err(mq_client_err!("The producer service state is ShutdownAlready"));
             }
-            ServiceState::Starting | ServiceState::Stopping => {
-                return Err(mq_client_err!("The producer service is starting or stopping"));
+            ServiceState::Starting => {
+                return Err(mq_client_err!("The producer service state is Starting"));
             }
             ServiceState::StartFailed => {
                 return Err(mq_client_err!(format!(

--- a/rocketmq-client/tests/phase3_lifecycle_integration.rs
+++ b/rocketmq-client/tests/phase3_lifecycle_integration.rs
@@ -6,6 +6,9 @@ use rocketmq_client_rust::consumer::listener::consume_concurrently_context::Cons
 use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
 use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
 use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_client_rust::factory::transport_health::subscribe_consumer_transport_events;
+use rocketmq_client_rust::factory::transport_health::ConsumerTransportOperation;
+use rocketmq_client_rust::factory::transport_health::ConsumerTransportOutcome;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_error::RocketMQResult;
 
@@ -39,6 +42,41 @@ fn consumer(group: String, nameserver: &str) -> DefaultMQPushConsumer {
     consumer
 }
 
+fn consumer_with_fast_heartbeat(group: String, nameserver: &str) -> DefaultMQPushConsumer {
+    let mut client_config = rocketmq_client_rust::base::client_config::ClientConfig::default();
+    client_config.set_namesrv_addr(nameserver.to_string().into());
+    client_config.set_heartbeat_broker_interval(250);
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .client_config(client_config)
+        .consumer_group(group)
+        .build();
+    consumer.subscribe("TopicTest", "*").expect("subscribe TopicTest");
+    consumer.register_message_listener_concurrently(NoopListener);
+    consumer
+}
+
+async fn wait_for_transport_event(
+    receiver: &mut tokio::sync::broadcast::Receiver<
+        rocketmq_client_rust::factory::transport_health::ConsumerTransportEvent,
+    >,
+    group: &str,
+    outcome: ConsumerTransportOutcome,
+) {
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            let event = receiver.recv().await.expect("transport event channel remains open");
+            if event.consumer_group == group
+                && event.operation == ConsumerTransportOperation::Heartbeat
+                && event.outcome == outcome
+            {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("expected transport event before timeout");
+}
+
 /// Requires a live RocketMQ NameServer. Run with:
 /// `ROCKETMQ_PHASE3_NAMESERVER=127.0.0.1:19876 cargo test -p rocketmq-client-rust --test
 /// phase3_lifecycle_integration -- --ignored`
@@ -56,4 +94,46 @@ async fn concurrent_clustering_consumers_share_startup_and_shutdown_cleanly() {
 
     first.shutdown().await;
     second.shutdown().await;
+}
+
+/// Requires a live NameServer and an external broker stop after the test prints
+/// its readiness line. For example:
+/// `ROCKETMQ_PHASE3_NAMESERVER=127.0.0.1:9876 ROCKETMQ_PHASE4_EXPECT_BROKER_STOP=1 \
+/// cargo test -p rocketmq-client-rust --test phase3_lifecycle_integration \
+/// transport_failure_is_emitted_after_broker_stops -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a live RocketMQ NameServer and controlled broker stop"]
+async fn transport_failure_is_emitted_after_broker_stops() {
+    if std::env::var("ROCKETMQ_PHASE4_EXPECT_BROKER_STOP").as_deref() != Ok("1") {
+        return;
+    }
+    let nameserver = std::env::var("ROCKETMQ_PHASE3_NAMESERVER")
+        .expect("set ROCKETMQ_PHASE3_NAMESERVER to a live NameServer address");
+    let group = unique_group("transport");
+    let mut events = subscribe_consumer_transport_events();
+    let mut consumer = consumer_with_fast_heartbeat(group.clone(), &nameserver);
+
+    consumer.start().await.expect("consumer starts before broker stop");
+    wait_for_transport_event(&mut events, &group, ConsumerTransportOutcome::Success).await;
+    println!("phase4_transport_ready group={group}");
+    wait_for_transport_event(&mut events, &group, ConsumerTransportOutcome::Failure).await;
+    consumer.shutdown().await;
+}
+
+/// Requires a live NameServer and a broker admin request issued while the
+/// consumer is held active. The runner supplies a stable group through
+/// `ROCKETMQ_PHASE4_ADMIN_GROUP` and invokes `mqadmin consumerStatus`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a live RocketMQ broker-admin diagnostic fixture"]
+async fn active_consumer_survives_admin_diagnostic_request() {
+    let nameserver = std::env::var("ROCKETMQ_PHASE3_NAMESERVER")
+        .expect("set ROCKETMQ_PHASE3_NAMESERVER to a live NameServer address");
+    let group = std::env::var("ROCKETMQ_PHASE4_ADMIN_GROUP")
+        .expect("set ROCKETMQ_PHASE4_ADMIN_GROUP to the fixture consumer group");
+    let mut consumer = consumer(group.clone(), &nameserver);
+
+    consumer.start().await.expect("consumer starts before admin request");
+    println!("phase4_admin_ready group={group}");
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    consumer.shutdown().await;
 }

--- a/rocketmq-client/tests/phase3_lifecycle_integration.rs
+++ b/rocketmq-client/tests/phase3_lifecycle_integration.rs
@@ -1,0 +1,59 @@
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+
+struct NoopListener;
+
+impl MessageListenerConcurrently for NoopListener {
+    fn consume_message(
+        &self,
+        _msgs: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}
+
+fn unique_group(suffix: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    format!("phase3_lifecycle_{suffix}_{nonce}")
+}
+
+fn consumer(group: String, nameserver: &str) -> DefaultMQPushConsumer {
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .consumer_group(group)
+        .name_server_addr(nameserver)
+        .build();
+    consumer.subscribe("TopicTest", "*").expect("subscribe TopicTest");
+    consumer.register_message_listener_concurrently(NoopListener);
+    consumer
+}
+
+/// Requires a live RocketMQ NameServer. Run with:
+/// `ROCKETMQ_PHASE3_NAMESERVER=127.0.0.1:19876 cargo test -p rocketmq-client-rust --test
+/// phase3_lifecycle_integration -- --ignored`
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a live RocketMQ NameServer and Broker"]
+async fn concurrent_clustering_consumers_share_startup_and_shutdown_cleanly() {
+    let nameserver = std::env::var("ROCKETMQ_PHASE3_NAMESERVER")
+        .expect("set ROCKETMQ_PHASE3_NAMESERVER to a live NameServer address");
+    let mut first = consumer(unique_group("first"), &nameserver);
+    let mut second = consumer(unique_group("second"), &nameserver);
+
+    let (first_result, second_result) = tokio::join!(first.start(), second.start());
+    first_result.expect("first clustering consumer starts");
+    second_result.expect("second clustering consumer starts");
+
+    first.shutdown().await;
+    second.shutdown().await;
+}

--- a/rocketmq-client/tests/phase3_lifecycle_integration.rs
+++ b/rocketmq-client/tests/phase3_lifecycle_integration.rs
@@ -18,7 +18,7 @@ impl MessageListenerConcurrently for NoopListener {
     fn consume_message(
         &self,
         _msgs: &[&MessageExt],
-        _context: &ConsumeConcurrentlyContext,
+        _context: &mut ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }

--- a/rocketmq-client/tests/phase3_lifecycle_integration.rs
+++ b/rocketmq-client/tests/phase3_lifecycle_integration.rs
@@ -62,7 +62,7 @@ async fn wait_for_transport_event(
     group: &str,
     outcome: ConsumerTransportOutcome,
 ) {
-    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+    tokio::time::timeout(std::time::Duration::from_secs(45), async {
         loop {
             let event = receiver.recv().await.expect("transport event channel remains open");
             if event.consumer_group == group
@@ -130,10 +130,12 @@ async fn active_consumer_survives_admin_diagnostic_request() {
         .expect("set ROCKETMQ_PHASE3_NAMESERVER to a live NameServer address");
     let group = std::env::var("ROCKETMQ_PHASE4_ADMIN_GROUP")
         .expect("set ROCKETMQ_PHASE4_ADMIN_GROUP to the fixture consumer group");
-    let mut consumer = consumer(group.clone(), &nameserver);
+    let mut events = subscribe_consumer_transport_events();
+    let mut consumer = consumer_with_fast_heartbeat(group.clone(), &nameserver);
 
     consumer.start().await.expect("consumer starts before admin request");
+    wait_for_transport_event(&mut events, &group, ConsumerTransportOutcome::Success).await;
     println!("phase4_admin_ready group={group}");
-    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
     consumer.shutdown().await;
 }

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -46,7 +46,7 @@ config.workspace = true
 #tools
 dirs.workspace = true
 
-flate2    = { version = "1.1.7", features = ["zlib"], default-features = false }
+flate2    = { version = "1.1.5", features = ["zlib"], default-features = false }
 lz4_flex  = { version = "0.12", default-features = false }
 zstd      = "0.13"
 byteorder = "1.5.0"

--- a/rocketmq-common/src/common/base/service_state.rs
+++ b/rocketmq-common/src/common/base/service_state.rs
@@ -18,6 +18,8 @@ use std::fmt::Display;
 pub enum ServiceState {
     /// Service just created, not started
     CreateJust,
+    /// Service initialization is in progress and it must not be exposed to work scheduling.
+    Starting,
     /// Service running
     Running,
     /// Service shutdown
@@ -30,9 +32,21 @@ impl Display for ServiceState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ServiceState::CreateJust => write!(f, "CreateJust"),
+            ServiceState::Starting => write!(f, "Starting"),
             ServiceState::Running => write!(f, "Running"),
             ServiceState::ShutdownAlready => write!(f, "ShutdownAlready"),
             ServiceState::StartFailed => write!(f, "StartFailed"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starting_has_a_distinct_display_value() {
+        assert_eq!(ServiceState::Starting.to_string(), "Starting");
+        assert_ne!(ServiceState::Starting, ServiceState::StartFailed);
     }
 }

--- a/rocketmq-common/src/common/base/service_state.rs
+++ b/rocketmq-common/src/common/base/service_state.rs
@@ -22,6 +22,8 @@ pub enum ServiceState {
     Starting,
     /// Service running
     Running,
+    /// Teardown is in progress. New pulls and callback scheduling must stop.
+    Stopping,
     /// Service shutdown
     ShutdownAlready,
     /// Service start failure
@@ -34,6 +36,7 @@ impl Display for ServiceState {
             ServiceState::CreateJust => write!(f, "CreateJust"),
             ServiceState::Starting => write!(f, "Starting"),
             ServiceState::Running => write!(f, "Running"),
+            ServiceState::Stopping => write!(f, "Stopping"),
             ServiceState::ShutdownAlready => write!(f, "ShutdownAlready"),
             ServiceState::StartFailed => write!(f, "StartFailed"),
         }

--- a/rocketmq-common/src/common/base/service_state.rs
+++ b/rocketmq-common/src/common/base/service_state.rs
@@ -22,8 +22,6 @@ pub enum ServiceState {
     Starting,
     /// Service running
     Running,
-    /// Teardown is in progress. New pulls and callback scheduling must stop.
-    Stopping,
     /// Service shutdown
     ShutdownAlready,
     /// Service start failure
@@ -36,7 +34,6 @@ impl Display for ServiceState {
             ServiceState::CreateJust => write!(f, "CreateJust"),
             ServiceState::Starting => write!(f, "Starting"),
             ServiceState::Running => write!(f, "Running"),
-            ServiceState::Stopping => write!(f, "Stopping"),
             ServiceState::ShutdownAlready => write!(f, "ShutdownAlready"),
             ServiceState::StartFailed => write!(f, "StartFailed"),
         }

--- a/rocketmq-common/src/common/resource/resource_pattern.rs
+++ b/rocketmq-common/src/common/resource/resource_pattern.rs
@@ -169,9 +169,9 @@ mod tests {
             ResourcePattern::Prefixed,
         ] {
             let serialized = serde_json::to_string(&variant)
-                .unwrap_or_else(|e| panic!("Could not serialize ResourcePattern::{:?}: {}", &variant.name(), e));
+                .unwrap_or_else(|e| panic!("Could not serialize ResourcePattern::{:?}: {}", variant.name(), e));
             let parsed: ResourcePattern = serde_json::from_str(&serialized)
-                .unwrap_or_else(|e| panic!("Could not parse {:?} as ResourcePattern: {}", &serialized, e));
+                .unwrap_or_else(|e| panic!("Could not parse {:?} as ResourcePattern: {}", serialized, e));
             assert_eq!(variant, parsed);
         }
     }

--- a/rocketmq-common/src/common/statistics/statistics_manager.rs
+++ b/rocketmq-common/src/common/statistics/statistics_manager.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::SystemTime;
 
 use parking_lot::RwLock;
 use tokio::task;
@@ -89,7 +88,7 @@ impl StatisticsManager {
                 interval.tick().await;
 
                 let stats_table = stats_table.read();
-                for (_kind, item_map) in stats_table.iter() {
+                for item_map in stats_table.values() {
                     let tmp_item_map: HashMap<_, _> = item_map.clone().into_iter().collect();
 
                     for item in tmp_item_map.values() {

--- a/rocketmq-common/src/utils/util_all.rs
+++ b/rocketmq-common/src/utils/util_all.rs
@@ -207,13 +207,13 @@ pub fn bytes_to_string(src: &[u8]) -> String {
 }
 
 pub fn write_int(buffer: &mut [char], pos: usize, value: i32) {
-    for (current_pos, move_bits) in (pos..).zip((0..=28).rev().step_by(4)){
+    for (current_pos, move_bits) in (pos..).zip((0..=28).rev().step_by(4)) {
         buffer[current_pos] = HEX_ARRAY[((value >> move_bits) & 0xF) as usize];
     }
 }
 
 pub fn write_short(buffer: &mut [char], pos: usize, value: i16) {
-    for (current_pos, move_bits) in (pos..).zip((0..=12).rev().step_by(4)){
+    for (current_pos, move_bits) in (pos..).zip((0..=12).rev().step_by(4)) {
         buffer[current_pos] = HEX_ARRAY[((value >> move_bits) & 0xF) as usize];
     }
 }

--- a/rocketmq-common/src/utils/util_all.rs
+++ b/rocketmq-common/src/utils/util_all.rs
@@ -207,18 +207,14 @@ pub fn bytes_to_string(src: &[u8]) -> String {
 }
 
 pub fn write_int(buffer: &mut [char], pos: usize, value: i32) {
-    let mut current_pos = pos;
-    for move_bits in (0..=28).rev().step_by(4) {
+    for (current_pos, move_bits) in (pos..).zip((0..=28).rev().step_by(4)){
         buffer[current_pos] = HEX_ARRAY[((value >> move_bits) & 0xF) as usize];
-        current_pos += 1;
     }
 }
 
 pub fn write_short(buffer: &mut [char], pos: usize, value: i16) {
-    let mut current_pos = pos;
-    for move_bits in (0..=12).rev().step_by(4) {
+    for (current_pos, move_bits) in (pos..).zip((0..=12).rev().step_by(4)){
         buffer[current_pos] = HEX_ARRAY[((value >> move_bits) & 0xF) as usize];
-        current_pos += 1;
     }
 }
 

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -95,7 +95,7 @@ impl MessageListenerConcurrently for MyMessageListener {
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
-        _context: &ConsumeConcurrentlyContext,
+        _context: &mut ConsumeConcurrentlyContext,
     ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
         for msg in msgs {
             info!("Receive message: {:?}", msg);

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -699,7 +699,7 @@ impl RouteInfoManager {
 
     fn operate_write_perm_of_broker(&self, broker_name: &CheetahString, request_code: RequestCode) -> i32 {
         let mut topic_cnt = 0;
-        for (_topic, qd_map) in self.topic_queue_table.mut_from_ref().iter_mut() {
+        for qd_map in self.topic_queue_table.mut_from_ref().values_mut()  {
             let qd = qd_map.get_mut(broker_name);
             if qd.is_none() {
                 continue;
@@ -902,7 +902,7 @@ impl RouteInfoManager {
             .broker_addr
             .clone_from(&CheetahString::from_slice(broker_addr_info.broker_addr.as_str()));
 
-        for (_broker_addr, broker_data) in self.broker_addr_table.iter() {
+        for broker_data in self.broker_addr_table.values() {
             if broker_addr_info.cluster_name != broker_data.cluster() {
                 continue;
             }

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -699,7 +699,7 @@ impl RouteInfoManager {
 
     fn operate_write_perm_of_broker(&self, broker_name: &CheetahString, request_code: RequestCode) -> i32 {
         let mut topic_cnt = 0;
-        for qd_map in self.topic_queue_table.mut_from_ref().values_mut()  {
+        for qd_map in self.topic_queue_table.mut_from_ref().values_mut() {
             let qd = qd_map.get_mut(broker_name);
             if qd.is_none() {
                 continue;

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -174,7 +174,7 @@ impl RouteInfoManagerV2 {
     /// Find broker name by broker address
     fn find_broker_name_by_addr(broker_addr_table: &BrokerAddrTable, broker_addr: &str) -> Option<String> {
         for (broker_name, broker_data) in broker_addr_table.get_all_brokers() {
-            for addr in broker_data.broker_addrs().values(){
+            for addr in broker_data.broker_addrs().values() {
                 if addr.as_str() == broker_addr {
                     return Some(broker_name.to_string());
                 }

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -174,7 +174,7 @@ impl RouteInfoManagerV2 {
     /// Find broker name by broker address
     fn find_broker_name_by_addr(broker_addr_table: &BrokerAddrTable, broker_addr: &str) -> Option<String> {
         for (broker_name, broker_data) in broker_addr_table.get_all_brokers() {
-            for (_broker_id, addr) in broker_data.broker_addrs().iter() {
+            for addr in broker_data.broker_addrs().values(){
                 if addr.as_str() == broker_addr {
                     return Some(broker_name.to_string());
                 }

--- a/rocketmq-namesrv/src/route/zone_route_rpc_hook.rs
+++ b/rocketmq-namesrv/src/route/zone_route_rpc_hook.rs
@@ -113,7 +113,7 @@ pub fn filter_by_zone_name(topic_route_data: &mut TopicRouteData, zone_name: &Ch
     // Remove filter server entries whose broker addresses belong to removed brokers
 
     if !topic_route_data.filter_server_table.is_empty() {
-        for (_, bd) in broker_data_removed.iter() {
+        for bd in broker_data_removed.values()  {
             for addr in bd.broker_addrs().values() {
                 topic_route_data.filter_server_table.remove(addr);
             }

--- a/rocketmq-namesrv/src/route/zone_route_rpc_hook.rs
+++ b/rocketmq-namesrv/src/route/zone_route_rpc_hook.rs
@@ -113,7 +113,7 @@ pub fn filter_by_zone_name(topic_route_data: &mut TopicRouteData, zone_name: &Ch
     // Remove filter server entries whose broker addresses belong to removed brokers
 
     if !topic_route_data.filter_server_table.is_empty() {
-        for bd in broker_data_removed.values()  {
+        for bd in broker_data_removed.values() {
             for addr in bd.broker_addrs().values() {
                 topic_route_data.filter_server_table.remove(addr);
             }

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![allow(dead_code)]
 #![allow(incomplete_features)]
-#![feature(sync_unsafe_cell)]
-#![feature(duration_constructors)]
-#![feature(fn_traits)]
 #![feature(impl_trait_in_assoc_type)]
 extern crate core;
 

--- a/rocketmq-remoting/src/protocol/body/batch_ack.rs
+++ b/rocketmq-remoting/src/protocol/body/batch_ack.rs
@@ -75,7 +75,6 @@ impl<'de> Deserialize<'de> for SerializableBitVec {
 
 #[cfg(test)]
 mod tests {
-    use bitvec::prelude::*;
     use cheetah_string::CheetahString;
     use serde_json;
 

--- a/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
@@ -115,7 +115,7 @@ impl RegisterBrokerBody {
         bytes_mut.put_i32(topic_number as i32);
 
         // Write topic configs one by one (align with Java: iterate entries)
-        for topic_config in topic_config_table.values()  {
+        for topic_config in topic_config_table.values() {
             let topic_config_str = topic_config.encode();
             let topic_config_bytes = topic_config_str.as_bytes();
             bytes_mut.put_i32(topic_config_bytes.len() as i32);

--- a/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
@@ -115,7 +115,7 @@ impl RegisterBrokerBody {
         bytes_mut.put_i32(topic_number as i32);
 
         // Write topic configs one by one (align with Java: iterate entries)
-        for (_topic_name, topic_config) in topic_config_table.iter() {
+        for topic_config in topic_config_table.values()  {
             let topic_config_str = topic_config.encode();
             let topic_config_bytes = topic_config_str.as_bytes();
             bytes_mut.put_i32(topic_config_bytes.len() as i32);

--- a/rocketmq-remoting/src/protocol/body/consume_status.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_status.rs
@@ -15,7 +15,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConsumeStatus {
     #[serde(rename = "pullRT")]
     pub pull_rt: f64,

--- a/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
@@ -12,5 +12,110 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Clone)]
-pub struct ConsumerRunningInfo {}
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json_any_key::*;
+
+use crate::protocol::body::consume_status::ConsumeStatus;
+use crate::protocol::body::process_queue_info::ProcessQueueInfo;
+use crate::protocol::heartbeat::subscription_data::SubscriptionData;
+
+/// Java RocketMQ 4.7.1 `ConsumerRunningInfo` — wire-compatible with the broker's
+/// `GetConsumerRunningInfo` command and the RocketMQ console.
+///
+/// Field names and types mirror the Java client's JSON serialization exactly so that the
+/// RocketMQ console can attribute Rust-owned queues just as it does Java-owned ones.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerRunningInfo {
+    /// Flat string properties: `PROP_NAMESERVER_ADDR`, `PROP_THREADPOOL_CORE_SIZE`, etc.
+    pub properties: BTreeMap<CheetahString, CheetahString>,
+
+    /// Active subscriptions keyed by topic.
+    #[serde(default)]
+    pub subscription_set: Vec<SubscriptionData>,
+
+    /// Per-queue process state.  Uses `serde_json_any_key` so that `MessageQueue` (a struct)
+    /// serialises as the JSON object key that the Java client and console expect.
+    #[serde(default, with = "any_key_map")]
+    pub mq_table: HashMap<MessageQueue, ProcessQueueInfo>,
+
+    /// Per-topic consume rate/error statistics.
+    #[serde(default)]
+    pub status_table: HashMap<CheetahString, ConsumeStatus>,
+
+    /// Optional thread-stack dump (only included when `jstackEnable=true`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jstack: Option<CheetahString>,
+}
+
+impl ConsumerRunningInfo {
+    /// Well-known property keys used by the Java console and tools.
+    pub const PROP_NAMESERVER_ADDR: &'static str = "PROP_NAMESERVER_ADDR";
+    pub const PROP_CONSUME_TYPE: &'static str = "PROP_CONSUME_TYPE";
+    pub const PROP_CLIENT_VERSION: &'static str = "PROP_CLIENT_VERSION";
+    pub const PROP_CONSUME_ORDERLY: &'static str = "PROP_CONSUME_ORDERLY";
+    pub const PROP_THREADPOOL_CORE_SIZE: &'static str = "PROP_THREADPOOL_CORE_SIZE";
+    pub const PROP_CONSUMER_START_TIMESTAMP: &'static str = "PROP_CONSUMER_START_TIMESTAMP";
+
+    /// Serialise to JSON bytes, as expected by `RemotingCommand::set_body`.
+    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialise from JSON bytes (used in tests and admin clients).
+    pub fn decode(body: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ConsumerRunningInfo {
+        let mut info = ConsumerRunningInfo::default();
+        info.properties.insert(
+            CheetahString::from_static_str(ConsumerRunningInfo::PROP_CONSUME_TYPE),
+            CheetahString::from_static_str("CONSUME_PASSIVELY"),
+        );
+        let mq = MessageQueue::from_parts("topic", "broker-a", 0);
+        info.mq_table.insert(mq, ProcessQueueInfo {
+            commit_offset: 5,
+            cached_msg_count: 3,
+            locked: false,
+            droped: false,
+            last_pull_timestamp: 1_000,
+            last_consume_timestamp: 900,
+            ..Default::default()
+        });
+        info
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let info = sample();
+        let bytes = info.encode().unwrap();
+        let decoded = ConsumerRunningInfo::decode(&bytes).unwrap();
+        assert_eq!(decoded.properties.get(ConsumerRunningInfo::PROP_CONSUME_TYPE).map(|s| s.as_str()), Some("CONSUME_PASSIVELY"));
+        assert_eq!(decoded.mq_table.len(), 1);
+        let pq = decoded.mq_table.values().next().unwrap();
+        assert_eq!(pq.commit_offset, 5);
+        assert_eq!(pq.cached_msg_count, 3);
+    }
+
+    #[test]
+    fn json_contains_java_compatible_field_names() {
+        let bytes = sample().encode().unwrap();
+        let json = std::str::from_utf8(&bytes).unwrap();
+        assert!(json.contains("\"properties\""), "missing properties");
+        assert!(json.contains("\"subscriptionSet\""), "missing subscriptionSet");
+        assert!(json.contains("\"mqTable\""), "missing mqTable");
+        assert!(json.contains("\"statusTable\""), "missing statusTable");
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/process_queue_info.rs
+++ b/rocketmq-remoting/src/protocol/body/process_queue_info.rs
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone, Copy)]
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Java RocketMQ 4.7.1 compatible `ProcessQueueInfo`.
+/// Field names match the Java client's JSON serialization exactly.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProcessQueueInfo {
     pub commit_offset: u64,
     pub cached_msg_min_offset: u64,
     pub cached_msg_max_offset: u64,
     pub cached_msg_count: u32,
+    /// Size in bytes (Java field name is `cachedMsgSizeInMiB` but carries bytes in practice).
+    #[serde(rename = "cachedMsgSizeInMiB")]
     pub cached_msg_size_in_mib: u32,
 
     pub transaction_msg_min_offset: u64,
@@ -37,10 +45,12 @@ impl std::fmt::Display for ProcessQueueInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ProcessQueueInfo [commit_offset: {}, cached_msg_min_offset: {}, cached_msg_max_offset: {}, \
-             cached_msg_count: {}, cached_msg_size_in_mib: {}, transaction_msg_min_offset: {}, \
-             transaction_msg_max_offset: {}, transaction_msg_count: {}, locked: {}, try_unlock_times: {}, \
-             last_lock_timestamp: {}, droped: {}, last_pull_timestamp: {}, last_consume_timestamp: {}]",
+            "ProcessQueueInfo [commit_offset: {}, cached_msg_min_offset: {}, \
+             cached_msg_max_offset: {}, cached_msg_count: {}, cached_msg_size_in_mib: {}, \
+             transaction_msg_min_offset: {}, transaction_msg_max_offset: {}, \
+             transaction_msg_count: {}, locked: {}, try_unlock_times: {}, \
+             last_lock_timestamp: {}, droped: {}, last_pull_timestamp: {}, \
+             last_consume_timestamp: {}]",
             self.commit_offset,
             self.cached_msg_min_offset,
             self.cached_msg_max_offset,
@@ -56,5 +66,41 @@ impl std::fmt::Display for ProcessQueueInfo {
             self.last_pull_timestamp,
             self.last_consume_timestamp
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_queue_info_roundtrip_json() {
+        let info = ProcessQueueInfo {
+            commit_offset: 10,
+            cached_msg_min_offset: 11,
+            cached_msg_max_offset: 20,
+            cached_msg_count: 9,
+            cached_msg_size_in_mib: 1024,
+            locked: true,
+            droped: false,
+            last_pull_timestamp: 1_000_000,
+            last_consume_timestamp: 999_000,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        // Verify Java-compatible field names
+        assert!(json.contains("\"commitOffset\""));
+        assert!(json.contains("\"cachedMsgMinOffset\""));
+        assert!(json.contains("\"cachedMsgMaxOffset\""));
+        assert!(json.contains("\"cachedMsgCount\""));
+        assert!(json.contains("\"cachedMsgSizeInMiB\""));
+        assert!(json.contains("\"lastPullTimestamp\""));
+        assert!(json.contains("\"lastConsumeTimestamp\""));
+        assert!(json.contains("\"droped\""));
+
+        let decoded: ProcessQueueInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.commit_offset, 10);
+        assert_eq!(decoded.cached_msg_count, 9);
+        assert!(decoded.locked);
     }
 }

--- a/rocketmq-remoting/src/protocol/route/route_data_view.rs
+++ b/rocketmq-remoting/src/protocol/route/route_data_view.rs
@@ -30,7 +30,7 @@ pub struct BrokerData {
     broker_addrs: HashMap<u64 /* broker id */, CheetahString /* broker ip */>,
     #[serde(rename = "zoneName")]
     zone_name: Option<CheetahString>,
-    #[serde(rename = "enableActingMaster")]
+    #[serde(default, rename = "enableActingMaster")]
     enable_acting_master: bool,
 }
 
@@ -151,7 +151,7 @@ pub struct QueueData {
     #[serde(rename = "writeQueueNums")]
     pub write_queue_nums: u32,
     pub perm: u32,
-    #[serde(rename = "topicSysFlag")]
+    #[serde(default, rename = "topicSysFlag", alias = "topicSynFlag")]
     pub topic_sys_flag: u32,
 }
 

--- a/rocketmq-remoting/src/protocol/route/topic_route_data.rs
+++ b/rocketmq-remoting/src/protocol/route/topic_route_data.rs
@@ -26,11 +26,11 @@ use crate::protocol::static_topic::topic_queue_info::TopicQueueMappingInfo;
 pub struct TopicRouteData {
     #[serde(rename = "orderTopicConf")]
     pub order_topic_conf: Option<CheetahString>,
-    #[serde(rename = "queueDatas")]
+    #[serde(default, rename = "queueDatas")]
     pub queue_datas: Vec<QueueData>,
-    #[serde(rename = "brokerDatas")]
+    #[serde(default, rename = "brokerDatas")]
     pub broker_datas: Vec<BrokerData>,
-    #[serde(rename = "filterServerTable")]
+    #[serde(default, rename = "filterServerTable")]
     pub filter_server_table: HashMap<CheetahString, Vec<CheetahString>>,
     #[serde(rename = "topicQueueMappingInfo")]
     pub topic_queue_mapping_by_broker: Option<HashMap<CheetahString, TopicQueueMappingInfo>>,

--- a/rocketmq-remoting/src/rpc/client_metadata.rs
+++ b/rocketmq-remoting/src/rpc/client_metadata.rs
@@ -147,7 +147,7 @@ impl ClientMetadata {
         for (scope, topic_queue_mapping_info_map) in mapping_infos_by_scope {
             let mut mq_endpoints: HashMap<MessageQueue, TopicQueueMappingInfo> = HashMap::new();
             let mut mapping_infos: Vec<_> = topic_queue_mapping_info_map.iter().collect();
-            mapping_infos.sort_by(|a, b| b.1.epoch.cmp(&a.1.epoch));
+            mapping_infos.sort_by_key(|b| std::cmp::Reverse(b.1.epoch));
 
             let mut max_total_nums = 0;
             let max_total_num_of_epoch = -1;

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![feature(sync_unsafe_cell)]
 
 pub mod base;
 pub mod config;

--- a/rocketmq-store/src/log_file/commit_log_recovery.rs
+++ b/rocketmq-store/src/log_file/commit_log_recovery.rs
@@ -146,7 +146,7 @@ impl<'a> BatchMessageIterator<'a> {
                         Some((msg_bytes, absolute_offset, msg_size))
                     } else {
                         None
-                    }
+                    };
                 } else {
                     // Refill buffer and retry
                     if !self.refill_buffer() {

--- a/rocketmq-store/src/log_file/commit_log_recovery.rs
+++ b/rocketmq-store/src/log_file/commit_log_recovery.rs
@@ -139,13 +139,13 @@ impl<'a> BatchMessageIterator<'a> {
                 // Message spans beyond current buffer, fetch larger chunk
                 if msg_size > PARSE_BATCH_SIZE {
                     // Large message, fetch directly
-                    if let Some(msg_bytes) = self.mapped_file.get_bytes(self.current_offset, msg_size) {
+                    return if let Some(msg_bytes) = self.mapped_file.get_bytes(self.current_offset, msg_size) {
                         self.current_offset += msg_size;
                         // Clear buffer to force refill on next call
                         self.buffer = Bytes::new();
-                        return Some((msg_bytes, absolute_offset, msg_size));
+                        Some((msg_bytes, absolute_offset, msg_size))
                     } else {
-                        return None;
+                        None
                     }
                 } else {
                     // Refill buffer and retry

--- a/rocketmq-store/src/log_file/mapped_file/metrics.rs
+++ b/rocketmq-store/src/log_file/mapped_file/metrics.rs
@@ -250,8 +250,7 @@ impl MappedFileMetrics {
     /// Average flush duration, or `Duration::ZERO` if no flushes occurred
     pub fn avg_flush_duration(&self) -> Duration {
         let flushes = self.total_flushes();
-        if flushes > 0 {
-            let avg_us = self.total_flush_time_us.load(Ordering::Relaxed) / flushes;
+        if let Some(avg_us)= self.total_flush_time_us.load(Ordering::Relaxed).checked_div(flushes) {
             Duration::from_micros(avg_us)
         } else {
             Duration::ZERO

--- a/rocketmq-store/src/log_file/mapped_file/metrics.rs
+++ b/rocketmq-store/src/log_file/mapped_file/metrics.rs
@@ -250,7 +250,7 @@ impl MappedFileMetrics {
     /// Average flush duration, or `Duration::ZERO` if no flushes occurred
     pub fn avg_flush_duration(&self) -> Duration {
         let flushes = self.total_flushes();
-        if let Some(avg_us)= self.total_flush_time_us.load(Ordering::Relaxed).checked_div(flushes) {
+        if let Some(avg_us) = self.total_flush_time_us.load(Ordering::Relaxed).checked_div(flushes) {
             Duration::from_micros(avg_us)
         } else {
             Duration::ZERO

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -115,8 +115,8 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
 
     async fn recover(&self) {
         let mut mutex = self.inner.consume_queue_table.lock().clone();
-        for (_topic, consume_queue_table) in mutex.iter_mut() {
-            for (_queue_id, consume_queue) in consume_queue_table.iter() {
+        for consume_queue_table in mutex.values_mut()  {
+            for consume_queue in consume_queue_table.values()  {
                 let queue_id = consume_queue.get_queue_id();
                 let topic = consume_queue.get_topic();
                 let mut file_queue_life_cycle = self.get_life_cycle(topic, queue_id);

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -115,8 +115,8 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
 
     async fn recover(&self) {
         let mut mutex = self.inner.consume_queue_table.lock().clone();
-        for consume_queue_table in mutex.values_mut()  {
-            for consume_queue in consume_queue_table.values()  {
+        for consume_queue_table in mutex.values_mut() {
+            for consume_queue in consume_queue_table.values() {
                 let queue_id = consume_queue.get_queue_id();
                 let topic = consume_queue.get_topic();
                 let mut file_queue_life_cycle = self.get_life_cycle(topic, queue_id);

--- a/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
+++ b/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
@@ -61,9 +61,7 @@ impl GetNamesrvConfigCommand {
         let config_map = NameServerService::get_namesrv_config(&mut admin, addrs).await?;
 
         // Flatten the map for display (assuming only one nameserver or merging all configs)
-        let config: std::collections::HashMap<String, String> = config_map
-            .into_iter()
-            .flat_map(|(_, configs)| configs.into_iter().map(|(k, v)| (k.to_string(), v.to_string())))
+        let config: std::collections::HashMap<String, String> = config_map.into_values().flat_map(|configs| configs.into_iter().map(|(k, v)| (k.to_string(), v.to_string())))
             .collect();
 
         // Format and display output

--- a/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
+++ b/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
@@ -61,7 +61,9 @@ impl GetNamesrvConfigCommand {
         let config_map = NameServerService::get_namesrv_config(&mut admin, addrs).await?;
 
         // Flatten the map for display (assuming only one nameserver or merging all configs)
-        let config: std::collections::HashMap<String, String> = config_map.into_values().flat_map(|configs| configs.into_iter().map(|(k, v)| (k.to_string(), v.to_string())))
+        let config: std::collections::HashMap<String, String> = config_map
+            .into_values()
+            .flat_map(|configs| configs.into_iter().map(|(k, v)| (k.to_string(), v.to_string())))
             .collect();
 
         // Format and display output

--- a/rocketmq-tools/src/commands/topic_commands/topic_status_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/topic_status_sub_command.rs
@@ -54,7 +54,7 @@ impl CommandExecute for TopicStatusSubCommand {
                             .examine_topic_stats(topic.into(), addr)
                             .await?
                             .get_offset_table();
-                        total_offset_table.extend(offset_table.into_iter());
+                        total_offset_table.extend(offset_table);
                     }
                     topic_stats_table.set_offset_table(total_offset_table);
                 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Java-compatible GetConsumerRunningInfo
- Fix F1 liveness timestamp bug  
- Flow-control stall observer  

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable broadcast-consumer retry delays and retry limits.
  * Added consumer transport health events for heartbeat and consumer-ID operations.
  * Added consumer runtime diagnostics and improved broker support for retrieving running information.
  * Added compatibility for additional route and consumer-state response formats.

* **Bug Fixes**
  * Improved batched message acknowledgement, retry handling, queue ordering, and offset updates.
  * Made consumer startup and shutdown safer, including repeated shutdowns and partial startup failures.
  * Prevented invalid acknowledgement indexes and message-count accounting errors.
  * Improved flow-control and stalled-pull tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->