### PR TITLE
[ISSUE #9068]✨Migrate inherited request headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/heartbeat_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/heartbeat_request_header.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.HeartbeatRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct HeartbeatRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/lite_subscription_ctl_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/lite_subscription_ctl_request_header.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.LiteSubscriptionCtlRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteSubscriptionCtlRequestHeader {
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -24,6 +24,8 @@ use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_h
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
+use rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader;
 use rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
@@ -179,6 +181,8 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<CreateTopicListRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
+        register::<HeartbeatRequestHeader>(),
+        register::<LiteSubscriptionCtlRequestHeader>(),
         register::<LockBatchMqRequestHeader>(),
         register::<SendMessageRequestHeader>(),
         register::<DeleteTopicFromNamesrvRequestHeader>(),
@@ -460,6 +464,8 @@ where
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
     assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(|header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<HeartbeatRequestHeader>(|header| &header.rpc_request);
+    assert_rpc_envelope_contract::<LiteSubscriptionCtlRequestHeader>(|header| &header.rpc_request_header);
     assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(|header| &header.rpc_request_header);
     assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(|header| &header.rpc_request_header);
 }

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 132,
-    "v3Count": 20,
-    "pendingCount": 132,
-    "migratedCount": 20
+    "v2Count": 130,
+    "v3Count": 22,
+    "pendingCount": 130,
+    "migratedCount": 22
   },
   "baseline": {
     "v2TypeIds": [
@@ -179,6 +179,8 @@
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader",
+      "rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader",
       "rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
@@ -1862,16 +1864,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1925,16 +1927,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 20)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 22)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9068

### Brief Description

Migrate `HeartbeatRequestHeader` and `LiteSubscriptionCtlRequestHeader` from `RequestHeaderCodecV2` to `RequestHeaderCodecV3`.

Preserve their pinned Java inheritance contract with an always-present flattened `RpcRequestHeader`, canonical RPC encoding, decode-only legacy aliases, and map-only encoding capability. Register both types in the typed schema inventory and advance the migration baseline from 20 to 22 accepted V3 headers without adding production `java_type` metadata or a `mod.rs` file.

### How Did You Test This Change?

- `python scripts/request-header-codec/migrate.py check` (passed: 152 registered, 22 V3, 130 frozen V2)
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'` (passed: 3 tests)
- `python scripts/request-header-codec/compare_header_schema.py` (passed: 143 Java mappings, 0 differences)
- `cargo fmt -p rocketmq-protocol -- --check` (passed)
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry` (passed: 11 tests)
- `cargo test --locked -p rocketmq-protocol --all-features` (passed: library, integration, UI, and documentation tests)
- `cargo clippy --locked -p rocketmq-protocol --no-deps --test request_header_codec_v3_registry --all-features -- -D warnings -A deprecated` (passed)
- `git diff --check` (passed)

Repository-wide `cargo fmt --all -- --check` remains blocked on Windows by OS error 206. Repository-wide strict Clippy remains blocked by pre-existing `rocketmq-model` deprecation and useless-conversion findings; the affected package and focused Clippy checks above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Migrated heartbeat and lightweight subscription control requests to the latest request-header protocol format.
  * Added complete protocol metadata and consistent RPC envelope handling for these requests.
  * Included both request types in typed schema registration and compatibility validation.

* **Tests**
  * Updated migration tracking and regression coverage to reflect the expanded set of supported protocol headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->