### PR TITLE
[ISSUE #9066]✨Migrate RPC envelope request headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/create_topic_list_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/create_topic_list_request_header.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.CreateTopicListRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTopicListRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/lock_batch_mq_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/lock_batch_mq_request_header.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.LockBatchMqRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct LockBatchMqRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/unlock_batch_mq_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/unlock_batch_mq_request_header.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.UnlockBatchMqRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct UnlockBatchMqRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -21,8 +21,10 @@ use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
+use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
@@ -34,6 +36,7 @@ use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessa
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
     HeaderRange, HeaderValueKind,
@@ -173,8 +176,10 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<NamesrvTopicRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register::<CleanBrokerDataRequestHeader>(),
+        register::<CreateTopicListRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
+        register::<LockBatchMqRequestHeader>(),
         register::<SendMessageRequestHeader>(),
         register::<DeleteTopicFromNamesrvRequestHeader>(),
         register::<QueryConsumeQueueRequestHeader>(),
@@ -185,6 +190,7 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<SendMessageRequestHeaderV2>(),
         register::<SendMessageResponseHeader>(),
         register::<NotificationRequestHeader>(),
+        register::<UnlockBatchMqRequestHeader>(),
     ]
 }
 
@@ -396,6 +402,66 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
             );
         }
     }
+}
+
+fn assert_rpc_envelope_contract<T>(rpc: fn(&T) -> &Option<RpcRequestHeader>)
+where
+    T: CommandCustomHeader + FromMap<Target = T> + HeaderCodec,
+    <T as FromMap>::Error: std::fmt::Debug,
+{
+    let input = HeaderMap::from([
+        ("ns".into(), "canonical-ns".into()),
+        ("namespace".into(), "legacy-ns".into()),
+        ("nsd".into(), "true".into()),
+        ("namespaced".into(), "false".into()),
+        ("bname".into(), "canonical-broker".into()),
+        ("brokerName".into(), "legacy-broker".into()),
+        ("oway".into(), "false".into()),
+        ("oneway".into(), "true".into()),
+    ]);
+    let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed RPC envelope decode");
+    let legacy = <T as FromMap>::from(&input).expect("legacy RPC envelope adapter");
+    for decoded in [rpc(&typed), rpc(&legacy)] {
+        let decoded = decoded
+            .as_ref()
+            .expect("Java inheritance is always present after decode");
+        assert_eq!(decoded.namespace.as_deref(), Some("canonical-ns"));
+        assert_eq!(decoded.namespaced, Some(true));
+        assert_eq!(decoded.broker_name.as_deref(), Some("canonical-broker"));
+        assert_eq!(decoded.oneway, Some(false));
+    }
+
+    let encoded = typed.to_map().expect("typed RPC envelope encode");
+    assert_eq!(encoded.get("ns").map(CheetahString::as_str), Some("canonical-ns"));
+    assert_eq!(encoded.get("nsd").map(CheetahString::as_str), Some("true"));
+    assert_eq!(
+        encoded.get("bname").map(CheetahString::as_str),
+        Some("canonical-broker")
+    );
+    assert_eq!(encoded.get("oway").map(CheetahString::as_str), Some("false"));
+    for alias in ["namespace", "namespaced", "brokerName", "oneway"] {
+        assert!(
+            !encoded.contains_key(alias),
+            "legacy alias {alias} must remain decode-only"
+        );
+    }
+
+    let empty = <T as HeaderCodec>::decode_from_map(&HeaderMap::new()).expect("empty inherited header");
+    let empty_rpc = rpc(&empty)
+        .as_ref()
+        .expect("Java parent exists even when all fields are absent");
+    assert_eq!(empty_rpc.namespace, None);
+    assert_eq!(empty_rpc.namespaced, None);
+    assert_eq!(empty_rpc.broker_name, None);
+    assert_eq!(empty_rpc.oneway, None);
+    assert_eq!(empty.encode_capability(), HeaderEncodeCapability::MapOnly);
+}
+
+#[test]
+fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
+    assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(|header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(|header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(|header| &header.rpc_request_header);
 }
 
 #[test]

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 135,
-    "v3Count": 17,
-    "pendingCount": 135,
-    "migratedCount": 17
+    "v2Count": 132,
+    "v3Count": 20,
+    "pendingCount": 132,
+    "migratedCount": 20
   },
   "baseline": {
     "v2TypeIds": [
@@ -176,8 +176,10 @@
     "acceptedV3TypeIds": [
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
+      "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
@@ -189,6 +191,7 @@
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
+      "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
       "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader",
       "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
     ],
@@ -940,16 +943,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1945,16 +1948,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3255,16 +3258,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 17)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 20)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9066

### Brief Description

Migrate `CreateTopicListRequestHeader`, `LockBatchMqRequestHeader`, and `UnlockBatchMqRequestHeader` from `RequestHeaderCodecV2` to `RequestHeaderCodecV3`.

Preserve the Java inheritance contract through an always-present flattened `RpcRequestHeader`, retain canonical encoding and decode-only legacy aliases, and register the headers in the typed schema inventory. Update the migration guard baseline from 17 to 20 accepted V3 headers.

### How Did You Test This Change?

- `python scripts/request-header-codec/migrate.py check` (passed: 152 registered, 20 V3, 132 frozen V2)
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'` (passed: 3 tests)
- `python scripts/request-header-codec/compare_header_schema.py` (passed: 143 Java mappings, 0 differences)
- `cargo fmt -p rocketmq-protocol -- --check` (passed)
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry` (passed: 11 tests)
- `cargo test --locked -p rocketmq-protocol --all-features` (passed: library, integration, UI, and documentation tests)
- `cargo clippy --locked -p rocketmq-protocol --no-deps --test request_header_codec_v3_registry --all-features -- -D warnings -A deprecated` (passed)
- `git diff --check` (passed)

Repository-wide `cargo fmt --all -- --check` remains blocked on Windows by OS error 206. Repository-wide strict Clippy remains blocked by pre-existing `rocketmq-model` deprecation and useless-conversion findings; the affected package and focused Clippy checks above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Improved request handling for topic-list creation, batch locking, and batch unlocking through the updated protocol format.
  * Preserved support for legacy request decoding while enabling canonical encoding for the migrated headers.

* **Testing**
  * Added coverage for typed, legacy, and map-based request envelope handling.
  * Updated migration validation to reflect the expanded set of supported protocol headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->